### PR TITLE
Add missing items to FunctionalBuildTests.allTests

### DIFF
--- a/Tests/dep/FunctionalBuildTests.swift
+++ b/Tests/dep/FunctionalBuildTests.swift
@@ -45,6 +45,7 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
             ("testExecDep", testExecDep),
             ("testExecDeps", testExecDeps),
             ("testMultDeps", testMultDeps),
+            ("testExcludeDirs", testExcludeDirs),
             ("test_exdeps", test_exdeps),
             ("test_exdeps_canRunBuildTwice", test_exdeps_canRunBuildTwice),
             ("test_get_ExternalDeps", test_get_ExternalDeps),
@@ -57,8 +58,10 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
             ("testSingleTargetWithCustomName", testSingleTargetWithCustomName),
             ("testCanBuildIfADependencyAlreadyCheckedOut", testCanBuildIfADependencyAlreadyCheckedOut),
             ("testCanBuildIfADependencyClonedButThenAborted", testCanBuildIfADependencyClonedButThenAborted),
-            ("testFailsIfVersionTagHasNoPackageSwift", testFailsIfVersionTagHasNoPackageSwift),
             ("testTipHasNoPackageSwift", testTipHasNoPackageSwift),
+            ("testFailsIfVersionTagHasNoPackageSwift", testFailsIfVersionTagHasNoPackageSwift),
+            ("testSymlinkedSourceDirectoryWorks", testSymlinkedSourceDirectoryWorks),
+            ("testSymlinkedNestedSourceDirectoryWorks", testSymlinkedNestedSourceDirectoryWorks),
         ]
     }
 
@@ -334,7 +337,7 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
     }
 
     // 29: Exclude Direcotries
-    func testExludeDirs() {
+    func testExcludeDirs() {
         let filesToVerify = ["BarLib.a", "FooBarLib.a"]
         let filesShouldNotExist = ["FooLib.a"]
         fixture(name: "29_exclude_directory") { prefix in


### PR DESCRIPTION
I noticed that `FunctionalBuildTest`'s `allTests` array was missing a few entries. I don't have a working Linux dev environment to properly test this change, but it compiles on OS X so the test symbol references are valid, at least.

Also includes a typo fix.