### PR TITLE
Throw error if no test module

### DIFF
--- a/Sources/swift-test/Error.swift
+++ b/Sources/swift-test/Error.swift
@@ -10,6 +10,7 @@ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 enum Error: ErrorType {
     case DebugYAMLNotFound
+    case TestsExecutableNotFound
 }
 
 extension Error: CustomStringConvertible {
@@ -17,6 +18,8 @@ extension Error: CustomStringConvertible {
         switch self {
         case .DebugYAMLNotFound:
             return "build the package using `swift build` before running tests"
+        case .TestsExecutableNotFound:
+            return "no tests found to execute, create a test-module in `Tests` directory"
         }
     }
 }

--- a/Sources/swift-test/main.swift
+++ b/Sources/swift-test/main.swift
@@ -27,7 +27,7 @@ do {
     guard yamlPath.exists else { throw Error.DebugYAMLNotFound }
     
     try build(YAMLPath: yamlPath, target: "test")
-    let success = test(dir.build, "debug")
+    let success = try test(dir.build, "debug")
     exit(success ? 0 : 1)
 
 } catch {


### PR DESCRIPTION
When no Test modules are present, running `swift test` produces this error :
```
Usage: xctest [-XCTest All | <TestCaseClassName/testMethodName>] <path of unit to be tested>

Failure: No test bundle found at path `/Users/ankit/mycode/temp/.build/debug/Package.xctest`

Displaying process arguments and environment for debugging purposes:
Arguments: (
    "/Applications/Xcode.app/Contents/Developer/usr/bin/xctest",
    "/Users/ankit/mycode/temp/.build/debug/Package.xctest"
)
Environment: {
    HOME = "/Users/ankit";
    PATH = "/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
    "SPM_INSTALL_PATH" = "/Users/ankit/mycode/temp/.build";
    "__CF_USER_TEXT_ENCODING" = "0x1F5:0x0:0x0";
}
```

This patch will show this error instead :
```
error: no tests found to execute, create a test-module in `Tests` directory
```
by checking if `Package.xctest` or `test-Package` exists. 

--

It might be possible to detect if there are no test targets during build phase of tests if in future swift-build-tools reports some error while building an empty target.
