### PR TITLE
use llbuild's default target

### DIFF
--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -70,6 +70,7 @@ public func describe(_ prefix: String, _ conf: Configuration, _ modules: [Module
         for target in [targets.test, targets.main] {
             writeln("  \(target.node): " + target.cmds.map{$0.node}.YAML)
         }
+        writeln("default: \(targets.main.node)")
         writeln("commands: ")
         for command in commands {
             writeln("  \(command.node):")
@@ -103,7 +104,7 @@ private func write(path: String, write: ((String) -> Void) -> Void) throws -> St
 
 private struct Targets {
     var test = Target(node: "test", cmds: [])
-    var main = Target(node: "default", cmds: [])
+    var main = Target(node: "main", cmds: [])
 
     mutating func append(_ command: Command, for buildable: Buildable) {
         if buildable.isTest {

--- a/Sources/Multitool/build().swift
+++ b/Sources/Multitool/build().swift
@@ -13,9 +13,13 @@ import PackageType
 import Utility
 import func libc.exit
 
-public func build(YAMLPath: String, target: String) throws {
+// Builds the default target in the llbuild manifest unless specified.
+public func build(YAMLPath: String, target: String? = nil) throws {
     do {
-        var args = [llbuild, "-f", YAMLPath, target]
+        var args = [llbuild, "-f", YAMLPath]
+        if let target = target {
+            args += [target]
+        }
         if verbosity != .Concise { args.append("-v") }
         try system(args)
     } catch {

--- a/Sources/swift-build/main.swift
+++ b/Sources/swift-build/main.swift
@@ -50,7 +50,7 @@ do {
         let (rootPackage, externalPackages) = try fetch(dirs.root)
         let (modules, externalModules, products) = try transmute(rootPackage, externalPackages: externalPackages)
         let yaml = try describe(dirs.build, conf, modules, Set(externalModules), products, Xcc: opts.Xcc, Xld: opts.Xld, Xswiftc: opts.Xswiftc, toolchain: toolchain)
-        try build(YAMLPath: yaml, target: "default")
+        try build(YAMLPath: yaml)
 
     case .Init(let initMode):
         let initPackage = InitPackage(mode: initMode)


### PR DESCRIPTION
This compliments the new addition to specify the default target to build in llbuild manifest file https://github.com/apple/swift-llbuild/pull/18