### PR TITLE
Allow #SWIFT_PACKAGE in Manifest

### DIFF
--- a/Fixtures/Miscellaneous/-DSWIFT_PACKAGE/Package.swift
+++ b/Fixtures/Miscellaneous/-DSWIFT_PACKAGE/Package.swift
@@ -1,3 +1,7 @@
 import PackageDescription
 
-let package = Package(name: "PackageManagerDefine")
+#if SWIFT_PACKAGE
+let package = Package(name: "PackageManagerIsDefined")
+#else
+let package = Package(name: "PackageManagerIsNotDefined")
+#endif

--- a/Sources/dep/Manifest.swift
+++ b/Sources/dep/Manifest.swift
@@ -150,7 +150,7 @@ public struct Manifest {
         // in the id of another file descriptor to write the output onto.
         let libDir = Resources.runtimeLibPath
         let swiftcPath = Resources.path.swiftc
-        var cmd = [swiftcPath, "--driver-mode=swift", "-I", libDir, "-L", libDir, "-lPackageDescription"]
+        var cmd = [swiftcPath, "--driver-mode=swift", "-I", libDir, "-L", libDir, "-lPackageDescription", "-DSWIFT_PACKAGE"]
 #if os(OSX)
         cmd += ["-target", "x86_64-apple-macosx10.10"]
 #endif

--- a/Tests/Functional/TestMiscellaneous.swift
+++ b/Tests/Functional/TestMiscellaneous.swift
@@ -216,6 +216,7 @@ class MiscellaneousTestCase: XCTestCase, XCTestCaseProvider {
     func testPackageManagerDefine() {
         fixture(name: "Miscellaneous/-DSWIFT_PACKAGE") { prefix in
             XCTAssertBuilds(prefix)
+            XCTAssertFileExists(prefix, ".build/debug/PackageManagerIsDefined.a")
         }
     }
 


### PR DESCRIPTION
This defines #SWIFT_PACKAGE for the manifest file, previously it was only defined for all other files built with the package manager.

It’s a fix for part of https://bugs.swift.org/browse/SR-588 although it doesn’t do anything for using getenv() for custom env variables in the manifest.