### PR TITLE
[Python] Add flake8 config

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,0 +1,3 @@
+[flake8]
+filename = *.py,bootstrap
+ignore = E101,E111,E128,E265,E302,E402,E501,W191

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -74,7 +74,7 @@ def write_file_if_changed(path, data):
     Write the given data to the path, only updating the file if the contents are
     different than the current ones.
     """
-    
+
     try:
         with open(path) as f:
             old_data = f.read()
@@ -100,11 +100,11 @@ class Target(object):
     @property
     def virtual_node(self):
         return "<target-%s>" % (self.name)
-    
+
     @property
     def linked_virtual_node(self):
         return "<link-%s>" % (self.name)
-    
+
     def __init__(self, name, dependencies=[], swiftflags=[], extra_libs=[],
                  subpath=None):
         self.name = name
@@ -119,7 +119,7 @@ class Target(object):
                 os.path.join(g_source_root, subpath or self.name)):
             for name in filenames:
                 path = os.path.join(dirpath, name)
-                _,ext = os.path.splitext(name)
+                _, ext = os.path.splitext(name)
                 if ext == '.swift':
                     if name == 'main.swift':
                         self.is_library = False
@@ -193,7 +193,7 @@ targets = [
     Target('swift-build', dependencies=["Transmute", "Multitool", "Build", "Get", "ManifestParser", "PackageDescription", "PackageType", "Utility", "POSIX", "libc"]),
     Target('swift-test', dependencies=["Multitool", "PackageType", "PackageDescription", "Utility", "POSIX", "libc"]),
 ]
-target_map = dict((t.name,t) for t in targets)
+target_map = dict((t.name, t) for t in targets)
 
 def create_bootstrap_files(sandbox_path, opts):
     # Write out the build file.
@@ -212,7 +212,7 @@ def create_bootstrap_files(sandbox_path, opts):
 
     # Compute the list of active targets.
     active_targets = targets
-    
+
     # Write out the targets list.
     #
     # We support 'all' (build all targets) and an individual name for each
@@ -242,7 +242,7 @@ def create_bootstrap_files(sandbox_path, opts):
     mkdir_p(module_dir)
 
     print("commands:", file=output)
-    for target in targets:        
+    for target in targets:
         print("  # Target Commands: %r" % (target.name,), file=output)
         target_build_dir = os.path.join(sandbox_path, target.name + ".build")
         mkdir_p(target_build_dir)
@@ -277,7 +277,7 @@ def create_bootstrap_files(sandbox_path, opts):
             link_command.append(' '.join(pipes.quote(o) for o in objects))
         else:
             link_output_path = os.path.join(bin_dir, target.name)
-                
+
             link_command = [opts.swiftc_path, '-o', pipes.quote(link_output_path)]
             if opts.sysroot:
                 link_command.extend(["-sdk", opts.sysroot])
@@ -311,7 +311,7 @@ def create_bootstrap_files(sandbox_path, opts):
             [target.linked_virtual_node]), file=output)
         print("    outputs: %s" % json.dumps([target.virtual_node]), file=output)
         print(file=output)
-    
+
     # Write the output file.
     write_file_if_changed(os.path.join(sandbox_path, "build.swift-build"),
                           output.getvalue())
@@ -327,7 +327,7 @@ def process_runtime_libraries(build_path, opts, bootstrap=False):
             build_path, "debug", "PackageDescription.swiftmodule")
         input_lib_path = os.path.join(
             build_path, "debug", "libPackageDescription.a")
-        
+
     lib_path = os.path.join(build_path, "lib", "swift", "pm")
     mkdir_p(lib_path)
     runtime_module_path = os.path.join(
@@ -357,7 +357,7 @@ def process_runtime_libraries(build_path, opts, bootstrap=False):
                "-Xlinker", input_lib_path,
                "-Xlinker", "--no-whole-archive", "-lswiftGlibc",
                "-Xlinker", "-rpath=$ORIGIN/../linux"]
-        
+
         # We need to pass one swift file here to bypass the "no input files"
         # error.
         tf = tempfile.NamedTemporaryFile(suffix=".swift")
@@ -393,7 +393,7 @@ def get_swift_build_tool_path():
         sbt_path = os.path.join(built_products_dir, "swift-build-tool")
         if os.path.exists(sbt_path):
             return sbt_path
-            
+
     if os.environ.get("SWIFT_BUILD_TOOL"):
         return os.environ.get("SWIFT_BUILD_TOOL")
 
@@ -418,7 +418,7 @@ def get_swift_build_tool_path():
     error("unable to find 'swift-build-tool' tool for bootstrap build")
 
 def main():
-    from optparse import OptionParser, OptionGroup
+    from optparse import OptionParser
     parser = OptionParser("""\
 usage: %prog [options] [clean|all|test|install]
 
@@ -446,7 +446,7 @@ a location ('--prefix').""")
                       help="Path to XCTest build directory")
     parser.add_option("", "--build-tests", dest="build_tests",
                       action="store_true", help="Deprecated")
-    opts,args = parser.parse_args()
+    opts, args = parser.parse_args()
 
     # When invoked via Xcode, it will automatically be passed a "build action".
     if len(args) == 0:
@@ -462,7 +462,7 @@ a location ('--prefix').""")
     # Compute the build paths.
     build_path = os.path.join(g_project_root, opts.build_path)
     sandbox_path = os.path.join(build_path, ".bootstrap")
