### PR TITLE
[swift-test] inherit enviroment when running xctest

### DIFF
--- a/Sources/swift-test/test.swift
+++ b/Sources/swift-test/test.swift
@@ -10,6 +10,7 @@
 
 import PackageType
 import Utility
+import class Foundation.NSProcessInfo
 
 func test(path: String, xctestArg: String? = nil) throws -> Bool {
 
@@ -31,7 +32,9 @@ func test(path: String, xctestArg: String? = nil) throws -> Bool {
     }
 #endif
 
-    let result: Void? = try? system(args)
+    // Execute the XCTest with inherited environment as it is convenient to pass senstive
+    // information like username, password etc to test cases via enviornment variables.
+    let result: Void? = try? system(args, environment: NSProcessInfo.processInfo().environment)
     return result != nil
 }
 


### PR DESCRIPTION
Fixes https://bugs.swift.org/browse/SR-1396