### PR TITLE
Fix documentation on version specification examples of `Package.swift`

### DIFF
--- a/Documentation/DevelopingPackages.md
+++ b/Documentation/DevelopingPackages.md
@@ -26,7 +26,7 @@ and amend your `Package.swift` so that its `package` declaration includes:
 ```swift
 let package = Package(
     dependencies: [
-        .Package(url: "…", versions: Version(1,0,0)..<Version(2,0,0)),
+        .Package(url: "…", versions: Version(1,0,0)..<Version(1,.max,.max)),
     ]
 )
 ```

--- a/Documentation/Package.swift.md
+++ b/Documentation/Package.swift.md
@@ -15,7 +15,7 @@ import PackageDescription
 let package = Package(
     name: "Hello",
     dependencies: [
-        .Package(url: "ssh://git@example.com/Greeter.git", versions: Version(1,0,0)..<Version(2,0,0)),
+        .Package(url: "ssh://git@example.com/Greeter.git", versions: Version(1,0,0)..<Version(1,.max,.max)),
     ]
 )
 ```
@@ -65,7 +65,7 @@ import PackageDescription
 let package = Package(
     name: "Hello",
     testDependencies: [
-        .Package(url: "ssh://git@example.com/Tester.git", versions: Version(1,0,0)..<Version(2,0,0)),
+        .Package(url: "ssh://git@example.com/Tester.git", versions: Version(1,0,0)..<Version(1,.max,.max)),
     ]
 )
 ```


### PR DESCRIPTION
Related to #140
It should use `.max` on `minor` or `patch` with same `major` version for avoiding pre-release suffixed next version matches.