### PR TITLE
Enable ARC by default when compiling clang modules

### DIFF
--- a/Sources/Build/Command.compile(ClangModule).swift
+++ b/Sources/Build/Command.compile(ClangModule).swift
@@ -79,7 +79,7 @@ struct ClangModuleBuildMetadata {
 
     /// Basic flags needed to compile this module.
     func basicCompileArgs() throws -> [String] {
-        return try basicArgs() + ["-fmodules", "-fmodule-name=\(module.c99name)"] + otherArgs + module.moduleCacheArgs(prefix: prefix)
+        return try basicArgs() + ["-fobjc-arc", "-fmodules", "-fmodule-name=\(module.c99name)"] + otherArgs + module.moduleCacheArgs(prefix: prefix)
     }
 
     /// Basic flags needed to link this module.


### PR DESCRIPTION
I'm not sure how configuration is planning on being handled, but for now, I think ARC is a reasonable default.