### PR TITLE
Added --dump-package option to dump Package.swift as JSON

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,6 +51,10 @@ let package = Package(
             name: "Multitool",
             dependencies: ["PackageType", "OptionsParser"]),
         Target(
+            /** Serialization to JSON */
+            name: "Serialization",
+            dependencies: ["PackageDescription"]),
+        Target(
             /** Generates Xcode projects */
             name: "Xcodeproj",
             dependencies: ["PackageType"]),
@@ -61,7 +65,7 @@ let package = Package(
         Target(
             /** The main executable provided by SwiftPM */
             name: "swift-build",
-            dependencies: ["ManifestParser", "Get", "Transmute", "Build", "Multitool", "Xcodeproj"]),
+            dependencies: ["ManifestParser", "Get", "Transmute", "Build", "Multitool", "Xcodeproj", "Serialization"]),
         Target(
             /** Runs package tests */
             name: "swift-test",

--- a/Sources/PackageDescription/Package.swift
+++ b/Sources/PackageDescription/Package.swift
@@ -102,8 +102,8 @@ public enum SystemPackageProvider {
     case Apt(String)
 }
 
-extension SystemPackageProvider: TOMLConvertible {
-    var nameValue: (String, String) {
+extension SystemPackageProvider {
+    public var nameValue: (String, String) {
         switch self {
         case .Brew(let name):
             return ("Brew", name)
@@ -111,6 +111,11 @@ extension SystemPackageProvider: TOMLConvertible {
             return ("Apt", name)
         }
     }
+}
+
+// MARK: TOMLConvertible
+
+extension SystemPackageProvider: TOMLConvertible {
     
     public func toTOML() -> String {
         let (name, value) = nameValue
@@ -120,9 +125,6 @@ extension SystemPackageProvider: TOMLConvertible {
         return str
     }
 }
-
-
-// MARK: TOMLConvertible
 
 extension Package.Dependency: TOMLConvertible {
     public func toTOML() -> String {

--- a/Sources/Serialization/JSONSerialization.swift
+++ b/Sources/Serialization/JSONSerialization.swift
@@ -22,7 +22,7 @@ public func jsonString(package: PackageDescription.Package) throws -> String {
     
     let json: AnyObject = package.toJSON()
     let data = try NSJSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
-    guard let string = String(data: data, encoding: NSUTF8StringEncoding) else { fatalError() }
+    guard let string = String(data: data, encoding: NSUTF8StringEncoding) else { fatalError("NSJSONSerialization emitted invalid data") }
     return string
 }
 

--- a/Sources/Serialization/JSONSerialization.swift
+++ b/Sources/Serialization/JSONSerialization.swift
@@ -1,0 +1,101 @@
+/*
+ This source file is part of the Swift.org open source project
+ 
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+ 
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Foundation
+import PackageDescription
+
+/// A JSON representation of an element.
+public protocol JSONSerializable {
+    
+    /// Return a JSON representation.
+    func toJSON() -> AnyObject
+}
+
+public func jsonString(package: PackageDescription.Package) throws -> String {
+    
+    let json: AnyObject = package.toJSON()
+    let data = try NSJSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
+    guard let string = String(data: data, encoding: NSUTF8StringEncoding) else { fatalError() }
+    return string
+}
+
+extension NSMutableDictionary {
+    public static func withNew(block: @noescape (dict: NSMutableDictionary) -> ()) -> NSMutableDictionary {
+        let dict = NSMutableDictionary()
+        block(dict: dict)
+        return dict
+    }
+}
+
+extension SystemPackageProvider: JSONSerializable {
+    public func toJSON() -> AnyObject {
+        let (name, value) = nameValue
+        
+        return NSMutableDictionary.withNew { (dict) in
+            dict[name] = value
+        }
+    }
+}
+
+extension Package.Dependency: JSONSerializable {
+    public func toJSON() -> AnyObject {
+        
+        let version: NSDictionary = [
+            "lowerBound": versionRange.lowerBound.description,
+            "upperBound": versionRange.upperBound.description
+        ]
+        
+        return NSMutableDictionary.withNew { (dict) in
+            dict["url"] = url
+            dict["version"] = version
+        }
+    }
+}
+
+extension Package: JSONSerializable {
+    public func toJSON() -> AnyObject {
+        
+        return NSMutableDictionary.withNew { (dict) in
+            if let name = self.name {
+                dict["name"] = name
+            }
+            if let pkgConfig = self.pkgConfig {
+                dict["pkgConfig"] = pkgConfig
+            }
+            dict["dependencies"] = dependencies.map { $0.toJSON() }
+            dict["testDependencies"] = testDependencies.map { $0.toJSON() }
+            dict["exclude"] = exclude
+            dict["package.targets"] = targets.map { $0.toJSON() }
+            if let providers = self.providers {
+                dict["package.providers"] = providers.map { $0.toJSON() }
+            }
+        }
+    }
+}
+
+extension Target.Dependency: JSONSerializable {
+    public func toJSON() -> AnyObject {
+        switch self {
+        case .Target(let name):
+            return name
+        }
+    }
+}
+
+extension Target: JSONSerializable {
+    public func toJSON() -> AnyObject {
+        
+        let deps: NSArray = dependencies.map { $0.toJSON() }
+        return NSMutableDictionary.withNew { (dict) in
+            dict["name"] = name
+            dict["dependencies"] = deps
+        }
+    }
+}

--- a/Sources/Serialization/JSONSerialization.swift
+++ b/Sources/Serialization/JSONSerialization.swift
@@ -27,7 +27,7 @@ public func jsonString(package: PackageDescription.Package) throws -> String {
 }
 
 extension NSMutableDictionary {
-    public static func withNew(block: @noescape (dict: NSMutableDictionary) -> ()) -> NSMutableDictionary {
+    static func withNew(block: @noescape (dict: NSMutableDictionary) -> ()) -> NSMutableDictionary {
         let dict = NSMutableDictionary()
         block(dict: dict)
         return dict

--- a/Sources/swift-build/main.swift
+++ b/Sources/swift-build/main.swift
@@ -22,6 +22,7 @@ import Xcodeproj
 import Utility
 import Build
 import Get
+import Serialization
 
 /// Declare additional conformance for our Options type.
 extension Options: XcodeprojOptions {}
@@ -128,6 +129,13 @@ do {
         let outpath = try Xcodeproj.generate(dstdir: dstdir, projectName: projectName, srcroot: opts.path.root, modules: xcodeModules, externalModules: externalXcodeModules, products: products, options: opts)
 
         print("generated:", outpath.prettyPath)
+        
+    case .DumpPackage:
+        let root = opts.path.root
+        let manifest = try parseManifest(path: root, baseURL: root)
+        let package = manifest.package
+        let json = try jsonString(package: package)
+        print(json)
     }
 
 } catch {

--- a/Sources/swift-build/usage.swift
+++ b/Sources/swift-build/usage.swift
@@ -48,6 +48,7 @@ enum Mode: Argument, Equatable, CustomStringConvertible {
     case Usage
     case Version
     case GenerateXcodeproj(String?)
+    case DumpPackage
 
     init?(argument: String, pop: () -> String?) throws {
         switch argument {
@@ -71,6 +72,8 @@ enum Mode: Argument, Equatable, CustomStringConvertible {
             self = .Version
         case "--generate-xcodeproj", "-X":
             self = .GenerateXcodeproj(pop())
+        case "--dump-package":
+            self = .DumpPackage
         default:
             return nil
         }
@@ -88,6 +91,7 @@ enum Mode: Argument, Equatable, CustomStringConvertible {
             case .Init(let mode): return "--init=\(mode)"
             case .Usage: return "--help"
             case .Version: return "--version"
+            case .DumpPackage: return "--dump-package"
         }
     }
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -44,4 +44,5 @@ XCTMain([
     testCase(DescribeTests.allTests),
     testCase(GitUtilityTests.allTests),
     testCase(PackageVersionDataTests.allTests),
+    testCase(SerializationTests.allTests)
 ])

--- a/Tests/Serialization/SerializationTests.swift
+++ b/Tests/Serialization/SerializationTests.swift
@@ -1,0 +1,49 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+@testable import Serialization
+import PackageDescription
+import XCTest
+
+class SerializationTests: XCTestCase {
+    
+    func testSimple() {
+        let package = Package(name: "Simple")
+        let exp = NSMutableDictionary.withNew { (dict) in
+            dict["name"] = "Simple"
+            fillWithEmptyArrays(keyNames: ["dependencies", "testDependencies", "exclude", "package.targets"], dict: dict)
+        }
+        assertEqual(package: package, expected: exp)
+    }
+    
+    //FIXME: more tests to come
+}
+
+extension SerializationTests {
+    
+    func fillWithEmptyArrays(keyNames: [String], dict: NSMutableDictionary) {
+        keyNames.forEach {
+            dict[$0] = NSArray()
+        }
+    }
+    
+    func assertEqual(package: Package, expected: NSMutableDictionary) {
+        let json = package.toJSON() as! NSMutableDictionary
+        XCTAssertEqual(json, expected)
+    }
+}
+
+extension SerializationTests {
+    static var allTests : [(String, (SerializationTests) -> () throws -> Void)] {
+        return [
+            ("testSimple", testSimple),
+        ]
+    }
+}


### PR DESCRIPTION
- The dumped information was modeled after the toTOML() output. 
- More tests will be added, I first want to get initial feedback before I invest more time into them.
- A new module `Serialization` was created, because I couldn't add this code to any other place that'd make sense.

Dependency: https://github.com/apple/swift-package-manager/pull/328