### PR TITLE
[Utility] Add infrastructure for efficient streaming output.

### DIFF
--- a/Sources/Utility/ByteString.swift
+++ b/Sources/Utility/ByteString.swift
@@ -1,0 +1,135 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// A `ByteString` represents a sequence of bytes.
+///
+/// This struct provides useful operations for working with buffers of
+/// bytes. Conceptually it is just a contiguous array of bytes (UInt8), but it
+/// contains methods and default behavor suitable for common operations done
+/// using bytes strings.
+///
+/// This struct *is not* intended to be used for significant mutation of byte
+/// strings, we wish to retain the flexibility to micro-optimize the memory
+/// allocation of the storage (for example, by inlining the storage for small
+/// strings or and by eliminating wasted space in growable arrays). For
+/// construction of byte arrays, clients should use the `OutputByteStream` class
+/// and then convert to a `ByteString` when complete.
+public struct ByteString: ArrayLiteralConvertible {
+    /// The buffer contents.
+    private var _bytes: [UInt8]
+
+    /// Create an empty byte string.
+    public init() {
+        _bytes = []
+    }
+    
+    /// Create a byte string from a byte array literal.
+    public init(arrayLiteral contents: UInt8...) {
+        _bytes = contents
+    }
+
+    /// Create a byte string from an array of bytes.
+    public init(_ contents: [UInt8]) {
+        _bytes = contents
+    }
+    
+    /// Create a byte string from an byte buffer.
+    public init(_ buffer: UnsafeBufferPointer<UInt8>) {
+        _bytes = [UInt8](buffer)
+    }
+    
+    /// Create a byte string from the UTF8 encoding of a string.
+    public init(encodingAsUTF8 string: String) {
+        let stringPtrStart = string._contiguousUTF8
+        defer { _fixLifetime(string) }
+        if stringPtrStart != nil {
+            _bytes = [UInt8](UnsafeBufferPointer(start: stringPtrStart, count: string.utf8.count))
+        } else {
+            _bytes = [UInt8](string.utf8)
+        }
+    }
+
+    /// Access the byte string contents as an array.
+    public var bytes: [UInt8] {
+        return _bytes
+    }
+
+    /// Return the byte string size.
+    public var count: Int {
+        return _bytes.count
+    }
+    
+    /// Return the string decoded as a UTF8 sequence, if possible.
+    public var asString: String? {
+        // FIXME: This is very inefficient, we need a way to pass a buffer. It
+        // is also wrong if the string contains embedded '\0' characters.
+        let tmp = _bytes + [UInt8(0)]
+        return tmp.withUnsafeBufferPointer { ptr in
+            return String(validatingUTF8: unsafeBitCast(ptr.baseAddress, to: UnsafePointer<CChar>.self))
+        }
+    }
+    
+    /// Return the string decoded as a UTF8 sequence, substituting replacement
+    /// characters for ill-formed UTF8 sequences.
+    public var asReadableString: String {
+        // FIXME: This is very inefficient, we need a way to pass a buffer. It
+        // is also wrong if the string contains embedded '\0' characters.
+        let tmp = _bytes + [UInt8(0)]
+        return tmp.withUnsafeBufferPointer { ptr in
+            return String(cString: unsafeBitCast(ptr.baseAddress, to: UnsafePointer<CChar>.self))
+        }
+    }
+}
+
+/// Conform to CustomStringConvertible.
+extension ByteString: CustomStringConvertible {
+    public var description: String {
+        // For now, default to the "readable string" representation.
+        return "<ByteString:\"\(asReadableString)\">"
+    }
+}
+
+/// Hashable conformance for a ByteString.
+extension ByteString: Hashable {
+    public var hashValue: Int {
+        // FIXME: Use a better hash function.
+        var result = bytes.count
+        for byte in bytes {
+            result = result &* 31 &+ Int(byte)
+        }
+        return result
+    }
+}
+public func ==(lhs: ByteString, rhs: ByteString) -> Bool {
+    return lhs.bytes == rhs.bytes
+}
+
+/// ByteStreamable conformance for a ByteString.
+extension ByteString: ByteStreamable {
+    public func writeTo(_ stream: OutputByteStream) {
+        stream.write(_bytes)
+    }
+}
+
+/// StringLiteralConvertable conformance for a ByteString.
+extension ByteString: StringLiteralConvertible {
+    public typealias UnicodeScalarLiteralType = StringLiteralType
+    public typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
+
+    public init(unicodeScalarLiteral value: UnicodeScalarLiteralType) {
+        _bytes = [UInt8](value.utf8)
+    }
+    public init(extendedGraphemeClusterLiteral value: ExtendedGraphemeClusterLiteralType) {
+        _bytes = [UInt8](value.utf8)
+    }
+    public init(stringLiteral value: StringLiteralType) {
+        _bytes = [UInt8](value.utf8)
+    }
+}

