### PR TITLE
Add -h, --help to swift test and send arguments to -XCTest directly

### DIFF
--- a/Sources/Multitool/Error.swift
+++ b/Sources/Multitool/Error.swift
@@ -15,7 +15,7 @@ import libc
 
 public enum CommandLineError: ErrorType {
     public enum UsageMode {
-        case Print, Imply
+        case Print, ImplySwiftBuild, ImplySwiftTest
     }
     case InvalidUsage(String, UsageMode)
 }
@@ -40,8 +40,10 @@ extension Error: CustomStringConvertible {
 
         if isatty(fileno(libc.stdin)) {
             switch mode {
-            case .Imply:
+            case .ImplySwiftBuild:
                 print("enter `swift build --help' for usage information", toStream: &stderr)
+            case .ImplySwiftTest:
+                print("enter `swift test --help' for usage information", toStream: &stderr)
             case .Print:
                 print("", toStream: &stderr)
                 usage { print($0, toStream: &stderr) }

--- a/Sources/swift-build/usage.swift
+++ b/Sources/swift-build/usage.swift
@@ -99,7 +99,7 @@ func parse(commandLineArguments args: [String]) throws -> (Mode, Options) {
             case (let ignoredArgument?, .Usage):
                 throw CommandLineError.InvalidUsage("Both --help and \(ignoredArgument) specified", .Print)
             case (let oldMode?, let newMode):
-                throw CommandLineError.InvalidUsage("Multiple modes specified: \(oldMode), \(newMode)", .Imply)
+                throw CommandLineError.InvalidUsage("Multiple modes specified: \(oldMode), \(newMode)", .ImplySwiftBuild)
             case (nil, .Build):
                 switch try cruncher.peek() {
                 case .Name("debug")?:
@@ -109,7 +109,7 @@ func parse(commandLineArguments args: [String]) throws -> (Mode, Options) {
                     mode = .Build(.Release)
                     cruncher.postPeekPop()
                 case .Name(let name)?:
-                    throw CommandLineError.InvalidUsage("Unknown build configuration: \(name)", .Imply)
+                    throw CommandLineError.InvalidUsage("Unknown build configuration: \(name)", .ImplySwiftBuild)
                 default:
                     break
                 }
@@ -124,7 +124,7 @@ func parse(commandLineArguments args: [String]) throws -> (Mode, Options) {
                     mode = .Init(.Library)
                     cruncher.postPeekPop()
                 case .Name(let name)?:
-                    throw CommandLineError.InvalidUsage("Unknown init mode: \(name)", .Imply)
+                    throw CommandLineError.InvalidUsage("Unknown init mode: \(name)", .ImplySwiftBuild)
                 default:
                     break
                 }
@@ -137,7 +137,7 @@ func parse(commandLineArguments args: [String]) throws -> (Mode, Options) {
                     mode = .Clean(.Dist)
                     cruncher.postPeekPop()
                 case .Name(let name)?:
-                    throw CommandLineError.InvalidUsage("Unknown clean mode: \(name)", .Imply)
+                    throw CommandLineError.InvalidUsage("Unknown clean mode: \(name)", .ImplySwiftBuild)
                 default:
                     break
                 }
@@ -153,14 +153,14 @@ func parse(commandLineArguments args: [String]) throws -> (Mode, Options) {
                 cruncher.postPeekPop()
                 opts.chdir = name
             default:
-                throw CommandLineError.InvalidUsage("Option `--chdir' requires subsequent directory argument", .Imply)
+                throw CommandLineError.InvalidUsage("Option `--chdir' requires subsequent directory argument", .ImplySwiftBuild)
             }
 
         case .Switch(.Verbose):
             opts.verbosity += 1
 
         case .Name(let name):
-            throw CommandLineError.InvalidUsage("Unknown argument: \(name)", .Imply)
+            throw CommandLineError.InvalidUsage("Unknown argument: \(name)", .ImplySwiftBuild)
 
         case .Switch(.Xcc):
             opts.Xcc.append(try cruncher.rawPop())
@@ -271,14 +271,14 @@ private struct Cruncher {
         }
         
         guard !arg.hasPrefix("-") else {
-            throw CommandLineError.InvalidUsage("unknown argument: \(arg)", .Imply)
+            throw CommandLineError.InvalidUsage("unknown argument: \(arg)", .ImplySwiftBuild)
         }
 
         return .Name(arg)
     }
 
     mutating func rawPop() throws -> String {
-        guard args.count > 0 else { throw CommandLineError.InvalidUsage("expected argument", .Imply) }
+        guard args.count > 0 else { throw CommandLineError.InvalidUsage("expected argument", .ImplySwiftBuild) }
         return args.removeFirst()
     }
 

--- a/Sources/swift-test/main.swift
+++ b/Sources/swift-test/main.swift
@@ -18,18 +18,26 @@ public var globalSymbolInMainBinary = 0
 Resources.initialize(&globalSymbolInMainBinary)
 
 do {
-    let dir = try directories()
+    let args = Array(Process.arguments.dropFirst())
+    let mode = try parse(commandLineArguments: args)
 
-    //FIXME this is a hack for SwiftPM’s own tests
-    setenv("SPM_INSTALL_PATH", dir.build, 0)
+    switch mode {
+    case .Usage:
+        usage()
+    case .Run(let xctestArg):
+        let dir = try directories()
+        
+        //FIXME this is a hack for SwiftPM’s own tests
+        setenv("SPM_INSTALL_PATH", dir.build, 0)
 
-    let yamlPath = Path.join(dir.build, "debug.yaml")
-    guard yamlPath.exists else { throw Error.DebugYAMLNotFound }
+        let yamlPath = Path.join(dir.build, "debug.yaml")
+        guard yamlPath.exists else { throw Error.DebugYAMLNotFound }
+
+        try build(YAMLPath: yamlPath, target: "test")
+        let success = try test(dir.build, "debug", xctestArg: xctestArg)
+        exit(success ? 0 : 1)
+    }
     
-    try build(YAMLPath: yamlPath, target: "test")
-    let success = try test(dir.build, "debug")
-    exit(success ? 0 : 1)
-
 } catch {
-    handleError(error, usage: { _ in })
+    handleError(error, usage: usage)
 }

--- a/Sources/swift-test/test.swift
+++ b/Sources/swift-test/test.swift
@@ -11,7 +11,7 @@
 import PackageType
 import Utility
 
-func test(path: String..., args: String? = nil) throws -> Bool {
+func test(path: String..., xctestArg: String? = nil) throws -> Bool {
     let path = Path.join(path)
     var args: [String] = []
     let testsPath: String
@@ -19,8 +19,11 @@ func test(path: String..., args: String? = nil) throws -> Bool {
 #if os(OSX)
     testsPath = Path.join(path, "Package.xctest")
     args = ["xcrun", "xctest"]
-    args += Process.arguments.dropFirst()
+    if let xctestArg = xctestArg {
+        args += ["-XCTest", xctestArg]
+    }
 #else
+    //FIXME: Pass xctestArg when swift-corelibs-xctest supports it
     testsPath = Path.join(path, "test-Package")
 #endif
 

--- a/Sources/swift-test/usage.swift
+++ b/Sources/swift-test/usage.swift
@@ -1,0 +1,47 @@
+/*
+This source file is part of the Swift.org open source project
+
+Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See http://swift.org/LICENSE.txt for license information
+See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import enum Multitool.CommandLineError
+
+func usage(print: (String) -> Void = { print($0) }) {
+    //.........10.........20.........30.........40.........50.........60.........70..
+    print("OVERVIEW: Build and run tests")
+    print("")
+    print("USAGE: swift test [options]")
+    print("")
+    print("OPTIONS:")
+    print("  TestModule.TestCase         Run a test case subclass")
+    print("  TestModule.TestCase/test1   Run a specific test method")
+}
+
+enum Mode {
+    case Usage
+    case Run(String)
+}
+
+func parse(commandLineArguments args: [String]) throws -> Mode {
+
+    if args.count == 0 {
+        return .Run("All")
+    }
+
+    guard let argument = args.first where args.count == 1 else {
+        throw CommandLineError.InvalidUsage("Unknown arguments: \(args)", .ImplySwiftTest)
+    }
+
+    switch argument {
+    case "--help", "-h":
+        return .Usage
+    case argument where argument.hasPrefix("-"):
+        throw CommandLineError.InvalidUsage("Unknown argument: \(argument)", .ImplySwiftTest)
+    default:
+        return .Run(argument)
+    }
+}


### PR DESCRIPTION
* adds `-h` and `--help` to `swift test`
* passes arguments for running specific tests directly to `xctest` without adding `-XCTest` as per [proposal](https://github.com/apple/swift-evolution/blob/master/proposals/0019-package-manager-testing.md)

examples:

```
$ swift test -h
OVERVIEW: Build and run tests

USAGE: swift test [options]

OPTIONS:
  TestModule.TestCase         Run a test case subclass
  TestModule.TestCase/test1   Run a specific test method
```

```
$ swift test TestModtest.TestMod/testFoo
Test Suite 'Selected tests' started at 2016-03-03 15:44:05.393
Test Suite 'TestMod' started at 2016-03-03 15:44:05.394
Test Case '-[TestModtest.TestMod testFoo]' started.
testing foo
Test Case '-[TestModtest.TestMod testFoo]' passed (0.001 seconds).
Test Suite 'TestMod' passed at 2016-03-03 15:44:05.395.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'Selected tests' passed at 2016-03-03 15:44:05.395.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (0.002) seconds
```