### PR TITLE
Fix llbuild prefix directory initialization

### DIFF
--- a/Sources/dep/llbuild.swift
+++ b/Sources/dep/llbuild.swift
@@ -46,7 +46,7 @@ public struct BuildParameters {
     private func requiredSubdirectories() -> [String] {
         return targets.flatMap { target in
             return target.sources.map { Path(components: $0, "..").relative(to: self.srcroot) }
-        } + [prefix]
+        } + [""]
     }
 }
 


### PR DESCRIPTION
Noticed some strange useless directories being created under `.build` anytime I compiled a project.

```
.build/
└── debug
    ├── Dealer
    ├── Dealer.dSYM
    │   └── Contents
    │       ├── Info.plist
    │       └── Resources
    │           └── DWARF
    │               └── Dealer
    ├── Dealer.o
    │   ├── Dealer
    │   │   ├── main.d
    │   │   ├── main.swiftdeps
    │   │   ├── main~partial.swiftdoc
    │   │   ├── main~partial.swiftmodule
    │   │   ├── master.swiftdeps
    │   │   └── output-file-map.json
    │   ├── Users
    │   │   └── josh
    │   │       └── Desktop
    │   │           └── example-package-dealer
    │   ├── build.db
    │   ├── llbuild.yaml
    │   └── main.swift.o
    ├── Dealer.swiftdoc
```

Each target would initialize a empty tree of directories with the path of the current project.

Dug into what was happening here.

Looks like `llbuild` is calling `mkdir` prepending the `tmpdir` path to an already absolute `prefix` path.

My current fix removes `prefix` from the `requiredSubdirectories` collection because it didn't seem like it was a "subdirectory", but always an absolute path.

Is `BuildParameters#prefix` always an absolute path? Or should it always be relative, or could it be either? Maybe we could document this.