### PR TITLE
Fix XCTestCaseProvider and allTests

### DIFF
--- a/Tests/dep/DependencyGraphTests.swift
+++ b/Tests/dep/DependencyGraphTests.swift
@@ -12,7 +12,7 @@ import XCTest
 @testable import dep
 @testable import struct PackageDescription.Version
 
-class VersionGraphTests: XCTestCase {
+class VersionGraphTests: XCTestCase, XCTestCaseProvider {
 
     var allTests : [(String, () -> ())] {
         return [

--- a/Tests/dep/PackageTests.swift
+++ b/Tests/dep/PackageTests.swift
@@ -11,10 +11,12 @@
 import XCTest
 @testable import dep
 
-class PackageTests: XCTestCase {
+class PackageTests: XCTestCase, XCTestCaseProvider {
 
     var allTests : [(String, () -> ())] {
-        return []
+        return [
+            ("testInitializer", testInitializer)
+        ]
     }
 
     func testInitializer() {

--- a/Tests/dep/UidTests.swift
+++ b/Tests/dep/UidTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 @testable import dep
 
-class ProjectTests: XCTestCase {
+class ProjectTests: XCTestCase, XCTestCaseProvider {
 
     var allTests : [(String, () -> ())] {
         return [

--- a/Tests/sys/PathTests.swift
+++ b/Tests/sys/PathTests.swift
@@ -12,7 +12,7 @@ import XCTest
 import POSIX
 @testable import sys
 
-class PathTests: XCTestCase {
+class PathTests: XCTestCase, XCTestCaseProvider {
 
     var allTests : [(String, () -> ())] {
         return [


### PR DESCRIPTION
Although I am not quite sure about what `XCTestCaseProvider` does, it seems these test case class should conform to `XCTestCaseProvider`. I also added a missed `allTests` entry in `PackageTests.swift`.