### PR TITLE
[Get/Fetcher] Improve `--fetch` behavior

### DIFF
--- a/Sources/Get/Error.swift
+++ b/Sources/Get/Error.swift
@@ -21,6 +21,7 @@ public enum Error: ErrorProtocol {
     case UpdateRequired(ClonePath)
     case Unversioned(ClonePath)
     case InvalidDependencyGraphMissingTag(package: String, requestedTag: String, existingTags: String)
+    case NewAvailableVersionExists(ClonePath, Version)
 }
 
 extension Error: CustomStringConvertible {
@@ -38,6 +39,8 @@ extension Error: CustomStringConvertible {
             return "No version tag found in (\(package)) package. Add a version tag with \"git tag\" command. Example: \"git tag 0.1.0\""
         case NoManifest(let clonePath, let version):
             return "The package at `\(clonePath)' has no Package.swift for the specific version: \(version)"
+        case .NewAvailableVersionExists(let package, let version):
+            return "'\(package)' is updated to '\(version)'."
         }
     }
 }

--- a/Sources/Get/Fetcher.swift
+++ b/Sources/Get/Fetcher.swift
@@ -9,6 +9,7 @@
 */
 
 import struct PackageDescription.Version
+import class Utility.Git
 
 /**
  Testable protocol to recursively fetch versioned resources.
@@ -82,6 +83,13 @@ extension Fetcher {
                     guard specifiedVersionRange ~= pkg.version else {
                         throw Error.UpdateRequired(url)
                     }
+                    
+                    if let repo = Git.Repo(path: url) {
+                        if let newAvailableVersion = try repo.newAvailableVersion(currentVersion: pkg.version, versionRange: specifiedVersionRange) {
+                            print(Error.NewAvailableVersionExists(repo.path, newAvailableVersion))
+                        }
+                    }
+                    
                     graph[url] = (pkg, specifiedVersionRange)
                     return try recurse(pkg.children) + [url]
 

--- a/Sources/Get/Git.swift
+++ b/Sources/Get/Git.swift
@@ -64,4 +64,9 @@ extension Git.Repo {
     var hasVersion: Bool {
         return !versions.isEmpty
     }
+    
+    func newAvailableVersion(currentVersion: Version, versionRange: Range<Version>) throws -> Version? {
+        let newAvailableVersions = versions.filter { $0 > currentVersion }
+        return newAvailableVersions.filter { versionRange ~= $0 }.last
+    }
 }


### PR DESCRIPTION
This is a proposal for `$ swift build --fetch`.
But, It's not done well enough.
Because I don't see any points, so I'd like to discuss them.

## Proposal

- I made the `newAvailableVersion` function in the `extension Git.Repo` to fetch new available version (tag).
- When running `$ swift build --fetch`, SwiftPM fetches new tags.
- But it does NOT UPDATE any packages.
- If there is a new available version provided by The Manifest File, SwiftPM displays `Error.NewAvailableVersionExists` with lastest version.

```
'<RepoPath>' is updated to '<NewAvailableVersion>'.
```

#### Example

Let's say in the following situation.

- My project depends on `PackageA 2.0.0`
- The PackageA `specifiedVersionRange` is `2.0.0..<3.0.0` provided by PackageA Manifest File.
- `PackageA 2.0.0` depends on `PackageB 1.0.0`.
- The PackageB `specifiedVersionRange` is `1.0.0..<2.0.0` provided by PackageA Manifest File.

#### `--fetch` behavior

#### Case 1:

- `PackageA` is updated to `2.1.0`.
  - Then, SwiftPM does NOT UPDATE `PackageA 2.0.0`. 
  - It displays a message that `PackageA 2.1.0` is available.

```
'.../PackageA' is updated to '2.1.0'.
```

#### Case 2:

- `PackageB` is updated to `1.1.0`. But `PackageA 2.0.0` is NOT updated. 
  - Then, SwiftPM does NOT UPDATE `PackageB 1.0.0`. 
  - It displays a message that `PackageB 1.1.0` is available.

#### Case 3:

- `PackageA` is updated to `3.0.0`.
  - Then, SwiftPM does NOT UPDATE `PackageA 2.0.0`.
  - It doesn't display any messages in the current implementation.

#### Case 4:

- Both `PackageA` and `PackageB` are NOT UPDATED. 
  - Then, SwiftPM does NOT UPDATE both `PackageA 2.0.0` and `PackageB 1.0.0`. 
  - It doesn't display any messages in the current implementation.

## Discussion (Question)

I'd like to discuss/ask the following points.

- I don't understand the following situation. In the current implementation, it seems not to be executed.
> https://github.com/apple/swift-package-manager/blob/master/Sources/Get/Fetcher.swift#L48

- I don't know WHEN an message should be displayed.
  1. New available version exists.
  2. Dependencies have already been fetched.(etc.)

- I don't know WHAT to write in English.
- So, I made the `Error.NewAvailableVersionExists` PROVISIONALLY. Could you direct me WHAT to do?