### PR TITLE
[Build] Set rpath to find co-located dylibs on Linux.

### DIFF
--- a/Fixtures/ClangModules/SwiftCMixed/Sources/SeaExec/main.swift
+++ b/Fixtures/ClangModules/SwiftCMixed/Sources/SeaExec/main.swift
@@ -1,3 +1,5 @@
 import SeaLib
 
 let a = foo(5)
+print("a = \(a)")
+

--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -57,7 +57,16 @@ public func describe(_ prefix: String, _ conf: Configuration, _ modules: [Module
     }
 
     for product in products {
-        let command = try Command.link(product, configuration: conf, prefix: prefix, otherArgs: Xld + swiftcArgs + toolchain.platformArgs, SWIFT_EXEC: SWIFT_EXEC)
+        var rpathArgs = [String]()
+        
+        // On Linux, always embed an RPATH adjacent to the linked binary. Note
+        // that the '$ORIGIN' here is literal, it is a reference which is
+        // understood by the dynamic linker.
+#if os(Linux)
+        rpathArgs += ["-Xlinker", "-rpath=$ORIGIN"]
+#endif
+        
+        let command = try Command.link(product, configuration: conf, prefix: prefix, otherArgs: Xld + swiftcArgs + toolchain.platformArgs + rpathArgs, SWIFT_EXEC: SWIFT_EXEC)
         commands.append(command)
         targets.append(command, for: product)
     }

--- a/Tests/Functional/ClangModuleTests.swift
+++ b/Tests/Functional/ClangModuleTests.swift
@@ -36,6 +36,10 @@ class TestClangModulesTestCase: XCTestCase {
         fixture(name: "ClangModules/SwiftCMixed") { prefix in
             XCTAssertBuilds(prefix)
             XCTAssertFileExists(prefix, ".build", "debug", "libSeaLib.so")
+            let exec = ".build/debug/SeaExec"
+            XCTAssertFileExists(prefix, exec)
+            let output = try popen([Path.join(prefix, exec)])
+            XCTAssertEqual(output, "a = 5\n")
         }
     }
     


### PR DESCRIPTION
 - This fixes swiftpm compiled binaries being able to be executed without
   setting LD_LIBRARY_PATH, and allows executables + libraries to be relocated.

 - Replaces #212.