### PR TITLE
[WIP][Build] Add repl mode to launch LLDB REPL

### DIFF
--- a/Sources/Build/misc.swift
+++ b/Sources/Build/misc.swift
@@ -19,6 +19,7 @@ public protocol Toolchain {
     var platformArgsSwiftc: [String] { get }
     var sysroot: String?  { get }
     var SWIFT_EXEC: String { get }
+    var swift: String { get }
     var clang: String { get }
 }
 

--- a/Sources/Commands/UserToolchain.swift
+++ b/Sources/Commands/UserToolchain.swift
@@ -23,6 +23,7 @@ struct UserToolchain: Toolchain {
     let SWIFT_EXEC: String
     let clang: String
     let sysroot: String?
+    let swift: String
 
 #if os(OSX)
     var platformArgsClang: [String] {
@@ -39,9 +40,15 @@ struct UserToolchain: Toolchain {
 
     init() throws {
         do {
+
             SWIFT_EXEC = getenv("SWIFT_EXEC")
                 // use the swiftc installed alongside ourselves
                 ?? AbsolutePath(Process.arguments[0].abspath).appending("../swiftc").asString
+
+            swift = getenv("SWIFT")
+                // use the swift installed alongside ourselves
+                ?? Path.join(Process.arguments[0], "../swift").abspath
+
 
             clang = try getenv("CC") ?? POSIX.popen(whichClangArgs).chomp()
 

--- a/Sources/PackageDescription/Product.swift
+++ b/Sources/PackageDescription/Product.swift
@@ -50,6 +50,48 @@ extension ProductType: CustomStringConvertible {
     }
 }
 
+extension ProductType: Hashable, Equatable {
+    public var hashValue: Int {
+        switch self {
+        case .Test:
+            return 10
+        case .Executable:
+            return 20
+        case .Library(.Static):
+            return 30
+        case .Library(.Dynamic):
+            return 40
+        }
+    }
+}
+
+public func ==(lhs: ProductType, rhs: ProductType) -> Bool {
+    switch (lhs, rhs) {
+    case (.Test, .Test):
+        return true
+    case (.Executable, .Executable):
+        return true
+    case (.Library(let lhsType), .Library(let rhsType)):
+        return lhsType == rhsType
+    default:
+        return false
+    }
+}
+
+
+extension LibraryType: Equatable {}
+
+public func ==(lhs: LibraryType, rhs: LibraryType) -> Bool {
+    switch (lhs, rhs) {
+    case (.Static, .Static):
+        return true
+    case (.Dynamic, .Dynamic):
+        return true
+    default:
+        return false
+    }
+}
+
 extension Product: TOMLConvertible {
     public func toTOML() -> String {
         var s = ""

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -60,3 +60,18 @@ extension Product: CustomStringConvertible {
         }
     }
 }
+
+
+extension Product: Hashable,Equatable {
+    public var hashValue: Int {
+        // FIXME: implement modules hash properly
+        return name.hashValue ^ type.hashValue ^ "\(modules)".hashValue
+    }
+}
+
+
+public func ==(lhs: Product, rhs: Product) -> Bool {
+    return (lhs.name == rhs.name)
+           && (lhs.type == rhs.type)
+           && (lhs.modules == rhs.modules)
+}

--- a/Tests/Build/DescribeTests.swift
+++ b/Tests/Build/DescribeTests.swift
@@ -22,6 +22,7 @@ final class DescribeTests: XCTestCase {
                 var platformArgsSwiftc: [String] { fatalError() }
                 var sysroot: String?  { fatalError() }
                 var SWIFT_EXEC: String { fatalError() }
+                var swift: String { fatalError() }
                 var clang: String { fatalError() }
             }
 


### PR DESCRIPTION
This patch adds `repl` sub command to `swift build` that can launch REPL with all the modules linked.

Dependencies:

- [x] Merging of #388 