### PR TITLE
Add to Platform arguments the default Homebrew search paths

### DIFF
--- a/Sources/Build/misc.swift
+++ b/Sources/Build/misc.swift
@@ -17,6 +17,8 @@ func platformArgs() -> [String] {
 
     #if os(OSX)
         args += ["-target", "x86_64-apple-macosx10.10"]
+        args += ["-Xcc", "-I/usr/local/include"]
+        args += ["-Xlinker", "-L/usr/local/lib"]
 
         if let sysroot = Resources.path.sysroot {
             args += ["-sdk", sysroot]


### PR DESCRIPTION
Since many user-level installations of C libraries are installed in /usr/local/include and /usr/local/lib this commit adds these search paths to Swift Package Manager. [Homebrew](http://brew.sh/) will install these libraries to /usr/local.  User installs will typically install it to /usr/local. However, Macports will install it to /opt/local so this patch would not handle this case.

The goal of this PR is to allow users to not need to specify the search paths:

`swift build -Xswiftc -I/usr/local/include -Xlinker -L/usr/local/lib`

and instead build using:

`swift build`

This could be applicable also, in some cases to the Linux environment, not just Mac OS X.