### PR TITLE
[Build] Include OSX sdk platform path in framework search paths

### DIFF
--- a/Sources/Build/Command.compile(ClangModule).swift
+++ b/Sources/Build/Command.compile(ClangModule).swift
@@ -13,11 +13,13 @@ import Utility
 import POSIX
 
 private extension ClangModule {
-    var basicArgs: [String] {
+    func basicArgs() throws -> [String] {
         var args: [String] = []
-        #if os(Linux)
-            args += ["-fPIC"]
-        #endif
+      #if os(OSX)
+        args += ["-F", try platformFrameworksPath()]
+      #else
+        args += ["-fPIC"]
+      #endif
         args += ["-fmodules", "-fmodule-name=\(name)"]
         return args
     }
@@ -87,7 +89,7 @@ extension Command {
         ///------------------------------ Compile -----------------------------------------
         var compileCommands = [Command]()
         let dependencies = module.dependencies.map{ $0.targetName }
-        var basicArgs = module.basicArgs + module.includeFlagsWithExternalModules(externalModules) + module.optimizationFlags(conf)
+        var basicArgs = try module.basicArgs() + module.includeFlagsWithExternalModules(externalModules) + module.optimizationFlags(conf)
         basicArgs += module.moduleCacheArgs(prefix: prefix)
         basicArgs += Xcc
 
@@ -113,7 +115,7 @@ extension Command {
         ///FIXME: This probably doesn't belong here
         ///------------------------------ Product -----------------------------------------
 
-        var args = module.basicArgs
+        var args = try module.basicArgs()
         args += module.optimizationFlags(conf)
         args += ["-L\(prefix)"]
         args += module.languageLinkArgs

--- a/Sources/Build/Command.link().swift
+++ b/Sources/Build/Command.link().swift
@@ -38,6 +38,10 @@ extension Command {
             args += ["-L\(prefix)"]
             args += ["-o", outpath]
 
+          #if os(OSX)
+            args += ["-F", try platformFrameworksPath()]
+          #endif
+
         case .Library(.Static):
             let inputs = buildables.map{ $0.targetName } + objects
             let outputs = [product.targetName, outpath]

--- a/Sources/Build/Error.swift
+++ b/Sources/Build/Error.swift
@@ -10,5 +10,4 @@
 
 public enum Error: ErrorProtocol {
     case noModules
-    case invalidPlatformPath
 }

--- a/Sources/Build/misc.swift
+++ b/Sources/Build/misc.swift
@@ -21,17 +21,6 @@ public protocol Toolchain {
     var clang: String { get }
 }
 
-func platformFrameworksPath() throws -> String {
-    // Lazily compute the platform the first time it is needed.
-    struct Static {
-        static let value = { try? POSIX.popen(["xcrun", "--sdk", "macosx", "--show-sdk-platform-path"]) }()
-    }
-    guard let popened = Static.value, let chuzzled = popened.chuzzle() else {
-        throw Error.invalidPlatformPath
-    }
-    return Path.join(chuzzled, "Developer/Library/Frameworks")
-}
-
 extension CModule {
     
     var moduleMap: String {

--- a/Sources/Utility/Error.swift
+++ b/Sources/Utility/Error.swift
@@ -15,6 +15,7 @@ public enum Error: ErrorProtocol {
     case unicodeEncodingError
     case couldNotCreateFile(path: String)
     case fileDoesNotExist(path: String)
+    case invalidPlatformPath
 }
 
 extension Error: CustomStringConvertible {
@@ -28,6 +29,7 @@ extension Error: CustomStringConvertible {
         case .unicodeEncodingError: return "Could not encode string into unicode"
         case .couldNotCreateFile(let path): return "Could not create file: \(path)"
         case .fileDoesNotExist(let path): return "File does not exist: \(path)"
+        case .invalidPlatformPath: return "Invalid platform path"
         }
     }
 }

--- a/Sources/Utility/Platform.swift
+++ b/Sources/Utility/Platform.swift
@@ -35,3 +35,14 @@ public enum Platform {
         return nil
     }
 }
+
+public func platformFrameworksPath() throws -> String {
+    // Lazily compute the platform the first time it is needed.
+    struct Static {
+        static let value = { try? POSIX.popen(["xcrun", "--sdk", "macosx", "--show-sdk-platform-path"]) }()
+    }
+    guard let popened = Static.value, let chuzzled = popened.chuzzle() else {
+        throw Error.invalidPlatformPath
+    }
+    return Path.join(chuzzled, "Developer/Library/Frameworks")
+}

--- a/Sources/Xcodeproj/Module+PBXProj.swift
+++ b/Sources/Xcodeproj/Module+PBXProj.swift
@@ -256,6 +256,9 @@ extension XcodeModuleProtocol  {
             buildSettings["OTHER_SWIFT_FLAGS"] = (["$(inherited)"] + pkgArgs.cFlags).joined(separator: " ")
         }
 
+        // Add framework search path to build settings.
+        buildSettings["FRAMEWORK_SEARCH_PATHS"] = Path.join("$(PLATFORM_DIR)", "Developer/Library/Frameworks")
+
         return buildSettings
     }
 }


### PR DESCRIPTION
This will allow importing frameworks like XCTest in targets.