### PR TITLE
Refactor enum Error to ModuleError

### DIFF
--- a/Sources/Transmute/Error.swift
+++ b/Sources/Transmute/Error.swift
@@ -11,7 +11,7 @@
 import PackageType
 
 extension Package {
-    public enum Error: ErrorType {
+    public enum ModuleError: ErrorType {
         case NoModules(Package)
         case ModuleNotFound(String)
         case InvalidLayout(InvalidLayoutType)

--- a/Sources/Transmute/Package+modules.swift
+++ b/Sources/Transmute/Package+modules.swift
@@ -23,7 +23,7 @@ extension Package {
 
         if srcroot != path {
             guard walk(path, recursively: false).filter(isValidSource).isEmpty else {
-                throw Error.InvalidLayout(.InvalidLayout)
+                throw ModuleError.InvalidLayout(.InvalidLayout)
             }
         }
 
@@ -31,7 +31,7 @@ extension Package {
 
         if maybeModules.count == 1 && maybeModules[0] != srcroot {
             guard walk(srcroot, recursively: false).filter(isValidSource).isEmpty else {
-                throw Error.InvalidLayout(.InvalidLayout)
+                throw ModuleError.InvalidLayout(.InvalidLayout)
             }
         }
 
@@ -40,7 +40,7 @@ extension Package {
             do {
                 modules = [SwiftModule(name: self.name, sources: try sourcify(srcroot))]
             } catch Module.Error.NoSources {
-                throw Error.NoModules(self)
+                throw ModuleError.NoModules(self)
             }
         } else {
             modules = try maybeModules.map(sourcify).map { sources in
@@ -65,7 +65,7 @@ extension Package {
                 switch $0 {
                 case .Target(let name):
                     guard let module = moduleForName(name) else {
-                        throw Error.ModuleNotFound(name)
+                        throw ModuleError.ModuleNotFound(name)
                     }
                     return module
                 }

--- a/Sources/Transmute/Package+sourceRoot.swift
+++ b/Sources/Transmute/Package+sourceRoot.swift
@@ -30,7 +30,7 @@ extension Package {
             return viableRoots[0]
         default:
             // eg. there is a `Sources' AND a `src'
-            throw Error.InvalidLayout(.MultipleSourceRoots(viableRoots))
+            throw ModuleError.InvalidLayout(.MultipleSourceRoots(viableRoots))
         }
     }
 }


### PR DESCRIPTION
Rename the enum `Error` in extension of PackageType.Package since it is already declared here : https://github.com/apple/swift-package-manager/blob/master/Sources/PackageType/Package.swift#L27

currently the project builds because of this bug : https://bugs.swift.org/browse/SR-808
(fails to build if any of those error cases is in catch statements)