### PR TITLE
Fix indentation and remove trailing whitespace of test files

### DIFF
--- a/Tests/PackageDescription/PackageDescriptionTests.swift
+++ b/Tests/PackageDescription/PackageDescriptionTests.swift
@@ -28,7 +28,7 @@ class PackageTests: XCTestCase, XCTestCaseProvider {
             ("testBasics", testBasics),
         ]
     }
-    
+
     func testBasics() {
         // Verify that we can round trip a basic package through TOML.
         let p1 = Package(name: "a", dependencies: [.Package(url: "https://example.com/example", majorVersion: 1)])

--- a/Tests/dep/DependencyGraphTests.swift
+++ b/Tests/dep/DependencyGraphTests.swift
@@ -19,19 +19,19 @@ class VersionGraphTests: XCTestCase {
             ("testNoGraph", testNoGraph),
             ("testOneDependency", testOneDependency),
             ("testOneDepenencyWithMultipleAvailableVersions", testOneDepenencyWithMultipleAvailableVersions),
-			("testOneDepenencyWithMultipleAvailableVersions", testOneDepenencyWithMultipleAvailableVersions),
-			("testTwoDependencies", testTwoDependencies),
-			("testTwoDirectDependencies", testTwoDirectDependencies),
-			("testTwoDirectDependenciesWhereOneAlsoDependsOnTheOther", testTwoDirectDependenciesWhereOneAlsoDependsOnTheOther),
-			("testSimpleVersionRestrictedGraph", testSimpleVersionRestrictedGraph),
-			("testComplexVersionRestrictedGraph", testComplexVersionRestrictedGraph),
-			("testVersionConstrain", testVersionConstrain),
-			("testTwoDependenciesRequireMutuallyExclusiveVersionsOfTheSameDependency_Simple", testTwoDependenciesRequireMutuallyExclusiveVersionsOfTheSameDependency_Simple),
-			("testTwoDependenciesRequireMutuallyExclusiveVersionsOfTheSameDependency_Complex", testTwoDependenciesRequireMutuallyExclusiveVersionsOfTheSameDependency_Complex),
-			("testVersionUnavailable", testVersionUnavailable)
+            ("testOneDepenencyWithMultipleAvailableVersions", testOneDepenencyWithMultipleAvailableVersions),
+            ("testTwoDependencies", testTwoDependencies),
+            ("testTwoDirectDependencies", testTwoDirectDependencies),
+            ("testTwoDirectDependenciesWhereOneAlsoDependsOnTheOther", testTwoDirectDependenciesWhereOneAlsoDependsOnTheOther),
+            ("testSimpleVersionRestrictedGraph", testSimpleVersionRestrictedGraph),
+            ("testComplexVersionRestrictedGraph", testComplexVersionRestrictedGraph),
+            ("testVersionConstrain", testVersionConstrain),
+            ("testTwoDependenciesRequireMutuallyExclusiveVersionsOfTheSameDependency_Simple", testTwoDependenciesRequireMutuallyExclusiveVersionsOfTheSameDependency_Simple),
+            ("testTwoDependenciesRequireMutuallyExclusiveVersionsOfTheSameDependency_Complex", testTwoDependenciesRequireMutuallyExclusiveVersionsOfTheSameDependency_Complex),
+            ("testVersionUnavailable", testVersionUnavailable)
         ]
     }
-    
+
     func testNoGraph() {
         class MockFetcher: _MockFetcher {
             override func fetch(url url: String) throws -> Fetchable {
@@ -332,10 +332,10 @@ private let v199 = Version(1,9,9)
 
 private enum MockProject: String {
     case A
-    case B 
-    case C 
-    case D 
-    case E 
+    case B
+    case C
+    case D
+    case E
     case F
     var url: String { return rawValue }
 }

--- a/Tests/dep/FunctionalBuildTests.swift
+++ b/Tests/dep/FunctionalBuildTests.swift
@@ -65,7 +65,7 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
             XCTAssertNotNil(try? executeSwiftBuild(prefix))
         }
     }
-    
+
     func verifyFilesExist(files: [String], fixturePath: String) -> Bool {
         for file in files {
             let name = fixturePath.characters.split("/").map(String.init).last!
@@ -80,23 +80,23 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
             default:
                 filePath = Path.join(fixturePath, ".build/debug", file)
             }
-            
+
             guard filePath.isFile else { return false }
         }
         return true
     }
-    
+
     func testIgnoreFiles() {
         fixture(name: "20_ignore_files") { prefix in
             XCTAssertNotNil(try? executeSwiftBuild(prefix))
-            
+
             let targets = try! determineTargets(packageName: "foo", prefix: prefix)
-            
+
             XCTAssertEqual(targets.count, 1)
             XCTAssertEqual(targets[0].sources.map({ $0.basename }), ["Foo.swift"])
         }
     }
