### PR TITLE
Fix "minor" version dependency pinning

### DIFF
--- a/Sources/PackageDescription/Package.swift
+++ b/Sources/PackageDescription/Package.swift
@@ -33,7 +33,7 @@ public final class Package {
             return Dependency(url, Version(majorVersion, 0, 0)..<Version(majorVersion + 1, 0, 0))
         }
         public class func Package(url url: String, majorVersion: Int, minor: Int) -> Dependency {
-            return Dependency(url, Version(majorVersion, minor, 0)..<Version(majorVersion + 1, 0, 0))
+            return Dependency(url, Version(majorVersion, minor, 0)..<Version(majorVersion, minor + 1, 0))
         }
         public class func Package(url url: String, _ version: Version) -> Dependency {
             return Dependency(url, version...version)


### PR DESCRIPTION
#### What's this PR do?

Fixes the pinning of dependencies with major _and_ minor version numbers specified.

#### Where should the reviewer start?

The diff is just one line, but the change is significant. If the package manifest specifies both major and minor version numbers for a dependency, it should be pinned to only allow differences in the patch number.

#### How should this be manually tested?

1. Create (or find) a package ("Package A") with tags for versions `1.0.0`, `1.0.1` and `1.1.0`.
2. Create a package ("Package B") with a dependency on version `1.0.x` of Package A.
  - For example: `.Package("https://example.com/pkg-a.git", majorVersion: 1, minor: 0)`
3. Build Package B (or at least install its dependencies).
  - Afterwards, you should end up with version `1.0.1` of Package A, **not** version `1.1.0`.

#### Any background context you want to provide?

Previously, there was no difference between a dependency specified with only a major version, and one specified with a major and minor version. Seems like probably just a copy-paste error.