### PR TITLE
[PackageDescription] Add Enforced Semantic Versioning

### DIFF
--- a/Sources/PackageDescription/Version.swift
+++ b/Sources/PackageDescription/Version.swift
@@ -116,3 +116,31 @@ extension Version: CustomStringConvertible {
         return base
     }
 }
+
+// MARK: Enforced Semantic Versioning
+
+enum UpdateType {
+    /// e.g. Remove a method from the public API or change a public method's signature
+    case Major
+    /// e.g. A new method is added to the public API
+    case Minor
+    /// e.g. Change only the implementation of a method
+    case Patch
+}
+
+extension Version {
+    /**
+     - seealso:
+     [Enforced Semantic Versioning](https://github.com/apple/swift-package-manager/blob/master/Documentation/PackageManagerCommunityProposal.md#enforced-semantic-versioning)
+     */
+    func newVersionEnforcedSemanticVersioning(updateType: UpdateType) -> Version {
+        switch updateType {
+        case .Major:
+            return Version(major + 1, 0, 0)
+        case .Minor:
+            return Version(major, minor + 1, 0)
+        case .Patch:
+            return successor()
+        }
+    }
+}

--- a/Tests/PackageDescription/VersionTests.swift
+++ b/Tests/PackageDescription/VersionTests.swift
@@ -341,7 +341,7 @@ extension VersionTests {
             ("testRange", testRange),
             ("testSuccessor", testSuccessor),
             ("testPredecessor", testPredecessor),
-            
+            ("testNewVersionEnforcedSemanticVersioning", testNewVersionEnforcedSemanticVersioning)
         ]
     }
 }

--- a/Tests/PackageDescription/VersionTests.swift
+++ b/Tests/PackageDescription/VersionTests.swift
@@ -341,7 +341,8 @@ extension VersionTests {
             ("testRange", testRange),
             ("testSuccessor", testSuccessor),
             ("testPredecessor", testPredecessor),
-            ("testNewVersionEnforcedSemanticVersioning", testNewVersionEnforcedSemanticVersioning)
+            ("testNewVersionEnforcedSemanticVersioning", testNewVersionEnforcedSemanticVersioning),
+            
         ]
     }
 }

--- a/Tests/PackageDescription/VersionTests.swift
+++ b/Tests/PackageDescription/VersionTests.swift
@@ -289,6 +289,26 @@ class VersionTests: XCTestCase {
 //        XCTAssertNotEqual(v4, Version(0,Int.max,Int.max))
     }
 
+    /**
+     - seealso:
+     [Enforced Semantic Versioning](https://github.com/apple/swift-package-manager/blob/master/Documentation/PackageManagerCommunityProposal.md#enforced-semantic-versioning)
+     */
+    func testNewVersionEnforcedSemanticVersioning() {
+        let v1 = Version(1,0,0)
+        XCTAssertEqual(v1.newVersionEnforcedSemanticVersioning(updateType: .Major), Version(2,0,0))
+        XCTAssertEqual(v1.newVersionEnforcedSemanticVersioning(updateType: .Minor), Version(1,1,0))
+        XCTAssertEqual(v1.newVersionEnforcedSemanticVersioning(updateType: .Patch), Version(1,0,1))
+        
+        let v2 = Version(9,9,9)
+        XCTAssertEqual(v2.newVersionEnforcedSemanticVersioning(updateType: .Major), Version(10,0,0))
+        XCTAssertEqual(v2.newVersionEnforcedSemanticVersioning(updateType: .Minor), Version(9,10,0))
+        XCTAssertEqual(v2.newVersionEnforcedSemanticVersioning(updateType: .Patch), Version(9,9,10))
+        
+        // TODO:
+        //let v3 = Version(Int.max,0,0)
+        //let v4 = Version(1,Int.max,0)
+        //let v5 = Version(1,0,Int.max)
+    }
 }
 
 


### PR DESCRIPTION
This is part of proposal for **[Enforced Semantic Versioning](https://github.com/apple/swift-package-manager/blob/master/Documentation/PackageManagerCommunityProposal.md#enforced-semantic-versioning)**.

First of all, I implemented `newVersionEnforcedSemanticVersioning` function and its tests, etc.
I intend to change small, so I have NOT implemented how to enforce Semantic Versioning yet.

For now, this function is called only at its tests.

===

By the way, I have some concerns about this.

1. How to handle overflow (e.g. the next to `Version(Int.max,Int.max,Int.max)`).

  I don't think it's an individual issue, so I have not implemented yet.

2. It might be implemented in other file. (e.g. `Build/PackageVersion.swift`)
3. These name are so long that it might be better to renamed them.

  e.g.
  - `newVersionEnforcedSemanticVersioning` to `newVersionEnforcedSemVer` or `nextVersionEnforcedSemVer`
  - `testNewVersionEnforcedSemanticVersioning` to `testNewVersionEnforcedSemVer` or `testNextVersionEnforcedSemVer`