### PR TITLE
[Build] Optimize YAML quoting for strings.

### DIFF
--- a/Sources/Build/YAML.swift
+++ b/Sources/Build/YAML.swift
@@ -15,6 +15,14 @@ protocol YAMLRepresentable {
 extension String: YAMLRepresentable {
     var YAML: String {
         if self == "" { return "\"\"" }
+        for c in utf8 {
+            switch c {
+            case UInt8(ascii: "@"), UInt8(ascii: " "), UInt8(ascii: "-"), UInt8(ascii: "&"):
+                return "\"\(self)\""
+            default:
+                continue
+            }
+        }
         return self
     }
 }
@@ -28,15 +36,6 @@ extension Bool: YAMLRepresentable {
 
 extension Array where Element: YAMLRepresentable {
     var YAML: String {
-        func quote(_ input: String) -> String {
-            for c in input.characters {
-                if c == "@" || c == " " || c == "-" || c == "&" {
-                    return "\"\(input)\""
-                }
-            }
-            return input
-        }
-        let stringArray = self.flatMap { String($0) }
-        return "[" + stringArray.map(quote).joined(separator: ", ") + "]"
+        return "[" + map{$0.YAML}.joined(separator: ", ") + "]"
     }
 }


### PR DESCRIPTION
- Check the UTF8 representation when determining if we need to quote.

 - Also, this moves the quoting into the YAMLRepresentable : String extension,
   which is a more correct place for it.

 - This is good for another ~10% win on SwiftPM null build of itself.

Depends on #272.