### PR TITLE
Invoking `swift package` with no options should show help

### DIFF
--- a/Sources/Basic/OptionParser.swift
+++ b/Sources/Basic/OptionParser.swift
@@ -18,6 +18,7 @@ public enum OptionParserError: ErrorProtocol {
     case expectedAssociatedValue(String)
     case unexpectedAssociatedValue(String, String)
     case invalidUsage(String)
+    case noCommandProvided(String)
 }
 
 extension OptionParserError: CustomStringConvertible {
@@ -33,6 +34,8 @@ extension OptionParserError: CustomStringConvertible {
             return "unknown command: \(cmd)"
         case .invalidUsage(let hint):
             return "invalid usage: \(hint)"
+        case .noCommandProvided(let hint):
+            return "no command provided: \(hint)"
         }
     }
 }

--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -56,10 +56,17 @@ extension Error: CustomStringConvertible {
             print("", to: &stderr)
             usage { print($0, to: &stderr) }
         }
+    case OptionParserError.noCommandProvided(let hint):
+        if !hint.isEmpty {
+            print(error: error)
+        }
+        if isTTY(.stdErr) {
+            usage { print($0, to: &stderr) }
+        }
     case is OptionParserError:
         print(error: error)
         if isTTY(.stdErr) {
-            let argv0 = Process.arguments.first ?? "swift build"
+            let argv0 = Process.arguments.first ?? "swift package"
             print("enter `\(argv0) --help' for usage information", to: &stderr)
         }
     default:

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -303,7 +303,8 @@ public struct SwiftPackageTool {
             return (mode, opts)
         }
         else {
-            throw OptionParserError.invalidUsage("no command provided: \(args)")
+            // FIXME: This needs to produce a properly quoted string, once we have such API.
+            throw OptionParserError.noCommandProvided(args.joined(separator: " "))
         }
     }
 }


### PR DESCRIPTION
Invoking the `swift package` command without any options currently prints an error message saying there are no commands, followed by a pair of square brackets, followed by a line saying to pass --help to get help.

It should just print the help.