### PR TITLE
Refactor Manifest.configureTargets(_:)

### DIFF
--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -14,6 +14,14 @@ public final class Target {
     public enum Dependency {
         /// A dependency on a target in the same project.
         case Target(name: String)
+
+        /// Extracts `name` from associated data
+        public var name: String {
+            switch self {
+            case let .Target(name):
+                return name
+            }
+        }
     }
 
     /// The name of the target.


### PR DESCRIPTION
This PR aims to simplify the configureTargets method by splitting it out in multiple methods. Focussing only on the part assigning the dependencies for each target.