### PR TITLE
Rename xctest executable to avoid inferring it as module name

### DIFF
--- a/Sources/Build/Command.link().swift
+++ b/Sources/Build/Command.link().swift
@@ -52,6 +52,7 @@ extension Command {
         case .Library(.Static):
             args.append(outpath)
         case .Test:
+            args += ["-module-name", product.name]
           #if os(OSX)
             args += ["-Xlinker", "-bundle"]
             args += ["-F", try platformFrameworksPath()]

--- a/Sources/Transmute/Package+products.swift
+++ b/Sources/Transmute/Package+products.swift
@@ -34,7 +34,9 @@ extension Package {
         if !testModules.isEmpty {
             let modules: [SwiftModule] = testModules.map{$0} // or linux compiler crash (2016-02-03)
             //TODO and then we should prefix all modules with their package probably
-            let product = Product(name: self.name, type: .Test, modules: modules)
+            //Suffix 'Tests' to test product so the module name of linux executable don't collide with
+            //main package, if present.
+            let product = Product(name: "\(self.name)Tests", type: .Test, modules: modules)
             products.append(product)
         }
 

--- a/Sources/swift-test/main.swift
+++ b/Sources/swift-test/main.swift
@@ -34,7 +34,7 @@ do {
             // that makes us depend on the whole Manifest system
 
             let packageName = opts.path.root.basename  //FIXME probably not true
-            let maybePath = Path.join(opts.path.build, configuration, "\(packageName).xctest")
+            let maybePath = Path.join(opts.path.build, configuration, "\(packageName)Tests.xctest")
 
             if maybePath.exists {
                 return maybePath


### PR DESCRIPTION
Fixes https://bugs.swift.org/browse/SR-1243