### PR TITLE
[Tests] Added more Path tests

### DIFF
--- a/Sources/swift-build/main.swift
+++ b/Sources/swift-build/main.swift
@@ -102,8 +102,7 @@ do {
 
             switch outpath {
             case let outpath? where outpath.hasSuffix(".xcodeproj"):
-                // if user specified path ending with .xcodeproj, generate that
-                "\(packageName).xcodeproj"
+                // if user specified path ending with .xcodeproj, use that
                 projectName = String(outpath.basename.characters.dropLast(10))
                 dstdir = outpath.parentDirectory
             case let outpath?:

--- a/Tests/Utility/FileTests.swift
+++ b/Tests/Utility/FileTests.swift
@@ -131,7 +131,8 @@ extension RelativePathTests {
             ("testAbsolute", testAbsolute),
             ("testRelative", testRelative),
             ("testMixed", testMixed),
-            ("testRelativeCommonSubprefix", testRelativeCommonSubprefix)
+            ("testRelativeCommonSubprefix", testRelativeCommonSubprefix),
+            ("testCombiningRelativePaths", testCombiningRelativePaths)
         ]
     }
 }

--- a/Tests/Utility/PathTests.swift
+++ b/Tests/Utility/PathTests.swift
@@ -216,4 +216,10 @@ class RelativePathTests: XCTestCase {
         XCTAssertEqual("../4/5", Path("/1/2/4/5").relative(to: "/1/2/3"))
         XCTAssertEqual("../../../4/5", Path("/1/2/4/5").relative(to: "/1/2/3/6/7"))
     }
+    
+    func testCombiningRelativePaths() {
+        XCTAssertEqual("/1/2/3", Path.join("/1/2/4", "../3").normpath)
+        XCTAssertEqual("/1/2", Path.join("/1/2/3", "..").normpath)
+        XCTAssertEqual("2", Path.join("2/3", "..").normpath)
+    }
 }


### PR DESCRIPTION
- added more Path tests ( @mxcl is this the case you alluded might not be working? `/a/b/c` + `../d` -> `/a/b/c/../d`, and `.normpath` gives the expected `/a/b/d`)
- removed unused string from previous refactoring