### PR TITLE
Fix TMPDIR path in mkdtemp

### DIFF
--- a/Sources/POSIX/mkdtemp.swift
+++ b/Sources/POSIX/mkdtemp.swift
@@ -20,8 +20,11 @@ import func libc.rmdir
 */
 public func mkdtemp<T>(template: String, prefix: String! = nil, @noescape body: (String) throws -> T) rethrows -> T {
     var prefix = prefix
-    if prefix == nil { prefix = getenv("TMPDIR") ?? "/tmp" }
-    let path = prefix + "/\(template).XXXXXX"
+    if prefix == nil { prefix = getenv("TMPDIR") ?? "/tmp/" }
+    if !prefix.hasSuffix("/") {
+        prefix! += "/"
+    }
+    let path = prefix + "\(template).XXXXXX"
 
     return try path.withCString { template in
         let mutable = UnsafeMutablePointer<Int8>(template)


### PR DESCRIPTION
`getenv("TMPDIR")` returns a a directory path and second `/` is redundant.  

Before:  path = ".../T//DependencyResolution_External_Complex.XXXXXX"
Now:  path = ".../T/DependencyResolution_External_Complex.XXXXXX"