### PR TITLE
rename enums to lowerCamelCase

### DIFF
--- a/Sources/Basic/OptionParser.swift
+++ b/Sources/Basic/OptionParser.swift
@@ -13,25 +13,25 @@
 #endif
 
 public enum OptionParserError: ErrorProtocol {
-    case UnknownArgument(String)
-    case MultipleModesSpecified([String])
-    case ExpectedAssociatedValue(String)
-    case UnexpectedAssociatedValue(String, String)
-    case InvalidUsage(String)
+    case unknownArgument(String)
+    case multipleModesSpecified([String])
+    case expectedAssociatedValue(String)
+    case unexpectedAssociatedValue(String, String)
+    case invalidUsage(String)
 }
 
 extension OptionParserError: CustomStringConvertible {
     public var description: String {
         switch self {
-        case .ExpectedAssociatedValue(let arg):
+        case .expectedAssociatedValue(let arg):
             return "expected associated value for argument: \(arg)"
-        case .UnexpectedAssociatedValue(let arg, let value):
+        case .unexpectedAssociatedValue(let arg, let value):
             return "unexpected associated value for argument: \(arg)=\(value)"
-        case .MultipleModesSpecified(let modes):
+        case .multipleModesSpecified(let modes):
             return "multiple modes specified: \(modes)"
-        case .UnknownArgument(let cmd):
+        case .unknownArgument(let cmd):
             return "unknown command: \(cmd)"
-        case .InvalidUsage(let hint):
+        case .invalidUsage(let hint):
             return "invalid usage: \(hint)"
         }
     }
@@ -60,12 +60,12 @@ public func parseOptions<Mode, Flag where Mode: Argument, Mode: Equatable, Flag:
         if let mkmode = try Mode(argument: arg, pop: { popped = true; return value ?? it.next() }) {
             guard mode == nil || mode == mkmode else {
                 let modes = [mode!, mkmode].map{"\($0)"}
-                throw OptionParserError.MultipleModesSpecified(modes)
+                throw OptionParserError.multipleModesSpecified(modes)
             }
             mode = mkmode
 
             if let value = value where !popped {
-                throw OptionParserError.UnexpectedAssociatedValue(arg, value)
+                throw OptionParserError.unexpectedAssociatedValue(arg, value)
             }
         } else {
             kept.append(rawArg)
@@ -85,8 +85,8 @@ public func parseOptions<Mode, Flag where Mode: Argument, Mode: Equatable, Flag:
 
             // attempt to split eg. `-xyz` to `-x -y -z`
 
-            guard !arg.hasPrefix("--") else { throw OptionParserError.UnknownArgument(arg) }
-            guard arg != "-" else { throw OptionParserError.UnknownArgument(arg) }
+            guard !arg.hasPrefix("--") else { throw OptionParserError.unknownArgument(arg) }
+            guard arg != "-" else { throw OptionParserError.unknownArgument(arg) }
 
             var characters = arg.characters.dropFirst()
 
@@ -104,16 +104,16 @@ public func parseOptions<Mode, Flag where Mode: Argument, Mode: Equatable, Flag:
             while !characters.isEmpty {
                 let c = characters.removeFirst()
                 guard let flag = try Flag(argument: "-\(c)", pop: pop) else {
-                    throw OptionParserError.UnknownArgument(arg)
+                    throw OptionParserError.unknownArgument(arg)
                 }
                 flags.append(flag)
             }
         } else {
-          throw OptionParserError.UnknownArgument(arg)
+          throw OptionParserError.unknownArgument(arg)
         }
 
         if let value = value where !popped {
-            throw OptionParserError.UnexpectedAssociatedValue(arg, value)
+            throw OptionParserError.unexpectedAssociatedValue(arg, value)
         }
     }
 

