### PR TITLE
Add XCTestCaseProvider conformance to GetTests

### DIFF
--- a/Tests/dep/GetTests.swift
+++ b/Tests/dep/GetTests.swift
@@ -11,9 +11,10 @@
 import POSIX
 import sys
 import XCTest
+import XCTestCaseProvider
 @testable import dep
 
-class GetTests: XCTestCase {
+class GetTests: XCTestCase, XCTestCaseProvider {
 
     var allTests : [(String, () -> ())] {
         return [


### PR DESCRIPTION
Fixes running tests from the bootstrap script