### PR TITLE
[Build] Pass Xcc and Xld to Clang

### DIFF
--- a/Fixtures/ClangModules/CDynamicLookup/Foo.c
+++ b/Fixtures/ClangModules/CDynamicLookup/Foo.c
@@ -1,0 +1,9 @@
+#include "include/Foo.h"
+
+int foo() {
+    bar();
+    int a = 5;
+    int b = a;
+    a = b;
+    return a;
+}

--- a/Fixtures/ClangModules/CDynamicLookup/include/Foo.h
+++ b/Fixtures/ClangModules/CDynamicLookup/include/Foo.h
@@ -1,0 +1,2 @@
+void bar();
+int foo();

--- a/Sources/Build/Command.compile(ClangModule).swift
+++ b/Sources/Build/Command.compile(ClangModule).swift
@@ -67,7 +67,7 @@ private extension Sources {
 }
 
 extension Command {
-    static func compile(clangModule module: ClangModule, externalModules: Set<Module>, configuration conf: Configuration, prefix: String, CC: String) throws -> [Command] {
+    static func compile(clangModule module: ClangModule, externalModules: Set<Module>, configuration conf: Configuration, prefix: String, CC: String, Xcc: [String], Xld: [String]) throws -> [Command] {
 
         let wd = module.buildDirectory(prefix)
         
@@ -80,6 +80,7 @@ extension Command {
         let dependencies = module.dependencies.map{ $0.targetName }
         var basicArgs = module.basicArgs + module.includeFlagsWithExternalModules(externalModules) + module.optimizationFlags(conf)
         basicArgs += module.moduleCacheArgs(prefix: prefix)
+        basicArgs += Xcc
 
         for path in module.sources.compilePathsForBuildDir(wd) {
             var args = basicArgs
@@ -106,6 +107,7 @@ extension Command {
         args += ["-L\(prefix)"]
         args += module.linkFlags
         args += module.sources.compilePathsForBuildDir(wd).map{$0.object}
+        args += Xld
 
         if module.type == .Library {
             args += ["-shared"]

--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -41,7 +41,7 @@ public func describe(_ prefix: String, _ conf: Configuration, _ modules: [Module
             targets.append(compile, for: module)
 
         case let module as ClangModule:
-            let compile = try Command.compile(clangModule: module, externalModules: externalModules, configuration: conf, prefix: prefix, CC: CC)
+            let compile = try Command.compile(clangModule: module, externalModules: externalModules, configuration: conf, prefix: prefix, CC: CC, Xcc: Xcc, Xld: Xld)
             commands += compile
             targets.main.cmds += compile
 

--- a/Tests/Functional/ClangModuleTests.swift
+++ b/Tests/Functional/ClangModuleTests.swift
@@ -97,6 +97,13 @@ class TestClangModulesTestCase: XCTestCase {
             XCTAssertFileExists(prefix, ".build", "debug", "Baz")
         }
     }
+
+    func testDynamicLookup() {
+        fixture(name: "ClangModules/CDynamicLookup") { prefix in
+            XCTAssertBuilds(prefix, Xld: ["-undefined", "dynamic_lookup"])
+            XCTAssertFileExists(prefix, ".build", "debug", "libCDynamicLookup.so")
+        }
+    }
 }
 
 


### PR DESCRIPTION
This was causing packages with C deps like https://github.com/antonmes/spm-dynlink/tree/ffdd9374ad52039a89a69acc0a80598c88248816 fail to build because the extra args to swift build are not passed on to clang.

```
$ brew install tarantool
$ swift build -Xcc -I/usr/local/include -Xlinker -undefined -Xlinker dynamic_lookup -Xswiftc -I/usr/local/include
```
Fails to build with error because `-undefined dynamic_lookup` is not passed to clang.
```
Linking CTarantoolSwiftHelper
Undefined symbols for architecture x86_64:
  "_fiber_new", referenced from:
      _fiber_rise in fiber.c.o
  "_fiber_start", referenced from:
      _fiber_rise in fiber.c.o
ld: symbol(s) not found for architecture x86_64
```

I am not too sure what is the correct way to solve such things /cc @ddunbar 
