### PR TITLE
pass extra header and library search path to swift-build

### DIFF
--- a/Sources/PackageDescription/Package.swift
+++ b/Sources/PackageDescription/Package.swift
@@ -59,13 +59,21 @@ public final class Package {
     /// The list of folders to exclude.
     public var exclude: [String]
 
+    /// The list of compile options
+    public var cflags: [String]
+    
+    /// The list of link options
+    public var ldflags: [String]
+    
     /// Construct a package.
-    public init(name: String? = nil, targets: [Target] = [], dependencies: [Dependency] = [], exclude: [String] = []) {
+    public init(name: String? = nil, targets: [Target] = [], dependencies: [Dependency] = [], exclude: [String] = [], cflags: [String] = [], ldflags: [String] = []) {
         self.name = name
         self.targets = targets
         self.dependencies = dependencies
         self.exclude = exclude
-
+        self.cflags = cflags
+        self.ldflags = ldflags
+        
         // Add custom exit handler to cause package to be dumped at exit, if requested.
         //
         // FIXME: This doesn't belong here, but for now is the mechanism we use
@@ -104,6 +112,10 @@ extension Package: TOMLConvertible {
         }
         result += "\n" + "exclude = \(exclude)"
 
+        result += "\n" + "cflags = \(cflags)"
+        
+        result += "\n" + "ldflags = \(ldflags)"
+        
         return result
     }
 }

--- a/Sources/dep/Manifest.swift
+++ b/Sources/dep/Manifest.swift
@@ -52,7 +52,25 @@ extension PackageDescription.Package {
             }
         }
         
-        return PackageDescription.Package(name: name, targets: targets, dependencies: dependencies, exclude: exclude)
+        //Parse the cflags options.
+        var cflags: [String] = []
+        if case .Some(.Array(let array)) = table.items["cflags"] {
+            for item in array.items {
+                guard case .String(let cflagItem) = item else { fatalError("cflags contains non string element") }
+                cflags.append(cflagItem)
+            }
+        }
+        
+        //Parse the ldflags options.
+        var ldflags: [String] = []
+        if case .Some(.Array(let array)) = table.items["ldflags"] {
+            for item in array.items {
+                guard case .String(let ldflagItem) = item else { fatalError("ldflags contains non string element") }
+                ldflags.append(ldflagItem)
+            }
+        }
+        
+        return PackageDescription.Package(name: name, targets: targets, dependencies: dependencies, exclude: exclude, cflags: cflags, ldflags: ldflags)
     }
 }
 

--- a/Sources/dep/llbuild.swift
+++ b/Sources/dep/llbuild.swift
@@ -30,6 +30,8 @@ public struct BuildParameters {
         targets = []
         dependencies = []
         conf = .Debug
+		compileExtraArgs = []
+		linkExtraArgs = []
     }
 
     public var srcroot: String
@@ -38,6 +40,9 @@ public struct BuildParameters {
 
     public var prefix: String = ""
     public var tmpdir: String = ""
+
+	public var compileExtraArgs: [String]
+	public var linkExtraArgs: [String]
 
     public var conf: Configuration
 
@@ -48,7 +53,7 @@ public struct BuildParameters {
     }
 }
 
