### PR TITLE
Fix a crash if a checkout has no a manifest

### DIFF
--- a/Sources/dep/get.swift
+++ b/Sources/dep/get.swift
@@ -185,6 +185,7 @@ extension Sandbox: Fetcher {
         }
 
         var dependencies: [(String, Range<Version>)] {
+            if manifest == nil { return [(String, Range<Version>)]() }
             //COPY PASTA from Package.dependencies
             return manifest.package.dependencies.map{ ($0.url, $0.versionRange) }
         }

--- a/Support/swiftpm.xcodeproj/project.pbxproj
+++ b/Support/swiftpm.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		63DC25221BF413BA00EDCFBF /* XCTestCaseProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DC25211BF413BA00EDCFBF /* XCTestCaseProvider.swift */; };
 		63DC25371BF413BF00EDCFBF /* XCTestCaseProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DC25211BF413BA00EDCFBF /* XCTestCaseProvider.swift */; };
 		63DC25381BF413C200EDCFBF /* XCTestCaseProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DC25211BF413BA00EDCFBF /* XCTestCaseProvider.swift */; };
+		A1A815631C17A8F000BD6927 /* GetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A815621C17A8E700BD6927 /* GetTests.swift */; };
 		B464B5F11BE41DE400086CE0 /* FunctionalBuildTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B464B5F01BE41DE400086CE0 /* FunctionalBuildTests.swift */; };
 		E136D9421BD5F3DD000DFCE6 /* TOMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E136D9411BD5F35D000DFCE6 /* TOMLTests.swift */; };
 		E1E286BA1BD72D700015F0C5 /* ManifestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E286B91BD72D700015F0C5 /* ManifestTests.swift */; };
@@ -193,6 +194,7 @@
 		63ACA7EB1BED42160095510D /* PackageDescriptionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PackageDescriptionTests.swift; path = ../Tests/PackageDescription/PackageDescriptionTests.swift; sourceTree = "<group>"; };
 		63D2BC171BFD6287006E395C /* PackageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PackageTests.swift; path = ../Tests/dep/PackageTests.swift; sourceTree = "<group>"; };
 		63DC25211BF413BA00EDCFBF /* XCTestCaseProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = XCTestCaseProvider.swift; path = ../Tests/XCTestCaseProvider.swift; sourceTree = "<group>"; };
+		A1A815621C17A8E700BD6927 /* GetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GetTests.swift; path = ../Tests/dep/GetTests.swift; sourceTree = "<group>"; };
 		B464B5F01BE41DE400086CE0 /* FunctionalBuildTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FunctionalBuildTests.swift; path = ../Tests/dep/FunctionalBuildTests.swift; sourceTree = "<group>"; };
 		E1066B6E1BC5931C00B892CE /* llbuild.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = llbuild.xcodeproj; path = ../../llbuild/llbuild.xcodeproj; sourceTree = "<group>"; };
 		E136D9411BD5F35D000DFCE6 /* TOMLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TOMLTests.swift; path = ../Tests/sys/TOMLTests.swift; sourceTree = "<group>"; };
@@ -284,6 +286,7 @@
 		63CF91C11BE9418D00265702 /* dep */ = {
 			isa = PBXGroup;
 			children = (
+				A1A815621C17A8E700BD6927 /* GetTests.swift */,
 				63D2BC171BFD6287006E395C /* PackageTests.swift */,
 				6305480D1BD708B30001290A /* DependencyGraphTests.swift */,
 				B464B5F01BE41DE400086CE0 /* FunctionalBuildTests.swift */,
@@ -621,6 +624,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A1A815631C17A8F000BD6927 /* GetTests.swift in Sources */,
 				6305480E1BD708B30001290A /* DependencyGraphTests.swift in Sources */,
 				E1E286BA1BD72D700015F0C5 /* ManifestTests.swift in Sources */,
 				63353A5A1BB4C4BC00D6C4B0 /* UidTests.swift in Sources */,

--- a/Tests/dep/GetTests.swift
+++ b/Tests/dep/GetTests.swift
@@ -1,0 +1,36 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import POSIX
+import sys
+import XCTest
+@testable import dep
+
+class GetTests: XCTestCase, XCTestCaseProvider {
+
+    var allTests : [(String, () -> ())] {
+        return [
+            ("testRawCloneDoesNotCrashIfManifestIsNotPresent", testRawCloneDoesNotCrashIfManifestIsNotPresent),
+        ]
+    }
+
+    func testRawCloneDoesNotCrashIfManifestIsNotPresent() {
+        fixture(name: "102_mattts_dealer") {
+            let path = Path.join($0, "FisherYates")
+            try system("git", "-C", path, "rm", "Package.swift")
+            try system("git", "-C", path, "commit", "-mwip")
+
+            let rawClone = Sandbox.RawClone(path: path)
+            XCTAssertEqual(rawClone.dependencies.count, 0)
+        }
+    }
+}
+
+

--- a/Tests/dep/main.swift
+++ b/Tests/dep/main.swift
@@ -24,3 +24,6 @@ ProjectTests().invokeTest()
 
 // VersionTests.swift
 VersionTests().invokeTest()
+
+// GetTests.swift
+GetTests().invokeTest()


### PR DESCRIPTION
Will update the PR with a test case if this change is desirable. I'm not sure if it would be better to fail at an earlier stage.