### PR TITLE
Make generate-xcodeproj subcommand honor the -Xcc, -Xlinker, -Xswiftc.

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -119,6 +119,14 @@ private enum PackageToolFlag: Argument {
             self = .colorMode(mode)
         case "--ignore-dependencies":
             self = .ignoreDependencies
+        case "-Xcc":
+            self = try .xcc(forcePop())
+        case "-Xlinker":
+            self = try .xld(forcePop())
+        case "-Xswiftc":
+            self = try .xswiftc(forcePop())
+        case "--xcconfig-overrides":
+            self = try .xcconfigOverrides(forcePop())
         default:
             return nil
         }


### PR DESCRIPTION
Make generate-xcodeproj subcommand honor the -Xcc, -Xlinker, -Xswiftc,
and --xcconfig-overrides flags. This functionality was in the `build`
subcommand but wasn't transferred over to the new `package` command;
it is needed in project generation as well, so that Xcode can get the
same custom flag overrides as building from `swift build`.

The first three of these flags are already documented in --help.  The
--xcconfig-overrides flag is not documented for the `build` command,
so it isn't documented here either.  I will file a bug report to cover the
documentation of this flag for both the `build` and the `package`
commands.

The new test case for system modules tests this functionality as part
of what its requirements.

(cherrypicked from commit d3fe415f69b4bfa3c130155adddd4f286f5ba642)