### PR TITLE
Add --show-dependencies option to dump external dependencies

### DIFF
--- a/Sources/swift-build/main.swift
+++ b/Sources/swift-build/main.swift
@@ -94,6 +94,10 @@ do {
 
     case .Doctor:
         doctor()
+    
+    case .ShowDependencies(let mode):
+        let (rootPackage, externalPackages) = try fetch(opts.path.root)
+        dumpDependenciesOf(rootPackage: rootPackage, mode: mode)
 
     case .Version:
         print("Apple Swift Package Manager 0.1")

--- a/Sources/swift-build/usage.swift
+++ b/Sources/swift-build/usage.swift
@@ -40,6 +40,7 @@ enum Mode: Argument, Equatable, CustomStringConvertible {
     case Build(Configuration, Toolchain)
     case Clean(CleanMode)
     case Doctor
+    case ShowDependencies(ShowDependenciesMode)
     case Fetch
     case Update
     case Init(InitMode)
@@ -55,6 +56,8 @@ enum Mode: Argument, Equatable, CustomStringConvertible {
             self = try .Clean(CleanMode(pop()))
         case "--doctor":
             self = .Doctor
+        case "--show-dependencies", "-D":
+            self = try .ShowDependencies(ShowDependenciesMode(pop()))
         case "--fetch":
             self = .Fetch
         case "--update":
@@ -77,6 +80,7 @@ enum Mode: Argument, Equatable, CustomStringConvertible {
             case .Build(let conf, _): return "--configuration=\(conf)"
             case .Clean(let mode): return "--clean=\(mode)"
             case .Doctor: return "--doctor"
+            case .ShowDependencies: return "--show-dependencies"
             case .GenerateXcodeproj: return "--generate-xcodeproj"
             case .Fetch: return "--fetch"
             case .Update: return "--update"
@@ -224,4 +228,28 @@ enum InitMode: CustomStringConvertible {
 
 func ==(lhs: Mode, rhs: Mode) -> Bool {
     return lhs.description == rhs.description
+}
+
+enum ShowDependenciesMode: CustomStringConvertible {
+    case Text
+    
+    private init(_ rawValue: String?) throws {
+        guard let rawValue = rawValue else {
+            self = .Text
+            return
+        }
+        
+        switch rawValue.lowercased() {
+        case "text":
+           self = .Text
+        default:
+            throw OptionsParser.Error.InvalidUsage("invalid show dependencies mode: \(rawValue)")
+        }
+    }
+    
+    var description: String {
+        switch self {
+        case .Text: return "text"
+        }
+    }
 }


### PR DESCRIPTION
Dump the external dependencies (along with their dependencies) to console.


Sample output for Vapor (v0.7.0):
```
$ swift-build --show-dependencies
.
├── C7<https://github.com/open-swift/C7.git@0.5.0>
├── S4<https://github.com/open-swift/S4.git@0.4.0>
│   └── C7<https://github.com/open-swift/C7.git@0.5.0>
├── String<https://github.com/Zewo/String.git@0.5.1>
├── StructuredData<https://github.com/Zewo/StructuredData.git@0.5.0>
│   └── C7<https://github.com/open-swift/C7.git@0.5.0>
├── JSON<https://github.com/Zewo/JSON.git@0.5.0>
│   └── StructuredData<https://github.com/Zewo/StructuredData.git@0.5.0>
│       └── C7<https://github.com/open-swift/C7.git@0.5.0>
├── Strand<https://github.com/ketzusaka/Strand.git@1.2.3>
├── Hummingbird<https://github.com/ketzusaka/Hummingbird.git@1.4.0>
│   ├── Strand<https://github.com/ketzusaka/Strand.git@1.2.3>
│   └── C7<https://github.com/open-swift/C7.git@0.5.0>
├── CryptoEssentials<https://github.com/CryptoKitten/CryptoEssentials.git@0.5.2>
├── HMAC<https://github.com/CryptoKitten/HMAC.git@0.5.2>
│   └── CryptoEssentials<https://github.com/CryptoKitten/CryptoEssentials.git@0.5.2>
├── SHA2<https://github.com/CryptoKitten/SHA2.git@0.5.1>
│   └── CryptoEssentials<https://github.com/CryptoKitten/CryptoEssentials.git@0.5.2>
└── Vapor<https://github.com/qutheory/vapor@0.7.0>
    ├── S4<https://github.com/open-swift/S4.git@0.4.0>
    │   └── C7<https://github.com/open-swift/C7.git@0.5.0>
    ├── String<https://github.com/Zewo/String.git@0.5.1>
    ├── JSON<https://github.com/Zewo/JSON.git@0.5.0>
    │   └── StructuredData<https://github.com/Zewo/StructuredData.git@0.5.0>
    │       └── C7<https://github.com/open-swift/C7.git@0.5.0>
    ├── Hummingbird<https://github.com/ketzusaka/Hummingbird.git@1.4.0>
    │   ├── Strand<https://github.com/ketzusaka/Strand.git@1.2.3>
    │   └── C7<https://github.com/open-swift/C7.git@0.5.0>
    ├── HMAC<https://github.com/CryptoKitten/HMAC.git@0.5.2>
    │   └── CryptoEssentials<https://github.com/CryptoKitten/CryptoEssentials.git@0.5.2>
    └── SHA2<https://github.com/CryptoKitten/SHA2.git@0.5.1>
        └── CryptoEssentials<https://github.com/CryptoKitten/CryptoEssentials.git@0.5.2>
```

Only plain text option is supported as of now. Code is extensible to support additional formats like Dot and JSON.

Will add support for other formats in my next PRs.