### PR TITLE
[swift-build--init] Consider executing `--init` twice.

### DIFF
--- a/Sources/swift-build/--init.swift
+++ b/Sources/swift-build/--init.swift
@@ -36,7 +36,8 @@ final class InitPackage {
     private func writeManifestFile() throws {
         let manifest = Path.join(rootd, Manifest.filename)
         guard manifest.exists == false else {
-            throw Error.ManifestAlreadyExists
+            print(Error.ManifestAlreadyExists)
+            return
         }
         
         let packageFP = try fopen(manifest, mode: .Write)
@@ -72,14 +73,16 @@ final class InitPackage {
     
     private func writeSources() throws {
         let sources = Path.join(rootd, "Sources")
-        guard sources.exists == false else {
-            return
+        if sources.exists == false {
+            print("Creating Sources/")
+            try mkdir(sources)
         }
-        print("Creating Sources/")
-        try mkdir(sources)
     
         let sourceFileName = (mode == .Executable) ? "main.swift" : "\(pkgname).swift"
         let sourceFile = Path.join(sources, sourceFileName)
+        guard sourceFile.exists == false else {
+            return
+        }
         let sourceFileFP = try fopen(sourceFile, mode: .Write)
         defer {
             fclose(sourceFileFP)


### PR DESCRIPTION
This is a proposal for `--init` behavior.

I'm sorry if I couldn't explain it well.

### Summary

- If the files and directories created by `--init` do NOT exist, SwiftPM creates them again.
- If they exist, SwiftPM does NOT create/overwrite them. (the same as the current implementation)

===

I suppose it's better to consider the following situation.
Concretely, it's better to create `main.swift` at 4.

For example:

1. Run `$ swift build --init=executable`. (Make a new start.)
2. For one reason or another, remove `Package.swift` and `main.swift`. (e.g. Execute discard changes)
3. Run `$ swift build --init=executable` again.
4. Currently, SwiftPM creates `Package.swift` only. `main.swift` is not created. The reason is `Sources/` directory exists.

===

In other words:

The behavior in **Case1** is different from **Case2**.
I suppose it's better to make them the same behavior.
Concretely, it's better to make them the same as **Case2**.

First, run `$ swift build --init=executable`.
Next,
**Case1:** remove `main.swift`
- Run `$ swift build --init=executable` again.
- Then, an error occurs and SwiftPM doesn't execute `--init`.

**Case2:** remove `Package.swift`
- Run `$ swift build --init=executable` again.
- Then, SwiftPM executes `--init` without errors.

===

For your information, when running `$ swift build --init=executable` twice, the following error occurs.
```
error: a manifest file already exists in this directory
```