### PR TITLE
Force-unwrap an optional so we print the value without Optional("...").

### DIFF
--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -303,7 +303,7 @@ enum CleanMode: CustomStringConvertible {
         case "dist"?, "distribution"?:
             self = .dist
         default:
-            throw OptionParserError.invalidUsage("invalid clean mode: \(rawValue)")
+            throw OptionParserError.invalidUsage("invalid clean mode: \(rawValue!)")
         }
     }
 


### PR DESCRIPTION
Small fix for an issue I noticed while using swift-build --clean.