### PR TITLE
#if SWIFT_PACKAGE_MANAGER

### DIFF
--- a/Documentation/DevelopingPackages.md
+++ b/Documentation/DevelopingPackages.md
@@ -52,3 +52,16 @@ caused dependency hell for your co-workers.
 
 It is our intention to provide tooling to prevent such situations,
 but for now please be aware of the caveats.
+
+## Packaging legacy code
+
+You may be working with code that builds both as a package and not.  For example, you may be packaging a project that also builds with Xcode.
+
+In these cases, you can use the build configuration `SWIFT_PACKAGE` to conditionally compile code for Swift packages.
+
+```swift
+#if SWIFT_PACKAGE
+import Foundation
+#endif
+```
+

--- a/Fixtures/Miscellaneous/PackageManagerDefine/Foo.swift
+++ b/Fixtures/Miscellaneous/PackageManagerDefine/Foo.swift
@@ -1,0 +1,7 @@
+class Foo{
+    var bar: Int = 0 
+    #if SWIFT_PACKAGE
+    #else
+    var bar: String = ""
+    #endif
+}

--- a/Fixtures/Miscellaneous/PackageManagerDefine/Package.swift
+++ b/Fixtures/Miscellaneous/PackageManagerDefine/Package.swift
@@ -1,0 +1,3 @@
+import PackageDescription
+
+let package = Package(name: "PackageManagerDefine")

--- a/Sources/dep/llbuild.swift
+++ b/Sources/dep/llbuild.swift
@@ -218,6 +218,8 @@ private class YAML {
                 args += ["-I", "/usr/local/include"]
             }
 
+            args += ["-D","SWIFT_PACKAGE"]
+
             return args
         }
 

--- a/Tests/Functional/TestMiscellaneous.swift
+++ b/Tests/Functional/TestMiscellaneous.swift
@@ -23,6 +23,7 @@ class MiscellaneousTestCase: XCTestCase, XCTestCaseProvider {
             ("testCanBuildIfADependencyClonedButThenAborted", testCanBuildIfADependencyClonedButThenAborted),
             ("testTipHasNoPackageSwift", testTipHasNoPackageSwift),
             ("testFailsIfVersionTagHasNoPackageSwift", testFailsIfVersionTagHasNoPackageSwift),
+            ("testPackageManagerDefine", testPackageManagerDefine),
         ]
     }
 
@@ -203,6 +204,12 @@ class MiscellaneousTestCase: XCTestCase, XCTestCaseProvider {
             try system("git", "-C", path, "tag", "--force", "1.2.3")
 
             XCTAssertBuildFails(prefix, "app")
+        }
+    }
+
+    func testPackageManagerDefine() {
+        fixture(name: "Miscellaneous/PackageManagerDefine") { prefix in
+            XCTAssertBuilds(prefix)
         }
     }
 }


### PR DESCRIPTION
This commit adds a `#define SWIFT_PACKAGE_MANAGER` when code is built via the package manager.  This simplifies the maintenance of codebases that build both in SwiftPM and another environment (like Xcode).

Specifically, SwiftPM (and Linux generally) doesn't support bridging headers (see [SR-76](https://bugs.swift.org/browse/SR-76)) and so I have to import all my frameworks at the top of each file, but only in the SwiftPM case–I don't want to do that for Xcode builds.