### PR TITLE
[PackageModel] Remove TestModule class.

### DIFF
--- a/Sources/Build/Buildable.swift
+++ b/Sources/Build/Buildable.swift
@@ -24,10 +24,6 @@ extension CModule {
 }
 
 extension Module: Buildable {
-    var isTest: Bool {
-        return self is TestModule
-    }
-
     func XccFlags(_ prefix: String) -> [String] {
         return recursiveDependencies.flatMap { module -> [String] in
             if let module = module as? ClangModule {

--- a/Sources/Build/Command.link().swift
+++ b/Sources/Build/Command.link().swift
@@ -65,7 +65,7 @@ extension Command {
           #else
             // HACK: To get a path to LinuxMain.swift, we just grab the
             //       parent directory of the first test module we can find.
-            let firstTestModule = product.modules.flatMap{ $0 as? TestModule }.first!
+            let firstTestModule = product.modules.filter{ $0.isTest }.first!
             let testDirectory = firstTestModule.sources.root.parentDirectory
             let main = Path.join(testDirectory, "LinuxMain.swift")
             args.append(main)

--- a/Sources/PackageLoading/transmute.swift
+++ b/Sources/PackageLoading/transmute.swift
@@ -38,7 +38,7 @@ public func transmute(_ rootPackage: Package, externalPackages: [Package]) throw
             let testModules = try package.testModules()
 
             // Set dependencies for test modules.
-            for testModule in testModules {
+            for case let testModule as SwiftModule in testModules {
                 if testModule.basename == "Functional" {
                     // FIXME: swiftpm's own Functional tests module does not
                     //        follow the normal rules--there is no corresponding
@@ -86,9 +86,9 @@ private func fillModuleGraph(_ packages: [Package], modulesForPackage: (Package)
         let packageModules = modulesForPackage(package)
         for dep in package.recursiveDependencies {
             let depModules = modulesForPackage(dep).filter{
+                guard !$0.isTest else { return false }
+
                 switch $0 {
-                case is TestModule:
-                    return false
                 case let module as SwiftModule where module.type == .library:
                     return true
                 case is CModule:

--- a/Sources/Xcodeproj/Module+PBXProj.swift
+++ b/Sources/Xcodeproj/Module+PBXProj.swift
@@ -111,7 +111,7 @@ extension XcodeModuleProtocol  {
     }
 
     var productType: String {
-        if self is TestModule {
+        if isTest {
             return "com.apple.product-type.bundle.unit-test"
         } else if isLibrary {
             return "com.apple.product-type.framework"
@@ -121,7 +121,7 @@ extension XcodeModuleProtocol  {
     }
 
     var explicitFileType: String {
-        if self is TestModule {
+        if isTest {
             return "compiled.mach-o.wrapper.cfbundle"
         } else if isLibrary {
             return "wrapper.framework"
@@ -133,7 +133,7 @@ extension XcodeModuleProtocol  {
 
 
     var productPath: String {
-        if self is TestModule {
+        if isTest {
             return "\(c99name).xctest"
         } else if isLibrary {
             return "\(c99name).framework"
@@ -151,7 +151,7 @@ extension XcodeModuleProtocol  {
     }
 
     var productName: String {
-        if isLibrary && !(self is TestModule) {
+        if isLibrary && !isTest {
             // you can go without a lib prefix, but something unexpected will break
             return "'lib$(TARGET_NAME)'"
         } else {
@@ -197,7 +197,7 @@ extension XcodeModuleProtocol  {
         var buildSettings = [String: String]()
         let plistPath = Path(Path.join(xcodeProjectPath, infoPlistFileName)).relative(to: xcodeProjectPath.parentDirectory)
 
-        if self is TestModule {
+        if isTest {
             buildSettings["EMBEDDED_CONTENT_CONTAINS_SWIFT"] = "YES"
 
             //FIXME this should not be required

--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -90,7 +90,7 @@ public func generate(dstdir: String, projectName: String, srcroot: String, modul
             print("  <key>CFBundleName</key>")
             print("  <string>$(PRODUCT_NAME)</string>")
             print("  <key>CFBundlePackageType</key>")
-            if module is TestModule {
+            if module.isTest {
                 print("  <string>BNDL</string>")
             } else {
                 print("  <string>FMWK</string>")

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -17,8 +17,8 @@ import Utility
 public func pbxproj(srcroot: String, projectRoot: String, xcodeprojPath: String, modules: [XcodeModuleProtocol], externalModules: [XcodeModuleProtocol], products _: [Product], options: XcodeprojOptions, printer print: (String) -> Void) throws {
     // let rootModulesSet = Set(modules).subtract(Set(externalModules))
     let rootModulesSet = modules
-    let nonTestRootModules = rootModulesSet.filter{ !($0 is TestModule) }
-    let (tests, nonTests) = modules.partition{ $0 is TestModule }
+    let nonTestRootModules = rootModulesSet.filter{ !$0.isTest }
+    let (tests, nonTests) = modules.partition{ $0.isTest }
 
     print("// !$*UTF8*$!")
     print("{")

--- a/Sources/Xcodeproj/xcscheme().swift
+++ b/Sources/Xcodeproj/xcscheme().swift
@@ -16,8 +16,7 @@ func xcscheme(container: String, modules: [XcodeModuleProtocol], printer print: 
     print("  <BuildAction parallelizeBuildables = \"YES\" buildImplicitDependencies = \"YES\">")
     print("    <BuildActionEntries>")
 
-    let nontests = modules.filter{ !($0 is TestModule) }
-    let tests = modules.filter{ $0 is TestModule }
+    let (tests, nontests) = modules.partition { $0.isTest }
 
     for module in nontests {
         print("      <BuildActionEntry buildForTesting = \"YES\" buildForRunning = \"YES\" buildForProfiling = \"YES\" buildForArchiving = \"YES\" buildForAnalyzing = \"YES\">")


### PR DESCRIPTION
… class `TestModule` which was a subclass of `SwiftModule` and add a bool to Module to indicate whether a module is a test or not."

Related bug: https://bugs.swift.org/browse/SR-1585