### PR TITLE
Print selected dependency versions

### DIFF
--- a/Sources/POSIX/popen.swift
+++ b/Sources/POSIX/popen.swift
@@ -10,11 +10,15 @@
 
 import libc
 
-public func popen(arguments: [String], redirectStandardError: Bool = false, environment: [String: String] = [:]) throws -> String
+public func popen(arguments: [String], redirectStandardError: Bool = false, printOutput: Bool = false, environment: [String: String] = [:]) throws -> String
 {
     var out = ""
     try popen(arguments, redirectStandardError: redirectStandardError, environment: environment) { line in
         out += line
+
+        if printOutput {
+            print(line, terminator: "")
+        }
     }
     return out
 }

--- a/Sources/POSIX/system.swift
+++ b/Sources/POSIX/system.swift
@@ -26,6 +26,9 @@ public func system(args: String...) throws {
  path is not absolute.
 */
 public func system(arguments: [String], environment: [String:String] = [:]) throws {
+    // make sure subprocess output doesn't get interleaved with our own
+    fflush(stdout)
+
     do {
         let pid = try posix_spawnp(arguments[0], args: arguments, environment: environment)
         let exitStatus = try waitpid(pid)

--- a/Sources/dep/get.swift
+++ b/Sources/dep/get.swift
@@ -166,11 +166,13 @@ extension Sandbox: Fetcher {
         }
 
         /// contract, you cannot call this before you have attempted to `constrain` this clone
-        func setVersion(v: Version) throws {
+        func setVersion(ver: Version) throws {
             let packageVersionsArePrefixed = repo.versionsArePrefixed
-            let v = (packageVersionsArePrefixed ? "v" : "") + v.description
+            let v = (packageVersionsArePrefixed ? "v" : "") + ver.description
             try popen([Git.tool, "-C", path, "reset", "--hard", v])
             try popen([Git.tool, "-C", path, "branch", "-m", v])
+
+            print("Using version \(ver) of package \(Package.name(forURL: url))")
 
             // we must re-read the manifest
             _manifest = nil

--- a/Tests/dep/FunctionalBuildTests.swift
+++ b/Tests/dep/FunctionalBuildTests.swift
@@ -49,6 +49,7 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
             ("test_exdeps", test_exdeps),
             ("test_exdeps_canRunBuildTwice", test_exdeps_canRunBuildTwice),
             ("test_get_ExternalDeps", test_get_ExternalDeps),
+            ("testPrintsSelectedDependencyVersion", testPrintsSelectedDependencyVersion),
             ("test_get_DealerBuild", test_get_DealerBuild),
             ("test_get_DealerBuildOutput", test_get_DealerBuildOutput),
             ("testNoArgumentsExitsWithOne", testNoArgumentsExitsWithOne),
@@ -374,6 +375,16 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
             XCTAssertNotNil(try? executeSwiftBuild("\(prefix)/Bar"))
             XCTAssertTrue(Path.join(prefix, "Bar/Packages/Foo-1.2.3").isDirectory)
             XCTAssertTrue(Path.join(prefix, "Bar/.build/debug/Bar").isFile)
+        }
+    }
+
+    func testPrintsSelectedDependencyVersion() {
+        fixture(name: "100_external_deps", tag: "1.3.5") { prefix in
+            let output = try executeSwiftBuild("\(prefix)/Bar")
+            let lines = output.componentsSeparatedByString("\n")
+            let matchingLines = lines.filter({ $0.containsString("1.3.5") && $0.containsString("Foo") })
+
+            XCTAssertEqual(matchingLines.count, 1)
         }
     }
 

--- a/Tests/dep/Utilities.swift
+++ b/Tests/dep/Utilities.swift
@@ -55,11 +55,11 @@ func fixture(name fixtureName: String, tag: String = "1.2.3", @noescape body: (S
 }
 
 
-func executeSwiftBuild(chdir: String) throws {
+func executeSwiftBuild(chdir: String, redirectStandardError: Bool = false) throws -> String {
     let toolPath = Resources.findExecutable("swift-build")
     var env = [String:String]()
     env["SWIFT_BUILD_TOOL"] = getenv("SWIFT_BUILD_TOOL")
-    try system([toolPath, "--chdir", chdir], environment: env)
+    return try popen([toolPath, "--chdir", chdir], redirectStandardError: redirectStandardError, printOutput: true, environment: env)
 }
 
 func mktmpdir(body: () throws -> Void) {


### PR DESCRIPTION
When examining the output emitted by `swift-build`, it can be useful to see which package versions were actually chosen by the dependency graph resolver. This is especially true when the build is executed on a remote system where it may not be possible to examine the contents of the `Packages` directory after the build completes.

This PR implements this behavior, along with some test infrastructure needed to perform assertions on the output of a `swift-build` invocation. With this patch, output looks like this:

```
$ swift build
Cloning Packages/Foo
Using version 1.3.5 of package Foo
Compiling Swift Module 'Foo' (1 sources)
Linking Library:  .build/debug/Foo.a
Compiling Swift Module 'Bar' (1 sources)
Linking Executable:  .build/debug/Bar
```

This change seemed to me to be "cosmetic" enough to not require too much discussion, but I'd be happy to solicit feedback on a mailing list if you feel that's needed.