--- a/Sources/Utility/OutputByteStream.swift
+++ b/Sources/Utility/OutputByteStream.swift
@@ -1,0 +1,359 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// Convert an integer in 0..<16 to its hexadecimal ASCII character.
+private func hexdigit(_ value: UInt8) -> UInt8 {
+    return value < 10 ? (0x30 + value) : (0x41 + value - 10)
+}
+
+/// Describes a type which can be written to a byte stream.
+public protocol ByteStreamable {
+    func writeTo(_ stream: OutputByteStream)
+}
+
+/// An output byte stream.
+///
+/// This class is designed to be able to support efficient streaming to
+/// different output destinations, e.g., a file or an in memory buffer. This is
+/// loosely modeled on LLVM's llvm::raw_ostream class.
+///
+/// The stream is generally used in conjunction with the custom streaming
+/// operator '<<<'. For example:
+///
+///   let stream = OutputByteStream()
+///   stream <<< "Hello, world!"
+///
+/// would write the UTF8 encoding of "Hello, world!" to the stream.
+///
+/// The stream accepts a number of custom formatting operators which are defined
+/// in the `Format` struct (used for namespacing purposes). For example:
+/// 
+///   let items = ["hello", "world"]
+///   stream <<< Format.asSeparatedList(items, separator: " ")
+///
+/// would write each item in the list to the stream, separating them with a
+/// space.
+public class OutputByteStream: OutputStream {
+    /// The data buffer.
+    private var buffer: [UInt8]
+    
+    public init() {
+        self.buffer = []
+    }
+
+    // MARK: Data Access API
+
+    /// The current offset within the output stream.
+    public var position: Int {
+        return buffer.count
+    }
+
+    /// The contents of the output stream.
+    ///
+    /// This method implicitly flushes the stream.
+    public var bytes: ByteString {
+        flush()
+        return ByteString(self.buffer)
+    }
+    
+    // MARK: Data Output API
+
+    public func flush() {
+        // Do nothing.
+    }
+
+    /// Write an individual byte to the buffer.
+    public func write(_ byte: UInt8) {
+        buffer.append(byte)
+    }
+    
+    /// Write a sequence of bytes to the buffer.
+    public func write(_ bytes: [UInt8]) {
+        buffer += bytes
+    }
+    
+    /// Write a sequence of bytes to the buffer.
+    public func write(_ bytes: ArraySlice<UInt8>) {
+        buffer += bytes
+    }
+    
+    /// Write a sequence of bytes to the buffer.
+    public func write<S: Sequence where S.Iterator.Element == UInt8>(_ sequence: S) {
+        buffer += sequence
+    }
+
+    /// Write a string to the buffer (as UTF8).
+    public func write(_ string: String) {
+        // Fast path for contiguous strings. For some reason Swift itself
+        // doesn't implement this optimization: <rdar://problem/24100375> Missing fast path for [UInt8] += String.UTF8View
+        let stringPtrStart = string._contiguousUTF8
+        if stringPtrStart != nil {
+            buffer += UnsafeBufferPointer(start: stringPtrStart, count: string.utf8.count)
+        } else {
+            buffer += string.utf8
+        }
+    }
+
+    /// Write a character to the buffer (as UTF8).
+    public func write(_ character: Character) {
+        buffer += String(character).utf8
+    }
+
+    /// Write an arbitrary byte streamable to the buffer.
+    public func write(_ value: ByteStreamable) {
+        value.writeTo(self)
+    }
+
+    /// Write an arbitrary streamable to the buffer.
+    public func write(_ value: Streamable) {
+        // Get a mutable reference.
+        var stream: OutputByteStream = self
+        value.write(to: &stream)
+    }
+
+    /// Write a string (as UTF8) to the buffer, with escaping appropriate for
+    /// embedding within a JSON document.
+    ///
+    /// NOTE: This writes the literal data applying JSON string escaping, but
+    /// does not write any other characters (like the quotes that would surround
+    /// a JSON string).
+    public func writeJSONEscaped(_ string: String) {
+        // See RFC7159 for reference.
+        for character in string.utf8 {
+            switch character {
+                // Literal characters.
+                //
+                // FIXME: Workaround: <rdar://problem/22546289> Unexpected crash with range to max value for type
+            case 0x20...0x21, 0x23...0x5B, 0x5D...0xFE, 0xFF:
+                buffer.append(character)
+            
+                // Single-character escaped characters.
+            case 0x22: // '"'
+                buffer.append(0x5C) // '\'
+                buffer.append(0x22) // '"'
+            case 0x5C: // '\\'
+                buffer.append(0x5C) // '\'
+                buffer.append(0x5C) // '\'
+            case 0x08: // '\b'
+                buffer.append(0x5C) // '\'
+                buffer.append(0x62) // 'b'
+            case 0x0C: // '\f'
+                buffer.append(0x5C) // '\'
+                buffer.append(0x66) // 'b'
+            case 0x0A: // '\n'
+                buffer.append(0x5C) // '\'
+                buffer.append(0x6E) // 'n'
+            case 0x0D: // '\r'
+                buffer.append(0x5C) // '\'
+                buffer.append(0x72) // 'r'
+            case 0x09: // '\t'
+                buffer.append(0x5C) // '\'
+                buffer.append(0x74) // 't'
+
+                // Multi-character escaped characters.
+            default:
+                buffer.append(0x5C) // '\'
+                buffer.append(0x75) // 'u'
+                buffer.append(hexdigit(0))
+                buffer.append(hexdigit(0))
+                buffer.append(hexdigit(character >> 4))
+                buffer.append(hexdigit(character & 0xF))
+            }
+        }
+    }
+}
+    
+/// Define an output stream operator. We need it to be left associative, so we
+/// use `<<<`.
+infix operator <<< { associativity left }
+
+// MARK: Output Operator Implementations
+//
+// NOTE: It would be nice to use a protocol here and the adopt it by all the
+// things we can efficiently stream out. However, that doesn't work because we
+// ultimately need to provide a manual overload sometimes, e.g., Streamable, but
+// that will then cause ambiguous lookup versus the implementation just using
+// the defined protocol.
+
+public func <<<(stream: OutputByteStream, value: UInt8) -> OutputByteStream {
+    stream.write(value)
+    return stream
+}
+
+public func <<<(stream: OutputByteStream, value: [UInt8]) -> OutputByteStream {
+    stream.write(value)
+    return stream
+}
+
+public func <<<(stream: OutputByteStream, value: ArraySlice<UInt8>) -> OutputByteStream {
+    stream.write(value)
+    return stream
+}
+
+public func <<<<S: Sequence where S.Iterator.Element == UInt8>(stream: OutputByteStream, value: S) -> OutputByteStream {
+    stream.write(value)
+    return stream
+}
+
+public func <<<(stream: OutputByteStream, value: String) -> OutputByteStream {
+    stream.write(value)
+    return stream
+}
+
+public func <<<(stream: OutputByteStream, value: Character) -> OutputByteStream {
+    stream.write(value)
+    return stream
+}
+
+public func <<<(stream: OutputByteStream, value: ByteStreamable) -> OutputByteStream {
+    stream.write(value)
+    return stream
+}
+
+public func <<<(stream: OutputByteStream, value: Streamable) -> OutputByteStream {
+    stream.write(value)
+    return stream
+}
+
+extension UInt8: ByteStreamable {
+    public func writeTo(_ stream: OutputByteStream) {
+        stream.write(self)
+    }
+}
+
+extension Character: ByteStreamable {
+    public func writeTo(_ stream: OutputByteStream) {
+        stream.write(self)
+    }
+}
+
+extension String: ByteStreamable {
+    public func writeTo(_ stream: OutputByteStream) {
+        stream.write(self)
+    }
+}
+
+// MARK: Formatted Streaming Output
+
+// Not nested because it is generic.
+private struct SeparatedListStreamable<T: ByteStreamable>: ByteStreamable {
+    let items: [T]
+    let separator: String
+    
+    func writeTo(_ stream: OutputByteStream) {
+        for (i, item) in items.enumerated() {
+            // Add the separator, if necessary.
+            if i != 0 {
+                stream <<< separator
+            }
+            
+            stream <<< item
+        }
+    }
+}
+
+// Not nested because it is generic.
+private struct TransformedSeparatedListStreamable<T>: ByteStreamable {
+    let items: [T]
+    let transform: (T) -> ByteStreamable
+    let separator: String
+    
+    func writeTo(_ stream: OutputByteStream) {
+        for (i, item) in items.enumerated() {
+            if i != 0 { stream <<< separator }
+            stream <<< transform(item)
+        }
+    }
+}
+
+// Not nested because it is generic.
+private struct JSONEscapedTransformedStringListStreamable<T>: ByteStreamable {
+    let items: [T]
+    let transform: (T) -> String
+
+    func writeTo(_ stream: OutputByteStream) {
+        stream <<< UInt8(ascii: "[")
+        for (i, item) in items.enumerated() {
+            if i != 0 { stream <<< "," }
+            stream <<< Format.asJSON(transform(item))
+        }
+        stream <<< UInt8(ascii: "]")
+    }
+}
+
+/// Provides operations for returning derived streamable objects to implement various forms of formatted output.
+public struct Format {
+    /// Write the input string encoded as a JSON object.
+    static public func asJSON(_ string: String) -> ByteStreamable {
+        return JSONEscapedStringStreamable(value: string)
+    }
+    private struct JSONEscapedStringStreamable: ByteStreamable {
+        let value: String
+        
+        func writeTo(_ stream: OutputByteStream) {
+            stream <<< UInt8(ascii: "\"")
+            stream.writeJSONEscaped(value)
+            stream <<< UInt8(ascii: "\"")
+        }
+    }
+    
+    /// Write the input string list encoded as a JSON object.
+    //
+    // FIXME: We might be able to make this more generic through the use of a "JSONEncodable" protocol.
+    static public func asJSON(_ items: [String]) -> ByteStreamable {
+        return JSONEscapedStringListStreamable(items: items)
+    }
+    private struct JSONEscapedStringListStreamable: ByteStreamable {
+        let items: [String]
+        
+        func writeTo(_ stream: OutputByteStream) {
+            stream <<< UInt8(ascii: "[")
+            for (i, item) in items.enumerated() {
+                if i != 0 { stream <<< "," }
+                stream <<< Format.asJSON(item)
+            }
+            stream <<< UInt8(ascii: "]")
+        }
+    }
+
+    /// Write the input dictionary encoded as a JSON object.
+    static public func asJSON(_ items: [String: String]) -> ByteStreamable {
+        return JSONEscapedDictionaryStreamable(items: items)
+    }
+    private struct JSONEscapedDictionaryStreamable: ByteStreamable {
+        let items: [String: String]
+        
+        func writeTo(_ stream: OutputByteStream) {
+            stream <<< UInt8(ascii: "{")
+            for (offset: i, element: (key: key, value: value)) in items.enumerated() {
+                if i != 0 { stream <<< "," }
+                stream <<< Format.asJSON(key) <<< ":" <<< Format.asJSON(value)
+            }
+            stream <<< UInt8(ascii: "}")
+        }
+    }
+
+    /// Write the input list (after applying a transform to each item) encoded as a JSON object.
+    //
+    // FIXME: We might be able to make this more generic through the use of a "JSONEncodable" protocol.
+    static public func asJSON<T>(_ items: [T], transform: (T) -> String) -> ByteStreamable {
+        return JSONEscapedTransformedStringListStreamable(items: items, transform: transform)
+    }
+
+    /// Write the input list to the stream with the given separator between items.
+    static public func asSeparatedList<T: ByteStreamable>(_ items: [T], separator: String) -> ByteStreamable {
+        return SeparatedListStreamable(items: items, separator: separator)
+    }
+
+    /// Write the input list to the stream (after applying a transform to each item) with the given separator between items.
+    static public func asSeparatedList<T>(_ items: [T], transform: (T) -> ByteStreamable, separator: String) -> ByteStreamable {
+        return TransformedSeparatedListStreamable(items: items, transform: transform, separator: separator)
+    }
+}

