### PR TITLE
xcode generation: get xcc and xld params from pconfig file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
         Target(
             /** Generates Xcode projects */
             name: "Xcodeproj",
-            dependencies: ["PackageType"]),
+            dependencies: ["PackageType", "Build"]),
         Target(
             /** Command line options parser */
             name: "OptionsParser",

--- a/Sources/Build/PkgConfig.swift
+++ b/Sources/Build/PkgConfig.swift
@@ -11,12 +11,12 @@
 import Utility
 import func POSIX.getenv
 
-enum PkgConfigError: ErrorProtocol {
+public enum PkgConfigError: ErrorProtocol {
     case CouldNotFindConfigFile
     case ParsingError(String)
 }
 
-struct PkgConfig {
+public struct PkgConfig {
     private static let searchPaths = ["/usr/local/lib/pkgconfig",
                               "/usr/local/share/pkgconfig",
                               "/usr/lib/pkgconfig",
@@ -24,10 +24,10 @@ struct PkgConfig {
                               ]
     let name: String
     let pcFile: String
-    let cFlags: [String]
-    let libs: [String]
+    public let cFlags: [String]
+    public let libs: [String]
     
-    init(name: String) throws {
+    public init(name: String) throws {
         self.name = name
         self.pcFile = try PkgConfig.locatePCFile(name: name)
         

--- a/Sources/Build/misc.swift
+++ b/Sources/Build/misc.swift
@@ -179,7 +179,7 @@ extension Product {
 
 extension SystemPackageProvider {
     
-    var installText: String {
+    public var installText: String {
         switch self {
         case .Brew(let name):
             return "    brew install \(name)\n"
@@ -203,7 +203,7 @@ extension SystemPackageProvider {
         return false
     }
     
-    static func providerForCurrentPlatform(providers: [SystemPackageProvider]) -> SystemPackageProvider? {
+    public static func providerForCurrentPlatform(providers: [SystemPackageProvider]) -> SystemPackageProvider? {
         return providers.filter{ $0.isAvailable }.first
     }
 }


### PR DESCRIPTION
Resolves https://bugs.swift.org/browse/SR-1368
But I see @ddunbar  working on refactoring in this minute on xcode generating.
https://github.com/apple/swift-package-manager/blob/master/Sources/Xcodeproj/pbxproj().swift#L189
you can use my `serializeArray` here
```swift
func serializeArray(_ array: [String]) -> String {
    return "( " + array.map({ "\"\($0)\"" }).joined(separator: ", ") + " )"
}
```
