### PR TITLE
[bootstrap] Fix Python 3 compatibility regression

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -58,7 +58,7 @@ def symlink_force(target, link_name):
         link_name = os.path.join(link_name, os.path.basename(target))
     try:
         os.symlink(target, link_name)
-    except OSError, e:
+    except OSError as e:
         if e.errno == errno.EEXIST:
             os.remove(link_name)
             os.symlink(target, link_name)


### PR DESCRIPTION
A new function introduced in 2ce8a1810994a5bc3809731c594f2f519b49a5a1 has Python 2 syntax. The script had been Python 3 compatible up until then. This patch restores that compatibility.