### PR TITLE
[Xcodeproj] Bugfix: Use proper Product Name

### DIFF
--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -95,7 +95,7 @@ public func pbxproj(srcroot: String, projectRoot: String, xcodeprojPath: String,
         print("            buildRules = ();")
         print("            dependencies = (\(module.nativeTargetDependencies));")
         print("            name = \(module.name);")
-        print("            productName = \(module.c99name);")
+        print("            productName = \(module.productName);")
         print("            productReference = \(module.productReference);")
         print("            productType = '\(module.productType)';")
         print("        };")


### PR DESCRIPTION
Using product name in Xcodeproj so that libraries have the lib* prefix, as they should so that the linker can find them. Fixes the issue with failing linker in generated Xcode projects that have C libs as dependencies.