### PR TITLE
Fix Xcode project rewrite because of invalid file type

### DIFF
--- a/Sources/Xcodeproj/Module+PBXProj.swift
+++ b/Sources/Xcodeproj/Module+PBXProj.swift
@@ -121,16 +121,13 @@ extension XcodeModuleProtocol  {
     }
 
     var explicitFileType: String {
-        func suffix() -> String {
-            if self is TestModule {
-                return "wrapper.cfbundle"
-            } else if isLibrary {
-                return "wrapper.framework"
-            } else {
-                return "executable"
-            }
+        if self is TestModule {
+            return "compiled.mach-o.wrapper.cfbundle"
+        } else if isLibrary {
+            return "wrapper.framework"
+        } else {
+            return "compiled.mach-o.executable"
         }
-        return "compiled.mach-o.\(suffix())"
     }
 
 


### PR DESCRIPTION
The file type for frameworks should be `wrapper.framework`, but it was being generated as `compiled.mach-o.wrapper.framework`, causing the project file rewrite.