### PR TITLE
Generate Xcode project at custom path

### DIFF
--- a/Sources/swift-build/main.swift
+++ b/Sources/swift-build/main.swift
@@ -90,13 +90,14 @@ do {
         case .Version:
             print("Apple Swift Package Manager 0.1")
             
-        case .GenerateXcodeproj:
+        case .GenerateXcodeproj(let xcodeprojPath):
             let dirs = try directories()
             let packages = try fetch(dirs.root)
             let (modules, products) = try transmute(packages, rootdir: dirs.root)
             let swiftModules = modules.flatMap{ $0 as? SwiftModule }
-
-            let path = try Xcodeproj.generate(path: try getcwd(), package: packages.last!, modules: swiftModules, products: products)
+            
+            let xcodeprojFolder = try (xcodeprojPath ?? ".").abspath()
+            let path = try Xcodeproj.generate(path: xcodeprojFolder, package: packages.last!, modules: swiftModules, products: products)
 
             print("generated:", path.prettied)
     }

--- a/Sources/swift-build/usage.swift
+++ b/Sources/swift-build/usage.swift
@@ -18,11 +18,11 @@ func usage(print: (String) -> Void = { print($0) }) {
     print("USAGE: swift build [options]")
     print("")
     print("MODES:")
-    print("  --configuration <value>  Build with configuration (debug|release) [-c]")
-    print("  --clean[=<mode>]         Delete artefacts (build|dist) [-k]")
-    print("  --init <mode>            Creates a new Swift package (executable|library)")
-    print("  --fetch                  Fetch package dependencies")
-    print("  --generate-xcodeproj     Generates an Xcode project for this package [-X]")
+    print("  --configuration <value>        Build with configuration (debug|release) [-c]")
+    print("  --clean[=<mode>]               Delete artefacts (build|dist) [-k]")
+    print("  --init <mode>                  Creates a new Swift package (executable|library)")
+    print("  --fetch                        Fetch package dependencies")
+    print("  --generate-xcodeproj [<path>]  Generates an Xcode project for this package [-X]")
     print("")
     print("OPTIONS:")
     print("  --chdir <value>    Change working directory before any other operation [-C]")
@@ -44,7 +44,7 @@ enum Mode {
     case Init(InitPackage.InitMode)
     case Usage
     case Version
-    case GenerateXcodeproj
+    case GenerateXcodeproj(String?)
 }
 
 struct Options {
@@ -148,7 +148,14 @@ func parse(commandLineArguments args: [String]) throws -> (Mode, Options) {
             case (nil, .Fetch):
                 mode = .Fetch
             case (nil, .GenerateXcodeproj):
-                mode = .GenerateXcodeproj
+                mode = .GenerateXcodeproj(nil)
+                switch try cruncher.peek() {
+                case .Name(let path)?:
+                    mode = .GenerateXcodeproj(path)
+                    cruncher.postPeekPop()
+                default:
+                    break
+                }
             }
 
         case .Switch(.Chdir):


### PR DESCRIPTION
Added a switch `--xcodeproj-path` to customize in which folder swiftpm generates the Xcode project.

- works for both relative and absolute paths
- switch shortcut `-P`
- pass `--xcodeproj-path Foo` in project Bar to generate `./Foo/Bar.xcodeproj`