### PR TITLE
[Commands] Don't blow away modified Packages.

### DIFF
--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -23,6 +23,7 @@ public enum Error: ErrorProtocol {
     case invalidInstallation(String)
     case invalidSwiftExec(String)
     case buildYAMLNotFound(String)
+    case repositoryHasChanges(String)
 }
 
 extension Error: CustomStringConvertible {
@@ -38,6 +39,8 @@ extension Error: CustomStringConvertible {
             return "invalid SWIFT_EXEC value: \(value)"
         case .buildYAMLNotFound(let value):
             return "no build YAML found: \(value)"
+        case .repositoryHasChanges(let value):
+            return "repository has changes: \(value)"
         }
     }
 }


### PR DESCRIPTION
 - This adds a limited safety check that we don't let the current update
   workflow remove any modified repositories under `Packages`. It doesn't detect
   modifications to untracked files, but it should catch most cases.

 - Will add test coverage for this in the swift-integration-tests repo.

(cherry picked from commit 48101cb0c442072dcfa61b48b3dfa63c6c054c12)

---

Explanation: Our current implementation of `swift package update` works by simply removing the `Packages` subdirectory containing the dependencies, and recloning. However, this is problematic if a user has modified some of the sources there. This change prevents us from doing the removal if we detect modified files.

Scope: Minimal, the change adds safety checks we run before performing the removal of `Packages` which is done as part of package updating.

Risk: Low, it increases our safety and is covered by automated tests in the swift-integration-tests repository.

Testing: Automated test here: https://github.com/apple/swift-integration-tests/commit/810defbc57912884ddc95892c5092d6d0f1e9b81