-    
+
     // 2: Package with one library target
     func testSingleLibTarget() {
         let filesToVerify = ["rootLib"]
@@ -105,8 +105,8 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
             XCTAssertTrue(self.verifyFilesExist(filesToVerify, fixturePath: prefix))
         }
     }
-    
-    
+
+
     // 3: Package with multiple library targets
     func testMultipleLibTargets() {
         let filesToVerify = ["BarLib.a", "FooBarLib.a", "FooLib.a"]
@@ -115,8 +115,8 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
             XCTAssertTrue(self.verifyFilesExist(filesToVerify, fixturePath: prefix))
         }
     }
-    
-    
+
+
     // 4: Package with one executable target
     func testSingleExecTarget() {
         let filesToVerify = ["rootExec"]
@@ -125,7 +125,7 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
             XCTAssertTrue(self.verifyFilesExist(filesToVerify, fixturePath: prefix))
         }
     }
-    
+
     // 5: Package with multiple exectuble targets
     func testMultipleExecTargets() {
         let filesToVerify = ["BarExec", "FooBarExec", "FooExec"]
@@ -152,7 +152,7 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
             XCTAssertTrue(self.verifyFilesExist(filesToVerify, fixturePath: prefix))
         }
     }
-    
+
     // 8: Package with multiple library targets in a sources directory
     func testMultipleLibTargetsInSources() {
         let filesToVerify = ["BarLib.a", "FooBarLib.a", "FooLib.a"]
@@ -161,7 +161,7 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
             XCTAssertTrue(self.verifyFilesExist(filesToVerify, fixturePath: prefix))
         }
     }
-    
+
     // 9: Package with a single executable target in a sources directory
     func testSingleExecTargetInSources() {
         let filesToVerify = ["rootExec"]
@@ -170,7 +170,7 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
             XCTAssertTrue(self.verifyFilesExist(filesToVerify, fixturePath: prefix))
         }
     }
-    
+
     // 10: Package with multiple executable targets in a sources directory
     func testMultipleExecTargetsInSources() {
         let filesToVerify = ["BarExec", "FooBarExec", "FooExec"]
@@ -188,7 +188,7 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
             XCTAssertTrue(self.verifyFilesExist(filesToVerify, fixturePath: prefix))
         }
     }
-    
+
     // 12: Package with a single library targets in a src directory
     func testSingleLibTargetSrc() {
         let filesToVerify = ["rootLib"]
@@ -238,8 +238,8 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
             }
         }
     }
-    
-    
+
+
     // 17: Package with multiple library targets in a sources and src directory
     func testMultipleLibTargetsSourcesSrc() {
         fixture(name: "17_buildlib_src_sources") { prefix in
@@ -253,8 +253,8 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
             }
         }
     }
-    
-    
+
+
     // 18: Package with multiple executable and library targets in a sources and src directory
     func testMultipleLibExecTargetsSourcesSrc() {
         fixture(name: "18_buildlibexec_src_sources") { prefix in
@@ -268,8 +268,8 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
             }
         }
     }
-    
-    
+
+
     // 19: Package with multiple executable and library targets in a sources and src directory, and externally
     func testMultipleLibExecTargetsSourcesSrcExt() {
         fixture(name: "19_buildlibexec_src_sources_external") { prefix in
@@ -283,8 +283,8 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
             }
         }
     }
-    
-    
+
+
     // 20: Single dependency where BarLib depends on FooLib
     func testLibDep() {
         let filesToVerify = ["BarLib.a", "FooLib.a"]

--- a/Tests/dep/ManifestTests.swift
+++ b/Tests/dep/ManifestTests.swift
@@ -21,7 +21,7 @@ class ManifestTests: XCTestCase, XCTestCaseProvider {
             ("testManifestLoading", testManifestLoading),
         ]
     }
