### PR TITLE
Explicitly set working directory for git

### DIFF
--- a/Tests/dep/FunctionalBuildTests.swift
+++ b/Tests/dep/FunctionalBuildTests.swift
@@ -462,8 +462,8 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
     func testTipHasNoPackageSwift() {
         fixture(name: "102_mattts_dealer") { prefix in
             let path = Path.join(prefix, "FisherYates")
-            try system("git", "config", "user.email", "example@example.com")
-            try system("git", "config", "user.name", "Example Example")
+            try system("git", "-C", path, "config", "user.email", "example@example.com")
+            try system("git", "-C", path, "config", "user.name", "Example Example")
             try system("git", "-C", path, "rm", "Package.swift")
             try system("git", "-C", path, "commit", "-mwip")
 


### PR DESCRIPTION
When running the tests under Xcode, `testTipHasNoPackageSwift()` in `FunctionalBuildTests` fails when setting the `git` config because the current working directory (`/private/tmp`) isn't a git repo. This change explicitly sets the working directory to be the fixture directory, the same way that the other `git` calls do.

Here is the failing test output before the change, for reference:
```
Test Case '-[dep_tests.FunctionalBuildTests testTipHasNoPackageSwift]' started.
error: could not lock config file .git/config: No such file or directory
/Users/devfloater106-xl/workspace/SwiftOnLinux/swift-package-manager/Tests/dep/Utilities.swift:53: error: -[dep_tests.FunctionalBuildTests testTipHasNoPackageSwift] : failed - exit(255): ["git", "config", "user.email", "example@example.com"]

Test Case '-[dep_tests.FunctionalBuildTests testTipHasNoPackageSwift]' failed (0.498 seconds).
```