### PR TITLE
Fixes to enable swift section objects

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -379,7 +379,7 @@ def process_runtime_libraries(build_path, opts, bootstrap=False):
             raise SystemExit("unable to understand 'swiftc' driver commands")
         del link_cmd[idx - 1]
         cmd = [arg for arg in link_cmd
-               if not arg.endswith(".o") and not arg.endswith(".autolink")]
+               if arg.endswith("swift_begin.o") or arg.endswith("swift_end.o") or (not arg.endswith(".o") and not arg.endswith(".autolink"))]
     subprocess.check_call(cmd)
     return (runtime_module_path, runtime_lib_path)
 


### PR DESCRIPTION
When the new section objects changes comes online https://github.com/apple/swift/pull/1157 swiftc adds section marker objects into the link.  As swiftc is only being used as a source of arguments to clang++ while bootstrapping swiftpm, and all .o's are filtered out, these objects are being dropped.  This change ads an exception to that filter so that they are preserved.

This change should have no effect on the current functioning of the bootstrap, and can be applied prior to the referenced pull request.

cc/ @gribozavr @tienex