### PR TITLE
SR-1305: [Xcodeproj] Relative path to Package.swift

### DIFF
--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -53,7 +53,7 @@ public func pbxproj(srcroot: String, projectRoot: String, modules: [XcodeModuleP
     print("            isa = PBXFileReference;")
     print("            lastKnownFileType = sourcecode.swift;")
     print("            name = '\(packageSwift.1)';")
-    print("            path = '\(packageSwift.2)';")
+    print("            path = '\(Path(packageSwift.2).relative(to: projectRoot))';")
     print("            sourceTree = '<group>';")
     print("        };")
 


### PR DESCRIPTION
See also [SR-1305][1]. The path to `Package.swift` required a Path.relative treatment.

[1]: https://bugs.swift.org/browse/SR-1305