### PR TITLE
Extends Target.Dependency to be StringLiteralConvertible

### DIFF
--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -53,6 +53,22 @@ extension Target: TOMLConvertible {
     }
 }
 
+// MARK: StringLiteralConvertible
+
+extension Target.Dependency : StringLiteralConvertible {
+  public init(unicodeScalarLiteral value: String) {
+    self = .Target(name: value)
+  }
+  
+  public init(extendedGraphemeClusterLiteral value: String) {
+    self = .Target(name: value)
+  }
+
+  public init(stringLiteral value: String) {
+    self = .Target(name: value)
+  } 
+}
+
 // MARK: Equatable
 
 extension Target : Equatable { }

--- a/Tests/PackageDescription/PackageDescriptionTests.swift
+++ b/Tests/PackageDescription/PackageDescriptionTests.swift
@@ -57,4 +57,8 @@ class PackageTests: XCTestCase, XCTestCaseProvider {
         let pFromTOML = Package.fromTOML(parseTOML(p.toTOML()))
         XCTAssertEqual(pFromTOML.testDependencies, dependencies)
     }
+    
+    func testTargetDependencyIsStringConvertible() {
+      XCTAssertEqual(Target.Dependency.Target(name: "foo"), "foo")
+    }
 }

--- a/Tests/dep/Fixtures/32_buildlib_singledep_string_target/BarLib/BarLib.swift
+++ b/Tests/dep/Fixtures/32_buildlib_singledep_string_target/BarLib/BarLib.swift
@@ -1,0 +1,10 @@
+import FooLib
+
+class BarLib {
+    var bar: FooLib
+    
+    init() {
+        let newFoo = FooLib()
+        bar = newFoo
+    }
+}

--- a/Tests/dep/Fixtures/32_buildlib_singledep_string_target/FooLib/FooLib.swift
+++ b/Tests/dep/Fixtures/32_buildlib_singledep_string_target/FooLib/FooLib.swift
@@ -1,0 +1,8 @@
+public class FooLib {
+    public var foo: Int
+    
+    public init() {
+        foo = 0
+    }
+}
+

--- a/Tests/dep/Fixtures/32_buildlib_singledep_string_target/Package.swift
+++ b/Tests/dep/Fixtures/32_buildlib_singledep_string_target/Package.swift
@@ -1,0 +1,10 @@
+import PackageDescription
+
+let package = Package(
+    name: "32_buildlib_singledep_string_target",
+    targets: [
+        Target(
+            name: "BarLib",
+            dependencies: ["FooLib"]),
+        Target(
+            name: "FooLib")])

--- a/Tests/dep/FunctionalBuildTests.swift
+++ b/Tests/dep/FunctionalBuildTests.swift
@@ -69,6 +69,7 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
             ("testBuildTestDeps", testBuildTestDeps),
             ("testDontGetChildrenPrivateDeps",testDontGetChildrenPrivateDeps),
             ("testBuildChildrenPrivateDeps", testBuildChildrenPrivateDeps),
+            ("testStringConvertibleTarget", testStringConvertibleTarget),
             ("testInvalidLayout1", testInvalidLayout1),
             ("testInvalidLayout2", testInvalidLayout2),
             ("testInvalidLayout3", testInvalidLayout3),
@@ -395,6 +396,15 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
             XCTAssertTrue(self.verifyFilesExist(filesToVerify, fixturePath: appPath))
             XCTAssertFalse(self.verifyFilesExist(["TestingFooLib.a"], fixturePath: appPath))
         }
+    }
+    
+    // 32: Single dependency with string convertible target
+    func testStringConvertibleTarget() {
+       let filesToVerify = ["BarLib.a", "FooLib.a"]
+       fixture(name: "32_buildlib_singledep_string_target") { prefix in
+           XCTAssertNotNil(try? executeSwiftBuild(prefix))
+           XCTAssertTrue(self.verifyFilesExist(filesToVerify, fixturePath: prefix))
+       }
     }
 
     func test_exdeps() {


### PR DESCRIPTION
This helps make the manifest file a little less noisy. See: SR-154