### PR TITLE
[tests] Create .travis.yml to enable continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+# Using Ubuntu 14.04 LTS Trusty (Travis CI Beta)
+language: generic
+sudo: required
+dist: trusty
+
+install:
+  - export SWIFT_VERSION=swift-2.2-SNAPSHOT-2015-12-01-b
+  - export SWIFT_FILE=${SWIFT_VERSION}-ubuntu14.04.tar.gz
+  - export SWIFT_URL=https://swift.org/builds/ubuntu1404/${SWIFT_VERSION}/${SWIFT_FILE}
+  - sudo apt-get update
+  - sudo apt-get -y --no-install-recommends install build-essential wget clang
+    libedit-dev python2.7 python2.7-dev libicu52 rsync
+  - wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -
+  - gpg --keyserver hkp://pool.sks-keyservers.net --refresh-keys Swift
+  - wget ${SWIFT_URL}
+  - wget ${SWIFT_URL}.sig
+  - gpg --verify ${SWIFT_FILE}.sig
+  - sudo tar -xvzf ${SWIFT_FILE} --directory / --strip-components=1
+
+script: ./Utilities/bootstrap --build-tests test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Swift Package Manager
 
+[![Build Status](https://travis-ci.org/apple/swift-package-manager.svg?branch=master)](https://travis-ci.org/apple/swift-package-manager)
+
 The Swift Package Manager is a tool for managing distribution of source code,
 aimed at making it easy to share your code and reuse others’ code. The tool
 directly addresses the challenges of compiling and linking Swift packages,
@@ -7,7 +9,7 @@ managing dependencies, versioning, and supporting flexible distribution and
 collaboration models.
 
 We’ve designed the system to make it really easy to share packages on services
-like GitHub, 
+like GitHub,
 but packages are also great for private personal development, sharing code
 within a team, or at any other granularity.
 
@@ -154,7 +156,7 @@ Swift will build a single executable called `foo`.
 To the package manager, everything is a package, hence `Package.swift`. However
 this does not mean you have to release your software to the wider world: you can
 develop your app without ever publishing it in a place where others can see or
-use. On the other hand, if one day you decide that your project _should_ be 
+use. On the other hand, if one day you decide that your project _should_ be
 available to a wider audience your sources are already in a form ready to be
 published.  The package manager is also independent of specific forms of
 distribution, so you can use it to share code within your personal projects,
@@ -189,7 +191,7 @@ and minimize the coordination costs associated with code reuse.
 Dependencies are specified in your `Package.swift` manifest file.
 
 > [Further Reading: Package.swift — The Manifest File](Documentation/Package.swift.md)
- 
+
 > [Further Reading: Developing Packages](Documentation/DevelopingPackages.md)
 
 ### Using System Libraries


### PR DESCRIPTION
Adds Travis CI to run tests for Ubuntu 14.04 LTS Linux architecture. This requires configuring this project on the Apple Travis CI account: https://travis-ci.org/apple 

A build status image has been added to the README.md. Example using this branch:  [![Build Status](https://travis-ci.org/eosrei/swift-package-manager.svg?branch=create-travisci)](https://travis-ci.org/eosrei/swift-package-manager)
