### PR TITLE
Check if git has a version tag

### DIFF
--- a/Sources/dep/Error.swift
+++ b/Sources/dep/Error.swift
@@ -18,6 +18,8 @@ public enum Error: ErrorType {
     case UpdateRequired(String)
 
     case GitCloneFailure(String, String)
+    case GitVersionTagRequired(String)
+
 }
 
 
@@ -40,6 +42,8 @@ extension Error: CustomStringConvertible {
             return "The dependency graph could not be satisfied because an update to `\(package)' is required"
         case .GitCloneFailure(let url, let dstdir):
             return "Failed to clone \(url) to \(dstdir)"
+        case .GitVersionTagRequired(let package):
+            return "No version tag found in (\(package)) package. Add a version tag with \"git tag\" command. Example: \"git tag 0.1.0\""
         }
     }
 }

--- a/Sources/dep/Git.swift
+++ b/Sources/dep/Git.swift
@@ -60,6 +60,11 @@ class Git {
             }
         }
 
+        /// Check if repo contains a version tag
+        var hasVersion: Bool {
+            return !versions.isEmpty
+        }
+
         /**
          - Returns: true if the package versions in this repository
            are all prefixed with "v", otherwise false. If there are

--- a/Sources/dep/get.swift
+++ b/Sources/dep/get.swift
@@ -101,6 +101,9 @@ extension Sandbox: Fetcher {
     func fetch(url url: String) throws -> Fetchable {
         let dstdir = Path.join(prefix, Package.name(forURL: url))
         if let repo = Git.Repo(root: dstdir) where repo.origin == url {
+            if !repo.hasVersion {
+                throw Error.GitVersionTagRequired(dstdir)
+            }
             //TODO need to canonicalize the URL need URL struct
             return RawClone(path: dstdir)
         }

--- a/Sources/dep/get.swift
+++ b/Sources/dep/get.swift
@@ -101,17 +101,14 @@ extension Sandbox: Fetcher {
     func fetch(url url: String) throws -> Fetchable {
         let dstdir = Path.join(prefix, Package.name(forURL: url))
         if let repo = Git.Repo(root: dstdir) where repo.origin == url {
-            if !repo.hasVersion {
-                throw Error.GitVersionTagRequired(dstdir)
-            }
             //TODO need to canonicalize the URL need URL struct
-            return RawClone(path: dstdir)
+            return try RawClone(path: dstdir)
         }
 
         // fetch as well, clone does not fetch all tags, only tags on the master branch
         try Git.clone(url, to: dstdir).fetch()
 
-        return RawClone(path: dstdir)
+        return try RawClone(path: dstdir)
     }
 
     func finalize(fetchable: Fetchable) throws -> Package {
@@ -150,8 +147,11 @@ extension Sandbox: Fetcher {
         }
         private var _manifest: Manifest?
 
-        init(path: String) {
+        init(path: String) throws {
             self.path = path
+          if !repo.hasVersion {
+            throw Error.GitVersionTagRequired(path)
+          }
         }
 
         var repo: Git.Repo {

--- a/Sources/dep/get.swift
+++ b/Sources/dep/get.swift
@@ -149,9 +149,9 @@ extension Sandbox: Fetcher {
 
         init(path: String) throws {
             self.path = path
-          if !repo.hasVersion {
-            throw Error.GitVersionTagRequired(path)
-          }
+            if !repo.hasVersion {
+                throw Error.GitVersionTagRequired(path)
+            }
         }
 
         var repo: Git.Repo {

--- a/Support/swiftpm.xcodeproj/project.pbxproj
+++ b/Support/swiftpm.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		63FDF0DA1C29EF4C00B3904D /* TestDependencyResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63FDF0D91C29EF4C00B3904D /* TestDependencyResolution.swift */; };
 		63FDF0F01C29F34D00B3904D /* TestMiscellaneous.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63FDF0EF1C29F34D00B3904D /* TestMiscellaneous.swift */; };
 		A1A815631C17A8F000BD6927 /* GetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A815621C17A8E700BD6927 /* GetTests.swift */; };
+		B59359861C429F5200AD4547 /* GitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59359851C429F5200AD4547 /* GitTests.swift */; };
 		DA3C2B1C1C1B4D7600893759 /* XCTestCaseProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3C2AE11C1B48C700893759 /* XCTestCaseProvider.swift */; };
 		E136D9421BD5F3DD000DFCE6 /* TOMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E136D9411BD5F35D000DFCE6 /* TOMLTests.swift */; };
 		E1E286BA1BD72D700015F0C5 /* ManifestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E286B91BD72D700015F0C5 /* ManifestTests.swift */; };
@@ -245,6 +246,7 @@
 		63FDF0D91C29EF4C00B3904D /* TestDependencyResolution.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestDependencyResolution.swift; path = ../Tests/Functional/TestDependencyResolution.swift; sourceTree = "<group>"; };
 		63FDF0EF1C29F34D00B3904D /* TestMiscellaneous.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestMiscellaneous.swift; path = ../Tests/Functional/TestMiscellaneous.swift; sourceTree = "<group>"; };
 		A1A815621C17A8E700BD6927 /* GetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GetTests.swift; path = ../Tests/dep/GetTests.swift; sourceTree = "<group>"; };
+		B59359851C429F5200AD4547 /* GitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GitTests.swift; path = ../Tests/dep/GitTests.swift; sourceTree = "<group>"; };
 		DA3C2AE11C1B48C700893759 /* XCTestCaseProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestCaseProvider.swift; sourceTree = "<group>"; };
 		DA3C2B141C1B4D4A00893759 /* XCTestCaseProvider.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = XCTestCaseProvider.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E1066B6E1BC5931C00B892CE /* llbuild.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = llbuild.xcodeproj; path = ../../llbuild/llbuild.xcodeproj; sourceTree = "<group>"; };
@@ -367,6 +369,7 @@
 			isa = PBXGroup;
 			children = (
 				A1A815621C17A8E700BD6927 /* GetTests.swift */,
