### PR TITLE
Add rpath for the build directory to all sets of linker parameters.

### DIFF
--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -130,7 +130,7 @@ public func describe(prefix: String, _ conf: Configuration, _ modules: [Module],
     #endif
     #if os(OSX)
         if let sysroot = Toolchain.sysroot {
-           args += ["-I\(sysroot)/usr/include"]
+           args += ["-isysroot", "\(sysroot)"]
         }
     #endif
         args += ["-fmodules", "-fmodule-name=\(module.name)"]

--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -128,6 +128,11 @@ public func describe(prefix: String, _ conf: Configuration, _ modules: [Module],
     #if os(Linux)
          args += ["-fPIC"]
     #endif
+    #if os(OSX)
+        if let sysroot = Toolchain.sysroot {
+           args += ["-I\(sysroot)/usr/include"]
+        }
+    #endif
         args += ["-fmodules", "-fmodule-name=\(module.name)"]
         args += ["-L\(prefix)"]
         

--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -135,6 +135,7 @@ public func describe(prefix: String, _ conf: Configuration, _ modules: [Module],
     #endif
         args += ["-fmodules", "-fmodule-name=\(module.name)"]
         args += ["-L\(prefix)"]
+        args += ["-rpath", "\(prefix)"]
         
         for case let dep as ClangModule in module.dependencies {
             let includeFlag: String
@@ -243,6 +244,7 @@ public func describe(prefix: String, _ conf: Configuration, _ modules: [Module],
         args += platformArgs() //TODO don't need all these here or above: split outname
         args += Xld
         args += ["-L\(prefix)"]
+        args += ["-Xlinker", "-rpath", "-Xlinker", "\(prefix)"]
         args += ["-o", outpath]
         args += objects
 


### PR DESCRIPTION
An rpath of the build directory is automatically added to the set of parameters for the linker, just the way an -L(build dir) parameter is added.

This enables swift test to load the any executable that uses shared libraries that were built by the Swift Package Manager, which will live in the build directory.