### PR TITLE
Add a system module test.

### DIFF
--- a/Fixtures/Miscellaneous/SystemModules/CFake/Package.swift
+++ b/Fixtures/Miscellaneous/SystemModules/CFake/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "CFake"
+)

--- a/Fixtures/Miscellaneous/SystemModules/CFake/module.modulemap
+++ b/Fixtures/Miscellaneous/SystemModules/CFake/module.modulemap
@@ -1,0 +1,5 @@
+module CFake [system] {
+    header "/tmp/fake.h"
+    link "fake"
+    export *
+}

--- a/Fixtures/Miscellaneous/SystemModules/TestExec/Package.swift
+++ b/Fixtures/Miscellaneous/SystemModules/TestExec/Package.swift
@@ -1,0 +1,8 @@
+import PackageDescription
+
+let package = Package(
+    name: "TestExec",
+    dependencies: [
+        .Package(url: "../CFake", majorVersion: 1)
+    ]
+)

--- a/Fixtures/Miscellaneous/SystemModules/TestExec/Sources/main.swift
+++ b/Fixtures/Miscellaneous/SystemModules/TestExec/Sources/main.swift
@@ -1,0 +1,3 @@
+import CFake
+
+print("Hello, \(GetFakeString())!")

--- a/Tests/Xcodeproj/FunctionalTests.swift
+++ b/Tests/Xcodeproj/FunctionalTests.swift
@@ -91,6 +91,37 @@ class FunctionalTests: XCTestCase {
             XCTAssertDirectoryExists(build, "B_C.framework")
         }
     }
+    
+    func testSystemModule() {
+        // Because there isn't any one system module that we can depend on for testing purposes, we build our own.
+        try! write(path: "/tmp/fake.h") { stream in
+            stream <<< "extern const char GetFakeString(void);\n"
+        }
+        try! write(path: "/tmp/fake.c") { stream in
+            stream <<< "const char * GetFakeString(void) { return \"abc\"; }\n"
+        }
+        var out = ""
+        do {
+            try popen(["env", "-u", "TOOLCHAINS", "xcrun", "clang", "-dynamiclib", "/tmp/fake.c", "-o", "/tmp/libfake.dylib"], redirectStandardError: true) {
+                out += $0
+            }
+        } catch {
+            print("output:", out)
+            XCTFail("Failed to create test library:\n\n\(error)\n")
+        }
+        // Now we use a fixture for both the system library wrapper and the text executable.
+        fixture(name: "Miscellaneous/SystemModules") { prefix in
+            XCTAssertBuilds(prefix, "TestExec", Xld: ["-L/tmp/"])
+            XCTAssertFileExists(prefix, "TestExec", ".build", "debug", "TestExec")
+            let fakeDir = Path.join(prefix, "CFake")
+            XCTAssertDirectoryExists(fakeDir)
+            let execDir = Path.join(prefix, "TestExec")
+            XCTAssertDirectoryExists(execDir)
+            XCTAssertXcodeprojGen(execDir, flags: ["-Xlinker", "-L/tmp/"])
+            let proj = Path.join(execDir, "TestExec.xcodeproj")
+            XCTAssertXcodeBuild(project: proj)
+        }
+    }
 }
 
 
@@ -125,10 +156,10 @@ func XCTAssertXcodeBuild(project: String, file: StaticString = #file, line: UInt
     }
 }
 
-func XCTAssertXcodeprojGen(_ prefix: String, env: [String: String] = [:], file: StaticString = #file, line: UInt = #line) {
+func XCTAssertXcodeprojGen(_ prefix: String, flags: [String] = [], env: [String: String] = [:], file: StaticString = #file, line: UInt = #line) {
     do {
         print("    Generating XcodeProject")
-        _ = try executeSwiftSubcommand("package", args: ["generate-xcodeproj"], chdir: prefix, printIfError: true, env: env)
+        _ = try executeSwiftSubcommand("package", args: ["generate-xcodeproj"] + flags, chdir: prefix, printIfError: true, env: env)
     } catch {
         XCTFail("`swift package generate-xcodeproj' failed:\n\n\(error)\n", file: file, line: line)
     }


### PR DESCRIPTION
The test uses a fake system module, since we don't want to depend on any particular actual system module that may or may not be available on a given machine.