--- a/Tests/Utility/ByteStringPerfTests.swift
+++ b/Tests/Utility/ByteStringPerfTests.swift
@@ -1,0 +1,39 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+import Utility
+
+// FIXME: Performance tests are disabled for the time being because they have
+// too high an impact on overall testing time.
+//
+// See: 
+#if false
+
+class ByteStringPerfTests: XCTestCase {
+    func testInitialization() {
+        let listOfStrings: [String] = (0..<10).map { "This is the number: \($0)!\n" }
+        let expectedTotalCount = listOfStrings.map({ $0.utf8.count }).reduce(0, combine: (+))
+        measure {
+            var count = 0
+            let N = 10000
+            for _ in 0..<N {
+                for string in listOfStrings {
+                    let bs = ByteString(encodingAsUTF8: string)
+                    count += bs.count
+                }
+            }
+            XCTAssertEqual(count, expectedTotalCount * N)
+        }
+    }
+}
+
+#endif

--- a/Tests/Utility/ByteStringTests.swift
+++ b/Tests/Utility/ByteStringTests.swift
@@ -1,0 +1,70 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+import Utility
+
+// Allow simple conversion from String, in the tests module.
+extension ByteString {
+    init(_ string: String) {
+        self.init(encodingAsUTF8: string)
+    }
+}
+
+class ByteStringTests: XCTestCase {
+    func testInitializers() {
+        do {
+            let data: ByteString = [1]
+            XCTAssertEqual(data.bytes, [1])
+        }
+
+        XCTAssertEqual(ByteString([1]).bytes, [1])
+
+        XCTAssertEqual(ByteString("A").bytes, [65])
+
+        // Test StringLiteralConvertible initialization.
+        XCTAssertEqual(ByteString([65]), "A")
+    }
+
+    func testAccessors() {
+        // Test basic accessors.
+        XCTAssertEqual(ByteString([]).count, 0)
+        XCTAssertEqual(ByteString([1, 2]).count, 2)
+    }
+
+    func testAsString() {
+        XCTAssertEqual(ByteString("hello").asString, "hello")
+        XCTAssertEqual(ByteString([0xFF,0xFF]).asString, nil)
+    }
+
+    func testDescription() {
+        XCTAssertEqual(ByteString("Hello, world!").description, "<ByteString:\"Hello, world!\">")
+    }
+    
+    func testHashable() {
+        var s = Set([ByteString([1]), ByteString([2])])
+        XCTAssert(s.contains(ByteString([1])))
+        XCTAssert(s.contains(ByteString([2])))
+        XCTAssert(!s.contains(ByteString([3])))
+
+        // Insert a long string which tests overflow in the hash function.
+        let long = ByteString([UInt8](0 ..< 100))
+        XCTAssert(!s.contains(long))
+        s.insert(long)
+        XCTAssert(s.contains(long))
+    }
+
+    func testByteStreamable() {
+        let s = OutputByteStream()
+        s <<< ByteString([1, 2, 3])
+        XCTAssertEqual(s.bytes, [1, 2, 3])
+    }
+}

