### PR TITLE
Specify exact path of generated Xcode project

### DIFF
--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -18,7 +18,12 @@ import POSIX
 */
 public func generate(path path: String, package: Package, modules: [SwiftModule], products: [Product]) throws -> String {
 
-    let rootdir = try mkdir(path, "\(package.name).xcodeproj")
+    /// If a specific *.xcodeproj path is already passed in, use that. 
+    /// Otherwise treat the path as the desired enclosing folder for
+    /// the .xcodeproj folder.
+    let rootdir = path.hasSuffix(".xcodeproj") ? path : Path.join(path, "\(package.name).xcodeproj")
+    try mkdir(rootdir)
+    
     let schemedir = try mkdir(rootdir, "xcshareddata/xcschemes")
 
 ////// the pbxproj file describes the project and its targets


### PR DESCRIPTION
Now allowing specifying the exact path of the `.xcodeproj`, not just the enclosing folder. Detected based on whether the path ends with ".xcodeproj" (uses exact path) or not (uses as enclosing folder, package name as the name of the project).

Requested [here](https://github.com/apple/swift-package-manager/pull/188#issuecomment-195619784).