### PR TITLE
skip Pre-release tags by default

### DIFF
--- a/Sources/Get/Fetchable.swift
+++ b/Sources/Get/Fetchable.swift
@@ -21,7 +21,7 @@ protocol Fetchable {
      */
     var availableVersions: [Version] { get }
 
-    func constrain(to versionRange: Range<Version>) -> Version?
+    func constrain(to versionRange: Range<Version>, includePrerelease: Bool) -> Version?
 
     //FIXME protocols cannot impose new property constraints,
     // so Package has a version { get } already, we cannot add

--- a/Sources/Get/Fetcher.swift
+++ b/Sources/Get/Fetcher.swift
@@ -39,7 +39,8 @@ extension Fetcher {
             return try urls.flatMap { url, specifiedVersionRange -> [String] in
 
                 func adjust(pkg: Fetchable, _ versionRange: Range<Version>) throws {
-                    guard let v = pkg.constrain(to: versionRange) else {
+                    // Don't include Pre-release Versions by default
+                    guard let v = pkg.constrain(to: versionRange, includePrerelease: false) else {
                         throw Error.InvalidDependencyGraphMissingTag(package: url, requestedTag: "\(versionRange)", existingTags: "\(pkg.availableVersions)")
                     }
                     try pkg.setVersion(v)

--- a/Sources/Get/Package.swift
+++ b/Sources/Get/Package.swift
@@ -37,7 +37,7 @@ extension Package: Fetchable {
         return Version(versionString)!
     }
 
-    func constrain(to versionRange: Range<Version>) -> Version? {
+    func constrain(to versionRange: Range<Version>, includePrerelease: Bool) -> Version? {
         return nil
     }
 

--- a/Sources/Get/RawClone.swift
+++ b/Sources/Get/RawClone.swift
@@ -75,11 +75,13 @@ class RawClone: Fetchable {
         }
     }
 
-    func constrain(to versionRange: Range<Version>) -> Version? {
-        return availableVersions.filter {
+    func constrain(to versionRange: Range<Version>, includePrerelease: Bool) -> Version? {
+        return availableVersions.filter { version in
+            let include = includePrerelease ? true : version.prereleaseIdentifiers.isEmpty
+
             // not using `contains` as it uses successor() and for Range<Version>
             // this involves iterating from 0 to Int.max!
-            versionRange ~= $0
+           return include && versionRange ~= version
         }.last
     }
 

--- a/Tests/Functional/TestValidLayouts.swift
+++ b/Tests/Functional/TestValidLayouts.swift
@@ -72,16 +72,16 @@ class ValidLayoutsTestCase: XCTestCase {
     func testPackageIdentifiers() {
         #if os(OSX)
             // this because sort orders vary on Linux on Mac currently
-            let tags = ["1.3.4-alpha.beta.gamma1", "1.2.3+24", "1.2.3", "1.2.3-beta5"]
+            let tags = ["1.3.4", "1.2.3", "1.2.3", "1.2.3"]
         #else
-            let tags = ["1.2.3", "1.2.3-beta5", "1.3.4-alpha.beta.gamma1", "1.2.3+24"]
+            let tags = ["1.2.3", "1.2.3", "1.3.4", "1.2.3"]
         #endif
         
         fixture(name: "DependencyResolution/External/Complex", tags: tags) { prefix in
             XCTAssertBuilds(prefix, "app", configurations: [.Debug])
-            XCTAssertDirectoryExists(prefix, "app/Packages/DeckOfPlayingCards-1.2.3-beta5")
-            XCTAssertDirectoryExists(prefix, "app/Packages/FisherYates-1.3.4-alpha.beta.gamma1")
-            XCTAssertDirectoryExists(prefix, "app/Packages/PlayingCard-1.2.3+24")
+            XCTAssertDirectoryExists(prefix, "app/Packages/DeckOfPlayingCards-1.2.3")
+            XCTAssertDirectoryExists(prefix, "app/Packages/FisherYates-1.3.4")
+            XCTAssertDirectoryExists(prefix, "app/Packages/PlayingCard-1.2.3")
         }
     }
 


### PR DESCRIPTION
This Pull Request solve the issue discussed in [ RP-79] (https://github.com/apple/swift-package-manager/pull/179)

It adds ability to skip the Pre-release version. By default we skip them. 
This code will no longer match or fetch any pre-release versions  
```swift
.Package(url: "…", versions: Version(1,0,0)..<Version(2,0,0))
```

 In future it would be easy to pass additional parameter to Fetcher and include Pre-release version when needed.

***
**Before merging**:
- [ ] Merge #223 
- [ ] Update it work with changes made in #223 