### PR TITLE
allow folders with suffix ".swift" in a package's root folder

### DIFF
--- a/Fixtures/ValidLayouts/SingleModule/SubfolderWithSwiftSuffix/Folder.swift/.gitignore
+++ b/Fixtures/ValidLayouts/SingleModule/SubfolderWithSwiftSuffix/Folder.swift/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/Fixtures/ValidLayouts/SingleModule/SubfolderWithSwiftSuffix/Package.swift
+++ b/Fixtures/ValidLayouts/SingleModule/SubfolderWithSwiftSuffix/Package.swift
@@ -1,0 +1,3 @@
+import PackageDescription
+
+let package = Package(name: "Bar")

--- a/Fixtures/ValidLayouts/SingleModule/SubfolderWithSwiftSuffix/Sources/Foo.swift
+++ b/Fixtures/ValidLayouts/SingleModule/SubfolderWithSwiftSuffix/Sources/Foo.swift
@@ -1,0 +1,3 @@
+class Foo {
+    var bar: Int = 0
+}

--- a/Sources/dep/Manifest+configureTargets.swift
+++ b/Sources/dep/Manifest+configureTargets.swift
@@ -187,7 +187,7 @@ private func isValidSourceFile(filename: String, isRoot: Bool = false) -> Bool {
         return false
     }
     
-    return !base.hasPrefix(".") && filename.lowercaseString.hasSuffix(".swift")
+    return !base.hasPrefix(".") && filename.lowercaseString.hasSuffix(".swift") && filename.isFile
 }
 
 private func isValidSourceFile(filename: String) -> Bool {

--- a/Tests/Functional/TestValidLayouts.swift
+++ b/Tests/Functional/TestValidLayouts.swift
@@ -37,6 +37,13 @@ class ValidLayoutsTestCase: XCTestCase, XCTestCaseProvider {
         }
     }
 
+    func testSingleModuleSubfolderWithSwiftSuffix() {
+        fixture(name: "ValidLayouts/SingleModule/SubfolderWithSwiftSuffix", file: __FILE__, line: __LINE__) { prefix in
+            XCTAssertBuilds(prefix)
+            XCTAssertFileExists(prefix, ".build", "debug", "Bar.a")
+        }
+    }
+
     func testMultipleModulesLibraries() {
         runLayoutFixture(name: "MultipleModules/Libraries") { prefix in
             XCTAssertBuilds(prefix)
@@ -101,6 +108,7 @@ extension ValidLayoutsTestCase {
             ("testSingleModuleLibrary", testSingleModuleLibrary),
             ("testSingleModuleExecutable", testSingleModuleExecutable),
             ("testSingleModuleCustomizedName", testSingleModuleCustomizedName),
+            ("testSingleModuleSubfolderWithSwiftSuffix", testSingleModuleSubfolderWithSwiftSuffix),
             ("testMultipleModulesLibraries", testMultipleModulesLibraries),
             ("testMultipleModulesExecutables", testMultipleModulesExecutables),
         ]


### PR DESCRIPTION
I created a swift library with the unfortunate name "progress.swift". To support cocoa pods i added an Xcode project in a subfolder named "Progress.swift".
As a result i got the following error message: `Your source structure is not supported due to invalid sources layout: .../Packages/Progress.swift-0.1.4. There should be no source files under: .../Packages/Progress.swift-0.1.4.` when trying to build it.

This pull request should fix the issue.