### PR TITLE
Fix coding style of param type () -> () to () -> Void

### DIFF
--- a/Tests/XCTestCaseProvider/XCTestCaseProvider.swift
+++ b/Tests/XCTestCaseProvider/XCTestCaseProvider.swift
@@ -21,7 +21,7 @@
 // swift-corelibs-xctest.
 #if os(OSX)
     public protocol XCTestCaseProvider {
-        var allTests : [(String, () -> ())] { get }
+        var allTests : [(String, () -> Void)] { get }
     }
 
     public func XCTMain(testCases: [XCTestCaseProvider]) {

--- a/Tests/dep/FunctionalBuildTests.swift
+++ b/Tests/dep/FunctionalBuildTests.swift
@@ -19,7 +19,7 @@ import XCTestCaseProvider
 
 class FunctionalBuildTests: XCTestCase, XCTestCaseProvider {
 
-    var allTests : [(String, () -> ())] {
+    var allTests : [(String, () -> Void)] {
         return [
             ("testEmptyPackageSwiftExitsWithZero", testEmptyPackageSwiftExitsWithZero),
             ("testIgnoreFiles", testIgnoreFiles),

--- a/Tests/dep/GetTests.swift
+++ b/Tests/dep/GetTests.swift
@@ -15,7 +15,7 @@ import XCTestCaseProvider
 
 class GetTests: XCTestCase, XCTestCaseProvider {
 
-    var allTests : [(String, () -> ())] {
+    var allTests : [(String, () -> Void)] {
         return [
             ("testRawCloneDoesNotCrashIfManifestIsNotPresent", testRawCloneDoesNotCrashIfManifestIsNotPresent),
         ]

--- a/Tests/dep/ManifestTests.swift
+++ b/Tests/dep/ManifestTests.swift
@@ -17,7 +17,7 @@ import libc
 
 class ManifestTests: XCTestCase, XCTestCaseProvider {
 
-    var allTests : [(String, () -> ())] {
+    var allTests : [(String, () -> Void)] {
         return [
             ("testManifestLoading", testManifestLoading),
         ]

--- a/Tests/dep/PackageTests.swift
+++ b/Tests/dep/PackageTests.swift
@@ -14,7 +14,7 @@ import XCTestCaseProvider
 
 class PackageTests: XCTestCase, XCTestCaseProvider {
 
-    var allTests : [(String, () -> ())] {
+    var allTests : [(String, () -> Void)] {
         return [
             ("testInitializer", testInitializer)
         ]

--- a/Tests/dep/TargetTests.swift
+++ b/Tests/dep/TargetTests.swift
@@ -31,7 +31,7 @@ extension Target {
 
 class TargetTests: XCTestCase, XCTestCaseProvider {
 
-    var allTests : [(String, () -> ())] {
+    var allTests : [(String, () -> Void)] {
         return [
             ("test1", test1),
             ("test2", test2),

--- a/Tests/dep/UidTests.swift
+++ b/Tests/dep/UidTests.swift
@@ -14,7 +14,7 @@ import XCTestCaseProvider
 
 class ProjectTests: XCTestCase, XCTestCaseProvider {
 
-    var allTests : [(String, () -> ())] {
+    var allTests : [(String, () -> Void)] {
         return [
             ("testUrlEndsInDotGit1", testUrlEndsInDotGit1),
             ("testUrlEndsInDotGit2", testUrlEndsInDotGit2),

--- a/Tests/dep/VersionTests.swift
+++ b/Tests/dep/VersionTests.swift
@@ -16,7 +16,7 @@ import libc
 
 class VersionTests: XCTestCase, XCTestCaseProvider {
 
-    var allTests : [(String, () -> ())] {
+    var allTests : [(String, () -> Void)] {
         return [
             ("testEquality", testEquality),
             ("testNegativeValuesBecomeZero", testNegativeValuesBecomeZero),


### PR DESCRIPTION
As stated in https://devforums.apple.com/message/1133616#1133616, () -> Void is now standard.