### PR TITLE
[bootstrap] Remove deprecated "--build-tests"

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Tests are an important part of the development and evolution of this project,
 and new contributions are expected to include tests for any functionality
 change.  To run the tests, pass the `test` verb to the `bootstrap` script:
 
-    ./Utilities/bootstrap --build-tests test
+    ./Utilities/bootstrap test
 
 > Long-term, we intend for testing to be an integral part of the Package Manager itself
 > and to not require custom support.

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -451,8 +451,6 @@ def main():
                         help="use verbose output")
     parser.add_argument("--xctest", dest="xctest_path",
                         help="Path to XCTest build directory")
-    parser.add_argument("--build-tests", action="store_true",
-                        help="Deprecated")
     args = parser.parse_args()
     build_actions = set(args.build_actions)
 


### PR DESCRIPTION
The "--build-tests" option is marked "deprecated" in the SwiftPM bootstrap script and is no longer used by the script. It is also no longer used by any systems calling the bootstrap script; its only usage in the Swift build script has been removed in https://github.com/apple/swift/pull/1547.

Remove the option to reduce confusion.