### PR TITLE
Add --init mode as proposed in SR-353

### DIFF
--- a/Sources/swift-build/initPackage.swift
+++ b/Sources/swift-build/initPackage.swift
@@ -1,0 +1,71 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import POSIX
+import struct dep.Manifest
+import struct sys.Path
+import func libc.fclose
+
+func initPackage() throws {
+    let rootd = try POSIX.getcwd()
+    let pkgname = rootd.basename
+    let manifest = Path.join(rootd, Manifest.filename)
+    let gitignore = Path.join(rootd, ".gitignore")
+    let sources = Path.join(rootd, "Sources")
+    let tests = Path.join(rootd, "Tests")
+    let main = Path.join(sources, "main.swift")
+    
+    guard !manifest.exists else {
+        throw Error.ManifestAlreadyExists
+    }
+    
+    let packageFP = try fopen(manifest, mode: .Write)
+    defer {
+        fclose(packageFP)
+    }
+    
+    print("Creating \(Manifest.filename)")
+    // print the manifest file
+    try fputs("import PackageDescription\n", packageFP)
+    try fputs("\n", packageFP)
+    try fputs("let package = Package(\n", packageFP)
+    try fputs("    name: \"\(pkgname)\"\n", packageFP)
+    try fputs(")\n", packageFP)
+    
+    if !gitignore.exists {
+        let gitignoreFP = try fopen(gitignore, mode: .Write)
+        defer {
+            fclose(gitignoreFP)
+        }
+        
+        print("Creating .gitignore")
+        // print the .gitignore
+        try fputs(".DS_Store\n", gitignoreFP)
+        try fputs("/.build\n", gitignoreFP)
+        try fputs("/Packages\n", gitignoreFP)
+    }
+    
+    if !sources.exists {
+        print("Creating Sources/")
+        try mkdir(sources)
+        
+        let mainFP = try fopen(main, mode: .Write)
+        defer {
+            fclose(mainFP)
+        }
+        print("Creating Sources/main.swift")
+        try fputs("print(\"Hello, world!\")\n", mainFP)
+    }
+    
+    if !tests.exists {
+        print("Creating Tests/")
+        try mkdir(tests)
+    }
+}

--- a/Sources/swift-build/main.swift
+++ b/Sources/swift-build/main.swift
@@ -101,6 +101,8 @@ do {
             throw POSIX.Error.ExitStatus(foo)
         }
 
+    case .Init:
+        try initPackage()
 
     case .Version:
         print("Apple Swift Package Manager 0.1")

--- a/Sources/swift-build/misc.swift
+++ b/Sources/swift-build/misc.swift
@@ -13,6 +13,7 @@ import struct sys.Path
 import struct dep.Manifest
 
 enum Error: ErrorType {
+    case ManifestAlreadyExists
     case NoManifestFound
     case NoTargetsFound
 }
@@ -20,6 +21,8 @@ enum Error: ErrorType {
 extension Error: CustomStringConvertible {
     var description: String {
         switch self {
+        case .ManifestAlreadyExists:
+            return "\(Manifest.filename) already exists"
         case .NoManifestFound:
             return "no \(Manifest.filename) file found"
         case .NoTargetsFound:

--- a/Sources/swift-build/usage.swift
+++ b/Sources/swift-build/usage.swift
@@ -23,6 +23,7 @@ func usage(print: (String) -> Void = { print($0) }) {
     print("                           build - Build intermediaries and products")
     print("                           dist  - All of 'build' plus downloaded packages")
     print("                           If no mode is given, 'build' is the default.")
+    print("  --init                   Creates a new Swift project")
     print("")
     print("OPTIONS:")
     print("  --chdir <value>    Change working directory before any other operation [-C]")
@@ -39,6 +40,7 @@ enum CleanMode: String {
 enum Mode {
     case Build(BuildParameters.Configuration)
     case Clean(CleanMode)
+    case Init
     case Usage
     case Version
 }
@@ -119,6 +121,8 @@ func parse(commandLineArguments args: [String]) throws -> (Mode, Options) {
                 }
             case (nil, .Usage):
                 mode = .Usage
+            case (nil, .Init):
+                mode = .Init
             case (nil, .Clean):
                 mode = .Clean(.Build)
                 switch try cruncher.peek() {
@@ -173,6 +177,7 @@ extension Mode: CustomStringConvertible {
         switch self {
             case .Build(let conf): return "--build \(conf)"
             case .Clean(let cleanMode): return "--clean=\(cleanMode)"
+            case .Init: return "--init"
             case .Usage: return "--help"
             case .Version: return "--version"
         }
@@ -185,6 +190,7 @@ private struct Cruncher {
         enum TheMode: String {
             case Build = "--configuration"
             case Clean = "--clean"
+            case Init = "--init"
             case Usage = "--help"
             case Version = "--version"
 
@@ -194,6 +200,8 @@ private struct Cruncher {
                     self = .Build
                 case Clean.rawValue, "-k":
                     self = .Clean
+                case Init.rawValue:
+                    self = .Init
                 case Usage.rawValue:
                     self = .Usage
                 case Version.rawValue:
@@ -277,6 +285,7 @@ private func ==(lhs: Mode, rhs: Cruncher.Crunch.TheMode) -> Bool {
     switch lhs {
         case .Build: return rhs == .Build
         case .Clean: return rhs == .Clean
+        case .Init: return rhs == .Init
         case .Version: return rhs == .Version
         case .Usage: return rhs == .Usage
     }


### PR DESCRIPTION
swift build —initializes a new swift project with the following structure.
```
├── .gitignore
├── Package.swift
├── Sources
│   └── main.swift
└── Tests
```
.gitignore content:
```
.DS_Store
/.build
/Packages
```
Package.swift content:
```swift
import PackageDescription

let package = Package(
    name: "foo"
)
```
where foo is the name of the working directory

main.swift content:
```swift
print("Hello, world!")
```

### Discussion points
#### Naming
maybe —create or —new would work too, but I prefer —init

#### VCS
the current implementation just creates a .gitignore for convenience, but we might want to discuss that