### PR TITLE
Added a mode to print a package's Package.swift contents in TOML

### DIFF
--- a/Sources/swift-build/main.swift
+++ b/Sources/swift-build/main.swift
@@ -54,7 +54,7 @@ do {
         let (modules, externalModules, products) = try transmute(rootPackage, externalPackages: externalPackages)
         let yaml = try describe(opts.path.build, conf, modules, Set(externalModules), products, Xcc: opts.Xcc, Xld: opts.Xld, Xswiftc: opts.Xswiftc, toolchain: toolchain)
         try build(YAMLPath: yaml)
-
+        
     case .Init(let initMode):
         let initPackage = try InitPackage(mode: initMode)
         try initPackage.writePackageStructure()
@@ -98,6 +98,12 @@ do {
     case .ShowDependencies(let mode):
         let (rootPackage, externalPackages) = try fetch(opts.path.root)
         dumpDependenciesOf(rootPackage: rootPackage, mode: mode)
+
+    case .ShowPackage:
+        let root = opts.path.root
+        let manifest = try parseManifest(path: root, baseURL: root)
+        let out = manifest.package.toTOML()
+        print(out)
 
     case .Version:
         print("Apple Swift Package Manager 0.1")

--- a/Sources/swift-build/usage.swift
+++ b/Sources/swift-build/usage.swift
@@ -26,6 +26,8 @@ func usage(_ print: (String) -> Void = { print($0) }) {
     print("  --fetch                        Fetch package dependencies")
     print("  --update                       Update package dependencies")
     print("  --generate-xcodeproj[=<path>]  Generates an Xcode project [-X]")
+    print("  --show-dependencies[=<mode>]   Print dependency graph (text|dot|json)")
+    print("  --show-package                 Print the contents of Package.swift")
     print("")
     print("OPTIONS:")
     print("  --chdir <path>       Change working directory before any other operation [-C]")
@@ -41,6 +43,7 @@ enum Mode: Argument, Equatable, CustomStringConvertible {
     case Clean(CleanMode)
     case Doctor
     case ShowDependencies(ShowDependenciesMode)
+    case ShowPackage
     case Fetch
     case Update
     case Init(InitMode)
@@ -58,6 +61,8 @@ enum Mode: Argument, Equatable, CustomStringConvertible {
             self = .Doctor
         case "--show-dependencies", "-D":
             self = try .ShowDependencies(ShowDependenciesMode(pop()))
+        case "--show-package":
+            self = .ShowPackage
         case "--fetch":
             self = .Fetch
         case "--update":
@@ -87,6 +92,7 @@ enum Mode: Argument, Equatable, CustomStringConvertible {
             case .Init(let mode): return "--init=\(mode)"
             case .Usage: return "--help"
             case .Version: return "--version"
+            case .ShowPackage: return "--show-package"
         }
     }
 }


### PR DESCRIPTION
Making the first step in making the Package.swift usable by other tools by adding a way to print the its parsed contents in the TOML format. 

As there's no TOML parser outside of SwiftPM, to make this much more useful, we should do one of these two things
1. write a TOML <-> JSON converter, by using most of the TOML parsing logic in SwiftPM and releasing it as a separate project
2. add serialization into JSON to Package in addition to the existing TOML, making it easy to print it in JSON as well (a flag would be added)

I think both are viable options, 1. is better for the long-term, we wouldn't need to maintain two sets of similar serialization code in SwiftPM, but 2. is better to enable tool integration with SwiftPM quickly.

/cc @ddunbar @mxcl @aciidb0mb3r  

(I also added a help line for --show-dependencies, keeping it in this PR to avoid a guaranteed conflict)