### PR TITLE
[PackageLoading] Throw error for invalid targets

### DIFF
--- a/Fixtures/Miscellaneous/PackageWithInvalidTargets/Package.swift
+++ b/Fixtures/Miscellaneous/PackageWithInvalidTargets/Package.swift
@@ -1,0 +1,10 @@
+import PackageDescription
+
+let package = Package(
+    name: "MyApp",
+    targets: [
+        Target(name: "App", dependencies: [.Target(name: "Foo"), .Target(name: "Bar")]),
+        Target(name: "Fake"),
+        Target(name: "Bake")
+    ]
+)

--- a/Fixtures/Miscellaneous/PackageWithInvalidTargets/Sources/App/main.swift
+++ b/Fixtures/Miscellaneous/PackageWithInvalidTargets/Sources/App/main.swift
@@ -1,0 +1,4 @@
+import Foo
+import Bar
+
+

--- a/Fixtures/Miscellaneous/PackageWithInvalidTargets/Sources/Bar/bar.swift
+++ b/Fixtures/Miscellaneous/PackageWithInvalidTargets/Sources/Bar/bar.swift
@@ -1,0 +1,2 @@
+struct Bar {
+}

--- a/Fixtures/Miscellaneous/PackageWithInvalidTargets/Sources/Foo/foo.swift
+++ b/Fixtures/Miscellaneous/PackageWithInvalidTargets/Sources/Foo/foo.swift
@@ -1,0 +1,2 @@
+struct Foo {
+}

--- a/Fixtures/Miscellaneous/PackageWithInvalidTargets/Tests/LinuxMain.swift
+++ b/Fixtures/Miscellaneous/PackageWithInvalidTargets/Tests/LinuxMain.swift
@@ -1,0 +1,6 @@
+import XCTest
+@testable import MyAppTestSuite
+
+XCTMain([
+     testCase(MyAppTests.allTests),
+])

--- a/Fixtures/Miscellaneous/PackageWithInvalidTargets/Tests/MyApp/AppTests.swift
+++ b/Fixtures/Miscellaneous/PackageWithInvalidTargets/Tests/MyApp/AppTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import MyApp
+
+class MyAppTests: XCTestCase {
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        XCTAssertEqual(MyApp().text, "Hello, World!")
+    }
+
+
+    static var allTests : [(String, (MyAppTests) -> () throws -> Void)] {
+        return [
+            ("testExample", testExample),
+        ]
+    }
+}

--- a/Sources/PackageLoading/PackageExtensions.swift
+++ b/Sources/PackageLoading/PackageExtensions.swift
@@ -13,23 +13,20 @@ import Utility
 
 import class PackageDescription.Target
 
