### PR TITLE
[Documentation] Fix "design designs" typo

### DIFF
--- a/Documentation/Internals/README.md
+++ b/Documentation/Internals/README.md
@@ -1,9 +1,9 @@
 # Swift Package Manager Developer Docs
 
-This directory contains documentation on the engineering design designs
-  and internals of the Swift package manager. It is primarily focused at developers
-  interested in working on the Swift package manager, but may also be useful to advanced users
-  wanting to understand exactly how the package manager behaves.
+This directory contains documentation on the engineering design decisions
+and internals of the Swift package manager. It is primarily focused at developers
+interested in working on the Swift package manager, but may also be useful to advanced users
+wanting to understand exactly how the package manager behaves.
 
 * [Swift-based Manifest Format](SwiftBasedManifestFormat.md)
 


### PR DESCRIPTION
Also remove the indent from the trailing lines in the first paragraph.