--- a/Sources/Build/Command.compile(ClangModule).swift
+++ b/Sources/Build/Command.compile(ClangModule).swift
@@ -47,9 +47,9 @@ private extension ClangModule {
 
     func optimizationFlags(_ conf: Configuration) -> [String] {
         switch conf {
-        case .Debug:
+        case .debug:
             return ["-g", "-O0"]
-        case .Release:
+        case .release:
             return ["-O2"]
         }
     }
@@ -71,7 +71,7 @@ extension Command {
 
         let wd = module.buildDirectory(prefix)
         
-        if module.type == .Library {
+        if module.type == .library {
             try module.generateModuleMap(inDir: wd)
         }
         
@@ -110,11 +110,11 @@ extension Command {
         args += module.sources.compilePathsForBuildDir(wd).map{$0.object}
         args += Xld
 
-        if module.type == .Library {
+        if module.type == .library {
             args += ["-shared"]
         }
 
-        let productPath = Path.join(prefix, module.type == .Library ? "lib\(module.c99name).so" : module.c99name)
+        let productPath = Path.join(prefix, module.type == .library ? "lib\(module.c99name).so" : module.c99name)
         args += ["-o", productPath]
         
         let shell = ShellTool(description: "Linking \(module.name)",

--- a/Sources/Build/Command.compile(SwiftModule).swift
+++ b/Sources/Build/Command.compile(SwiftModule).swift
@@ -18,9 +18,9 @@ extension Command {
         var args = ["-j\(SwiftcTool.numThreads)", "-D", "SWIFT_PACKAGE"]
 
         switch conf {
-        case .Debug:
+        case .debug:
             args += ["-Onone", "-g", "-enable-testing"]
-        case .Release:
+        case .release:
             args += ["-O"]
         }
 

--- a/Sources/Build/Command.link().swift
+++ b/Sources/Build/Command.link().swift
@@ -32,7 +32,7 @@ extension Command {
         case .Library(.Dynamic), .Executable, .Test:
             args = [SWIFT_EXEC] + otherArgs
 
-            if conf == .Debug {
+            if conf == .debug {
                 args += ["-g"]
             }
             args += ["-L\(prefix)"]
@@ -56,7 +56,7 @@ extension Command {
             args += ["-F", try platformFrameworksPath()]
 
             // TODO should be llbuild rules∫
-            if conf == .Debug {
+            if conf == .debug {
                 try Utility.makeDirectories(outpath.parentDirectory)
                 try fopen(outpath.parentDirectory.parentDirectory, "Info.plist", mode: .write) { fp in
                     try fputs(product.Info.plist, fp)

--- a/Sources/Build/Configuration.swift
+++ b/Sources/Build/Configuration.swift
@@ -9,12 +9,12 @@
 */
 
 public enum Configuration {
-    case Debug, Release
+    case debug, release
 
     var dirname: String {
         switch self {
-            case .Debug: return "debug"
-            case .Release: return "release"
+            case .debug: return "debug"
+            case .release: return "release"
         }
     }
 }

--- a/Sources/Build/Error.swift
+++ b/Sources/Build/Error.swift
@@ -9,6 +9,6 @@
 */
 
 public enum Error: ErrorProtocol {
-    case NoModules
-    case InvalidPlatformPath
+    case noModules
+    case invalidPlatformPath
 }

--- a/Sources/Build/ToolProtocol.swift
+++ b/Sources/Build/ToolProtocol.swift
@@ -68,12 +68,12 @@ struct SwiftcTool: ToolProtocol {
     var tempsPath: String                   { return Path.join(prefix, "\(module.c99name).build") }
     var objects: [String]                   { return module.sources.relativePaths.map{ Path.join(tempsPath, "\($0).o") } }
     var sources: [String]                   { return module.sources.paths }
-    var isLibrary: Bool                     { return module.type == .Library }
+    var isLibrary: Bool                     { return module.type == .library }
     var enableWholeModuleOptimization: Bool {
         #if EnableWorkaroundForSR1457
             return false
         #else
-            return conf == .Release
+            return conf == .release
         #endif
     }
 

--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -21,7 +21,7 @@ public func describe(_ prefix: String, _ conf: Configuration, _ modules: [Module
     precondition(prefix.isAbsolute)
 
     guard modules.count > 0 else {
-        throw Error.NoModules
+        throw Error.noModules
     }
 
     let Xcc = Xcc.flatMap{ ["-Xcc", $0] }

--- a/Sources/Build/misc.swift
+++ b/Sources/Build/misc.swift
@@ -27,7 +27,7 @@ func platformFrameworksPath() throws -> String {
         static let value = { try? POSIX.popen(["xcrun", "--sdk", "macosx", "--show-sdk-platform-path"]) }()
     }
     guard let popened = Static.value, let chuzzled = popened.chuzzle() else {
-        throw Error.InvalidPlatformPath
+        throw Error.invalidPlatformPath
     }
     return Path.join(chuzzled, "Developer/Library/Frameworks")
 }
@@ -85,7 +85,7 @@ extension ClangModule {
 extension ClangModule {
     
     public enum ModuleMapError: ErrorProtocol {
-        case UnsupportedIncludeLayoutForModule(String)
+        case unsupportedIncludeLayoutForModule(String)
     }
     
     ///FIXME: we recompute the generated modulemap's path
@@ -122,21 +122,21 @@ extension ClangModule {
 
         let umbrellaHeaderFlat = Path.join(includeDir, "\(c99name).h")
         if umbrellaHeaderFlat.isFile {
-            guard dirs.isEmpty else { throw ModuleMapError.UnsupportedIncludeLayoutForModule(name) }
-            try createModuleMap(inDir: wd, type: .Header(umbrellaHeaderFlat))
+            guard dirs.isEmpty else { throw ModuleMapError.unsupportedIncludeLayoutForModule(name) }
+            try createModuleMap(inDir: wd, type: .header(umbrellaHeaderFlat))
             return
         }
         diagnoseInvalidUmbrellaHeader(includeDir)
 
         let umbrellaHeader = Path.join(includeDir, c99name, "\(c99name).h")
         if umbrellaHeader.isFile {
-            guard dirs.count == 1 && files.isEmpty else { throw ModuleMapError.UnsupportedIncludeLayoutForModule(name) }
-            try createModuleMap(inDir: wd, type: .Header(umbrellaHeader))
+            guard dirs.count == 1 && files.isEmpty else { throw ModuleMapError.unsupportedIncludeLayoutForModule(name) }
+            try createModuleMap(inDir: wd, type: .header(umbrellaHeader))
             return
         }
         diagnoseInvalidUmbrellaHeader(Path.join(includeDir, c99name))
 
-        try createModuleMap(inDir: wd, type: .Directory(includeDir))
+        try createModuleMap(inDir: wd, type: .directory(includeDir))
     }
 
     ///warn user if in case module name and c99name are different and there a `name.h` umbrella header
@@ -149,8 +149,8 @@ extension ClangModule {
     }
 
     private enum UmbrellaType {
-        case Header(String)
-        case Directory(String)
+        case header(String)
+        case directory(String)
     }
     
     private func createModuleMap(inDir wd: String, type: UmbrellaType) throws {
@@ -161,9 +161,9 @@ extension ClangModule {
         
         var output = "module \(c99name) {\n"
         switch type {
-        case .Header(let header):
+        case .header(let header):
             output += "    umbrella header \"\(header)\"\n"
-        case .Directory(let path):
+        case .directory(let path):
             output += "    umbrella \"\(path)\"\n"
         }
         output += "    link \"\(c99name)\"\n"
@@ -230,11 +230,11 @@ extension SystemPackageProvider {
         guard let platform = Platform.currentPlatform else { return false }
         switch self {
         case .Brew(_):
-            if case .Darwin = platform  {
+            if case .darwin = platform  {
                 return true
             }
         case .Apt(_):
-            if case .Linux(.Debian) = platform  {
+            if case .linux(.debian) = platform  {
                 return true
             }
         }

--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -18,25 +18,25 @@ import func Utility.isTTY
 import var Utility.stderr
 
 public enum Error: ErrorProtocol {
-    case NoManifestFound
-    case InvalidToolchain
-    case InvalidInstallation(String)
-    case InvalidSwiftExec(String)
-    case BuildYAMLNotFound(String)
+    case noManifestFound
+    case invalidToolchain
+    case invalidInstallation(String)
+    case invalidSwiftExec(String)
+    case buildYAMLNotFound(String)
 }
 
 extension Error: CustomStringConvertible {
     public var description: String {
         switch self {
-        case .NoManifestFound:
+        case .noManifestFound:
             return "no \(Manifest.filename) file found"
-        case .InvalidToolchain:
+        case .invalidToolchain:
             return "invalid inferred toolchain"
-        case .InvalidInstallation(let prefix):
+        case .invalidInstallation(let prefix):
             return "invalid or incomplete Swift toolchain:\n    \(prefix)"
-        case .InvalidSwiftExec(let value):
+        case .invalidSwiftExec(let value):
             return "invalid SWIFT_EXEC value: \(value)"
-        case .BuildYAMLNotFound(let value):
+        case .buildYAMLNotFound(let value):
             return "no build YAML found: \(value)"
         }
     }
@@ -45,17 +45,17 @@ extension Error: CustomStringConvertible {
 @noreturn public func handle(error: Any, usage: ((String) -> Void) -> Void) {
 
     switch error {
-    case OptionParserError.MultipleModesSpecified(let modes):
+    case OptionParserError.multipleModesSpecified(let modes):
         print(error: error)
 
-        if isTTY(.StdErr)
+        if isTTY(.stdErr)
              && (modes.contains{ ["--help", "-h", "--usage"].contains($0) }) {
             print("", to: &stderr)
             usage { print($0, to: &stderr) }
         }
     case is OptionParserError:
         print(error: error)
-        if isTTY(.StdErr) {
+        if isTTY(.stdErr) {
             let argv0 = Process.arguments.first ?? "swift build"
             print("enter `\(argv0) --help' for usage information", to: &stderr)
         }
@@ -67,8 +67,8 @@ extension Error: CustomStringConvertible {
 }
 
 private func print(error: Any) {
-    if ColorWrap.isAllowed(for: .StdErr) {
-        print(ColorWrap.wrap("error:", with: .Red, for: .StdErr), error, to: &stderr)
+    if ColorWrap.isAllowed(for: .stdErr) {
+        print(ColorWrap.wrap("error:", with: .Red, for: .stdErr), error, to: &stderr)
     } else {
         let cmd = Process.arguments.first?.basename ?? "SwiftPM"
         print("\(cmd): error:", error, to: &stderr)

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -50,7 +50,7 @@ private func getroot() -> String {
             // don't have to correctly figure out all those paths
             // ahead of time, since that is flakier
             
-            let header = ColorWrap.wrap("error:", with: .Red, for: .StdErr) 
+            let header = ColorWrap.wrap("error:", with: .Red, for: .stdErr) 
 
             print("\(header): no Package.swift found", to: &stderr)
             exit(1)

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -31,35 +31,35 @@ extension PackageToolOptions: XcodeprojOptions {}
 
 private enum Mode: Argument, Equatable, CustomStringConvertible {
     case Init(InitMode)
-    case Doctor
-    case ShowDependencies(ShowDependenciesMode)
-    case Fetch
-    case Update
-    case Usage
-    case Version
-    case GenerateXcodeproj(String?)
-    case DumpPackage(String?)
+    case doctor
+    case showDependencies(ShowDependenciesMode)
+    case fetch
+    case update
+    case usage
+    case version
+    case generateXcodeproj(String?)
+    case dumpPackage(String?)
 
     init?(argument: String, pop: () -> String?) throws {
         switch argument {
         case "init", "initialize":
             self = try .Init(InitMode(pop()))
         case "doctor":
-            self = .Doctor
+            self = .doctor
         case "show-dependencies", "-D":
-            self = try .ShowDependencies(ShowDependenciesMode(pop()))
+            self = try .showDependencies(ShowDependenciesMode(pop()))
         case "fetch":
-            self = .Fetch
+            self = .fetch
         case "update":
-            self = .Update
+            self = .update
         case "help", "usage", "--help", "-h":
-            self = .Usage
+            self = .usage
         case "version":
-            self = .Version
+            self = .version
         case "generate-xcodeproj":
-            self = .GenerateXcodeproj(pop())
+            self = .generateXcodeproj(pop())
         case "dump-package":
-            self = .DumpPackage(pop())
+            self = .dumpPackage(pop())
         default:
             return nil
         }
@@ -68,14 +68,14 @@ private enum Mode: Argument, Equatable, CustomStringConvertible {
     var description: String {
         switch self {
         case .Init(let type): return "init=\(type)"
-        case .Doctor: return "doctor"
-        case .ShowDependencies: return "show-dependencies"
-        case .GenerateXcodeproj: return "generate-xcodeproj"
-        case .Fetch: return "fetch"
-        case .Update: return "update"
-        case .Usage: return "help"
-        case .Version: return "version"
-        case .DumpPackage: return "dump-package"
+        case .doctor: return "doctor"
+        case .showDependencies: return "show-dependencies"
+        case .generateXcodeproj: return "generate-xcodeproj"
+        case .fetch: return "fetch"
+        case .update: return "update"
+        case .usage: return "help"
+        case .version: return "version"
+        case .dumpPackage: return "dump-package"
         }
     }
 }
@@ -83,9 +83,9 @@ private enum Mode: Argument, Equatable, CustomStringConvertible {
 private enum PackageToolFlag: Argument {
     case chdir(String)
     case colorMode(ColorWrap.Mode)
-    case Xcc(String)
-    case Xld(String)
-    case Xswiftc(String)
+    case xcc(String)
+    case xld(String)
+    case xswiftc(String)
     case xcconfigOverrides(String)
     case ignoreDependencies
     case verbose(Int)
@@ -93,7 +93,7 @@ private enum PackageToolFlag: Argument {
     init?(argument: String, pop: () -> String?) throws {
 
         func forcePop() throws -> String {
-            guard let value = pop() else { throw OptionParserError.ExpectedAssociatedValue(argument) }
+            guard let value = pop() else { throw OptionParserError.expectedAssociatedValue(argument) }
             return value
         }
 
@@ -107,7 +107,7 @@ private enum PackageToolFlag: Argument {
         case "--color":
             let rawValue = try forcePop()
             guard let mode = ColorWrap.Mode(rawValue) else  {
-                throw OptionParserError.InvalidUsage("invalid color mode: \(rawValue)")
+                throw OptionParserError.invalidUsage("invalid color mode: \(rawValue)")
             }
             self = .colorMode(mode)
         case "--ignore-dependencies":
@@ -168,31 +168,31 @@ public struct SwiftPackageTool {
                 let initPackage = try InitPackage(mode: initMode)
                 try initPackage.writePackageStructure()
                             
-            case .Update:
+            case .update:
                 try Utility.removeFileTree(opts.path.Packages)
                 fallthrough
                 
-            case .Fetch:
+            case .fetch:
                 _ = try fetch(opts.path.root)
         
-            case .Usage:
+            case .usage:
                 usage()
         
-            case .Doctor:
+            case .doctor:
                 doctor()
             
-            case .ShowDependencies(let mode):
+            case .showDependencies(let mode):
                 let (rootPackage, _) = try fetch(opts.path.root)
                 dumpDependenciesOf(rootPackage: rootPackage, mode: mode)
         
-            case .Version:
+            case .version:
                 #if HasCustomVersionString
                     print(String(cString: VersionInfo.DisplayString()))
                 #else
                     print("Swift Package Manager – Swift 3.0")
                 #endif
                 
-            case .GenerateXcodeproj(let outpath):
+            case .generateXcodeproj(let outpath):
                 let (rootPackage, externalPackages) = try fetch(opts.path.root)
                 let (modules, externalModules, products) = try transmute(rootPackage, externalPackages: externalPackages)
                 
@@ -219,7 +219,7 @@ public struct SwiftPackageTool {
         
                 print("generated:", outpath.prettyPath)
                 
-            case .DumpPackage(let packagePath):
+            case .dumpPackage(let packagePath):
                 
                 let root = packagePath ?? opts.path.root
                 let manifest = try parseManifest(path: root, baseURL: root)
@@ -265,11 +265,11 @@ public struct SwiftPackageTool {
             switch flag {
             case .chdir(let path):
                 opts.chdir = path
-            case .Xcc(let value):
+            case .xcc(let value):
                 opts.Xcc.append(value)
-            case .Xld(let value):
+            case .xld(let value):
                 opts.Xld.append(value)
-            case .Xswiftc(let value):
+            case .xswiftc(let value):
                 opts.Xswiftc.append(value)
             case .verbose(let amount):
                 opts.verbosity += amount
@@ -285,7 +285,7 @@ public struct SwiftPackageTool {
             return (mode, opts)
         }
         else {
-            throw OptionParserError.InvalidUsage("no command provided: \(args)")
+            throw OptionParserError.invalidUsage("no command provided: \(args)")
         }
     }
 }

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -17,29 +17,29 @@ import func POSIX.chdir
 import func libc.exit
 
 private enum TestError: ErrorProtocol {
-    case TestsExecutableNotFound
+    case testsExecutableNotFound
 }
 
 extension TestError: CustomStringConvertible {
     var description: String {
         switch self {
-        case .TestsExecutableNotFound:
+        case .testsExecutableNotFound:
             return "no tests found to execute, create a module in your `Tests' directory"
         }
     }
 }
 
 private enum Mode: Argument, Equatable, CustomStringConvertible {
-    case Usage
-    case Run(String?)
+    case usage
+    case run(String?)
 
     init?(argument: String, pop: () -> String?) throws {
         switch argument {
         case "--help", "--usage", "-h":
-            self = .Usage
+            self = .usage
         case "-s":
-            guard let specifier = pop() else { throw OptionParserError.ExpectedAssociatedValue(argument) }
-            self = .Run(specifier)
+            guard let specifier = pop() else { throw OptionParserError.expectedAssociatedValue(argument) }
+            self = .run(specifier)
         default:
             return nil
         }
@@ -47,9 +47,9 @@ private enum Mode: Argument, Equatable, CustomStringConvertible {
 
     var description: String {
         switch self {
-        case .Usage:
+        case .usage:
             return "--help"
-        case .Run(let specifier):
+        case .run(let specifier):
             return specifier ?? ""
         }
     }
@@ -65,7 +65,7 @@ private enum TestToolFlag: Argument {
     init?(argument: String, pop: () -> String?) throws {
         switch argument {
         case "--chdir", "-C":
-            guard let path = pop() else { throw OptionParserError.ExpectedAssociatedValue(argument) }
+            guard let path = pop() else { throw OptionParserError.expectedAssociatedValue(argument) }
             self = .chdir(path)
         default:
             return nil
@@ -90,10 +90,10 @@ public struct SwiftTestTool {
             }
         
             switch mode {
-            case .Usage:
+            case .usage:
                 usage()
         
-            case .Run(let specifier):
+            case .run(let specifier):
                 let configuration = "debug"  //FIXME should swift-test support configuration option?
         
                 func determineTestPath() throws -> String {
@@ -113,7 +113,7 @@ public struct SwiftTestTool {
                         }
                         
                         guard let path = possiblePaths.first else {
-                            throw TestError.TestsExecutableNotFound
+                            throw TestError.testsExecutableNotFound
                         }
                         
                         return path
@@ -125,7 +125,7 @@ public struct SwiftTestTool {
                 let success = try test(path: determineTestPath(), xctestArg: specifier)
                 exit(success ? 0 : 1)
             }
-        } catch Error.BuildYAMLNotFound {
+        } catch Error.buildYAMLNotFound {
             print("error: you must run `swift build` first", to: &stderr)
             exit(1)
         } catch {
@@ -159,12 +159,12 @@ public struct SwiftTestTool {
             }
         }
 
-        return (mode ?? .Run(nil), opts)
+        return (mode ?? .run(nil), opts)
     }
 
     private func test(path: String, xctestArg: String? = nil) throws -> Bool {
         guard path.isValidTest else {
-            throw TestError.TestsExecutableNotFound
+            throw TestError.testsExecutableNotFound
         }
 
         var args: [String] = []

--- a/Sources/Commands/UserToolchain.swift
+++ b/Sources/Commands/UserToolchain.swift
@@ -47,10 +47,10 @@ struct UserToolchain: Toolchain {
             #endif
 
             guard !SWIFT_EXEC.isEmpty && !clang.isEmpty && (sysroot == nil || !sysroot!.isEmpty) else {
-                throw Error.InvalidToolchain
+                throw Error.invalidToolchain
             }
-        } catch POSIX.Error.ExitStatus {
-            throw Error.InvalidToolchain
+        } catch POSIX.Error.exitStatus {
+            throw Error.invalidToolchain
         }
     }
 }

--- a/Sources/Commands/build().swift
+++ b/Sources/Commands/build().swift
@@ -20,7 +20,7 @@ public func build(YAMLPath: String, target: String? = nil) throws {
         if let target = target {
             args += [target]
         }
-        if verbosity != .Concise { args.append("-v") }
+        if verbosity != .concise { args.append("-v") }
         try system(args)
     } catch {
 
@@ -32,7 +32,7 @@ public func build(YAMLPath: String, target: String? = nil) throws {
         if YAMLPath.isFile {
             throw error
         } else {
-            throw Error.BuildYAMLNotFound(YAMLPath)
+            throw Error.buildYAMLNotFound(YAMLPath)
         }
     }
 }

--- a/Sources/Commands/init.swift
+++ b/Sources/Commands/init.swift
@@ -18,13 +18,13 @@ import func Utility.makeDirectories
 import struct Utility.Path
 
 private enum InitError: ErrorProtocol {
-    case ManifestAlreadyExists
+    case manifestAlreadyExists
 }
 
 extension InitError: CustomStringConvertible {
     var description: String {
         switch self {
-        case .ManifestAlreadyExists:
+        case .manifestAlreadyExists:
             return "a manifest file already exists in this directory"
         }
     }
@@ -55,7 +55,7 @@ final class InitPackage {
     private func writeManifestFile() throws {
         let manifest = Path.join(rootd, Manifest.filename)
         guard manifest.exists == false else {
-            throw InitError.ManifestAlreadyExists
+            throw InitError.manifestAlreadyExists
         }
         
         let packageFP = try Utility.fopen(manifest, mode: .write)
@@ -93,16 +93,16 @@ final class InitPackage {
         print("Creating Sources/")
         try Utility.makeDirectories(sources)
     
-        let sourceFileName = (mode == .Executable) ? "main.swift" : "\(pkgname).swift"
+        let sourceFileName = (mode == .executable) ? "main.swift" : "\(pkgname).swift"
         let sourceFile = Path.join(sources, sourceFileName)
         let sourceFileFP = try Utility.fopen(sourceFile, mode: .write)
         defer { sourceFileFP.closeFile() }
         print("Creating Sources/\(sourceFileName)")
         switch mode {
-        case .Library:            
+        case .library:
             try fputs("struct \(pkgname) {\n\n", sourceFileFP)
             try fputs("}\n", sourceFileFP)
-        case .Executable:
+        case .executable:
             try fputs("print(\"Hello, world!\")\n", sourceFileFP)
         }
     }
@@ -115,7 +115,7 @@ final class InitPackage {
         print("Creating Tests/")
         try Utility.makeDirectories(tests)
         ///Only libraries are testable for now
-        if mode == .Library {
+        if mode == .library {
             try writeLinuxMain(testsPath: tests)
             try writeTestFileStubs(testsPath: tests)
         }
@@ -166,23 +166,23 @@ final class InitPackage {
 
 /// Represents a package type for the purposes of initialization.
 enum InitMode: CustomStringConvertible {
-    case Library, Executable
+    case library, executable
 
     init(_ rawValue: String?) throws {
         switch rawValue?.lowercased() {
         case "library"?, "lib"?:
-            self = .Library
+            self = .library
         case nil, "executable"?, "exec"?, "exe"?:
-            self = .Executable
+            self = .executable
         default:
-            throw OptionParserError.InvalidUsage("invalid initialization type: \(rawValue)")
+            throw OptionParserError.invalidUsage("invalid initialization type: \(rawValue)")
         }
     }
 
     var description: String {
         switch self {
-            case .Library: return "library"
-            case .Executable: return "executable"
+            case .library: return "library"
+            case .executable: return "executable"
         }
     }
 }

--- a/Sources/Commands/show-dependencies.swift
+++ b/Sources/Commands/show-dependencies.swift
@@ -15,11 +15,11 @@ import struct PackageDescription.Version
 func dumpDependenciesOf(rootPackage: Package, mode: ShowDependenciesMode) {
     let dumper: DependenciesDumper
     switch mode {
-    case .Text:
+    case .text:
         dumper = PlainTextDumper()
-    case .DOT:
+    case .dot:
         dumper = DotDumper()
-    case .JSON:
+    case .json:
         dumper = JsonDumper()
     }
     dumper.dump(dependenciesOf: rootPackage)
@@ -118,31 +118,31 @@ private final class JsonDumper: DependenciesDumper {
 }
 
 enum ShowDependenciesMode: CustomStringConvertible {
-    case Text, DOT, JSON
+    case text, dot, json
     
     init(_ rawValue: String?) throws {
         guard let rawValue = rawValue else {
-            self = .Text
+            self = .text
             return
         }
         
         switch rawValue.lowercased() {
         case "text":
-           self = .Text
+           self = .text
         case "dot":
-           self = .DOT
+           self = .dot
         case "json":
-           self = .JSON
+           self = .json
         default:
-            throw OptionParserError.InvalidUsage("invalid show dependencies mode: \(rawValue)")
+            throw OptionParserError.invalidUsage("invalid show dependencies mode: \(rawValue)")
         }
     }
     
     var description: String {
         switch self {
-        case .Text: return "text"
-        case .DOT: return "dot"
-        case .JSON: return "json"
+        case .text: return "text"
+        case .dot: return "dot"
+        case .json: return "json"
         }
     }
 }

--- a/Sources/Get/Error.swift
+++ b/Sources/Get/Error.swift
@@ -15,28 +15,28 @@ enum Error: ErrorProtocol {
     typealias ClonePath = String
     typealias URL = String
 
-    case GitCloneFailure(URL, ClonePath)
-    case InvalidDependencyGraph(ClonePath)
-    case NoManifest(ClonePath, Version)
-    case UpdateRequired(ClonePath)
-    case Unversioned(ClonePath)
-    case InvalidDependencyGraphMissingTag(package: String, requestedTag: String, existingTags: String)
+    case gitCloneFailure(URL, ClonePath)
+    case invalidDependencyGraph(ClonePath)
+    case noManifest(ClonePath, Version)
+    case updateRequired(ClonePath)
+    case unversioned(ClonePath)
+    case invalidDependencyGraphMissingTag(package: String, requestedTag: String, existingTags: String)
 }
 
 extension Error: CustomStringConvertible {
     var description: String {
         switch self {
-        case .InvalidDependencyGraph(let package):
+        case .invalidDependencyGraph(let package):
             return "The dependency graph could not be satisfied (\(package))"
-        case .InvalidDependencyGraphMissingTag(let package, let requestedTag, let existingTags):
+        case .invalidDependencyGraphMissingTag(let package, let requestedTag, let existingTags):
             return "The dependency graph could not be satisfied. The package (\(package)) with version tag in range (\(requestedTag)) is not found. Found tags (\(existingTags))"
-        case .UpdateRequired(let package):
+        case .updateRequired(let package):
             return "The dependency graph could not be satisfied because an update to `\(package)' is required"
-        case .GitCloneFailure(let url, let dstdir):
+        case .gitCloneFailure(let url, let dstdir):
             return "Failed to clone \(url) to \(dstdir)"
-        case .Unversioned(let package):
+        case .unversioned(let package):
             return "No version tag found in (\(package)) package. Add a version tag with \"git tag\" command. Example: \"git tag 0.1.0\""
-        case .NoManifest(let clonePath, let version):
+        case .noManifest(let clonePath, let version):
             return "The package at `\(clonePath)' has no Package.swift for the specific version: \(version)"
         }
     }

--- a/Sources/Get/Fetcher.swift
+++ b/Sources/Get/Fetcher.swift
@@ -40,7 +40,7 @@ extension Fetcher {
 
                 func adjust(_ pkg: Fetchable, _ versionRange: Range<Version>) throws {
                     guard let v = pkg.constrain(to: versionRange) else {
-                        throw Error.InvalidDependencyGraphMissingTag(package: url, requestedTag: "\(versionRange)", existingTags: "\(pkg.availableVersions)")
+                        throw Error.invalidDependencyGraphMissingTag(package: url, requestedTag: "\(versionRange)", existingTags: "\(pkg.availableVersions)")
                     }
                     try pkg.setVersion(v)
                 }
@@ -51,7 +51,7 @@ extension Fetcher {
                     // verify that it satisfies the requested version range
 
                     guard let updatedRange = cumulativeVersionRange.constrain(to: specifiedVersionRange) else {
-                        throw Error.InvalidDependencyGraph(url)
+                        throw Error.invalidDependencyGraph(url)
                     }
 
                     if updatedRange ~= pkg.version {
@@ -80,7 +80,7 @@ extension Fetcher {
                     // range.
 
                     guard specifiedVersionRange ~= pkg.version else {
-                        throw Error.UpdateRequired(url)
+                        throw Error.updateRequired(url)
                     }
                     graph[url] = (pkg, specifiedVersionRange)
                     return try recurse(pkg.children) + [url]

--- a/Sources/Get/Git.swift
+++ b/Sources/Get/Git.swift
@@ -35,12 +35,12 @@ extension Git {
                        "--recursive",   // get submodules too so that developers can use these if they so choose
                 "--depth", "10",
                 url, dstdir, environment: environment, message: "Cloning \(url)")
-        } catch POSIX.Error.ExitStatus {
+        } catch POSIX.Error.exitStatus {
             // Git 2.0 or higher is required
             if Git.majorVersionNumber < 2 {
-                throw Utility.Error.ObsoleteGitVersion
+                throw Utility.Error.obsoleteGitVersion
             } else {
-                throw Error.GitCloneFailure(url, dstdir)
+                throw Error.gitCloneFailure(url, dstdir)
             }
         }
 

--- a/Sources/Get/Package.swift
+++ b/Sources/Get/Package.swift
@@ -16,7 +16,7 @@ extension Package {
     // FIXME we *always* have a manifest, don't reparse it
 
     static func make(repo: Git.Repo, manifestParser: (path: String, url: String) throws -> Manifest) throws -> Package? {
-        guard let origin = repo.origin else { throw Error.NoOrigin(repo.path) }
+        guard let origin = repo.origin else { throw Error.noOrigin(repo.path) }
         let manifest = try manifestParser(path: repo.path, url: origin)
         let pkg = Package(manifest: manifest, url: origin)
         if let version = Version(pkg.versionString) {
@@ -49,6 +49,6 @@ extension Package: Fetchable {
     }
 
     func setVersion(_ newValue: Version) throws {
-        throw Get.Error.InvalidDependencyGraph(url)
+        throw Get.Error.invalidDependencyGraph(url)
     }
 }

--- a/Sources/Get/RawClone.swift
+++ b/Sources/Get/RawClone.swift
@@ -40,7 +40,7 @@ class RawClone: Fetchable {
         self.path = path
         self.manifestParser = manifestParser
         if !repo.hasVersion {
-            throw Error.Unversioned(path)
+            throw Error.unversioned(path)
         }
     }
 
@@ -71,7 +71,7 @@ class RawClone: Fetchable {
         // we must re-read the manifest
         _manifest = nil
         if manifest == nil {
-            throw Error.NoManifest(path, ver)
+            throw Error.noManifest(path, ver)
         }
     }
 

--- a/Sources/POSIX/Error.swift
+++ b/Sources/POSIX/Error.swift
@@ -102,8 +102,8 @@ extension SystemError: CustomStringConvertible {
 
 
 public enum Error: ErrorProtocol {
-    case ExitStatus(Int32, [String])
-    case ExitSignal
+    case exitStatus(Int32, [String])
+    case exitSignal
 }
 
 public enum ShellError: ErrorProtocol {
@@ -114,10 +114,10 @@ public enum ShellError: ErrorProtocol {
 extension Error: CustomStringConvertible {
     public var description: String {
         switch self {
-        case .ExitStatus(let code, let args):
+        case .exitStatus(let code, let args):
             return "exit(\(code)): \(prettyArguments(args))"
 
-        case .ExitSignal:
+        case .exitSignal:
             return "Child process exited with signal"
         }
     }

--- a/Sources/POSIX/popen.swift
+++ b/Sources/POSIX/popen.swift
@@ -94,7 +94,7 @@ public func popen(_ arguments: [String], redirectStandardError: Bool = false, en
         let exitStatus = try POSIX.waitpid(pid)
 
         guard exitStatus == 0 else {
-            throw Error.ExitStatus(exitStatus, arguments)
+            throw Error.exitStatus(exitStatus, arguments)
         }
 
     } catch let underlyingError as SystemError {

--- a/Sources/POSIX/system.swift
+++ b/Sources/POSIX/system.swift
@@ -32,7 +32,7 @@ public func system(_ arguments: [String], environment: [String:String] = [:]) th
     do {
         let pid = try posix_spawnp(arguments[0], args: arguments, environment: environment)
         let exitStatus = try waitpid(pid)
-        guard exitStatus == 0 else { throw Error.ExitStatus(exitStatus, arguments) }
+        guard exitStatus == 0 else { throw Error.exitStatus(exitStatus, arguments) }
     } catch let underlyingError as SystemError {
         throw ShellError.system(arguments: arguments, underlyingError)
     }
@@ -106,7 +106,7 @@ func waitpid(_ pid: pid_t) throws -> Int32 {
             if WIFEXITED(exitStatus) {
                 return WEXITSTATUS(exitStatus)
             } else {
-                throw Error.ExitSignal
+                throw Error.exitSignal
             }
         } else if errno == EINTR {
             continue  // see: man waitpid

--- a/Sources/PackageLoading/Manifest+parse.swift
+++ b/Sources/PackageLoading/Manifest+parse.swift
@@ -32,7 +32,7 @@ extension Manifest {
         let path: String = inputPath.isDirectory ? Path.join(inputPath, Manifest.filename) : inputPath
 
         // Validate that the file exists.
-        guard path.isFile else { throw PackageModel.Package.Error.NoManifest(path) }
+        guard path.isFile else { throw PackageModel.Package.Error.noManifest(path) }
 
         // Load the manifest description.
         if let toml = try parse(path: path, swiftc: swiftc, libdir: libdir) {
@@ -103,29 +103,29 @@ extension PackageDescription.Package {
     static func fromTOML(_ item: TOMLItem, baseURL: String? = nil) -> PackageDescription.Package {
         // This is a private API, currently, so we do not currently try and
         // validate the input.
-        guard case .Table(let topLevelTable) = item else { fatalError("unexpected item") }
-        guard case .Table(let table)? = topLevelTable.items["package"] else { fatalError("missing package") }
+        guard case .table(let topLevelTable) = item else { fatalError("unexpected item") }
+        guard case .table(let table)? = topLevelTable.items["package"] else { fatalError("missing package") }
 
         var name: String? = nil
-        if case .String(let value)? = table.items["name"] {
+        if case .string(let value)? = table.items["name"] {
             name = value
         }
         
         var pkgConfig: String? = nil
-        if case .String(let value)? = table.items["pkgConfig"] {
+        if case .string(let value)? = table.items["pkgConfig"] {
             pkgConfig = value
         }
 
         // Parse the targets.
         var targets: [PackageDescription.Target] = []
-        if case .Array(let array)? = table.items["targets"] {
+        if case .array(let array)? = table.items["targets"] {
             for item in array.items {
                 targets.append(PackageDescription.Target.fromTOML(item))
             }
         }
         
         var providers: [PackageDescription.SystemPackageProvider]? = nil
-        if case .Array(let array)? = table.items["providers"] {
+        if case .array(let array)? = table.items["providers"] {
             providers = []
             for item in array.items {
                 providers?.append(PackageDescription.SystemPackageProvider.fromTOML(item))
@@ -134,7 +134,7 @@ extension PackageDescription.Package {
         
         // Parse the dependencies.
         var dependencies: [PackageDescription.Package.Dependency] = []
-        if case .Array(let array)? = table.items["dependencies"] {
+        if case .array(let array)? = table.items["dependencies"] {
             for item in array.items {
                 dependencies.append(PackageDescription.Package.Dependency.fromTOML(item, baseURL: baseURL))
             }
@@ -142,7 +142,7 @@ extension PackageDescription.Package {
 
         // Parse the test dependencies.
         var testDependencies: [PackageDescription.Package.Dependency] = []
-        if case .Array(let array)? = table.items["testDependencies"] {
+        if case .array(let array)? = table.items["testDependencies"] {
             for item in array.items {
                 testDependencies.append(PackageDescription.Package.Dependency.fromTOML(item, baseURL: baseURL))
             }
@@ -150,9 +150,9 @@ extension PackageDescription.Package {
 
         //Parse the exclude folders.
         var exclude: [String] = []
-        if case .Array(let array)? = table.items["exclude"] {
+        if case .array(let array)? = table.items["exclude"] {
             for item in array.items {
-                guard case .String(let excludeItem) = item else { fatalError("exclude contains non string element") }
+                guard case .string(let excludeItem) = item else { fatalError("exclude contains non string element") }
                 exclude.append(excludeItem)
             }
         }
@@ -163,12 +163,12 @@ extension PackageDescription.Package {
 
 extension PackageDescription.Package.Dependency {
     static func fromTOML(_ item: TOMLItem, baseURL: String?) -> PackageDescription.Package.Dependency {
-        guard case .Array(let array) = item where array.items.count == 3 else {
+        guard case .array(let array) = item where array.items.count == 3 else {
             fatalError("Unexpected TOMLItem")
         }
-        guard case .String(let url) = array.items[0],
-              case .String(let vv1) = array.items[1],
-              case .String(let vv2) = array.items[2],
+        guard case .string(let url) = array.items[0],
+              case .string(let vv1) = array.items[1],
+              case .string(let vv2) = array.items[2],
               let v1 = Version(vv1), v2 = Version(vv2)
         else {
             fatalError("Unexpected TOMLItem")
@@ -188,9 +188,9 @@ extension PackageDescription.Package.Dependency {
 
 extension PackageDescription.SystemPackageProvider {
     private static func fromTOML(_ item: TOMLItem) -> PackageDescription.SystemPackageProvider {
-        guard case .Table(let table) = item else { fatalError("unexpected item") }
-        guard case .String(let name)? = table.items["name"] else { fatalError("missing name") }
-        guard case .String(let value)? = table.items["value"] else { fatalError("missing value") }
+        guard case .table(let table) = item else { fatalError("unexpected item") }
+        guard case .string(let name)? = table.items["name"] else { fatalError("missing name") }
+        guard case .string(let value)? = table.items["value"] else { fatalError("missing value") }
         switch name {
         case "Brew":
             return .Brew(value)
@@ -206,13 +206,13 @@ extension PackageDescription.Target {
     private static func fromTOML(_ item: TOMLItem) -> PackageDescription.Target {
         // This is a private API, currently, so we do not currently try and
         // validate the input.
-        guard case .Table(let table) = item else { fatalError("unexpected item") }
+        guard case .table(let table) = item else { fatalError("unexpected item") }
 
-        guard case .String(let name)? = table.items["name"] else { fatalError("missing name") }
+        guard case .string(let name)? = table.items["name"] else { fatalError("missing name") }
 
         // Parse the dependencies.
         var dependencies: [PackageDescription.Target.Dependency] = []
-        if case .Array(let array)? = table.items["dependencies"] {
+        if case .array(let array)? = table.items["dependencies"] {
             for item in array.items {
                 dependencies.append(PackageDescription.Target.Dependency.fromTOML(item))
             }
@@ -224,7 +224,7 @@ extension PackageDescription.Target {
 
 extension PackageDescription.Target.Dependency {
     private static func fromTOML(_ item: TOMLItem) -> PackageDescription.Target.Dependency {
-        guard case .String(let name) = item else { fatalError("unexpected item") }
+        guard case .string(let name) = item else { fatalError("unexpected item") }
         return .Target(name: name)
     }
 }
@@ -232,27 +232,27 @@ extension PackageDescription.Target.Dependency {
 
 extension PackageDescription.Product {
     private init(toml item: TOMLItem) {
-        guard case .Table(let table) = item else { fatalError("unexpected item") }
-        guard case .String(let name)? = table.items["name"] else { fatalError("missing name") }
+        guard case .table(let table) = item else { fatalError("unexpected item") }
+        guard case .string(let name)? = table.items["name"] else { fatalError("missing name") }
 
         let type: ProductType
         switch table.items["type"] {
-        case .String("exe")?:
+        case .string("exe")?:
             type = .Executable
-        case .String("a")?:
+        case .string("a")?:
             type = .Library(.Static)
-        case .String("dylib")?:
+        case .string("dylib")?:
             type = .Library(.Dynamic)
-        case .String("test")?:
+        case .string("test")?:
             type = .Test
         default:
             fatalError("missing type")
         }
 
-        guard case .Array(let mods)? = table.items["mods"] else { fatalError("missing mods") }
+        guard case .array(let mods)? = table.items["mods"] else { fatalError("missing mods") }
 
         let modules = mods.items.map { item -> String in
-            guard case TOMLItem.String(let string) = item else { fatalError("invalid modules") }
+            guard case TOMLItem.string(let string) = item else { fatalError("invalid modules") }
             return string
         }
 
@@ -260,9 +260,9 @@ extension PackageDescription.Product {
     }
 
     static func fromTOML(_ item: TOMLItem) -> [PackageDescription.Product] {
-        guard case .Table(let root) = item else { fatalError("unexpected item") }
+        guard case .table(let root) = item else { fatalError("unexpected item") }
         guard let productsItem = root.items["products"] else { return [] }
-        guard case .Array(let array) = productsItem else { fatalError("products wrong type") }
+        guard case .array(let array) = productsItem else { fatalError("products wrong type") }
         return array.items.map(Product.init)
     }
 }

--- a/Sources/PackageLoading/Module+PkgConfig.swift
+++ b/Sources/PackageLoading/Module+PkgConfig.swift
@@ -41,7 +41,7 @@ extension ModuleProtocol {
                 libs += pkgConfig.libs
                 try whitelist(pcFile: pkgConfigName, flags: (cFlags, libs))
             }
-            catch PkgConfigError.CouldNotFindConfigFile {
+            catch PkgConfigError.couldNotFindConfigFile {
                 if let providers = module.providers,
                     provider = SystemPackageProvider.providerForCurrentPlatform(providers: providers) {
                     print("note: you may be able to install \(pkgConfigName) using your system-packager:\n")
@@ -68,11 +68,11 @@ private extension SystemPackageProvider {
         guard let platform = Platform.currentPlatform else { return false }
         switch self {
         case .Brew(_):
-            if case .Darwin = platform  {
+            if case .darwin = platform  {
                 return true
             }
         case .Apt(_):
-            if case .Linux(.Debian) = platform  {
+            if case .linux(.debian) = platform  {
                 return true
             }
         }
@@ -109,6 +109,6 @@ func whitelist(pcFile: String, flags: (cFlags: [String], libs: [String])) throws
     }
     let filtered = filter(flags: flags.cFlags, filters: ["-I", "-F"]) + filter(flags: flags.libs, filters: ["-L", "-l", "-F", "-framework"])
     guard filtered.isEmpty else {
-        throw PkgConfigError.NonWhitelistedFlags("Non whitelisted flags found: \(filtered) in pc file \(pcFile)")
+        throw PkgConfigError.nonWhitelistedFlags("Non whitelisted flags found: \(filtered) in pc file \(pcFile)")
     }
 }

--- a/Sources/PackageLoading/transmute.swift
+++ b/Sources/PackageLoading/transmute.swift
@@ -24,7 +24,7 @@ public func transmute(_ rootPackage: Package, externalPackages: [Package]) throw
         var modules: [Module]
         do {
             modules = try package.modules()
-        } catch Package.ModuleError.NoModules(let pkg) where pkg === rootPackage {
+        } catch Package.ModuleError.noModules(let pkg) where pkg === rootPackage {
             //Ignore and print warning if root package doesn't contain any sources
             print("warning: root package '\(pkg)' does not contain any sources")
             if packages.count == 1 { exit(0) } //Exit now if there is no more packages 
@@ -88,7 +88,7 @@ private func fillModuleGraph(_ packages: [Package], modulesForPackage: (Package)
                 switch $0 {
                 case is TestModule:
                     return false
-                case let module as SwiftModule where module.type == .Library:
+                case let module as SwiftModule where module.type == .library:
                     return true
                 case is CModule:
                     return true
@@ -143,7 +143,7 @@ private func recursiveDependencies(_ modules: [Module]) throws -> [Module] {
                 continue;
             }
 
-            throw Module.Error.DuplicateModule(top.name)
+            throw Module.Error.duplicateModule(top.name)
         }
     }
 

--- a/Sources/PackageModel/Module.swift
+++ b/Sources/PackageModel/Module.swift
@@ -45,7 +45,7 @@ public class Module: ModuleProtocol {
 }
 
 public enum ModuleType {
-    case Library, Executable
+    case library, executable
 }
 
 public protocol ModuleTypeProtocol {
@@ -60,7 +60,7 @@ extension ModuleTypeProtocol {
            // Look for a main.xxx file avoiding cases like main.xxx.xxx
            return file.hasPrefix("main.") && file.characters.filter({$0 == "."}).count == 1
         }
-        return isLibrary ? .Library : .Executable
+        return isLibrary ? .library : .executable
     }
 }
 

--- a/Sources/PackageModel/Package.swift
+++ b/Sources/PackageModel/Package.swift
@@ -27,8 +27,8 @@ public class Package {
     }
 
     public enum Error: ErrorProtocol {
-        case NoManifest(String)
-        case NoOrigin(String)
+        case noManifest(String)
+        case noOrigin(String)
     }
 }
 

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -45,7 +45,7 @@ public class Product {
 }
 
 public enum LibraryType {
-    case Dynamic
+    case dynamic
     case Static
 }
 

--- a/Sources/PackageModel/c99name().swift
+++ b/Sources/PackageModel/c99name().swift
@@ -201,7 +201,7 @@ public func c99name(name: String) throws  -> String {
     }
 
     guard mapped.count > 0 else {
-        throw Error.InvalidPackageName(name)
+        throw Error.invalidPackageName(name)
     }
 
     // String(mapped) AND map(String.init) didn't work ¯\_(ツ)_/¯
@@ -209,13 +209,13 @@ public func c99name(name: String) throws  -> String {
 }
 
 enum Error: ErrorProtocol {
-    case InvalidPackageName(String)
+    case invalidPackageName(String)
 }
 
 extension Error: CustomStringConvertible {
     var description: String {
         switch self {
-        case .InvalidPackageName(let name):
+        case .invalidPackageName(let name):
             return "Invalid Package Name. \(name) is not a valid C99 extended identifier"
         }
     }

--- a/Sources/Utility/ColorWrap.swift
+++ b/Sources/Utility/ColorWrap.swift
@@ -23,7 +23,7 @@ public enum ColorWrap {
     ///     or
     ///     --color=always
     public static func wrap(_ input: String, with color: Color, for stream: Stream) -> String {
-        guard ColorWrap.isAllowed(for: .StdErr) else { return input }
+        guard ColorWrap.isAllowed(for: .stdErr) else { return input }
         return input.wrapped(in: color)
     }
 

--- a/Sources/Utility/Error.swift
+++ b/Sources/Utility/Error.swift
@@ -9,25 +9,25 @@
 */
 
 public enum Error: ErrorProtocol {
-    case ObsoleteGitVersion
-    case UnknownGitError
-    case UnicodeDecodingError
-    case UnicodeEncodingError
-    case CouldNotCreateFile(path: String)
-    case FileDoesNotExist(path: String)
+    case obsoleteGitVersion
+    case unknownGitError
+    case unicodeDecodingError
+    case unicodeEncodingError
+    case couldNotCreateFile(path: String)
+    case fileDoesNotExist(path: String)
 }
 
 extension Error: CustomStringConvertible {
     public var description: String {
         switch self {
-        case .ObsoleteGitVersion:
+        case .obsoleteGitVersion:
             return "Git 2.0 or higher is required. Please update git and retry."
-        case .UnknownGitError:
+        case .unknownGitError:
             return "Failed to invoke git command. Please try updating git"
-        case .UnicodeDecodingError: return "Could not decode input file into unicode"
-        case .UnicodeEncodingError: return "Could not encode string into unicode"
-        case .CouldNotCreateFile(let path): return "Could not create file: \(path)"
-        case .FileDoesNotExist(let path): return "File does not exist: \(path)"
+        case .unicodeDecodingError: return "Could not decode input file into unicode"
+        case .unicodeEncodingError: return "Could not encode string into unicode"
+        case .couldNotCreateFile(let path): return "Could not create file: \(path)"
+        case .fileDoesNotExist(let path): return "File does not exist: \(path)"
         }
     }
 }

--- a/Sources/Utility/File.swift
+++ b/Sources/Utility/File.swift
@@ -22,17 +22,17 @@ public func fopen(_ path: String, mode: FopenMode = .read) throws -> NSFileHandl
     case .write:
         #if os(OSX) || os(iOS)
             guard NSFileManager.`default`().createFile(atPath: path, contents: nil) else {
-                throw Error.CouldNotCreateFile(path: path)
+                throw Error.couldNotCreateFile(path: path)
             }
         #else
             guard NSFileManager.defaultManager().createFile(atPath: path, contents: nil) else {
-                throw Error.CouldNotCreateFile(path: path)
+                throw Error.couldNotCreateFile(path: path)
             }
         #endif
         handle = NSFileHandle(forWritingAtPath: path)
     }
     guard handle != nil else {
-        throw Error.FileDoesNotExist(path: path)
+        throw Error.fileDoesNotExist(path: path)
     }
     return handle
 }
@@ -45,7 +45,7 @@ public func fopen(_ path: String..., mode: FopenMode = .read, body: (NSFileHandl
 
 public func fputs(_ string: String, _ handle: NSFileHandle) throws {
     guard let data = string.data(using: NSUTF8StringEncoding) else {
-        throw Error.UnicodeEncodingError
+        throw Error.unicodeEncodingError
     }
 
     #if os(OSX) || os(iOS)
@@ -70,7 +70,7 @@ public func fputs(_ bytes: [UInt8], _ handle: NSFileHandle) throws {
 extension NSFileHandle: Sequence {
     public func enumerate(separatedBy separator: String = "\n") throws -> IndexingIterator<[String]> {
         guard let contents = String(data: readDataToEndOfFile(), encoding: NSUTF8StringEncoding) else {
-            throw Error.UnicodeDecodingError
+            throw Error.unicodeDecodingError
         }
 
         if contents == "" {

--- a/Sources/Utility/Git.swift
+++ b/Sources/Utility/Git.swift
@@ -99,9 +99,9 @@ public class Git {
     @noreturn public class func handle(_ error: ErrorProtocol) {
         // Git 2.0 or higher is required
         if Git.majorVersionNumber < 2 {
-            print("error: ", Error.ObsoleteGitVersion)
+            print("error: ", Error.obsoleteGitVersion)
         } else {
-            print("error: ", Error.UnknownGitError)
+            print("error: ", Error.unknownGitError)
         }
         exit(1)
     }

--- a/Sources/Utility/PkgConfig.swift
+++ b/Sources/Utility/PkgConfig.swift
@@ -12,9 +12,9 @@ import func POSIX.getenv
 import func POSIX.popen
 
 public enum PkgConfigError: ErrorProtocol {
-    case CouldNotFindConfigFile
-    case ParsingError(String)
-    case NonWhitelistedFlags(String)
+    case couldNotFindConfigFile
+    case parsingError(String)
+    case nonWhitelistedFlags(String)
 }
 
 /// Get search paths from pkg-config itself.
@@ -96,7 +96,7 @@ public struct PkgConfig {
                 return pcFile
             }
         }
-        throw PkgConfigError.CouldNotFindConfigFile
+        throw PkgConfigError.couldNotFindConfigFile
     }
 }
 
@@ -142,7 +142,7 @@ struct PkgConfigParser {
                 variables[name.chuzzle() ?? ""] = try resolveVariables(value)
             } else {
                 // Unexpected thing in the pc file, abort.
-                throw PkgConfigError.ParsingError("Unexpected line: \(line) in \(pcFile)")
+                throw PkgConfigError.parsingError("Unexpected line: \(line) in \(pcFile)")
             }
         }
     }
@@ -207,7 +207,7 @@ struct PkgConfigParser {
             if operators.contains(arg) {
                 // We should have a version number next, skip.
                 guard let _ = it.next() else {
-                    throw PkgConfigError.ParsingError("Expected version number after \(deps.last) \(arg) in \"\(depString)\" in \(pcFile)")
+                    throw PkgConfigError.parsingError("Expected version number after \(deps.last) \(arg) in \"\(depString)\" in \(pcFile)")
                 }
             } else {
                 // Otherwise it is a dependency.
@@ -243,7 +243,7 @@ struct PkgConfigParser {
                 // Append the contents before the variable.
                 result += fragment[fragment.characters.startIndex..<variable.startIndex]
                 guard let variableValue = variables[variable.name] else {
-                    throw PkgConfigError.ParsingError("Expected variable in \(pcFile)")
+                    throw PkgConfigError.parsingError("Expected variable in \(pcFile)")
                 }
                 // Append the value of the variable.
                 result += variableValue

--- a/Sources/Utility/Platform.swift
+++ b/Sources/Utility/Platform.swift
@@ -11,11 +11,11 @@
 import func POSIX.popen
 
 public enum Platform {
-    case Darwin
-    case Linux(LinuxFlavor)
+    case darwin
+    case linux(LinuxFlavor)
     
     public enum LinuxFlavor {
-        case Debian
+        case debian
     }
     
     // Lazily return current platform.
@@ -24,10 +24,10 @@ public enum Platform {
         guard let uname = try? popen(["uname"]).chomp().lowercased() else { return nil }
         switch uname {
         case "darwin":
-            return .Darwin
+            return .darwin
         case "linux":
             if "/etc/debian_version".isFile {
-                return .Linux(.Debian)
+                return .linux(.debian)
             }
         default:
             return nil

--- a/Sources/Utility/TTY.swift
+++ b/Sources/Utility/TTY.swift
@@ -15,11 +15,11 @@ import libc
 /// Check if this stream is TTY.
 public func isTTY(_ stream: Stream) -> Bool {
     switch stream {
-    case .StdOut: return isatty(fileno(libc.stdout))
-    case .StdErr: return isatty(fileno(libc.stderr))
+    case .stdOut: return isatty(fileno(libc.stdout))
+    case .stdErr: return isatty(fileno(libc.stderr))
     }
 }
 
 public enum Stream {
-    case StdOut, StdErr
+    case stdOut, stdErr
 }

--- a/Sources/Utility/Verbosity.swift
+++ b/Sources/Utility/Verbosity.swift
@@ -9,35 +9,35 @@
 */
 
 public enum Verbosity: Int {
-    case Concise
-    case Verbose
-    case Debug
+    case concise
+    case verbose
+    case debug
 
     public init(rawValue: Int) {
         switch rawValue {
         case Int.min...0:
-            self = .Concise
+            self = .concise
         case 1:
-            self = .Verbose
+            self = .verbose
         default:
-            self = .Debug
+            self = .debug
         }
     }
 
     public var ccArgs: [String] {
         switch self {
-        case .Concise:
+        case .concise:
             return []
-        case .Verbose:
+        case .verbose:
             // the first level of verbosity is passed to llbuild itself
             return []
-        case .Debug:
+        case .debug:
             return ["-v"]
         }
     }
 }
 
-public var verbosity = Verbosity.Concise
+public var verbosity = Verbosity.concise
 
 
 import func libc.fputs
@@ -74,8 +74,8 @@ private func prettyArguments(_ arguments: [String], for stream: Stream) -> Strin
 }
 
 private func printArgumentsIfVerbose(_ arguments: [String]) {
-    if verbosity != .Concise {
-        print(prettyArguments(arguments, for: .StdOut))
+    if verbosity != .concise {
+        print(prettyArguments(arguments, for: .stdOut))
     }
 }
 
@@ -102,7 +102,7 @@ import enum POSIX.Error
 public func system(_ arguments: String..., environment: [String:String] = [:], message: String?) throws {
     var out = ""
     do {
-        if Utility.verbosity == .Concise {
+        if Utility.verbosity == .concise {
             if let message = message {
                 print(message)
                 fflush(stdout)  // ensure we display `message` before git asks for credentials
@@ -114,8 +114,8 @@ public func system(_ arguments: String..., environment: [String:String] = [:], m
             try system(arguments, environment: environment)
         }
     } catch {
-        if verbosity == .Concise {
-            print(prettyArguments(arguments, for: .StdOut), to: &stderr)
+        if verbosity == .concise {
+            print(prettyArguments(arguments, for: .stdOut), to: &stderr)
             print(out, to: &stderr)
         }
         throw error

--- a/Sources/Xcodeproj/Module+PBXProj.swift
+++ b/Sources/Xcodeproj/Module+PBXProj.swift
@@ -103,7 +103,7 @@ func fileRefs(forCompilePhaseSourcesInModule module: XcodeModuleProtocol, srcroo
 extension XcodeModuleProtocol  {
 
     var isLibrary: Bool {
-        return type == .Library
+        return type == .library
     }
 
     var infoPlistFileName: String {

--- a/Tests/Basic/OptionParserTests.swift
+++ b/Tests/Basic/OptionParserTests.swift
@@ -52,7 +52,7 @@ class OptionParserTests: XCTestCase {
         do {
             let _: (Mode?, [Flag]) = try parseOptions(arguments: ["--A", "--B"])
             XCTFail()
-        } catch OptionParserError.MultipleModesSpecified(let args) {
+        } catch OptionParserError.multipleModesSpecified(let args) {
             XCTAssertEqual(args, ["A", "B"])
         } catch {
             XCTFail()
@@ -69,7 +69,7 @@ class OptionParserTests: XCTestCase {
         do {
             let _: (Mode?, [Flag]) = try parseOptions(arguments: ["--F"])
             XCTFail()
-        } catch OptionParserError.ExpectedAssociatedValue {
+        } catch OptionParserError.expectedAssociatedValue {
             // güd
         } catch {
             XCTFail("\(error)")
@@ -80,7 +80,7 @@ class OptionParserTests: XCTestCase {
         do {
             let _: (Mode?, [Flag]) = try parseOptions(arguments: ["--E=foo", "--G=123"])
             XCTFail()
-        } catch OptionParserError.UnexpectedAssociatedValue {
+        } catch OptionParserError.unexpectedAssociatedValue {
             // güd
         } catch {
             XCTFail("\(error)")
@@ -91,7 +91,7 @@ class OptionParserTests: XCTestCase {
         do {
             let _: (Mode?, [Flag]) = try parseOptions(arguments: ["--A=foo", "--G=123"])
             XCTFail()
-        } catch OptionParserError.UnexpectedAssociatedValue {
+        } catch OptionParserError.unexpectedAssociatedValue {
             // güd
         } catch {
             XCTFail("\(error)")
@@ -169,10 +169,10 @@ enum Flag: Argument, Equatable {
         case "--E":
             self = .E
         case "--F":
-            guard let str = pop() else { throw OptionParserError.ExpectedAssociatedValue("") }
+            guard let str = pop() else { throw OptionParserError.expectedAssociatedValue("") }
             self = .F(str)
         case "--G":
-            guard let str = pop(), int = Int(str) else { throw OptionParserError.ExpectedAssociatedValue("") }
+            guard let str = pop(), int = Int(str) else { throw OptionParserError.expectedAssociatedValue("") }
             self = .G(int)
         case "-H":
             self = .H
@@ -181,7 +181,7 @@ enum Flag: Argument, Equatable {
         case "-J":
             self = .J
         case "-K":
-            guard let str = pop() else { throw OptionParserError.ExpectedAssociatedValue("") }
+            guard let str = pop() else { throw OptionParserError.expectedAssociatedValue("") }
             self = .K(str)
         default:
             return nil

--- a/Tests/Basic/TOMLTests.swift
+++ b/Tests/Basic/TOMLTests.swift
@@ -14,11 +14,11 @@ import XCTest
 
 // Test the basic types.
 private func toArray(_ items: [TOMLItem]) -> TOMLItem {
-    return .Array(contents: TOMLItemArray(items: items))
+    return .array(contents: TOMLItemArray(items: items))
 }
 
 private func toTable(_ items: [String: TOMLItem]) -> TOMLItem {
-    return .Table(contents: TOMLItemTable(items: items))
+    return .table(contents: TOMLItemTable(items: items))
 }
 
 private func parseTOML(_ data: String) -> TOMLItem {
@@ -45,18 +45,18 @@ class TOMLTests: XCTestCase {
     }
 
     func testParser() {
-        XCTAssertEqual(parseTOML("a = b"), toTable(["a": .String(value: "b")]))
-        XCTAssertEqual(parseTOML("a = \"b\""), toTable(["a": .String(value: "b")]))
-        XCTAssertEqual(parseTOML("a = 1"), toTable(["a": .Int(value: 1)]))
-        XCTAssertEqual(parseTOML("a = 1.234"), toTable(["a": .Float(value: 1.234)]))
-        XCTAssertEqual(parseTOML("a = 1.2e-2"), toTable(["a": .Float(value: 1.2e-2)]))
-        XCTAssertEqual(parseTOML("a = -12_34_56"), toTable(["a": .Int(value: -123456)]))
-        XCTAssertEqual(parseTOML("a = +1.2_34_56"), toTable(["a": .Float(value: 1.23456)]))
-        XCTAssertEqual(parseTOML("a = true\n\nb = false"), toTable(["a": .Bool(value: true), "b": .Bool(value: false)]))
+        XCTAssertEqual(parseTOML("a = b"), toTable(["a": .string(value: "b")]))
+        XCTAssertEqual(parseTOML("a = \"b\""), toTable(["a": .string(value: "b")]))
+        XCTAssertEqual(parseTOML("a = 1"), toTable(["a": .int(value: 1)]))
+        XCTAssertEqual(parseTOML("a = 1.234"), toTable(["a": .float(value: 1.234)]))
+        XCTAssertEqual(parseTOML("a = 1.2e-2"), toTable(["a": .float(value: 1.2e-2)]))
+        XCTAssertEqual(parseTOML("a = -12_34_56"), toTable(["a": .int(value: -123456)]))
+        XCTAssertEqual(parseTOML("a = +1.2_34_56"), toTable(["a": .float(value: 1.23456)]))
+        XCTAssertEqual(parseTOML("a = true\n\nb = false"), toTable(["a": .bool(value: true), "b": .bool(value: false)]))
 
         // Test arrays.
-        XCTAssertEqual(parseTOML("a = [1, 2]"), toTable(["a": toArray([.Int(value: 1), .Int(value: 2)])]))
-        XCTAssertEqual(parseTOML("a = [1,\n[\n2,\n] ]"), toTable(["a": toArray([.Int(value: 1), toArray([.Int(value: 2)])])]))
+        XCTAssertEqual(parseTOML("a = [1, 2]"), toTable(["a": toArray([.int(value: 1), .int(value: 2)])]))
+        XCTAssertEqual(parseTOML("a = [1,\n[\n2,\n] ]"), toTable(["a": toArray([.int(value: 1), toArray([.int(value: 2)])])]))
     }
 
     func testParsingTables() {
@@ -71,13 +71,13 @@ class TOMLTests: XCTestCase {
                 "[t2.t1]\n" +
                 "b = 4\n")),
             toTable([
-                "a": .Int(value: 1),
+                "a": .int(value: 1),
                 "t1": toTable([
-                    "b": .Int(value: 2)]),
+                    "b": .int(value: 2)]),
                 "t2": toTable([
-                    "b": .Int(value: 3),
+                    "b": .int(value: 3),
                     "t1": toTable([
-                        "b": .Int(value: 4)])])]))
+                        "b": .int(value: 4)])])]))
 
         // Check handling of empty nested tables.
         XCTAssertEqual(parseTOML("[[t1]]"), toTable([
@@ -92,8 +92,8 @@ class TOMLTests: XCTestCase {
                 "a = 2\n")),
             toTable([
                 "t1": toArray([
-                    toTable(["a": .Int(value: 1)]),
-                    toTable(["a": .Int(value: 2)])])]))
+                    toTable(["a": .int(value: 1)]),
+                    toTable(["a": .int(value: 2)])])]))
 
         // Check handling of insert into array of tables.
         XCTAssertEqual(parseTOML(
@@ -104,7 +104,7 @@ class TOMLTests: XCTestCase {
             toTable([
                 "t1": toArray([
                     toTable([
-                        "t2": toTable(["a": .Int(value: 1)])])])]))
+                        "t2": toTable(["a": .int(value: 1)])])])]))
     }
 }
 

--- a/Tests/Build/DescribeTests.swift
+++ b/Tests/Build/DescribeTests.swift
@@ -26,10 +26,10 @@ final class DescribeTests: XCTestCase {
 
             try POSIX.mkdtemp("spm-tests") { prefix in
                 defer { _ = try? Utility.removeFileTree(prefix) }
-                let _ = try describe(Path.join(prefix, "foo"), .Debug, [], [], [], Xcc: [], Xld: [], Xswiftc: [], toolchain: InvalidToolchain())
+                let _ = try describe(Path.join(prefix, "foo"), .debug, [], [], [], Xcc: [], Xld: [], Xswiftc: [], toolchain: InvalidToolchain())
                 XCTFail("This call should throw")
             }
-        } catch Build.Error.NoModules {
+        } catch Build.Error.noModules {
             XCTAssert(true, "This error should be thrown")
         } catch {
             XCTFail("No other error should be thrown")

--- a/Tests/Functional/MiscellaneousTests.swift
+++ b/Tests/Functional/MiscellaneousTests.swift
@@ -181,7 +181,7 @@ class MiscellaneousTestCase: XCTestCase {
         var foo = false
         do {
             try executeSwiftBuild("/")
-        } catch POSIX.Error.ExitStatus(let code, _) {
+        } catch POSIX.Error.exitStatus(let code, _) {
 
             // if our code crashes we'll get an exit code of 256
             XCTAssertEqual(code, Int32(1))
@@ -198,7 +198,7 @@ class MiscellaneousTestCase: XCTestCase {
             var foo = false
             do {
                 try executeSwiftBuild(prefix)
-            } catch POSIX.Error.ExitStatus(let code, _) {
+            } catch POSIX.Error.exitStatus(let code, _) {
 
                 // if our code crashes we'll get an exit code of 256
                 XCTAssertEqual(code, Int32(1))

--- a/Tests/Functional/Utilities.swift
+++ b/Tests/Functional/Utilities.swift
@@ -192,7 +192,7 @@ func XCTAssertBuildFails(_ paths: String..., file: StaticString = #file, line: U
 
         XCTFail("`swift build' succeeded but should have failed", file: file, line: line)
 
-    } catch POSIX.Error.ExitStatus(let status, _) where status == 1{
+    } catch POSIX.Error.exitStatus(let status, _) where status == 1{
         // noop
     } catch {
         XCTFail("`swift build' failed in an unexpected manner")

--- a/Tests/Get/GetTests.swift
+++ b/Tests/Get/GetTests.swift
@@ -25,7 +25,7 @@ class GetTests: XCTestCase {
             guard let repo = makeGitRepo(tmpdir, tag: "0.1.0") else { return XCTFail() }
             try systemQuietly(["git", "-C", repo.path, "remote", "add", "origin", repo.path])
             let clone = try RawClone(path: repo.path, manifestParser: { _,_ throws -> Manifest in
-                throw Package.Error.NoManifest(tmpdir)
+                throw Package.Error.noManifest(tmpdir)
             })
             XCTAssertEqual(clone.children.count, 0)
         }

--- a/Tests/Get/GitTests.swift
+++ b/Tests/Get/GitTests.swift
@@ -66,7 +66,7 @@ private func tryCloningRepoWithTag(_ tag: String?, shouldCrash: Bool) {
             _ = try RawClone(path: path, manifestParser: { _ throws in
                 return Manifest(path: path, package: PackageDescription.Package(), products: [])
             })
-        } catch Error.Unversioned {
+        } catch Error.unversioned {
             done = shouldCrash
         } catch {
             XCTFail()

--- a/Tests/Get/VersionGraphTests.swift
+++ b/Tests/Get/VersionGraphTests.swift
@@ -229,7 +229,7 @@ class VersionGraphTests: XCTestCase {
                 (MockProject.A.url, Version.maxRange),
                 (MockProject.B.url, Version.maxRange)
             ])
-        } catch Error.InvalidDependencyGraph(let url) {
+        } catch Error.invalidDependencyGraph(let url) {
             invalidGraph = true
             XCTAssertEqual(url, MockProject.C.url)
         } catch {
@@ -259,7 +259,7 @@ class VersionGraphTests: XCTestCase {
             _ = try MyMockFetcher().recursivelyFetch([
                 (MockProject.A.url, v1..<v1.successor()),
             ])
-        } catch Error.InvalidDependencyGraphMissingTag(let url, _, _) {
+        } catch Error.invalidDependencyGraphMissingTag(let url, _, _) {
             XCTAssertEqual(url, MockProject.F.url)
             invalidGraph = true
         } catch {
@@ -278,7 +278,7 @@ class VersionGraphTests: XCTestCase {
         var success = false
         do {
             _ = try MyMockFetcher().recursivelyFetch([(MockProject.A.url, v1..<v2)])
-        } catch Error.InvalidDependencyGraphMissingTag {
+        } catch Error.invalidDependencyGraphMissingTag {
             success = true
         } catch {
             XCTFail()

--- a/Tests/PackageLoading/WhitelistTests.swift
+++ b/Tests/PackageLoading/WhitelistTests.swift
@@ -28,7 +28,7 @@ final class PkgConfigWhitelistTests: XCTestCase {
         do {
             try whitelist(pcFile: "dummy", flags: (cFlags, libs))
         } catch {
-           let errorString = "NonWhitelistedFlags(\"Non whitelisted flags found: [\\\"-L/hello\\\", \\\"-module-name\\\", \\\"name\\\"] in pc file dummy\")"
+           let errorString = "nonWhitelistedFlags(\"Non whitelisted flags found: [\\\"-L/hello\\\", \\\"-module-name\\\", \\\"name\\\"] in pc file dummy\")"
            XCTAssertEqual("\(error)", errorString)
         }
     }
@@ -39,7 +39,7 @@ final class PkgConfigWhitelistTests: XCTestCase {
         do {
             try whitelist(pcFile: "dummy", flags: (cFlags, libs))
         } catch {
-           let errorString = "NonWhitelistedFlags(\"Non whitelisted flags found: [\\\"-L/hello\\\", \\\"-module-name\\\", \\\"ok\\\", \\\"name\\\"] in pc file dummy\")"
+           let errorString = "nonWhitelistedFlags(\"Non whitelisted flags found: [\\\"-L/hello\\\", \\\"-module-name\\\", \\\"ok\\\", \\\"name\\\"] in pc file dummy\")"
            XCTAssertEqual("\(error)", errorString)
         }
     }

--- a/Tests/SourceControl/CheckoutManagerTests.swift
+++ b/Tests/SourceControl/CheckoutManagerTests.swift
@@ -15,7 +15,7 @@ import SourceControl
 import func POSIX.mkdtemp
 
 private enum DummyError: ErrorProtocol {
-    case InvalidRepository
+    case invalidRepository
 }
 
 private class DummyRepositoryProvider: RepositoryProvider {
@@ -26,7 +26,7 @@ private class DummyRepositoryProvider: RepositoryProvider {
         
         // We only support one dummy URL.
         if repository.url.basename != "dummy" {
-            throw DummyError.InvalidRepository
+            throw DummyError.invalidRepository
         }
     }
 }


### PR DESCRIPTION
Follow the Swift 3.0 naming convention for enums.
![cjduzt3xaaa17f4](https://cloud.githubusercontent.com/assets/1086260/15453942/bb40858e-2029-11e6-8015-9b34b1a5e15d.jpg)

Change: 
- Make all enum cases lowercase.
- Add `Target` method to `Target.Dependency` because it's used in Manifest files, we don't make  breaking changes.
```swift 
public static func Target(name: String) -> Dependency {
  return .target(name: name)
}
```
- Left  `case Init(InitMode)` as UpperCase. It has conflicts with `init` method 
- use \`\`  for  case \`static\`