### PR TITLE
[Build] Link XCTest with Foundation [AsyncXCTest 5/6]

### DIFF
--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -22,7 +22,7 @@ public func describe(prefix: String, _ conf: Configuration, _ modules: [Module],
         throw Error.NoModules
     }
 
-    let Xcc = Xcc.flatMap{ ["-Xcc", $0] } + extraImports()
+    let Xcc = Xcc.flatMap{ ["-Xcc", $0] }
     let Xld = Xld.flatMap{ ["-Xlinker", $0] }
     let prefix = try mkdir(prefix, conf.dirname)
     let yaml = try YAML(path: "\(prefix).yaml")
@@ -190,14 +190,5 @@ public func describe(prefix: String, _ conf: Configuration, _ modules: [Module],
 extension Product {
     private var buildables: [SwiftModule] {
         return recursiveDependencies(modules.map{$0}).flatMap{ $0 as? SwiftModule }
-    }
-}
-
-private func extraImports() -> [String] {
-    //FIXME HACK
-    if let I = getenv("SWIFTPM_EXTRA_IMPORT") {
-        return ["-I", I]
-    } else {
-        return []
     }
 }

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -542,13 +542,18 @@ def main():
     cmd.extend(["-Xlinker", "-rpath", "-Xlinker", embed_rpath])
 
     cmd = [os.path.join(sandbox_path, "bin", "swift-build")]
-    if args.xctest_path:
-        env_cmd.append("SWIFTPM_EXTRA_IMPORT=" + args.xctest_path)
+    if args.foundation_path and args.xctest_path:
+        core_foundation_path = os.path.join(
+            args.foundation_path, "usr", "lib", "swift")
         # Tell the linker where to look for XCTest, but autolinking
         # knows to pass -lXCTest.
         cmd.extend(["-Xlinker", "-L", "-Xlinker", args.xctest_path])
         # Add an RPATH, so that the tests can be run directly.
         cmd.extend(["-Xlinker", "-rpath", "-Xlinker", args.xctest_path])
+        cmd.extend(["-Xlinker", "-rpath", "-Xlinker", args.foundation_path])
+        cmd.extend(["-Xswiftc", "-I{}".format(args.xctest_path)])
+        cmd.extend(["-Xswiftc", "-I{}".format(args.foundation_path)])
+        cmd.extend(["-Xswiftc", "-I{}".format(core_foundation_path)])
 
     cmd = env_cmd + cmd
 


### PR DESCRIPTION
> This is [the fifth of six pull requests](https://github.com/apple/swift-corelibs-xctest/pull/43#issuecomment-192813377) necessary to introduce asynchronous testing to swift-corelibs-xctest. All of its dependencies have been merged, so this is ready to be reviewed and merged itself.

In order to implement asynchronous tests, swift-corelibs-xctest will take on a dependency upon swift-corelibs-foundation. To properly link the two:

- Allow the package manager to take a path to a Foundation build.
- Add the Foundation and CoreFoundation directories to the swiftc include paths.
- While we're at it, remove the `SWIFTPM_EXTRA_IMPORTS` hack in favor of `-Xswiftc`.