### PR TITLE
Fix functional build tests for swiftpm target

### DIFF
--- a/Support/swiftpm.xcodeproj/xcshareddata/xcschemes/swiftpm.xcscheme
+++ b/Support/swiftpm.xcodeproj/xcshareddata/xcschemes/swiftpm.xcscheme
@@ -141,7 +141,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "SPM_INSTALL_PATH"
-            value = "$(PROJECT_DIR)/../.build"
+            value = "$(PROJECT_DIR)/../.build/.bootstrap"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable


### PR DESCRIPTION
## Problem

All of the `FunctionalBuildTests` is now failing when testing in Xcode with Cmd+U.

It seems that the executable file `swift-build` is placed under `.build/.bootstrap/bin`. At the same time, the `Resources.computeResourcesPaths()` is using "SPM_INSTALL_PATH" environment variable to search the built product. However, the install path is set to `$(PROJECT_DIR)/../.build`. This leads the correct executable could not be found and the default `swift-build` is returned.

So invoking of `executeSwiftBuild(_:)` will always fail if the `swift-build` could not be found in system search path. Even it is there, the executable might be an older one instead of newly built file. This might not be the expected behavior.

![snip20151205_5](https://cloud.githubusercontent.com/assets/1019875/11593747/57481e5e-9ae9-11e5-91f7-46c107b366bd.png)

## Fix

Simply changing the "SPM_INSTALL_PATH" from `$(PROJECT_DIR)/../.build` to `$(PROJECT_DIR)/../.build/.bootstrap` would solve it and make all tests green.

![snip20151205_4](https://cloud.githubusercontent.com/assets/1019875/11593777/7c81a1fe-9ae9-11e5-97db-1f8c0eabecb6.png)

### P.S.

Everything goes well when using bootstrap script.

```bash
./Utilities/bootstrap --build-tests test
```

Since the `sandbox_path` is set correctly.

```python
sandbox_path = os.path.join(build_path, ".bootstrap")
# ...
env_cmd = ["env",
                   "SWIFTC=" + opts.swiftc_path,
                   "SWIFT_BUILD_TOOL=" + opts.sbt_path,
                   "SPM_INSTALL_PATH=" + sandbox_path]
```