### PR TITLE
Add support for empty source packages

### DIFF
--- a/Fixtures/Miscellaneous/ExactDependencies/EmptyWithDependency/Package.swift
+++ b/Fixtures/Miscellaneous/ExactDependencies/EmptyWithDependency/Package.swift
@@ -1,0 +1,7 @@
+import PackageDescription
+
+let package = Package(
+    name: "EmptyWithDependency",
+    dependencies: [
+		.Package(url: "../FooLib2", majorVersion: 1),
+	])

--- a/Sources/swift-build/main.swift
+++ b/Sources/swift-build/main.swift
@@ -44,7 +44,7 @@ do {
         case .Build(let conf):
             let dirs = try directories()
             let packages = try fetch(dirs.root)
-            let (modules, products) = try transmute(packages)
+            let (modules, products) = try transmute(packages, rootdir: dirs.root)
             let yaml = try describe(dirs.build, conf, modules, products, Xcc: opts.Xcc, Xld: opts.Xld, Xswiftc: opts.Xswiftc)
             try build(YAMLPath: yaml, target: "default")
 

--- a/Tests/Functional/TestInvalidLayouts.swift
+++ b/Tests/Functional/TestInvalidLayouts.swift
@@ -14,13 +14,6 @@ import func POSIX.unlink
 
 class InvalidLayoutsTestCase: XCTestCase {
 
-    func testNoTargets() {
-        fixture(name: "InvalidLayouts/NoTargets") { prefix in
-            XCTAssertFileExists(prefix, "Package.swift")
-            XCTAssertBuildFails(prefix)
-        }
-    }
-
     func testMultipleRoots() {
         fixture(name: "InvalidLayouts/MultipleRoots1") { prefix in
             XCTAssertBuildFails(prefix)

--- a/Tests/Functional/TestMiscellaneous.swift
+++ b/Tests/Functional/TestMiscellaneous.swift
@@ -31,6 +31,25 @@ class MiscellaneousTestCase: XCTestCase {
         }
     }
 
+    func testPackageWithNoSources() {
+
+        // Tests a package with no source files
+
+        fixture(name: "Miscellaneous/Empty") { prefix in
+            XCTAssertBuilds(prefix)
+        }
+    }
+
+    func testPackageWithNoSourcesButDependency() {
+
+        // Tests a package with no source files but dependency, dependency should build.
+
+        fixture(name: "Miscellaneous/ExactDependencies") { prefix in
+            XCTAssertBuilds(prefix, "EmptyWithDependency")
+            XCTAssertFileExists(prefix, "EmptyWithDependency/.build/debug/FooLib2.swiftmodule")
+        }
+    }
+
     func testManifestExcludes1() {
 
         // Tests exclude syntax where no target customization is specified

--- a/Tests/Functional/TestValidLayouts.swift
+++ b/Tests/Functional/TestValidLayouts.swift
@@ -145,7 +145,6 @@ extension DependencyResolutionTestCase {
 extension InvalidLayoutsTestCase {
     static var allTests : [(String, InvalidLayoutsTestCase -> () throws -> Void)] {
         return [
-            ("testNoTargets", testNoTargets),
             ("testMultipleRoots", testMultipleRoots),
             ("testInvalidLayout1", testInvalidLayout1),
             ("testInvalidLayout2", testInvalidLayout2),
@@ -160,6 +159,8 @@ extension MiscellaneousTestCase {
     static var allTests : [(String, MiscellaneousTestCase -> () throws -> Void)] {
         return [
             ("testPrintsSelectedDependencyVersion", testPrintsSelectedDependencyVersion),
+            ("testPackageWithNoSources", testPackageWithNoSources),
+            ("testPackageWithNoSourcesButDependency", testPackageWithNoSourcesButDependency),
             ("testManifestExcludes1", testManifestExcludes1),
             ("testManifestExcludes2", testManifestExcludes2),
             ("testManifestExcludes3", testManifestExcludes3),

--- a/Tests/Transmute/ModuleTests.swift
+++ b/Tests/Transmute/ModuleTests.swift
@@ -201,7 +201,7 @@ extension ModuleTests {
             let prefix = Path.join(prefix, "App")
             let manifest = try Manifest(path: prefix, baseURL: prefix)
             let packages = try get(manifest)
-            let (modules, _) = try transmute(packages)
+            let (modules, _) = try transmute(packages, rootdir: prefix)
 
             XCTAssertEqual(modules.count, 3)
             XCTAssertEqual(recursiveDependencies(modules).count, 3)
@@ -212,7 +212,7 @@ extension ModuleTests {
             let prefix = Path.join(prefix, "App")
             let manifest = try Manifest(path: prefix, baseURL: prefix)
             let packages = try get(manifest)
-            let (modules, _) = try transmute(packages)
+            let (modules, _) = try transmute(packages, rootdir: prefix)
 
             XCTAssertEqual(modules.count, 2)
             XCTAssertTrue(modules.first is CModule)


### PR DESCRIPTION
Fixes https://bugs.swift.org/browse/SR-793

I am not sure if rootdir should be passed to transmute method, maybe Package should have a property isRoot ?