### PR TITLE
Throw error when tests are found directly under Tests

### DIFF
--- a/Sources/swift-test/main.swift
+++ b/Sources/swift-test/main.swift
@@ -28,7 +28,7 @@ do {
     case .Run(let specifier):
         let configuration = "debug"  //FIXME should swift-test support configuration option?
 
-        func determineTestPath() -> String {
+        func determineTestPath() throws -> String {
 
             //FIXME better, ideally without parsing manifest since
             // that makes us depend on the whole Manifest system
@@ -39,10 +39,16 @@ do {
             if maybePath.exists {
                 return maybePath
             } else {
-                return walk(opts.path.build).filter {
+                let possiblePaths = walk(opts.path.build).filter {
                     $0.basename != "Package.xctest" &&   // this was our hardcoded name, may still exist if no clean
                     $0.hasSuffix(".xctest")
-                }.first!
+                }
+                
+                guard let path = possiblePaths.first else {
+                    throw Error.TestsExecutableNotFound
+                }
+                
+                return path
             }
         }
 


### PR DESCRIPTION
If tests are directly under Tests directory, `swift test` will fail because it tries to unwrap a `nil` value.

Fixed it by throwing `TestsExecutableNotFound` error.