### PR TITLE
[bootstrap] Preemptively add argument for Foundation [AsyncXCTest 3/6]

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -449,6 +449,8 @@ def main():
                         default="/usr/local", metavar="PATH")
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="use verbose output")
+    parser.add_argument("--foundation", dest="foundation_path",
+                        help="Path to Foundation build directory")
     parser.add_argument("--xctest", dest="xctest_path",
                         help="Path to XCTest build directory")
     parser.add_argument("--build-tests", action="store_true",


### PR DESCRIPTION
> This is [the third of six pull requests](https://github.com/apple/swift-corelibs-xctest/pull/43#issuecomment-192813377) necessary to introduce asynchronous testing to swift-corelibs-xctest. This pull request may be reviewed and merged at any time.

https://github.com/apple/swift-corelibs-xctest/pull/43 will add a dependency between swift-corelibs-xctest and swift-corelibs-foundation. This will necessitate the path to a Foundation build be passed to the SwiftPM bootstrap script. See #177 for details on what this path will be used for.

In order to prevent CI from breaking, we'll modify the Swift build script to pass the correct parameters *before* those parameters are actually used. To do that, this commit ensures the bootstrap script accepts the new parameter: "--foundation".