-    
+
     private func loadManifest(inputName: String) -> Manifest {
         let input = Path.join(__FILE__, "../Inputs", inputName).normpath
         do {
@@ -30,20 +30,20 @@ class ManifestTests: XCTestCase, XCTestCaseProvider {
             fatalError("unexpected error: \(err)")
         }
     }
-    
+
     func testManifestLoading() {
         // Check a trivial manifest.
         var manifest = loadManifest("trivial-manifest")
         XCTAssertEqual(manifest.package.name, "Trivial")
         XCTAssertEqual(manifest.package.targets, [])
         XCTAssertEqual(manifest.package.dependencies, [])
-        
+
         // Check a manifest with package specifications.
         manifest = loadManifest("package-deps-manifest")
         XCTAssertEqual(manifest.package.name, "PackageDeps")
         XCTAssertEqual(manifest.package.targets, [])
         XCTAssertEqual(manifest.package.dependencies, [Package.Dependency.Package(url: "https://example.com/example", majorVersion: 1)])
-        
+
         // Check a manifest with targets.
         manifest = loadManifest("target-deps-manifest")
         XCTAssertEqual(manifest.package.name, "TargetDeps")

--- a/Tests/dep/PackageTests.swift
+++ b/Tests/dep/PackageTests.swift
@@ -12,11 +12,11 @@ import XCTest
 @testable import dep
 
 class PackageTests: XCTestCase {
-  
+
     var allTests : [(String, () -> ())] {
         return []
     }
-  
+
     func testInitializer() {
         do {
             // valid path, but no manifest so check throw is correct

--- a/Tests/dep/TargetTests.swift
+++ b/Tests/dep/TargetTests.swift
@@ -40,7 +40,7 @@ class TargetTests: XCTestCase, XCTestCaseProvider {
             ("test6", test6),
         ]
     }
-    
+
     func test1() {
         let t1 = try! Target(name: "t1", files: [], type: .Library)
         let t2 = try! Target(name: "t2", files: [], type: .Library)

--- a/Tests/dep/Utilities.swift
+++ b/Tests/dep/Utilities.swift
@@ -46,7 +46,7 @@ func fixture(name fixtureName: String, tag: String = "1.2.3", @noescape body: (S
         }
         var stream = TempStream()
         print(error, toStream: &stream)
-        
+
         XCTFail("\(stream.result)")
     }
 }

--- a/Tests/dep/VersionTests.swift
+++ b/Tests/dep/VersionTests.swift
@@ -26,22 +26,22 @@ class VersionTests: XCTestCase, XCTestCaseProvider {
             ("testRange", testRange),
         ]
     }
-    
+
     func testEquality() {
         func test(@autoclosure v: () -> Version) {
             XCTAssertEqual(v(), v())
         }
-        
+
         test(Version(1,2,3))
         test(Version(0,0,0))
         test(Version(Int.min, Int.min, Int.min))
         test(Version(Int.max, Int.max, Int.max))
     }
-    
+
     func testNegativeValuesBecomeZero() {
         XCTAssertEqual(Version(-1, -2, -3), Version(0,0,0))
     }
-    
+
     func testComparable() {
         do {
             let v1 = Version(1,2,3)
@@ -104,11 +104,11 @@ class VersionTests: XCTestCase, XCTestCaseProvider {
             XCTAssertGreaterThanOrEqual(v8, v8)
         }
     }
-    
+
     func testDescription() {
         XCTAssertEqual(Version(123,234,345).description, "123.234.345")
     }
-    
+
     func testFromString() {
         XCTAssertNil(Version(""))
         XCTAssertNil(Version("1"))
@@ -116,7 +116,7 @@ class VersionTests: XCTestCase, XCTestCaseProvider {
         XCTAssertEqual(Version(1,2,3), Version("1.2.3"))
         XCTAssertNil(Version("1.2.3.4"))
         XCTAssertNil(Version("1.2.3.4.5"))
-        
+
         XCTAssertNil(Version("a"))
         XCTAssertNil(Version("1.a"))
         XCTAssertNil(Version("a.2"))

--- a/Tests/sys/PathTests.swift
+++ b/Tests/sys/PathTests.swift
@@ -16,7 +16,7 @@ class PathTests: XCTestCase {
 
     var allTests : [(String, () -> ())] {
         return [
-			("test", test),
+            ("test", test),
             ("testPrecombined", testPrecombined),
             ("testExtraSeparators", testExtraSeparators),
             ("testEmpties", testEmpties),
@@ -93,11 +93,11 @@ class WalkTests: XCTestCase {
 
     var allTests : [(String, () -> ())] {
         return [
-			("testNonRecursive", testNonRecursive),
+            ("testNonRecursive", testNonRecursive),
             ("testRecursive", testRecursive),
         ]
-    }    
-    
+    }
+
     func testNonRecursive() {
         var expected = ["/usr", "/bin", "/sbin"]
 
@@ -132,13 +132,13 @@ class StatTests: XCTestCase {
 
     var allTests : [(String, () -> ())] {
         return [
-			("test_isdir", test_isdir),
+            ("test_isdir", test_isdir),
             ("test_isfile", test_isfile),
             ("test_realpath", test_realpath),
             ("test_basename", test_basename),
         ]
-    }    
-    
+    }
+
     func test_isdir() {
         XCTAssertTrue("/usr".isDirectory)
         XCTAssertTrue("/etc/passwd".isFile)
@@ -166,12 +166,12 @@ class RelativePathTests: XCTestCase {
 
     var allTests : [(String, () -> ())] {
         return [
-			("testAbsolute", testAbsolute),
+            ("testAbsolute", testAbsolute),
             ("testRelative", testRelative),
             ("testMixed", testMixed),
         ]
-    }    
-    
+    }
+
     func testAbsolute() {
         XCTAssertEqual("2/3", Path("/1/2/3").relative(to: "/1/"))
         XCTAssertEqual("3/4", Path("/1/2////3/4///").relative(to: "////1//2//"))

--- a/Tests/sys/ResourcesTests.swift
+++ b/Tests/sys/ResourcesTests.swift
@@ -20,7 +20,7 @@ class ResourcesTests: XCTestCase, XCTestCaseProvider {
             ("testResources", testResources),
         ]
     }
-    
+
     func testResources() {
         // Cause resources to be initialized, even though the path won't actually be correct.
         Resources.initialize(&globalSymbolInNonMainBinary)

--- a/Tests/sys/ShellTests.swift
+++ b/Tests/sys/ShellTests.swift
@@ -20,11 +20,11 @@ class ShellTests: XCTestCase, XCTestCaseProvider {
             ("testPopenWithBufferLargerThanThatAllocated", testPopenWithBufferLargerThanThatAllocated)
         ]
     }
-    
+
     func testPopen() {
         XCTAssertEqual(try! popen(["echo", "foo"]), "foo\n")
     }
-    
+
     func testPopenWithBufferLargerThanThatAllocated() {
         let path = Path.join(__FILE__, "../../dep/FunctionalBuildTests.swift").normpath
         XCTAssertGreaterThan(try! popen(["cat", path]).characters.count, 4096)

--- a/Tests/sys/StringTests.swift
+++ b/Tests/sys/StringTests.swift
@@ -20,7 +20,7 @@ class StringTests: XCTestCase, XCTestCaseProvider {
             ("testChuzzle", testChuzzle),
         ]
     }
-    
+
     func testTrailingChomp() {
         XCTAssertEqual("abc\n".chomp(), "abc")
         XCTAssertEqual("abc\r\n".chomp(), "abc")
@@ -54,7 +54,7 @@ class URLTests: XCTestCase, XCTestCaseProvider {
             ("testSchema", testSchema),
         ]
     }
-    
+
     func testSchema() {
         let a = "http://github.com/foo/bar"
         let b = "https://github.com/foo/bar"

--- a/Tests/sys/TOMLTests.swift
+++ b/Tests/sys/TOMLTests.swift
@@ -37,7 +37,7 @@ class TOMLTests: XCTestCase, XCTestCaseProvider {
             ("testParsingTables", testParsingTables),
         ]
     }
-    
+
     func testLexer() {
         // Test the basics.
         XCTAssertEqual(lexTOML("# Comment\nfoo"), ["Comment", "Identifier(\"foo\")"])
@@ -49,18 +49,18 @@ class TOMLTests: XCTestCase, XCTestCaseProvider {
         XCTAssertEqual(lexTOML("+12"), ["Number(\"+12\")"])
         XCTAssertEqual(lexTOML("1.2e-10"), ["Number(\"1.2e-10\")"])
     }
-    
+
     func testParser() {
         XCTAssertEqual(parseTOML("a = b"), toTable(["a": .String(value: "b")]))
         XCTAssertEqual(parseTOML("a = \"b\""), toTable(["a": .String(value: "b")]))
         XCTAssertEqual(parseTOML("a = 1"), toTable(["a": .Int(value: 1)]))
         XCTAssertEqual(parseTOML("a = true\n\nb = false"), toTable(["a": .Bool(value: true), "b": .Bool(value: false)]))
-        
+
         // Test arrays.
         XCTAssertEqual(parseTOML("a = [1, 2]"), toTable(["a": toArray([.Int(value: 1), .Int(value: 2)])]))
         XCTAssertEqual(parseTOML("a = [1,\n[\n2,\n] ]"), toTable(["a": toArray([.Int(value: 1), toArray([.Int(value: 2)])])]))
     }
-    
+
     func testParsingTables() {
         // Test nested tables.
         XCTAssertEqual(parseTOML(
@@ -84,7 +84,7 @@ class TOMLTests: XCTestCase, XCTestCaseProvider {
         // Check handling of empty nested tables.
         XCTAssertEqual(parseTOML("[[t1]]"), toTable([
             "t1": toArray([toTable([:])])]))
-            
+
         // Check basic append handling.
         XCTAssertEqual(parseTOML(
             (
@@ -96,7 +96,7 @@ class TOMLTests: XCTestCase, XCTestCaseProvider {
                 "t1": toArray([
                     toTable(["a": .Int(value: 1)]),
                     toTable(["a": .Int(value: 2)])])]))
-        
+
         // Check handling of insert into array of tables.
         XCTAssertEqual(parseTOML(
             (


### PR DESCRIPTION
Since most parts of the files were using spaces I converted all of them to use spaces as tabs.