### PR TITLE
Improve TOML parser

### DIFF
--- a/Sources/sys/TOML.swift
+++ b/Sources/sys/TOML.swift
@@ -239,7 +239,7 @@ private struct Lexer {
         case "\n".utf8Constant:
             return .Newline
             
-            // Comments.
+        // Comments.
         case "#".utf8Constant:
             // Scan to the end of the line.
             while let c = look() {
@@ -250,7 +250,7 @@ private struct Lexer {
             }
             return .Comment
 
-            // Whitespace.
+        // Whitespace.
         case let c where c.isSpace():
             // Scan to the end of the whitespace
             while let c = look() where c.isSpace() {
@@ -258,7 +258,7 @@ private struct Lexer {
             }
             return .Whitespace
 
-            // Strings.
+        // Strings.
         case "\"".utf8Constant:
             // Scan to the end of the string.
             //
@@ -275,10 +275,10 @@ private struct Lexer {
             }
             return .StringLiteral(value: String(utf8[Range(start: startIndex.advancedBy(1), end: endIndex)]))
 
-            // Numeric literals.
-            //
-            // NOTE: It is important we parse this ahead of identifiers, as
-            // numbers are valid identifiers but should be reconfigured as such.
+        // Numeric literals.
+        //
+        // NOTE: It is important we parse this ahead of identifiers, as
+        // numbers are valid identifiers but should be reconfigured as such.
         case let c where c.isNumberInitialChar():
             // Scan to the end of the number.
             while let c = look() where c.isNumberChar() {
@@ -286,7 +286,7 @@ private struct Lexer {
             }
             return .Number(value: String(utf8[Range(start: startIndex, end: index)]))
 
-            // Identifiers.
+        // Identifiers.
         case let c where c.isIdentifierChar():
             // Scan to the end of the identifier.
             while let c = look() where c.isIdentifierChar() {
@@ -302,9 +302,9 @@ private struct Lexer {
                 return .Boolean(value: false)
             default:
                 return .Identifier(value: value)
-        }
+            }
             
-            // Punctuation.
+        // Punctuation.
         case ",".utf8Constant:
             return .Comma
         case "=".utf8Constant:

--- a/Sources/sys/TOML.swift
+++ b/Sources/sys/TOML.swift
@@ -19,12 +19,12 @@ import libc
 
 /// Represents a TOML encoded value.
 public enum TOMLItem {
-case Bool(value: Swift.Bool)
-case Int(value: Swift.Int)
-case Float(value: Swift.Float)
-case String(value: Swift.String)
-case Array(contents: TOMLItemArray)
-case Table(contents: TOMLItemTable)
+    case Bool(value: Swift.Bool)
+    case Int(value: Swift.Int)
+    case Float(value: Swift.Float)
+    case String(value: Swift.String)
+    case Array(contents: TOMLItemArray)
+    case Table(contents: TOMLItemTable)
 }
 
 public class TOMLItemArray: CustomStringConvertible {
@@ -149,34 +149,34 @@ private extension UInt8 {
 private struct Lexer {
     private enum Token {
         /// Any comment.
-    case Comment
+        case Comment
         /// Any whitespace.
-    case Whitespace
+        case Whitespace
         /// A newline.
-    case Newline
+        case Newline
         /// A literal string.
-    case StringLiteral(value: String)
+        case StringLiteral(value: String)
         /// An identifier (i.e., 'foo').
-    case Identifier(value: String)
+        case Identifier(value: String)
         /// A boolean constant.
-    case Boolean(value: Bool)
+        case Boolean(value: Bool)
         /// A numeric constant (which may not be well formed).
-    case Number(value: String)
+        case Number(value: String)
         /// The end of file marker.
-    case EOF
+        case EOF
         /// An unknown character.
-    case Unknown(value: UInt8)
+        case Unknown(value: UInt8)
 
         /// A ',' character.
-    case Comma
+        case Comma
         /// An '=' character.
-    case Equals
+        case Equals
         /// A left square bracket ('[').
-    case LSquare
+        case LSquare
         /// A right square bracket (']').
-    case RSquare
+        case RSquare
         /// A '.' character.
-    case Period
+        case Period
     }
 
     /// The string being lexed.

--- a/Sources/sys/TOML.swift
+++ b/Sources/sys/TOML.swift
@@ -167,7 +167,7 @@ private struct Lexer {
     case Equals
         /// A left square bracket ('[').
     case LSquare
-        /// A right square bracket ('[').
+        /// A right square bracket (']').
     case RSquare
         /// A '.' character.
     case Period

--- a/Sources/sys/TOML.swift
+++ b/Sources/sys/TOML.swift
@@ -10,7 +10,7 @@
  -------------------------------------------------------------------------
  This file defines a minimal TOML parser. It is currently designed only to
  support the needs of the package manager, not to be a general purpose TOML
- library. There is currently no support for the date types.
+ library. There is currently no support for the date type.
 */
 
 import libc

--- a/Tests/sys/TOMLTests.swift
+++ b/Tests/sys/TOMLTests.swift
@@ -48,12 +48,17 @@ class TOMLTests: XCTestCase, XCTestCaseProvider {
         XCTAssertEqual(lexTOML("false true"), ["Boolean(false)", "Whitespace", "Boolean(true)"])
         XCTAssertEqual(lexTOML("+12"), ["Number(\"+12\")"])
         XCTAssertEqual(lexTOML("1.2e-10"), ["Number(\"1.2e-10\")"])
+        XCTAssertEqual(lexTOML("1.234"), ["Number(\"1.234\")"])
     }
 
     func testParser() {
         XCTAssertEqual(parseTOML("a = b"), toTable(["a": .String(value: "b")]))
         XCTAssertEqual(parseTOML("a = \"b\""), toTable(["a": .String(value: "b")]))
         XCTAssertEqual(parseTOML("a = 1"), toTable(["a": .Int(value: 1)]))
+        XCTAssertEqual(parseTOML("a = 1.234"), toTable(["a": .Float(value: 1.234)]))
+        XCTAssertEqual(parseTOML("a = 1.2e-2"), toTable(["a": .Float(value: 1.2e-2)]))
+        XCTAssertEqual(parseTOML("a = -12_34_56"), toTable(["a": .Int(value: -123456)]))
+        XCTAssertEqual(parseTOML("a = +1.2_34_56"), toTable(["a": .Float(value: 1.23456)]))
         XCTAssertEqual(parseTOML("a = true\n\nb = false"), toTable(["a": .Bool(value: true), "b": .Bool(value: false)]))
 
         // Test arrays.


### PR DESCRIPTION
This p-r mainly:

1. Add `Float` support and `e`, `_` support for number item, as well as tests for them.
2. Convert parameter of `consumeIf` to `@autoclosure` for better readability.
3. Fix a document mistake on commenting `]` to  `[`.
4. Some indent fix for to align code and comment better.