### PR TITLE
Improve Error message for "Can't satisfy requested version tag"

### DIFF
--- a/Sources/Get/Error.swift
+++ b/Sources/Get/Error.swift
@@ -17,6 +17,8 @@ public enum Error: ErrorType {
 
     case ManifestTargetNotFound(String)
     case InvalidDependencyGraph(String)
+    case InvalidDependencyGraphMissingTag(package: String, requestedTag: String, existingTags: String)
+
     case InvalidSourcesLayout(path: String, type: InvalidSourcesLayoutError)
     case UpdateRequired(String)
     
@@ -41,6 +43,8 @@ extension Error: CustomStringConvertible {
             return "The manifest describes a target that cannot be found in your source tree: \(target)"
         case InvalidDependencyGraph(let package):
             return "The dependency graph could not be satisfied (\(package))"
+        case InvalidDependencyGraphMissingTag(let package, let requestedTag, let existingTags):
+            return "The dependency graph could not be satisfied. The package (\(package)) with version tag in range (\(requestedTag)) is not found. Found tags (\(existingTags))"
         case InvalidSourcesLayout(let path, let errorType):
             return "Your source structure is not supported due to invalid sources layout: \(path). \(errorType)"
         case UpdateRequired(let package):

--- a/Sources/Get/Fetcher.swift
+++ b/Sources/Get/Fetcher.swift
@@ -40,7 +40,7 @@ extension Fetcher {
 
                 func adjust(pkg: Fetchable, _ versionRange: Range<Version>) throws {
                     guard let v = pkg.constrain(to: versionRange) else {
-                        throw Error.InvalidDependencyGraph(url)
+                        throw Error.InvalidDependencyGraphMissingTag(package: url, requestedTag: "\(versionRange)", existingTags: "\(pkg.availableVersions)")
                     }
                     try pkg.setVersion(v)
                 }

--- a/Tests/Get/DependencyGraphTests.swift
+++ b/Tests/Get/DependencyGraphTests.swift
@@ -259,7 +259,7 @@ class VersionGraphTests: XCTestCase {
             try MyMockFetcher().recursivelyFetch([
                 (MockProject.A.url, v1...v1),
             ])
-        } catch Error.InvalidDependencyGraph(let url) {
+        } catch Error.InvalidDependencyGraphMissingTag(let url, _, _) {
             XCTAssertEqual(url, MockProject.F.url)
             invalidGraph = true
         } catch {
@@ -278,7 +278,7 @@ class VersionGraphTests: XCTestCase {
         var success = false
         do {
             try MyMockFetcher().recursivelyFetch([(MockProject.A.url, v1..<v2)])
-        } catch Error.InvalidDependencyGraph {
+        } catch Error.InvalidDependencyGraphMissingTag {
             success = true
         } catch {
             XCTFail()


### PR DESCRIPTION
It's about  [SR-441](https://bugs.swift.org/browse/SR-441) issue

It happens when requested version tag can't be found.
The error message doesn't provide enough information about what happened exactly and how to fix it.

Before: 
`error: The dependency graph could not be satisfied (/Hello/LibADep)` 
Now: 
`error: The dependency graph could not be satisfied. The package (/Hello/LibADep) with version tag in range (1.0.0..<1.0.1) is not found. Found tags ([0.1.0])`