### PR TITLE
Enable Travis for first-pass PR tests/feedback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ sudo: required
 dist: trusty
 osx_image: xcode7.3
 install:
+  - echo "DEVELOPMENT-SNAPSHOT-2016-02-25-a" > .swift-version
   - curl -sL https://gist.github.com/kylef/5c0475ff02b7c7671d2a/raw/621ef9b29bbb852fdfd2e10ed147b321d792c1e4/swiftenv-install.sh | bash
 script:
   - . ~/.swiftenv/init

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 script:
   - . ~/.swiftenv/init
   - Utilities/bootstrap
-  - swift test
+  - .build/bin/swift-test
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+os:
+  - linux
+  - osx
+language: generic
+sudo: required
+dist: trusty
+osx_image: xcode7.3
+install:
+  - curl -sL https://gist.github.com/kylef/5c0475ff02b7c7671d2a/raw/621ef9b29bbb852fdfd2e10ed147b321d792c1e4/swiftenv-install.sh | bash
+script:
+  - . ~/.swiftenv/init
+  - Utilities/bootstrap
+  - swift test
+notifications:
+  email:
+    on_success: never
+    on_failure: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ language: generic
 sudo: required
 dist: trusty
 osx_image: xcode7.3
+env:
+  - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2016-02-25-a
 install:
-  - echo "DEVELOPMENT-SNAPSHOT-2016-02-25-a" > .swift-version
-  - curl -sL https://gist.github.com/kylef/5c0475ff02b7c7671d2a/raw/621ef9b29bbb852fdfd2e10ed147b321d792c1e4/swiftenv-install.sh | bash
+  - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/02090c7ede5a637b76e6df1710e83cd0bbe7dcdf/swiftenv-install.sh)"
 script:
-  - . ~/.swiftenv/init
   - Utilities/bootstrap
   - .build/bin/swift-test
 notifications:


### PR DESCRIPTION
I thought it might be worth it to start a discussion of automatic testing of open PRs on this repo. I understand the reasons why the current Jenkins build needs to be triggered by someone from Apple, but I believe that quicker turnaround time could lead to faster handling of PRs.

I added a simple `.travis.yml` file which runs SwiftPM tests on both OS X and Linux in total of 7 minutes (see my fork of SwiftPM [passing tests here](https://travis-ci.org/czechboy0/swift-package-manager/builds/112577136)) from when a developer pushes her code. I recommend that we merge this and enable Travis for this repo (one of the owners of this repo need to do that) as the **first** stage of PR validation.

I think this can be valuable to people who e.g. develop on a Mac and don't test locally on Linux - Travis would fail and the dev can go back and fix the issue before anyone else spends their time looking over the PR/triggering manual CI. Also, going forward we'll have more platforms to test on and this would scale nicely with that (Travis builds run in parallel).

The updated workflow would be
1. dev opens a PR or pushes further code to an open PR
2. Travis tests the code on both platforms (including any new in the future/can test multiple Swift versions as well) and reports back
3. in case of test failures, goto 1
4. Travis gives :+1:, reviewer looks over the code & gives comments, if that requires further pushes, goto 1
5. once reviewer gives :+1:, he kicks off a Jenkins build with `please test`
6. in case of test failures, changes needed, goto 1
7. Jenkins gives :+1:, reviewer merges PR
8. profit :fireworks: 

If this goes against the direction of what is planned here, feel free to reject this PR, it's just a suggestion.