### PR TITLE
File generator separator

### DIFF
--- a/Sources/sys/File.swift
+++ b/Sources/sys/File.swift
@@ -60,7 +60,7 @@ public class FileLineGenerator: GeneratorType, SequenceType {
     }
 
     deinit {
-        libc.fclose(fp)
+        fclose(fp)
     }
 
     public func next() -> String? {
@@ -77,7 +77,7 @@ public class FileLineGenerator: GeneratorType, SequenceType {
                     return nil
                 }
             }
-            if c == 10 { return out }
+            if c == separator { return out }
 
             // fgetc is documented to return unsigned char converted to an int
             out.append(UnicodeScalar(UInt8(c)))

--- a/Support/swiftpm.xcodeproj/project.pbxproj
+++ b/Support/swiftpm.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4BAA4BAC1C16CABE0074DA44 /* FileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BAA4BAB1C16CABE0074DA44 /* FileTests.swift */; };
 		6305480E1BD708B30001290A /* DependencyGraphTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6305480D1BD708B30001290A /* DependencyGraphTests.swift */; };
 		63353A5A1BB4C4BC00D6C4B0 /* UidTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63353A581BB4C4BC00D6C4B0 /* UidTests.swift */; };
 		63353A5B1BB4C4BC00D6C4B0 /* VersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63353A591BB4C4BC00D6C4B0 /* VersionTests.swift */; };
@@ -178,6 +179,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4BAA4BAB1C16CABE0074DA44 /* FileTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FileTests.swift; path = ../Tests/sys/FileTests.swift; sourceTree = "<group>"; };
 		6305480D1BD708B30001290A /* DependencyGraphTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DependencyGraphTests.swift; path = ../Tests/dep/DependencyGraphTests.swift; sourceTree = "<group>"; };
 		63353A3E1BB4C40E00D6C4B0 /* sys-tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "sys-tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		63353A4B1BB4C46200D6C4B0 /* dep-tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "dep-tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -305,6 +307,7 @@
 				63353A5D1BB4C4CD00D6C4B0 /* ShellTests.swift */,
 				63353A5E1BB4C4CD00D6C4B0 /* StringTests.swift */,
 				E136D9411BD5F35D000DFCE6 /* TOMLTests.swift */,
+				4BAA4BAB1C16CABE0074DA44 /* FileTests.swift */,
 			);
 			name = sys;
 			sourceTree = "<group>";
@@ -612,6 +615,7 @@
 				63353A611BB4C4CD00D6C4B0 /* ShellTests.swift in Sources */,
 				E1E286D61BD83BE40015F0C5 /* ResourcesTests.swift in Sources */,
 				63DC25371BF413BF00EDCFBF /* XCTestCaseProvider.swift in Sources */,
+				4BAA4BAC1C16CABE0074DA44 /* FileTests.swift in Sources */,
 				636EF11A1C0D0F1E00626610 /* MiscTests.swift in Sources */,
 				63353A621BB4C4CD00D6C4B0 /* StringTests.swift in Sources */,
 			);

--- a/Tests/sys/FileTests.swift
+++ b/Tests/sys/FileTests.swift
@@ -1,0 +1,78 @@
+/*
+ This source file is part of the Swift.org open source project
+ 
+ Copyright 2015 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+ 
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+@testable import sys
+
+class FileTests: XCTestCase,  XCTestCaseProvider {
+
+    var allTests : [(String, () -> ())] {
+        return [
+            ("testOpenFile", testOpenFile),
+            ("testOpenFileFail", testOpenFileFail),
+            ("testReadRegularTextFile", testReadRegularTextFile),
+            ("testReadRegularTextFileWithSeparator", testReadRegularTextFileWithSeparator)
+        ]
+    }
+    
+    private func loadInputFile(name: String) -> File {
+        let input = Path.join(__FILE__, "../Inputs", name).normpath
+        return File(path: input)
+    }
+    
+    func testOpenFile() {
+        let file = loadInputFile("empty_file")
+        do {
+            let generator = try file.enumerate()
+            XCTAssertNil(generator.next())
+        } catch {
+            XCTFail("The file should be opened without problem")
+        }
+    }
+    
+    func testOpenFileFail() {
+        let file = loadInputFile("file_not_existing")
+        do {
+            let _ = try file.enumerate()
+            XCTFail("The file should not be opened since it is not existing")
+        } catch {
+            
+        }
+    }
+    
+    func testReadRegularTextFile() {
+        let file = loadInputFile("regular_text_file")
+        do {
+            let generator = try file.enumerate()
+            XCTAssertEqual(generator.next(), "Hello world")
+            XCTAssertEqual(generator.next(), "It is a regular text file.")
+            XCTAssertNil(generator.next())
+        } catch {
+            XCTFail("The file should be opened without problem")
+        }
+    }
+    
+    func testReadRegularTextFileWithSeparator() {
+        let file = loadInputFile("regular_text_file")
+        do {
+            let generator = try file.enumerate(" ")
+            XCTAssertEqual(generator.next(), "Hello")
+            XCTAssertEqual(generator.next(), "world\nIt")
+            XCTAssertEqual(generator.next(), "is")
+            XCTAssertEqual(generator.next(), "a")
+            XCTAssertEqual(generator.next(), "regular")
+            XCTAssertEqual(generator.next(), "text")
+            XCTAssertEqual(generator.next(), "file.\n")
+            XCTAssertNil(generator.next())
+        } catch {
+            XCTFail("The file should be opened without problem")
+        }
+    }
+}

--- a/Tests/sys/Inputs/regular_text_file
+++ b/Tests/sys/Inputs/regular_text_file
@@ -1,0 +1,2 @@
+Hello world
+It is a regular text file.


### PR DESCRIPTION
This p-r fixed an potential issue that the inputed separator is ignored when reading a file.

And I also added some tests for `File`.

It seems the `File` now can only read ascii files, maybe we should turn it to a UTF-8 reader? If it is necessary, please let me know. I am glad to do it later.

Thanks in advance.