### PR TITLE
Fix Package versions value in documentation.

### DIFF
--- a/Documentation/DevelopingPackages.md
+++ b/Documentation/DevelopingPackages.md
@@ -23,7 +23,7 @@ Now delete the subdirectory, and amend your `Package.swift` so that its `package
 ```swift
 let package = Package(
     dependencies: [
-        .Package(url: "…", versions: "1.0.0"),
+        .Package(url: "…", versions: Version(1,0,0)..<Version(2,0,0)),
     ]
 )
 ```

--- a/Documentation/Package.swift.md
+++ b/Documentation/Package.swift.md
@@ -15,7 +15,7 @@ import PackageDescription
 let package = Package(
     name: "Hello",
     dependencies: [
-        .Package(url: "ssh://git@example.com/Greeter.git", versions: "1.0.0"),
+        .Package(url: "ssh://git@example.com/Greeter.git", versions: Version(1,0,0)..<Version(2,0,0)),
     ]
 )
 ```


### PR DESCRIPTION
Proper value is type of [Version], not String.

ref: https://github.com/apple/swift-package-manager/blob/14f47ad34967c7e7808863fb29fa3f9baf5db7a4/Tests/dep/Fixtures/101_mattts_dealer/app/Package.swift#L6