### PR TITLE
Add --color argument to turn color output on/off

### DIFF
--- a/Sources/Multitool/Options.swift
+++ b/Sources/Multitool/Options.swift
@@ -49,8 +49,10 @@ private func getroot() -> String {
             // any path that requires this property errors, but we
             // don't have to correctly figure out all those paths
             // ahead of time, since that is flakier
+            
+            let header = ColorWrap.wrap("error:", with: .Red, for: .StdErr) 
 
-            print("error: no Package.swift found", to: &stderr)
+            print("\(header): no Package.swift found", to: &stderr)
             exit(1)
         }
     }

--- a/Sources/Utility/ColorWrap.swift
+++ b/Sources/Utility/ColorWrap.swift
@@ -1,0 +1,88 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+
+import func POSIX.isatty
+import libc
+
+public var colorMode = ColorWrap.Mode.Auto 
+
+/// Wrap the text with color.
+public enum ColorWrap {
+
+    /// Wrap the given text with provided color for a stream.
+    /// Color codes will only be added if and only if:
+    ///     stream is TTY && --color=auto
+    ///     or
+    ///     --color=always
+    public static func wrap(_ input: String, with color: Color, for stream: Stream) -> String {
+        guard ColorWrap.isAllowed(for: .StdErr) else { return input }
+        return input.wrapped(in: color)
+    }
+
+    /// Check if color code generation is enabled for this stream.
+    public static func isAllowed(for stream: Stream) -> Bool {
+        switch colorMode {
+        case .Auto: return isTTY(stream)
+        case .Never: return false
+        case .Always: return true
+        }
+    }
+
+    /// Color modes supported by `--color` flag
+    ///
+    /// auto: Use Color codes only when printing to a terminal
+    /// always: Always print color codes
+    /// never: No color codes at all
+    public enum Mode: CustomStringConvertible {
+        case Auto, Always, Never
+
+        public init?(_ rawValue: String?) {
+            guard let rawValue = rawValue else {
+                self = .Auto
+                return
+            }
+            switch rawValue.lowercased() {
+            case "auto": self = .Auto
+            case "always": self = .Always
+            case "never": self = .Never
+            default: return nil
+            }
+        }
+
+        public var description: String {
+            switch self {
+            case .Auto: return "auto"
+            case .Always: return "always"
+            case .Never: return "never"
+            }
+        }
+    }
+
+    public enum Color {
+        case Red, Blue
+    }
+}
+
+
+extension String {
+    /// Surround this string with color codes.
+    func wrapped(in color: ColorWrap.Color) -> String {
+        let ESC = "\u{001B}"
+        let CSI = "\(ESC)["
+
+        switch color {
+        case .Blue:
+            return "\(CSI)34m\(self)\(CSI)0m"
+        case .Red:
+            return "\(CSI)31m\(self)\(CSI)0m"
+        }
+    }
+}

--- a/Sources/Utility/TTY.swift
+++ b/Sources/Utility/TTY.swift
@@ -1,0 +1,25 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+
+import func POSIX.isatty
+import libc
+
+/// Check if this stream is TTY.
+public func isTTY(_ stream: Stream) -> Bool {
+    switch stream {
+    case .StdOut: return isatty(fileno(libc.stdout))
+    case .StdErr: return isatty(fileno(libc.stderr))
+    }
+}
+
+public enum Stream {
+    case StdOut, StdErr
+}

--- a/Sources/Utility/Verbosity.swift
+++ b/Sources/Utility/Verbosity.swift
@@ -52,7 +52,6 @@ public class StandardErrorOutputStream: OutputStream {
 public var stderr = StandardErrorOutputStream()
 
 
-
 import func POSIX.system
 import func POSIX.popen
 import func POSIX.prettyArguments
@@ -61,21 +60,19 @@ public func system(_ args: String...) throws {
     try Utility.system(args)
 }
 
-private let ESC = "\u{001B}"
-private let CSI = "\(ESC)["
 
-private func prettyArguments(_ arguments: [String]) -> String {
+private func prettyArguments(_ arguments: [String], for stream: Stream) -> String {
     guard arguments.count > 0 else { return "" }
 
     var arguments = arguments
-    let arg0 = blue(which(arguments.removeFirst()))
+    let arg0 = which(arguments.removeFirst())
 
-    return arg0 + " " + POSIX.prettyArguments(arguments)
+    return ColorWrap.wrap(arg0, with: .Blue, for: stream) + " " + POSIX.prettyArguments(arguments)
 }
 
 private func printArgumentsIfVerbose(_ arguments: [String]) {
     if verbosity != .Concise {
-        print(prettyArguments(arguments))
+        print(prettyArguments(arguments, for: .StdOut))
     }
 }
 
@@ -115,7 +112,7 @@ public func system(_ arguments: String..., environment: [String:String] = [:], m
         }
     } catch {
         if verbosity == .Concise {
-            print(prettyArguments(arguments), to: &stderr)
+            print(prettyArguments(arguments, for: .StdOut), to: &stderr)
             print(out, to: &stderr)
         }
         throw error
@@ -130,8 +127,4 @@ private func which(_ arg0: String) -> String {
     } else {
         return arg0
     }
-}
-
-private func blue(_ input: String) -> String {
-    return CSI + "34m" + input + CSI + "0m"
 }

--- a/Sources/swift-build/main.swift
+++ b/Sources/swift-build/main.swift
@@ -31,6 +31,7 @@ do {
     let (mode, opts) = try parse(commandLineArguments: args)
 
     verbosity = Verbosity(rawValue: opts.verbosity)
+    colorMode = opts.colorMode
 
     if let dir = opts.chdir {
         try chdir(dir)


### PR DESCRIPTION
`swift build` output is not clearly readable, when it is ran in terminal that doesn't support color codes (like, Xcode debug console)

Example:
```
[31merror:[0m exit(1):
```

Which should read as:
```
error: exit(1):
```

This PR adds `--color[=auto|never|always]` flag which is identical to that of GNU `grep`.

- `auto` - Emits color codes only when standard output is connected to a terminal.
- `never` - Don't emit any color codes
- `always` - Always emit color codes even when piped to a file or other commands.

If `--color` flag is not specified, it will be `auto` by default.

##### Caveats:
Because of the way options parser is written, color codes will still creep in when the option parsing fails, even with `--color=never` option. 

To fix this, we need to read all the given flags, instead of bailing out at first error in parsing.