### PR TITLE
Disable gpgsign in test repos

### DIFF
--- a/Tests/Get/RawCloneTests.swift
+++ b/Tests/Get/RawCloneTests.swift
@@ -48,6 +48,7 @@ private func makeGitRepo(dstdir: String, tag: String?, file: StaticString = #fil
         try popen(["git", "-C", dstdir, "init"])
         try popen(["git", "-C", dstdir, "config", "user.email", "example@example.com"])
         try popen(["git", "-C", dstdir, "config", "user.name", "Example Example"])
+        try popen(["git", "-C", dstdir, "config", "commit.gpgsign", "false"])
         try popen(["git", "-C", dstdir, "add", "."])
         try popen(["git", "-C", dstdir, "commit", "-m", "msg"])
         if let tag = tag {
@@ -115,7 +116,6 @@ extension GitTests: XCTestCaseProvider {
             ("testHasNoVersion", testHasNoVersion),
             ("testCloneShouldNotCrashWihoutTags", testCloneShouldNotCrashWihoutTags),
             ("testCloneShouldCrashWihoutTags", testCloneShouldCrashWihoutTags),
-            
         ]
     }
 }


### PR DESCRIPTION
Previously, if you had this option set in your global gitconfig, it would be inherited for these repos, which would make running `git commit` fail, and subsequently the tests would crash. Now we explicitly disable this for the example repo.

I'm not sure if we want to keep adding one offs when other cases like this come up. I looked through `man git` for a way to not inherit/ignore the global config but didn't see anything (expect for ignoring the system one)