### PR TITLE
Allow any "Tests"-suffixed directories to be ignored from `swift build`.

### DIFF
--- a/Documentation/SourceLayouts.md
+++ b/Documentation/SourceLayouts.md
@@ -35,6 +35,6 @@ Where `foo` is an executable and `bar.a` a static library.
 
 ## Other Rules
 
-* Directories named `Tests` are ignored
+* Directories named with suffix `*Tests` are ignored
 * Sub directories of a directory named `Sources`, `Source`, `srcs` or `src` become modules
 * It is acceptable to have no `Sources` directory, in which case the root directory is treated as a single module (place your sources there) or sub directories of the root are considered modules. Use this layout convention for simple projects.

--- a/Sources/dep/Manifest+configureTargets.swift
+++ b/Sources/dep/Manifest+configureTargets.swift
@@ -139,7 +139,7 @@ public func ==(lhs: Target, rhs: Target) -> Bool {
  */
 private func shouldConsiderDirectory(subdir: String) -> Bool {
     let subdir = subdir.basename.lowercaseString
-    if subdir == "tests" { return false }
+    if subdir.hasSuffix("tests") { return false }
     if subdir.hasSuffix(".xcodeproj") { return false }
     if subdir.hasSuffix(".playground") { return false }
     if subdir.hasPrefix(".") { return false }  // eg .git


### PR DESCRIPTION
According to [Documentation/SourceLayouts.md](https://github.com/apple/swift-package-manager/blob/664763b9ef84d4d1af71902b7515e81992e5ad53/Documentation/SourceLayouts.md), only directory named "Tests" can be ignored from `swift build`, but Xcode normally generates directory name e.g. `MyFrameworkTests`, and I want to ignore this as well.

BTW, it will be even better if we can specify test directory names in `Package.swift` :blush: