### PR TITLE
remove String replace function

### DIFF
--- a/Sources/sys/StringExtensions.swift
+++ b/Sources/sys/StringExtensions.swift
@@ -71,8 +71,4 @@ extension String {
 
         return String(cc)
     }
-
-    public func replace(token: String, with: String) -> String {
-        return ""
-    }
 }


### PR DESCRIPTION
This function was't implemented and it is not used anywhere.

The project builds and all tests are passing. 
Is it safe to delete some unused functions like these or could they be used in some other dependent projects?