### PR TITLE
Added --dump-package option to dump Package.swift as JSON

### DIFF
--- a/Sources/ManifestSerializer/JSONSerialization.swift
+++ b/Sources/ManifestSerializer/JSONSerialization.swift
@@ -1,0 +1,101 @@
+/*
+ This source file is part of the Swift.org open source project
+ 
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+ 
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Foundation
+import PackageDescription
+
+/// A JSON representation of an element.
+public protocol JSONSerializable {
+    
+    /// Return a JSON representation.
+    func toJSON() -> AnyObject
+}
+
+public func jsonString(package: PackageDescription.Package) throws -> String {
+    
+    let json: AnyObject = package.toJSON()
+    let data = try NSJSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
+    guard let string = String(data: data, encoding: NSUTF8StringEncoding) else { fatalError("NSJSONSerialization emitted invalid data") }
+    return string
+}
+
+extension NSMutableDictionary {
+    static func withNew(block: @noescape (dict: NSMutableDictionary) -> ()) -> NSMutableDictionary {
+        let dict = NSMutableDictionary()
+        block(dict: dict)
+        return dict
+    }
+}
+
+extension SystemPackageProvider: JSONSerializable {
+    public func toJSON() -> AnyObject {
+        let (name, value) = nameValue
+        
+        return NSMutableDictionary.withNew { (dict) in
+            dict[name] = value
+        }
+    }
+}
+
+extension Package.Dependency: JSONSerializable {
+    public func toJSON() -> AnyObject {
+        
+        let version: NSDictionary = [
+            "lowerBound": versionRange.lowerBound.description,
+            "upperBound": versionRange.upperBound.description
+        ]
+        
+        return NSMutableDictionary.withNew { (dict) in
+            dict["url"] = url
+            dict["version"] = version
+        }
+    }
+}
+
+extension Package: JSONSerializable {
+    public func toJSON() -> AnyObject {
+        
+        return NSMutableDictionary.withNew { (dict) in
+            if let name = self.name {
+                dict["name"] = name
+            }
+            if let pkgConfig = self.pkgConfig {
+                dict["pkgConfig"] = pkgConfig
+            }
+            dict["dependencies"] = dependencies.map { $0.toJSON() }
+            dict["testDependencies"] = testDependencies.map { $0.toJSON() }
+            dict["exclude"] = exclude
+            dict["package.targets"] = targets.map { $0.toJSON() }
+            if let providers = self.providers {
+                dict["package.providers"] = providers.map { $0.toJSON() }
+            }
+        }
+    }
+}
+
+extension Target.Dependency: JSONSerializable {
+    public func toJSON() -> AnyObject {
+        switch self {
+        case .Target(let name):
+            return name
+        }
+    }
+}
+
+extension Target: JSONSerializable {
+    public func toJSON() -> AnyObject {
+        
+        let deps: NSArray = dependencies.map { $0.toJSON() }
+        return NSMutableDictionary.withNew { (dict) in
+            dict["name"] = name
+            dict["dependencies"] = deps
+        }
+    }
+}

--- a/Sources/ManifestSerializer/JSONSerialization.swift
+++ b/Sources/ManifestSerializer/JSONSerialization.swift
@@ -38,6 +38,10 @@ extension NSMutableDictionary {
         block(dict: dict)
         return dict
     }
+    
+    func set(object: AnyObject, forKey key: String) {
+        self[key.asNS()] = object
+    }
 }
 
 extension String {
@@ -55,7 +59,7 @@ extension SystemPackageProvider: JSONSerializable {
         let (name, value) = nameValue
         
         return NSMutableDictionary.withNew { (dict) in
-            dict[name.asNS()] = value.asNS()
+            dict.set(object: value.asNS(), forKey: name)
         }
     }
 }
@@ -69,8 +73,8 @@ extension Package.Dependency: JSONSerializable {
         ]
         
         return NSMutableDictionary.withNew { (dict) in
-            dict["url"] = url.asNS()
-            dict["version"] = version
+            dict.set(object: url.asNS(), forKey: "url")
+            dict.set(object: version, forKey: "version")
         }
     }
 }
@@ -80,17 +84,17 @@ extension Package: JSONSerializable {
         
         return NSMutableDictionary.withNew { (dict) in
             if let name = self.name {
-                dict["name"] = name.asNS()
+                dict.set(object: name.asNS(), forKey: "name")
             }
             if let pkgConfig = self.pkgConfig {
-                dict["pkgConfig"] = pkgConfig.asNS()
+                dict.set(object: pkgConfig.asNS(), forKey: "pkgConfig")
             }
-            dict["dependencies"] = dependencies.map { $0.toJSON() } as NSArray
-            dict["testDependencies"] = testDependencies.map { $0.toJSON() } as NSArray
-            dict["exclude"] = exclude as NSArray
-            dict["package.targets"] = targets.map { $0.toJSON() } as NSArray
+            dict.set(object: dependencies.map { $0.toJSON() } as NSArray, forKey: "dependencies")
+            dict.set(object: testDependencies.map { $0.toJSON() } as NSArray, forKey: "testDependencies")
+            dict.set(object: exclude as NSArray, forKey: "exclude")
+            dict.set(object: targets.map { $0.toJSON() } as NSArray, forKey: "package.targets")
             if let providers = self.providers {
-                dict["package.providers"] = providers.map { $0.toJSON() } as NSArray
+                dict.set(object: providers.map { $0.toJSON() } as NSArray, forKey: "package.providers")
             }
         }
     }
@@ -110,8 +114,8 @@ extension Target: JSONSerializable {
         
         let deps = dependencies.map { $0.toJSON() } as NSArray
         return NSMutableDictionary.withNew { (dict) in
-            dict["name"] = name.asNS()
-            dict["dependencies"] = deps
+            dict.set(object: name.asNS(), forKey: "name")
+            dict.set(object: deps, forKey: "dependencies")
         }
     }
 }

--- a/Sources/ManifestSerializer/JSONSerialization.swift
+++ b/Sources/ManifestSerializer/JSONSerialization.swift
@@ -20,8 +20,14 @@ public protocol JSONSerializable {
 
 public func jsonString(package: PackageDescription.Package) throws -> String {
     
+    #if os(Linux)
+        let options: NSJSONWritingOptions = .PrettyPrinted
+    #else
+        let options: NSJSONWritingOptions = .prettyPrinted
+    #endif
+    
     let json: AnyObject = package.toJSON()
-    let data = try NSJSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
+    let data = try NSJSONSerialization.data(withJSONObject: json, options: options)
     guard let string = String(data: data, encoding: NSUTF8StringEncoding) else { fatalError("NSJSONSerialization emitted invalid data") }
     return string
 }
@@ -39,7 +45,7 @@ extension SystemPackageProvider: JSONSerializable {
         let (name, value) = nameValue
         
         return NSMutableDictionary.withNew { (dict) in
-            dict[name] = value
+            dict[name as NSString] = value as NSString
         }
     }
 }
@@ -48,12 +54,12 @@ extension Package.Dependency: JSONSerializable {
     public func toJSON() -> AnyObject {
         
         let version: NSDictionary = [
-            "lowerBound": versionRange.lowerBound.description,
-            "upperBound": versionRange.upperBound.description
+            "lowerBound": versionRange.lowerBound.description as NSString,
+            "upperBound": versionRange.upperBound.description as NSString
         ]
         
         return NSMutableDictionary.withNew { (dict) in
-            dict["url"] = url
+            dict["url"] = url as NSString
             dict["version"] = version
         }
     }
@@ -64,17 +70,17 @@ extension Package: JSONSerializable {
         
         return NSMutableDictionary.withNew { (dict) in
             if let name = self.name {
-                dict["name"] = name
+                dict["name"] = name as NSString
             }
             if let pkgConfig = self.pkgConfig {
-                dict["pkgConfig"] = pkgConfig
+                dict["pkgConfig"] = pkgConfig as NSString
             }
-            dict["dependencies"] = dependencies.map { $0.toJSON() }
-            dict["testDependencies"] = testDependencies.map { $0.toJSON() }
-            dict["exclude"] = exclude
-            dict["package.targets"] = targets.map { $0.toJSON() }
+            dict["dependencies"] = dependencies.map { $0.toJSON() } as NSArray
+            dict["testDependencies"] = testDependencies.map { $0.toJSON() } as NSArray
+            dict["exclude"] = exclude as NSArray
+            dict["package.targets"] = targets.map { $0.toJSON() } as NSArray
             if let providers = self.providers {
-                dict["package.providers"] = providers.map { $0.toJSON() }
+                dict["package.providers"] = providers.map { $0.toJSON() } as NSArray
             }
         }
     }
@@ -84,7 +90,7 @@ extension Target.Dependency: JSONSerializable {
     public func toJSON() -> AnyObject {
         switch self {
         case .Target(let name):
-            return name
+            return name as NSString
         }
     }
 }
@@ -92,9 +98,9 @@ extension Target.Dependency: JSONSerializable {
 extension Target: JSONSerializable {
     public func toJSON() -> AnyObject {
         
-        let deps: NSArray = dependencies.map { $0.toJSON() }
+        let deps = dependencies.map { $0.toJSON() } as NSArray
         return NSMutableDictionary.withNew { (dict) in
-            dict["name"] = name
+            dict["name"] = name as NSString
             dict["dependencies"] = deps
         }
     }

--- a/Sources/ManifestSerializer/JSONSerialization.swift
+++ b/Sources/ManifestSerializer/JSONSerialization.swift
@@ -40,12 +40,22 @@ extension NSMutableDictionary {
     }
 }
 
+extension String {
+    public func asNS() -> NSString {
+        #if os(Linux)
+            return self.bridge()
+        #else
+            return self as NSString
+        #endif
+    }
+}
+
 extension SystemPackageProvider: JSONSerializable {
     public func toJSON() -> AnyObject {
         let (name, value) = nameValue
         
         return NSMutableDictionary.withNew { (dict) in
-            dict[name as NSString] = value as NSString
+            dict[name.asNS()] = value.asNS()
         }
     }
 }
@@ -54,12 +64,12 @@ extension Package.Dependency: JSONSerializable {
     public func toJSON() -> AnyObject {
         
         let version: NSDictionary = [
-            "lowerBound": versionRange.lowerBound.description as NSString,
-            "upperBound": versionRange.upperBound.description as NSString
+            "lowerBound": versionRange.lowerBound.description.asNS(),
+            "upperBound": versionRange.upperBound.description.asNS()
         ]
         
         return NSMutableDictionary.withNew { (dict) in
-            dict["url"] = url as NSString
+            dict["url"] = url.asNS()
             dict["version"] = version
         }
     }
@@ -70,10 +80,10 @@ extension Package: JSONSerializable {
         
         return NSMutableDictionary.withNew { (dict) in
             if let name = self.name {
-                dict["name"] = name as NSString
+                dict["name"] = name.asNS()
             }
             if let pkgConfig = self.pkgConfig {
-                dict["pkgConfig"] = pkgConfig as NSString
+                dict["pkgConfig"] = pkgConfig.asNS()
             }
             dict["dependencies"] = dependencies.map { $0.toJSON() } as NSArray
             dict["testDependencies"] = testDependencies.map { $0.toJSON() } as NSArray
@@ -90,7 +100,7 @@ extension Target.Dependency: JSONSerializable {
     public func toJSON() -> AnyObject {
         switch self {
         case .Target(let name):
-            return name as NSString
+            return name.asNS()
         }
     }
 }
@@ -100,7 +110,7 @@ extension Target: JSONSerializable {
         
         let deps = dependencies.map { $0.toJSON() } as NSArray
         return NSMutableDictionary.withNew { (dict) in
-            dict["name"] = name as NSString
+            dict["name"] = name.asNS()
             dict["dependencies"] = deps
         }
     }

--- a/Sources/PackageDescription/Package.swift
+++ b/Sources/PackageDescription/Package.swift
@@ -102,8 +102,8 @@ public enum SystemPackageProvider {
     case Apt(String)
 }
 
-extension SystemPackageProvider: TOMLConvertible {
-    var nameValue: (String, String) {
+extension SystemPackageProvider {
+    public var nameValue: (String, String) {
         switch self {
         case .Brew(let name):
             return ("Brew", name)
@@ -111,6 +111,11 @@ extension SystemPackageProvider: TOMLConvertible {
             return ("Apt", name)
         }
     }
+}
+
+// MARK: TOMLConvertible
+
+extension SystemPackageProvider: TOMLConvertible {
     
     public func toTOML() -> String {
         let (name, value) = nameValue
@@ -120,9 +125,6 @@ extension SystemPackageProvider: TOMLConvertible {
         return str
     }
 }
-
-
-// MARK: TOMLConvertible
 
 extension Package.Dependency: TOMLConvertible {
     public func toTOML() -> String {

--- a/Sources/swift-build/main.swift
+++ b/Sources/swift-build/main.swift
@@ -128,6 +128,14 @@ do {
         let outpath = try Xcodeproj.generate(dstdir: dstdir, projectName: projectName, srcroot: opts.path.root, modules: xcodeModules, externalModules: externalXcodeModules, products: products, options: opts)
 
         print("generated:", outpath.prettyPath)
+        
+    case .DumpPackage(let packagePath):
+        
+        let root = packagePath ?? opts.path.root
+        let manifest = try parseManifest(path: root, baseURL: root)
+        let package = manifest.package
+        let json = try jsonString(package: package)
+        print(json)
     }
 
 } catch {

--- a/Sources/swift-build/usage.swift
+++ b/Sources/swift-build/usage.swift
@@ -27,6 +27,7 @@ func usage(_ print: (String) -> Void = { print($0) }) {
     print("  --update                       Update package dependencies")
     print("  --generate-xcodeproj[=<path>]  Generates an Xcode project [-X]")
     print("  --show-dependencies[=<mode>]   Print dependency graph (text|dot|json)")
+    print("  --dump-package[=<path>]        Print Package.swift as JSON")
     print("")
     print("OPTIONS:")
     print("  --chdir <path>       Change working directory before any other operation [-C]")
@@ -48,6 +49,7 @@ enum Mode: Argument, Equatable, CustomStringConvertible {
     case Usage
     case Version
     case GenerateXcodeproj(String?)
+    case DumpPackage(String?)
 
     init?(argument: String, pop: () -> String?) throws {
         switch argument {
@@ -71,6 +73,8 @@ enum Mode: Argument, Equatable, CustomStringConvertible {
             self = .Version
         case "--generate-xcodeproj", "-X":
             self = .GenerateXcodeproj(pop())
+        case "--dump-package":
+            self = .DumpPackage(pop())
         default:
             return nil
         }
@@ -88,6 +92,7 @@ enum Mode: Argument, Equatable, CustomStringConvertible {
             case .Init(let mode): return "--init=\(mode)"
             case .Usage: return "--help"
             case .Version: return "--version"
+            case .DumpPackage: return "--dump-package"
         }
     }
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -24,6 +24,7 @@ XCTMain([
     testCase(ManifestTests.allTests),
     testCase(MiscellaneousTestCase.allTests),
     testCase(ManifestSerializerTestSuite.PackageTests.allTests),
+    testCase(ManifestSerializerTestSuite.JSONSerializationTests.allTests),
     testCase(ModuleDependencyTests.allTests),
     testCase(ValidSourcesTests.allTests),
     testCase(PrimitiveResolutionTests.allTests),

--- a/Tests/ManifestSerializer/JSONSerializationTests.swift
+++ b/Tests/ManifestSerializer/JSONSerializationTests.swift
@@ -38,15 +38,15 @@ class JSONSerializationTests: XCTestCase {
                                           "lowerBound":"3.0.0",
                                           "upperBound":"3.9223372036854775807.9223372036854775807"
                 ]
-            ]
+            ] as NSDictionary
             let dep2 = [
                            "url": "https://github.com/apple/llvm.git",
                            "version": [
                                           "lowerBound":"2.0.0",
                                           "upperBound":"2.9223372036854775807.9223372036854775807"
                 ]
-            ]
-            dict["dependencies"] = [dep1, dep2]
+            ] as NSDictionary
+            dict["dependencies"] = [dep1, dep2] as NSArray
             fillWithEmptyArrays(keyNames: ["testDependencies", "exclude", "package.targets"], dict: dict)
         }
         assertEqual(package: package, expected: exp)
@@ -86,9 +86,9 @@ class JSONSerializationTests: XCTestCase {
         let package = Package(name: "Targets", targets: [t1, t2])
         let exp = NSMutableDictionary.withNew { (dict) in
             dict["name"] = "Targets"
-            let ts1 = ["name": "One", "dependencies": [String]()]
-            let ts2 = ["name": "Two", "dependencies": ["One"]]
-            dict["package.targets"] = [ts1, ts2]
+            let ts1 = ["name": "One", "dependencies": NSArray()] as NSDictionary
+            let ts2 = ["name": "Two", "dependencies": ["One"] as NSArray] as NSDictionary
+            dict["package.targets"] = [ts1, ts2] as NSArray
             fillWithEmptyArrays(keyNames: ["dependencies", "testDependencies", "exclude", ], dict: dict)
         }
         assertEqual(package: package, expected: exp)
@@ -99,7 +99,7 @@ extension JSONSerializationTests {
     
     func fillWithEmptyArrays(keyNames: [String], dict: NSMutableDictionary) {
         keyNames.forEach {
-            dict[$0] = NSArray()
+            dict[$0 as NSString] = NSArray()
         }
     }
     

--- a/Tests/ManifestSerializer/JSONSerializationTests.swift
+++ b/Tests/ManifestSerializer/JSONSerializationTests.swift
@@ -1,0 +1,49 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+@testable import ManifestSerializer
+import PackageDescription
+import XCTest
+
+class JSONSerializationTests: XCTestCase {
+    
+    func testSimple() {
+        let package = Package(name: "Simple")
+        let exp = NSMutableDictionary.withNew { (dict) in
+            dict["name"] = "Simple"
+            fillWithEmptyArrays(keyNames: ["dependencies", "testDependencies", "exclude", "package.targets"], dict: dict)
+        }
+        assertEqual(package: package, expected: exp)
+    }
+    
+    //FIXME: more tests to come
+}
+
+extension JSONSerializationTests {
+    
+    func fillWithEmptyArrays(keyNames: [String], dict: NSMutableDictionary) {
+        keyNames.forEach {
+            dict[$0] = NSArray()
+        }
+    }
+    
+    func assertEqual(package: Package, expected: NSMutableDictionary) {
+        let json = package.toJSON() as! NSMutableDictionary
+        XCTAssertEqual(json, expected)
+    }
+}
+
+extension JSONSerializationTests {
+    static var allTests : [(String, (JSONSerializationTests) -> () throws -> Void)] {
+        return [
+            ("testSimple", testSimple),
+        ]
+    }
+}

--- a/Tests/ManifestSerializer/JSONSerializationTests.swift
+++ b/Tests/ManifestSerializer/JSONSerializationTests.swift
@@ -11,13 +11,14 @@
 @testable import ManifestSerializer
 import PackageDescription
 import XCTest
+import Foundation
 
 class JSONSerializationTests: XCTestCase {
     
     func testSimple() {
         let package = Package(name: "Simple")
         let exp = NSMutableDictionary.withNew { (dict) in
-            dict["name"] = "Simple"
+            dict.set(object: "Simple".asNS(), forKey: "name")
             dict.fillWithEmptyArrays(keyNames: ["dependencies", "testDependencies", "exclude", "package.targets"])
         }
         assertEqual(package: package, expected: exp)
@@ -31,22 +32,24 @@ class JSONSerializationTests: XCTestCase {
         ]
         let package = Package(name: "WithDeps", pkgConfig: nil, providers: nil, targets: [], dependencies: deps, testDependencies: [], exclude: [])
         let exp = NSMutableDictionary.withNew { (dict) in
-            dict["name"] = "WithDeps"
-            let dep1 = [
-                           "url": "https://github.com/apple/swift.git",
-                           "version": [
-                                          "lowerBound":"3.0.0",
-                                          "upperBound":"3.9223372036854775807.9223372036854775807"
-                ]
-            ] as NSDictionary
-            let dep2 = [
-                           "url": "https://github.com/apple/llvm.git",
-                           "version": [
-                                          "lowerBound":"2.0.0",
-                                          "upperBound":"2.9223372036854775807.9223372036854775807"
-                ]
-            ] as NSDictionary
-            dict["dependencies"] = [dep1, dep2] as NSArray
+            dict.set(object: "WithDeps".asNS(), forKey: "name")
+            let dep1version: NSDictionary = [
+                "lowerBound".asNS():"3.0.0".asNS(),
+                "upperBound".asNS():"3.9223372036854775807.9223372036854775807".asNS()
+            ]
+            let dep1: NSDictionary = [
+                "url".asNS(): "https://github.com/apple/swift.git".asNS(),
+                "version".asNS(): dep1version
+            ]
+            let dep2version: NSDictionary = [
+                "lowerBound".asNS():"2.0.0".asNS(),
+                "upperBound".asNS():"2.9223372036854775807.9223372036854775807".asNS()
+            ]
+            let dep2: NSDictionary = [
+                "url".asNS(): "https://github.com/apple/llvm.git".asNS(),
+                "version".asNS(): dep2version
+            ]
+            dict["dependencies".asNS()] = [dep1, dep2].asNS()
             dict.fillWithEmptyArrays(keyNames: ["testDependencies", "exclude", "package.targets"])
         }
         assertEqual(package: package, expected: exp)
@@ -59,12 +62,13 @@ class JSONSerializationTests: XCTestCase {
                             ]
         let package = Package(name: "PkgPackage", pkgConfig: "PkgPackage-1.0", providers: providers)
         let exp = NSMutableDictionary.withNew { (dict) in
-            dict["name"] = "PkgPackage"
-            dict["pkgConfig"] = "PkgPackage-1.0"
-            dict["package.providers"] = [
-                ["Brew": "BrewPackage"],
-                ["Apt": "AptPackage"]
+            dict.set(object: "PkgPackage".asNS(), forKey: "name")
+            dict.set(object: "PkgPackage-1.0".asNS(), forKey: "pkgConfig")
+            let providers: [AnyObject] = [
+                ["Brew".asNS() : "BrewPackage".asNS()] as NSDictionary,
+                ["Apt".asNS() : "AptPackage".asNS()] as NSDictionary
             ]
+            dict.set(object: providers.asNS(), forKey: "package.providers") 
             dict.fillWithEmptyArrays(keyNames: ["dependencies", "testDependencies", "exclude", "package.targets"])
         }
         assertEqual(package: package, expected: exp)
@@ -73,8 +77,8 @@ class JSONSerializationTests: XCTestCase {
     func testExclude() {
         let package = Package(name: "Exclude", exclude: ["pikachu", "bulbasaur"])
         let exp = NSMutableDictionary.withNew { (dict) in
-            dict["name"] = "Exclude"
-            dict["exclude"] = ["pikachu", "bulbasaur"]
+            dict.set(object: "Exclude".asNS(), forKey: "name")
+            dict.set(object: ["pikachu".asNS(), "bulbasaur".asNS()].asNS(), forKey: "exclude") 
             dict.fillWithEmptyArrays(keyNames: ["dependencies", "testDependencies", "package.targets"])
         }
         assertEqual(package: package, expected: exp)
@@ -85,10 +89,10 @@ class JSONSerializationTests: XCTestCase {
         let t2 = Target(name: "Two", dependencies: [.Target(name: "One")])
         let package = Package(name: "Targets", targets: [t1, t2])
         let exp = NSMutableDictionary.withNew { (dict) in
-            dict["name"] = "Targets"
-            let ts1 = ["name": "One", "dependencies": NSArray()] as NSDictionary
-            let ts2 = ["name": "Two", "dependencies": ["One"] as NSArray] as NSDictionary
-            dict["package.targets"] = [ts1, ts2] as NSArray
+            dict.set(object: "Targets".asNS(), forKey: "name")
+            let ts1 = ["name".asNS(): "One".asNS(), "dependencies": NSArray()] as NSDictionary
+            let ts2 = ["name".asNS(): "Two".asNS(), "dependencies": ["One"].asNS()] as NSDictionary
+            dict.set(object: [ts1, ts2].asNS(), forKey: "package.targets")
             dict.fillWithEmptyArrays(keyNames: ["dependencies", "testDependencies", "exclude", ])
         }
         assertEqual(package: package, expected: exp)
@@ -99,7 +103,7 @@ extension NSMutableDictionary {
     
     func fillWithEmptyArrays(keyNames: [String]) {
         keyNames.forEach {
-            self[$0 as NSString] = NSArray()
+            self[$0.asNS()] = NSArray()
         }
     }
 }

--- a/Tests/ManifestSerializer/JSONSerializationTests.swift
+++ b/Tests/ManifestSerializer/JSONSerializationTests.swift
@@ -23,7 +23,76 @@ class JSONSerializationTests: XCTestCase {
         assertEqual(package: package, expected: exp)
     }
     
-    //FIXME: more tests to come
+    func testDependencies() {
+        let deps: [Package.Dependency] =
+            [
+                .Package(url: "https://github.com/apple/swift.git", majorVersion: 3),
+                .Package(url: "https://github.com/apple/llvm.git", majorVersion: 2)
+        ]
+        let package = Package(name: "WithDeps", pkgConfig: nil, providers: nil, targets: [], dependencies: deps, testDependencies: [], exclude: [])
+        let exp = NSMutableDictionary.withNew { (dict) in
+            dict["name"] = "WithDeps"
+            let dep1 = [
+                           "url": "https://github.com/apple/swift.git",
+                           "version": [
+                                          "lowerBound":"3.0.0",
+                                          "upperBound":"3.9223372036854775807.9223372036854775807"
+                ]
+            ]
+            let dep2 = [
+                           "url": "https://github.com/apple/llvm.git",
+                           "version": [
+                                          "lowerBound":"2.0.0",
+                                          "upperBound":"2.9223372036854775807.9223372036854775807"
+                ]
+            ]
+            dict["dependencies"] = [dep1, dep2]
+            fillWithEmptyArrays(keyNames: ["testDependencies", "exclude", "package.targets"], dict: dict)
+        }
+        assertEqual(package: package, expected: exp)
+    }
+    
+    func testPkgConfig() {
+        let providers: [SystemPackageProvider] = [
+                            .Brew("BrewPackage"),
+                            .Apt("AptPackage")
+                            ]
+        let package = Package(name: "PkgPackage", pkgConfig: "PkgPackage-1.0", providers: providers)
+        let exp = NSMutableDictionary.withNew { (dict) in
+            dict["name"] = "PkgPackage"
+            dict["pkgConfig"] = "PkgPackage-1.0"
+            dict["package.providers"] = [
+                ["Brew": "BrewPackage"],
+                ["Apt": "AptPackage"]
+            ]
+            fillWithEmptyArrays(keyNames: ["dependencies", "testDependencies", "exclude", "package.targets"], dict: dict)
+        }
+        assertEqual(package: package, expected: exp)
+    }
+    
+    func testExclude() {
+        let package = Package(name: "Exclude", exclude: ["pikachu", "bulbasaur"])
+        let exp = NSMutableDictionary.withNew { (dict) in
+            dict["name"] = "Exclude"
+            dict["exclude"] = ["pikachu", "bulbasaur"]
+            fillWithEmptyArrays(keyNames: ["dependencies", "testDependencies", "package.targets"], dict: dict)
+        }
+        assertEqual(package: package, expected: exp)
+    }
+    
+    func testTargets() {
+        let t1 = Target(name: "One")
+        let t2 = Target(name: "Two", dependencies: [.Target(name: "One")])
+        let package = Package(name: "Targets", targets: [t1, t2])
+        let exp = NSMutableDictionary.withNew { (dict) in
+            dict["name"] = "Targets"
+            let ts1 = ["name": "One", "dependencies": [String]()]
+            let ts2 = ["name": "Two", "dependencies": ["One"]]
+            dict["package.targets"] = [ts1, ts2]
+            fillWithEmptyArrays(keyNames: ["dependencies", "testDependencies", "exclude", ], dict: dict)
+        }
+        assertEqual(package: package, expected: exp)
+    }
 }
 
 extension JSONSerializationTests {
@@ -44,6 +113,10 @@ extension JSONSerializationTests {
     static var allTests : [(String, (JSONSerializationTests) -> () throws -> Void)] {
         return [
             ("testSimple", testSimple),
+            ("testDependencies", testDependencies),
+            ("testPkgConfig", testPkgConfig),
+            ("testExclude", testExclude),
+            ("testTargets", testTargets),
         ]
     }
 }

--- a/Tests/ManifestSerializer/JSONSerializationTests.swift
+++ b/Tests/ManifestSerializer/JSONSerializationTests.swift
@@ -18,7 +18,7 @@ class JSONSerializationTests: XCTestCase {
         let package = Package(name: "Simple")
         let exp = NSMutableDictionary.withNew { (dict) in
             dict["name"] = "Simple"
-            fillWithEmptyArrays(keyNames: ["dependencies", "testDependencies", "exclude", "package.targets"], dict: dict)
+            dict.fillWithEmptyArrays(keyNames: ["dependencies", "testDependencies", "exclude", "package.targets"])
         }
         assertEqual(package: package, expected: exp)
     }
@@ -47,7 +47,7 @@ class JSONSerializationTests: XCTestCase {
                 ]
             ] as NSDictionary
             dict["dependencies"] = [dep1, dep2] as NSArray
-            fillWithEmptyArrays(keyNames: ["testDependencies", "exclude", "package.targets"], dict: dict)
+            dict.fillWithEmptyArrays(keyNames: ["testDependencies", "exclude", "package.targets"])
         }
         assertEqual(package: package, expected: exp)
     }
@@ -65,7 +65,7 @@ class JSONSerializationTests: XCTestCase {
                 ["Brew": "BrewPackage"],
                 ["Apt": "AptPackage"]
             ]
-            fillWithEmptyArrays(keyNames: ["dependencies", "testDependencies", "exclude", "package.targets"], dict: dict)
+            dict.fillWithEmptyArrays(keyNames: ["dependencies", "testDependencies", "exclude", "package.targets"])
         }
         assertEqual(package: package, expected: exp)
     }
@@ -75,7 +75,7 @@ class JSONSerializationTests: XCTestCase {
         let exp = NSMutableDictionary.withNew { (dict) in
             dict["name"] = "Exclude"
             dict["exclude"] = ["pikachu", "bulbasaur"]
-            fillWithEmptyArrays(keyNames: ["dependencies", "testDependencies", "package.targets"], dict: dict)
+            dict.fillWithEmptyArrays(keyNames: ["dependencies", "testDependencies", "package.targets"])
         }
         assertEqual(package: package, expected: exp)
     }
@@ -89,19 +89,22 @@ class JSONSerializationTests: XCTestCase {
             let ts1 = ["name": "One", "dependencies": NSArray()] as NSDictionary
             let ts2 = ["name": "Two", "dependencies": ["One"] as NSArray] as NSDictionary
             dict["package.targets"] = [ts1, ts2] as NSArray
-            fillWithEmptyArrays(keyNames: ["dependencies", "testDependencies", "exclude", ], dict: dict)
+            dict.fillWithEmptyArrays(keyNames: ["dependencies", "testDependencies", "exclude", ])
         }
         assertEqual(package: package, expected: exp)
     }
 }
 
-extension JSONSerializationTests {
+extension NSMutableDictionary {
     
-    func fillWithEmptyArrays(keyNames: [String], dict: NSMutableDictionary) {
+    func fillWithEmptyArrays(keyNames: [String]) {
         keyNames.forEach {
-            dict[$0 as NSString] = NSArray()
+            self[$0 as NSString] = NSArray()
         }
     }
+}
+
+extension JSONSerializationTests {
     
     func assertEqual(package: Package, expected: NSMutableDictionary) {
         let json = package.toJSON() as! NSMutableDictionary


### PR DESCRIPTION
- The dumped information was modeled after the toTOML() output. 
- More tests will be added, I first want to get initial feedback before I invest more time into them.

TODO:
- [x] fix on Linux now that implicit bridging is gone 
- [x] make edits suggested in comments