+				B59359851C429F5200AD4547 /* GitTests.swift */,
 				63D2BC171BFD6287006E395C /* PackageTests.swift */,
 				6305480D1BD708B30001290A /* DependencyGraphTests.swift */,
 				635C147C1BCDA0A900D4C4A9 /* TargetTests.swift */,
@@ -789,6 +792,7 @@
 				634D97011C2874670056FAAA /* Utilities.swift in Sources */,
 				63353A5B1BB4C4BC00D6C4B0 /* VersionTests.swift in Sources */,
 				63D2BC181BFD6287006E395C /* PackageTests.swift in Sources */,
+				B59359861C429F5200AD4547 /* GitTests.swift in Sources */,
 				635C147D1BCDA0A900D4C4A9 /* TargetTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/dep/GetTests.swift
+++ b/Tests/dep/GetTests.swift
@@ -30,7 +30,7 @@ class GetTests: XCTestCase, XCTestCaseProvider {
             try system("git", "-C", path, "rm", "Package.swift")
             try system("git", "-C", path, "commit", "-mwip")
 
-            let rawClone = Sandbox.RawClone(path: path)
+            let rawClone = try Sandbox.RawClone(path: path)
             XCTAssertEqual(rawClone.dependencies.count, 0)
         }
     }

--- a/Tests/dep/GitTests.swift
+++ b/Tests/dep/GitTests.swift
@@ -1,0 +1,60 @@
+//
+//  GitTests.swift
+//  swiftpm
+//
+//  Created by Kostiantyn Koval on 09/01/16.
+//  Copyright © 2016 Apple, Inc. All rights reserved.
+//
+
+import XCTest
+import XCTestCaseProvider
+
+import struct sys.Path
+@testable import dep
+import func POSIX.popen
+
+class GitTests: XCTestCase, XCTestCaseProvider {
+
+    var allTests : [(String, () -> Void)] {
+        return [
+            ("testHasVersion", testHasVersion),
+            ("testHasNoVersion", testHasNoVersion),
+        ]
+    }
+
+    func testHasVersion() {
+        mktmpdir { path in
+            let gitRepo = makeGitRepo(path, tag: "0.1.0")!
+            XCTAssertTrue(gitRepo.hasVersion)
+        }
+    }
+
+    func testHasNoVersion() {
+        mktmpdir { path in
+            let gitRepo = makeGitRepo(path, tag: nil)!
+            XCTAssertFalse(gitRepo.hasVersion)
+        }
+    }
+}
+
+//MARK: - Helpers
+
+private func makeGitRepo(dstdir: String, tag: String?, file: String = __FILE__, line: UInt = __LINE__) -> Git.Repo? {
+    do {
+        let file = Path.join(dstdir, "file.swift")
+        try popen(["touch", file])
+        try popen(["git", "-C", dstdir, "init"])
+        try popen(["git", "-C", dstdir, "config", "user.email", "example@example.com"])
+        try popen(["git", "-C", dstdir, "config", "user.name", "Example Example"])
+        try popen(["git", "-C", dstdir, "add", "."])
+        try popen(["git", "-C", dstdir, "commit", "-m", "msg"])
+        if let tag = tag {
+            try popen(["git", "-C", dstdir, "tag", tag])
+        }
+        return Git.Repo(root: dstdir)
+    }
+    catch {
+        XCTFail(safeStringify(error), file: file, line: line)
+    }
+    return nil
+}

--- a/Tests/dep/GitTests.swift
+++ b/Tests/dep/GitTests.swift
@@ -39,7 +39,7 @@ class GitTests: XCTestCase, XCTestCaseProvider {
 
 //MARK: - Helpers
 
-private func makeGitRepo(dstdir: String, tag: String?, file: String = __FILE__, line: UInt = __LINE__) -> Git.Repo? {
+private func makeGitRepo(dstdir: String, tag: String?, file: StaticString = __FILE__, line: UInt = __LINE__) -> Git.Repo? {
     do {
         let file = Path.join(dstdir, "file.swift")
         try popen(["touch", file])

--- a/Tests/dep/GitTests.swift
+++ b/Tests/dep/GitTests.swift
@@ -1,11 +1,12 @@
-//
-//  GitTests.swift
-//  swiftpm
-//
-//  Created by Kostiantyn Koval on 09/01/16.
-//  Copyright © 2016 Apple, Inc. All rights reserved.
-//
+/*
+ This source file is part of the Swift.org open source project
 
+ Copyright 2015 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
 import XCTest
 import XCTestCaseProvider
 

--- a/Tests/dep/main.swift
+++ b/Tests/dep/main.swift
@@ -22,4 +22,7 @@ XCTMain([
     
     // GetTests.swift
     GetTests(),
+
+    // GitTests.swift
+    GitTests(),
 ])


### PR DESCRIPTION
The packages must have a version tag, it would be nice to notify users when there is no `tag` and give them "How to fix that" tips.
This is exactly that this PR contains. 
This is related to that issue https://bugs.swift.org/browse/SR-441