### PR TITLE
Add #if for XCTestCaseProvider conformance

### DIFF
--- a/Tests/Build/DescribeTests.swift
+++ b/Tests/Build/DescribeTests.swift
@@ -24,7 +24,7 @@ final class DescribeTests: XCTestCase {
     }
 }
 
-
+#if os(Linux)
 extension DescribeTests: XCTestCaseProvider {
     var allTests: [(String, () throws -> Void)] {
         return [
@@ -32,3 +32,4 @@ extension DescribeTests: XCTestCaseProvider {
         ]
     }
 }
+#endif


### PR DESCRIPTION
This was breaking `Utilities/bootstrap test` on OSX

```
╰─$ Utilities/bootstrap test
bootstrap: note: building stage1: /Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin/swift-build-tool -f /Users/aciid/mycode/swift.org/swift-package-manager/.build/.bootstrap/build.swift-build
bootstrap: note: building self-hosted 'swift-build': env SWIFT_EXEC=swiftc SWIFT_BUILD_TOOL=/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin/swift-build-tool SWIFT_BUILD_PATH=/Users/aciid/mycode/swift.org/swift-package-manager/.build SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk SWIFTPM_EMBED_RPATH=@executable_path/../lib/swift/macosx /Users/aciid/mycode/swift.org/swift-package-manager/.build/.bootstrap/bin/swift-build
bootstrap: note: built: /Users/aciid/mycode/swift.org/swift-package-manager/.build/debug/swift-build
Compiling Swift Module 'Buildtest' (1 sources)
/Users/aciid/mycode/swift.org/swift-package-manager/Tests/Build/DescribeTests.swift:28:26: error: use of undeclared type 'XCTestCaseProvider'
extension DescribeTests: XCTestCaseProvider {
                         ^~~~~~~~~~~~~~~~~~
<unknown>:0: error: build had 1 command failures
error: exit(1): /Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin/swift-build-tool -f /Users/aciid/mycode/swift.org/swift-package-manager/.build/debug.yaml test
bootstrap: error: tests failed with exit status 1
```