### PR TITLE
[Xcodeproj] Remove serializeArray method, use joined(separator:) instead

### DIFF
--- a/Sources/Xcodeproj/Module+PBXProj.swift
+++ b/Sources/Xcodeproj/Module+PBXProj.swift
@@ -92,10 +92,6 @@ func fileRefs(forCompilePhaseSourcesInModule module: XcodeModuleProtocol, srcroo
     }
 }
 
-func serializeArray(_ array: [String]) -> String {
-    return "( " + array.map({ "\"\($0)\"" }).joined(separator: ", ") + " )"
-}
-
 extension XcodeModuleProtocol  {
 
     private var isLibrary: Bool {
@@ -164,7 +160,7 @@ extension XcodeModuleProtocol  {
             return (headerPathKey, first)
         }
 
-        let headerPathValue = serializeArray(headerPaths)
+        let headerPathValue = headerPaths.joined(separator: " ")
         
         return (headerPathKey, headerPathValue)
     }


### PR DESCRIPTION
Fixes https://bugs.swift.org/browse/SR-1441
