### PR TITLE
Relative paths fix, Xcode generation at non-root path fix

### DIFF
--- a/Sources/Utility/Path.swift
+++ b/Sources/Utility/Path.swift
@@ -86,6 +86,24 @@ public struct Path {
             if path.starts(with: pivot) {
                 let relativePortion = path.dropFirst(pivot.count)
                 return join(Array(relativePortion))
+            } else if path.starts(with: pivot.prefix(1)) {
+                //only the first matches, so we will be able to find a relative
+                //path by adding jumps back the directory tree
+                var newPath = ArraySlice(path)
+                var newPivot = ArraySlice(pivot)
+                repeat {
+                    //remove all shared components in the prefix
+                    newPath = newPath.dropFirst()
+                    newPivot = newPivot.dropFirst()
+                } while newPath.prefix(1) == newPivot.prefix(1)
+                
+                //as we found the first differing point, the final path is
+                //a) as many ".." as there are components in newPivot
+                //b) what's left in newPath
+                var final = Array(repeating: "..", count: newPivot.count)
+                final.append(contentsOf: newPath)
+                let relativePath = Path.join(final)
+                return relativePath
             } else {
                 let prefix = abs.path ? "/" : ""
                 return prefix + join(path)

--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -23,7 +23,7 @@ public func generate(path path: String, package: Package, modules: [SwiftModule]
 
 ////// the pbxproj file describes the project and its targets
     try open(rootdir, "project.pbxproj") { fwrite in
-        pbxproj(package: package, modules: modules, products: products, printer: fwrite)
+        pbxproj(projectPath: path, package: package, modules: modules, products: products, printer: fwrite)
     }
 
 ////// the scheme acts like an aggregate target for all our targets

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -15,9 +15,9 @@
 import PackageType
 import Utility
 
-public func pbxproj(package package: Package, modules: [SwiftModule], products _: [Product], printer print: (String) -> Void) {
+public func pbxproj(projectPath projectPath: String, package: Package, modules: [SwiftModule], products _: [Product], printer print: (String) -> Void) {
 
-    let srcroot = package.path
+    let srcroot = projectPath
     let nontests = modules.filter{ !($0 is TestModule) }
     let tests = modules.filter{ $0 is TestModule }
 

--- a/Tests/Utility/FileTests.swift
+++ b/Tests/Utility/FileTests.swift
@@ -131,6 +131,7 @@ extension RelativePathTests {
             ("testAbsolute", testAbsolute),
             ("testRelative", testRelative),
             ("testMixed", testMixed),
+            ("testRelativeCommonSubprefix", testRelativeCommonSubprefix)
         ]
     }
 }

--- a/Tests/Utility/PathTests.swift
+++ b/Tests/Utility/PathTests.swift
@@ -210,4 +210,10 @@ class RelativePathTests: XCTestCase {
     func testMixed() {
         XCTAssertEqual("3/4", Path(try! getcwd() + "/1/2/3/4").relative(to: "1/2"))
     }
+    
+    func testRelativeCommonSubprefix() {
+        XCTAssertEqual("../4", Path("/1/2/4").relative(to: "/1/2/3"))
+        XCTAssertEqual("../4/5", Path("/1/2/4/5").relative(to: "/1/2/3"))
+        XCTAssertEqual("../../../4/5", Path("/1/2/4/5").relative(to: "/1/2/3/6/7"))
+    }
 }


### PR DESCRIPTION
Added support for properly creating relative paths even when the pivot isn't a full prefix of the path. Also fixed Xcode project generation at non-root path.

Properly finishes #188, together with #189.