### PR TITLE
[Xcodeproj] Generating clibs targets, beginning

### DIFF
--- a/Sources/PackageType/Module.swift
+++ b/Sources/PackageType/Module.swift
@@ -45,16 +45,16 @@ public func ==(lhs: Module, rhs: Module) -> Bool {
     return lhs.c99name == rhs.c99name
 }
 
+public enum ModuleType {
+    case Library, Executable
+}
+
 public class SwiftModule: Module {
     public let sources: Sources
 
     public init(name: String, sources: Sources) {
         self.sources = sources
         super.init(name: name)
-    }
-
-    public enum ModuleType {
-        case Library, Executable
     }
 
     public var type: ModuleType {
@@ -96,6 +96,28 @@ public class TestModule: SwiftModule {
 
     override public var c99name: String {
         return PackageType.c99name(name: basename) + "TestSuite"
+    }
+}
+
+public class XcodeModule: Module {
+    public var sources: Sources 
+    public var type: ModuleType
+    public init?(module: Module){
+        switch module {
+            case let swiftModule as SwiftModule:
+                sources = swiftModule.sources
+                type = swiftModule.type
+                
+            case let clangModule as ClangModule:
+                sources = clangModule.sources
+                type = .Library
+        
+            default:
+                return nil
+        }
+        super.init(name: module.name)
+        dependencies = module.dependencies
+        // dependencies = module.dependencies.map { XcodeModule(module: $0) }
     }
 }
 

--- a/Sources/PackageType/Module.swift
+++ b/Sources/PackageType/Module.swift
@@ -103,16 +103,19 @@ public class XcodeModule: Module {
     public var sources: Sources 
     public var type: ModuleType
     public var fileType: String
+    public var modulemap: String?
     public init?(module: Module){
         switch module {
             case let swiftModule as SwiftModule:
                 sources = swiftModule.sources
                 type = swiftModule.type
                 fileType = "sourcecode.swift"
+                modulemap = nil
             case let clangModule as ClangModule:
                 sources = clangModule.sources
                 type = .Library
                 fileType = "sourcecode.c.c"
+                modulemap = clangModule.path+"/module.modulemap"
             default:
                 return nil
         }

--- a/Sources/PackageType/Module.swift
+++ b/Sources/PackageType/Module.swift
@@ -102,16 +102,17 @@ public class TestModule: SwiftModule {
 public class XcodeModule: Module {
     public var sources: Sources 
     public var type: ModuleType
+    public var fileType: String
     public init?(module: Module){
         switch module {
             case let swiftModule as SwiftModule:
                 sources = swiftModule.sources
                 type = swiftModule.type
-                
+                fileType = "sourcecode.swift"
             case let clangModule as ClangModule:
                 sources = clangModule.sources
                 type = .Library
-        
+                fileType = "sourcecode.c.c"
             default:
                 return nil
         }

--- a/Sources/Xcodeproj/Module+PBXProj.swift
+++ b/Sources/Xcodeproj/Module+PBXProj.swift
@@ -132,13 +132,8 @@ extension XcodeModule {
         return dependencies.map{ $0.dependencyReference }.joined(separator: ", ")
     }
 
-    var productName: String {
-        if isLibrary && !(self is TestModule) {
-            // you can go without a lib prefix, but something unexpected will break
-            return "'lib$(TARGET_NAME)'"
-        } else {
-            return "'$(TARGET_NAME)'"
-        }
+    var productName: String {    
+       return "'$(TARGET_NAME)'"
     }
 
     var debugBuildSettings: String {
@@ -182,6 +177,10 @@ extension XcodeModule {
             if isLibrary {
                 buildSettings["ENABLE_TESTABILITY"] = "YES"
                 buildSettings["DYLIB_INSTALL_NAME_BASE"] = "'$(CONFIGURATION_BUILD_DIR)'"
+                if let modulemap = modulemap {
+                    buildSettings["DEFINES_MODULE"] = "YES"
+                    buildSettings["MODULEMAP_FILE"] = modulemap
+                }
             } else {
                 // override default behavior, instead link dynamically
                 buildSettings["SWIFT_FORCE_STATIC_LINK_STDLIB"] = "NO"

--- a/Sources/Xcodeproj/Module+PBXProj.swift
+++ b/Sources/Xcodeproj/Module+PBXProj.swift
@@ -70,7 +70,7 @@ private func fileRef(suffixForModuleSourceFile path: String, srcroot: String) ->
     }.joined(separator: "")
 }
 
-func fileRefs(forModuleSources module: SwiftModule, srcroot: String) -> [(String, String)] {
+func fileRefs(forModuleSources module: XcodeModule, srcroot: String) -> [(String, String)] {
     return module.sources.relativePaths.map { relativePath in
         let path = Path.join(module.sources.root, relativePath)
         let suffix = fileRef(suffixForModuleSourceFile: path, srcroot: srcroot)
@@ -78,7 +78,7 @@ func fileRefs(forModuleSources module: SwiftModule, srcroot: String) -> [(String
     }
 }
 
-func fileRefs(forCompilePhaseSourcesInModule module: SwiftModule, srcroot: String) -> [(String, String)] {
+func fileRefs(forCompilePhaseSourcesInModule module: XcodeModule, srcroot: String) -> [(String, String)] {
     return fileRefs(forModuleSources: module, srcroot: srcroot).map { ref1, relativePath in
         let path = Path.join(module.sources.root, relativePath)
         let suffix = fileRef(suffixForModuleSourceFile: path, srcroot: srcroot)
@@ -86,7 +86,7 @@ func fileRefs(forCompilePhaseSourcesInModule module: SwiftModule, srcroot: Strin
     }
 }
 
-extension SwiftModule {
+extension XcodeModule {
     private var isLibrary: Bool {
         return type == .Library
     }
@@ -95,7 +95,7 @@ extension SwiftModule {
         if self is TestModule {
             return "com.apple.product-type.bundle.unit-test"
         } else if isLibrary {
-            return "com.apple.product-type.library.dynamic"
+            return "com.apple.product-type.framework"
         } else {
             return "com.apple.product-type.tool"
         }
@@ -106,7 +106,7 @@ extension SwiftModule {
             if self is TestModule {
                 return "wrapper.cfbundle"
             } else if isLibrary {
-                return "dylib"
+                return "framework"
             } else {
                 return "executable"
             }
@@ -118,7 +118,7 @@ extension SwiftModule {
         if self is TestModule {
             return "\(c99name).xctest"
         } else if isLibrary {
-            return "\(c99name).dylib"
+            return "\(c99name).framework"
         } else {
             return name
         }
@@ -194,7 +194,7 @@ extension SwiftModule {
 }
 
 
-extension SwiftModule {
+extension XcodeModule {
     var blueprintIdentifier: String {
         return targetReference
     }

--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -16,7 +16,7 @@ import POSIX
  Generates an xcodeproj at the specified path.
  - Returns: the path to the generated project
 */
-public func generate(dstdir dstdir: String, projectName: String, srcroot: String, modules: [SwiftModule], products: [Product]) throws -> String {
+public func generate(dstdir dstdir: String, projectName: String, srcroot: String, modules: [XcodeModule], products: [Product]) throws -> String {
 
     let xcodeprojName = "\(projectName).xcodeproj"
     let xcodeprojPath = try mkdir(dstdir, xcodeprojName)

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -15,7 +15,7 @@
 import PackageType
 import Utility
 
-public func pbxproj(srcroot srcroot: String, projectRoot: String, modules: [SwiftModule], products _: [Product], printer print: (String) -> Void) {
+public func pbxproj(srcroot srcroot: String, projectRoot: String, modules: [XcodeModule], products _: [Product], printer print: (String) -> Void) {
     let nontests = modules.filter{ !($0 is TestModule) }
     let tests = modules.filter{ $0 is TestModule }
 

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -67,7 +67,7 @@ public func pbxproj(srcroot srcroot: String, projectRoot: String, modules: [Xcod
         for (ref, path) in fileRefs(forModuleSources: module, srcroot: srcroot) {
             print("        \(ref) = {")
             print("            isa = PBXFileReference;")
-            print("            lastKnownFileType = sourcecode.swift;")
+            print("            lastKnownFileType = \(module.fileType);")
             print("            name = '\(Path(path).relative(to: module.sources.root))';")
             print("            sourceTree = '<group>';")
             print("        };")

--- a/Sources/Xcodeproj/xcscheme().swift
+++ b/Sources/Xcodeproj/xcscheme().swift
@@ -10,7 +10,7 @@
 
 import PackageType
 
-func xcscheme(container container: String, modules: [SwiftModule], printer print: (String) -> Void) {
+func xcscheme(container container: String, modules: [XcodeModule], printer print: (String) -> Void) {
     print("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
     print("<Scheme LastUpgradeVersion = \"9999\" version = \"1.3\">")
     print("  <BuildAction parallelizeBuildables = \"YES\" buildImplicitDependencies = \"YES\">")

--- a/Sources/swift-build/main.swift
+++ b/Sources/swift-build/main.swift
@@ -94,7 +94,7 @@ do {
             let dirs = try directories()
             let packages = try fetch(dirs.root)
             let (modules, products) = try transmute(packages, rootdir: dirs.root)
-            let swiftModules = modules.flatMap{ $0 as? SwiftModule }
+            let xcodeModules = modules.flatMap{ XcodeModule(module: $0) }
 
             let projectName: String
             let dstdir: String
@@ -114,7 +114,7 @@ do {
                 projectName = packageName
             }
 
-            let outpath = try Xcodeproj.generate(dstdir: dstdir, projectName: projectName, srcroot: dirs.root, modules: swiftModules, products: products)
+            let outpath = try Xcodeproj.generate(dstdir: dstdir, projectName: projectName, srcroot: dirs.root, modules: xcodeModules, products: products)
 
             print("generated:", outpath.prettied)
     }


### PR DESCRIPTION
Now `-X` command ignoring c targets and deps. This commit is early beginning, nothing is working. 
Created PR, because I need help.
Xcode now writes
```
 <unknown>:0: error: unexpected input file: /Users/badim/github/swift/Venice/Packages/CLibvenice-0.4.0/Sources/chan.c
```
errors. To reproduce:
```bash 
git clone git@github.com:Zewo/Venice.git
swift build -X
```
It's just an example, it could be other lib
So the question. How I can setup xcode project to build c lib from source and use modulemap as module to export. I just need generated xcodeproj xml, so I can reproduce it in spm code. 
Thanks