### PR TITLE
Package version data

### DIFF
--- a/Sources/Build/PackageVersion.swift
+++ b/Sources/Build/PackageVersion.swift
@@ -14,17 +14,16 @@ import struct Utility.Path
 import func libc.fclose
 
 public func generateVersionData(rootDir: String, packages: [Package]) throws {
-    let dirPath = rootDir + "/.build/versionData/"
+    let dirPath = Path.join(rootDir, ".build/versionData")
     try mkdir(dirPath)
-    let versionData = generateData(packages)
 
-    for (pkgName, data) in versionData {
+    for (pkgName, data) in generateData(packages) {
         try saveVersionData(dirPath, packageName: pkgName, data: data)
     }
 }
 
 func generateData(packages: [Package]) -> [String : String] {
-    var versionData: [String : String] = [:]
+    var versionData = [String : String]()
     for pkg in packages {
         versionData[pkg.name] = packageVersionData(pkg)
     }

--- a/Sources/Build/PackageVersion.swift
+++ b/Sources/Build/PackageVersion.swift
@@ -1,0 +1,50 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import POSIX
+import PackageType
+import struct Utility.Path
+import func libc.fclose
+
+public func generateVersionData(rootDir: String, packages: [Package]) throws {
+    let dirPath = rootDir + "/.build/versionData/"
+    try mkdir(dirPath)
+    let versionData = generateData(packages)
+
+    for (pkgName, data) in versionData {
+        try saveVersionData(dirPath, packageName: pkgName, data: data)
+    }
+}
+
+func generateData(packages: [Package]) -> [String : String] {
+    var versionData: [String : String] = [:]
+    for pkg in packages {
+        versionData[pkg.name] = packageVersionData(pkg)
+    }
+    return versionData
+}
+
+func packageVersionData(package: Package) -> String {
+    var data = "public let url: String = \"\(package.url)\" \n" +
+        "public let version: (Int, Int, Int, [String], String?)?"
+    if let version = package.version {
+        data += " = \(version.major, version.minor, version.patch, version.prereleaseIdentifiers, version.buildMetadataIdentifier) \n"
+    }
+    return data
+}
+
+private func saveVersionData(dirPath: String, packageName: String, data: String) throws {
+    let filePath = Path.join(dirPath, "\(packageName).swift")
+    let file = try fopen(filePath, mode: .Write)
+    defer {
+        libc.fclose(file)
+    }
+    try fputs(data, file)
+}

--- a/Sources/Get/Git.swift
+++ b/Sources/Get/Git.swift
@@ -64,13 +64,4 @@ extension Git.Repo {
     var hasVersion: Bool {
         return !versions.isEmpty
     }
-
-    /**
-     - Returns: true if the package versions in this repository
-     are all prefixed with "v", otherwise false. If there are
-     no versions, returns false.
-     */
-    var versionsArePrefixed: Bool {
-        return (try? Git.runPopen([Git.tool, "-C", path, "tag", "-l"]))?.hasPrefix("v") ?? false
-    }
 }

--- a/Sources/Get/Package.swift
+++ b/Sources/Get/Package.swift
@@ -19,6 +19,7 @@ extension Package {
         guard let origin = repo.origin else { throw Error.NoOrigin(repo.path) }
         let manifest = try manifestParser(path: repo.path, url: origin)
         let pkg = Package(manifest: manifest, url: origin)
+        pkg.version = Version(pkg.versionString)!
         guard Version(pkg.versionString) != nil else { return nil }
         return pkg
     }

--- a/Sources/Get/Package.swift
+++ b/Sources/Get/Package.swift
@@ -19,7 +19,9 @@ extension Package {
         guard let origin = repo.origin else { throw Error.NoOrigin(repo.path) }
         let manifest = try manifestParser(path: repo.path, url: origin)
         let pkg = Package(manifest: manifest, url: origin)
-        pkg.version = Version(pkg.versionString)!
+        if let version = Version(pkg.versionString) {
+            pkg.version = version
+        }
         guard Version(pkg.versionString) != nil else { return nil }
         return pkg
     }

--- a/Sources/Get/get().swift
+++ b/Sources/Get/get().swift
@@ -24,6 +24,7 @@ public func get(_ manifest: Manifest, manifestParser: (path: String, url: String
     //TODO don't lose the dependency information during the Fetcher process!
     
     let rootPackage = Package(manifest: manifest, url: manifest.path.parentDirectory)
+    rootPackage.version = Git.Repo(path: rootPackage.path)?.versions.last
     let extPackages = try box.recursivelyFetch(manifest.dependencies)
     
     let pkgs = extPackages + [rootPackage]

--- a/Sources/PackageType/Package.swift
+++ b/Sources/PackageType/Package.swift
@@ -9,11 +9,13 @@
 */
 
 import Utility
+import struct PackageDescription.Version
 
 public class Package {
     public let url: String
     public let path: String
     public let name: String
+    public var version: Version?
     public var dependencies: [Package] = []
     public let manifest: Manifest
 

--- a/Sources/Utility/Git.swift
+++ b/Sources/Utility/Git.swift
@@ -44,6 +44,28 @@ public class Git {
             return try? Git.runPopen([Git.tool, "-C", path, "rev-parse", "--abbrev-ref", "HEAD"]).chomp()
         }
 
+        public var sha: String! {
+            return try? Git.runPopen([Git.tool, "-C", path, "rev-parse", "--verify", "HEAD"]).chomp()
+        }
+        
+        public func versionSha(tag: String) throws -> String {
+            return try Git.runPopen([Git.tool, "-C", path, "rev-parse", "--verify", "\(tag)"]).chomp()
+        }
+        
+        public var hasLocalChanges: Bool {
+            let changes = try? Git.runPopen([Git.tool, "-C", path, "status", "--porcelain"]).chomp()
+            return !(changes?.isEmpty ?? true)
+        }
+
+        /**
+         - Returns: true if the package versions in this repository
+         are all prefixed with "v", otherwise false. If there are
+         no versions, returns false.
+         */
+        public var versionsArePrefixed: Bool {
+            return (try? Git.runPopen([Git.tool, "-C", path, "tag", "-l"]))?.hasPrefix("v") ?? false
+        }
+
         public func fetch() throws {
             do {
                 try system(Git.tool, "-C", path, "fetch", "--tags", "origin", message: nil)

--- a/Sources/swift-build/main.swift
+++ b/Sources/swift-build/main.swift
@@ -48,6 +48,7 @@ do {
     case .Build(let conf, let toolchain):
         let dirs = try directories()
         let (rootPackage, externalPackages) = try fetch(dirs.root)
+        try generateVersionData(dirs.root, rootPackage: rootPackage, externalPackages: externalPackages)
         let (modules, externalModules, products) = try transmute(rootPackage, externalPackages: externalPackages)
         let yaml = try describe(dirs.build, conf, modules, Set(externalModules), products, Xcc: opts.Xcc, Xld: opts.Xld, Xswiftc: opts.Xswiftc, toolchain: toolchain)
         try build(YAMLPath: yaml, target: "default")

--- a/Tests/Build/PackageVersionDataTests.swift
+++ b/Tests/Build/PackageVersionDataTests.swift
@@ -21,13 +21,17 @@ final class PackageVersionDataTests: XCTestCase {
     }
 
     func testPackageData(_ package: PackageType.Package, url: String, version: Version?) {
-        var expected = "public let url: String = \"\(url)\" \n" +
-            "public let version: (Int, Int, Int, [String], String?)?"
+        var expected = "public let url: String = \"\(url)\"\n"
+        expected += "public let version: (major: Int, minor: Int, patch: Int, prereleaseIdentifiers: [String], buildMetadata: String?) = "
         if let version = version {
-            expected += " = (\(version.major), \(version.minor), \(version.patch), \(version.prereleaseIdentifiers), \(version.buildMetadataIdentifier)) \n"
+            expected += "\(version.major, version.minor, version.patch, version.prereleaseIdentifiers, version.buildMetadataIdentifier)\n"
+            expected += "public let versionString: String = \"\(version)\"\n"
+        } else {
+            expected += "(0, 0, 0, [], nil) \n"
+            expected += "public let versionString: String = \"0.0.0\"\n"
         }
 
-        let metadata = packageVersionData(package)
+        let metadata = versionData(package: package)
         XCTAssertEqual(metadata, expected)
     }
 

--- a/Tests/Build/PackageVersionDataTests.swift
+++ b/Tests/Build/PackageVersionDataTests.swift
@@ -20,7 +20,7 @@ final class PackageVersionDataTests: XCTestCase {
         return Package(manifest: m, url: "https://github.com/testPkg")
     }
 
-    func testPackageData(package: PackageType.Package, url: String, version: Version?) {
+    func testPackageData(_ package: PackageType.Package, url: String, version: Version?) {
         var expected = "public let url: String = \"\(url)\" \n" +
             "public let version: (Int, Int, Int, [String], String?)?"
         if let version = version {
@@ -46,7 +46,11 @@ final class PackageVersionDataTests: XCTestCase {
     func testSavePackageVersionDataToFile() {
         mktmpdir { dir in
             let package = makePackage()
-            try generateVersionData(dir, packages: [package])
+
+            let m = Manifest(path: "path", package: PackageDescription.Package(), products: [])
+            let rootPkg = Package(manifest: m, url: "https://github.com/rootPkg")
+
+            try generateVersionData(dir, rootPackage:rootPkg, externalPackages: [package])
             XCTAssertFileExists(dir, ".build/versionData/", "\(package.name).swift")
         }
     }

--- a/Tests/Build/PackageVersionDataTests.swift
+++ b/Tests/Build/PackageVersionDataTests.swift
@@ -1,0 +1,63 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+@testable import Build
+import PackageType
+import XCTest
+import PackageDescription
+
+final class PackageVersionDataTests: XCTestCase {
+
+    func makePackage() -> PackageType.Package {
+        let m = Manifest(path: "path", package: PackageDescription.Package(), products: [])
+        return Package(manifest: m, url: "https://github.com/testPkg")
+    }
+
+    func testPackageData(package: PackageType.Package, url: String, version: Version?) {
+        var expected = "public let url: String = \"\(url)\" \n" +
+            "public let version: (Int, Int, Int, [String], String?)?"
+        if let version = version {
+            expected += " = (\(version.major), \(version.minor), \(version.patch), \(version.prereleaseIdentifiers), \(version.buildMetadataIdentifier)) \n"
+        }
+
+        let metadata = packageVersionData(package)
+        XCTAssertEqual(metadata, expected)
+    }
+
+    func testPackageVersionData() {
+        let package = makePackage()
+        package.version = Version(1, 2, 3)
+        testPackageData(package, url: "https://github.com/testPkg", version: Version(1, 2, 3))
+    }
+
+    func testPackageEmptyVersionData() {
+        let package = makePackage()
+        package.version = nil
+        testPackageData(package, url: "https://github.com/testPkg", version: nil)
+    }
+
+    func testSavePackageVersionDataToFile() {
+        mktmpdir { dir in
+            let package = makePackage()
+            try generateVersionData(dir, packages: [package])
+            XCTAssertFileExists(dir, ".build/versionData/", "\(package.name).swift")
+        }
+    }
+}
+
+extension PackageVersionDataTests {
+    static var allTests: [(String, PackageVersionDataTests -> () throws -> Void)] {
+        return [
+                   ("testPackageVersionData", testPackageVersionData),
+                   ("testPackageEmptyVersionData", testPackageEmptyVersionData),
+                   ("testSavePackageVersionDataToFile", testSavePackageVersionDataToFile),
+        ]
+    }
+}

--- a/Tests/Build/Utilities.swift
+++ b/Tests/Build/Utilities.swift
@@ -1,0 +1,1 @@
+../Functional/Utilities.swift

--- a/Tests/Functional/Utilities.swift
+++ b/Tests/Functional/Utilities.swift
@@ -73,6 +73,24 @@ func fixture(name fixtureName: String, tags: [String] = [], file: StaticString =
     }
 }
 
+func initGitRepo(_ dstdir: String, tag: String? = nil, file: StaticString = #file, line: UInt = #line) {
+    do {
+        let file = Path.join(dstdir, "file.swift")
+        try popen(["touch", file])
+        try popen(["git", "-C", dstdir, "init"])
+        try popen(["git", "-C", dstdir, "config", "user.email", "example@example.com"])
+        try popen(["git", "-C", dstdir, "config", "user.name", "Example Example"])
+        try popen(["git", "-C", dstdir, "add", "."])
+        try popen(["git", "-C", dstdir, "commit", "-m", "msg"])
+        if let tag = tag {
+            try popen(["git", "-C", dstdir, "tag", tag])
+        }
+    }
+    catch {
+        XCTFail("\(error)", file: file, line: line)
+    }
+}
+
 enum Configuration {
     case Debug
     case Release

--- a/Tests/Get/RawCloneTests.swift
+++ b/Tests/Get/RawCloneTests.swift
@@ -44,24 +44,8 @@ class GitTests: XCTestCase {
 //MARK: - Helpers
 
 func makeGitRepo(_ dstdir: String, tag: String? = nil, file: StaticString = #file, line: UInt = #line) -> Git.Repo? {
-    do {
-        let file = Path.join(dstdir, "file.swift")
-        try popen(["touch", file])
-        try popen(["git", "-C", dstdir, "init"])
-        try popen(["git", "-C", dstdir, "config", "user.email", "example@example.com"])
-        try popen(["git", "-C", dstdir, "config", "user.name", "Example Example"])
-        try popen(["git", "-C", dstdir, "config", "commit.gpgsign", "false"])
-        try popen(["git", "-C", dstdir, "add", "."])
-        try popen(["git", "-C", dstdir, "commit", "-m", "msg"])
-        if let tag = tag {
-            try popen(["git", "-C", dstdir, "tag", tag])
-        }
-        return Git.Repo(path: dstdir)
-    }
-    catch {
-        XCTFail("\(error)", file: file, line: line)
-    }
-    return nil
+    initGitRepo(dstdir, tag: tag)
+    return Git.Repo(path: dstdir)
 }
 
 private func tryCloningRepoWithTag(_ tag: String?, shouldCrash: Bool) {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -41,4 +41,5 @@ XCTMain([
     testCase(ModuleMapsTestCase.allTests),
     testCase(DescribeTests.allTests),
     testCase(GitUtilityTests.allTests),
+    testCase(PackageVersionDataTests.allTests),
 ])

--- a/Tests/Utility/GitTests.swift
+++ b/Tests/Utility/GitTests.swift
@@ -32,12 +32,74 @@ class GitUtilityTests: XCTestCase {
         GitMoc.mocVersion = "1.25.4"
         XCTAssertEqual(GitMoc.majorVersionNumber, 1)
     }
+    
+    func testHeadSha() {
+        mktmpdir { dir in
+            initGitRepo(dir)            
+            let sha = Git.Repo(path: dir)?.sha
+            checkSha(sha!)
+        }
+    }
+    
+    func testVersionSha() {
+        mktmpdir { dir in
+            initGitRepo(dir, tag: "0.1.0") 
+            let sha = try Git.Repo(path: dir)?.versionSha(tag: "0.1.0")
+            checkSha(sha!)
+        }
+    }
+
+    func testHeadAndVersionSha() {
+        mktmpdir { dir in
+            initGitRepo(dir, tag: "0.1.0")
+            try commit(dir, file: "file2.swift") 
+            
+            let headSha = Git.Repo(path: dir)?.sha
+            let versionSha = try Git.Repo(path: dir)?.versionSha(tag: "0.1.0")
+            checkSha(headSha!)
+            checkSha(versionSha!)
+            XCTAssertNotEqual(headSha, versionSha)
+        }
+    }
+
+    func testHasLocalChanges() {
+        mktmpdir { dir in
+            initGitRepo(dir, tag: "0.1.0")
+            let repo = Git.Repo(path: dir)!
+            XCTAssertFalse(repo.hasLocalChanges)
+
+            let filePath = Path.join(dir, "file2.swift")
+            try popen(["touch", filePath])
+
+            XCTAssertTrue(repo.hasLocalChanges)
+        }
+    }
+
+//MARK: - Helpers
+    
+    func checkSha(_ sha: String) {
+        XCTAssertNotNil(sha)
+        XCTAssertFalse(sha.isEmpty)
+        XCTAssertEqual(sha.characters.count, 40)
+    }
+    
+    func commit(_ dstdir: String, file: String) throws {
+        let filePath = Path.join(dstdir, file)
+        try popen(["touch", filePath])
+
+        try popen(["git", "-C", dstdir, "add", "."])
+        try popen(["git", "-C", dstdir, "commit", "-m", "msg"])
+    }
 }
 
 extension GitUtilityTests {
     static var allTests : [(String, GitUtilityTests -> () throws -> Void)] {
         return [
                    ("testGitVersion", testGitVersion),
+                   ("testHeadSha", testHeadSha),
+                   ("testVersionSha", testVersionSha),
+                   ("testHeadAndVersionSha", testHeadAndVersionSha),
+                   ("testHasLocalChanges", testHasLocalChanges),
         ]
     }
 }

--- a/Tests/Utility/Utilities.swift
+++ b/Tests/Utility/Utilities.swift
@@ -1,0 +1,1 @@
+../Functional/Utilities.swift


### PR DESCRIPTION
**Work in Progress** 
This is initial commit for [SR-473](https://bugs.swift.org/browse/SR-473)

We need to generate version data for every package on build.
Now it creates a new folder `versionData` inside `.build` dir and creates a swift file for every package.

Could you please provide any feedback for the initial implementation. 
- Should these files be inside `.build` dir or somewhere else?
- Should we generate a new `.swift` file for every Package or place all data in 1 file?
- Any other suggestion?

ToDo:
- [x] Add unit test
- [x] Add better error handling
- [x] Merge PR #225 
- [x] add additional information to Root package (local changes)