### PR TITLE
Improve popen error when binary output is returned

### DIFF
--- a/Sources/POSIX/popen.swift
+++ b/Sources/POSIX/popen.swift
@@ -82,8 +82,7 @@ public func popen(arguments: [String], redirectStandardError: Bool = false, envi
                 if let str = String.fromCString(buf) {
                     body(str)
                 } else {
-                    //TODO better
-                    fatalError("fatal: popen: couldn't convert buffer to string")
+                    throw SystemError.popen(EILSEQ, arguments[0])
                 }
             }
         }

--- a/Tests/sys/ShellTests.swift
+++ b/Tests/sys/ShellTests.swift
@@ -17,7 +17,8 @@ class ShellTests: XCTestCase, XCTestCaseProvider {
     var allTests : [(String, () -> Void)] {
         return [
             ("testPopen", testPopen),
-            ("testPopenWithBufferLargerThanThatAllocated", testPopenWithBufferLargerThanThatAllocated)
+            ("testPopenWithBufferLargerThanThatAllocated", testPopenWithBufferLargerThanThatAllocated),
+            ("testPopenWithBinaryOutput", testPopenWithBinaryOutput)
         ]
     }
 
@@ -28,5 +29,11 @@ class ShellTests: XCTestCase, XCTestCaseProvider {
     func testPopenWithBufferLargerThanThatAllocated() {
         let path = Path.join(__FILE__, "../../dep/DependencyGraphTests.swift").normpath
         XCTAssertGreaterThan(try! popen(["cat", path]).characters.count, 4096)
+    }
+
+    func testPopenWithBinaryOutput() {
+        if (try? popen(["cat", "/bin/cat"])) != nil {
+            XCTFail("popen succeeded but should have failed")
+        }
     }
 }


### PR DESCRIPTION
`popen` will fatally crash if any non-unicode data is returned from stdout. This implements a todo to throw a swift error type instead.

It seems unlikely anyone will actually hit this in practice. All the current `popen` use cases just shell out to utilities like `git` which should be returning simple ASCII.

More ideal might be returning `NSData` instead of a `String`. But it seems like SPM is trying to avoid any `Foundation` dependencies at the moment.