### PR TITLE
Add DOT format for dumping dependencies

### DIFF
--- a/Sources/swift-build/usage.swift
+++ b/Sources/swift-build/usage.swift
@@ -231,7 +231,7 @@ func ==(lhs: Mode, rhs: Mode) -> Bool {
 }
 
 enum ShowDependenciesMode: CustomStringConvertible {
-    case Text
+    case Text, DOT
     
     private init(_ rawValue: String?) throws {
         guard let rawValue = rawValue else {
@@ -242,6 +242,8 @@ enum ShowDependenciesMode: CustomStringConvertible {
         switch rawValue.lowercased() {
         case "text":
            self = .Text
+        case "dot":
+           self = .DOT
         default:
             throw OptionsParser.Error.InvalidUsage("invalid show dependencies mode: \(rawValue)")
         }
@@ -250,6 +252,7 @@ enum ShowDependenciesMode: CustomStringConvertible {
     var description: String {
         switch self {
         case .Text: return "text"
+        case .DOT: return "dot"
         }
     }
 }


### PR DESCRIPTION
This will dump the dependencies in DOT format

```bash
$ swift-build --show-dependencies dot > dependencies.gv
$ dot -T png dependencies.gv -o dependencies.png
$ open dependencies.png
```

> Note: you need to have `graphviz` package installed to be able to convert the `.gv` file to `.png` or any other format.
