### PR TITLE
Fix and simplify Range.constrain(:)

### DIFF
--- a/Sources/dep/get.swift
+++ b/Sources/dep/get.swift
@@ -312,14 +312,12 @@ extension Range where Element: BidirectionalIndexType, Element: Comparable {
      If the two ranges do not overlap at all returns `nil`.
     */
     func constrain(to constraint: Range) -> Range? {
-        guard self ~= constraint.endIndex.predecessor() || self ~= constraint.startIndex else {
+        let start = max(self.startIndex, constraint.startIndex)
+        let end = min(self.endIndex, constraint.endIndex)
+        if start < end {
+            return start..<end
+        } else {
             return nil
         }
-
-        let lhs = constraint
-        let rhs = self
-        let start = [lhs.startIndex, rhs.startIndex].maxElement()!
-        let end = [lhs.endIndex, rhs.endIndex].minElement()!
-        return start..<end
     }
 }

--- a/Tests/dep/GetTests.swift
+++ b/Tests/dep/GetTests.swift
@@ -11,6 +11,7 @@
 import XCTest
 import XCTestCaseProvider
 @testable import dep
+@testable import struct PackageDescription.Version
 
 import POSIX
 import struct sys.Path
@@ -20,6 +21,7 @@ class GetTests: XCTestCase, XCTestCaseProvider {
     var allTests : [(String, () -> Void)] {
         return [
             ("testRawCloneDoesNotCrashIfManifestIsNotPresent", testRawCloneDoesNotCrashIfManifestIsNotPresent),
+            ("testRangeConstrain", testRangeConstrain),
         ]
     }
 
@@ -33,6 +35,41 @@ class GetTests: XCTestCase, XCTestCaseProvider {
             XCTAssertEqual(rawClone.dependencies.count, 0)
         }
     }
+    
+    func testRangeConstrain() {
+        let r1 = Version(2, 0, 0)..<Version(3, 0, 0)
+        let r2 = Version(1, 0, 0)..<Version(2, 0, 0)
+        let r3 = Version(1, 0, 0)...Version(2, 0, 0)
+        let r4 = Version(1, 5, 0)..<Version(2, 5, 0)
+        let r5 = Version(2, 5, 0)..<Version(2, 6, 0)
+        let r6 = Version(2, 5, 0)..<Version(3, 5, 0)
+        let r7 = Version(3, 0, 0)..<Version(4, 0, 0)
+        let r8 = Version(1, 0, 0)..<Version(4, 0, 0)
+        
+        let r12: Range<Version>? = nil
+        let r13 = r1.startIndex...r1.startIndex
+        let r14 = r1.startIndex..<r4.endIndex
+        let r15 = r5
+        let r16 = r6.startIndex..<r1.endIndex
+        let r17: Range<Version>? = nil
+        let r18 = r1
+        
+        XCTAssertEqual(r1.constrain(to: r2), r12)
+        XCTAssertEqual(r2.constrain(to: r1), r12)
+        XCTAssertEqual(r1.constrain(to: r3), r13)
+        XCTAssertEqual(r3.constrain(to: r1), r13)
+        XCTAssertEqual(r1.constrain(to: r4), r14)
+        XCTAssertEqual(r4.constrain(to: r1), r14)
+        XCTAssertEqual(r1.constrain(to: r5), r15)
+        XCTAssertEqual(r5.constrain(to: r1), r15)
+        XCTAssertEqual(r1.constrain(to: r6), r16)
+        XCTAssertEqual(r6.constrain(to: r1), r16)
+        XCTAssertEqual(r1.constrain(to: r7), r17)
+        XCTAssertEqual(r7.constrain(to: r1), r17)
+        XCTAssertEqual(r1.constrain(to: r8), r18)
+        XCTAssertEqual(r8.constrain(to: r1), r18)
+    }
+    
 }
 
 


### PR DESCRIPTION
If self is completely within constraint it should return self but now it returns nil.