### PR TITLE
[SE-0085] Add a `package` subcommand to handle package-oriented operations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -89,6 +89,10 @@ let package = Package(
             dependencies: ["Basic", "Build", "Get", "PackageGraph", "Xcodeproj"]),
         Target(
             /** The main executable provided by SwiftPM */
+            name: "swift-package",
+            dependencies: ["Commands"]),
+        Target(
+            /** Builds packages */
             name: "swift-build",
             dependencies: ["Commands"]),
         Target(

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -52,7 +52,7 @@ private enum Mode: Argument, Equatable, CustomStringConvertible {
             self = .Fetch
         case "update":
             self = .Update
-        case "help", "usage", "-h":
+        case "help", "usage", "--help", "-h":
             self = .Usage
         case "version":
             self = .Version

--- a/Sources/Commands/init.swift
+++ b/Sources/Commands/init.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basic
 import PackageModel
 import POSIX
 
@@ -160,5 +161,28 @@ final class InitPackage {
         try fputs("\t\t]\n", testsFileFP)
         try fputs("\t}\n", testsFileFP)
         try fputs("}\n", testsFileFP)
+    }
+}
+
+/// Represents a package type for the purposes of initialization.
+enum InitMode: CustomStringConvertible {
+    case Library, Executable
+
+    init(_ rawValue: String?) throws {
+        switch rawValue?.lowercased() {
+        case "library"?, "lib"?:
+            self = .Library
+        case nil, "executable"?, "exec"?, "exe"?:
+            self = .Executable
+        default:
+            throw OptionParserError.InvalidUsage("invalid initialization type: \(rawValue)")
+        }
+    }
+
+    var description: String {
+        switch self {
+            case .Library: return "library"
+            case .Executable: return "executable"
+        }
     }
 }

--- a/Sources/Commands/show-dependencies.swift
+++ b/Sources/Commands/show-dependencies.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basic
 import PackageModel
 import struct PackageDescription.Version
 
@@ -113,5 +114,35 @@ private final class JsonDumper: DependenciesDumper {
         }
 
         recursiveWalk(rootpkg: rootpkg)
+    }
+}
+
+enum ShowDependenciesMode: CustomStringConvertible {
+    case Text, DOT, JSON
+    
+    init(_ rawValue: String?) throws {
+        guard let rawValue = rawValue else {
+            self = .Text
+            return
+        }
+        
+        switch rawValue.lowercased() {
+        case "text":
+           self = .Text
+        case "dot":
+           self = .DOT
+        case "json":
+           self = .JSON
+        default:
+            throw OptionParserError.InvalidUsage("invalid show dependencies mode: \(rawValue)")
+        }
+    }
+    
+    var description: String {
+        switch self {
+        case .Text: return "text"
+        case .DOT: return "dot"
+        case .JSON: return "json"
+        }
     }
 }

--- a/Sources/swift-package/main.swift
+++ b/Sources/swift-package/main.swift
@@ -1,0 +1,14 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Commands
+
+let tool = SwiftPackageTool(args: Array(Process.arguments.dropFirst()))
+tool.run()


### PR DESCRIPTION
This moves the package-management commands from the `build` subcommand to
`package`, but leaves building (and, currently, cleaning) on the `build`
subcommand.  The `test` subcommand is likewise unmodified.

I had to temporarily move down the enums for InitMode and ShowDependen-
ciesMode, so that both package and build can share them, but this will
be consolidated again when build and test are reimplemented in terms of
package as well.  The build and test functionality is not yet moved in
order to minimize changes while still ending up with the desired func-
tionality.