### PR TITLE
[Git] Don't initalise empty Git repos

### DIFF
--- a/Sources/Utility/Git.swift
+++ b/Sources/Utility/Git.swift
@@ -20,6 +20,9 @@ public class Git {
             guard let realroot = try? realpath(path) else { return nil }
             self.path = realroot
             guard Path.join(path, ".git").isDirectory else { return nil }
+            // If number of objects is zero then its an empty repo.
+            guard let numObjects = try? Git.runPopen([Git.tool, "-C", path, "count-objects"]) else { return nil }
+            if numObjects.hasPrefix("0") { return nil }
         }
 
         public lazy var origin: String? = { repo in


### PR DESCRIPTION
Fixes https://bugs.swift.org/browse/SR-1401
However I am not sure if this is the correct way but I would guess there is no point creating a git object if repo is empty.