-extension Package {
-    /// An error in the package organization of modules.
-    enum ModuleError: ErrorProtocol {
-        case noModules(Package)
-        case modulesNotFound([String])
-        case invalidLayout(InvalidLayoutType)
-        case executableAsDependency(String)
-    }
-
-    enum InvalidLayoutType {
-        case multipleSourceRoots([String])
-        case invalidLayout([String])
-    }
+public enum ModuleError: ErrorProtocol {
+    case noModules(Package)
+    case modulesNotFound([String])
+    case invalidLayout(InvalidLayoutType)
+    case executableAsDependency(String)
 }
 
-extension Package.InvalidLayoutType: CustomStringConvertible {
-    var description: String {
+public enum InvalidLayoutType {
+    case multipleSourceRoots([String])
+    case invalidLayout([String])
+}
+
+extension InvalidLayoutType: CustomStringConvertible {
+    public var description: String {
         switch self {
         case .multipleSourceRoots(let paths):
             return "multiple source roots found: " + paths.joined(separator: ", ")
@@ -145,12 +142,12 @@ extension Package {
             }
         }
 
-        /// Check for targets that are not mapped to any modules
+        /// Check for targets that are not mapped to any modules.
         let targetNames = Set(manifest.package.targets.map{ $0.name })
         let moduleNames = Set(modules.map{ $0.name })
         let diff = targetNames.subtracting(moduleNames)
             
-        if diff.count > 0 {
+        guard diff.isEmpty else {
             throw ModuleError.modulesNotFound(Array(diff))
         }
 
@@ -189,7 +186,6 @@ extension Package {
     private func targetForName(_ name: String) -> Target? {
         return manifest.package.targets.pick{ $0.name == name }
     }
-
 }
 
 

--- a/Sources/PackageLoading/PackageExtensions.swift
+++ b/Sources/PackageLoading/PackageExtensions.swift
@@ -17,7 +17,7 @@ extension Package {
     /// An error in the package organization of modules.
     enum ModuleError: ErrorProtocol {
         case noModules(Package)
-        case moduleNotFound(String)
+        case modulesNotFound([String])
         case invalidLayout(InvalidLayoutType)
         case executableAsDependency(String)
     }
@@ -135,7 +135,7 @@ extension Package {
                 switch $0 {
                 case .Target(let name):
                     guard let dependency = moduleForName(name) else {
-                        throw ModuleError.moduleNotFound(name)
+                        throw ModuleError.modulesNotFound([name])
                     }
                     if let moduleType = dependency as? ModuleTypeProtocol where moduleType.type != .library {
                         throw ModuleError.executableAsDependency("\(module.name) cannot have an executable \(name) as a dependency")
@@ -143,6 +143,15 @@ extension Package {
                     return dependency
                 }
             }
+        }
+
+        /// Check for targets that are not mapped to any modules
+        let targetNames = Set(manifest.package.targets.map{ $0.name })
+        let moduleNames = Set(modules.map{ $0.name })
+        let diff = targetNames.subtracting(moduleNames)
+            
+        if diff.count > 0 {
+            throw ModuleError.modulesNotFound(Array(diff))
         }
 
         return modules
@@ -180,6 +189,7 @@ extension Package {
     private func targetForName(_ name: String) -> Target? {
         return manifest.package.targets.pick{ $0.name == name }
     }
+
 }
 
 

--- a/Sources/PackageLoading/transmute.swift
+++ b/Sources/PackageLoading/transmute.swift
@@ -25,7 +25,7 @@ public func transmute(_ rootPackage: Package, externalPackages: [Package]) throw
         var modules: [Module]
         do {
             modules = try package.modules()
-        } catch Package.ModuleError.noModules(let pkg) where pkg === rootPackage {
+        } catch ModuleError.noModules(let pkg) where pkg === rootPackage {
             //Ignore and print warning if root package doesn't contain any sources
             print("warning: root package '\(pkg)' does not contain any sources")
             if packages.count == 1 { exit(0) } //Exit now if there is no more packages 

--- a/Tests/Functional/MiscellaneousTests.swift
+++ b/Tests/Functional/MiscellaneousTests.swift
@@ -67,10 +67,7 @@ class MiscellaneousTestCase: XCTestCase {
         // Refs: https://github.com/apple/swift-package-manager/pull/83
 
         fixture(name: "Miscellaneous/ExcludeDiagnostic2") { prefix in
-            XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix, ".build", "debug", "BarLib.swiftmodule")
-            XCTAssertFileExists(prefix, ".build", "debug", "FooBarLib.swiftmodule")
-            XCTAssertNoSuchPath(prefix, ".build", "debug", "FooLib.swiftmodule")
+            XCTAssertBuildFails(prefix)
         }
     }
 

--- a/Tests/PackageLoading/ManifestTests.swift
+++ b/Tests/PackageLoading/ManifestTests.swift
@@ -92,6 +92,22 @@ class ManifestTests: XCTestCase {
         let foo = try? Manifest(path: "/non-existent-file", baseURL: "/", swiftc: swiftc, libdir: libdir)
         XCTAssertNil(foo)
     }
+
+    func testInvalidTargetName() {
+        fixture(name: "Miscellaneous/PackageWithInvalidTargets") { prefix in
+            do {
+                let manifest = try Manifest(path: Path.join(prefix, "Package.swift"), baseURL: prefix, swiftc: swiftc, libdir: libdir)
+                let package = Package(manifest: manifest, url: prefix)
+
+                let _ = try package.modules()
+
+            } catch ModuleError.modulesNotFound(let moduleNames) {
+                XCTAssertEqual(Set(moduleNames), Set(["Bake", "Fake"]))
+            } catch {
+                XCTFail("Failed with error: \(error)")
+            }
+        }
+    }
 }
 
 extension ManifestTests {
@@ -99,6 +115,7 @@ extension ManifestTests {
         return [
             ("testManifestLoading", testManifestLoading),
             ("testNoManifest", testNoManifest),
+            ("testInvalidTargetName", testInvalidTargetName)
         ]
     }
 }


### PR DESCRIPTION
This will catch errors incase of typos in target names.

There is one problem with this approach though. This error will be caught only at package loading phase. The `.Package.toml` still contains invalid targets info. I'm wondering whether this is correct approach?

I think, once the `.Package.toml` is generated, it should be in a valid state (no invalid targets, etc.,).

Comments?