### PR TITLE
[tests] Fix missing tests and outdated comments

### DIFF
--- a/Tests/PackageDescription/main.swift
+++ b/Tests/PackageDescription/main.swift
@@ -6,5 +6,5 @@ public protocol XCTestCaseProvider {
 }
 #endif
 
-// SharesTests.swift
+// PackageDescriptionTests.swift
 PackageTests().invokeTest()

--- a/Tests/dep/main.swift
+++ b/Tests/dep/main.swift
@@ -24,3 +24,6 @@ ProjectTests().invokeTest()
 
 // VersionTests.swift
 VersionTests().invokeTest()
+
+// PackageTests.swift
+PackageTests().invokeTest()

--- a/Tests/sys/PathTests.swift
+++ b/Tests/sys/PathTests.swift
@@ -90,7 +90,7 @@ class PathTests: XCTestCase, XCTestCaseProvider {
     }
 }
 
-class WalkTests: XCTestCase {
+class WalkTests: XCTestCase, XCTestCaseProvider {
 
     var allTests : [(String, () -> ())] {
         return [
@@ -175,7 +175,7 @@ class WalkTests: XCTestCase {
     }
 }
 
-class StatTests: XCTestCase {
+class StatTests: XCTestCase, XCTestCaseProvider {
 
     var allTests : [(String, () -> ())] {
         return [
@@ -226,7 +226,7 @@ class StatTests: XCTestCase {
 }
 
 
-class RelativePathTests: XCTestCase {
+class RelativePathTests: XCTestCase, XCTestCaseProvider {
 
     var allTests : [(String, () -> ())] {
         return [

--- a/Tests/sys/main.swift
+++ b/Tests/sys/main.swift
@@ -7,7 +7,7 @@ public protocol XCTestCaseProvider {
 }
 #endif
 
-// POSIXTests.swift
+// PathTests.swift
 PathTests().invokeTest()
 WalkTests().invokeTest()
 StatTests().invokeTest()
@@ -25,3 +25,6 @@ URLTests().invokeTest()
 
 // TOMLTests.swift
 TOMLTests().invokeTest()
+
+// FileTests.swift
+FileTests().invokeTest()


### PR DESCRIPTION
See individual commit messages for details. The gist is:

- Some test files weren't being included in Linux builds (which don't automatically discover them).
- Some test cases weren't explicitly conforming to `XCTestCaseProvider`, which means they could have not worked properly on Linux (by not defining `allTests`), and we wouldn't have known until the tests were run.
- Some comments referenced files that no longer existed.