### PR TITLE
Framework target in generated Xcodeproj

### DIFF
--- a/Sources/PackageLoading/Manifest+parse.swift
+++ b/Sources/PackageLoading/Manifest+parse.swift
@@ -60,7 +60,16 @@ private func parse(path manifestPath: String, swiftc: String, libdir: String) th
     cmd += ["--driver-mode=swift"]
     cmd += verbosity.ccArgs
     cmd += ["-I", libdir]
-    cmd += ["-L", libdir, "-lPackageDescription"]
+
+    // When running from Xcode, load PackageDescription.framework
+    // else load the dylib version of it
+#if Xcode
+    cmd += ["-F", libdir]
+    cmd += ["-framework", "PackageDescription"]
+#else
+    cmd += ["-L", libdir, "-lPackageDescription"] 
+#endif
+
 #if os(OSX)
     cmd += ["-target", "x86_64-apple-macosx10.10"]
 #endif

--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -71,6 +71,43 @@ public func generate(dstdir: String, projectName: String, srcroot: String, modul
         print("</plist>")
     }
 
+    for module in modules where module.isLibrary {
+        ///// For framework targets, generate module.c99Name_Info.plist files in the 
+        ///// directory that Xcode project is generated
+        let name = module.infoPlistFileName
+        try open(xcodeprojPath, name) { print in
+            print("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+            print("<plist version=\"1.0\">")
+            print("<dict>")
+            print("  <key>CFBundleDevelopmentRegion</key>")
+            print("  <string>en</string>")
+            print("  <key>CFBundleExecutable</key>")
+            print("  <string>$(EXECUTABLE_NAME)</string>")
+            print("  <key>CFBundleIdentifier</key>")
+            print("  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>")
+            print("  <key>CFBundleInfoDictionaryVersion</key>")
+            print("  <string>6.0</string>")
+            print("  <key>CFBundleName</key>")
+            print("  <string>$(PRODUCT_NAME)</string>")
+            print("  <key>CFBundlePackageType</key>")
+            if module is TestModule {
+                print("  <string>BNDL</string>")
+            } else {
+                print("  <string>FMWK</string>")
+            }
+            print("  <key>CFBundleShortVersionString</key>")
+            print("  <string>1.0</string>")
+            print("  <key>CFBundleSignature</key>")
+            print("  <string>????</string>")
+            print("  <key>CFBundleVersion</key>")
+            print("  <string>$(CURRENT_PROJECT_VERSION)</string>")
+            print("  <key>NSPrincipalClass</key>")
+            print("  <string></string>")
+            print("</dict>")
+            print("</plist>")
+        }
+    }
+
     return xcodeprojPath
 }
 

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -65,17 +65,35 @@ public func pbxproj(srcroot: String, projectRoot: String, xcodeprojPath: String,
 ////// modules group
     for module in modules {
 
+        let sourceFileRefPaths = fileRefs(forModuleSources: module, srcroot: srcroot)
+        var sourceRefs = sourceFileRefPaths.map{$0.0}
+
+        ////// Info.plist file reference if this a framework target
+        if module.isLibrary {
+            let (ref, path, name) = fileRef(ofInfoPlistFor: module, inDirectory: xcodeprojPath)
+            print("        \(ref) = {")
+            print("            isa = PBXFileReference;")
+            print("            lastKnownFileType = text.plist.xml;")
+            print("            name = '\(name)';")
+            print("            path = '\(Path(path).relative(to: projectRoot))';")
+            print("            sourceTree = SOURCE_ROOT;")
+            print("        };")
+
+            sourceRefs.append(ref)
+        }
+
+
         // the “Project Navigator” group for this module
         print("        \(module.groupReference) = {")
         print("            isa = PBXGroup;")
         print("            name = \(module.name);")
         print("            path = '\(Path(module.sources.root).relative(to: projectRoot))';")
         print("            sourceTree = '<group>';")
-        print("            children = (" + fileRefs(forModuleSources: module, srcroot: srcroot).map{$0.0}.joined(separator: ", ") + ");")
+        print("            children = (" + sourceRefs.joined(separator: ", ") + ");")
         print("        };")
 
         // the contents of the “Project Navigator” group for this module
-        for (ref, path) in fileRefs(forModuleSources: module, srcroot: srcroot) {
+        for (ref, path) in sourceFileRefPaths {
             print("        \(ref) = {")
             print("            isa = PBXFileReference;")
             print("            lastKnownFileType = \(module.fileType);")
@@ -143,12 +161,12 @@ public func pbxproj(srcroot: String, projectRoot: String, xcodeprojPath: String,
         print("        };")
         print("        \(module.debugConfigurationReference) = {")
         print("            isa = XCBuildConfiguration;")
-        print("            buildSettings = { \(module.getDebugBuildSettings(options)) };")
+        print("            buildSettings = { \(module.getDebugBuildSettings(options, xcodeProjectPath: xcodeprojPath)) };")
         print("            name = Debug;")
         print("        };")
         print("        \(module.releaseConfigurationReference) = {")
         print("            isa = XCBuildConfiguration;")
-        print("            buildSettings = { \(module.getReleaseBuildSettings(options)) };")
+        print("            buildSettings = { \(module.getReleaseBuildSettings(options, xcodeProjectPath: xcodeprojPath)) };")
         print("            name = Release;")
         print("        };")
 

--- a/Tests/Xcodeproj/FunctionalTests.swift
+++ b/Tests/Xcodeproj/FunctionalTests.swift
@@ -27,8 +27,7 @@ class FunctionalTests: XCTestCase {
             XCTAssertDirectoryExists(pbx)
             XCTAssertXcodeBuild(project: pbx)
             let build = Path.join(prefix, "build", "Debug")
-            XCTAssertDirectoryExists(build, "Library.swiftmodule")
-            XCTAssertFileExists(build, "libLibrary.dylib")
+            XCTAssertDirectoryExists(build, "Library.framework")
         }
     }
 
@@ -39,7 +38,6 @@ class FunctionalTests: XCTestCase {
             try! write(path: seaLibModuleMap) { stream in
                 stream <<< "module SeaLib {"
                 stream <<< "    umbrella \".\""
-                stream <<< "    link \"SeaLib\""
                 stream <<< "    export *"
                 stream <<< "}"
             }
@@ -48,9 +46,8 @@ class FunctionalTests: XCTestCase {
             XCTAssertDirectoryExists(pbx)
             XCTAssertXcodeBuild(project: pbx)
             let build = Path.join(prefix, "build", "Debug")
-            XCTAssertDirectoryExists(build, "SeaExec.swiftmodule")
+            XCTAssertDirectoryExists(build, "SeaLib.framework")
             XCTAssertFileExists(build, "SeaExec")
-            XCTAssertFileExists(build, "libSeaLib.dylib")
         }
     }
 
@@ -90,8 +87,8 @@ class FunctionalTests: XCTestCase {
             XCTAssertDirectoryExists(pbx)
             XCTAssertXcodeBuild(project: pbx)
             let build = Path.join(prefix, "build", "Debug")
-            XCTAssertFileExists(build, "libA-B.dylib")
-            XCTAssertFileExists(build, "libB-C.dylib")
+            XCTAssertDirectoryExists(build, "A_B.framework")
+            XCTAssertDirectoryExists(build, "B_C.framework")
         }
     }
 }


### PR DESCRIPTION
Added ability to select between `framework` and `dylib` targets using `--product-type=[framework|dylib]` flag in generated Xcode project

This patch also generates `module.c99name_Info.plist` files for `framework` targets.