### PR TITLE
Removed workaround from .ExitStatus description

### DIFF
--- a/Sources/POSIX/Error.swift
+++ b/Sources/POSIX/Error.swift
@@ -123,16 +123,7 @@ extension Error: CustomStringConvertible {
     public var description: String {
         switch self {
         case .ExitStatus(let code, let args):
-            // Work around for a miscompile when converting error type to string. rdar://problem/23616384
-            struct TempStream: OutputStreamType {
-                var result: String = ""
-                mutating func write(string: String) {
-                    result += string
-                }
-            }
-            var stream = TempStream()
-            print(args, toStream: &stream)
-            return "exit(\(code)): \(stream.result)"
+            return "exit(\(code)): \(args.joinWithSeparator(" "))"
             
             //let args = prettyArguments(args)
             //return "exit(\(code)): \(args)"

--- a/Sources/POSIX/Error.swift
+++ b/Sources/POSIX/Error.swift
@@ -123,7 +123,7 @@ extension Error: CustomStringConvertible {
     public var description: String {
         switch self {
         case .ExitStatus(let code, let args):
-            return "exit(\(code)): \(args.joinWithSeparator(" "))"
+            return "exit(\(code)): \(prettyArguments(args))"
             
             //let args = prettyArguments(args)
             //return "exit(\(code)): \(args)"

--- a/Sources/POSIX/Error.swift
+++ b/Sources/POSIX/Error.swift
@@ -124,9 +124,6 @@ extension Error: CustomStringConvertible {
         switch self {
         case .ExitStatus(let code, let args):
             return "exit(\(code)): \(prettyArguments(args))"
-            
-            //let args = prettyArguments(args)
-            //return "exit(\(code)): \(args)"
 
         case .ExitSignal:
             return "Child process exited with signal"


### PR DESCRIPTION
Also joined separators with a space.

I feel like it better communicates the intent of the error message, and swift-build doesn't seem to trip on this implementation.