### PR TITLE
[SR-1555] Temporarily disable whole-module optimization to avoid SR-1457

### DIFF
--- a/Sources/Build/ToolProtocol.swift
+++ b/Sources/Build/ToolProtocol.swift
@@ -69,7 +69,13 @@ struct SwiftcTool: ToolProtocol {
     var objects: [String]                   { return module.sources.relativePaths.map{ Path.join(tempsPath, "\($0).o") } }
     var sources: [String]                   { return module.sources.paths }
     var isLibrary: Bool                     { return module.type == .Library }
-    var enableWholeModuleOptimization: Bool { return conf == .Release }
+    var enableWholeModuleOptimization: Bool {
+        #if EnableWorkaroundForSR1457
+            return false
+        #else
+            return conf == .Release
+        #endif
+    }
 
     func append(to stream: OutputByteStream) {
         stream <<< "    tool: swift-compiler\n"

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -174,6 +174,9 @@ class Target(object):
         compile_swift_node = '<compile-swift-%s>' % (self.name,)
         link_input_nodes.append(compile_swift_node)
 
+        # Enable the workaround for SR-1457 until it is fixed.
+        other_args.extend(["-DEnableWorkaroundForSR1457"])
+        
         print("  %s:" % json.dumps(compile_swift_node), file=output)
         print("    tool: swift-compiler", file=output)
         print("    executable: %s" % json.dumps(args.swiftc_path), file=output)


### PR DESCRIPTION
This is a workaround for SR-1457. SR-1556 tracks removing the workaround.