### PR TITLE
Use -Xlinker forwarding instead of the SWIFTPM_EMBED_RPATH env-var

### DIFF
--- a/Sources/Build/misc.swift
+++ b/Sources/Build/misc.swift
@@ -23,17 +23,6 @@ func platformArgs() -> [String] {
         }
     #endif
 
-    // We support a custom override in conjunction with the
-    // bootstrap script to allow embedding an appropriate RPATH for
-    // the package manager tools themselves on Linux, so they can be
-    // relocated with the Swift compiler.
-
-    //TODO replace with -Xlinker forwarding since we have that now
-
-    if let rpath = getenv("SWIFTPM_EMBED_RPATH") {
-        args += ["-Xlinker", "-rpath", "-Xlinker", rpath]
-    }
-
     return args
 }
 

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -532,12 +532,14 @@ def main():
                "SWIFT_BUILD_PATH=" + build_path]
     if args.sysroot:
         env_cmd.append("SYSROOT=" + args.sysroot)
-    # On Linux, we need to embed an RPATH so swift-{build,get} can find the core
+
+    # We need to embed an RPATH so swift-{build,test} can find the core 
     # libraries.
     if platform.system() == 'Linux':
-        env_cmd.append("SWIFTPM_EMBED_RPATH=$ORIGIN/../lib/swift/linux")
+        embed_rpath = "$ORIGIN/../lib/swift/linux"
     else:
-        env_cmd.append("SWIFTPM_EMBED_RPATH=@executable_path/../lib/swift/macosx")
+        embed_rpath = "@executable_path/../lib/swift/macosx"
+    cmd.extend(["-Xlinker", "-rpath", "-Xlinker", embed_rpath])
 
     cmd = [os.path.join(sandbox_path, "bin", "swift-build")]
     if args.xctest_path:


### PR DESCRIPTION
I found this TODO while trying to understand some behavior I was seeing, and thought I'd clean it up.