### PR TITLE
List tests from XCTest bundle for OSX

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -95,6 +95,9 @@ let package = Package(
             /** Runs package tests */
             name: "swift-test",
             dependencies: ["Commands"]),
+        Target(
+            /** Shim tool to find test names on OS X */
+            name: "spm-test-finder"),
     ])
 
 

--- a/Sources/Build/Command.link().swift
+++ b/Sources/Build/Command.link().swift
@@ -38,6 +38,10 @@ extension Command {
             args += ["-L\(prefix)"]
             args += ["-o", outpath]
 
+          #if os(OSX)
+            args += ["-F", try platformFrameworksPath()]
+          #endif
+
         case .Library(.Static):
             let inputs = buildables.map{ $0.targetName } + objects
             let outputs = [product.targetName, outpath]

--- a/Sources/Build/misc.swift
+++ b/Sources/Build/misc.swift
@@ -21,7 +21,7 @@ public protocol Toolchain {
     var clang: String { get }
 }
 
-func platformFrameworksPath() throws -> String {
+public func platformFrameworksPath() throws -> String {
     // Lazily compute the platform the first time it is needed.
     struct Static {
         static let value = { try? POSIX.popen(["xcrun", "--sdk", "macosx", "--show-sdk-platform-path"]) }()

--- a/Sources/spm-test-finder/main.swift
+++ b/Sources/spm-test-finder/main.swift
@@ -1,0 +1,48 @@
+#if os(OSX)
+
+import XCTest
+import Foundation
+
+enum Error: ErrorProtocol {
+    case invalidUsage
+    case unableToLoadBundle(String)
+}
+
+do {
+    guard Process.arguments.count == 2 else {
+        throw Error.invalidUsage
+    }
+    var bundlePath = Process.arguments[1]
+    if !(bundlePath as NSString).isAbsolutePath {
+        bundlePath = NSFileManager.default().currentDirectoryPath + "/" + bundlePath
+    }
+    bundlePath = (bundlePath as NSString).standardizingPath
+
+    guard let bundle = NSBundle(path: bundlePath) where bundle.load() else {
+        throw Error.unableToLoadBundle(bundlePath)
+    }
+    
+    let suite = XCTestSuite(forBundlePath: bundlePath)
+    let splitSet: Set<Character> = ["[", " ", "]", ":"]
+    for case let testCaseSuite as XCTestSuite in suite.tests {
+        for case let test as XCTestCase in testCaseSuite.tests {
+            let exploded = test.description.characters.split(isSeparator: splitSet.contains).map(String.init)
+            let moduleName = String(String(reflecting: test.dynamicType).characters.split(separator: ".").first!)
+            let className = exploded[1]
+            var methodName = exploded[2]
+            if methodName.hasSuffix("AndReturnError") {
+                methodName = methodName[methodName.startIndex..<methodName.index(methodName.endIndex, offsetBy: -14)]
+            }
+            print("\(moduleName).\(className)/\(methodName)")
+        }
+        print()
+    }
+} catch Error.invalidUsage {
+    print("Usage: spm-test-finder <bundle_path>")
+} catch {
+    print("error: \(error)")
+}
+
+#else
+print("Only OSX supported.")
+#endif

--- a/Sources/spm-test-finder/main.swift
+++ b/Sources/spm-test-finder/main.swift
@@ -22,20 +22,23 @@ do {
         throw Error.unableToLoadBundle(bundlePath)
     }
     
-    let suite = XCTestSuite(forBundlePath: bundlePath)
+    let suite = XCTestSuite.default()
+
     let splitSet: Set<Character> = ["[", " ", "]", ":"]
     for case let testCaseSuite as XCTestSuite in suite.tests {
-        for case let test as XCTestCase in testCaseSuite.tests {
-            let exploded = test.description.characters.split(isSeparator: splitSet.contains).map(String.init)
-            let moduleName = String(String(reflecting: test.dynamicType).characters.split(separator: ".").first!)
-            let className = exploded[1]
-            var methodName = exploded[2]
-            if methodName.hasSuffix("AndReturnError") {
-                methodName = methodName[methodName.startIndex..<methodName.index(methodName.endIndex, offsetBy: -14)]
+        for case let testCaseSuite as XCTestSuite in testCaseSuite.tests {
+            for case let test as XCTestCase in testCaseSuite.tests {
+                let exploded = test.description.characters.split(isSeparator: splitSet.contains).map(String.init)
+                let moduleName = String(String(reflecting: test.dynamicType).characters.split(separator: ".").first!)
+                let className = exploded[1]
+                var methodName = exploded[2]
+                if methodName.hasSuffix("AndReturnError") {
+                    methodName = methodName[methodName.startIndex..<methodName.index(methodName.endIndex, offsetBy: -14)]
+                }
+                print("\(moduleName).\(className)/\(methodName)")
             }
-            print("\(moduleName).\(className)/\(methodName)")
+            print()
         }
-        print()
     }
 } catch Error.invalidUsage {
     print("Usage: spm-test-finder <bundle_path>")

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -108,7 +108,7 @@ g_default_sysroot = None
 if platform.system() == 'Darwin':
     g_platform_path = subprocess.check_output(
         ["xcrun", "--sdk", "macosx", "--show-sdk-platform-path"],
-        universal_newlines=True).strip()
+        universal_newlines=True).strip() + "/Developer/Library/Frameworks"
     g_default_sysroot = subprocess.check_output(
         ["xcrun", "--sdk", "macosx", "--show-sdk-path"],
         universal_newlines=True).strip()
@@ -169,6 +169,7 @@ class Target(object):
         other_args = ['-Onone', '-j%d' % g_num_cpus] + self.swiftflags
         if platform.system() == 'Darwin':
             other_args.extend(["-target", "x86_64-apple-macosx10.10"])
+            other_args.extend(["-F", g_platform_path])
         if args.sysroot:
             other_args.extend(["-sdk", args.sysroot])
         compile_swift_node = '<compile-swift-%s>' % (self.name,)
@@ -379,6 +380,7 @@ def create_bootstrap_files(sandbox_path, args):
                 link_command.extend(["-sdk", args.sysroot])
             if platform.system() == 'Darwin':
                 link_command.extend(["-target", "x86_64-apple-macosx10.10"])
+                link_command.extend(["-F", g_platform_path])
             link_command.append(' '.join(pipes.quote(o) for o in objects))
             for dependency in target.dependencies:
                 dependency_lib_path = os.path.join(lib_dir, "%s.a" % dependency)
@@ -734,6 +736,7 @@ def main():
 
     swift_build_path = os.path.join(build_path, conf, "swift-build")
     swift_test_path = os.path.join(build_path, conf, "swift-test")
+    spm_test_finder_path = os.path.join(build_path, conf, "spm-test-finder")
 
     # If testing, run each of the test bundles.
     if "test" in build_actions:
@@ -752,7 +755,7 @@ def main():
                                         "lib", "swift", "pm")
         mkdir_p(bin_install_path)
         mkdir_p(lib_install_path)
-        for product_path in [swift_build_path, swift_test_path]:
+        for product_path in [swift_build_path, swift_test_path, spm_test_finder_path]:
             cmd = ["install", product_path, bin_install_path]
             note("installing %s: %s" % (
                 os.path.basename(product_path), ' '.join(cmd)))


### PR DESCRIPTION
Bug: https://bugs.swift.org/browse/SR-1541
This PR adds a new executable tool : `spm-test-finder` as described by @ddunbar in JIRA comments.

The output is in format of ->
`<moduleName>.<className>/<methodName>`