-    
+
     # If the action is "clean", just remove the bootstrap and build directories.
     if "clean" in build_actions:
         cmd = ["rm", "-rf", sandbox_path]
@@ -470,7 +470,7 @@ a location ('--prefix').""")
         result = subprocess.call(cmd)
         if result != 0:
             error("build failed with exit status %d" % (result,))
-            
+
         cmd = ["rm", "-rf", build_path]
         note("cleaning self-hosted: %s" % (' '.join(cmd),))
         result = subprocess.call(cmd)
@@ -479,21 +479,21 @@ a location ('--prefix').""")
         raise SystemExit(0)
 
     # All other actions build.
-    
+
     # Create the sandbox.
     mkdir_p(sandbox_path)
 
     # Determine the swift-build-tool to use.
     opts.sbt_path = os.path.abspath(
         opts.sbt_path or get_swift_build_tool_path())
-        
+
     # Due to bug in Xcode where SWIFT_EXEC is not set correctly by downloadable toolchain
     if os.getenv("XCODE_DEFAULT_TOOLCHAIN_OVERRIDE"):
         opts.swiftc = os.path.join(os.getenv("XCODE_DEFAULT_TOOLCHAIN_OVERRIDE"), "usr/bin/swiftc")
 
     # Create or update the bootstrap files.
     create_bootstrap_files(sandbox_path, opts)
-    
+
     # Run the stage1 build.
     cmd = [opts.sbt_path, "-f", os.path.join(sandbox_path, "build.swift-build")]
     if opts.verbose:
@@ -506,19 +506,19 @@ a location ('--prefix').""")
     # Stage the stage1 runtime library.
     #
     # FIXME: Integrate this into the bootstrap build.
-    runtime_module_path,runtime_lib_path = process_runtime_libraries(
+    runtime_module_path, runtime_lib_path = process_runtime_libraries(
         sandbox_path, opts, bootstrap=True)
-        
+
     # Symlink the expected lib location so that we don't yet
     # have to support installation logic in SwiftPM proper
     symlink_path = os.path.join(build_path, "lib", "swift", "pm")
-    if os.path.islink(symlink_path) == False:
+    if not os.path.islink(symlink_path):
         path = os.path.join(build_path, "lib", "swift")
         shutil.rmtree(path, True)
         mkdir_p(path)
         os.symlink(os.path.join(build_path, "debug"), symlink_path)
     symlink_path = os.path.join(build_path, "bin")
-    if os.path.islink(symlink_path) == False:
+    if not os.path.islink(symlink_path):
         path = os.path.join(build_path, "debug")
         shutil.rmtree(path, True)
         os.symlink(path, symlink_path)
@@ -536,7 +536,7 @@ a location ('--prefix').""")
         env_cmd.append("SWIFTPM_EMBED_RPATH=$ORIGIN/../lib/swift/linux")
     else:
         env_cmd.append("SWIFTPM_EMBED_RPATH=@executable_path/../lib/swift/macosx")
-    
+
     cmd = [os.path.join(sandbox_path, "bin", "swift-build")]
     if opts.xctest_path:
         env_cmd.append("SWIFTPM_EXTRA_IMPORT=" + opts.xctest_path)
@@ -547,7 +547,7 @@ a location ('--prefix').""")
         cmd.extend(["-Xlinker", "-rpath", "-Xlinker", opts.xctest_path])
 
     cmd = env_cmd + cmd
-    
+
     note("building self-hosted 'swift-build': %s" % (
         ' '.join(cmd),))
     result = subprocess.call(cmd, cwd=g_project_root)
@@ -557,7 +557,7 @@ a location ('--prefix').""")
     swift_build_path = os.path.join(build_path, "debug", "swift-build")
     swift_test_path = os.path.join(build_path, "debug", "swift-test")
     note("built: %s" % (swift_build_path,))
-  
+
     # If testing, run each of the test bundles.
     if "test" in build_actions:
         # Construct the test environment.
@@ -586,8 +586,8 @@ a location ('--prefix').""")
             result = subprocess.call(cmd)
             if result != 0:
                 error("install failed with exit status %d" % (result,))
-        for (resource_path,is_lib) in [(runtime_module_path, False),
-                                       (runtime_lib_path, True)]:
+        for (resource_path, is_lib) in [(runtime_module_path, False),
+                                        (runtime_lib_path, True)]:
             cmd = ["install"]
             if not is_lib:
                 cmd.extend(["-m", "0644"])
@@ -597,6 +597,6 @@ a location ('--prefix').""")
             result = subprocess.call(cmd)
             if result != 0:
                 error("install failed with exit status %d" % (result,))
-        
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## What's in this pull request?

In https://github.com/apple/swift/pull/1153, @practicalswift added a flake8 config to the Swift project, in order to lint the Python scripts used by that project. This does the same for the package manager.

This includes all the linting rules active on the main Swift repository. It also includes tweaks to `Utilities/bootstrap`, which bring this project in full compliance with those linting rules.

## Why merge this pull request?

This attempts to enforce a common set of rules for Python in the Swift repository, hopefully making the bootstrap script easier to read.

## What are the downsides to merging this pull request?

- There's only one Python script in this repository so far, so the benefits of introducing lint rules is marginal.
- The rules are useless if not enforced, and their enforcement is not part of CI. It's up to contributors to run `flake8` on this repository from time to time to discover violations. This may be more noise than the maintainers of this project would care for.