### PR TITLE
Add --type option to specity dylib or framework product type

### DIFF
--- a/Sources/Xcodeproj/Module+PBXProj.swift
+++ b/Sources/Xcodeproj/Module+PBXProj.swift
@@ -88,34 +88,46 @@ extension SwiftModule {
         return type == .Library
     }
 
-    var type: String {
+    func productType(forType type: ProductBuildType) -> String {
         if self is TestModule {
             return "com.apple.product-type.bundle.unit-test"
         } else if isLibrary {
-            return "com.apple.product-type.library.dynamic"
+            switch type {
+            case .Framework:
+                return "com.apple.product-type.framework"
+            case .DyLib:
+                return "com.apple.product-type.library.dynamic"
+            }
         } else {
             return "com.apple.product-type.tool"
         }
     }
 
-    var explicitFileType: String {
-        func suffix() -> String {
-            if self is TestModule {
-                return "wrapper.cfbundle"
-            } else if isLibrary {
-                return "dylib"
-            } else {
-                return "executable"
+    func explicitFileType(forType type: ProductBuildType) -> String {
+        if self is TestModule {
+            return "wrapper.cfbundle"
+        } else if isLibrary {
+            switch type {
+            case .Framework:
+                return "wrapper.framework"
+            case .DyLib:
+                return "compiled.mach-o.dylib"
             }
+        } else {
+            return "compiled.mach-o.executable"
         }
-        return "compiled.mach-o.\(suffix())"
     }
 
-    var productPath: String {
+    func productPath(forType type: ProductBuildType) -> String {
         if self is TestModule {
             return "\(c99name).xctest"
         } else if isLibrary {
-            return "\(c99name).dylib"
+            switch type {
+            case .Framework:
+                return "\(c99name).framework"
+            case .DyLib:
+                return "\(c99name).dylib"
+            }
         } else {
             return name
         }
@@ -185,11 +197,16 @@ extension SwiftModule {
         return targetReference
     }
 
-    var buildableName: String {
+    func buildableName(forType type: ProductBuildType) -> String {
         if isLibrary && !(self is TestModule) {
-            return "lib\(productPath)"
+            switch type {
+            case .Framework:
+                return "\(productPath(forType: type)).framework"
+            case .DyLib:
+                return "lib\(productPath(forType: type))"
+            }
         } else {
-            return productPath
+            return productPath(forType: type)
         }
     }
 

--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -12,24 +12,29 @@ import PackageType
 import Utility
 import POSIX
 
+public enum ProductBuildType: String {
+    case DyLib = "dylib"
+    case Framework = "framework"
+}
+
 /** 
  Generates an xcodeproj at the specified path.
  - Returns: the path to the generated project
 */
-public func generate(path path: String, package: Package, modules: [SwiftModule], products: [Product]) throws -> String {
+public func generate(path path: String, package: Package, modules: [SwiftModule], products: [Product], productType: ProductBuildType) throws -> String {
 
     let rootdir = try mkdir(path, "\(package.name).xcodeproj")
     let schemedir = try mkdir(rootdir, "xcshareddata/xcschemes")
 
 ////// the pbxproj file describes the project and its targets
     try open(rootdir, "project.pbxproj") { fwrite in
-        pbxproj(package: package, modules: modules, products: products, printer: fwrite)
+        pbxproj(package: package, modules: modules, products: products, printer: fwrite, productType: productType)
     }
 
 ////// the scheme acts like an aggregate target for all our targets
    /// it has all tests associated so CMD+U works
     try open(schemedir, "\(package.name).xcscheme") { fwrite in
-        xcscheme(packageName: package.name, modules: modules, printer: fwrite)
+        xcscheme(packageName: package.name, modules: modules, printer: fwrite, productType: productType)
     }
 
 ////// we generate this file to ensure our main scheme is listed

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -15,7 +15,7 @@
 import PackageType
 import Utility
 
-public func pbxproj(package package: Package, modules: [SwiftModule], products _: [Product], printer print: (String) -> Void) {
+public func pbxproj(package package: Package, modules: [SwiftModule], products _: [Product], printer print: (String) -> Void, productType: ProductBuildType) {
 
     let srcroot = package.path
     let nontests = modules.filter{ !($0 is TestModule) }
@@ -85,14 +85,14 @@ public func pbxproj(package package: Package, modules: [SwiftModule], products _
         print("            name = \(module.name);")
         print("            productName = \(module.c99name);")
         print("            productReference = \(module.productReference);")
-        print("            productType = '\(module.type)';")
+        print("            productType = '\(module.productType(forType: productType))';")
         print("        };")
 
         // the product file reference
         print("        \(module.productReference) = {")
         print("            isa = PBXFileReference;")
-        print("            explicitFileType = '\(module.explicitFileType)';")
-        print("            path = '\(module.productPath)';")
+        print("            explicitFileType = '\(module.explicitFileType(forType: productType))';")
+        print("            path = '\(module.productPath(forType: productType))';")
         print("            sourceTree = BUILT_PRODUCTS_DIR;")
         print("        };")
 

--- a/Sources/Xcodeproj/xcscheme().swift
+++ b/Sources/Xcodeproj/xcscheme().swift
@@ -10,7 +10,8 @@
 
 import PackageType
 
-func xcscheme(packageName packageName: String, modules: [SwiftModule], printer print: (String) -> Void) {
+func xcscheme(packageName packageName: String, modules: [SwiftModule], printer print: (String) -> Void, productType: ProductBuildType) {
+    
     print("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
     print("<Scheme LastUpgradeVersion = \"9999\" version = \"1.3\">")
     print("  <BuildAction parallelizeBuildables = \"YES\" buildImplicitDependencies = \"YES\">")
@@ -24,7 +25,7 @@ func xcscheme(packageName packageName: String, modules: [SwiftModule], printer p
         print("        <BuildableReference")
         print("          BuildableIdentifier = \"primary\"")
         print("          BlueprintIdentifier = \"\(module.blueprintIdentifier)\"")
-        print("          BuildableName = \"\(module.buildableName)\"")
+        print("          BuildableName = \"\(module.buildableName(forType: productType))\"")
         print("          BlueprintName = \"\(module.blueprintName)\"")
         print("          ReferencedContainer = \"container:\(packageName).xcodeproj\">")
         print("        </BuildableReference>")
@@ -46,7 +47,7 @@ func xcscheme(packageName packageName: String, modules: [SwiftModule], printer p
         print("      <BuildableReference")
         print("        BuildableIdentifier = \"primary\"")
         print("        BlueprintIdentifier = \"\(module.blueprintIdentifier)\"")
-        print("        BuildableName = \"\(module.buildableName)\"")
+        print("        BuildableName = \"\(module.buildableName(forType: productType))\"")
         print("        BlueprintName = \"\(module.blueprintName)\"")
         print("        ReferencedContainer = \"container:\(packageName).xcodeproj\">")
         print("      </BuildableReference>")

--- a/Sources/swift-build/main.swift
+++ b/Sources/swift-build/main.swift
@@ -97,7 +97,7 @@ do {
             let swiftModules = modules.flatMap{ $0 as? SwiftModule }
             
             let xcodeprojFolder = try (xcodeprojPath ?? ".").abspath()
-            let path = try Xcodeproj.generate(path: xcodeprojFolder, package: packages.last!, modules: swiftModules, products: products)
+            let path = try Xcodeproj.generate(path: xcodeprojFolder, package: packages.last!, modules: swiftModules, products: products, productType: opts.type)
 
             print("generated:", path.prettied)
     }


### PR DESCRIPTION
`--generate-xcodeproj` currently can only generate `.dylib` products.

Added a `--type` option, which can be used to specify required product type (`framework` or `dylib`).

>Note: This option applies to all the products in a project.

**Example:**
```bash
$ swift-build --generate-xcodeproj --type framework

.
└── Products
    ├── libFooModule.framework
    ├── libDependency1.framework
    ├── libDependency2.framework
    .


$ swift-build --generate-xcodeproj --type dylib

.
└── Products
    ├── libFooModule.dylib
    ├── libDependency1.dylib
    ├── libDependency2.dylib
    .
```