### PR TITLE
Add option to only pull dependencies without compiling

### DIFF
--- a/Sources/swift-build/main.swift
+++ b/Sources/swift-build/main.swift
@@ -82,7 +82,7 @@ do {
         do {
             let dependencies = try get(manifest.package.dependencies, prefix: depsdir)
             
-            if opts.pull == false {
+            if opts.get == false {
                 try build(dependencies)
                 try build(try get(manifest.package.testDependencies, prefix: depsdir))
 

--- a/Sources/swift-build/main.swift
+++ b/Sources/swift-build/main.swift
@@ -81,12 +81,14 @@ do {
 
         do {
             let dependencies = try get(manifest.package.dependencies, prefix: depsdir)
+            
+            if opts.pull == false {
+                try build(dependencies)
+                try build(try get(manifest.package.testDependencies, prefix: depsdir))
 
-            try build(dependencies)
-            try build(try get(manifest.package.testDependencies, prefix: depsdir))
-
-            // build the current directory
-            try llbuild(srcroot: rootd, targets: targets, dependencies: dependencies, prefix: builddir, tmpdir: Path.join(builddir, "\(pkgname).o"), configuration: configuration)
+                // build the current directory
+                try llbuild(srcroot: rootd, targets: targets, dependencies: dependencies, prefix: builddir, tmpdir: Path.join(builddir, "\(pkgname).o"), configuration: configuration)
+            }
         } catch POSIX.Error.ExitStatus(let foo) {
 #if os(Linux)
             // it is a common error on Linux for clang++ to not be installed, but

--- a/Sources/swift-build/usage.swift
+++ b/Sources/swift-build/usage.swift
@@ -29,7 +29,7 @@ func usage(print: (String) -> Void = { print($0) }) {
     print("  -v[v]              Increase verbosity of informational output")
     print("  -Xcc <flag>        Pass flag through to all compiler instantiations")
     print("  -Xlinker <flag>    Pass flag through to all linker instantiations")
-    print("  --pull             Only pull down dependencies without building binaries")
+    print("  --get             Only pull down dependencies without building binaries")
 }
 
 enum CleanMode: String {
@@ -56,7 +56,7 @@ struct Options {
     var verbosity: Int = 0
     var Xcc: [String] = []
     var Xlinker: [String] = []
-    var pull = false
+    var get = false
 }
 
 func parse(commandLineArguments args: [String]) throws -> (Mode, Options) {
@@ -158,8 +158,8 @@ func parse(commandLineArguments args: [String]) throws -> (Mode, Options) {
 
         case .Switch(.Xlinker):
             opts.Xlinker.append(try cruncher.rawPop())
-        case .Switch(.Pull):
-            opts.pull = true
+        case .Switch(.get):
+            opts.get = true
         }
     }
 
@@ -212,7 +212,7 @@ private struct Cruncher {
             case Verbose = "--verbose"
             case Xcc = "-Xcc"
             case Xlinker = "-Xlinker"
-            case Pull = "--pull"
+            case Get = "--get"
             
             init?(rawValue: String) {
                 switch rawValue {
@@ -224,8 +224,8 @@ private struct Cruncher {
                     self = .Xcc
                 case Xlinker.rawValue:
                     self = .Xlinker
-                case Pull.rawValue:
-                    self = .Pull
+                case Get.rawValue:
+                    self = .Get
                 default:
                     return nil
                 }

--- a/Sources/swift-build/usage.swift
+++ b/Sources/swift-build/usage.swift
@@ -29,6 +29,7 @@ func usage(print: (String) -> Void = { print($0) }) {
     print("  -v[v]              Increase verbosity of informational output")
     print("  -Xcc <flag>        Pass flag through to all compiler instantiations")
     print("  -Xlinker <flag>    Pass flag through to all linker instantiations")
+    print("  --pull             Only pull down dependencies without building binaries")
 }
 
 enum CleanMode: String {
@@ -55,6 +56,7 @@ struct Options {
     var verbosity: Int = 0
     var Xcc: [String] = []
     var Xlinker: [String] = []
+    var pull = false
 }
 
 func parse(commandLineArguments args: [String]) throws -> (Mode, Options) {
@@ -156,6 +158,8 @@ func parse(commandLineArguments args: [String]) throws -> (Mode, Options) {
 
         case .Switch(.Xlinker):
             opts.Xlinker.append(try cruncher.rawPop())
+        case .Switch(.Pull):
+            opts.pull = true
         }
     }
 
@@ -208,6 +212,7 @@ private struct Cruncher {
             case Verbose = "--verbose"
             case Xcc = "-Xcc"
             case Xlinker = "-Xlinker"
+            case Pull = "--pull"
             
             init?(rawValue: String) {
                 switch rawValue {
@@ -219,6 +224,8 @@ private struct Cruncher {
                     self = .Xcc
                 case Xlinker.rawValue:
                     self = .Xlinker
+                case Pull.rawValue:
+                    self = .Pull
                 default:
                     return nil
                 }


### PR DESCRIPTION
In my current workflow, I have packages that I would like to use the SwiftPM to pull down and track but contain only C code that the SwiftPM cannot compile. This option allows me to only pull down packages without attempting to compile. This feature should be included as it allows developers to more granularly specify what they want the SwiftPM to do.