### PR TITLE
Deconflict multiple tests by using package name

### DIFF
--- a/Sources/Transmute/Package+products.swift
+++ b/Sources/Transmute/Package+products.swift
@@ -28,9 +28,8 @@ extension Package {
 
         if !testModules.isEmpty {
             let modules: [SwiftModule] = testModules.map{$0} // or linux compiler crash (2016-02-03)
-            //TODO name should be package name
-            //TODO and then we should prefix all modules with their package probably
-            let product = Product(name: "Package", type: .Test, modules: modules)
+            //TODO we should prefix all modules with their package probably
+            let product = Product(name: self.name, type: .Test, modules: modules)
             products.append(product)
         }
 


### PR DESCRIPTION
rather than "Package" in the construction of "Package.test"