### PR TITLE
Clean up options and flags for `package`, `build`, and `test` subcommands

### DIFF
--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -48,8 +48,7 @@ extension Error: CustomStringConvertible {
     case OptionParserError.multipleModesSpecified(let modes):
         print(error: error)
 
-        if isTTY(.stdErr)
-             && (modes.contains{ ["--help", "-h", "--usage"].contains($0) }) {
+        if isTTY(.stdErr) && (modes.contains{ ["--help", "-h"].contains($0) }) {
             print("", to: &stderr)
             usage { print($0, to: &stderr) }
         }

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -37,7 +37,7 @@ private enum Mode: Argument, Equatable, CustomStringConvertible {
 
     init?(argument: String, pop: () -> String?) throws {
         switch argument {
-        case "--configuration", "--config":
+        case "--configuration", "--config", "-c":
             self = try .build(Configuration(pop()), UserToolchain())
         case "--clean":
             self = try .clean(CleanMode(pop()))
@@ -211,17 +211,17 @@ public struct SwiftBuildTool {
         print("USAGE: swift build [mode] [options]")
         print("")
         print("MODES:")
-        print("  --configuration <value>   Build with configuration (debug|release)")
-        print("  --clean [<mode>]          Delete artifacts (build|dist)")
+        print("  -c, --configuration <value>   Build with configuration (debug|release)")
+        print("  --clean <mode>                Delete artifacts (build|dist)")
         print("")
         print("OPTIONS:")
-        print("  --chdir <path>       Change working directory before any other operation [-C]")
-        print("  --build-path <path>  Specify build directory")
-        print("  --color <mode>       Specify color mode (auto|always|never)")
-        print("  --verbose            Increase verbosity of informational output [-v]")
-        print("  -Xcc <flag>          Pass flag through to all C compiler instantiations")
-        print("  -Xlinker <flag>      Pass flag through to all linker instantiations")
-        print("  -Xswiftc <flag>      Pass flag through to all Swift compiler instantiations")
+        print("  -C, --chdir <path>       Change working directory before any other operation")
+        print("  --build-path <path>      Specify build directory")
+        print("  --color <mode>           Specify color mode (auto|always|never)")
+        print("  -v, --verbose            Increase verbosity of informational output")
+        print("  -Xcc <flag>              Pass flag through to all C compiler invocations")
+        print("  -Xlinker <flag>          Pass flag through to all linker invocations")
+        print("  -Xswiftc <flag>          Pass flag through to all Swift compiler invocations")
         print("")
         print("NOTE: Use `swift package` to perform other functions on packages")
     }

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -37,11 +37,11 @@ private enum Mode: Argument, Equatable, CustomStringConvertible {
 
     init?(argument: String, pop: () -> String?) throws {
         switch argument {
-        case "--configuration", "--conf", "-c":
+        case "--configuration", "--config":
             self = try .build(Configuration(pop()), UserToolchain())
         case "--clean":
             self = try .clean(CleanMode(pop()))
-        case "--help", "--usage", "-h":
+        case "--help", "-h":
             self = .usage
         case "--version":
             self = .version
@@ -52,8 +52,8 @@ private enum Mode: Argument, Equatable, CustomStringConvertible {
 
     var description: String {
         switch self {
-            case .build(let conf, _): return "--configuration=\(conf)"
-            case .clean(let mode): return "--clean=\(mode)"
+            case .build(let conf, _): return "--configuration \(conf)"
+            case .clean(let mode): return "--clean \(mode)"
             case .usage: return "--help"
             case .version: return "--version"
         }
@@ -84,8 +84,6 @@ private enum BuildToolFlag: Argument {
             self = try .chdir(forcePop())
         case "--verbose", "-v":
             self = .verbose(1)
-        case "-vv":
-            self = .verbose(2)
         case "-Xcc":
             self = try .xcc(forcePop())
         case "-Xlinker":
@@ -213,14 +211,14 @@ public struct SwiftBuildTool {
         print("USAGE: swift build [mode] [options]")
         print("")
         print("MODES:")
-        print("  --configuration <value>        Build with configuration (debug|release) [-c]")
-        print("  --clean[=<mode>]               Delete artifacts (build|dist)")
+        print("  --configuration <value>   Build with configuration (debug|release)")
+        print("  --clean [<mode>]          Delete artifacts (build|dist)")
         print("")
         print("OPTIONS:")
         print("  --chdir <path>       Change working directory before any other operation [-C]")
         print("  --build-path <path>  Specify build directory")
         print("  --color <mode>       Specify color mode (auto|always|never)")
-        print("  -v[v]                Increase verbosity of informational output")
+        print("  --verbose            Increase verbosity of informational output [-v]")
         print("  -Xcc <flag>          Pass flag through to all C compiler instantiations")
         print("  -Xlinker <flag>      Pass flag through to all linker instantiations")
         print("  -Xswiftc <flag>      Pass flag through to all Swift compiler instantiations")

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -30,34 +30,34 @@ import func POSIX.chdir
 extension PackageToolOptions: XcodeprojOptions {}
 
 private enum Mode: Argument, Equatable, CustomStringConvertible {
-    case initPackage
     case doctor
-    case showDependencies
+    case dumpPackage
     case fetch
+    case generateXcodeproj
+    case initPackage
+    case showDependencies
     case update
     case usage
     case version
-    case generateXcodeproj
-    case dumpPackage
 
     init?(argument: String, pop: () -> String?) throws {
         switch argument {
-        case "init":
-            self = .initPackage
         case "doctor":
             self = .doctor
-        case "show-dependencies":
-            self = .showDependencies
+        case "dump-package":
+            self = .dumpPackage
         case "fetch":
             self = .fetch
+        case "generate-xcodeproj":
+            self = .generateXcodeproj
+        case "init":
+            self = .initPackage
+        case "show-dependencies":
+            self = .showDependencies
         case "update":
             self = .update
         case "--help", "-h":
             self = .usage
-        case "generate-xcodeproj":
-            self = .generateXcodeproj
-        case "dump-package":
-            self = .dumpPackage
         case "--version":
             self = .version
         default:
@@ -67,13 +67,13 @@ private enum Mode: Argument, Equatable, CustomStringConvertible {
 
     var description: String {
         switch self {
-        case .initPackage: return "initPackage"
         case .doctor: return "doctor"
-        case .showDependencies: return "show-dependencies"
-        case .generateXcodeproj: return "generate-xcodeproj"
-        case .fetch: return "fetch"
-        case .update: return "update"
         case .dumpPackage: return "dump-package"
+        case .fetch: return "fetch"
+        case .generateXcodeproj: return "generate-xcodeproj"
+        case .initPackage: return "initPackage"
+        case .showDependencies: return "show-dependencies"
+        case .update: return "update"
         case .usage: return "--help"
         case .version: return "--version"
         }

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -73,9 +73,9 @@ private enum Mode: Argument, Equatable, CustomStringConvertible {
         case .generateXcodeproj: return "generate-xcodeproj"
         case .fetch: return "fetch"
         case .update: return "update"
-        case .usage: return "help"
-        case .version: return "version"
         case .dumpPackage: return "dump-package"
+        case .usage: return "--help"
+        case .version: return "--version"
         }
     }
 }

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -42,24 +42,24 @@ private enum Mode: Argument, Equatable, CustomStringConvertible {
 
     init?(argument: String, pop: () -> String?) throws {
         switch argument {
-        case "init", "initialize":
+        case "init":
             self = .initPackage
         case "doctor":
             self = .doctor
-        case "show-dependencies", "show-deps":
+        case "show-dependencies":
             self = .showDependencies
         case "fetch":
             self = .fetch
         case "update":
             self = .update
-        case "help", "usage", "--help", "-h":
+        case "help", "--help", "-h":
             self = .usage
-        case "version", "--version":
-            self = .version
         case "generate-xcodeproj":
             self = .generateXcodeproj
         case "dump-package":
             self = .dumpPackage
+        case "--version":
+            self = .version
         default:
             return nil
         }
@@ -249,7 +249,7 @@ public struct SwiftPackageTool {
         print("USAGE: swift package [command] [options]")
         print("")
         print("COMMANDS:")
-        print("  init [--type <type>]                   Initialize a new package (executable|library)")
+        print("  init [--type <type>]                   Initialize package (library|executable)")
         print("  fetch                                  Fetch package dependencies")
         print("  update                                 Update package dependencies")
         print("  generate-xcodeproj [--output <path>]   Generates an Xcode project")
@@ -257,12 +257,13 @@ public struct SwiftPackageTool {
         print("  dump-package [--output <path>]         Print Package.swift as JSON")
         print("")
         print("OPTIONS:")
-        print("  --chdir <path>       Change working directory before any command [-C]")
-        print("  --color <mode>       Specify color mode (auto|always|never)")
-        print("  --verbose            Increase verbosity of informational output [-v]")
-        print("  -Xcc <flag>          Pass flag through to all C compiler instantiations")
-        print("  -Xlinker <flag>      Pass flag through to all linker instantiations")
-        print("  -Xswiftc <flag>      Pass flag through to all Swift compiler instantiations")
+        print("  -C, --chdir <path>        Change working directory before any other operation")
+        print("  --color <mode>            Specify color mode (auto|always|never)")
+        print("  -v, --verbose             Increase verbosity of informational output")
+        print("  --version                 Print the Swift Package Manager version")
+        print("  -Xcc <flag>               Pass flag through to all C compiler invocations")
+        print("  -Xlinker <flag>           Pass flag through to all linker invocations")
+        print("  -Xswiftc <flag>           Pass flag through to all Swift compiler invocations")
         print("")
         print("NOTE: Use `swift build` to build packages, and `swift test` to test packages")
     }

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -52,7 +52,7 @@ private enum Mode: Argument, Equatable, CustomStringConvertible {
             self = .fetch
         case "update":
             self = .update
-        case "help", "--help", "-h":
+        case "--help", "-h":
             self = .usage
         case "generate-xcodeproj":
             self = .generateXcodeproj

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -35,7 +35,7 @@ private enum Mode: Argument, Equatable, CustomStringConvertible {
 
     init?(argument: String, pop: () -> String?) throws {
         switch argument {
-        case "--help", "--usage", "-h":
+        case "--help", "-h":
             self = .usage
         case "-s":
             guard let specifier = pop() else { throw OptionParserError.expectedAssociatedValue(argument) }

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -37,7 +37,7 @@ private enum Mode: Argument, Equatable, CustomStringConvertible {
         switch argument {
         case "--help", "-h":
             self = .usage
-        case "-s":
+        case "-s", "--specifier":
             guard let specifier = pop() else { throw OptionParserError.expectedAssociatedValue(argument) }
             self = .run(specifier)
         default:
@@ -140,8 +140,8 @@ public struct SwiftTestTool {
         print("USAGE: swift test [specifier] [options]")
         print("")
         print("SPECIFIER:")
-        print("  -s TestModule.TestCase         Run a test case subclass")
-        print("  -s TestModule.TestCase/test1   Run a specific test method")
+        print("  -s, --specifier <test-module>.<test-case>         Run a test case subclass")
+        print("  -s, --specifier <test-module>.<test-case>/<test>  Run a specific test method")
         print("")
         print("OPTIONS:")
         print("  -C, --chdir <path>     Change working directory before any other operation")

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -144,8 +144,8 @@ public struct SwiftTestTool {
         print("  -s TestModule.TestCase/test1   Run a specific test method")
         print("")
         print("OPTIONS:")
-        print("  --chdir              Change working directory before any other operation [-C]")
-        print("  --build-path <path>  Specify build directory")
+        print("  -C, --chdir <path>     Change working directory before any other operation")
+        print("  --build-path <path>    Specify build directory")
         print("")
         print("NOTE: Use `swift package` to perform other functions on packages")
     }

--- a/Sources/Commands/init.swift
+++ b/Sources/Commands/init.swift
@@ -182,11 +182,11 @@ final class InitPackage {
 enum InitMode: CustomStringConvertible {
     case library, executable
 
-    init(_ rawValue: String?) throws {
-        switch rawValue?.lowercased() {
-        case "library"?, "lib"?:
+    init(_ rawValue: String) throws {
+        switch rawValue.lowercased() {
+        case "library", "lib":
             self = .library
-        case nil, "executable"?, "exec"?, "exe"?:
+        case "executable", "exec", "exe":
             self = .executable
         default:
             throw OptionParserError.invalidUsage("invalid initialization type: \(rawValue)")

--- a/Sources/Commands/init.swift
+++ b/Sources/Commands/init.swift
@@ -184,9 +184,9 @@ enum InitMode: CustomStringConvertible {
 
     init(_ rawValue: String) throws {
         switch rawValue.lowercased() {
-        case "library", "lib":
+        case "library":
             self = .library
-        case "executable", "exec", "exe":
+        case "executable":
             self = .executable
         default:
             throw OptionParserError.invalidUsage("invalid initialization type: \(rawValue)")

--- a/Sources/Commands/show-dependencies.swift
+++ b/Sources/Commands/show-dependencies.swift
@@ -134,7 +134,7 @@ enum ShowDependenciesMode: CustomStringConvertible {
         case "json":
            self = .json
         default:
-            throw OptionParserError.invalidUsage("invalid show dependencies mode: \(rawValue)")
+            throw OptionParserError.invalidUsage("invalid show-dependencies mode: \(rawValue)")
         }
     }
     


### PR DESCRIPTION
Changes for [https://bugs.swift.org/browse/SR-1605](https://bugs.swift.org/browse/SR-1605)
This cleans up the options that the new `package` and the old `build`
and `test` subcommands take.  Things had become ugly after implementing
SE-0085.