### PR TITLE
[swift-test] [BLOCKED by #143] Disambiguate Package.test targets

### DIFF
--- a/Sources/Build/misc.swift
+++ b/Sources/Build/misc.swift
@@ -65,7 +65,7 @@ extension Product {
 
 func infoPlist(test: Product) -> String {
 
-    let bundleExecutable = "Package"
+    let bundleExecutable = test.name
     let bundleID = "org.swift.pm." + test.name
     let bundleName = test.name
 

--- a/Sources/Transmute/Package+products.swift
+++ b/Sources/Transmute/Package+products.swift
@@ -28,9 +28,8 @@ extension Package {
 
         if !testModules.isEmpty {
             let modules: [SwiftModule] = testModules.map{$0} // or linux compiler crash (2016-02-03)
-            //TODO name should be package name
             //TODO and then we should prefix all modules with their package probably
-            let product = Product(name: "Package", type: .Test, modules: modules)
+            let product = Product(name: self.name, type: .Test, modules: modules)
             products.append(product)
         }
 

--- a/Sources/swift-test/main.swift
+++ b/Sources/swift-test/main.swift
@@ -21,11 +21,14 @@ do {
         usage()
     case .Run(let xctestArg):
         let dir = try directories()
+
+        //FIXME find a reliable name to detect the name of the root test Package
+        let testPackageName = dir.root.basename
         let yamlPath = Path.join(dir.build, "debug.yaml")
         guard yamlPath.exists else { throw Error.DebugYAMLNotFound }
 
         try build(YAMLPath: yamlPath, target: "test")
-        let success = try test(dir.build, "debug", xctestArg: xctestArg)
+        let success = try test(dir.build, "debug", testPackageName: testPackageName, xctestArg: xctestArg)
         exit(success ? 0 : 1)
     }
 } catch {

--- a/Sources/swift-test/test.swift
+++ b/Sources/swift-test/test.swift
@@ -11,20 +11,20 @@
 import PackageType
 import Utility
 
-func test(path: String..., xctestArg: String? = nil) throws -> Bool {
+func test(path: String..., testPackageName: String, xctestArg: String? = nil) throws -> Bool {
     let path = Path.join(path)
     var args: [String] = []
     let testsPath: String
 
 #if os(OSX)
-    testsPath = Path.join(path, "Package.xctest")
+    testsPath = Path.join(path, "\(testPackageName).xctest")
     args = ["xcrun", "xctest"]
     if let xctestArg = xctestArg {
         args += ["-XCTest", xctestArg]
     }
 #else
     //FIXME: Pass xctestArg when swift-corelibs-xctest supports it
-    testsPath = Path.join(path, "test-Package")
+    testsPath = Path.join(path, "test-\(testPackageName)")
 #endif
 
     guard testsPath.testExecutableExists else {


### PR DESCRIPTION
This tries to solve the same problem as #151. 

This seems to work on OS X, I'm in the process of testing it on Linux.

! I need guidance on what the best way to pull the root package's name is. Currently I'm using the root folder's name, which of course isn't robust at all. 

This aims to fix https://bugs.swift.org/browse/SR-989