### PR TITLE
Add additional linkage for libdispatch

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -678,6 +678,9 @@ def main():
             mkdir_p(libswiftdir)
             symlink_force(os.path.join(args.foundation_path, 'libFoundation.so'),
                 libswiftdir)
+            if args.libdispatch_build_dir:
+                symlink_force(os.path.join(args.libdispatch_build_dir, "src", ".libs", "libdispatch.so"),
+                    libswiftdir)
 
     make_fake_toolchain()
 
@@ -721,6 +724,12 @@ def main():
         # Add an RPATH, so that the tests can be run directly.
         cmd.extend(["-Xlinker", "-rpath", "-Xlinker", args.xctest_path])
         cmd.extend(["-Xswiftc", "-I{}".format(args.xctest_path)])
+
+    if args.libdispatch_build_dir:
+        cmd.extend(["-Xswiftc", "-I{}".format(os.path.join(args.libdispatch_build_dir,
+                                             "src"))])
+        cmd.extend(["-Xswiftc", "-I{}".format(args.libdispatch_source_dir)])
+        cmd.extend(["-Xcc", "-fblocks"])
 
     if args.release:
         cmd.extend(["--configuration", "release"])


### PR DESCRIPTION
This adds additional compile and link options for Dispatch in the actual Swift PM build step.

The symlink is added so that Foundation can dynamically link to libdispatch - there's also a PR against Foundation to adds a RPATH of ORIGIN so that its on the search path in both the fake toolchain and the final Swift toolchain:
https://github.com/apple/swift-corelibs-foundation/pull/405

The other options are so that the Dispatch overlay can be found and blocks used for the actual Swift PM build (in addition to the build of the fake toolchain).