### PR TITLE
Fix duplicate url issue for different casing and .git suffix.

### DIFF
--- a/Sources/PackageDescription/Package.swift
+++ b/Sources/PackageDescription/Package.swift
@@ -22,7 +22,7 @@ public final class Package {
         public let url: String
 
         init(_ url: String, _ versionRange: Range<Version>) {
-            self.url = url.normalizedURL()
+            self.url = url
             self.versionRange = versionRange
         }
 
@@ -180,7 +180,8 @@ public func ==(lhs: Package, rhs: Package) -> Bool {
 
 extension Package.Dependency : Equatable { }
 public func ==(lhs: Package.Dependency, rhs: Package.Dependency) -> Bool {
-    return lhs.url == rhs.url && lhs.versionRange == rhs.versionRange
+    return lhs.url.normalizedURL() == rhs.url.normalizedURL() &&
+        lhs.versionRange == rhs.versionRange
 }
 
 // MARK: Package Dumping

--- a/Sources/PackageDescription/Package.swift
+++ b/Sources/PackageDescription/Package.swift
@@ -22,7 +22,7 @@ public final class Package {
         public let url: String
 
         init(_ url: String, _ versionRange: Range<Version>) {
-            self.url = url
+            self.url = url.normalizedURL()
             self.versionRange = versionRange
         }
 
@@ -202,4 +202,16 @@ private func dumpPackageAtExit(_ package: Package, fileNo: Int32) {
     }
     dumpInfo = (package, fileNo)
     atexit(dump)
+}
+
+// MARK: URL Normalization
+
+extension String {
+    private func normalizedURL() -> String {
+        var url = self.lowercased()
+        if !url.hasSuffix(".git") {
+            url += ".git"
+        }
+        return url
+    }
 }

--- a/Sources/PackageDescription/Package.swift
+++ b/Sources/PackageDescription/Package.swift
@@ -10,6 +10,7 @@
 
 #if os(Linux)
 import Glibc
+import libc
 #else
 import Darwin.C
 #endif

--- a/Tests/PackageDescription/PackageTests.swift
+++ b/Tests/PackageDescription/PackageTests.swift
@@ -41,6 +41,7 @@ extension PackageTests {
     static var allTests : [(String, PackageTests -> () throws -> Void)] {
         return [
             ("testMatchDependencyWithPreReleaseVersion", testMatchDependencyWithPreReleaseVersion),
+            ("testNameConflicts", testNameConflicts)
         ]
     }
 }

--- a/Tests/PackageDescription/PackageTests.swift
+++ b/Tests/PackageDescription/PackageTests.swift
@@ -27,6 +27,14 @@ class PackageTests: XCTestCase {
         XCTAssertFalse(majorAndMinorVersionSpecified.versionRange ~= "0.11.0")
     }
 
+    func testNameConflicts() {
+        let packageOne: Package.Dependency = .Package(url: "https://github.com/example/SomeDependency",
+                                                      majorVersion: 1)
+        let packageTwo: Package.Dependency = .Package(url: "https://github.com/example/somedependency.git",
+                                                      majorVersion: 1)
+        XCTAssert(packageOne == packageTwo)
+    }
+
 }
 
 extension PackageTests {


### PR DESCRIPTION
If two dependencies are declared that use different casings in the spelling, for example.

```Swift
.Package(url: "https://github.com/swiftx/s4.git", majorVersion: 0, minor: 2)
```

And somewhere else in the dependency tree:

```Swift
.Package(url: "https://github.com/SwiftX/S4.git", majorVersion: 0, minor: 2),
```

Then there will be a collision

```
fatal: destination path '/path/to/project/vapor/vapor/Packages/s4' already exists and is not an empty directory.

error: Failed to clone https://github.com/swiftx/s4.git to /path/to/project/vapor/vapor/Packages/s4
```

By normalizing all urls to lowercase and requiring `.git` suffix, we can ensure that these types of collisions do not occur. Please let me know if you have any feedback on things I should adjust or if you'd prefer an alternative approach to the solution.