### PR TITLE
Find swiftc for tests with the default xctoolchain

### DIFF
--- a/Tests/Functional/Utilities.swift
+++ b/Tests/Functional/Utilities.swift
@@ -100,8 +100,14 @@ func executeSwiftBuild(_ chdir: String, configuration: Configuration = .Debug, p
     case "swiftc"?, nil:
         //FIXME Xcode should set this during tests
         // rdar://problem/24134324
-        let bindir = Path.join(getenv("XCODE_DEFAULT_TOOLCHAIN_OVERRIDE")!, "usr/bin")
-        env["SWIFT_EXEC"] = Path.join(bindir, "swiftc")
+        let swiftc: String
+        if let base = getenv("XCODE_DEFAULT_TOOLCHAIN_OVERRIDE")?.chuzzle() {
+            swiftc = Path.join(base, "usr/bin/swiftc")
+        } else {
+            swiftc = try popen(["xcrun", "--find", "swiftc"]).chuzzle() ?? "BADPATH"
+        }
+        precondition(swiftc != "/usr/bin/swiftc")
+        env["SWIFT_EXEC"] = swiftc
     default:
         fatalError("HURRAY! This is fixed")
     }

--- a/Tests/ManifestParser/ManifestTests.swift
+++ b/Tests/ManifestParser/ManifestTests.swift
@@ -11,6 +11,7 @@
 @testable import ManifestParser
 @testable import Utility
 import func POSIX.getenv
+import func POSIX.popen
 import PackageDescription
 import PackageType
 import XCTest
@@ -28,7 +29,16 @@ class ManifestTests: XCTestCase {
 
 #if os(OSX)
   #if Xcode
-    let swiftc = Path.join(getenv("XCODE_DEFAULT_TOOLCHAIN_OVERRIDE")!, "usr/bin/swiftc")
+    let swiftc: String = {
+        let swiftc: String
+        if let base = getenv("XCODE_DEFAULT_TOOLCHAIN_OVERRIDE")?.chuzzle() {
+            swiftc = Path.join(base, "usr/bin/swiftc")
+        } else {
+            swiftc = try! popen(["xcrun", "--find", "swiftc"]).chuzzle() ?? "BADPATH"
+        }
+        precondition(swiftc != "/usr/bin/swiftc")
+        return swiftc
+    }()
   #else
     let swiftc = Path.join(bundleRoot(), "swiftc")
   #endif

--- a/Tests/Transmute/ModuleTests.swift
+++ b/Tests/Transmute/ModuleTests.swift
@@ -10,6 +10,7 @@
 
 @testable import Transmute
 import struct Utility.Path
+import func POSIX.popen
 import ManifestParser
 import PackageType
 import XCTest
@@ -259,7 +260,13 @@ extension Manifest {
 
     #if os(OSX)
         #if Xcode
-            let swiftc = Path.join(getenv("XCODE_DEFAULT_TOOLCHAIN_OVERRIDE")!, "usr/bin/swiftc")
+            let swiftc: String
+            if let base = getenv("XCODE_DEFAULT_TOOLCHAIN_OVERRIDE")?.chuzzle() {
+                swiftc = Path.join(base, "usr/bin/swiftc")
+            } else {
+                swiftc = try popen(["xcrun", "--find", "swiftc"]).chuzzle() ?? "BADPATH"
+            }
+            precondition(swiftc != "/usr/bin/swiftc")
         #else
             let swiftc = Path.join(bundleRoot(), "swiftc")
         #endif


### PR DESCRIPTION
There is no useful environment variable set :{