### PR TITLE
[ClangModule] Include module name in warning of no include directory

### DIFF
--- a/Sources/Build/misc.swift
+++ b/Sources/Build/misc.swift
@@ -104,7 +104,7 @@ extension ClangModule {
         
         ///Warn and return if no include directory
         guard includeDir.isDirectory else {
-            print("warning: No include directory found, a library can not be imported without any public headers.")
+            print("warning: No include directory found for module '\(name)'. A library can not be imported without any public headers.")
             return
         }
         


### PR DESCRIPTION
https://bugs.swift.org/browse/SR-1580