--- a/Tests/Utility/OutputByteStreamPerfTests.swift
+++ b/Tests/Utility/OutputByteStreamPerfTests.swift
@@ -1,0 +1,121 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+import Utility
+
+// FIXME: Performance tests are disabled for the time being because they have
+// too high an impact on overall testing time.
+//
+// See: 
+#if false
+
+class OutputByteStreamPerfTests: XCTestCase {
+    func test1MBOf16ByteArrays_X100() {
+        // Test writing 1MB worth of 16 byte strings.
+        let bytes16 = [UInt8](repeating: 0, count: 1 << 4)
+        
+        measure {
+            for _ in 0..<100 {
+                let stream = OutputByteStream()
+                for _ in 0..<(1 << 16) {
+                    stream <<< bytes16
+                }
+                XCTAssertEqual(stream.bytes.count, 1 << 20)
+            }
+        }
+    }
+    
+    func test1MBOf1KByteArrays_X1000() {
+        // Test writing 1MB worth of 1K byte strings.
+        let bytes1k = [UInt8](repeating: 0, count: 1 << 10)
+        
+        measure {
+            for _ in 0..<1000 {
+                let stream = OutputByteStream()
+                for _ in 0..<(1 << 10) {
+                    stream <<< bytes1k
+                }
+                XCTAssertEqual(stream.bytes.count, 1 << 20)
+            }
+        }
+    }
+
+    func test1MBOf16ByteStrings_X10() {
+        // Test writing 1MB worth of 16 byte strings.
+        let string16 = String(repeating: Character("X"), count: 1 << 4)
+        
+        measure {
+            for _ in 0..<10 {
+                let stream = OutputByteStream()
+                for _ in 0..<(1 << 16) {
+                    stream <<< string16
+                }
+                XCTAssertEqual(stream.bytes.count, 1 << 20)
+            }
+        }
+    }
+
+    func test1MBOf1KByteStrings_X100() {
+        // Test writing 1MB worth of 1K byte strings.
+        let bytes1k = String(repeating: Character("X"), count: 1 << 10)
+        
+        measure {
+            for _ in 0..<100 {
+                let stream = OutputByteStream()
+                for _ in 0..<(1 << 10) {
+                    stream <<< bytes1k
+                }
+                XCTAssertEqual(stream.bytes.count, 1 << 20)
+            }
+        }
+    }
+    
+    func test1MBOfJSONEncoded16ByteStrings_X10() {
+        // Test writing 1MB worth of JSON encoded 16 byte strings.
+        let string16 = String(repeating: Character("X"), count: 1 << 4)
+        
+        measure {
+            for _ in 0..<10 {
+                let stream = OutputByteStream()
+                for _ in 0..<(1 << 16) {
+                    stream.writeJSONEscaped(string16)
+                }
+                XCTAssertEqual(stream.bytes.count, 1 << 20)
+            }
+        }
+    }
+    
+    func testFormattedJSONOutput() {
+        // Test the writing of JSON formatted output using stream operators.
+        struct Thing {
+            var value: String
+            init(_ value: String) { self.value = value }
+        }
+        let listOfStrings: [String] = (0..<10).map { "This is the number: \($0)!\n" }
+        let listOfThings: [Thing] = listOfStrings.map(Thing.init)
+        measure {
+            for _ in 0..<10 {
+                let stream = OutputByteStream()
+                for _ in 0..<(1 << 10) {
+                    for string in listOfStrings {
+                        stream <<< Format.asJSON(string)
+                    }
+                    stream <<< Format.asJSON(listOfStrings)
+                    stream <<< Format.asJSON(listOfThings, transform: { $0.value })
+                }
+                XCTAssertGreaterThan(stream.bytes.count, 1000)
+            }
+        }
+    }
+}
+
+#endif

