### PR TITLE
SR-1298: [swift-test] Allow running specific tests

### DIFF
--- a/Sources/swift-test/usage.swift
+++ b/Sources/swift-test/usage.swift
@@ -35,7 +35,7 @@ enum Mode: Argument, Equatable, CustomStringConvertible {
         case "--help", "--usage", "-h":
             self = .Usage
         default:
-            return nil
+            self = .Run(argument)
         }
     }
 


### PR DESCRIPTION
`swift-test -h` advertises the ability to test specific test cases, by passing a specifier. However the specifier is ignored and all tests are run. This change allows passing a specifier which is used. Tested on both OS X and Ubuntu 15.10.

See also [SR-1298][1].

[1]: https://bugs.swift.org/browse/SR-1298