### PR TITLE
[swift-build] update `swift build --init library` tests format

### DIFF
--- a/Sources/swift-build/initPackage.swift
+++ b/Sources/swift-build/initPackage.swift
@@ -122,9 +122,9 @@ final class InitPackage {
         }
         print("Creating Tests/LinuxMain.swift")
         try fputs("import XCTest\n", linuxMainFP)
-        try fputs("@testable import \(pkgname)test\n\n", linuxMainFP)
+        try fputs("@testable import \(pkgname)TestSuite\n\n", linuxMainFP)
         try fputs("XCTMain([\n", linuxMainFP)
-        try fputs("\t\(pkgname)(),\n", linuxMainFP)
+        try fputs("\t testCase(\(pkgname).allTests),\n", linuxMainFP)
         try fputs("])\n", linuxMainFP)
     }
     
@@ -151,14 +151,12 @@ final class InitPackage {
     
         try fputs("}\n", testsFileFP)
     
-        try fputs("\n#if os(Linux)\n", testsFileFP)
-        try fputs("extension \(pkgname): XCTestCaseProvider {\n", testsFileFP)
-        try fputs("\tvar allTests : [(String, () throws -> Void)] {\n", testsFileFP)
+        try fputs("extension \(pkgname) {\n", testsFileFP)
+        try fputs("\tstatic var allTests : [(String, \(pkgname) -> () throws -> Void)] {\n", testsFileFP)
         try fputs("\t\treturn [\n", testsFileFP)
         try fputs("\t\t\t(\"testExample\", testExample),\n", testsFileFP)
         try fputs("\t\t]\n", testsFileFP)
         try fputs("\t}\n", testsFileFP)
         try fputs("}\n", testsFileFP)
-        try fputs("#endif\n", testsFileFP)
     }
 }

--- a/Sources/swift-build/initPackage.swift
+++ b/Sources/swift-build/initPackage.swift
@@ -124,7 +124,7 @@ final class InitPackage {
         try fputs("import XCTest\n", linuxMainFP)
         try fputs("@testable import \(pkgname)TestSuite\n\n", linuxMainFP)
         try fputs("XCTMain([\n", linuxMainFP)
-        try fputs("\t testCase(\(pkgname).allTests),\n", linuxMainFP)
+        try fputs("\t testCase(\(pkgname)Tests.allTests),\n", linuxMainFP)
         try fputs("])\n", linuxMainFP)
     }
     
@@ -133,8 +133,8 @@ final class InitPackage {
         print("Creating Tests/\(pkgname)/")
         try mkdir(testModule)
         
-        let testsFile = Path.join(testModule, "\(pkgname).swift")
-        print("Creating Tests/\(pkgname)/\(pkgname).swift")
+        let testsFile = Path.join(testModule, "\(pkgname)Tests.swift")
+        print("Creating Tests/\(pkgname)/\(pkgname)Tests.swift")
         let testsFileFP = try fopen(testsFile, mode: .Write)
         defer {
             fclose(testsFileFP)
@@ -142,7 +142,7 @@ final class InitPackage {
         try fputs("import XCTest\n", testsFileFP)
         try fputs("@testable import \(pkgname)\n\n", testsFileFP)
     
-        try fputs("class \(pkgname): XCTestCase {\n\n", testsFileFP)
+        try fputs("class \(pkgname)Tests: XCTestCase {\n\n", testsFileFP)
     
         try fputs("\tfunc testExample() {\n", testsFileFP)
         try fputs("\t\t// This is an example of a functional test case.\n", testsFileFP)
@@ -151,8 +151,8 @@ final class InitPackage {
     
         try fputs("}\n", testsFileFP)
     
-        try fputs("extension \(pkgname) {\n", testsFileFP)
-        try fputs("\tstatic var allTests : [(String, \(pkgname) -> () throws -> Void)] {\n", testsFileFP)
+        try fputs("extension \(pkgname)Tests {\n", testsFileFP)
+        try fputs("\tstatic var allTests : [(String, \(pkgname)Tests -> () throws -> Void)] {\n", testsFileFP)
         try fputs("\t\treturn [\n", testsFileFP)
         try fputs("\t\t\t(\"testExample\", testExample),\n", testsFileFP)
         try fputs("\t\t]\n", testsFileFP)


### PR DESCRIPTION
Update test to new format. The old format doesn't work on Linux any more.

run `sb --init library` in `NewInit` folder
This genere these File:

//LinuxMain.swift
```swift
import XCTest
@testable import NewInitTestSuite

XCTMain([
	 testCase(NewInit.allTests),
])

```
//Tests/NewInit/NewInit.swift
```swift
import XCTest
@testable import NewInit

class NewInit: XCTestCase {

	func testExample() {
		// This is an example of a functional test case.
		// Use XCTAssert and related functions to verify your tests produce the correct results.
	}

}
extension NewInit {
	static var allTests : [(String, NewInit -> () throws -> Void)] {
		return [
			("testExample", testExample),
		]
	}
}
```

### Notes: 
The only think I don't like here that `NewInit` TestCase class and file has the same name as source file. 
I think it would be nice to add a suffix, like: `NewInitTests ` or `NewInitTestCase`

I see that in SwiftPM we use both naming conventions.