### PR TITLE
Add search paths from pkg-config

### DIFF
--- a/Sources/Utility/CollectionExtensions.swift
+++ b/Sources/Utility/CollectionExtensions.swift
@@ -69,3 +69,21 @@ extension Collection where Iterator.Element : Equatable {
         return (orig, nil)
     }
 }
+
+extension Collection where Iterator.Element: Hashable {
+
+    /// Returns Unique elements from this collection maintaining its Order.
+    public func unique() -> [Iterator.Element]{
+        var registry = Set<Iterator.Element>()
+        var elements = Array<Iterator.Element>()
+
+        for item in self {
+            guard !registry.contains(item) else { continue }
+
+            registry.insert(item)
+            elements.append(item)
+        }
+
+        return elements
+    }
+}

--- a/Tests/Utility/CollectionTests.swift
+++ b/Tests/Utility/CollectionTests.swift
@@ -63,6 +63,12 @@ class CollectionTests: XCTestCase {
         eq(["f", "o", "o", ":"].split(around: [":"]), (["f", "o", "o"], []))
         eq([":", "b", "a", "r"].split(around: [":"]), ([], ["b", "a", "r"]))
         eq(["f", "o", "o", ":", "b", "a", "r"].split(around: [":"]), (["f", "o", "o"], ["b", "a", "r"]))
+    }
 
+    func testUnique() {
+       XCTAssertEqual(["a", "b", "c"].unique(), ["a", "b", "c"])
+       XCTAssertEqual(["f", "o", "o"].unique(), ["f", "o"])
+       XCTAssertEqual(["f", "o", "b", "o", "a", "r"].unique(), ["f", "o", "b", "a", "r"])
+       XCTAssertEqual(["f", "f", "o", "b", "f", "b"].unique(), ["f", "o", "b"])
     }
 }

--- a/Tests/Utility/XCTestManifests.swift
+++ b/Tests/Utility/XCTestManifests.swift
@@ -27,7 +27,8 @@ extension CollectionTests {
                    ("testPick", testPick),
                    ("testPartitionByType", testPartitionByType),
                    ("testPartitionByClosure", testPartitionByClosure),
-                   ("testSplitAround", testSplitAround)
+                   ("testSplitAround", testSplitAround),
+                   ("testUnique", testUnique)
         ]
     }
 }


### PR DESCRIPTION
Adding search paths from `pkg-config --variable pc_path pkg-config` to locate `.pc` file