### PR TITLE
SR-1005: Ground work for building against Foundation

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -627,18 +627,24 @@ def main():
         embed_rpath = "@executable_path/../lib/swift/macosx"
     cmd.extend(["-Xlinker", "-rpath", "-Xlinker", embed_rpath])
 
-    if args.foundation_path and args.xctest_path:
+    if args.foundation_path:
         core_foundation_path = os.path.join(
             args.foundation_path, "usr", "lib", "swift")
+        # Tell the linker where to look for XCTest, but autolinking
+        # knows to pass -lXCTest.
+        cmd.extend(["-Xlinker", "-L", "-Xlinker", args.foundation_path])
+        # Add an RPATH, so that the tests can be run directly.
+        cmd.extend(["-Xlinker", "-rpath", "-Xlinker", args.foundation_path])
+        cmd.extend(["-Xswiftc", "-I{}".format(args.foundation_path)])
+        cmd.extend(["-Xswiftc", "-I{}".format(core_foundation_path)])
+
+    if args.xctest_path:
         # Tell the linker where to look for XCTest, but autolinking
         # knows to pass -lXCTest.
         cmd.extend(["-Xlinker", "-L", "-Xlinker", args.xctest_path])
         # Add an RPATH, so that the tests can be run directly.
         cmd.extend(["-Xlinker", "-rpath", "-Xlinker", args.xctest_path])
-        cmd.extend(["-Xlinker", "-rpath", "-Xlinker", args.foundation_path])
         cmd.extend(["-Xswiftc", "-I{}".format(args.xctest_path)])
-        cmd.extend(["-Xswiftc", "-I{}".format(args.foundation_path)])
-        cmd.extend(["-Xswiftc", "-I{}".format(core_foundation_path)])
 
     if args.release:
         cmd.extend(["--configuration", "release"])

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -357,8 +357,12 @@ def create_bootstrap_files(sandbox_path, args):
                 link_command.extend(["-Xlinker", "-all_load"])
             for lib in target.extra_libs:
                 link_command.extend(["-Xlinker", "-l%s" % (lib,)])
-            link_command.extend(
-                ["-Xlinker", "-rpath=\\$ORIGIN/../lib/swift/linux"])
+            if platform.system() == 'Linux':
+                link_command.extend(
+                    ["-Xlinker", "-rpath=\\$ORIGIN/../lib/swift/linux"])
+            else:
+                link_command.extend(
+                    ["-Xlinker", "-rpath=@executable_path/../lib/swift/macosx]"])
             if args.foundation_path:
                 link_command.extend(["-L", args.foundation_path])
 
@@ -607,7 +611,11 @@ def main():
         sandbox_path, args, bootstrap=True)
 
     libdir = os.path.join(build_path, "lib")
-    mkdir_p(os.path.join(sandbox_path, "lib", "swift", "linux"))
+    if platform.system() == 'Linux':
+        libswiftdir = os.path.join(sandbox_path, "lib", "swift", "linux")
+    else:
+        libswiftdir = os.path.join(sandbox_path, "lib", "swift", "macosx")
+    mkdir_p(libswiftdir)
     bindir = os.path.join(build_path, "debug")
     mkdir_p(bindir)
     bootstrapped_product = os.path.join(bindir, "swift-build-stage1")
@@ -622,8 +630,7 @@ def main():
             shutil.rmtree(libdir)   # TODO remove, here to prevent revlock incremental CI build failures
         symlink_force(os.path.join(sandbox_path, "lib"), build_path)
         symlink_force(os.path.join(args.foundation_path, 'libFoundation.so'),
-            os.path.join(sandbox_path, "lib", "swift", "linux"))
-
+            libswiftdir)
 
     make_fake_toolchain()
 

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -607,6 +607,7 @@ def main():
         sandbox_path, args, bootstrap=True)
 
     libdir = os.path.join(build_path, "lib")
+    mkdir_p(os.path.join(sandbox_path, "lib", "swift", "linux"))
     bindir = os.path.join(build_path, "debug")
     mkdir_p(bindir)
     bootstrapped_product = os.path.join(bindir, "swift-build-stage1")
