### PR TITLE
Fix coding style of param type () -> () to () -> Void

### DIFF
--- a/Tests/XCTestCaseProvider/XCTestCaseProvider.swift
+++ b/Tests/XCTestCaseProvider/XCTestCaseProvider.swift
@@ -21,7 +21,7 @@
 // swift-corelibs-xctest.
 #if os(OSX)
     public protocol XCTestCaseProvider {
-        var allTests : [(String, () -> ())] { get }
+        var allTests : [(String, () -> Void)] { get }
     }
 
     public func XCTMain(testCases: [XCTestCaseProvider]) {


### PR DESCRIPTION
As stated in https://devforums.apple.com/message/1133616#1133616, () -> Void is now standard.