### PR TITLE
Fix Package versions in documentation

### DIFF
--- a/Documentation/DevelopingPackages.md
+++ b/Documentation/DevelopingPackages.md
@@ -23,7 +23,7 @@ Now delete the subdirectory, and amend your `Package.swift` so that its `package
 ```swift
 let package = Package(
     dependencies: [
-        .Package(url: "…", versions: "1.0.0"),
+        .Package(url: "…", majorVersion: 1, minor: 1),
     ]
 )
 ```

--- a/Documentation/DevelopingPackages.md
+++ b/Documentation/DevelopingPackages.md
@@ -23,7 +23,7 @@ Now delete the subdirectory, and amend your `Package.swift` so that its `package
 ```swift
 let package = Package(
     dependencies: [
-        .Package(url: "…", majorVersion: 1, minor: 1),
+        .Package(url: "…", majorVersion: 1, minor: 0),
     ]
 )
 ```

--- a/Documentation/Package.swift.md
+++ b/Documentation/Package.swift.md
@@ -15,7 +15,7 @@ import PackageDescription
 let package = Package(
     name: "Hello",
     dependencies: [
-        .Package(url: "ssh://git@example.com/Greeter.git", majorVersion: 1, minor: 1),
+        .Package(url: "ssh://git@example.com/Greeter.git", majorVersion: 1, minor: 0),
     ]
 )
 ```

--- a/Documentation/Package.swift.md
+++ b/Documentation/Package.swift.md
@@ -15,7 +15,7 @@ import PackageDescription
 let package = Package(
     name: "Hello",
     dependencies: [
-        .Package(url: "ssh://git@example.com/Greeter.git", versions: "1.0.0"),
+        .Package(url: "ssh://git@example.com/Greeter.git", majorVersion: 1, minor: 1),
     ]
 )
 ```


### PR DESCRIPTION
# Fix Package versions in documentation

I tried like the docs, but I can't.
`error: cannot convert value of type 'String' to expected argument type 'Range<Version>'`

We should use `Range<Version>` or `Package(url url: String, majorVersion: Int, minor: Int, patch: Int)` needed?