### PR TITLE
[Build/YAML.swift] Improve `quote`

### DIFF
--- a/Sources/Build/YAML.swift
+++ b/Sources/Build/YAML.swift
@@ -29,6 +29,9 @@ extension Bool: YAMLRepresentable {
 extension Array where Element: YAMLRepresentable {
     var YAML: String {
         func quote(_ input: String) -> String {
+            guard !(input.hasPrefix("<") && input.hasSuffix(">")) else {
+                return input
+            }
             for c in input.characters {
                 if c == "@" || c == " " || c == "-" || c == "&" {
                     return "\"\(input)\""


### PR DESCRIPTION
When I build SwiftPM itself, the following changes are occurred by executing the `quote` method  in the `Build/YAML.swift`.

**Before the change:**
- \<swift-build.module\>
- \<swift-test.module\>
- \<swift-build.exe\>
- \<swift-test.exe\>

**After the change:**
- "\<swift-build.module\>"
- "\<swift-test.module\>"
- "\<swift-build.exe\>"
- "\<swift-test.exe\>"

It seems no problems so far, but I don't think it's expected behavior.
So, I added a `guard` statement.

I'm sorry if I got the wrong idea.

===

For your information:
<details>
<summary>Here is SwiftPM `debug.yaml` diff.</summary>
```diff
6c6
<   main: [<Build.module>, <Get.module>, <libc.module>, <ManifestParser.module>, <Multitool.module>, <OptionsParser.module>, <PackageDescription.module>, <PackageType.module>, <POSIX.module>, "<swift-build.module>", "<swift-test.module>", <Transmute.module>, <Utility.module>, <Xcodeproj.module>, "<swift-build.exe>", "<swift-test.exe>", <PackageDescription.dylib>]
---
>   main: [<Build.module>, <Get.module>, <libc.module>, <ManifestParser.module>, <Multitool.module>, <OptionsParser.module>, <PackageDescription.module>, <PackageType.module>, <POSIX.module>, <swift-build.module>, <swift-test.module>, <Transmute.module>, <Utility.module>, <Xcodeproj.module>, <swift-build.exe>, <swift-test.exe>, <PackageDescription.dylib>]
181c181
<     outputs: ["<swift-build.module>", "/Users/.../swiftpm/.build/debug/swiftbuild.build/--doctor.swift.o", "/Users/.../swiftpm/.build/debug/swiftbuild.build/--init.swift.o", /Users/.../swiftpm/.build/debug/swiftbuild.build/Error.swift.o, /Users/.../swiftpm/.build/debug/swiftbuild.build/main.swift.o, /Users/.../swiftpm/.build/debug/swiftbuild.build/usage.swift.o, /Users/.../swiftpm/.build/debug/swiftbuild.build/UserToolchain.swift.o, /Users/.../swiftpm/.build/debug/swiftbuild.build/xp.swift.o]
---
>     outputs: [<swift-build.module>, "/Users/.../swiftpm/.build/debug/swiftbuild.build/--doctor.swift.o", "/Users/.../swiftpm/.build/debug/swiftbuild.build/--init.swift.o", /Users/.../swiftpm/.build/debug/swiftbuild.build/Error.swift.o, /Users/.../swiftpm/.build/debug/swiftbuild.build/main.swift.o, /Users/.../swiftpm/.build/debug/swiftbuild.build/usage.swift.o, /Users/.../swiftpm/.build/debug/swiftbuild.build/UserToolchain.swift.o, /Users/.../swiftpm/.build/debug/swiftbuild.build/xp.swift.o]
199c199
<     outputs: ["<swift-test.module>", /Users/.../swiftpm/.build/debug/swifttest.build/Error.swift.o, /Users/.../swiftpm/.build/debug/swifttest.build/main.swift.o, /Users/.../swiftpm/.build/debug/swifttest.build/test.swift.o, /Users/.../swiftpm/.build/debug/swifttest.build/usage.swift.o]
---
>     outputs: [<swift-test.module>, /Users/.../swiftpm/.build/debug/swifttest.build/Error.swift.o, /Users/.../swiftpm/.build/debug/swifttest.build/main.swift.o, /Users/.../swiftpm/.build/debug/swifttest.build/test.swift.o, /Users/.../swiftpm/.build/debug/swifttest.build/usage.swift.o]
445c445
<     outputs: ["<swift-build.exe>", "/Users/.../swiftpm/.build/debug/swift-build"]
---
>     outputs: [<swift-build.exe>, "/Users/.../swiftpm/.build/debug/swift-build"]
452c452
<     outputs: ["<swift-test.exe>", "/Users/.../swiftpm/.build/debug/swift-test"]
---
>     outputs: [<swift-test.exe>, "/Users/.../swiftpm/.build/debug/swift-test"]
```
</details>