### PR TITLE
[Build] Remove unused mkdir tool and create directory command

### DIFF
--- a/Sources/Build/Command.swift
+++ b/Sources/Build/Command.swift
@@ -11,8 +11,4 @@
 struct Command {
     let node: String
     let tool: ToolProtocol
-
-    static func createDirectory(_ path: String) -> Command {
-        return Command(node: path, tool: MkdirTool(path: path))
-    }
 }

--- a/Sources/Build/ToolProtocol.swift
+++ b/Sources/Build/ToolProtocol.swift
@@ -93,18 +93,6 @@ struct Target {
     var cmds: [Command]
 }
 
-struct MkdirTool: ToolProtocol {
-    let path: String
-
-    var inputs: [String] { return [] }
-    var outputs: [String] { return [path] }
-
-    func append(to stream: OutputByteStream) {
-        stream <<< "    tool: mkdir\n"
-        stream <<< "    outputs: " <<< Format.asJSON(outputs) <<< "\n"
-    }
-}
-
 struct ClangTool: ToolProtocol {
     let desc: String
     let inputs: [String]


### PR DESCRIPTION
These are not used anywhere in code now because llbuild automatically infers and does this now.
Ref: https://github.com/apple/swift-package-manager/pull/319