### PR TITLE
Rename repo root to path

### DIFF
--- a/Sources/Get/Git.swift
+++ b/Sources/Get/Git.swift
@@ -39,13 +39,13 @@ extension Git {
             throw Error.GitCloneFailure(url, dstdir)
         }
 
-        return Repo(root: dstdir)!  //TODO no bangs
+        return Repo(path: dstdir)!  //TODO no bangs
     }
 }
 
 extension Git.Repo {
     var versions: [Version] {
-        let out = (try? popen([Git.tool, "-C", root, "tag", "-l"])) ?? ""
+        let out = (try? popen([Git.tool, "-C", path, "tag", "-l"])) ?? ""
         let tags = out.characters.split(Character.newline)
         let versions = tags.flatMap(Version.init).sort()
         if !versions.isEmpty {
@@ -66,6 +66,6 @@ extension Git.Repo {
      no versions, returns false.
      */
     var versionsArePrefixed: Bool {
-        return (try? popen([Git.tool, "-C", root, "tag", "-l"]))?.hasPrefix("v") ?? false
+        return (try? popen([Git.tool, "-C", path, "tag", "-l"]))?.hasPrefix("v") ?? false
     }
 }

--- a/Sources/Get/Package.swift
+++ b/Sources/Get/Package.swift
@@ -17,8 +17,8 @@ extension Package {
     // FIXME we *always* have a manifest, don't reparse it
 
     static func make(repo repo: Git.Repo) throws -> Package? {
-        guard let origin = repo.origin else { throw Error.NoOrigin(repo.root) }
-        let manifest = try Manifest(path: repo.root, baseURL: origin)
+        guard let origin = repo.origin else { throw Error.NoOrigin(repo.path) }
+        let manifest = try Manifest(path: repo.path, baseURL: origin)
         let pkg = Package(manifest: manifest, url: origin)
         guard Version(pkg.versionString) != nil else { return nil }
         return pkg

--- a/Sources/Get/PackagesDirectory.swift
+++ b/Sources/Get/PackagesDirectory.swift
@@ -31,7 +31,7 @@ extension PackagesDirectory: Fetcher {
 
     func find(url url: String) throws -> Fetchable? {
         for prefix in walk(self.prefix, recursively: false) {
-            guard let repo = Git.Repo(root: prefix) else { continue }  //TODO warn user
+            guard let repo = Git.Repo(path: prefix) else { continue }  //TODO warn user
             guard repo.origin == url else { continue }
             return try Package.make(repo: repo)
         }
@@ -40,7 +40,7 @@ extension PackagesDirectory: Fetcher {
 
     func fetch(url url: String) throws -> Fetchable {
         let dstdir = Path.join(prefix, Package.nameForURL(url))
-        if let repo = Git.Repo(root: dstdir) where repo.origin == url {
+        if let repo = Git.Repo(path: dstdir) where repo.origin == url {
             //TODO need to canonicalize the URL need URL struct
             return try RawClone(path: dstdir)
         }
@@ -57,7 +57,7 @@ extension PackagesDirectory: Fetcher {
             let prefix = Path.join(self.prefix, clone.finalName)
             try mkdir(prefix.parentDirectory)
             try rename(old: clone.path, new: prefix)
-            return try Package.make(repo: Git.Repo(root: prefix)!)!
+            return try Package.make(repo: Git.Repo(path: prefix)!)!
         case let pkg as Package:
             return pkg
         default:

--- a/Sources/Get/RawClone.swift
+++ b/Sources/Get/RawClone.swift
@@ -44,7 +44,7 @@ class RawClone: Fetchable {
     }
 
     var repo: Git.Repo {
-        return Git.Repo(root: path)!
+        return Git.Repo(path: path)!
     }
 
     var version: Version {

--- a/Sources/Utility/Git.swift
+++ b/Sources/Utility/Git.swift
@@ -13,17 +13,17 @@ import func POSIX.getenv
 
 public class Git {
     public class Repo {
-        public let root: String  //TODO rename path
+        public let path: String
 
-        public init?(root: String) {
-            guard let realroot = try? realpath(root) else { return nil }
-            self.root = realroot
-            guard Path.join(root, ".git").isDirectory else { return nil }
+        public init?(path: String) {
+            guard let realroot = try? realpath(path) else { return nil }
+            self.path = realroot
+            guard Path.join(path, ".git").isDirectory else { return nil }
         }
 
         public lazy var origin: String? = { repo in
             do {
-                guard let url = try popen([Git.tool, "-C", repo.root, "config", "--get", "remote.origin.url"]).chuzzle() else {
+                guard let url = try popen([Git.tool, "-C", repo.path, "config", "--get", "remote.origin.url"]).chuzzle() else {
                     return nil
                 }
                 if URL.scheme(url) == nil {
@@ -34,17 +34,17 @@ public class Git {
 
             } catch {
                 //TODO better
-                print("Bad git repository: \(repo.root)", toStream: &stderr)
+                print("Bad git repository: \(repo.path)", toStream: &stderr)
                 return nil
             }
         }(self)
 
         public var branch: String! {
-            return try? popen([Git.tool, "-C", root, "rev-parse", "--abbrev-ref", "HEAD"]).chomp()
+            return try? popen([Git.tool, "-C", path, "rev-parse", "--abbrev-ref", "HEAD"]).chomp()
         }
 
         public func fetch() throws {
-            try system(Git.tool, "-C", root, "fetch", "--tags", "origin", message: nil)
+            try system(Git.tool, "-C", path, "fetch", "--tags", "origin", message: nil)
         }
     }
 

--- a/Tests/Get/GetTests.swift
+++ b/Tests/Get/GetTests.swift
@@ -66,11 +66,11 @@ class GetTests: XCTestCase {
     func testGitRepoInitialization() {
 
         fixture(name: "DependencyResolution/External/Complex") { prefix in
-            XCTAssertNotNil(Git.Repo(root: Path.join(prefix, "app")))
+            XCTAssertNotNil(Git.Repo(path: Path.join(prefix, "app")))
         }
 
-        XCTAssertNil(Git.Repo(root: #file))
-        XCTAssertNil(Git.Repo(root: #file.parentDirectory))
+        XCTAssertNil(Git.Repo(path: #file))
+        XCTAssertNil(Git.Repo(path: #file.parentDirectory))
     }
 }
 

--- a/Tests/Get/RawCloneTests.swift
+++ b/Tests/Get/RawCloneTests.swift
@@ -53,7 +53,7 @@ private func makeGitRepo(dstdir: String, tag: String?, file: StaticString = #fil
         if let tag = tag {
             try popen(["git", "-C", dstdir, "tag", tag])
         }
-        return Git.Repo(root: dstdir)
+        return Git.Repo(path: dstdir)
     }
     catch {
         XCTFail("\(error)", file: file, line: line)


### PR DESCRIPTION
I noticed this line in the code:

```swift
public let root: String  //TODO rename path
```

So I renamed this property to `path`. The tests seem to have the same pass/fail rate as they did before as well.