### PR TITLE
move TOML printing to toTOML methods.

### DIFF
--- a/Sources/PackageDescription/Package.swift
+++ b/Sources/PackageDescription/Package.swift
@@ -38,6 +38,12 @@ public final class Package {
         public class func Package(url url: String, _ version: Version) -> Dependency {
             return Dependency(url, version...version)
         }
+
+        /// Print a representation of the dependency as TOML.
+        public func toTOML() -> String {
+            return "[\"\(url)\", \"\(versionRange.startIndex)\", \"\(versionRange.endIndex)\"],"
+        }
+
     }
     
     /// The name of the package, if specified.
@@ -74,7 +80,7 @@ public final class Package {
         }
         result += "dependencies = ["
         for dependency in dependencies {
-            result += "[\"\(dependency.url)\", \"\(dependency.versionRange.startIndex)\", \"\(dependency.versionRange.endIndex)\"],"
+            result += dependency.toTOML()
         }
         result += "]\n"
         for target in targets {

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -14,6 +14,14 @@ public final class Target {
     public enum Dependency {
         /// A dependency on a target in the same project.
         case Target(name: String)
+
+        /// Print a representation of the target dependency as TOML.
+        public func toTOML() -> String {
+            switch self {
+            case .Target(let name):
+                return "\"\(name)\","
+            }
+        }
     }
 
     /// The name of the target.
@@ -35,10 +43,7 @@ public final class Target {
         result += "name = \"\(name)\"\n"
         result += "dependencies = ["
         for dependency in dependencies {
-            switch dependency {
-            case .Target(let name):
-                result += "\"\(name)\","
-            }
+            result += dependency.toTOML()
         }
         result += "]\n"
         return result


### PR DESCRIPTION
Every type should know how to TOML itself and don't expose it to others.

I just moved correct implementation to `toTOML()` methods for a type.
I think it makes reading code much easier, because implementation details are hidden.
What do you think about it?
The next step I thought could be creating `TOMLable` protocol and conforming to it