### PR TITLE
[Xcodeproj] Bugfix: Pkgconfig flags need to inherit + add more, not overwrite

### DIFF
--- a/Sources/Xcodeproj/Module+PBXProj.swift
+++ b/Sources/Xcodeproj/Module+PBXProj.swift
@@ -243,8 +243,8 @@ extension XcodeModuleProtocol  {
         }
 
         if let pkgArgs = try? self.pkgConfigArgs() {
-            buildSettings["OTHER_LDFLAGS"] = pkgArgs.libs.joined(separator: " ")
-            buildSettings["OTHER_SWIFT_FLAGS"] = pkgArgs.cFlags.joined(separator: " ")
+            buildSettings["OTHER_LDFLAGS"] = (["$(inherited)"] + pkgArgs.libs).joined(separator: " ")
+            buildSettings["OTHER_SWIFT_FLAGS"] = (["$(inherited)"] + pkgArgs.cFlags).joined(separator: " ")
         }
 
         return buildSettings


### PR DESCRIPTION
Fixed the bug where flags e.g. `-DXcode`, defined in the project, were getting overwritten at the target level, which caused SwiftPM to use the wrong compile-time-path (thought it was running out of Xcode).

Now flags defined higher in the hierarchy are inherited and pkgconfig flags are just added.

/cc @aciidb0mb3r 