### PR TITLE
Rename systém function to loggedSystem

### DIFF
--- a/Sources/dep/Git.swift
+++ b/Sources/dep/Git.swift
@@ -68,7 +68,7 @@ class Git {
         }
 
         func fetch() throws {
-            try loggedSystem(Git.tool, "-C", root, "fetch", "--tags", "origin")
+            try system(Git.tool, "-C", root, "fetch", "--tags", "origin")
         }
     }
 
@@ -80,10 +80,10 @@ class Git {
         }
 
         do {
-            try loggedSystem(Git.tool, "clone",
+            try system(Git.tool, "clone",
                 "--recursive",   // get submodules too so that developers can use these if they so choose
                 "--depth", "10",
-                url, dstdir, preamble: "Cloning \(Path(dstdir).relative(to: "."))")
+                url, dstdir, message: "Cloning \(Path(dstdir).relative(to: "."))")
         } catch POSIX.Error.ExitStatus {
             throw Error.GitCloneFailure(url, dstdir)
         }
@@ -97,14 +97,12 @@ class Git {
 }
 
 
-private func loggedSystem(args: String..., preamble: String? = nil) throws {
+private func system(args: String..., message: String) throws {
     var out = ""
     do {
         if sys.verbosity == .Concise {
-            if let preamble = preamble {
-                print(preamble)
-                fflush(stdout)  // should git ask for credentials ensure we displayed the above status message first
-            }
+            print(message)
+            fflush(stdout)  // should git ask for credentials ensure we displayed the above status message first
             try popen(args, redirectStandardError: true) { line in
                 out += line
             }

--- a/Sources/dep/Git.swift
+++ b/Sources/dep/Git.swift
@@ -68,7 +68,7 @@ class Git {
         }
 
         func fetch() throws {
-            try systém(Git.tool, "-C", root, "fetch", "--tags", "origin")
+            try loggedSystem(Git.tool, "-C", root, "fetch", "--tags", "origin")
         }
     }
 
@@ -80,7 +80,7 @@ class Git {
         }
 
         do {
-            try systém(Git.tool, "clone",
+            try loggedSystem(Git.tool, "clone",
                 "--recursive",   // get submodules too so that developers can use these if they so choose
                 "--depth", "10",
                 url, dstdir, preamble: "Cloning \(Path(dstdir).relative(to: "."))")
@@ -97,7 +97,7 @@ class Git {
 }
 
 
-private func systém(args: String..., preamble: String? = nil) throws {
+private func loggedSystem(args: String..., preamble: String? = nil) throws {
     var out = ""
     do {
         if sys.verbosity == .Concise {

--- a/Sources/dep/Git.swift
+++ b/Sources/dep/Git.swift
@@ -68,7 +68,7 @@ class Git {
         }
 
         func fetch() throws {
-            try system(Git.tool, "-C", root, "fetch", "--tags", "origin")
+            try system(Git.tool, "-C", root, "fetch", "--tags", "origin", message: nil)
         }
     }
 
@@ -97,12 +97,14 @@ class Git {
 }
 
 
-private func system(args: String..., message: String) throws {
+private func system(args: String..., message: String?  ) throws {
     var out = ""
     do {
         if sys.verbosity == .Concise {
-            print(message)
-            fflush(stdout)  // should git ask for credentials ensure we displayed the above status message first
+			if let message = message {
+	            print(message)
+	            fflush(stdout)  // should git ask for credentials ensure we displayed the above status message first
+			}
             try popen(args, redirectStandardError: true) { line in
                 out += line
             }


### PR DESCRIPTION
A small little change for renaming `systém` to `loggedSystem`, which seems like a more descriptive function name and is easier to type.