### PR TITLE
[swift-build] Fix `-c` mode

### DIFF
--- a/Sources/swift-build/usage.swift
+++ b/Sources/swift-build/usage.swift
@@ -49,7 +49,7 @@ enum Mode: Argument, Equatable, CustomStringConvertible {
 
     init?(argument: String, pop: () -> String?) throws {
         switch argument {
-        case "--configuration", "--conf":
+        case "--configuration", "--conf", "-c":
             self = try .Build(Configuration(pop()), UserToolchain())
         case "--clean":
             self = try .Clean(CleanMode(pop()))


### PR DESCRIPTION
I made `$ swift build -c [mode]` available to fix https://bugs.swift.org/browse/SR-1309.

In the current implementation, it seems that `-c` is not available but `--conf` is available.
It is not consistent with the usage.
```
print("  --configuration <value>        Build with configuration (debug|release) [-c]")
```

I think we should make `-c` available.

- - -

Or we should fix the usage.
e.g.
```
print("  --configuration <value>        Build with configuration (debug|release) [--conf]")
```