@@ -620,6 +621,9 @@ def main():
         if os.path.isdir(libdir) and not os.path.islink(libdir):
             shutil.rmtree(libdir)   # TODO remove, here to prevent revlock incremental CI build failures
         symlink_force(os.path.join(sandbox_path, "lib"), build_path)
+        symlink_force(os.path.join(args.foundation_path, 'libFoundation.so'),
+            os.path.join(sandbox_path, "lib", "swift", "linux"))
+
 
     make_fake_toolchain()
 

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -360,9 +360,6 @@ def create_bootstrap_files(sandbox_path, args):
             if platform.system() == 'Linux':
                 link_command.extend(
                     ["-Xlinker", "-rpath=\\$ORIGIN/../lib/swift/linux"])
-            else:
-                link_command.extend(
-                    ["-Xlinker", "-rpath=@executable_path/../lib/swift/macosx]"])
             if args.foundation_path:
                 link_command.extend(["-L", args.foundation_path])
 
@@ -611,11 +608,6 @@ def main():
         sandbox_path, args, bootstrap=True)
 
     libdir = os.path.join(build_path, "lib")
-    if platform.system() == 'Linux':
-        libswiftdir = os.path.join(sandbox_path, "lib", "swift", "linux")
-    else:
-        libswiftdir = os.path.join(sandbox_path, "lib", "swift", "macosx")
-    mkdir_p(libswiftdir)
     bindir = os.path.join(build_path, "debug")
     mkdir_p(bindir)
     bootstrapped_product = os.path.join(bindir, "swift-build-stage1")
@@ -629,8 +621,11 @@ def main():
         if os.path.isdir(libdir) and not os.path.islink(libdir):
             shutil.rmtree(libdir)   # TODO remove, here to prevent revlock incremental CI build failures
         symlink_force(os.path.join(sandbox_path, "lib"), build_path)
-        symlink_force(os.path.join(args.foundation_path, 'libFoundation.so'),
-            libswiftdir)
+        if args.foundation_path:
+            libswiftdir = os.path.join(sandbox_path, "lib", "swift", "linux")
+            mkdir_p(libswiftdir)
+            symlink_force(os.path.join(args.foundation_path, 'libFoundation.so'),
+                libswiftdir)
 
     make_fake_toolchain()
 

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -188,8 +188,16 @@ class Target(object):
               file=output)
         print("    sources: %s" % json.dumps(self.swift_sources), file=output)
         print("    objects: %s" % json.dumps(swift_objects), file=output)
-        print("    import-paths: %s" % json.dumps(
-            [module_dir]), file=output)
+        import_paths = [module_dir]
+        if args.foundation_path:
+            import_paths.append(args.foundation_path)
+            import_paths.append(os.path.join(args.foundation_path,
+                                             "usr/lib/swift/CoreFoundation"))
+            import_paths.append(os.path.join(args.foundation_path,
+                                             "usr/lib/swift"))
+        if args.xctest_path:
+            import_paths.append(args.xctest_path)
+        print("    import-paths: %s" % json.dumps(import_paths), file=output)
         print("    other-args: %s" % json.dumps(' '.join(other_args)),
               file=output)
         print("    temps-path: %s" % json.dumps(target_build_dir), file=output)
@@ -349,6 +357,10 @@ def create_bootstrap_files(sandbox_path, args):
                 link_command.extend(["-Xlinker", "-all_load"])
             for lib in target.extra_libs:
                 link_command.extend(["-Xlinker", "-l%s" % (lib,)])
+            link_command.extend(
+                ["-Xlinker", "-rpath=\\$ORIGIN/../lib/swift/linux"])
+            if args.foundation_path:
+                link_command.extend(["-L", args.foundation_path])
 
         # Write out the link command.
         print("  %s:" % json.dumps(target.linked_virtual_node), file=output)


### PR DESCRIPTION
As requested by Daniel on slack, I've split the ground work of the Foundation PRs into a separate PR. This replaces the custom String+Linux by the default Foundation implementation. However there is a build issue on Linux that prevents this PR from being merged.