### PR TITLE
[Build] Add module cache path inside .build for swift modules

### DIFF
--- a/Sources/Build/Command.compile(ClangModule).swift
+++ b/Sources/Build/Command.compile(ClangModule).swift
@@ -80,7 +80,9 @@ extension Command {
         ///------------------------------ Compile -----------------------------------------
         var compileCommands = [Command]()
         let dependencies = module.dependencies.map{ $0.targetName }
-        let basicArgs = module.basicArgs + module.includeFlagsWithExternalModules(externalModules) + module.optimizationFlags(conf)
+        var basicArgs = module.basicArgs + module.includeFlagsWithExternalModules(externalModules) + module.optimizationFlags(conf)
+        basicArgs += module.moduleCacheArgs(prefix: prefix)
+
         for path in module.sources.compilePathsForBuildDir(wd) {
             var args = basicArgs
             args += ["-MD", "-MT", "dependencies", "-MF", path.deps]

--- a/Sources/Build/Command.compile(SwiftModule).swift
+++ b/Sources/Build/Command.compile(SwiftModule).swift
@@ -14,8 +14,8 @@ import Utility
 extension Command {
     static func compile(swiftModule module: SwiftModule, configuration conf: Configuration, prefix: String, otherArgs: [String], SWIFT_EXEC: String) throws -> (Command, [Command]) {
 
-        let otherArgs = otherArgs + module.XccFlags(prefix) + (try module.pkgConfigArgs())
-        
+        let otherArgs = otherArgs + module.XccFlags(prefix) + (try module.pkgConfigArgs()) + module.moduleCacheArgs(prefix: prefix)
+
         func cmd(_ tool: ToolProtocol) -> Command {
             return Command(node: module.targetName, tool: tool)
         }

--- a/Sources/Build/misc.swift
+++ b/Sources/Build/misc.swift
@@ -220,6 +220,9 @@ extension ClangModuleCachable {
 
 extension ClangModule: ClangModuleCachable {
     func moduleCacheArgs(prefix: String) -> [String] {
+        // FIXME: We use this hack to let swiftpm's functional test use shared cache
+        // so it doesn't become painfully slow.
+        if let _ = getenv("IS_SWIFTPM_TEST") { return [] }
         let moduleCachePath = moduleCacheDir(prefix: prefix)
         return ["-fmodules-cache-path=\(moduleCachePath)"]
     }
@@ -227,6 +230,9 @@ extension ClangModule: ClangModuleCachable {
 
 extension SwiftModule: ClangModuleCachable {
     func moduleCacheArgs(prefix: String) -> [String] {
+        // FIXME: We use this hack to let swiftpm's functional test use shared cache
+        // so it doesn't become painfully slow.
+        if let _ = getenv("IS_SWIFTPM_TEST") { return [] }
         let moduleCachePath = moduleCacheDir(prefix: prefix)
         return ["-module-cache-path", moduleCachePath]
     }

--- a/Sources/Build/misc.swift
+++ b/Sources/Build/misc.swift
@@ -208,3 +208,26 @@ extension SystemPackageProvider {
     }
 }
 
+protocol ClangModuleCachable {
+    func moduleCacheArgs(prefix: String) -> [String]
+}
+
+extension ClangModuleCachable {
+    func moduleCacheDir(prefix: String) -> String {
+        return Path.join(prefix, "ModuleCache")
+    }
+}
+
+extension ClangModule: ClangModuleCachable {
+    func moduleCacheArgs(prefix: String) -> [String] {
+        let moduleCachePath = moduleCacheDir(prefix: prefix)
+        return ["-fmodules-cache-path=\(moduleCachePath)"]
+    }
+}
+
+extension SwiftModule: ClangModuleCachable {
+    func moduleCacheArgs(prefix: String) -> [String] {
+        let moduleCachePath = moduleCacheDir(prefix: prefix)
+        return ["-module-cache-path", moduleCachePath]
+    }
+}

--- a/Tests/Functional/Utilities.swift
+++ b/Tests/Functional/Utilities.swift
@@ -113,6 +113,10 @@ func swiftBuildPath() -> String {
 
 func executeSwiftBuild(_ chdir: String, configuration: Configuration = .Debug, printIfError: Bool = false, Xld: [String] = []) throws -> String {
     var env = [String:String]()
+
+    // FIXME: We use this private enviroment variable hack to be able to
+    // create special conditions in swift-build for swiftpm tests.
+    env["IS_SWIFTPM_TEST"] = "1"
 #if Xcode
     switch getenv("SWIFT_EXEC") {
     case "swiftc"?, nil:


### PR DESCRIPTION
Fixes the inconsistent --clean behavior reported https://bugs.swift.org/browse/SR-1383