### PR TITLE
Throw error when duplicate modules are detected

### DIFF
--- a/Fixtures/DependencyResolution/External/DuplicateModules/Bar/Package.swift
+++ b/Fixtures/DependencyResolution/External/DuplicateModules/Bar/Package.swift
@@ -1,0 +1,6 @@
+import PackageDescription
+
+let package = Package(
+    name: "Bar",
+    dependencies: [
+        .Package(url: "../Foo", majorVersion: 1)])

--- a/Fixtures/DependencyResolution/External/DuplicateModules/Bar/Sources/Bar/Bar.swift
+++ b/Fixtures/DependencyResolution/External/DuplicateModules/Bar/Sources/Bar/Bar.swift
@@ -1,0 +1,2 @@
+public func bar() {
+}

--- a/Fixtures/DependencyResolution/External/DuplicateModules/Bar/Sources/app/main.swift
+++ b/Fixtures/DependencyResolution/External/DuplicateModules/Bar/Sources/app/main.swift
@@ -1,0 +1,5 @@
+import Foo
+import Biz
+
+foo()
+biz()

--- a/Fixtures/DependencyResolution/External/DuplicateModules/Foo/Sources/Bar/Bar.swift
+++ b/Fixtures/DependencyResolution/External/DuplicateModules/Foo/Sources/Bar/Bar.swift
@@ -1,0 +1,2 @@
+public func bar() {
+}

--- a/Fixtures/DependencyResolution/External/DuplicateModules/Foo/Sources/Biz/Biz.swift
+++ b/Fixtures/DependencyResolution/External/DuplicateModules/Foo/Sources/Biz/Biz.swift
@@ -1,0 +1,2 @@
+public func biz() {
+}

--- a/Sources/Transmute/Error.swift
+++ b/Sources/Transmute/Error.swift
@@ -40,6 +40,7 @@ extension Module {
     public enum Error: ErrorProtocol {
         case NoSources(String)
         case MixedSources(String)
+        case DuplicateModule(String)
     }
 }
 

--- a/Sources/Transmute/recursiveDependencies().swift
+++ b/Sources/Transmute/recursiveDependencies().swift
@@ -9,7 +9,7 @@
 */
 
 import class PackageType.Module
-import protocol PackageType.XcodeModuleProtocol
+import protocol PackageType.ModuleTypeProtocol
 
 public func recursiveDependencies(_ modules: [Module]) throws -> [Module] {
     var stack = modules
@@ -24,8 +24,8 @@ public func recursiveDependencies(_ modules: [Module]) throws -> [Module] {
             stack += top.dependencies
         } else {
             guard let index = set.index(of: top),
-                  let moduleInSet = set[index] as? XcodeModuleProtocol,
-                  let module = top as? XcodeModuleProtocol
+                  let moduleInSet = set[index] as? ModuleTypeProtocol,
+                  let module = top as? ModuleTypeProtocol
                       where module.sources.root != moduleInSet.sources.root else {
                 continue;
             }

--- a/Sources/Transmute/recursiveDependencies().swift
+++ b/Sources/Transmute/recursiveDependencies().swift
@@ -1,0 +1,38 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import class PackageType.Module
+import protocol PackageType.XcodeModuleProtocol
+
+public func recursiveDependencies(_ modules: [Module]) throws -> [Module] {
+    var stack = modules
+    var set = Set<Module>()
+    var rv = [Module]()
+
+    while stack.count > 0 {
+        let top = stack.removeFirst()
+        if !set.contains(top) {
+            rv.append(top)
+            set.insert(top)
+            stack += top.dependencies
+        } else {
+            guard let index = set.index(of: top),
+                  let moduleInSet = set[index] as? XcodeModuleProtocol,
+                  let module = top as? XcodeModuleProtocol
+                      where module.sources.root != moduleInSet.sources.root else {
+                continue;
+            }
+
+            throw Module.Error.DuplicateModule(top.name)
+        }
+    }
+
+    return rv
+}

--- a/Sources/Transmute/transmute().swift
+++ b/Sources/Transmute/transmute().swift
@@ -74,8 +74,8 @@ public func transmute(_ rootPackage: Package, externalPackages: [Package]) throw
     // ensure modules depend on the modules of any dependent packages
     fillModuleGraph(packages, modulesForPackage: { map[$0]! })
 
-    let modules = recursiveDependencies(packages.flatMap{ map[$0] ?? [] })
-    let externalModules = recursiveDependencies(externalPackages.flatMap{ map[$0] ?? [] })
+    let modules = try Transmute.recursiveDependencies(packages.flatMap{ map[$0] ?? [] })
+    let externalModules = try Transmute.recursiveDependencies(externalPackages.flatMap{ map[$0] ?? [] })
 
     return (modules, externalModules, products)
 }

--- a/Tests/Functional/DependencyResolutionTests.swift
+++ b/Tests/Functional/DependencyResolutionTests.swift
@@ -45,6 +45,12 @@ class DependencyResolutionTestCase: XCTestCase {
         }
     }
 
+    func testExternalDuplicateModule() {
+        fixture(name: "DependencyResolution/External/DuplicateModules") { prefix in
+            XCTAssertBuildFails(prefix)
+        }
+    }
+
     func testExternalComplex() {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
             XCTAssertBuilds(prefix, "app")

--- a/Tests/Functional/ValidLayoutTests.swift
+++ b/Tests/Functional/ValidLayoutTests.swift
@@ -137,6 +137,7 @@ extension DependencyResolutionTestCase {
             ("testInternalSimple", testInternalSimple),
             ("testInternalComplex", testInternalComplex),
             ("testExternalSimple", testExternalSimple),
+            ("testExternalDuplicateModule", testExternalDuplicateModule),
             ("testExternalComplex", testExternalComplex),
             ("testIndirectTestsDontBuild", testIndirectTestsDontBuild),
         ]


### PR DESCRIPTION
If root package has modules `A` & `B` and it depends on Package `Foo` which has modules `B` & `C`, we have duplicate module `B`. Current implementation will silently ignore root package's B and keep `Foo` package's `B`, which is wrong.

This patch will throw an error in that case.