### PR TITLE
[PackageModel] Delete unused LibraryType

### DIFF
--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -41,11 +41,6 @@ public class Product {
     }
 }
 
-public enum LibraryType {
-    case dynamic
-    case Static
-}
-
 extension Product: CustomStringConvertible {
     public var description: String {
         let base = outname.basename


### PR DESCRIPTION
This patch removes `LibraryType` enum in `Product`, which is not used anymore.