### PR TITLE
Fix versions in documentation

### DIFF
--- a/Documentation/DevelopingPackages.md
+++ b/Documentation/DevelopingPackages.md
@@ -23,7 +23,7 @@ Now delete the subdirectory, and amend your `Package.swift` so that its `package
 ```swift
 let package = Package(
     dependencies: [
-        .Package(url: "…", versions: "1.0.0"),
+        .Package(url: "…", "1.0.0"),
     ]
 )
 ```

--- a/Documentation/Package.swift.md
+++ b/Documentation/Package.swift.md
@@ -15,7 +15,7 @@ import PackageDescription
 let package = Package(
     name: "Hello",
     dependencies: [
-        .Package(url: "ssh://git@example.com/Greeter.git", versions: "1.0.0"),
+        .Package(url: "ssh://git@example.com/Greeter.git", "1.0.0"),
     ]
 )
 ```


### PR DESCRIPTION
The `Package(url:versions:)` requires a `Range<Version>` as argument, passing a `String` to it will fail the package building with this error.

> cannot convert value of type 'String' to expected argument type 'Range<Version>'

Although `Version` itself is `StringLiteralConvertible`, the `Range<Version>` is not.

Another way to fix it would be something like `.Package(url: "…", versions: "1.0.0"..."1.0.2")`. But I guess we'd better to keep it simple for demonstration purpose.

See #13 and #17 as well.