### PR TITLE
Fix bug that causes ignored 'exclude' directive

### DIFF
--- a/Sources/PackageDescription/Package.swift
+++ b/Sources/PackageDescription/Package.swift
@@ -108,12 +108,12 @@ extension Package: TOMLConvertible {
         }
         result += "]\n"
 
-        for target in targets {
+        result += "\n" + "exclude = \(exclude)" + "\n"
 
+        for target in targets {
             result += "[[package.targets]]\n"
             result += target.toTOML()
         }
-        result += "\n" + "exclude = \(exclude)"
 
         return result
     }

--- a/Tests/dep/Fixtures/29_exclude_directory/Package.swift
+++ b/Tests/dep/Fixtures/29_exclude_directory/Package.swift
@@ -1,7 +1,6 @@
 import PackageDescription
 
 let package = Package(
-
     name: "29_exclude_directory",
     exclude: ["FooLib"]
 )

--- a/Tests/dep/Fixtures/32_exclude_directory_with_targets/BarLib/Bar.swift
+++ b/Tests/dep/Fixtures/32_exclude_directory_with_targets/BarLib/Bar.swift
@@ -1,0 +1,3 @@
+class Bar {
+    var bar: Int = 0
+}

--- a/Tests/dep/Fixtures/32_exclude_directory_with_targets/FooBarLib/FooBar.swift
+++ b/Tests/dep/Fixtures/32_exclude_directory_with_targets/FooBarLib/FooBar.swift
@@ -1,0 +1,3 @@
+class FooBar{
+    var bar: Int = 0 
+}

--- a/Tests/dep/Fixtures/32_exclude_directory_with_targets/FooLib/Foo.swift
+++ b/Tests/dep/Fixtures/32_exclude_directory_with_targets/FooLib/Foo.swift
@@ -1,0 +1,3 @@
+class Foo {
+    var bar: Int = 0
+}

--- a/Tests/dep/Fixtures/32_exclude_directory_with_targets/Package.swift
+++ b/Tests/dep/Fixtures/32_exclude_directory_with_targets/Package.swift
@@ -1,0 +1,7 @@
+import PackageDescription
+
+let package = Package(
+    name: "32_exclude_directory_with_targets",
+    targets: [Target(name: "FooLib")],
+    exclude: ["FooLib"]
+)

--- a/Tests/dep/FunctionalBuildTests.swift
+++ b/Tests/dep/FunctionalBuildTests.swift
@@ -46,6 +46,7 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
             ("testExecDeps", testExecDeps),
             ("testMultDeps", testMultDeps),
             ("testExcludeDirs", testExcludeDirs),
+            ("testExcludeWithTarget", testExcludeWithTarget),
             ("test_exdeps", test_exdeps),
             ("test_exdeps_canRunBuildTwice", test_exdeps_canRunBuildTwice),
             ("test_get_ExternalDeps", test_get_ExternalDeps),
@@ -388,6 +389,18 @@ class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
             XCTAssertNotNil(try? executeSwiftBuild(appPath))
             XCTAssertTrue(self.verifyFilesExist(filesToVerify, fixturePath: appPath))
             XCTAssertFalse(self.verifyFilesExist(["TestingFooLib.a"], fixturePath: appPath))
+        }
+    }
+
+    // 32 exclude directories (with targets)
+    // (see https://github.com/apple/swift-package-manager/pull/83)
+    func testExcludeWithTarget() {
+        let filesToVerify = ["BarLib.a", "FooBarLib.a"]
+        let filesShouldNotExist = ["FooLib.a"]
+        fixture(name: "32_exclude_directory_with_targets") { prefix in
+            XCTAssertNotNil(try? executeSwiftBuild(prefix))
+            XCTAssertTrue(self.verifyFilesExist(filesToVerify, fixturePath: prefix))
+            XCTAssertFalse(self.verifyFilesExist(filesShouldNotExist, fixturePath: prefix))
         }
     }
 


### PR DESCRIPTION
When building a `Package` that has one or more `Target`s specified,
the `exclude` gets treated as though it's a key of the latest target.
By moving the `exclude` directive above `Target`, this bug is fixed.