### PR TITLE
Add ability to exclude folders in Manifest.

### DIFF
--- a/Sources/PackageDescription/Package.swift
+++ b/Sources/PackageDescription/Package.swift
@@ -49,11 +49,15 @@ public final class Package {
     /// The list of dependencies.
     public var dependencies: [Dependency]
 
+    /// The list of folders to exlude
+    public var exclude: [String]
+
     /// Construct a package.
-    public init(name: String? = nil, targets: [Target] = [], dependencies: [Dependency] = []) {
+    public init(name: String? = nil, targets: [Target] = [], dependencies: [Dependency] = [], exclude: [String] = []) {
         self.name = name
         self.targets = targets
         self.dependencies = dependencies
+        self.exclude = exclude
 
         // Add custom exit handler to cause package to be dumped at exit, if requested.
         //
@@ -80,6 +84,8 @@ public final class Package {
         for target in targets {
             result += target.toTOML("package.targets")
         }
+        result += "\n" + "exclude = \(exclude)"
+
         return result
     }
 }

--- a/Sources/dep/Manifest.swift
+++ b/Sources/dep/Manifest.swift
@@ -42,8 +42,16 @@ extension PackageDescription.Package {
                 dependencies.append(PackageDescription.Package.Dependency.fromTOML(item, baseURL: baseURL))
             }
         }
+
+        var exclude: [String] = []
+        if case .Some(.Array(let array)) = table.items["exclude"] {
+            for item in array.items {
+                guard case .String(let exludeItem) = item else { fatalError("exclude contains non string element") }
+                exclude.append(exludeItem)
+            }
+        }
         
-        return PackageDescription.Package(name: name, targets: targets, dependencies: dependencies)
+        return PackageDescription.Package(name: name, targets: targets, dependencies: dependencies, exclude: exclude)
     }
 }
 

--- a/Sources/swift-build/main.swift
+++ b/Sources/swift-build/main.swift
@@ -41,8 +41,11 @@ do {
         let rootd = try findSourceRoot()
         let manifest = try Manifest(path: "\(rootd)/Package.swift", baseURL: rootd)
         let pkgname = manifest.package.name ?? rootd.basename
+        let excludedirs = manifest.package.exclude.map { Path.join(rootd, $0) }
+
         let depsdir = Path.join(rootd, "Packages")
-        let computedTargets = try determineTargets(packageName: pkgname, prefix: rootd, ignore: [depsdir])
+        let computedTargets = try determineTargets(packageName: pkgname, prefix: rootd, ignore: [depsdir] + excludedirs)
+
         let targets = try manifest.configureTargets(computedTargets)
         let dependencies = try get(manifest.package.dependencies, prefix: depsdir)
         let builddir = Path.join(getenv("SWIFT_BUILD_PATH") ?? Path.join(rootd, ".build"), configuration.dirname)

--- a/Tests/PackageDescription/PackageDescriptionTests.swift
+++ b/Tests/PackageDescription/PackageDescriptionTests.swift
@@ -34,4 +34,11 @@ class PackageTests: XCTestCase, XCTestCaseProvider {
         let p1 = Package(name: "a", dependencies: [.Package(url: "https://example.com/example", majorVersion: 1)])
         XCTAssertEqual(p1, Package.fromTOML(parseTOML(p1.toTOML())))
     }
+
+    func testExclude() {
+        let exclude = ["Images", "A/B"]
+        let p1 = Package(name: "a", exclude: exclude)
+        let pFromTOML = Package.fromTOML(parseTOML(p1.toTOML()))
+        XCTAssertEqual(pFromTOML.exclude, exclude)
+    }
 }

--- a/Tests/dep/Fixtures/29_exclude_directory/BarLib/Bar.swift
+++ b/Tests/dep/Fixtures/29_exclude_directory/BarLib/Bar.swift
@@ -1,0 +1,3 @@
+class Bar {
+    var bar: Int = 0
+}

--- a/Tests/dep/Fixtures/29_exclude_directory/FooBarLib/FooBar.swift
+++ b/Tests/dep/Fixtures/29_exclude_directory/FooBarLib/FooBar.swift
@@ -1,0 +1,3 @@
+class FooBar{
+    var bar: Int = 0 
+}

--- a/Tests/dep/Fixtures/29_exclude_directory/FooLib/Foo.swift
+++ b/Tests/dep/Fixtures/29_exclude_directory/FooLib/Foo.swift
@@ -1,0 +1,3 @@
+class Foo {
+    var bar: Int = 0
+}

--- a/Tests/dep/Fixtures/29_exclude_directory/Package.swift
+++ b/Tests/dep/Fixtures/29_exclude_directory/Package.swift
@@ -1,0 +1,7 @@
+import PackageDescription
+
+let package = Package(
+
+    name: "29_exclude_directory",
+    exclude: ["FooLib"]
+)

--- a/Tests/dep/FunctionalBuildTests.swift
+++ b/Tests/dep/FunctionalBuildTests.swift
@@ -332,6 +332,17 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
         }
     }
 
+    // 29: Exclude Direcotries
+    func testExludeDirs() {
+        let filesToVerify = ["BarLib.a", "FooBarLib.a"]
+        let filesShouldNotExist = ["FooLib.a"]
+        fixture(name: "29_exclude_directory") { prefix in
+            XCTAssertNotNil(try? executeSwiftBuild(prefix))
+            XCTAssertTrue(self.verifyFilesExist(filesToVerify, fixturePath: prefix))
+            XCTAssertFalse(self.verifyFilesExist(filesShouldNotExist, fixturePath: prefix))
+        }
+    }
+
     func test_exdeps() {
         fixture(name: "102_mattts_dealer") { prefix in
             let prefix = Path.join(prefix, "app")


### PR DESCRIPTION
Now you can specify what folders do you want to ignore when building targets.
FooLib will be excluded when building targets.

```swift
let package = Package(
    name: "29_exclude_directory",
    exclude: ["FooLib"]
) 
```
SR-29 jira tasks. https://bugs.swift.org/browse/SR-29
@krzyzanowskim 