### PR TITLE
Make Specifier.init(_ characters:) non-failable

### DIFF
--- a/Sources/PackageDescription/Version.swift
+++ b/Sources/PackageDescription/Version.swift
@@ -229,7 +229,7 @@ public struct Specifier {
         self.patch = patch.map{ Swift.max($0, 0) }
     }
 
-    public init?(_ characters: String.CharacterView) {
+    public init(_ characters: String.CharacterView) {
         let components = characters.split(".", maxSplit: 2).map(String.init).flatMap{ Int($0) }.filter{ $0 >= 0 }
 
         self.major = components.count >= 1 ? components[0] : nil
@@ -263,7 +263,7 @@ public struct Specifier {
 
 extension Specifier: StringLiteralConvertible {
     public init(stringLiteral value: String) {
-        self.init(value.characters)!
+        self.init(value.characters)
     }
 
     public init(extendedGraphemeClusterLiteral value: String) {


### PR DESCRIPTION
Specifier.init(_ characters:) never fails.