### PR TITLE
Support for specifying a branch for a dependency.

### DIFF
--- a/Sources/Get/Fetchable.swift
+++ b/Sources/Get/Fetchable.swift
@@ -12,7 +12,7 @@ import struct PackageDescription.Version
 
 protocol Fetchable {
     var version: Version { get }
-    var children: [(String, Range<Version>)] { get }
+    var children: [(String, String, Range<Version>)] { get }
 
     /**
      This should be a separate protocol. But Swift 2 was not happy

--- a/Sources/Get/Fetcher.swift
+++ b/Sources/Get/Fetcher.swift
@@ -18,10 +18,10 @@ protocol Fetcher {
     associatedtype T: Fetchable
 
     func find(url url: String) throws -> Fetchable?
-    func fetch(url url: String) throws -> Fetchable
+	func fetch(url url: String, branch: String) throws -> Fetchable
     func finalize(fetchable: Fetchable) throws -> T
 
-    func recursivelyFetch(urls: [(String, Range<Version>)]) throws -> [T]
+    func recursivelyFetch(urls: [(String, String, Range<Version>)]) throws -> [T]
 }
 
 extension Fetcher {
@@ -30,13 +30,13 @@ extension Fetcher {
      
      This is our standard implementation that we override when testing.
      */
-    func recursivelyFetch(urls: [(String, Range<Version>)]) throws -> [T] {
+    func recursivelyFetch(urls: [(String, String, Range<Version>)]) throws -> [T] {
 
         var graph = [String: (Fetchable, Range<Version>)]()
 
-        func recurse(urls: [(String, Range<Version>)]) throws -> [String] {
+        func recurse(urls: [(String, String, Range<Version>)]) throws -> [String] {
 
-            return try urls.flatMap { url, specifiedVersionRange -> [String] in
+            return try urls.flatMap { url, branch, specifiedVersionRange -> [String] in
 
                 func adjust(pkg: Fetchable, _ versionRange: Range<Version>) throws {
                     guard let v = pkg.constrain(to: versionRange) else {
@@ -89,7 +89,7 @@ extension Fetcher {
 
                     // clone the package
 
-                    let clone = try self.fetch(url: url)
+					let clone = try self.fetch(url: url, branch: branch)
                     try adjust(clone, specifiedVersionRange)
                     graph[url] = (clone, specifiedVersionRange)
                     return try recurse(clone.children) + [url]

--- a/Sources/Get/Git.swift
+++ b/Sources/Get/Git.swift
@@ -15,7 +15,7 @@ import enum POSIX.Error
 import Utility
 
 extension Git {
-    class func clone(url: String, to dstdir: String) throws -> Repo {
+	class func clone(url: String, branch: String, to dstdir: String) throws -> Repo {
         // canonicalize URL
         var url = url
         if URL.scheme(url) == nil {
@@ -34,7 +34,10 @@ extension Git {
             try system(Git.tool, "clone",
                        "--recursive",   // get submodules too so that developers can use these if they so choose
                 "--depth", "10",
-                url, dstdir, environment: environment, message: "Cloning \(url)")
+                "--branch", branch, "--single-branch",
+                url, dstdir,
+                environment: environment,
+                message: "Cloning \(url)" + (branch == "master" ? "" : " \(branch)"))
         } catch POSIX.Error.ExitStatus {
             // Git 2.0 or higher is required
             if Git.majorVersionNumber < 2 {

--- a/Sources/Get/Package.swift
+++ b/Sources/Get/Package.swift
@@ -25,8 +25,8 @@ extension Package {
 }
 
 extension Package: Fetchable {
-    var children: [(String, Range<Version>)] {
-        return manifest.package.dependencies.map{ ($0.url, $0.versionRange) }
+    var children: [(String, String, Range<Version>)] {
+		return manifest.package.dependencies.map{ ($0.url, $0.branch, $0.versionRange) }
     }
 
     private var versionString: String.CharacterView {

--- a/Sources/Get/PackagesDirectory.swift
+++ b/Sources/Get/PackagesDirectory.swift
@@ -39,7 +39,7 @@ extension PackagesDirectory: Fetcher {
         return nil
     }
 
-    func fetch(url url: String) throws -> Fetchable {
+	func fetch(url url: String, branch: String) throws -> Fetchable {
         let dstdir = Path.join(prefix, Package.nameForURL(url))
         if let repo = Git.Repo(path: dstdir) where repo.origin == url {
             //TODO need to canonicalize the URL need URL struct
@@ -47,7 +47,7 @@ extension PackagesDirectory: Fetcher {
         }
 
         // fetch as well, clone does not fetch all tags, only tags on the master branch
-        try Git.clone(url, to: dstdir).fetch()
+		try Git.clone(url, branch: branch, to: dstdir).fetch()
 
         return try RawClone(path: dstdir, manifestParser: manifestParser)
     }

--- a/Sources/Get/RawClone.swift
+++ b/Sources/Get/RawClone.swift
@@ -83,7 +83,7 @@ class RawClone: Fetchable {
         }.last
     }
 
-    var children: [(String, Range<Version>)] {
+    var children: [(String, String, Range<Version>)] {
         guard manifest != nil else {
             // manifest may not exist, if so the package is BAD,
             // still: we should not crash. Build failure will occur

--- a/Sources/Get/get().swift
+++ b/Sources/Get/get().swift
@@ -43,7 +43,7 @@ public func get(manifest: Manifest, manifestParser: (path: String, url: String) 
 import PackageDescription
 
 extension Manifest {
-    var dependencies: [(String, Range<Version>)] {
-        return package.dependencies.map{ ($0.url, $0.versionRange) }
+    var dependencies: [(String, String, Range<Version>)] {
+        return package.dependencies.map{ ($0.url, $0.branch, $0.versionRange) }
     }
 }

--- a/Sources/ManifestParser/fromTOML().swift
+++ b/Sources/ManifestParser/fromTOML().swift
@@ -62,12 +62,13 @@ extension PackageDescription.Package {
 
 extension PackageDescription.Package.Dependency {
     public static func fromTOML(item: TOMLItem, baseURL: String?) -> PackageDescription.Package.Dependency {
-        guard case .Array(let array) = item where array.items.count == 3 else {
+        guard case .Array(let array) = item where array.items.count == 4 else {
             fatalError("Unexpected TOMLItem")
         }
         guard case .String(let url) = array.items[0],
-              case .String(let vv1) = array.items[1],
-              case .String(let vv2) = array.items[2],
+		      case .String(let branch) = array.items[1],
+              case .String(let vv1) = array.items[2],
+              case .String(let vv2) = array.items[3],
               let v1 = Version(vv1), v2 = Version(vv2)
         else {
             fatalError("Unexpected TOMLItem")
@@ -81,7 +82,7 @@ extension PackageDescription.Package.Dependency {
             }
         }
 
-        return PackageDescription.Package.Dependency.Package(url: fixURL(), versions: v1..<v2)
+		return PackageDescription.Package.Dependency.Package(url: fixURL(), branch: branch, versions: v1..<v2)
     }
 }
 

--- a/Sources/PackageDescription/Package.swift
+++ b/Sources/PackageDescription/Package.swift
@@ -20,23 +20,25 @@ public final class Package {
     public class Dependency {
         public let versionRange: Range<Version>
         public let url: String
+		public let branch: String
 
-        init(_ url: String, _ versionRange: Range<Version>) {
+		init(_ url: String, _ branch: String, _ versionRange: Range<Version>) {
             self.url = url
+			self.branch = branch
             self.versionRange = versionRange
         }
 
-        public class func Package(url url: String, versions: Range<Version>) -> Dependency {
-            return Dependency(url, versions)
+		public class func Package(url url: String, branch: String = "master", versions: Range<Version>) -> Dependency {
+            return Dependency(url, branch, versions)
         }
-        public class func Package(url url: String, majorVersion: Int) -> Dependency {
-            return Dependency(url, Version(majorVersion, 0, 0)..<Version(majorVersion, .max, .max))
+        public class func Package(url url: String, branch: String = "master", majorVersion: Int) -> Dependency {
+            return Dependency(url, branch, Version(majorVersion, 0, 0)..<Version(majorVersion, .max, .max))
         }
-        public class func Package(url url: String, majorVersion: Int, minor: Int) -> Dependency {
-            return Dependency(url, Version(majorVersion, minor, 0)..<Version(majorVersion, minor, .max))
+        public class func Package(url url: String, branch: String = "master", majorVersion: Int, minor: Int) -> Dependency {
+            return Dependency(url, branch, Version(majorVersion, minor, 0)..<Version(majorVersion, minor, .max))
         }
-        public class func Package(url url: String, _ version: Version) -> Dependency {
-            return Dependency(url, version...version)
+        public class func Package(url url: String, branch: String = "master", _ version: Version) -> Dependency {
+            return Dependency(url, branch, version...version)
         }
     }
     
@@ -80,7 +82,7 @@ public final class Package {
 
 extension Package.Dependency: TOMLConvertible {
     public func toTOML() -> String {
-        return "[\"\(url)\", \"\(versionRange.startIndex)\", \"\(versionRange.endIndex)\"],"
+        return "[\"\(url)\", \"\(branch)\", \"\(versionRange.startIndex)\", \"\(versionRange.endIndex)\"],"
     }
 }
 

--- a/Tests/Get/DependencyGraphTests.swift
+++ b/Tests/Get/DependencyGraphTests.swift
@@ -16,7 +16,7 @@ class VersionGraphTests: XCTestCase {
 
     func testNoGraph() {
         class MockFetcher: _MockFetcher {
-            override func fetch(url url: String) throws -> Fetchable {
+            override func fetch(url url: String, branch: String) throws -> Fetchable {
                 switch MockProject(rawValue: url)! {
                     case .A: return MockCheckout(.A, [v1])
                 default:
@@ -25,7 +25,7 @@ class VersionGraphTests: XCTestCase {
             }
         }
 
-        let rv: [MockCheckout] = try! MockFetcher().recursivelyFetch([(MockProject.A.url, v1...v1)])
+        let rv: [MockCheckout] = try! MockFetcher().recursivelyFetch([(MockProject.A.url, MockProject.A.branch, v1...v1)])
 
         XCTAssertEqual(rv, [
             MockCheckout(.A, v1)
@@ -34,9 +34,9 @@ class VersionGraphTests: XCTestCase {
 
     func testOneDependency() {
         class MockFetcher: _MockFetcher {
-            override func fetch(url url: String) throws -> Fetchable {
+            override func fetch(url url: String, branch: String) throws -> Fetchable {
                 switch MockProject(rawValue: url)! {
-                case .A: return MockCheckout(.A, [v1], (MockProject.B.url, v1...v1))
+                case .A: return MockCheckout(.A, [v1], (MockProject.B.url, MockProject.B.branch, v1...v1))
                 case .B: return MockCheckout(.B, [v1])
                 default:
                     fatalError()
@@ -44,7 +44,7 @@ class VersionGraphTests: XCTestCase {
             }
         }
 
-        let rv: [MockCheckout] = try! MockFetcher().recursivelyFetch([(MockProject.A.url, v1...v1)])
+        let rv: [MockCheckout] = try! MockFetcher().recursivelyFetch([(MockProject.A.url, MockProject.A.branch, v1...v1)])
 
         XCTAssertEqual(rv, [
             MockCheckout(.B, v1),
@@ -54,9 +54,9 @@ class VersionGraphTests: XCTestCase {
 
     func testOneDepenencyWithMultipleAvailableVersions() {
         class MockFetcher: _MockFetcher {
-            override func fetch(url url: String) throws -> Fetchable {
+			override func fetch(url url: String, branch: String) throws -> Fetchable {
                 switch MockProject(rawValue: url)! {
-                    case .A: return MockCheckout(.A, [v1], (MockProject.B.url, v1..<v2))
+                    case .A: return MockCheckout(.A, [v1], (MockProject.B.url, MockProject.B.branch, v1..<v2))
                     case .B: return MockCheckout(.B, [v1, v199, v2, "3.0.0"])
                 default:
                     fatalError()
@@ -64,7 +64,7 @@ class VersionGraphTests: XCTestCase {
             }
         }
 
-        let rv: [MockCheckout] = try! MockFetcher().recursivelyFetch([(MockProject.A.url, v1...v1)])
+        let rv: [MockCheckout] = try! MockFetcher().recursivelyFetch([(MockProject.A.url, MockProject.A.branch, v1...v1)])
 
         XCTAssertEqual(rv, [
             MockCheckout(.B, v199),
@@ -74,10 +74,10 @@ class VersionGraphTests: XCTestCase {
 
     func testTwoDependencies() {
         class MockFetcher: _MockFetcher {
-            override func fetch(url url: String) throws -> Fetchable {
+            override func fetch(url url: String, branch: String) throws -> Fetchable {
                 switch MockProject(rawValue: url)! {
-                    case .A: return MockCheckout(.A, [v1], (MockProject.B.url, v1...v1))
-                    case .B: return MockCheckout(.B, [v1], (MockProject.C.url, v1...v1))
+                    case .A: return MockCheckout(.A, [v1], (MockProject.B.url, MockProject.B.branch, v1...v1))
+                    case .B: return MockCheckout(.B, [v1], (MockProject.C.url, MockProject.C.branch, v1...v1))
                     case .C: return MockCheckout(.C, [v1])
                 default:
                     fatalError()
@@ -85,7 +85,7 @@ class VersionGraphTests: XCTestCase {
             }
         }
 
-        let rv: [MockCheckout] = try! MockFetcher().recursivelyFetch([(MockProject.A.url, v1...v1)])
+        let rv: [MockCheckout] = try! MockFetcher().recursivelyFetch([(MockProject.A.url, MockProject.A.branch, v1...v1)])
 
         XCTAssertEqual(rv, [
             MockCheckout(.C, v1),
@@ -96,9 +96,9 @@ class VersionGraphTests: XCTestCase {
 
     func testTwoDirectDependencies() {
         class MockFetcher: _MockFetcher {
-            override func fetch(url url: String) throws -> Fetchable {
+            override func fetch(url url: String, branch: String) throws -> Fetchable {
                 switch MockProject(rawValue: url)! {
-                    case .A: return MockCheckout(.A, [v1], (MockProject.B.url, v1...v1), (MockProject.C.url, v1...v1))
+                    case .A: return MockCheckout(.A, [v1], (MockProject.B.url, MockProject.B.branch, v1...v1), (MockProject.C.url, MockProject.C.branch, v1...v1))
                     case .B: return MockCheckout(.B, [v1])
                     case .C: return MockCheckout(.C, [v1])
                 default:
@@ -107,7 +107,7 @@ class VersionGraphTests: XCTestCase {
             }
         }
 
-        let rv: [MockCheckout] = try! MockFetcher().recursivelyFetch([(MockProject.A.url, v1...v1)])
+        let rv: [MockCheckout] = try! MockFetcher().recursivelyFetch([(MockProject.A.url, MockProject.A.branch, v1...v1)])
 
         XCTAssertEqual(rv, [
             MockCheckout(.B, v1),
@@ -118,10 +118,10 @@ class VersionGraphTests: XCTestCase {
 
     func testTwoDirectDependenciesWhereOneAlsoDependsOnTheOther() {
         class MockFetcher: _MockFetcher {
-            override func fetch(url url: String) throws -> Fetchable {
+            override func fetch(url url: String, branch: String) throws -> Fetchable {
                 switch MockProject(rawValue: url)! {
-                    case .A: return MockCheckout(.A, [v1], (MockProject.B.url, v1...v1), (MockProject.C.url, v1...v1))
-                    case .B: return MockCheckout(.B, [v1], (MockProject.C.url, v1...v1))
+                    case .A: return MockCheckout(.A, [v1], (MockProject.B.url, MockProject.B.branch, v1...v1), (MockProject.C.url, MockProject.C.branch, v1...v1))
+                    case .B: return MockCheckout(.B, [v1], (MockProject.C.url, MockProject.C.branch, v1...v1))
                     case .C: return MockCheckout(.C, [v1])
                 default:
                     fatalError()
@@ -129,7 +129,7 @@ class VersionGraphTests: XCTestCase {
             }
         }
 
-        let rv: [MockCheckout] = try! MockFetcher().recursivelyFetch([(MockProject.A.url, v1...v1)])
+        let rv: [MockCheckout] = try! MockFetcher().recursivelyFetch([(MockProject.A.url, MockProject.A.branch, v1...v1)])
 
         XCTAssertEqual(rv, [
             MockCheckout(.C, v1),
@@ -141,10 +141,10 @@ class VersionGraphTests: XCTestCase {
     func testSimpleVersionRestrictedGraph() {
 
         class MockFetcher: _MockFetcher {
-            override func fetch(url url: String) throws -> Fetchable {
+            override func fetch(url url: String, branch: String) throws -> Fetchable {
                 switch MockProject(rawValue: url)! {
-                    case .A: return MockCheckout(.A, [v1], (MockProject.C.url, v123..<v2))
-                    case .B: return MockCheckout(.B, [v2], (MockProject.C.url, v123...v126))
+                    case .A: return MockCheckout(.A, [v1], (MockProject.C.url, MockProject.C.branch, v123..<v2))
+                    case .B: return MockCheckout(.B, [v2], (MockProject.C.url, MockProject.C.branch, v123...v126))
                     case .C: return MockCheckout(.C, [v126])
                 default:
                     fatalError()
@@ -153,8 +153,8 @@ class VersionGraphTests: XCTestCase {
         }
 
         let rv: [MockCheckout] = try! MockFetcher().recursivelyFetch([
-            (MockProject.A.url, v1...v1),
-            (MockProject.B.url, v2...v2)
+            (MockProject.A.url, MockProject.A.branch, v1...v1),
+            (MockProject.B.url, MockProject.B.branch, v2...v2)
         ])
 
         XCTAssertEqual(rv, [
@@ -167,20 +167,20 @@ class VersionGraphTests: XCTestCase {
     func testComplexVersionRestrictedGraph() {
 
         class MyMockFetcher: _MockFetcher {
-            override func fetch(url url: String) throws -> Fetchable {
+            override func fetch(url url: String, branch: String) throws -> Fetchable {
                 switch MockProject(rawValue: url)! {
-                    case .A: return MockCheckout(.A, [v1], (MockProject.C.url, Version(1,2,3)..<v2), (MockProject.D.url, v126...v2), (MockProject.B.url, v1...v2))
-                    case .B: return MockCheckout(.B, [v2], (MockProject.C.url, Version(1,2,3)...v126), (MockProject.E.url, v2...v2))
-                    case .C: return MockCheckout(.C, [v126], (MockProject.D.url, v2...v2), (MockProject.E.url, v1..<Version(2,1,0)))
-                    case .D: return MockCheckout(.D, [v2], (MockProject.F.url, v1..<v2))
-                    case .E: return MockCheckout(.E, [v2], (MockProject.F.url, v1...v1))
+                    case .A: return MockCheckout(.A, [v1], (MockProject.C.url, MockProject.C.branch, Version(1,2,3)..<v2), (MockProject.D.url, MockProject.D.branch, v126...v2), (MockProject.B.url, MockProject.B.branch, v1...v2))
+                    case .B: return MockCheckout(.B, [v2], (MockProject.C.url, MockProject.C.branch, Version(1,2,3)...v126), (MockProject.E.url, MockProject.E.branch, v2...v2))
+                    case .C: return MockCheckout(.C, [v126], (MockProject.D.url, MockProject.D.branch, v2...v2), (MockProject.E.url, MockProject.E.branch, v1..<Version(2,1,0)))
+                    case .D: return MockCheckout(.D, [v2], (MockProject.F.url, MockProject.F.branch, v1..<v2))
+                    case .E: return MockCheckout(.E, [v2], (MockProject.F.url, MockProject.F.branch, v1...v1))
                     case .F: return MockCheckout(.F, [v1])
                 }
             }
         }
 
         let rv: [MockCheckout] = try! MyMockFetcher().recursivelyFetch([
-            (MockProject.A.url, v1...v1),
+            (MockProject.A.url, MockProject.A.branch, v1...v1),
         ])
 
         XCTAssertEqual(rv, [
@@ -212,10 +212,10 @@ class VersionGraphTests: XCTestCase {
 
     func testTwoDependenciesRequireMutuallyExclusiveVersionsOfTheSameDependency_Simple() {
         class MyMockFetcher: _MockFetcher {
-            override func fetch(url url: String) throws -> Fetchable {
+            override func fetch(url url: String, branch: String) throws -> Fetchable {
                 switch MockProject(rawValue: url)! {
-                    case .A: return MockCheckout(.A, [v1], (MockProject.C.url, Version(1,2,3)..<v2))
-                    case .B: return MockCheckout(.B, [v1], (MockProject.C.url, v2...v2))  // this is outside the above bounds
+                    case .A: return MockCheckout(.A, [v1], (MockProject.C.url, MockProject.C.branch, Version(1,2,3)..<v2))
+                    case .B: return MockCheckout(.B, [v1], (MockProject.C.url, MockProject.C.branch, v2...v2))  // this is outside the above bounds
                     case .C: return MockCheckout(.C, ["1.2.3", "1.9.9", "2.0.1"])
                 default:
                     fatalError()
@@ -226,8 +226,8 @@ class VersionGraphTests: XCTestCase {
         var invalidGraph = false
         do {
             try MyMockFetcher().recursivelyFetch([
-                (MockProject.A.url, Version.maxRange),
-                (MockProject.B.url, Version.maxRange)
+                (MockProject.A.url, MockProject.A.branch, Version.maxRange),
+                (MockProject.B.url, MockProject.B.branch, Version.maxRange)
             ])
         } catch Error.InvalidDependencyGraph(let url) {
             invalidGraph = true
@@ -242,13 +242,13 @@ class VersionGraphTests: XCTestCase {
     func testTwoDependenciesRequireMutuallyExclusiveVersionsOfTheSameDependency_Complex() {
 
         class MyMockFetcher: _MockFetcher {
-            override func fetch(url url: String) throws -> Fetchable {
+            override func fetch(url url: String, branch: String) throws -> Fetchable {
                 switch MockProject(rawValue: url)! {
-                    case .A: return MockCheckout(.A, [v1], (MockProject.C.url, Version(1,2,3)..<v2), (MockProject.D.url, v126...v2), (MockProject.B.url, v1...v2))
-                    case .B: return MockCheckout(.B, [v2], (MockProject.C.url, Version(1,2,3)...v126), (MockProject.E.url, v2...v2))
-                    case .C: return MockCheckout(.C, ["1.2.4"], (MockProject.D.url, v2...v2), (MockProject.E.url, v1..<Version(2,1,0)))
-                    case .D: return MockCheckout(.D, [v2], (MockProject.F.url, v1..<v2))
-                    case .E: return MockCheckout(.E, ["2.0.1"], (MockProject.F.url, v2...v2))
+                    case .A: return MockCheckout(.A, [v1], (MockProject.C.url, MockProject.C.branch, Version(1,2,3)..<v2), (MockProject.D.url, MockProject.D.branch, v126...v2), (MockProject.B.url, MockProject.B.branch, v1...v2))
+                    case .B: return MockCheckout(.B, [v2], (MockProject.C.url, MockProject.C.branch, Version(1,2,3)...v126), (MockProject.E.url, MockProject.E.branch, v2...v2))
+                    case .C: return MockCheckout(.C, ["1.2.4"], (MockProject.D.url, MockProject.D.branch, v2...v2), (MockProject.E.url, MockProject.E.branch, v1..<Version(2,1,0)))
+                    case .D: return MockCheckout(.D, [v2], (MockProject.F.url, MockProject.F.branch, v1..<v2))
+                    case .E: return MockCheckout(.E, ["2.0.1"], (MockProject.F.url, MockProject.F.branch, v2...v2))
                     case .F: return MockCheckout(.F, [v2])
                 }
             }
@@ -257,7 +257,7 @@ class VersionGraphTests: XCTestCase {
         var invalidGraph = false
         do {
             try MyMockFetcher().recursivelyFetch([
-                (MockProject.A.url, v1...v1),
+                (MockProject.A.url, MockProject.A.branch, v1...v1),
             ])
         } catch Error.InvalidDependencyGraphMissingTag(let url, _, _) {
             XCTAssertEqual(url, MockProject.F.url)
@@ -270,14 +270,14 @@ class VersionGraphTests: XCTestCase {
 
     func testVersionUnavailable() {
         class MyMockFetcher: _MockFetcher {
-            override func fetch(url url: String) throws -> Fetchable {
+            override func fetch(url url: String, branch: String) throws -> Fetchable {
                 return MockCheckout(.A, [v2])
             }
         }
 
         var success = false
         do {
-            try MyMockFetcher().recursivelyFetch([(MockProject.A.url, v1..<v2)])
+            try MyMockFetcher().recursivelyFetch([(MockProject.A.url, MockProject.A.branch, v1..<v2)])
         } catch Error.InvalidDependencyGraphMissingTag {
             success = true
         } catch {
@@ -320,15 +320,16 @@ private enum MockProject: String {
     case E
     case F
     var url: String { return rawValue }
+	var branch: String { return "master" }
 }
 
 private class MockCheckout: Equatable, CustomStringConvertible, Fetchable {
     let project: MockProject
-    let children: [(String, Range<Version>)]
+    let children: [(String, String, Range<Version>)]
     var availableVersions: [Version]
     var _version: Version?
 
-    init(_ project: MockProject, _ availableVersions: [Version], _ dependencies: (String, Range<Version>)...) {
+    init(_ project: MockProject, _ availableVersions: [Version], _ dependencies: (String, String, Range<Version>)...) {
         self.availableVersions = availableVersions
         self.project = project
         self.children = dependencies
@@ -371,7 +372,7 @@ private class _MockFetcher: Fetcher {
         return fetchable as! T
     }
 
-    func fetch(url url: String) throws -> Fetchable {
+	func fetch(url url: String, branch: String) throws -> Fetchable {
         fatalError("This must be implemented in each test")
     }
 }

--- a/Tests/ManifestParser/Inputs/package-deps-manifest
+++ b/Tests/ManifestParser/Inputs/package-deps-manifest
@@ -3,4 +3,4 @@ import PackageDescription
 let package = Package(
     name: "PackageDeps",
     dependencies: [
-        .Package(url: "https://example.com/example", majorVersion: 1)])
+        .Package(url: "https://example.com/example", branch: "dev", majorVersion: 1)])

--- a/Tests/ManifestParser/ManifestTests.swift
+++ b/Tests/ManifestParser/ManifestTests.swift
@@ -59,7 +59,7 @@ class ManifestTests: XCTestCase {
         loadManifest("package-deps-manifest") { manifest in
             XCTAssertEqual(manifest.package.name, "PackageDeps")
             XCTAssertEqual(manifest.package.targets, [])
-            XCTAssertEqual(manifest.package.dependencies, [Package.Dependency.Package(url: "https://example.com/example", majorVersion: 1)])
+			XCTAssertEqual(manifest.package.dependencies, [Package.Dependency.Package(url: "https://example.com/example", branch: "dev", majorVersion: 1)])
         }
 
         // Check a manifest with targets.


### PR DESCRIPTION
In a Package dependency, you can now specify an optional branch, and this branch will get cloned when getting dependencies.
It currently defaults to "master" if not specified (and will use 'git clone -b master').
Currently the branch will not influence the package name, but the name and tag should be enough that it doesn't conflict.