### PR TITLE
[WIP] add --chdir argument to swift-test

### DIFF
--- a/Sources/swift-test/main.swift
+++ b/Sources/swift-test/main.swift
@@ -11,10 +11,14 @@
 import func libc.exit
 import Multitool
 import Utility
+import func POSIX.chdir
 
 do {
     let args = Array(Process.arguments.dropFirst())
-    let mode = try parse(commandLineArguments: args)
+    let (mode, opts) = try parse(commandLineArguments: args)
+    if let dir = opts.chdir {
+        try chdir(dir)
+    }
 
     switch mode {
     case .Usage:


### PR DESCRIPTION
Add ability to change directory before running tests. 
I think it would be very useful, because we can do similar when running `swift-build`

Example: `swift-test --chdir myProject/A`
