### PR TITLE
Removed small instance of force unwrapping

### DIFF
--- a/Sources/POSIX/system.swift
+++ b/Sources/POSIX/system.swift
@@ -58,6 +58,7 @@ func posix_spawnp(path: String, args: [String], environment: [String: String] = 
     var pid = pid_t()
     let rv: Int32
     if let fileActions = fileActions {
+        // required for the `&fileActions` inout parameter
         var fileActions = fileActions
         rv = posix_spawnp(&pid, argv[0], &fileActions, nil, argv + [nil], env + [nil])
     } else {

--- a/Sources/POSIX/system.swift
+++ b/Sources/POSIX/system.swift
@@ -57,8 +57,8 @@ func posix_spawnp(path: String, args: [String], environment: [String: String] = 
     
     var pid = pid_t()
     let rv: Int32
-    if fileActions != nil {
-        var fileActions = fileActions!
+    if let fileActions = fileActions {
+        var fileActions = fileActions
         rv = posix_spawnp(&pid, argv[0], &fileActions, nil, argv + [nil], env + [nil])
     } else {
         rv = posix_spawnp(&pid, argv[0], nil, nil, argv + [nil], env + [nil])


### PR DESCRIPTION
So that the unwrapping does not have to happen twice. Could also benefit from `if var ...` however as that seems to be removed soon, I went with the canonical `var` variant.