### PR TITLE
Add additional compiler/linker options in Package.swift

### DIFF
--- a/Fixtures/Miscellaneous/ExtraArgs/Foo.swift
+++ b/Fixtures/Miscellaneous/ExtraArgs/Foo.swift
@@ -1,0 +1,7 @@
+class Foo {
+    var bar: Int = 0
+    #if GOT_EXTRA_ARG
+    #else
+    var bar: Int = 0
+    #endif
+}

--- a/Fixtures/Miscellaneous/ExtraArgs/Package.swift
+++ b/Fixtures/Miscellaneous/ExtraArgs/Package.swift
@@ -1,0 +1,6 @@
+import PackageDescription
+
+let package = Package(
+    name: "ExtraArgs",
+    otherCompilerOptions: ["-D","GOT_EXTRA_ARG"]
+)

--- a/Fixtures/Miscellaneous/ExtraArgsTarget/ExtraArgsTarget/Foo.swift
+++ b/Fixtures/Miscellaneous/ExtraArgsTarget/ExtraArgsTarget/Foo.swift
@@ -1,0 +1,7 @@
+class Foo {
+    var bar: Int = 0
+    #if GOT_EXTRA_ARG
+    #else
+    var bar: Int = 0
+    #endif
+}

--- a/Fixtures/Miscellaneous/ExtraArgsTarget/Package.swift
+++ b/Fixtures/Miscellaneous/ExtraArgsTarget/Package.swift
@@ -1,0 +1,7 @@
+import PackageDescription
+
+let package = Package(
+    name: "ExtraArgsTarget",
+    otherCompilerOptions: ["-D","GOT_EXTRA_ARG"],
+    targets: [Target(name: "ExtraArgsTarget")]
+)

