### PR TITLE
[swift-build] Improve `clean` behavior

### DIFF
--- a/Sources/swift-build/main.swift
+++ b/Sources/swift-build/main.swift
@@ -67,7 +67,7 @@ do {
         usage()
 
     case .Clean(.Dist):
-        try rmtree(opts.path.Packages)
+        if opts.path.Packages.isDirectory { try rmtree(opts.path.Packages) }
         fallthrough
 
     case .Clean(.Build):
@@ -83,7 +83,7 @@ do {
         let versionData = Path.join(opts.path.build, "versionData")
         if versionData.isDirectory { try rmtree(versionData) }
 
-        try rmdir(opts.path.build)
+        if opts.path.build.isDirectory { try rmdir(opts.path.build) }
 
     case .Doctor:
         doctor()


### PR DESCRIPTION
It's an improvement on #263.

I rewrote the same as the following.
https://github.com/apple/swift-package-manager/blob/master/Sources/swift-build/main.swift#L84

I don't edit the `rmtree` function.