### PR TITLE
Better error description for typos in local repository paths

### DIFF
--- a/Sources/POSIX/Error.swift
+++ b/Sources/POSIX/Error.swift
@@ -90,8 +90,8 @@ extension SystemError: CustomStringConvertible {
             return "readdir error: \(strerror(errno))"
         case readlink(let errno, let path):
             return "readlink error: \(path), \(strerror(errno))"
-        case .realpath(let errno, _):
-            return "realpath error: \(strerror(errno))"
+        case .realpath(let errno, let path):
+            return "realpath error: \(strerror(errno)): \(path)"
         case .rename(let errno, let old, let new):
             return "rename error: \(strerror(errno)): \(old) -> \(new)"
         case .rmdir(let errno, let path):


### PR DESCRIPTION
If the path to a local package repository contains a typo, the error message is not particularly helpful. Consider this `Package.swift`:

```
let package = Package(
  dependencies: [
    .Package(url: "../CJPG.swift", majorVersion: 1)
  ]
)
```
If the actual repo is called `CJPEG.swift` then the following error will be generated by `swift build`:

`swift build: realpath error: No such file or directory (2)`

This may confuse users and is especially difficult if there're a lot of dependencies. Printing the offending path in the error case should clear things up.