### PR TITLE
Add --release flag for bootstrap script

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -651,15 +651,20 @@ def main():
     if result != 0:
         error("build failed with exit status %d" % (result,))
 
-    swift_build_path = os.path.join(build_path, "debug", "swift-build")
-    swift_test_path = os.path.join(build_path, "debug", "swift-test")
+    if args.release:
+        conf = "release"
+    else:
+        conf = "debug"
+
+    swift_build_path = os.path.join(build_path, conf, "swift-build")
+    swift_test_path = os.path.join(build_path, conf, "swift-test")
 
     # If testing, run each of the test bundles.
     if "test" in build_actions:
         # Construct the test environment.
         env_cmd = ["env", "SWIFT_EXEC=" + os.path.join(bindir, "swiftc"),
                           "SWIFT_BUILD_PATH=" + build_path]
-        cmd = env_cmd + [os.path.join(build_path, "debug", "swift-test")]
+        cmd = env_cmd + [swift_test_path]
         result = subprocess.call(cmd, cwd=g_project_root)
         if result != 0:
             error("tests failed with exit status %d" % (result,))

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -534,6 +534,8 @@ def main():
                         help="Path to Foundation build directory")
     parser.add_argument("--xctest", dest="xctest_path",
                         help="Path to XCTest build directory")
+    parser.add_argument("--release", action="store_true",
+                        help="Build stage 2 for release")
     args = parser.parse_args()
 
     if not args.swiftc_path:
@@ -638,6 +640,9 @@ def main():
         cmd.extend(["-Xswiftc", "-I{}".format(args.foundation_path)])
         cmd.extend(["-Xswiftc", "-I{}".format(core_foundation_path)])
 
+    if args.release:
+        cmd.extend(["--configuration", "release"])
+
     cmd = env_cmd + cmd
 
     note("building self-hosted 'swift-build': %s" % (
@@ -648,7 +653,6 @@ def main():
 
     swift_build_path = os.path.join(build_path, "debug", "swift-build")
     swift_test_path = os.path.join(build_path, "debug", "swift-test")
-    note("built: %s" % (swift_build_path,))
 
     # If testing, run each of the test bundles.
     if "test" in build_actions:


### PR DESCRIPTION
This allows the bootstrap script to build SwiftPM in release mode.

We need to add integration to the swift build-script so that we are built in release mode as part of snapshots.