### PR TITLE
Use Product API for C language targets

### DIFF
--- a/Sources/Build/Command.compile(ClangModule).swift
+++ b/Sources/Build/Command.compile(ClangModule).swift
@@ -36,15 +36,6 @@ private extension ClangModule {
             return ["-O2"]
         }
     }
-
-    var productName: String {
-        switch type {
-        case .library:
-            return c99name.soname
-        case .executable:
-            return c99name
-        }
-    }
 }
 
 /// A helper struct for ClangModule to compute basic
@@ -77,27 +68,25 @@ struct ClangModuleBuildMetadata {
         }
     }
 
+    /// Returns all the objects files for this module.
+    var objects: [String] { return compilePaths().map{$0.object} }
+
     /// Basic flags needed to compile this module.
     func basicCompileArgs() throws -> [String] {
-        return try basicArgs() + ["-fmodules", "-fmodule-name=\(module.c99name)"] + otherArgs + module.moduleCacheArgs(prefix: prefix)
+        return try ClangModuleBuildMetadata.basicArgs() + ["-fmodules", "-fmodule-name=\(module.c99name)"] + otherArgs + module.moduleCacheArgs(prefix: prefix)
     }
 
-    /// Basic flags needed to link this module.
-    func basicLinkArgs() throws -> [String] {
-        return try basicArgs() + linkDependenciesFlags + otherArgs + module.languageLinkArgs
-    }
-
-    /// Flags to link the C language dependencies of this module.
-    private var linkDependenciesFlags: [String] {
-        var args: [String] = []
-        for case let dep as ClangModule in module.dependencies {
-            args += ["-l\(dep.c99name)"]
+    /// Objects of all the dependencies of this module.
+    var dependenciesObjects: [String] {
+        return module.dependencies.flatMap { module -> [String] in
+            guard case let module as ClangModule = module else { return [] }                
+            let buildMeta = ClangModuleBuildMetadata(module: module, prefix: prefix, otherArgs: [])
+            return buildMeta.objects
         }
-        return args
     }
 
     /// Basic arguments needed for both compiling and linking.
-    private func basicArgs() throws -> [String] {
+    static func basicArgs() throws -> [String] {
         var args: [String] = []
       #if os(OSX)
         args += ["-F", try platformFrameworksPath()]
@@ -111,7 +100,7 @@ struct ClangModuleBuildMetadata {
 extension Command {
     static func compile(clangModule module: ClangModule, externalModules: Set<Module>, configuration conf: Configuration, prefix: String, CC: String, Xcc: [String], Xld: [String]) throws -> [Command] {
 
-        var buildMeta = ClangModuleBuildMetadata(module: module, prefix: prefix, otherArgs: Xcc)
+        let buildMeta = ClangModuleBuildMetadata(module: module, prefix: prefix, otherArgs: Xcc)
         
         if module.type == .library {
             try module.generateModuleMap(inDir: buildMeta.buildDirectory)
@@ -140,30 +129,6 @@ extension Command {
             compileCommands.append(command)
         }
 
-
-        ///FIXME: This probably doesn't belong here
-        ///------------------------------ Product -----------------------------------------
-
-        buildMeta = ClangModuleBuildMetadata(module: module, prefix: prefix, otherArgs: Xld)
-
-        var args = try buildMeta.basicLinkArgs()
-        args += ["-L\(prefix)"]
-        args += buildMeta.compilePaths().map{$0.object}
-
-        if module.type == .library {
-            args += ["-shared"]
-        }
-
-        let productPath = Path.join(prefix, module.productName)
-        args += ["-o", productPath]
-        
-        let shell = ShellTool(description: "Linking \(module.name)",
-                              inputs: buildMeta.inputs + compileCommands.map{$0.node},
-                              outputs: [productPath, module.targetName],
-                              args: [CC] + args)
-        
-        let command = Command(node: module.targetName, tool: shell)
-
-        return compileCommands + [command]
+       return compileCommands
     }
 }

--- a/Sources/Build/Command.link(ClangModule).swift
+++ b/Sources/Build/Command.link(ClangModule).swift
@@ -1,0 +1,51 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import PackageModel
+import PackageLoading
+import Utility
+
+extension Command {
+    static func linkClangModule(_ product: Product, configuration conf: Configuration, prefix: String, otherArgs: [String], CC: String) throws -> Command {
+        precondition(prefix.isAbsolute)
+        precondition(product.containsOnlyClangModules)
+
+        let clangModules = product.modules.flatMap { $0 as? ClangModule }
+        var args = [String]()
+
+        // Collect all the objects.
+        let objects = clangModules.flatMap { module -> [String] in 
+            let buildMeta = ClangModuleBuildMetadata(module: module, prefix: prefix, otherArgs: [])
+            return buildMeta.objects + buildMeta.dependenciesObjects
+        }
+
+        args += try ClangModuleBuildMetadata.basicArgs() + otherArgs
+        args += ["-L\(prefix)"]
+        args += objects
+
+        switch product.type {
+        case .Executable: break
+        case .Library(.Dynamic):
+            args += ["-shared"]
+        case .Test, .Library(.Static):
+            fatalError("Can't build \(product.name), \(product.type) is not yet supported.")
+        }
+
+        let productPath = Path.join(prefix, product.outname)
+        args += ["-o", productPath]
+        
+        let shell = ShellTool(description: "Linking \(product.name)",
+                              inputs: objects,
+                              outputs: [productPath, product.targetName],
+                              args: [CC] + args)
+        
+        return Command(node: product.targetName, tool: shell)
+    }
+}

--- a/Sources/Build/Command.link(SwiftModule).swift
+++ b/Sources/Build/Command.link(SwiftModule).swift
@@ -15,7 +15,7 @@ import Utility
 //FIXME messy :/
 
 extension Command {
-    static func link(_ product: Product, configuration conf: Configuration, prefix: String, otherArgs: [String], SWIFT_EXEC: String) throws -> Command {
+    static func linkSwiftModule(_ product: Product, configuration conf: Configuration, prefix: String, otherArgs: [String], SWIFT_EXEC: String) throws -> Command {
         precondition(prefix.isAbsolute)
 
         // Get the set of all input modules.
@@ -69,7 +69,7 @@ extension Command {
           #else
             // HACK: To get a path to LinuxMain.swift, we just grab the
             //       parent directory of the first test module we can find.
-            let firstTestModule = product.modules.filter{ $0.isTest }.first!
+            let firstTestModule = product.modules.flatMap{ $0 as? SwiftModule }.filter{ $0.isTest }.first!
             let testDirectory = firstTestModule.sources.root.parentDirectory
             let main = Path.join(testDirectory, "LinuxMain.swift")
             args.append(main)

--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -65,8 +65,13 @@ public func describe(_ prefix: String, _ conf: Configuration, _ modules: [Module
 #if os(Linux)
         rpathArgs += ["-Xlinker", "-rpath=$ORIGIN"]
 #endif
-        
-        let command = try Command.link(product, configuration: conf, prefix: prefix, otherArgs: Xld + swiftcArgs + toolchain.platformArgs + rpathArgs, SWIFT_EXEC: SWIFT_EXEC)
+        let command: Command
+        if product.containsOnlyClangModules {
+            command = try Command.linkClangModule(product, configuration: conf, prefix: prefix, otherArgs: Xld, CC: CC)
+        } else {
+            command = try Command.linkSwiftModule(product, configuration: conf, prefix: prefix, otherArgs: Xld + swiftcArgs + toolchain.platformArgs + rpathArgs, SWIFT_EXEC: SWIFT_EXEC)
+        }
+
         commands.append(command)
         targets.append(command, for: product)
     }

--- a/Sources/Build/misc.swift
+++ b/Sources/Build/misc.swift
@@ -61,6 +61,11 @@ extension ClangModule {
 }
 
 extension Product {
+    /// Returns true iff all the modules in this product are ClangModules. 
+    var containsOnlyClangModules: Bool {
+        return modules.filter{ $0 is ClangModule }.count == modules.count
+    }
+
     var Info: (_: Void, plist: String) {
         precondition(isTest)
 

--- a/Sources/PackageLoading/PackageExtensions.swift
+++ b/Sources/PackageLoading/PackageExtensions.swift
@@ -207,11 +207,25 @@ extension Package {
             }
         }
 
+    ////// Implict products for ClangModules.
+
+        for case let module as ClangModule in modules {
+            let type: ProductType
+            switch module.type {
+            case .executable:
+                type = .Executable
+            case .library:
+                type = .Library(.Dynamic)
+            }
+            let product = Product(name: module.name, type: type, modules: [module])
+            products.append(product)
+        }
+
     ////// auto-determine tests
 
         if !testModules.isEmpty {
             // FIXME: Product should support all modules.
-            let modules: [SwiftModule] = testModules.flatMap{$0 as? SwiftModule} // or linux compiler crash (2016-02-03)
+            let modules: [Module] = testModules.filter{$0 is SwiftModule} // or linux compiler crash (2016-02-03)
             //TODO and then we should prefix all modules with their package probably
             //Suffix 'Tests' to test product so the module name of linux executable don't collide with
             //main package, if present.
@@ -222,8 +236,8 @@ extension Package {
     ////// add products from the manifest
 
         for p in manifest.products {
-            let modules: [SwiftModule] = p.modules.flatMap{ moduleName in
-                guard case let picked as SwiftModule = (modules.pick{ $0.name == moduleName }) else {
+            let modules: [Module] = p.modules.flatMap{ moduleName in
+                guard let picked = (modules.pick{ $0.name == moduleName }) else {
                     print("warning: No module \(moduleName) found for product \(p.name)")
                     return nil
                 }

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -14,9 +14,9 @@ import Utility
 public class Product {
     public let name: String
     public let type: ProductType
-    public let modules: [SwiftModule]
+    public let modules: [Module]
 
-    public init(name: String, type: ProductType, modules: [SwiftModule]) {
+    public init(name: String, type: ProductType, modules: [Module]) {
         self.name = name
         self.type = type
         self.modules = modules


### PR DESCRIPTION
Depends on https://github.com/apple/swift-package-manager/pull/387 merge.
This is the last piece of puzzle after which the C language in Test targets can be supported.