### PR TITLE
[Xcodeproj] Added Package.swift to the root of generated Xcode projects

### DIFF
--- a/Sources/Xcodeproj/Module+PBXProj.swift
+++ b/Sources/Xcodeproj/Module+PBXProj.swift
@@ -70,6 +70,11 @@ private func fileRef(suffixForModuleSourceFile path: String, srcroot: String) ->
     }.joined(separator: "")
 }
 
+func fileRef(inProjectRoot name: String, srcroot: String) -> (String, String, String) {
+    let suffix = fileRef(suffixForModuleSourceFile: name, srcroot: srcroot)
+    return ("'\(sourceGroupFileRefPrefix)\(suffix)'", name, Path.join(srcroot, name))
+}
+
 func fileRefs(forModuleSources module: SwiftModule, srcroot: String) -> [(String, String)] {
     return module.sources.relativePaths.map { relativePath in
         let path = Path.join(module.sources.root, relativePath)

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -153,7 +153,7 @@ public func pbxproj(srcroot srcroot: String, projectRoot: String, modules: [Swif
         print("            target = \(module.targetReference);")
         print("        };")
     }
-    
+
 ////// “Sources” group
     print("        \(sourcesGroupReference) = {")
     print("            isa = PBXGroup;")

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -44,10 +44,20 @@ public func pbxproj(srcroot srcroot: String, projectRoot: String, modules: [Swif
     print("            targets = (" + modules.map{ $0.targetReference }.joined(separator: ", ") + ");")
     print("        };")
 
+////// Package.swift file
+    let packageSwift = fileRef(inProjectRoot: "Package.swift", srcroot: srcroot)
+    print("        \(packageSwift.0) = {")
+    print("            isa = PBXFileReference;")
+    print("            lastKnownFileType = sourcecode.swift;")
+    print("            name = '\(packageSwift.1)';")
+    print("            path = '\(packageSwift.2)';")
+    print("            sourceTree = '<group>';")
+    print("        };")
+
 ////// root group
     print("        \(rootGroupReference) = {")
     print("            isa = PBXGroup;")
-    print("            children = (\(sourcesGroupReference), \(testsGroupReference), \(productsGroupReference));")
+    print("            children = (\(packageSwift.0), \(sourcesGroupReference), \(testsGroupReference), \(productsGroupReference));")
     print("            sourceTree = '<group>';")
     print("        };")
 
@@ -143,7 +153,7 @@ public func pbxproj(srcroot srcroot: String, projectRoot: String, modules: [Swif
         print("            target = \(module.targetReference);")
         print("        };")
     }
-
+    
 ////// “Sources” group
     print("        \(sourcesGroupReference) = {")
     print("            isa = PBXGroup;")


### PR DESCRIPTION
This should make it easier to edit `Package.swift` from the generated Xcode project.

<img width="561" alt="screenshot 2016-03-19 19 30 40" src="https://cloud.githubusercontent.com/assets/2182121/13900912/be4ae802-ee09-11e5-91d7-ad2e18f2b0fb.png">
 