### PR TITLE
Updated tests for SE-0036 and SE-0066

### DIFF
--- a/Tests/Build/DescribeTests.swift
+++ b/Tests/Build/DescribeTests.swift
@@ -32,7 +32,7 @@ final class DescribeTests: XCTestCase {
 }
 
 extension DescribeTests {
-    static var allTests: [(String, DescribeTests -> () throws -> Void)] {
+    static var allTests: [(String, (DescribeTests) -> () throws -> Void)] {
         return [
             ("testDescribingNoModulesThrows", testDescribingNoModulesThrows),
         ]

--- a/Tests/Build/PackageVersionDataTests.swift
+++ b/Tests/Build/PackageVersionDataTests.swift
@@ -61,7 +61,7 @@ final class PackageVersionDataTests: XCTestCase {
 }
 
 extension PackageVersionDataTests {
-    static var allTests: [(String, PackageVersionDataTests -> () throws -> Void)] {
+    static var allTests: [(String, (PackageVersionDataTests) -> () throws -> Void)] {
         return [
                    ("testPackageVersionData", testPackageVersionData),
                    ("testPackageEmptyVersionData", testPackageEmptyVersionData),

--- a/Tests/Build/PkgConfigParserTests.swift
+++ b/Tests/Build/PkgConfigParserTests.swift
@@ -66,7 +66,7 @@ final class PkgConfigParserTests: XCTestCase {
 
 
 extension PkgConfigParserTests {
-    static var allTests : [(String, PkgConfigParserTests -> () throws -> Void)] {
+    static var allTests : [(String, (PkgConfigParserTests) -> () throws -> Void)] {
         return [
                    ("testGTK3PCFile", testGTK3PCFile),
         ]

--- a/Tests/Functional/ClangModuleTests.swift
+++ b/Tests/Functional/ClangModuleTests.swift
@@ -101,7 +101,7 @@ class TestClangModulesTestCase: XCTestCase {
 
 
 extension TestClangModulesTestCase {
-    static var allTests : [(String, TestClangModulesTestCase -> () throws -> Void)] {
+    static var allTests : [(String, (TestClangModulesTestCase) -> () throws -> Void)] {
         return [
             ("testSingleModuleFlatCLibrary", testSingleModuleFlatCLibrary),
             ("testSingleModuleCLibraryInSources", testSingleModuleCLibraryInSources),

--- a/Tests/Functional/ModuleMapTests.swift
+++ b/Tests/Functional/ModuleMapTests.swift
@@ -68,7 +68,7 @@ class ModuleMapsTestCase: XCTestCase {
 
 
 extension ModuleMapsTestCase {
-    static var allTests : [(String, ModuleMapsTestCase -> () throws -> Void)] {
+    static var allTests : [(String, (ModuleMapsTestCase) -> () throws -> Void)] {
         return [
             ("testDirectDependency", testDirectDependency),
             ("testTransitiveDependency", testTransitiveDependency),

--- a/Tests/Functional/ValidLayoutTests.swift
+++ b/Tests/Functional/ValidLayoutTests.swift
@@ -132,7 +132,7 @@ extension ValidLayoutsTestCase {
 
 
 extension DependencyResolutionTestCase {
-    static var allTests : [(String, DependencyResolutionTestCase -> () throws -> Void)] {
+    static var allTests : [(String, (DependencyResolutionTestCase) -> () throws -> Void)] {
         return [
             ("testInternalSimple", testInternalSimple),
             ("testInternalComplex", testInternalComplex),
@@ -144,7 +144,7 @@ extension DependencyResolutionTestCase {
 }
 
 extension InvalidLayoutsTestCase {
-    static var allTests : [(String, InvalidLayoutsTestCase -> () throws -> Void)] {
+    static var allTests : [(String, (InvalidLayoutsTestCase) -> () throws -> Void)] {
         return [
             ("testMultipleRoots", testMultipleRoots),
             ("testInvalidLayout1", testInvalidLayout1),
@@ -157,7 +157,7 @@ extension InvalidLayoutsTestCase {
 }
 
 extension MiscellaneousTestCase {
-    static var allTests : [(String, MiscellaneousTestCase -> () throws -> Void)] {
+    static var allTests : [(String, (MiscellaneousTestCase) -> () throws -> Void)] {
         return [
             ("testPrintsSelectedDependencyVersion", testPrintsSelectedDependencyVersion),
             ("testPackageWithNoSources", testPackageWithNoSources),
@@ -189,7 +189,7 @@ extension MiscellaneousTestCase {
 }
 
 extension ValidLayoutsTestCase {
-    static var allTests : [(String, ValidLayoutsTestCase -> () throws -> Void)] {
+    static var allTests : [(String, (ValidLayoutsTestCase) -> () throws -> Void)] {
         return [
             ("testSingleModuleLibrary", testSingleModuleLibrary),
             ("testSingleModuleExecutable", testSingleModuleExecutable),

--- a/Tests/Get/RawCloneTests.swift
+++ b/Tests/Get/RawCloneTests.swift
@@ -67,7 +67,7 @@ private func tryCloningRepoWithTag(_ tag: String?, shouldCrash: Bool) {
 
 
 extension VersionGraphTests {
-    static var allTests : [(String, VersionGraphTests -> () throws -> Void)] {
+    static var allTests : [(String, (VersionGraphTests) -> () throws -> Void)] {
         return [
             ("testNoGraph", testNoGraph),
             ("testOneDependency", testOneDependency),
@@ -87,7 +87,7 @@ extension VersionGraphTests {
 }
 
 extension GetTests {
-    static var allTests : [(String, GetTests -> () throws -> Void)] {
+    static var allTests : [(String, (GetTests) -> () throws -> Void)] {
         return [
             ("testRawCloneDoesNotCrashIfManifestIsNotPresent", testRawCloneDoesNotCrashIfManifestIsNotPresent),
             ("testRangeConstrain", testRangeConstrain),
@@ -97,7 +97,7 @@ extension GetTests {
 }
 
 extension GitTests {
-    static var allTests : [(String, GitTests -> () throws -> Void)] {
+    static var allTests : [(String, (GitTests) -> () throws -> Void)] {
         return [
             ("testHasVersion", testHasVersion),
             ("testHasNoVersion", testHasNoVersion),

--- a/Tests/ManifestParser/TOMLTests.swift
+++ b/Tests/ManifestParser/TOMLTests.swift
@@ -109,7 +109,7 @@ class TOMLTests: XCTestCase {
 
 
 extension TOMLTests {
-    static var allTests : [(String, TOMLTests -> () throws -> Void)] {
+    static var allTests : [(String, (TOMLTests) -> () throws -> Void)] {
         return [
             ("testLexer", testLexer),
             ("testParser", testParser),
@@ -119,7 +119,7 @@ extension TOMLTests {
 }
 
 extension ManifestTests {
-    static var allTests : [(String, ManifestTests -> () throws -> Void)] {
+    static var allTests : [(String, (ManifestTests) -> () throws -> Void)] {
         return [
             ("testManifestLoading", testManifestLoading),
         ]
@@ -127,7 +127,7 @@ extension ManifestTests {
 }
 
 extension PackageTests {
-    static var allTests : [(String, PackageTests -> () throws -> Void)] {
+    static var allTests : [(String, (PackageTests) -> () throws -> Void)] {
         return [
             ("testBasics", testBasics),
             ("testExclude", testExclude),

--- a/Tests/OptionsParser/OptionParserTests.swift
+++ b/Tests/OptionsParser/OptionParserTests.swift
@@ -118,11 +118,11 @@ enum Mode: String, Argument {
     init?(argument: String, pop: () -> String?) throws {
         switch argument {
         case "--A":
-            self = A
+            self = .A
         case "--B":
-            self = B
+            self = .B
         case "--C":
-            self = C
+            self = .C
         default:
             return nil
         }
@@ -135,15 +135,15 @@ enum Flag: Argument, Equatable {
     init?(argument: String, pop: () -> String?) throws {
         switch argument {
         case "--D":
-            self = D
+            self = .D
         case "--E":
-            self = E
+            self = .E
         case "--F":
             guard let str = pop() else { throw Error.ExpectedAssociatedValue("") }
-            self = F(str)
+            self = .F(str)
         case "--G":
             guard let str = pop(), int = Int(str) else { throw Error.ExpectedAssociatedValue("") }
-            self = G(int)
+            self = .G(int)
         case "-H":
             self = .H
         case "-I":

--- a/Tests/PackageDescription/PackageTests.swift
+++ b/Tests/PackageDescription/PackageTests.swift
@@ -30,7 +30,7 @@ class PackageTests: XCTestCase {
 }
 
 extension PackageTests {
-    static var allTests : [(String, PackageTests -> () throws -> Void)] {
+    static var allTests : [(String, (PackageTests) -> () throws -> Void)] {
         return [
             ("testMatchDependencyWithPreReleaseVersion", testMatchDependencyWithPreReleaseVersion),
         ]

--- a/Tests/PackageDescription/VersionTests.swift
+++ b/Tests/PackageDescription/VersionTests.swift
@@ -238,7 +238,7 @@ class VersionTests: XCTestCase {
 
 
 extension VersionTests {
-    static var allTests : [(String, VersionTests -> () throws -> Void)] {
+    static var allTests : [(String, (VersionTests) -> () throws -> Void)] {
         return [
             ("testEquality", testEquality),
             ("testNegativeValuesBecomeZero", testNegativeValuesBecomeZero),

--- a/Tests/PackageType/PackageNameTests.swift
+++ b/Tests/PackageType/PackageNameTests.swift
@@ -36,7 +36,7 @@ class PackageTests: XCTestCase {
 
 
 extension PackageTests {
-    static var allTests : [(String, PackageTests -> () throws -> Void)] {
+    static var allTests : [(String, (PackageTests) -> () throws -> Void)] {
         return [
             ("testUrlEndsInDotGit1", testUrlEndsInDotGit1),
             ("testUrlEndsInDotGit2", testUrlEndsInDotGit2),

--- a/Tests/Transmute/XCTestManifests.swift
+++ b/Tests/Transmute/XCTestManifests.swift
@@ -9,7 +9,7 @@
 */
 
 extension ModuleDependencyTests {
-    static var allTests : [(String, ModuleDependencyTests -> () throws -> Void)] {
+    static var allTests : [(String, (ModuleDependencyTests) -> () throws -> Void)] {
         return [
            ("test1", test1),
            ("test2", test2),
@@ -22,7 +22,7 @@ extension ModuleDependencyTests {
 }
 
 extension PrimitiveResolutionTests {
-    static var allTests : [(String, PrimitiveResolutionTests -> () throws -> Void)] {
+    static var allTests : [(String, (PrimitiveResolutionTests) -> () throws -> Void)] {
         return [
            ("testResolvesSingleSwiftModule", testResolvesSingleSwiftModule),
            ("testResolvesSystemModulePackage", testResolvesSystemModulePackage),
@@ -32,7 +32,7 @@ extension PrimitiveResolutionTests {
 }
 
 extension ValidSourcesTests {
-    static var allTests : [(String, ValidSourcesTests -> () throws -> Void)] {
+    static var allTests : [(String, (ValidSourcesTests) -> () throws -> Void)] {
         return [
             ("testDotFilesAreIgnored", testDotFilesAreIgnored),
         ]

--- a/Tests/Utility/GitTests.swift
+++ b/Tests/Utility/GitTests.swift
@@ -93,7 +93,7 @@ class GitUtilityTests: XCTestCase {
 }
 
 extension GitUtilityTests {
-    static var allTests : [(String, GitUtilityTests -> () throws -> Void)] {
+    static var allTests : [(String, (GitUtilityTests) -> () throws -> Void)] {
         return [
                    ("testGitVersion", testGitVersion),
                    ("testHeadSha", testHeadSha),

--- a/Tests/Utility/XCTestManifests.swift
+++ b/Tests/Utility/XCTestManifests.swift
@@ -9,7 +9,7 @@
  */
 
 extension ByteStringTests {
-    static var allTests : [(String, ByteStringTests -> () throws -> Void)] {
+    static var allTests : [(String, (ByteStringTests) -> () throws -> Void)] {
         return [
                    ("testInitializers", testInitializers),
                    ("testAccessors", testAccessors),
@@ -22,7 +22,7 @@ extension ByteStringTests {
 }
 
 extension CollectionTests {
-    static var allTests : [(String, CollectionTests -> () throws -> Void)] {
+    static var allTests : [(String, (CollectionTests) -> () throws -> Void)] {
         return [
                    ("testPick", testPick),
                    ("testPartitionByType", testPartitionByType),
@@ -33,7 +33,7 @@ extension CollectionTests {
 }
 
 extension FileTests {
-    static var allTests : [(String, FileTests -> () throws -> Void)] {
+    static var allTests : [(String, (FileTests) -> () throws -> Void)] {
         return [
                    ("testOpenFile", testOpenFile),
                    ("testOpenFileFail", testOpenFileFail),
@@ -45,7 +45,7 @@ extension FileTests {
 
 
 extension RmtreeTests {
-    static var allTests : [(String, RmtreeTests -> () throws -> Void)] {
+    static var allTests : [(String, (RmtreeTests) -> () throws -> Void)] {
         return [
                    ("testDoesNotFollowSymlinks", testDoesNotFollowSymlinks),
         ]
@@ -53,7 +53,7 @@ extension RmtreeTests {
 }
 
 extension OutputByteStreamTests {
-    static var allTests : [(String, OutputByteStreamTests -> () throws -> Void)] {
+    static var allTests : [(String, (OutputByteStreamTests) -> () throws -> Void)] {
         return [
                    ("testBasics", testBasics),
                    ("testStreamOperator", testStreamOperator),
@@ -64,7 +64,7 @@ extension OutputByteStreamTests {
 }
 
 extension PathTests {
-    static var allTests : [(String, PathTests -> () throws -> Void)] {
+    static var allTests : [(String, (PathTests) -> () throws -> Void)] {
         return [
                    ("test", test),
                    ("testPrecombined", testPrecombined),
@@ -78,7 +78,7 @@ extension PathTests {
 }
 
 extension WalkTests {
-    static var allTests : [(String, WalkTests -> () throws -> Void)] {
+    static var allTests : [(String, (WalkTests) -> () throws -> Void)] {
         return [
                    ("testNonRecursive", testNonRecursive),
                    ("testRecursive", testRecursive),
@@ -89,7 +89,7 @@ extension WalkTests {
 }
 
 extension StatTests {
-    static var allTests : [(String, StatTests -> () throws -> Void)] {
+    static var allTests : [(String, (StatTests) -> () throws -> Void)] {
         return [
                    ("test_isdir", test_isdir),
                    ("test_isfile", test_isfile),
@@ -100,7 +100,7 @@ extension StatTests {
 }
 
 extension RelativePathTests {
-    static var allTests : [(String, RelativePathTests -> () throws -> Void)] {
+    static var allTests : [(String, (RelativePathTests) -> () throws -> Void)] {
         return [
                    ("testAbsolute", testAbsolute),
                    ("testRelative", testRelative),
@@ -112,7 +112,7 @@ extension RelativePathTests {
 }
 
 extension ShellTests {
-    static var allTests : [(String, ShellTests -> () throws -> Void)] {
+    static var allTests : [(String, (ShellTests) -> () throws -> Void)] {
         return [
                    ("testPopen", testPopen),
                    ("testPopenWithBufferLargerThanThatAllocated", testPopenWithBufferLargerThanThatAllocated),
@@ -123,7 +123,7 @@ extension ShellTests {
 
 
 extension StringTests {
-    static var allTests : [(String, StringTests -> () throws -> Void)] {
+    static var allTests : [(String, (StringTests) -> () throws -> Void)] {
         return [
                    ("testTrailingChomp", testTrailingChomp),
                    ("testEmptyChomp", testEmptyChomp),
@@ -136,7 +136,7 @@ extension StringTests {
 }
 
 extension URLTests {
-    static var allTests : [(String, URLTests -> () throws -> Void)] {
+    static var allTests : [(String, (URLTests) -> () throws -> Void)] {
         return [
                    ("testSchema", testSchema),
         ]


### PR DESCRIPTION
[SE-0066](https://github.com/apple/swift-evolution/blob/master/proposals/0066-standardize-function-type-syntax.md) has already been implemented in swift and currently swift-pm tests are currently failing.

The pull request for [SE-0036](https://github.com/apple/swift-evolution/blob/master/proposals/0036-enum-dot.md) is pending, tests for it are failing without this update. 

Both changes are backwards-compatible and do not require any further implementation in swift.