### PR TITLE
Allow v-prefixed version string in Package.swift

### DIFF
--- a/Sources/PackageDescription/Version+StringLiteralConvertible.swift
+++ b/Sources/PackageDescription/Version+StringLiteralConvertible.swift
@@ -30,6 +30,7 @@ extension Version {
     }
 
     public init?(_ characters: String.CharacterView) {
+        let characters = characters.first == "v" ? characters.dropFirst() : characters
         let prereleaseStartIndex = characters.index(of: "-")
         let metadataStartIndex = characters.index(of: "+")
 

--- a/Tests/PackageDescription/VersionTests.swift
+++ b/Tests/PackageDescription/VersionTests.swift
@@ -147,7 +147,7 @@ class VersionTests: XCTestCase {
         XCTAssertNil(Version(".1.2.3"))
         XCTAssertNil(Version("v.1.2.3"))
         XCTAssertNil(Version("1.2..3"))
-        XCTAssertNil(Version("v1.2.3"))
+        XCTAssertEqual(Version(1,2,3), Version("v1.2.3"))
 
         XCTAssertEqual(Version(1,2,3), Version("01.002.0003"))
 


### PR DESCRIPTION
e.g.
```swift
import PackageDescription

let package = Package(
    name: "Quick",
    dependencies: [
        .Package(url: "https://github.com/norio-nomura/Nimble", "v5.0.0-alpha.3020160412a")
    ]
)
```