### PR TITLE
[swift-build] Improve --clean=dist

### DIFF
--- a/Sources/Utility/misc.swift
+++ b/Sources/Utility/misc.swift
@@ -35,7 +35,11 @@ public func rmtree(_ components: String...) throws {
             // Ignore ENOENT.
         }
     }
-    try POSIX.rmdir(path)
+    do {
+        try POSIX.rmdir(path)
+    } catch .rmdir(let errno, _) as SystemError where errno == ENOENT {
+        // Ignore ENOENT.
+    }
 }
 
 

--- a/Sources/swift-build/main.swift
+++ b/Sources/swift-build/main.swift
@@ -13,7 +13,9 @@ import func POSIX.getenv
 import func POSIX.unlink
 import func POSIX.chdir
 import func POSIX.rmdir
+import enum POSIX.SystemError
 import func libc.exit
+import var libc.ENOENT
 import ManifestParser
 import PackageType
 import Multitool
@@ -83,7 +85,11 @@ do {
         let versionData = Path.join(opts.path.build, "versionData")
         if versionData.isDirectory { try rmtree(versionData) }
 
-        try rmdir(opts.path.build)
+        do {
+            try rmdir(opts.path.build)
+        } catch .rmdir(let errno, _) as SystemError where errno == ENOENT {
+            // Ignore ENOENT.
+        }
 
     case .Doctor:
         doctor()


### PR DESCRIPTION
I wrote the same error handling as the following.
https://github.com/apple/swift-package-manager/blob/master/Sources/Utility/misc.swift#L32-L36

The reason why I did that is to ignore `ENOENT` when running `--clean` or `--clean=dist` twice.
```
error: rmdir error: No such file or directory (2):
```

In my opinion, it is not better to display error message.
Because the directory is specified by SwiftPM.
It is not that SwiftPM USER made a mistake.

So, I think it might to ignore `ENOENT`.