### PR TITLE
switch to associatedtype

### DIFF
--- a/Sources/dep/get.swift
+++ b/Sources/dep/get.swift
@@ -44,7 +44,7 @@ public func get(urls: [(String, Range<Version>)], prefix: String) throws -> [dep
  Our usage fetches remote packages by having Sandbox conform.
 */
 protocol Fetcher {
-    typealias T: Fetchable
+    associatedtype T: Fetchable
 
     func find(url url: String) throws -> Fetchable?
     func fetch(url url: String) throws -> Fetchable


### PR DESCRIPTION
The new `associatedtype` syntax was implemented and it's available for usage. [Task](https://bugs.swift.org/browse/SR-511)

However, `associatedtype` is not available in latest Toolchain snapshot, meaning it's not possible to compile project in Xcode, so maybe it would be better to wait for new Toolchain snapshot before merging this PR.