### PR TITLE
Pass args to XCTest on linux

### DIFF
--- a/Sources/swift-test/test.swift
+++ b/Sources/swift-test/test.swift
@@ -22,16 +22,18 @@ func test(path: String..., xctestArg: String? = nil) throws -> Bool {
     if let xctestArg = xctestArg {
         args += ["-XCTest", xctestArg]
     }
+    args += [testsPath]
 #else
-    //FIXME: Pass xctestArg when swift-corelibs-xctest supports it
     testsPath = Path.join(path, "test-Package")
+    args += [testsPath]
+    if let xctestArg = xctestArg {
+        args += [xctestArg]
+    }
 #endif
 
     guard testsPath.testExecutableExists else {
         throw Error.TestsExecutableNotFound
     }
-
-    args += [testsPath]
 
     let result: Void? = try? system(args)
     return result != nil

--- a/Sources/swift-test/usage.swift
+++ b/Sources/swift-test/usage.swift
@@ -23,13 +23,13 @@ func usage(print: (String) -> Void = { print($0) }) {
 
 enum Mode {
     case Usage
-    case Run(String)
+    case Run(String?)
 }
 
 func parse(commandLineArguments args: [String]) throws -> Mode {
 
     if args.count == 0 {
-        return .Run("All")
+        return .Run(nil)
     }
 
     guard let argument = args.first where args.count == 1 else {


### PR DESCRIPTION
This allows passing args to xctest on linux, so we can do this on linux :
```
$ swift test FunctionalTestSuite.TestClangModulesTestCase/testSingleModuleCLibraryInSources
```