--- a/Tests/Utility/OutputByteStreamTests.swift
+++ b/Tests/Utility/OutputByteStreamTests.swift
@@ -1,0 +1,109 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+import Utility
+
+class OutputByteStreamTests: XCTestCase {
+    func testBasics() {
+        let stream = OutputByteStream()
+        
+        stream.write("Hello")
+        stream.write(Character(","))
+        stream.write(Character(" "))
+        stream.write([UInt8]("wor".utf8))
+        stream.write([UInt8]("world".utf8)[3..<5])
+        
+        let streamable: Streamable = Character("!")
+        stream.write(streamable)
+
+        stream.flush()
+        
+        XCTAssertEqual(stream.position, "Hello, world!".utf8.count)
+        XCTAssertEqual(stream.bytes, "Hello, world!")
+    }
+    
+    func testStreamOperator() {
+        let stream = OutputByteStream()
+
+        let streamable: Streamable = Character("!")
+        stream <<< "Hello" <<< Character(",") <<< Character(" ") <<< [UInt8]("wor".utf8) <<< [UInt8]("world".utf8)[3..<5] <<< streamable
+        
+        XCTAssertEqual(stream.position, "Hello, world!".utf8.count)
+        XCTAssertEqual(stream.bytes, "Hello, world!")
+
+        let stream2 = OutputByteStream()
+        stream2 <<< (0..<5)
+        XCTAssertEqual(stream2.bytes, [0, 1, 2, 3, 4])
+    }
+    
+    func testJSONEncoding() {
+        // Test string encoding.
+        func asJSON(_ value: String) -> ByteString {
+            let stream = OutputByteStream()
+            stream.writeJSONEscaped(value)
+            return stream.bytes
+        }
+        XCTAssertEqual(asJSON("a'\"\\"), "a'\\\"\\\\")
+        XCTAssertEqual(asJSON("\u{0008}"), "\\b")
+        XCTAssertEqual(asJSON("\u{000C}"), "\\f")
+        XCTAssertEqual(asJSON("\n"), "\\n")
+        XCTAssertEqual(asJSON("\r"), "\\r")
+        XCTAssertEqual(asJSON("\t"), "\\t")
+        XCTAssertEqual(asJSON("\u{0001}"), "\\u0001")
+    }
+    
+    func testFormattedOutput() {
+        do {
+            let stream = OutputByteStream()
+            stream <<< Format.asJSON("\n")
+            XCTAssertEqual(stream.bytes, "\"\\n\"")
+        }
+        
+        do {
+            let stream = OutputByteStream()
+            stream <<< Format.asJSON(["hello", "world\n"])
+            XCTAssertEqual(stream.bytes, "[\"hello\",\"world\\n\"]")
+        }
+        
+        do {
+            let stream = OutputByteStream()
+            stream <<< Format.asJSON(["hello": "world\n"])
+            XCTAssertEqual(stream.bytes, "{\"hello\":\"world\\n\"}")
+        }
+
+        do {
+            struct MyThing {
+                let value: String
+                init(_ value: String) { self.value = value }
+            }
+            let stream = OutputByteStream()
+            stream <<< Format.asJSON([MyThing("hello"), MyThing("world\n")], transform: { $0.value })
+            XCTAssertEqual(stream.bytes, "[\"hello\",\"world\\n\"]")
+        }
+
+        do {
+            let stream = OutputByteStream()
+            stream <<< Format.asSeparatedList(["hello", "world"], separator: ", ")
+            XCTAssertEqual(stream.bytes, "hello, world")
+        }
+        
+        do {
+            struct MyThing {
+                let value: String
+                init(_ value: String) { self.value = value }
+            }
+            let stream = OutputByteStream()
+            stream <<< Format.asSeparatedList([MyThing("hello"), MyThing("world")], transform: { $0.value }, separator: ", ")
+            XCTAssertEqual(stream.bytes, "hello, world")
+        }
+    }
+}

