### PR TITLE
Throw errors for invalid describe input

### DIFF
--- a/Sources/Build/Error.swift
+++ b/Sources/Build/Error.swift
@@ -1,0 +1,14 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+public enum Error: ErrorType {
+    case NoModules
+    case InvalidPlatformPath
+}

--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -19,7 +19,7 @@ import Utility
 public func describe(prefix: String, _ conf: Configuration, _ modules: [Module], _ products: [Product], Xcc: [String], Xld: [String]) throws -> String {
 
     guard modules.count > 0 else {
-        fatalError("No modules input")  //TODO throw
+        throw Error.NoModules
     }
 
     let Xcc = Xcc.flatMap{ ["-Xcc", $0] } + extraImports()
@@ -51,10 +51,11 @@ public func describe(prefix: String, _ conf: Configuration, _ modules: [Module],
             args.append("-enable-testing")
 
         #if os(OSX)
-            //TODO if this fails and is required, throw
             if let platformPath = Resources.path.platformPath {
                 let path = Path.join(platformPath, "Developer/Library/Frameworks")
                 args += ["-F", path]
+            } else {
+                throw Error.InvalidPlatformPath
             }
         #endif
 
@@ -126,10 +127,11 @@ public func describe(prefix: String, _ conf: Configuration, _ modules: [Module],
             #if os(OSX)
                 args += ["-Xlinker", "-bundle"]
 
-                //TODO if this fails and is required, throw
                 if let platformPath = Resources.path.platformPath {
                     let path = Path.join(platformPath, "Developer/Library/Frameworks")
                     args += ["-F", path]
+                } else {
+                    throw Error.InvalidPlatformPath
                 }
 
                 // TODO should be llbuild rules
@@ -140,7 +142,7 @@ public func describe(prefix: String, _ conf: Configuration, _ modules: [Module],
                     }
                 }
             #else
-                //HACK
+                // TODO HACK
                 let hack1 = product.modules.flatMap{ $0 as? TestModule }.first!
                 let hack2 = hack1.sources.root.parentDirectory
                 let hack3 = Path.join(hack2, "LinuxMain.swift")

--- a/Tests/Build/DescribeTests.swift
+++ b/Tests/Build/DescribeTests.swift
@@ -1,0 +1,25 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Build
+import XCTest
+
+final class DescribeTests: XCTestCase {
+    func testDescribingNoModulesThrows() {
+        do {
+            let _ = try describe("foo", .Debug, [], [], Xcc: [], Xld: [])
+            XCTFail("This call should throw")
+        } catch Build.Error.NoModules {
+            XCTAssert(true, "This error should be throw")
+        } catch {
+            XCTFail("No other error should be thrown")
+        }
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,7 +1,7 @@
 
 // we want to generate this.
 // read the AST and generate it
-// ticket: 
+// ticket:
 
 import XCTest
 
@@ -37,4 +37,5 @@ XCTMain([
 	VersionTests(),
 	WalkTests(),
     ModuleMapsTestCase(),
+    DescribeTests(),
 ])


### PR DESCRIPTION
Previously this would either crash or ignore failures, now this throws newly created errors.

Let me know if the structure for these errors isn't what we want. I saw that many other modules also had the `Error.swift` file, so I added that here for new errors as well.