### PR TITLE
Corrected Issue SR-997. 

### DIFF
--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -130,7 +130,7 @@ public func describe(prefix: String, _ conf: Configuration, _ modules: [Module],
     #endif
     #if os(OSX)
         if let sysroot = Toolchain.sysroot {
-           args += ["-I\(sysroot)/usr/include"]
+           args += ["-isysroot", "\(sysroot)"]
         }
     #endif
         args += ["-fmodules", "-fmodule-name=\(module.name)"]

--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -128,11 +128,9 @@ public func describe(prefix: String, _ conf: Configuration, _ modules: [Module],
     #if os(Linux)
          args += ["-fPIC"]
     #endif
-    #if os(OSX)
         if let sysroot = Toolchain.sysroot {
-           args += ["-isysroot", "\(sysroot)"]
+            args += ["-isysroot", sysroot]
         }
-    #endif
         args += ["-fmodules", "-fmodule-name=\(module.name)"]
         args += ["-L\(prefix)"]
         

--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -128,6 +128,11 @@ public func describe(prefix: String, _ conf: Configuration, _ modules: [Module],
     #if os(Linux)
          args += ["-fPIC"]
     #endif
+    #if os(OSX)
+        if let sysroot = Toolchain.sysroot {
+           args += ["-I\(sysroot)/usr/include"]
+        }
+    #endif
         args += ["-fmodules", "-fmodule-name=\(module.name)"]
         args += ["-L\(prefix)"]
         

--- a/Sources/Utility/Toolchain.swift
+++ b/Sources/Utility/Toolchain.swift
@@ -51,11 +51,14 @@ public struct Toolchain: Installation {
     public static let clang = getenv("CC") ?? Toolchain.which("clang")
 }
 
-#if os(OSX)
 extension Toolchain {
+#if os(OSX)
     public static let sysroot = getenv("SYSROOT") ?? (try? POSIX.popen(["xcrun", "--sdk", "macosx", "--show-sdk-path"]))?.chuzzle()
     public static let platformPath = (try? POSIX.popen(["xcrun", "--sdk", "macosx", "--show-sdk-platform-path"]))?.chuzzle()
-}
+#else
+    public static let sysroot: String? = nil
+    public static let platformPath: String? = nil
 #endif
+}
 
 


### PR DESCRIPTION
On OSX when building C modukles using the Swift Package Manager, C files that #include standard C headers fail to compile, because Clang isn't passed the location of the standard C include files, which are in the usr/include subdirectory of one of the SDKs shipped with XCode.

Added include dir argument (-I) using the chosen SDK's usr/include directory to the list of arguments for Clang in the case of C modules.