### PR TITLE
[Build] Cache result of SDK path lookup, on OS X.

### DIFF
--- a/Sources/Build/misc.swift
+++ b/Sources/Build/misc.swift
@@ -24,9 +24,12 @@ public protocol Toolchain {
 }
 
 func platformFrameworksPath() throws -> String {
-    guard let  popened = try? POSIX.popen(["xcrun", "--sdk", "macosx", "--show-sdk-platform-path"]),
-        let chuzzled = popened.chuzzle() else {
-            throw Error.InvalidPlatformPath
+    // Lazily compute the platform the first time it is needed.
+    struct Static {
+        static let value = { try? POSIX.popen(["xcrun", "--sdk", "macosx", "--show-sdk-platform-path"]) }()
+    }
+    guard let popened = Static.value, let chuzzled = popened.chuzzle() else {
+        throw Error.InvalidPlatformPath
     }
     return Path.join(chuzzled, "Developer/Library/Frameworks")
 }


### PR DESCRIPTION
 - Good for a 35% speedup in SwiftPM null build of itself.

Depends on #273 