--- a/Sources/PackageDescription/Package.swift
+++ b/Sources/PackageDescription/Package.swift
@@ -69,7 +69,7 @@ public final class Package {
     public var otherLinkerOptions: [String]
     
     /// Construct a package.
-    public init(name: String? = nil, targets: [Target] = [], dependencies: [Dependency] = [], testDependencies: [Dependency], exclude: [String] = [], otherCompilerOptions: [String] = [], otherLinkerOptions: [String] = []) {
+    public init(name: String? = nil, targets: [Target] = [], dependencies: [Dependency] = [], testDependencies: [Dependency] = [], exclude: [String] = [], otherCompilerOptions: [String] = [], otherLinkerOptions: [String] = []) {
         self.name = name
         self.targets = targets
         self.dependencies = dependencies
@@ -123,9 +123,9 @@ extension Package: TOMLConvertible {
             result += target.toTOML()
         }
 
-        result += "\n" + "cflags = \(otherCompilerOptions)"
+        result += "\n" + "otherCompilerOptions = \(otherCompilerOptions)"
         
-        result += "\n" + "ldflags = \(otherLinkerOptions)"
+        result += "\n" + "otherLinkerOptions = \(otherLinkerOptions)"
 
         return result
     }

--- a/Sources/PackageDescription/Package.swift
+++ b/Sources/PackageDescription/Package.swift
@@ -62,13 +62,21 @@ public final class Package {
     /// The list of folders to exclude.
     public var exclude: [String]
 
+    /// The list of compile options
+    public var otherCompilerOptions: [String]
+    
+    /// The list of link options
+    public var otherLinkerOptions: [String]
+    
     /// Construct a package.
-    public init(name: String? = nil, targets: [Target] = [], dependencies: [Dependency] = [], testDependencies: [Dependency] = [], exclude: [String] = []) {
+    public init(name: String? = nil, targets: [Target] = [], dependencies: [Dependency] = [], testDependencies: [Dependency], exclude: [String] = [], otherCompilerOptions: [String] = [], otherLinkerOptions: [String] = []) {
         self.name = name
         self.targets = targets
         self.dependencies = dependencies
         self.testDependencies = testDependencies
         self.exclude = exclude
+        self.otherCompilerOptions = otherCompilerOptions
+        self.otherLinkerOptions = otherLinkerOptions
 
         // Add custom exit handler to cause package to be dumped at exit, if requested.
         //
@@ -114,6 +122,10 @@ extension Package: TOMLConvertible {
             result += "[[package.targets]]\n"
             result += target.toTOML()
         }
+
+        result += "\n" + "cflags = \(otherCompilerOptions)"
+        
+        result += "\n" + "ldflags = \(otherLinkerOptions)"
 
         return result
     }

--- a/Sources/PackageDescription/Package.swift
+++ b/Sources/PackageDescription/Package.swift
@@ -118,14 +118,14 @@ extension Package: TOMLConvertible {
 
         result += "\n" + "exclude = \(exclude)" + "\n"
 
+        result += "\n" + "otherCompilerOptions = \(otherCompilerOptions)" + "\n"
+        
+        result += "\n" + "otherLinkerOptions = \(otherLinkerOptions)" + "\n"
+
         for target in targets {
             result += "[[package.targets]]\n"
             result += target.toTOML()
         }
-
-        result += "\n" + "otherCompilerOptions = \(otherCompilerOptions)"
-        
-        result += "\n" + "otherLinkerOptions = \(otherLinkerOptions)"
 
         return result
     }

--- a/Sources/dep/Manifest.swift
+++ b/Sources/dep/Manifest.swift
@@ -61,7 +61,25 @@ extension PackageDescription.Package {
             }
         }
         
-        return PackageDescription.Package(name: name, targets: targets, dependencies: dependencies, testDependencies: testDependencies, exclude: exclude)
+        //Parse the cflags options.
+        var otherCompilerOptions: [String] = []
+        if case .Some(.Array(let array)) = table.items["otherCompilerOptions"] {
+            for item in array.items {
+                guard case .String(let flag) = item else { fatalError("otherCompilerOptions contains non string element") }
+                otherCompilerOptions.append(flag)
+            }
+        }
+        
+        //Parse the ldflags options.
+        var otherLinkerOptions: [String] = []
+        if case .Some(.Array(let array)) = table.items["otherLinkerOptions"] {
+            for item in array.items {
+                guard case .String(let flag) = item else { fatalError("otherLinkerOptions contains non string element") }
+                otherLinkerOptions.append(flag)
+            }
+        }
+        
+        return PackageDescription.Package(name: name, targets: targets, dependencies: dependencies, testDependencies: testDependencies, exclude: exclude, otherCompilerOptions: otherCompilerOptions, otherLinkerOptions: otherLinkerOptions)
     }
 }
 

--- a/Sources/dep/llbuild.swift
+++ b/Sources/dep/llbuild.swift
@@ -32,6 +32,8 @@ public struct BuildParameters {
         targets = []
         dependencies = []
         conf = .Debug
+        compilerExtraArgs = []
+        linkerExtraArgs = []
     }
 
     public var srcroot: String
@@ -42,6 +44,9 @@ public struct BuildParameters {
     public var tmpdir: String = ""
 
     public var conf: Configuration
+    
+    public var compilerExtraArgs: [String]
+    public var linkerExtraArgs: [String]
 
     private func requiredSubdirectories() -> [String] {
         return targets.flatMap { target in
@@ -50,7 +55,7 @@ public struct BuildParameters {
     }
 }
 
-public func llbuild(srcroot srcroot: String, targets: [Target], dependencies: [Package], prefix: String, tmpdir: String, configuration: BuildParameters.Configuration) throws -> BuildParameters {
+public func llbuild(srcroot srcroot: String, targets: [Target], dependencies: [Package], prefix: String, tmpdir: String, configuration: BuildParameters.Configuration, compilerExtraArgs: [String], linkerExtraArgs: [String]) throws -> BuildParameters {
     var parms = BuildParameters()
     parms.srcroot = srcroot
     parms.targets = targets
@@ -58,6 +63,8 @@ public func llbuild(srcroot srcroot: String, targets: [Target], dependencies: [P
     parms.prefix = prefix
     parms.tmpdir = tmpdir
     parms.conf = configuration
+    parms.compilerExtraArgs = compilerExtraArgs
+    parms.linkerExtraArgs = linkerExtraArgs
     try llbuild(parms)
     return parms
 }
@@ -218,6 +225,8 @@ private class YAML {
                 args += ["-I", "/usr/local/include"]
             }
 
+            args += parms.compilerExtraArgs
+            
             return args
         }
 
@@ -303,6 +312,8 @@ private class YAML {
                     //TODO we only want to do this if a module map wants to do this
                     args += ["-L/usr/local/lib"]
                 }
+
+                args += parms.linkerExtraArgs
 
                 return args
             }

--- a/Sources/swift-build/main.swift
+++ b/Sources/swift-build/main.swift
@@ -68,7 +68,7 @@ do {
                 for d in dependencies where d.url == dd.url { return d }
                 fatalError("Could not find dependency for \(dd)")
             }
-            try llbuild(srcroot: pkg.path, targets: try pkg.targets(), dependencies: dependencies, prefix: builddir, tmpdir: Path.join(builddir, "\(pkg.name).o"), configuration: configuration)
+            try llbuild(srcroot: pkg.path, targets: try pkg.targets(), dependencies: dependencies, prefix: builddir, tmpdir: Path.join(builddir, "\(pkg.name).o"), configuration: configuration, , compilerExtraArgs:manifest.package.otherCompilerOptions, linkerExtraArgs:manifest.package.otherLinkerOptions)
         }
 
         let testDependencies = try get(manifest.package.testDependencies, prefix: depsdir)
@@ -78,7 +78,7 @@ do {
 
         do {
             // build the current directory
-            try llbuild(srcroot: rootd, targets: targets, dependencies: dependencies, prefix: builddir, tmpdir: Path.join(builddir, "\(pkgname).o"), configuration: configuration)
+            try llbuild(srcroot: rootd, targets: targets, dependencies: dependencies, prefix: builddir, tmpdir: Path.join(builddir, "\(pkgname).o"), configuration: configuration, compilerExtraArgs:manifest.package.otherCompilerOptions, linkerExtraArgs:manifest.package.otherLinkerOptions)
         } catch POSIX.Error.ExitStatus(let foo) {
 #if os(Linux)
             // it is a common error on Linux for clang++ to not be installed, but

--- a/Sources/swift-build/main.swift
+++ b/Sources/swift-build/main.swift
@@ -68,12 +68,12 @@ do {
                 for d in dependencies where d.url == dd.url { return d }
                 fatalError("Could not find dependency for \(dd)")
             }
-            try llbuild(srcroot: pkg.path, targets: try pkg.targets(), dependencies: dependencies, prefix: builddir, tmpdir: Path.join(builddir, "\(pkg.name).o"), configuration: configuration, , compilerExtraArgs:manifest.package.otherCompilerOptions, linkerExtraArgs:manifest.package.otherLinkerOptions)
+            try llbuild(srcroot: pkg.path, targets: try pkg.targets(), dependencies: dependencies, prefix: builddir, tmpdir: Path.join(builddir, "\(pkg.name).o"), configuration: configuration, compilerExtraArgs:manifest.package.otherCompilerOptions, linkerExtraArgs:manifest.package.otherLinkerOptions)
         }
 
         let testDependencies = try get(manifest.package.testDependencies, prefix: depsdir)
         for pkg in testDependencies {
-            try llbuild(srcroot: pkg.path, targets: try pkg.targets(), dependencies: testDependencies, prefix: builddir, tmpdir: Path.join(builddir, "\(pkg.name).o"), configuration: configuration)
+            try llbuild(srcroot: pkg.path, targets: try pkg.targets(), dependencies: testDependencies, prefix: builddir, tmpdir: Path.join(builddir, "\(pkg.name).o"), configuration: configuration, compilerExtraArgs: manifest.package.otherCompilerOptions, linkerExtraArgs: manifest.package.otherLinkerOptions)
         }
 
         do {

--- a/Tests/Functional/TestMiscellaneous.swift
+++ b/Tests/Functional/TestMiscellaneous.swift
@@ -211,5 +211,8 @@ class MiscellaneousTestCase: XCTestCase, XCTestCaseProvider {
         fixture(name: "Miscellaneous/ExtraArgs") { prefix in
             XCTAssertBuilds(prefix)
         }
+        fixture(name: "Miscellaneous/ExtraArgsTarget") { prefix in
+            XCTAssertBuilds(prefix)
+        }
     }
 }

--- a/Tests/Functional/TestMiscellaneous.swift
+++ b/Tests/Functional/TestMiscellaneous.swift
@@ -23,6 +23,7 @@ class MiscellaneousTestCase: XCTestCase, XCTestCaseProvider {
             ("testCanBuildIfADependencyClonedButThenAborted", testCanBuildIfADependencyClonedButThenAborted),
             ("testTipHasNoPackageSwift", testTipHasNoPackageSwift),
             ("testFailsIfVersionTagHasNoPackageSwift", testFailsIfVersionTagHasNoPackageSwift),
+            ("testExtraArgs", testExtraArgs)
         ]
     }
 
@@ -203,6 +204,12 @@ class MiscellaneousTestCase: XCTestCase, XCTestCaseProvider {
             try system("git", "-C", path, "tag", "--force", "1.2.3")
 
             XCTAssertBuildFails(prefix, "app")
+        }
+    }
+
+    func testExtraArgs() {
+        fixture(name: "Miscellaneous/ExtraArgs") { prefix in
+            XCTAssertBuilds(prefix)
         }
     }
 }


### PR DESCRIPTION
For various reasons, users may want to add custom compiler and linker flags, at least for the present.

# Why should we do this?

Because it provides either a solution or a workaround for all these bugs:

* https://bugs.swift.org/browse/SR-397
* https://bugs.swift.org/browse/SR-415 (possible dupe of SR-397)
* https://bugs.swift.org/browse/SR-235
* https://bugs.swift.org/browse/SR-145
* https://bugs.swift.org/browse/SR-83

That's 20% of the open bugs.  There are probably more than that, that we haven't heard about yet.

While this approach is far from perfect... it *works*, and a patch in the hand is worth two in the bush.  Designing "perfect" solutions can happen in parallel with offering a workaround for these problems *right now*.

# What should we add to this?

Maybe we should print a notice to people who use this feature that they should file a bug in the tracker to explain why.

Maybe we should warn the user that this feature is "deprecated" and that we intend to remove it when we have "final" solutions to the problems it solves.

# Haven't we tried this before?

Yes, this is the resurrection of #75 by @OutOfBedlam [as I suggested on the mailing list](https://lists.swift.org/pipermail/swift-build-dev/Week-of-Mon-20151228/000139.html).  Differences include:

* Rebased; this PR is fresh
* Test coverage, and more test coverage
* Bugs fixed
* We now have more SwiftPM bugs that can be worked around via this PR then we did when reviewing #75.