### PR TITLE
Conform to PEP 0394 in Python sources

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
  This source file is part of the Swift.org open source project


### PR DESCRIPTION
As per [PEP 0394](https://www.python.org/dev/peps/pep-0394/), scripts should use `python2` in the shebang line to be compatible with platforms where `python` is not Python 2 such as Archlinux (came into this problem when trying to run this there). Since this script does not support python3, it should have `python2` in the shebang line.

> In order to tolerate differences across platforms, all new code that needs to invoke the Python interpreter should not specify python, but rather should specify either python2 or python3.