### PR TITLE
[Xcodeproj] Improve portability of generated projects

### DIFF
--- a/Sources/Xcodeproj/Module+PBXProj.swift
+++ b/Sources/Xcodeproj/Module+PBXProj.swift
@@ -190,6 +190,18 @@ extension XcodeModuleProtocol  {
         buildSettings["PRODUCT_MODULE_NAME"] = c99name
         buildSettings["OTHER_SWIFT_FLAGS"] = serializeArray(options.Xswiftc+["-DXcode"])
 
+        // Set SUPPORTED_PLATFORMS to all platforms.
+        //
+        // The goal here is to define targets which *can be* built for any
+        // platform (although some might not work correctly). It is then up to
+        // the integrating project to only set these targets up as dependencies
+        // where appropriate.
+        buildSettings["SUPPORTED_PLATFORMS"] = serializeArray([
+                "macosx",
+                "iphoneos", "iphonesimulator",
+                "tvos", "tvsimulator",
+                "watchos", "watchsimulator"])
+        
         // Propagate any user provided build flag overrides.
         buildSettings["OTHER_CFLAGS"] = serializeArray(options.Xcc)
         buildSettings["OTHER_LDFLAGS"] = serializeArray(options.Xld)

--- a/Sources/Xcodeproj/Module+PBXProj.swift
+++ b/Sources/Xcodeproj/Module+PBXProj.swift
@@ -189,10 +189,10 @@ extension XcodeModuleProtocol  {
         var buildSettings = ["PRODUCT_NAME": productName]
         buildSettings["PRODUCT_MODULE_NAME"] = c99name
         buildSettings["OTHER_SWIFT_FLAGS"] = serializeArray(options.Xswiftc+["-DXcode"])
+
+        // Propagate any user provided build flag overrides.
         buildSettings["OTHER_CFLAGS"] = serializeArray(options.Xcc)
         buildSettings["OTHER_LDFLAGS"] = serializeArray(options.Xld)
-
-        buildSettings["MACOSX_DEPLOYMENT_TARGET"] = "'10.10'"
 
         // prevents Xcode project upgrade warnings
         buildSettings["COMBINE_HIDPI_IMAGES"] = "YES"


### PR DESCRIPTION
This PR lets our generated projects be built for any platform (it will be driven by the user's selected run destination).

This is part of our goal to generate a single project and have it be usable by a variety of projects... this is only a first step in that direction.