--- a/Tests/Utility/XCTestManifests.swift
+++ b/Tests/Utility/XCTestManifests.swift
@@ -8,6 +8,19 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+extension ByteStringTests {
+    static var allTests : [(String, ByteStringTests -> () throws -> Void)] {
+        return [
+                   ("testInitializers", testInitializers),
+                   ("testAccessors", testAccessors),
+                   ("testAsString", testAsString),
+                   ("testDescription", testDescription),
+                   ("testHashable", testHashable),
+                   ("testByteStreamable", testByteStreamable),
+        ]
+    }
+}
+
 extension CollectionTests {
     static var allTests : [(String, CollectionTests -> () throws -> Void)] {
         return [
@@ -35,6 +48,17 @@ extension RmtreeTests {
     static var allTests : [(String, RmtreeTests -> () throws -> Void)] {
         return [
                    ("testDoesNotFollowSymlinks", testDoesNotFollowSymlinks),
+        ]
+    }
+}
+
+extension OutputByteStreamTests {
+    static var allTests : [(String, OutputByteStreamTests -> () throws -> Void)] {
+        return [
+                   ("testBasics", testBasics),
+                   ("testStreamOperator", testStreamOperator),
+                   ("testJSONEncoding", testJSONEncoding),
+                   ("testFormattedOutput", testFormattedOutput),
         ]
     }
 }


### PR DESCRIPTION
This adds Utility infrastructure for several closely related things:

 - A new ByteString type, which is just a wrapper for a UInt8 array. This is
   useful to have as a separate type because operations on arrays of bytes are
   very common and can benefit from extra support.

 - An OutputByteStream class, which is designed to expose an efficient API for
   the writing of streaming data. For now, it just supports writing to an
   internal buffer, but the goal is that eventually it could support streaming
   directly to disk to avoid unnecessary in memory data.

   This is closely modeled on `llvm::raw_ostream`.

 - A streaming operator `<<<` for use with the above stream.

 - An infrastructure for streaming out "formatted" data (e.g., JSON) without
   unnecessary copying. For example, this API allows writing a JSON-formatted
   list with needing to construct temporary strings.

This commit adds performance tests, which you can run and use to investigate
performance on a release build, but they are disabled completely for now because
we don't have a way to disable them for debug builds, where they are too slow to
run as part of incremental development.