### PR TITLE
Refactor describe(), add llbuild tool types

### DIFF
--- a/Sources/Build/YAML.swift
+++ b/Sources/Build/YAML.swift
@@ -8,56 +8,35 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import struct Utility.Path
-import struct libc.FILE
-import func libc.fclose
-import POSIX
+protocol YAMLRepresentable {
+    var YAML: String { get }
+}
 
-class YAML {
-    let path: String
-    private let fp: UnsafeMutablePointer<FILE>
-
-    init(path: String...) throws {
-        self.path = Path.join(path)
-        fp = try fopen(self.path, mode: .Write)
-    }
-
-    func close() {
-        fclose(fp)
-    }
-
-    func write(anys: Any...) throws {
-        var anys = anys
-        try fputs(anys.removeFirst() as! String, fp)
-        if !anys.isEmpty {
-            try fputs(anys.map(toYAML).joinWithSeparator(""), fp)
-        }
-        try fputs("\n", fp)
-
+extension String: YAMLRepresentable {
+    var YAML: String {
+        if self == "" { return "\"\"" }
+        return self
     }
 }
 
-private func toYAML(any: Any) -> String {
-
-    func quote(input: String) -> String {
-        for c in input.characters {
-            if c == "@" || c == " " || c == "-" {
-                return "\"\(input)\""
-            }
-        }
-        return input
+extension Bool: YAMLRepresentable {
+    var YAML: String {
+        if self { return "true" }
+        return "false"
     }
+}
 
-    switch any {
-    case let string as String where string == "":
-        return "\"\""
-    case let string as String:
-        return string
-    case let array as [String]:
-        return "[" + array.map(quote).joinWithSeparator(", ") + "]"
-    case let bool as Bool:
-        return bool ? "true" : "false"
-    default:
-        fatalError("Unimplemented YAML type")
+extension Array where Element: YAMLRepresentable {
+    var YAML: String {
+        func quote(input: String) -> String {
+            for c in input.characters {
+                if c == "@" || c == " " || c == "-" {
+                    return "\"\(input)\""
+                }
+            }
+            return input
+        }
+        let stringArray = self.flatMap { String($0) }
+        return "[" + stringArray.map(quote).joinWithSeparator(", ") + "]"
     }
 }

--- a/Sources/Build/llbuild.swift
+++ b/Sources/Build/llbuild.swift
@@ -1,0 +1,126 @@
+/*
+This source file is part of the Swift.org open source project
+
+Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See http://swift.org/LICENSE.txt for license information
+See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+protocol ToolType {
+    var name: String { get }
+    var inputs: [String] { get }
+    var outputs: [String] { get }
+    ///YAML representation of the tool
+    var llbuildYAML: String { get }
+}
+
+protocol ShellToolType: ToolType {
+    var description: String { get }
+    var args: [String] { get }
+}
+
+extension ShellToolType {
+    
+    var name: String {
+        return "shell"
+    }
+    
+    var llbuildYAML: String {
+        var yaml = ""
+        yaml += "    tool: " + name.YAML + "\n"
+        yaml += "    description: " + description.YAML + "\n"
+        yaml += "    inputs: " + inputs.YAML + "\n"
+        yaml += "    outputs: " + outputs.YAML + "\n"
+        yaml += "    args: " + args.YAML + "\n"
+        return yaml
+    }
+}
+
+struct ShellTool: ShellToolType {
+    let description: String
+    let inputs: [String]
+    let outputs: [String]
+    let args: [String]
+}
+
+protocol SwiftcToolType: ToolType {
+    var executable: String { get }
+    var moduleName: String { get }
+    var moduleOutputPath: String { get }
+    var importPaths: String { get }
+    var tempsPath: String { get }
+    var objects: [String] { get }
+    var otherArgs: [String] { get }
+    var sources: [String] { get }
+    var isLibrary: Bool { get }
+}
+
+extension SwiftcToolType {
+    
+    var name: String {
+        return "swift-compiler"
+    }
+    
+    var llbuildYAML: String {
+        var yaml = ""
+        yaml += "    tool: " + name.YAML + "\n"
+        yaml += "    executable: " + executable.YAML + "\n"
+        yaml += "    module-name: " + moduleName.YAML + "\n"
+        yaml += "    module-output-path: " + moduleOutputPath.YAML + "\n"
+        yaml += "    inputs: " + inputs.YAML + "\n"
+        yaml += "    outputs: " + outputs.YAML + "\n"
+        yaml += "    import-paths: " + importPaths.YAML + "\n"
+        yaml += "    temps-path: " + tempsPath.YAML + "\n"
+        yaml += "    objects: " + objects.YAML + "\n"
+        yaml += "    other-args: " + otherArgs.YAML + "\n"
+        yaml += "    sources: " + sources.YAML + "\n"
+        yaml += "    is-library: " + isLibrary.YAML + "\n"
+        return yaml
+    }
+}
+
+struct SwiftcTool: SwiftcToolType {
+    let inputs: [String]
+    let outputs: [String]
+    let executable: String
+    let moduleName: String
+    let moduleOutputPath: String
+    let importPaths: String
+    let tempsPath: String
+    let objects: [String]
+    let otherArgs: [String]
+    let sources: [String]
+    let isLibrary: Bool
+}
+
+typealias Command = (name: String, tool: ToolType)
+
+struct Target {
+    let name: String
+    let commands: [Command]
+}
+
+func llbuildYAML(targets targets: [Target]) -> String {
+    
+    var yaml = ""
+    yaml += "client:" + "\n"
+    yaml += "  name: swift-build" + "\n"
+    yaml += "tools: {}" + "\n"
+    
+    yaml += "targets:" + "\n"
+    for target in targets {
+        yaml += "  \(target.name): " + target.commands.map{$0.name}.YAML + "\n"
+    }
+    
+    yaml += "commands: " + "\n"
+    
+    let commands = targets.reduce([Command]()) { $0 + $1.commands }
+    for command in commands {
+        yaml += "  " + command.name + ":" + "\n"
+        yaml += command.tool.llbuildYAML
+    }
+    
+    return yaml
+}


### PR DESCRIPTION
This PR adds models for the llbuild tools used by swift-build and method which can take array of llbuild Targets to produce YAML.
