### PR TITLE
[WIP][Xcodeproj] Make module name as bundle identifier

### DIFF
--- a/Sources/Xcodeproj/Module+PBXProj.swift
+++ b/Sources/Xcodeproj/Module+PBXProj.swift
@@ -233,6 +233,9 @@ extension XcodeModuleProtocol  {
                 buildSettings["INFOPLIST_FILE"] = plistPath
 
                 buildSettings["PRODUCT_MODULE_NAME"] = "$(TARGET_NAME:c99extidentifier)"
+
+                // FIXME: This should be user speficiable
+                buildSettings["PRODUCT_BUNDLE_IDENTIFIER"] = c99name
             } else {
                 // override default behavior, instead link dynamically
                 buildSettings["SWIFT_FORCE_STATIC_LINK_STDLIB"] = "NO"


### PR DESCRIPTION
The frameworks in the generated Xcode project have the value `$(PRODUCT_BUNDLE_IDENTIFIER)` for the key `CFBundleIdentifier`. This actually doesn't allow such framework to be installed into an iOS app.

Fixed it by changing `CFBundleIdentifier` to be the concrete name of the framework.

@ddunbar Is this fine? This approach doesn't allow user to enter custom bundle identifier like "com.example.foolib" for each framework target (this will be overridden to module name every time `generate-xcodeproj` is invoked)