### PR TITLE
Update LICENSE to correct the license owner

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -175,18 +175,7 @@
 
     END OF TERMS AND CONDITIONS
 
-    APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-    Copyright [yyyy] [name of copyright owner]
+    Copyright 2015 Apple Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
The license text was left as an Apache License template. According to the "APPENDIX" part of the template, the copyright year and owner should be modified [to apply the Apache License](http://www.apache.org/licenses/LICENSE-2.0#apply).

This pull request corresponds to the following pull request to swift repository.
apple/swift#124