### PR TITLE
Remove redundant protocol conformance

### DIFF
--- a/Sources/PackageDescription/Version.swift
+++ b/Sources/PackageDescription/Version.swift
@@ -135,7 +135,7 @@ public func <(lhs: Version, rhs: Version) -> Bool {
 
 // MARK: ForwardIndexType
 
-extension Version: BidirectionalIndexType, ForwardIndexType {
+extension Version: BidirectionalIndexType {
     public func successor() -> Version {
         return successor(.Patch)
     }


### PR DESCRIPTION
ForwardIndexType is implied by BidirectionalIndexType so is redundant.