### PR TITLE
[Multitool/Options] Fix Path.Packages for `swift build --clean=dist`

### DIFF
--- a/Sources/Multitool/Options.swift
+++ b/Sources/Multitool/Options.swift
@@ -19,7 +19,7 @@ public class Options {
 
     public class Path {
         public lazy var root = getroot()
-        public var Packages: String { return Utility.Path.join(self.root) }
+        public var Packages: String { return Utility.Path.join(self.root, "Packages") }
 
         public var build: String {
             get { return _build ?? Utility.Path.join(getroot(), ".build") }


### PR DESCRIPTION
When running `$ swift build --clean=dist`, SwiftPM removes the root directory of the project.

For example, when running `$ swift build --clean=dist` at the root directory of `MyProject`, SwiftPM removes the `MyProject` directory.

Have the function of `--clean=dist` been changed?