### PR TITLE
change __LINE__ to #line and  __FILE__ to #file

### DIFF
--- a/Tests/Functional/TestValidLayouts.swift
+++ b/Tests/Functional/TestValidLayouts.swift
@@ -38,7 +38,7 @@ class ValidLayoutsTestCase: XCTestCase, XCTestCaseProvider {
     }
 
     func testSingleModuleSubfolderWithSwiftSuffix() {
-        fixture(name: "ValidLayouts/SingleModule/SubfolderWithSwiftSuffix", file: __FILE__, line: __LINE__) { prefix in
+        fixture(name: "ValidLayouts/SingleModule/SubfolderWithSwiftSuffix", file: #file, line: #line) { prefix in
             XCTAssertBuilds(prefix)
             XCTAssertFileExists(prefix, ".build", "debug", "Bar.a")
         }
@@ -83,14 +83,14 @@ class ValidLayoutsTestCase: XCTestCase, XCTestCaseProvider {
 //MARK: Utility
 
 extension ValidLayoutsTestCase {
-    func runLayoutFixture(name name: String, line: UInt = __LINE__, @noescape body: (String) throws -> Void) {
+    func runLayoutFixture(name name: String, line: UInt = #line, @noescape body: (String) throws -> Void) {
         let name = "ValidLayouts/\(name)"
 
         // 1. Rooted layout
-        fixture(name: name, file: __FILE__, line: line, body: body)
+        fixture(name: name, file: #file, line: line, body: body)
 
         // 2. Move everything to a directory called "Sources"
-        fixture(name: name, file: __FILE__, line: line) { prefix in
+        fixture(name: name, file: #file, line: line) { prefix in
             let files = walk(prefix, recursively: false).filter{ $0.basename != "Package.swift" }
             let dir = try mkdir(prefix, "Sources")
             for file in files {
@@ -101,7 +101,7 @@ extension ValidLayoutsTestCase {
         }
 
         // 3. Symlink some other directory to a directory called "Sources"
-        fixture(name: name, file: __FILE__, line: line) { prefix in
+        fixture(name: name, file: #file, line: line) { prefix in
             let files = walk(prefix, recursively: false).filter{ $0.basename != "Package.swift" }
             let dir = try mkdir(prefix, "Floobles")
             for file in files {

--- a/Tests/Functional/Utilities.swift
+++ b/Tests/Functional/Utilities.swift
@@ -16,7 +16,7 @@ import func POSIX.system
 import func POSIX.popen
 
 
-func fixture(name fixtureName: String, tags: [String] = [], file: StaticString = __FILE__, line: UInt = __LINE__, @noescape body: (String) throws -> Void) {
+func fixture(name fixtureName: String, tags: [String] = [], file: StaticString = #file, line: UInt = #line, @noescape body: (String) throws -> Void) {
 
     func gsub(input: String) -> String {
         return input.characters.split("/").map(String.init).joinWithSeparator("_")
@@ -26,7 +26,7 @@ func fixture(name fixtureName: String, tags: [String] = [], file: StaticString =
         try POSIX.mkdtemp(gsub(fixtureName)) { prefix in
             defer { _ = try? rmtree(prefix) }
 
-            let rootd = Path.join(__FILE__, "../../../Fixtures", fixtureName).normpath
+            let rootd = Path.join(#file, "../../../Fixtures", fixtureName).normpath
 
             guard rootd.isDirectory else {
                 XCTFail("No such fixture: \(rootd)", file: file, line: line)
@@ -75,7 +75,7 @@ func executeSwiftBuild(chdir: String) throws -> String {
     return try popen([toolPath, "--chdir", chdir], redirectStandardError: true, environment: env)
 }
 
-func mktmpdir(file: StaticString = __FILE__, line: UInt = __LINE__, @noescape body: (String) throws -> Void) {
+func mktmpdir(file: StaticString = #file, line: UInt = #line, @noescape body: (String) throws -> Void) {
     do {
         try POSIX.mkdtemp("spm-tests") { dir in
             defer { _ = try? rmtree(dir) }
@@ -86,7 +86,7 @@ func mktmpdir(file: StaticString = __FILE__, line: UInt = __LINE__, @noescape bo
     }
 }
 
-func XCTAssertBuilds(paths: String..., file: StaticString = __FILE__, line: UInt = __LINE__) {
+func XCTAssertBuilds(paths: String..., file: StaticString = #file, line: UInt = #line) {
     let prefix = Path.join(paths)
     do {
         try executeSwiftBuild(prefix)
@@ -95,28 +95,28 @@ func XCTAssertBuilds(paths: String..., file: StaticString = __FILE__, line: UInt
     }
 }
 
-func XCTAssertBuildFails(paths: String..., file: StaticString = __FILE__, line: UInt = __LINE__) {
+func XCTAssertBuildFails(paths: String..., file: StaticString = #file, line: UInt = #line) {
     let prefix = Path.join(paths)
     if (try? executeSwiftBuild(prefix)) != nil {
         XCTFail("`swift build' succeeded but should have failed", file: file, line: line)
     }
 }
 
-func XCTAssertFileExists(paths: String..., file: StaticString = __FILE__, line: UInt = __LINE__) {
+func XCTAssertFileExists(paths: String..., file: StaticString = #file, line: UInt = #line) {
     let path = Path.join(paths)
     if !path.isFile {
         XCTFail("Expected file doesn’t exist: \(path)", file: file, line: line)
     }
 }
 
-func XCTAssertDirectoryExists(paths: String..., file: StaticString = __FILE__, line: UInt = __LINE__) {
+func XCTAssertDirectoryExists(paths: String..., file: StaticString = #file, line: UInt = #line) {
     let path = Path.join(paths)
     if !path.isDirectory {
         XCTFail("Expected directory doesn’t exist: \(path)", file: file, line: line)
     }
 }
 
-func XCTAssertNoSuchPath(paths: String..., file: StaticString = __FILE__, line: UInt = __LINE__) {
+func XCTAssertNoSuchPath(paths: String..., file: StaticString = #file, line: UInt = #line) {
     let path = Path.join(paths)
     if path.exists {
         XCTFail("path exists by should not: \(path)", file: file, line: line)

--- a/Tests/dep/GetTests.swift
+++ b/Tests/dep/GetTests.swift
@@ -75,8 +75,8 @@ class GetTests: XCTestCase, XCTestCaseProvider {
             XCTAssertNotNil(Git.Repo(root: Path.join(prefix, "app")))
         }
 
-        XCTAssertNil(Git.Repo(root: __FILE__))
-        XCTAssertNil(Git.Repo(root: __FILE__.parentDirectory))
+        XCTAssertNil(Git.Repo(root: #file))
+        XCTAssertNil(Git.Repo(root: #file.parentDirectory))
     }
 }
 

--- a/Tests/dep/GitTests.swift
+++ b/Tests/dep/GitTests.swift
@@ -51,7 +51,7 @@ class GitTests: XCTestCase, XCTestCaseProvider {
 
 //MARK: - Helpers
 
-private func makeGitRepo(dstdir: String, tag: String?, file: StaticString = __FILE__, line: UInt = __LINE__) -> Git.Repo? {
+private func makeGitRepo(dstdir: String, tag: String?, file: StaticString = #file, line: UInt = #line) -> Git.Repo? {
     do {
         let file = Path.join(dstdir, "file.swift")
         try popen(["touch", file])

--- a/Tests/dep/ManifestTests.swift
+++ b/Tests/dep/ManifestTests.swift
@@ -22,12 +22,12 @@ class ManifestTests: XCTestCase, XCTestCaseProvider {
         ]
     }
 
-    private func loadManifest(inputName: String, line: UInt = __LINE__, body: (Manifest) -> Void) {
+    private func loadManifest(inputName: String, line: UInt = #line, body: (Manifest) -> Void) {
         do {
-            let input = Path.join(__FILE__, "../Inputs", inputName).normpath
+            let input = Path.join(#file, "../Inputs", inputName).normpath
             body(try Manifest(path: input))
         } catch {
-            XCTFail("Unexpected error: \(safeStringify(error))", file: __FILE__, line: line)
+            XCTFail("Unexpected error: \(safeStringify(error))", file: #file, line: line)
         }
     }
 

--- a/Tests/dep/PackageTests.swift
+++ b/Tests/dep/PackageTests.swift
@@ -53,10 +53,10 @@ class PackageTests: XCTestCase, XCTestCaseProvider {
                 oldpath = newpath
             }
 
-            try test("Module-1.2.3-alpha", line: __LINE__)
-            try test("Module-1.2.3-beta1.foo", line: __LINE__)
-            try test("Module-1.2.3-beta1.foo+23", line: __LINE__)
-            try test("Module-1.2.3+23", line: __LINE__)
+            try test("Module-1.2.3-alpha", line: #line)
+            try test("Module-1.2.3-beta1.foo", line: #line)
+            try test("Module-1.2.3-beta1.foo+23", line: #line)
+            try test("Module-1.2.3+23", line: #line)
         }
     }
 

--- a/Tests/sys/FileTests.swift
+++ b/Tests/sys/FileTests.swift
@@ -24,7 +24,7 @@ class FileTests: XCTestCase,  XCTestCaseProvider {
     }
     
     private func loadInputFile(name: String) -> File {
-        let input = Path.join(__FILE__, "../Inputs", name).normpath
+        let input = Path.join(#file, "../Inputs", name).normpath
         return File(path: input)
     }
     

--- a/Tests/sys/PathTests.swift
+++ b/Tests/sys/PathTests.swift
@@ -116,7 +116,7 @@ class WalkTests: XCTestCase, XCTestCaseProvider {
     }
 
     func testRecursive() {
-        let root = Path.join(__FILE__, "../../../Sources").normpath
+        let root = Path.join(#file, "../../../Sources").normpath
         var expected = [
             Path.join(root, "dep"),
             Path.join(root, "sys")

--- a/Tests/sys/ShellTests.swift
+++ b/Tests/sys/ShellTests.swift
@@ -27,7 +27,7 @@ class ShellTests: XCTestCase, XCTestCaseProvider {
     }
 
     func testPopenWithBufferLargerThanThatAllocated() {
-        let path = Path.join(__FILE__, "../../dep/DependencyGraphTests.swift").normpath
+        let path = Path.join(#file, "../../dep/DependencyGraphTests.swift").normpath
         XCTAssertGreaterThan(try! popen(["cat", path]).characters.count, 4096)
     }
 


### PR DESCRIPTION
Changes for [SE-0028](https://github.com/apple/swift-evolution/blob/master/proposals/0028-modernizing-debug-identifiers.md). It's in master already [commit](https://github.com/apple/swift/commit/0619e57a61f27f721e273ab6f808ac81011aeb2c)

Maybe it's better to wait with merging this, until it's available in next snapshot?