### PR TITLE
Refactor unwrapping optionals in Specifier

### DIFF
--- a/Sources/PackageDescription/Version.swift
+++ b/Sources/PackageDescription/Version.swift
@@ -145,23 +145,10 @@ public struct Specifier {
     }
 
     private init(_ major: Int?, _ minor: Int?, _ patch: Int?) {
-        if let major = major {
-            self.major = Swift.max(major, 0)
-        } else {
-            self.major = nil
-        }
 
-        if let minor = minor {
-            self.minor = Swift.max(minor, 0)
-        } else {
-            self.minor = nil
-        }
-
-        if let patch = patch {
-            self.patch = Swift.max(patch, 0)
-        } else {
-            self.patch = nil
-        }
+        self.major = major.map{ Swift.max($0, 0) }
+        self.minor = minor.map{ Swift.max($0, 0) }
+        self.patch = patch.map{ Swift.max($0, 0) }
     }
 
     public init?(_ characters: String.CharacterView) {


### PR DESCRIPTION
The Optionals map function does exactly the same but it looks much cleaner.

`./Utilities/bootstrap --build-tests test` passes 
Executed 69 tests, with 0 failures (0 unexpected) in 19.261 (19.266) seconds