### PR TITLE
[OptionsParser] Throw Unknown Argument if can't consume argument

### DIFF
--- a/Sources/OptionsParser/OptionsParser.swift
+++ b/Sources/OptionsParser/OptionsParser.swift
@@ -73,6 +73,8 @@ public func parse<Mode, Flag where Mode: Argument, Mode: Equatable, Flag: Argume
                 }
                 flags.append(flag)
             }
+        } else {
+          throw Error.UnknownArgument(arg)
         }
 
         if let value = value where !popped {


### PR DESCRIPTION
This takes care of cases when something is left unconsumed in commandline args. i.e.

`$ swift build blah`
or 
`$ swift test OptionsParserTestSuite.OptionsParserTests` 
should properly error out instead of silently ignoring.