### PR TITLE
[POSIX] Add mktemp method.

### DIFF
--- a/Sources/POSIX/Error.swift
+++ b/Sources/POSIX/Error.swift
@@ -16,6 +16,7 @@ public enum SystemError: ErrorProtocol {
     case fread(Int32)
     case getcwd(Int32)
     case mkdtemp(Int32)
+    case mktemp(Int32)
     case opendir(Int32, String)
     case pipe(Int32)
     case popen(Int32, String)
@@ -57,6 +58,8 @@ extension SystemError: CustomStringConvertible {
             return "getcwd error: \(strerror(errno))"
         case .mkdtemp(let errno):
             return "mkdtemp error: \(strerror(errno))"
+        case .mktemp(let errno):
+            return "mktemp error: \(strerror(errno))"
         case .opendir(let errno, _):
             return "opendir error: \(strerror(errno))"
         case .pipe(let errno):

--- a/Sources/POSIX/mktemp.swift
+++ b/Sources/POSIX/mktemp.swift
@@ -1,0 +1,41 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import var libc.errno
+import func libc.mktemp
+import func libc.unlink
+
+#if os(Linux)
+    import Foundation  // String.hasSuffix
+#endif
+
+/// Creates a temporary file available till duration of closure.
+///
+/// - Parameters:
+///     - template: Filename template to be used.
+///     - prefix: If present, this path will be the prefix for file to be created, otherwise
+///               temp directory will be used.
+///     - body: Closure to be executed. The temp file path will be passed to the closure.
+///
+/// - Throws: SystemError.mktemp
+public func mktemp<T>(_ template: String, prefix: String! = nil, body: @noescape(String) throws -> T) rethrows -> T {
+    var prefix = prefix ?? getenv("TMPDIR") ?? "/tmp/"
+    if !prefix.hasSuffix("/") { prefix += "/" }
+
+    let path = prefix + "\(template).XXXXXX"
+
+    return try path.withCString { template in
+        let mutable = UnsafeMutablePointer<Int8>(template)
+        guard let file = libc.mktemp(mutable) else { throw SystemError.mktemp(errno) }
+        // Remove the file on exit.
+        defer { unlink(file) }
+        return try body(String(validatingUTF8: file)!)
+    }
+}


### PR DESCRIPTION
This method, similar to mkdtemp, will help creating a temporary file for
duration of the closure passed to it.