-public func llbuild(srcroot srcroot: String, targets: [Target], dependencies: [Package], prefix: String, tmpdir: String, configuration: BuildParameters.Configuration) throws -> BuildParameters {
+public func llbuild(srcroot srcroot: String, targets: [Target], dependencies: [Package], prefix: String, tmpdir: String, configuration: BuildParameters.Configuration, compileExtraArgs:[String], linkExtraArgs:[String]) throws -> BuildParameters {
     var parms = BuildParameters()
     parms.srcroot = srcroot
     parms.targets = targets
@@ -56,6 +61,8 @@ public func llbuild(srcroot srcroot: String, targets: [Target], dependencies: [P
     parms.prefix = prefix
     parms.tmpdir = tmpdir
     parms.conf = configuration
+	parms.compileExtraArgs = compileExtraArgs
+	parms.linkExtraArgs = linkExtraArgs
     try llbuild(parms)
     return parms
 }
@@ -82,7 +89,6 @@ private class YAML {
     var filePointer: UnsafeMutablePointer<FILE>
     let filename: String
 
-    
     /**
       The 'swiftc' executable path to use.
     */
@@ -210,6 +216,8 @@ private class YAML {
             // Swift doesn’t include /usr/local by default
             args += ["-I", "/usr/local/include"]
 
+			args += parms.compileExtraArgs
+
             return args
         }
 
@@ -293,6 +301,8 @@ private class YAML {
                 // Swift doesn’t include /usr/local by default
                 //TODO we only want to do this if a module map wants to do this
                 args += ["-L/usr/local/lib"]
+
+				args += parms.linkExtraArgs
 
                 return args
             }

--- a/Sources/swift-build/main.swift
+++ b/Sources/swift-build/main.swift
@@ -19,7 +19,7 @@ Resources.initialize(&globalSymbolInMainBinary)
 
 do {
     let args = Array(Process.arguments.dropFirst())
-    let (mode, chdir, verbosity) = try parse(commandLineArguments: args)
+    let (mode, chdir, verbosity, headers, libs) = try parse(commandLineArguments: args)
 
     sys.verbosity = Verbosity(rawValue: verbosity)
 
@@ -50,13 +50,28 @@ do {
         let dependencies = try get(manifest.package.dependencies, prefix: depsdir)
         let builddir = Path.join(getenv("SWIFT_BUILD_PATH") ?? Path.join(rootd, ".build"), configuration.dirname)
 
+		var compileExtraArgs:[String] = []
+		var linkExtraArgs:[String] = []
+		for header in headers {
+			compileExtraArgs += ["-I", header]
+		}
+		for lib in libs {
+			linkExtraArgs += ["-L", lib]
+		}
+
         for pkg in dependencies {
-            try llbuild(srcroot: pkg.path, targets: try pkg.targets(), dependencies: dependencies, prefix: builddir, tmpdir: Path.join(builddir, "\(pkg.name).o"), configuration: configuration)
+			try llbuild(srcroot: pkg.path, targets: try pkg.targets(), dependencies: dependencies, prefix: builddir, tmpdir: Path.join(builddir, "\(pkg.name).o"),
+				configuration: configuration,
+				compileExtraArgs:compileExtraArgs,
+				linkExtraArgs:linkExtraArgs)
         }
 
         do {
             // build the current directory
-            try llbuild(srcroot: rootd, targets: targets, dependencies: dependencies, prefix: builddir, tmpdir: Path.join(builddir, "\(pkgname).o"), configuration: configuration)
+            try llbuild(srcroot: rootd, targets: targets, dependencies: dependencies, prefix: builddir, tmpdir: Path.join(builddir, "\(pkgname).o"),
+				configuration: configuration,
+				compileExtraArgs:compileExtraArgs,
+				linkExtraArgs:linkExtraArgs)
         } catch POSIX.Error.ExitStatus(let foo) {
 #if os(Linux)
             // it is a common error on Linux for clang++ to not be installed, but

--- a/Sources/swift-build/usage.swift
+++ b/Sources/swift-build/usage.swift
@@ -22,8 +22,8 @@ func usage(print: (String) -> Void = { print($0) }) {
     print("")
     print("OPTIONS:")
     print("  --chdir <value>    Change working directory before any other operation [-C]")
-	print("  --headers <value>  Header file search paths, separated by colon(:)")
-	print("  --lib <value>      Library search paths, separated by colon(:)")
+	print("  --headers <value>  Header file search paths, separated by colon(:) [-I]")
+	print("  --libs <value>     Library search paths, separated by colon(:) [-L]")
     print("  -v                 Increase verbosity of informational output")
 }
 
@@ -168,9 +168,9 @@ private struct Cruncher {
                     self = .Chdir
                 case Verbose.rawValue, "-vv":
                     self = .Verbose
-				case Headers.rawValue:
+				case Headers.rawValue, "-I":
 					self = .Headers
-				case Libs.rawValue:
+				case Libs.rawValue, "-L":
 					self = .Libs
                 default:
                     return nil


### PR DESCRIPTION
make swift-build to receive extra header and library path

- add header search path (--headers paths_separated_by_colon)
- add lib search path (--libs paths_separated_by_colon)

```sh
swift build --headers /usr/include/glib-2.0:/usr/lib/x86_64-linux-gnu/glib-2.0/include \
            --libs /lib/x86_64-linux-gnu/
```