### PR TITLE
[Utility] chomp the searchPaths obtains from pkg-config. The output c…

### DIFF
--- a/Sources/Utility/PkgConfig.swift
+++ b/Sources/Utility/PkgConfig.swift
@@ -21,7 +21,7 @@ public enum PkgConfigError: ErrorProtocol {
 /// This is needed because on Linux machines, the search paths can be different
 /// from the standard locations that we are currently searching.
 private let pkgConfigSearchPaths: [String] = {
-    let searchPaths = try? POSIX.popen(["pkg-config", "--variable", "pc_path", "pkg-config"])
+    let searchPaths = try? POSIX.popen(["pkg-config", "--variable", "pc_path", "pkg-config"]).chomp()
     return searchPaths?.characters.split(separator: ":").map(String.init) ?? []
 }()
 


### PR DESCRIPTION
…ontains `\n` at the end making the last directory an invalid path.