### PR TITLE
Change platform name to tvOS

### DIFF
--- a/Documentation/Package.swift.md
+++ b/Documentation/Package.swift.md
@@ -64,4 +64,4 @@ With a standard configuration file format like JSON such a feature would result 
 
 ## Depending on Apple Modules (eg. Foundation)
 
-At this time there is no explicit support for depending on Foundation, AppKit, etc, though importing these modules should work if they are present in the proper system location. We will add explicit support for system dependencies in the future. Note that at this time the Package Manager has no support for iOS, watchOS, or AppleTV platforms.
+At this time there is no explicit support for depending on Foundation, AppKit, etc, though importing these modules should work if they are present in the proper system location. We will add explicit support for system dependencies in the future. Note that at this time the Package Manager has no support for iOS, watchOS, or tvOS platforms.


### PR DESCRIPTION
Switch platform name from AppleTV to tvOS