### PR TITLE
[SR-1679] Restore `-X` as a shortcut for `generate-xcodeproj`

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -48,7 +48,7 @@ private enum Mode: Argument, Equatable, CustomStringConvertible {
             self = .dumpPackage
         case "fetch":
             self = .fetch
-        case "generate-xcodeproj":
+        case "-X", "generate-xcodeproj":
             self = .generateXcodeproj
         case "init":
             self = .initPackage
@@ -273,14 +273,14 @@ public struct SwiftPackageTool {
         print("USAGE: swift package [command] [options]")
         print("")
         print("COMMANDS:")
-        print("  init [--type <type>]                   Initialize a new package")
-        print("                                         (type: library|executable|system-module)")
-        print("  fetch                                  Fetch package dependencies")
-        print("  update                                 Update package dependencies")
-        print("  generate-xcodeproj [--output <path>]   Generates an Xcode project")
-        print("  show-dependencies [--format <format>]  Print the resolved dependency graph")
-        print("                                         (format: text|dot|json)")
-        print("  dump-package [--output <path>]         Print parsed Package.swift as JSON")
+        print("  init [--type <type>]                      Initialize a new package")
+        print("                                            (library|executable|system-module)")
+        print("  fetch                                     Fetch package dependencies")
+        print("  update                                    Update package dependencies")
+        print("  -X, generate-xcodeproj [--output <path>]  Generates an Xcode project")
+        print("  show-dependencies [--format <format>]     Print the resolved dependency graph")
+        print("                                            (text|dot|json)")
+        print("  dump-package [--output <path>]            Print parsed Package.swift as JSON")
         print("")
         print("OPTIONS:")
         print("  -C, --chdir <path>        Change working directory before any other operation")

--- a/Tests/Xcodeproj/FunctionalTests.swift
+++ b/Tests/Xcodeproj/FunctionalTests.swift
@@ -22,7 +22,7 @@ import func POSIX.mkdtemp
 class FunctionalTests: XCTestCase {
     func testSingleModuleLibrary() {
         fixture(name: "ValidLayouts/SingleModule/Library") { prefix in
-            XCTAssertXcodeprojGen(prefix)
+            XCTAssertXcodeprojGen(prefix, useShortcutFlag: true)
             let pbx = Path.join(prefix, "Library.xcodeproj")
             XCTAssertDirectoryExists(pbx)
             XCTAssertXcodeBuild(project: pbx)
@@ -149,10 +149,10 @@ func XCTAssertXcodeBuild(project: String, file: StaticString = #file, line: UInt
     }
 }
 
-func XCTAssertXcodeprojGen(_ prefix: String, flags: [String] = [], env: [String: String] = [:], file: StaticString = #file, line: UInt = #line) {
+func XCTAssertXcodeprojGen(_ prefix: String, useShortcutFlag: Bool = false, flags: [String] = [], env: [String: String] = [:], file: StaticString = #file, line: UInt = #line) {
     do {
         print("    Generating XcodeProject")
-        _ = try SwiftPMProduct.SwiftPackage.execute(["generate-xcodeproj"] + flags, chdir: prefix, env: env, printIfError: true)
+        _ = try SwiftPMProduct.SwiftPackage.execute([useShortcutFlag ? "-X" : "generate-xcodeproj"] + flags, chdir: prefix, env: env, printIfError: true)
     } catch {
         XCTFail("`swift package generate-xcodeproj' failed:\n\n\(error)\n", file: file, line: line)
     }


### PR DESCRIPTION
This diff restores the `-X` shortcut that was lost when implementing
SE-0085 Package Manager Command Names.

For testing, this also adds an option to the helper function that invokes
swift package so that some tests can use the shortcut and others the long
form.