### PR TITLE
SR-1331: Better error message when file layout is invalid

### DIFF
--- a/Sources/Transmute/Error.swift
+++ b/Sources/Transmute/Error.swift
@@ -19,9 +19,21 @@ extension Package {
 
     public enum InvalidLayoutType {
         case MultipleSourceRoots([String])
-        case InvalidLayout
+        case InvalidLayout([String])
     }
 }
+
+extension Package.InvalidLayoutType: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .MultipleSourceRoots(let paths):
+            return "multiple source roots found: " + paths.joined(separator: ", ")
+        case .InvalidLayout(let paths):
+            return "unexpected source file(s) found: " + paths.joined(separator: ", ")
+        }
+    }
+}
+
 
 extension Module {
     public enum Error: ErrorProtocol {

--- a/Sources/Transmute/Package+modules.swift
+++ b/Sources/Transmute/Package+modules.swift
@@ -22,16 +22,18 @@ extension Package {
         let srcroot = try sourceRoot()
 
         if srcroot != path {
-            guard walk(path, recursively: false).filter(isValidSource).isEmpty else {
-                throw ModuleError.InvalidLayout(.InvalidLayout)
+            let invalidRootFiles = walk(path, recursively: false).filter(isValidSource)
+            guard invalidRootFiles.isEmpty else {
+                throw ModuleError.InvalidLayout(.InvalidLayout(invalidRootFiles))
             }
         }
 
         let maybeModules = walk(srcroot, recursively: false).filter(shouldConsiderDirectory)
 
         if maybeModules.count == 1 && maybeModules[0] != srcroot {
-            guard walk(srcroot, recursively: false).filter(isValidSource).isEmpty else {
-                throw ModuleError.InvalidLayout(.InvalidLayout)
+            let invalidModuleFiles = walk(srcroot, recursively: false).filter(isValidSource)
+            guard invalidModuleFiles.isEmpty else {
+                throw ModuleError.InvalidLayout(.InvalidLayout(invalidModuleFiles))
             }
         }
 


### PR DESCRIPTION
See also [SR-1331][1]. If a package has an invalid layout, SwiftPM gives the following cryptic error message:

    error: InvalidLayout((extension in Transmute):PackageType.Package.InvalidLayoutType.InvalidLayout)

With this patch, the error message reads:

    error: InvalidLayout(unexpected source file(s) found: /Users/bouke/Developer/swift-package-manager/a.swift, /Users/bouke/Developer/swift-package-manager/b.c)

[1]: https://bugs.swift.org/browse/SR-1331