### PR TITLE
Stop matching pre-release suffixed next version

### DIFF
--- a/Sources/PackageDescription/Package.swift
+++ b/Sources/PackageDescription/Package.swift
@@ -31,10 +31,10 @@ public final class Package {
             return Dependency(url, versions)
         }
         public class func Package(url url: String, majorVersion: Int) -> Dependency {
-            return Dependency(url, Version(majorVersion, 0, 0)..<Version(majorVersion + 1, 0, 0))
+            return Dependency(url, Version(majorVersion, 0, 0)..<Version(majorVersion, .max, .max))
         }
         public class func Package(url url: String, majorVersion: Int, minor: Int) -> Dependency {
-            return Dependency(url, Version(majorVersion, minor, 0)..<Version(majorVersion, minor + 1, 0))
+            return Dependency(url, Version(majorVersion, minor, 0)..<Version(majorVersion, minor, .max))
         }
         public class func Package(url url: String, _ version: Version) -> Dependency {
             return Dependency(url, version...version)

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -24,6 +24,7 @@ XCTMain([
     MiscellaneousTestCase(),
     ManifestParsertest.PackageTests(),
 	ModuleTests(),
+    PackageDescriptiontest.PackageTests(),
     PackageTypetest.PackageTests(),
 	PathTests(),
 	RelativePathTests(),

--- a/Tests/PackageDescription/PackageTests.swift
+++ b/Tests/PackageDescription/PackageTests.swift
@@ -1,0 +1,42 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+@testable import PackageDescription
+import XCTest
+
+class PackageTests: XCTestCase {
+
+    func testMatchDependencyWithPreReleaseVersion() {
+
+        // Tests matching dependency with pre-release suffixed version
+        // Refs: https://bugs.swift.org/browse/SR-787
+
+        let majorVersionSpecified: Package.Dependency = .Package(url: "", majorVersion: 1)
+        XCTAssertFalse(majorVersionSpecified.versionRange ~= "2.0.0-alpha")
+        XCTAssertFalse(majorVersionSpecified.versionRange ~= "2.0.0")
+
+        let majorAndMinorVersionSpecified: Package.Dependency = .Package(url: "", majorVersion: 0, minor: 10)
+        XCTAssertFalse(majorAndMinorVersionSpecified.versionRange ~= "0.11.0-test")
+        XCTAssertFalse(majorAndMinorVersionSpecified.versionRange ~= "0.11.0")
+    }
+
+}
+
+
+#if os(Linux)
+extension PackageTests: XCTestCaseProvider {
+    var allTests : [(String, () throws -> Void)] {
+        return [
+            ("testMatchDependencyWithPreReleaseVersion", testMatchDependencyWithPreReleaseVersion),
+
+        ]
+    }
+}
+#endif


### PR DESCRIPTION
Fix https://bugs.swift.org/browse/SR-787