### PR TITLE
Be tolerant of empty test modules

### DIFF
--- a/Sources/Transmute/Package+testModules.swift
+++ b/Sources/Transmute/Package+testModules.swift
@@ -13,8 +13,13 @@ import Utility
 
 extension Package {
     func testModules() throws -> [TestModule] {
-        return try walk(path, "Tests", recursively: false).filter{ $0.isDirectory }.map { dir in
-            return TestModule(basename: dir.basename, sources: try self.sourcify(dir))
+        return walk(path, "Tests", recursively: false).filter{ $0.isDirectory }.flatMap { dir in
+            if let sources = try? self.sourcify(dir) {
+                return TestModule(basename: dir.basename, sources: sources)
+            } else {
+                print("warning: no sources in test module: \(path)")
+                return nil
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes Alamofire build.

This should either be deprecated and made an error, or changed based on my forth coming No More Magic proposal.