### PR TITLE
Target type of OS X 10.11

### DIFF
--- a/Sources/ManifestParser/Manifest+parse.swift
+++ b/Sources/ManifestParser/Manifest+parse.swift
@@ -64,7 +64,7 @@ private func parse(path manifestPath: String, swiftc: String, libdir: String) th
     cmd += ["-I", libdir]
     cmd += ["-L", libdir, "-lPackageDescription"]
 #if os(OSX)
-    cmd += ["-target", "x86_64-apple-macosx10.10"]
+    cmd += ["-target", "x86_64-apple-macosx10.11"]
 #endif
     cmd += [manifestPath]
 

--- a/Sources/swift-build/UserToolchain.swift
+++ b/Sources/swift-build/UserToolchain.swift
@@ -26,7 +26,7 @@ struct UserToolchain: Toolchain {
 
 #if os(OSX)
     var platformArgs: [String] {
-        return ["-target", "x86_64-apple-macosx10.10", "-sdk", sysroot!]
+        return ["-target", "x86_64-apple-macosx10.11", "-sdk", sysroot!]
     }
 #else
     let platformArgs: [String] = []


### PR DESCRIPTION
Fixed target type to match the Xcodeproj-generated deployment target of El Capitan (Swift.org says that El Cap is required for OSS Swift anyway).

The error was:

```
/Users/honzadvorsky/Documents/Jay/Package.swift:1:8: error: module file's minimum deployment target is OS X v10.11: /Users/honzadvorsky/Library/Developer/Xcode/DerivedData/SwiftPM-fdiqtsijzcpkmybidirbouryiuld/Build/Products/Debug/PackageDescription.swiftmodule/x86_64.swiftmodule
import PackageDescription
       ^
[31merror:[0m exit(1): /Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2016-05-03-a.xctoolchain/usr/bin/swiftc --driver-mode=swift -I /Users/honzadvorsky/Library/Developer/Xcode/DerivedData/SwiftPM-fdiqtsijzcpkmybidirbouryiuld/Build/Products/Debug -L /Users/honzadvorsky/Library/Developer/Xcode/DerivedData/SwiftPM-fdiqtsijzcpkmybidirbouryiuld/Build/Products/Debug -lPackageDescription -target x86_64-apple-macosx10.10 /Users/honzadvorsky/Documents/Jay/Package.swift -fileno 3
```