### PR TITLE
Add the start of AbsolutePath and RelativePath types for path handling

### DIFF
--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -163,12 +163,13 @@ public struct RelativePath {
         _impl = PathImpl(string: normalize(relative: string))
     }
     
-    /// Directory component.  For a relative path, this may be empty.
+    /// Directory component.  For a relative path without any path separators,
+    /// this is the `.` string instead of the empty string.
     public var dirname: String {
         return _impl.dirname
     }
     
-    /// Last path component (including the suffix, if any).  it is never empty.
+    /// Last path component (including the suffix, if any).  It is never empty.
     public var basename: String {
         return _impl.basename
     }
@@ -226,17 +227,17 @@ private struct PathImpl {
     private let string: String
     
     /// Private function that returns the directory part of the stored path
-    /// string (relying on the fact that it has been normalized).  Returns an
-    /// empty string if there is no directory part (which is the case if and
-    /// only if there is no path separator).
+    /// string (relying on the fact that it has been normalized).  Returns a
+    /// string consisting of just `.` if there is no directory part (which is
+    /// the case if and only if there is no path separator).
     private var dirname: String {
         // FIXME: This method seems too complicated; it should be simplified,
         //        if possible, and certainly optimized (using UTF8View).
         let chars = string.characters
         // Find the last path separator.
         guard let idx = chars.rindex(of: pathSeparatorCharacter) else {
-            // No path separators, so the directory name is empty.
-            return ""
+            // No path separators, so the directory name is `.`.
+            return "."
         }
         // Check if it's the only one in the string.
         if idx == chars.startIndex {

--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -75,7 +75,8 @@ public struct AbsolutePath {
     }
     
     /// Suffix (including leading `.` character) if any.  Note that a basename
-    /// that starts with a `.` character is not considered a suffix.
+    /// that starts with a `.` character is not considered a suffix, nor is a
+    /// trailing `.` character.
     public var suffix: String? {
         return _impl.suffix
     }
@@ -159,7 +160,8 @@ public struct RelativePath {
     }
     
     /// Suffix (including leading `.` character) if any.  Note that a basename
-    /// that starts with a `.` character is not considered a suffix.
+    /// that starts with a `.` character is not considered a suffix, nor is a
+    /// trailing `.` character.
     public var suffix: String? {
         return _impl.suffix
     }

--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -8,9 +8,6 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import libc
-import POSIX
-
 
 /// Path separator character (always `/`).  If a path separator occurs at the
 /// beginning of a path, the path is considered to be absolute.

--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -1,0 +1,473 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import libc
+import POSIX
+
+
+/// Path separator character (always `/`).  If a path separator occurs at the
+/// beginning of a path, the path is considered to be absolute.
+public let PathSeparatorCharacter: Character = "/"
+
+/// User directory replacement character (always `~`).  When it occurs at the
+/// beginning of the first component of a path (optionally followed by a user
+/// name), that first path component is replaced by the absolute path of the
+/// home directory of the user.
+public let HomeDirectoryCharacter: Character = "~"
+
+
+/// Represents an absolute file system path, independently of what (or whether
+/// anything at all) exists at that path in the file system at any given time.
+/// An absolute path always starts with a `/` character, and holds a normalized
+/// string representation.  This normalization is strictly syntactic, and does
+/// not access the file system in any way.
+public struct AbsolutePath {
+    /// Private implementation details, shared with the RelativePath struct.
+    private let _impl: PathImpl
+    
+    /// Initializes the AbsolutePath from `string`, which must be an absolute
+    /// path (which means that it must begin with either a path separator or a
+    /// tilde, denoting an absolute path of a user account home directory).
+    ///
+    /// The path string will be normalized by:
+    /// - Collapsing `..` path components
+    /// - Removing `.` path components
+    /// - Expanding `~` or `~user` prefix
+    /// - Removing any trailing path separator
+    /// - Removing any redundant path separators
+    ///
+    /// This string manipulation may change the meaning of a path if any of the
+    /// path components are symbolic links on disk.  However, the file system is
+    /// never accessed in any way when initializing an AbsolutePath.
+    public init(_ string: String) {
+        precondition(string.characters.first == PathSeparatorCharacter
+                  || string.characters.first == HomeDirectoryCharacter)
+        
+        // Get a hold of the character view.
+        // FIXME: We need to investigate what is most performant here.
+        //        For example, is UTF-8 view more efficient, or unichars, etc?
+        var chars = string.characters
+        
+        // Expand any `~` or `~user` prefix.
+        if chars.first == HomeDirectoryCharacter {
+            // We're doing home directory substitution. Check for a user name.
+            let nStart = chars.index(after: chars.startIndex)
+            let nEnd = chars.index(of: PathSeparatorCharacter) ?? chars.endIndex
+            if nStart == nEnd {
+                // No user name, so we need home directory of effective user.
+                let homeDir = gethomedir().characters
+                chars.replaceSubrange(chars.startIndex ..< nEnd, with: homeDir)
+            }
+            else {
+                // A user name was provided, so we try to look that up.
+                // FIXME:  What do we do if we cannot find the user name? Most
+                //         shells leave it as a relative path, which we do not
+                //         want to do since we want the type safety of knowing
+                //         up-front whether a path is absolute or relative.
+                let name = String(chars[nStart ..< nEnd])
+                let homeDir = gethomedir(user: name).characters
+                chars.replaceSubrange(chars.startIndex ..< nEnd, with: homeDir)
+            }
+        }
+        
+        // At this point we expect to have a path separator as first character.
+        assert(chars.first == PathSeparatorCharacter)
+
+        // Split the character array into parts, folding components as we go.
+        // As we do so, we count the number of characters we'll end up with in
+        // the normalized string representation.
+        var parts: [String.CharacterView] = []
+        var capacity = 0
+        for part in chars.split(separator: PathSeparatorCharacter) {
+            switch part.count {
+              case 0:
+                // Ignore empty path components.
+                continue
+              case 1 where part.first == ".":
+                // Ignore `.` path components.
+                continue
+              case 2 where part.first == "." && part.last == ".":
+                // If there's a previous part, drop it; otherwise, do nothing.
+                if let prev = parts.last {
+                    parts.removeLast()
+                    capacity -= prev.count
+                }
+              default:
+                // Any other component gets appended.
+                parts.append(part)
+                capacity += part.count
+            }
+        }
+        capacity += max(parts.count, 1)
+        
+        // Create an output buffer using the capacity we've calculated.
+        // FIXME: Determine whether this is the most efficient way to do it.
+        var result = ""
+        result.reserveCapacity(capacity)
+        
+        // Put the normalized parts back together again.
+        var iter = parts.makeIterator()
+        result.append(PathSeparatorCharacter)
+        if let first = iter.next() {
+            result.append(contentsOf: first)
+            while let next = iter.next() {
+                result.append(PathSeparatorCharacter)
+                result.append(contentsOf: next)
+            }
+        }
+        
+        // Sanity-check the result (including the capacity we reserved).
+        assert(!result.isEmpty, "unexpected empty string")
+        assert(result.characters.count == capacity, "count: " +
+            "\(result.characters.count), cap: \(capacity)")
+        
+        // Use the result as our stored string.
+        _impl = PathImpl(string: String(result))
+    }
+    
+    /// Directory component.  An absolute path always has a non-empty directory
+    /// component (the directory component of the root path is the root itself).
+    public var dirname: String {
+        return _impl.dirname!
+    }
+    
+    /// Last path component (including the suffix, if any).  it is never empty.
+    public var basename: String {
+        return _impl.basename
+    }
+    
+    /// Suffix (including leading `.` character) if any.  Note that a basename
+    /// that starts with a `.` character is not considered a suffix.
+    public var suffix: String? {
+        return _impl.suffix
+    }
+    
+    /// Absolute path of parent directory.  This always returns a path, because
+    /// every directory has a parent (the parent directory of the root directory
+    /// is considered to be the root directory itself).
+    public var parentDirectory: AbsolutePath {
+        return isRoot ? self : AbsolutePath(_impl.dirname!)
+    }
+    
+    /// True if the path is the root directory.
+    public var isRoot: Bool {
+        let chars = _impl.string.characters
+        return chars.count == 1 && chars.first == PathSeparatorCharacter
+    }
+    
+    /// Returns the absolute path with the relative path applied.
+    public func join(_ subpath: RelativePath) -> AbsolutePath {
+        let slash = String(PathSeparatorCharacter)
+        return AbsolutePath(asString + slash + subpath.asString)
+    }
+    
+    /// NOTE: We will want to add other methods here, such as a join() method
+    ///       that takes an arbitrary number of parameters, etc.  Most likely
+    ///       we will also make the `+` operator mean `join()`.
+    
+    /// Root directory (whose string representation is just a path separator).
+    public static var root: AbsolutePath {
+        // FIXME: If this is called a lot, we should maybe cache the root path.
+        return AbsolutePath(String(PathSeparatorCharacter))
+    }
+    
+    /// Home directory of the effective user.
+    public static var home: AbsolutePath {
+        // FIXME: We need a real implementation here.
+        return AbsolutePath(gethomedir())
+    }
+    
+    /// Normalized string representation (the normalization rules are described
+    /// in the documentation of the initializer).  This string is never empty.
+    public var asString: String {
+        return _impl.string
+    }
+}
+
+
+/// Represents a relative file system path.  A relative path is a string that
+/// doesn't start with a `/` or a `~` character, and holds a normalized string
+/// representation.  As with AbsolutePath, the normalization is strictly syn-
+/// tactic, and does not access the file system in any way.
+public struct RelativePath {
+    /// Private implementation details, shared with the AbsolutePath struct.
+    private let _impl: PathImpl
+    
+    /// Initializes the RelativePath from `str`, which must be a relative path
+    /// (which means that it must not begin with a path separator or a tilde).
+    /// An empty input path is allowed, but will be normalized to a single `.`
+    /// character.
+    ///
+    /// The path string will be normalized by:
+    /// - Collapsing `..` path components that aren't at the beginning
+    /// - Removing extraneous `.` path components
+    /// - Removing any trailing path separator
+    /// - Removing any redundant path separators
+    /// - Replacing a completely empty path with a `.`
+    ///
+    /// This string manipulation may change the meaning of a path if any of the
+    /// path components are symbolic links on disk.  However, the file system is
+    /// never accessed in any way when initializing an AbsolutePath.
+    public init(_ string: String) {
+        precondition(string.characters.first != PathSeparatorCharacter
+                  && string.characters.first != HomeDirectoryCharacter)
+        // Get a hold of the character view.
+        // FIXME: We need to investigate what is most performant here.
+        //        For example, is UTF-8 view more efficient, or unichars, etc?
+        let chars = string.characters
+        
+        // Split the character array into parts, folding components as we go.
+        // As we do so, we count the number of characters we'll end up with in
+        // the normalized string representation.
+        var parts: [String.CharacterView] = []
+        var capacity = 0
+        for part in chars.split(separator: PathSeparatorCharacter) {
+            switch part.count {
+              case 0:
+                // Ignore empty path components.
+                continue
+              case 1 where part.first == ".":
+                // Ignore `.` path components.
+                continue
+              case 2 where part.first == "." && part.last == ".":
+                // If at beginning, fall through to treat the `..` literally.
+                guard let prev = parts.last else {
+                    fallthrough
+                }
+                // If previous component is anything other than `..`, drop it.
+                if !(prev.count == 2 && prev.first == "." && prev.last == ".") {
+                    parts.removeLast()
+                    capacity -= prev.count
+                    continue
+                }
+                // Otherwise, fall through to treat the `..` literally.
+                fallthrough
+              default:
+                // Any other component gets appended.
+                parts.append(part)
+                capacity += part.count
+            }
+        }
+        capacity += max(parts.count - 1, 0)
+        
+        // Create an output buffer using the capacity we've calculated.
+        // FIXME: Determine whether this is the most efficient way to do it.
+        var result = ""
+        result.reserveCapacity(capacity)
+        
+        // Put the normalized parts back together again.
+        var iter = parts.makeIterator()
+        if let first = iter.next() {
+            result.append(contentsOf: first)
+            while let next = iter.next() {
+                result.append(PathSeparatorCharacter)
+                result.append(contentsOf: next)
+            }
+        }
+        
+        // Sanity-check the result (including the capacity we reserved).
+        assert(result.characters.count == capacity, "count: " +
+            "\(result.characters.count), cap: \(capacity)")
+
+        // Use the result (or `.` if it's empty) as our stored string.
+        _impl = PathImpl(string: result.isEmpty ? "." : String(result))
+    }
+    
+    /// Directory component.  For a relative path, this may be empty.
+    public var dirname: String? {
+        return _impl.dirname
+    }
+    
+    /// Last path component (including the suffix, if any).  it is never empty.
+    public var basename: String {
+        return _impl.basename
+    }
+    
+    /// Suffix (including leading `.` character) if any.  Note that a basename
+    /// that starts with a `.` character is not considered a suffix.
+    public var suffix: String? {
+        return _impl.suffix
+    }
+    
+    /// Normalized string representation (the normalization rules are described
+    /// in the documentation of the initializer).  This string is never empty.
+    public var asString: String {
+        return _impl.string
+    }
+}
+
+
+// Make absolute paths Hashable.
+extension AbsolutePath : Hashable {
+    public var hashValue: Int {
+        return self.asString.hashValue
+    }
+}
+
+// Make absolute paths Equatable.
+extension AbsolutePath : Equatable { }
+public func ==(lhs: AbsolutePath, rhs: AbsolutePath) -> Bool {
+    return lhs.asString == rhs.asString
+}
+
+
+// Make relative paths Hashable.
+extension RelativePath : Hashable {
+    public var hashValue: Int {
+        return self.asString.hashValue
+    }
+}
+
+// Make relative paths Equatable.
+extension RelativePath : Equatable { }
+public func ==(lhs: RelativePath, rhs: RelativePath) -> Bool {
+    return lhs.asString == rhs.asString
+}
+
+
+/// Private implementation shared between AbsolutePath and RelativePath.  It is
+/// a little unfortunate that there needs to be duplication at all between the
+/// AbsolutePath and RelativePath struct, but PathImpl helps mitigate it.  From
+/// a type safety perspective, absolute paths and relative paths are genuinely
+/// different.
+private struct PathImpl {
+    /// Normalized string of the (absolute or relative) path.  Never empty.
+    private let string: String
+    
+    /// Private function that returns the directory part of the stored path
+    /// string (relying on the fact that it has been normalized).  Returns nil
+    /// if there is no directory part (which is the case iff there is no path
+    /// separator).
+    private var dirname: String? {
+        let chars = string.characters
+        guard let idx = chars.rindex(of: PathSeparatorCharacter) else {
+            return nil
+        }
+        return idx == chars.startIndex ? String(chars[idx])
+            : String(chars.prefix(upTo: idx))
+    }
+    
+    private var basename: String {
+        // FIXME: This needs to be rewritten.
+        guard !string.isEmpty else { return "." }
+        let parts = string.characters.split(separator: PathSeparatorCharacter)
+        guard !parts.isEmpty else { return "/" }
+        return String(parts.last!)
+    }
+    
+    private var suffix: String? {
+        // FIXME: This needs to be rewritten.
+        let chars = string.characters
+        guard chars.contains(".") else { return nil }
+        let parts = chars.split(separator: ".")
+        if let last = parts.last where parts.count > 1 { return String(last) }
+        return nil
+    }
+}
+
+
+/// Private functions for use by the path logic.  These should move out into a
+/// public place, but we'll need to debate the names, etc, etc.
+private extension String.CharacterView {
+    
+    /// Returns the index of the last occurrence of `char`, or nil if none.
+    private func rindex(of char: Character) -> Index? {
+        var idx = endIndex
+        while idx > startIndex {
+            idx = index(before: idx)
+            if self[idx] == char {
+                return idx
+            }
+        }
+        return nil
+    }
+}
+
+
+/// Private function that returns a string containing the home directory of the
+/// effective user.  This should definitely move out into a public place, but
+/// we'll need to debate the names, etc, etc.
+/// FIXME:  Should this function return an optional or throw an error if there
+/// is a problem with the current user id?
+private func gethomedir() -> String {
+    /// First respect the `HOME` environment variable, if it's set.
+    if let path = POSIX.getenv("HOME") {
+        return path
+    }
+    // Otherwise check effective user id, falling back on actual user id.
+    var uid = geteuid()
+    if uid == 0 { uid = getuid() }
+    // Look up the user in the account database.
+    let pwd = getpwuid(uid)
+    if let cdir = pwd?.pointee.pw_dir {
+        // We found the user, so construct a string from the pw_dir.
+        if let dir = String(validatingUTF8: cdir) {
+            return dir
+        }
+        // FIXME: How should we recover from bad UTF-8 in the home directory?
+        //        Should we just throw an error and punt the problem upwards?
+    }
+    // FIXME: What should we return if all else fails?
+    return "/tmp/~"
+}
+
+
+/// Private function that returns a string containing the home directory of the
+/// name user.  This should definitely move out into a public place, but we'll
+/// need to debate the names, etc, etc.
+/// FIXME:  Should this function return an optional or throw an error if there
+/// is no user with the given name?
+private func gethomedir(user: String) -> String {
+    // Look up the user in the account database.
+    let pwd = getpwnam(user)
+    if let cdir = pwd?.pointee.pw_dir {
+        // We found the user, so construct a string from the pw_dir.
+        if let dir = String(validatingUTF8: cdir) {
+            return dir
+        }
+        // FIXME: How should we recover from bad UTF-8 in the home directory?
+        //        Should we just throw an error and punt the problem upwards?
+    }
+    // FIXME: What should we return if all else fails?
+    return "/tmp/~\(user)"
+}
+
+
+/// Convenience properties that access the file system, making it convenient to
+/// get information about a file system entity at a particular path.  Note that
+/// none of these functions is allowed to mutate the file system.
+extension AbsolutePath {
+    // FIXME: Factor out a method to return the stat record, and then move the
+    //        other methods to the stat record.  That makes it easier to avoid
+    //        blithely stat:ing over and over again if multple properties are
+    //        checked (e.g. `isFile || isSymlink` etc).
+    
+    public var isDirectory: Bool {
+        var mystat = stat()
+        let rv = lstat(self.asString, &mystat)
+        return rv == 0 && (mystat.st_mode & S_IFMT) == S_IFDIR
+    }
+    
+    public var isFile: Bool {
+        var mystat = stat()
+        let rv = lstat(self.asString, &mystat)
+        return rv == 0 && (mystat.st_mode & S_IFMT) == S_IFREG
+    }
+        
+    public var isSymlink: Bool {
+        var mystat = stat()
+        let rv = lstat(self.asString, &mystat)
+        return rv == 0 && (mystat.st_mode & S_IFMT) == S_IFLNK
+    }
+    
+    public var exists: Bool {
+        return access(self.asString, F_OK) == 0
+    }
+}

--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -14,13 +14,10 @@ import POSIX
 
 /// Path separator character (always `/`).  If a path separator occurs at the
 /// beginning of a path, the path is considered to be absolute.
-public let PathSeparatorCharacter: Character = "/"
-
-/// User directory replacement character (always `~`).  When it occurs at the
-/// beginning of the first component of a path (optionally followed by a user
-/// name), that first path component is replaced by the absolute path of the
-/// home directory of the user.
-public let HomeDirectoryCharacter: Character = "~"
+/// FIXME: We can probably get rid of this, since a) this is not likely to be
+/// something we can ever change, and b) the other characters that have special
+/// meaning (such as `.`) do not have similar constants.
+public let pathSeparatorCharacter: Character = "/"
 
 
 /// Represents an absolute file system path, independently of what (or whether
@@ -28,114 +25,48 @@ public let HomeDirectoryCharacter: Character = "~"
 /// An absolute path always starts with a `/` character, and holds a normalized
 /// string representation.  This normalization is strictly syntactic, and does
 /// not access the file system in any way.
+///
+/// The path string is normalized by:
+/// - Collapsing `..` path components
+/// - Removing `.` path components
+/// - Removing any trailing path separator
+/// - Removing any redundant path separators
+///
+/// This string manipulation may change the meaning of a path if any of the
+/// path components are symbolic links on disk.  However, the file system is
+/// never accessed in any way when initializing an AbsolutePath.
+///
+/// FIXME: We will also need to add support for `~` resolution.
 public struct AbsolutePath {
     /// Private implementation details, shared with the RelativePath struct.
     private let _impl: PathImpl
     
     /// Initializes the AbsolutePath from `string`, which must be an absolute
-    /// path (which means that it must begin with either a path separator or a
-    /// tilde, denoting an absolute path of a user account home directory).
-    ///
-    /// The path string will be normalized by:
-    /// - Collapsing `..` path components
-    /// - Removing `.` path components
-    /// - Expanding `~` or `~user` prefix
-    /// - Removing any trailing path separator
-    /// - Removing any redundant path separators
-    ///
-    /// This string manipulation may change the meaning of a path if any of the
-    /// path components are symbolic links on disk.  However, the file system is
-    /// never accessed in any way when initializing an AbsolutePath.
+    /// path (i.e. it must begin with a path separator; this initializer does
+    /// not interpret leading `~` characters as home directory specifiers).
+    /// The input string will be normalized if needed, in accordance with the
+    /// rules described in the documentation for AbsolutePath.
     public init(_ string: String) {
-        precondition(string.characters.first == PathSeparatorCharacter
-                  || string.characters.first == HomeDirectoryCharacter)
-        
-        // Get a hold of the character view.
-        // FIXME: We need to investigate what is most performant here.
-        //        For example, is UTF-8 view more efficient, or unichars, etc?
-        var chars = string.characters
-        
-        // Expand any `~` or `~user` prefix.
-        if chars.first == HomeDirectoryCharacter {
-            // We're doing home directory substitution. Check for a user name.
-            let nStart = chars.index(after: chars.startIndex)
-            let nEnd = chars.index(of: PathSeparatorCharacter) ?? chars.endIndex
-            if nStart == nEnd {
-                // No user name, so we need home directory of effective user.
-                let homeDir = gethomedir().characters
-                chars.replaceSubrange(chars.startIndex ..< nEnd, with: homeDir)
-            }
-            else {
-                // A user name was provided, so we try to look that up.
-                // FIXME:  What do we do if we cannot find the user name? Most
-                //         shells leave it as a relative path, which we do not
-                //         want to do since we want the type safety of knowing
-                //         up-front whether a path is absolute or relative.
-                let name = String(chars[nStart ..< nEnd])
-                let homeDir = gethomedir(user: name).characters
-                chars.replaceSubrange(chars.startIndex ..< nEnd, with: homeDir)
-            }
-        }
-        
-        // At this point we expect to have a path separator as first character.
-        assert(chars.first == PathSeparatorCharacter)
-
-        // Split the character array into parts, folding components as we go.
-        // As we do so, we count the number of characters we'll end up with in
-        // the normalized string representation.
-        var parts: [String.CharacterView] = []
-        var capacity = 0
-        for part in chars.split(separator: PathSeparatorCharacter) {
-            switch part.count {
-              case 0:
-                // Ignore empty path components.
-                continue
-              case 1 where part.first == ".":
-                // Ignore `.` path components.
-                continue
-              case 2 where part.first == "." && part.last == ".":
-                // If there's a previous part, drop it; otherwise, do nothing.
-                if let prev = parts.last {
-                    parts.removeLast()
-                    capacity -= prev.count
-                }
-              default:
-                // Any other component gets appended.
-                parts.append(part)
-                capacity += part.count
-            }
-        }
-        capacity += max(parts.count, 1)
-        
-        // Create an output buffer using the capacity we've calculated.
-        // FIXME: Determine whether this is the most efficient way to do it.
-        var result = ""
-        result.reserveCapacity(capacity)
-        
-        // Put the normalized parts back together again.
-        var iter = parts.makeIterator()
-        result.append(PathSeparatorCharacter)
-        if let first = iter.next() {
-            result.append(contentsOf: first)
-            while let next = iter.next() {
-                result.append(PathSeparatorCharacter)
-                result.append(contentsOf: next)
-            }
-        }
-        
-        // Sanity-check the result (including the capacity we reserved).
-        assert(!result.isEmpty, "unexpected empty string")
-        assert(result.characters.count == capacity, "count: " +
-            "\(result.characters.count), cap: \(capacity)")
-        
-        // Use the result as our stored string.
-        _impl = PathImpl(string: String(result))
+        // Normalize the absolute string and store it as our PathImpl.
+        _impl = PathImpl(string: normalize(absolute: string))
     }
+    
+    /// Initializes the AbsolutePath from an AbsolutePath and a RelativePath.
+    public init(_ absPath: AbsolutePath, _ relPath: RelativePath) {
+        // Both paths are already normalized, so we just construct a new path.
+        let absStr = absPath._impl.string
+        let relStr = relPath._impl.string
+        _impl = PathImpl(string: relStr == "." ? absStr :
+            absStr + String(pathSeparatorCharacter) + relStr)
+    }
+    
+    /// NOTE: We will want to add other initializers, such as ones that take
+    ///       an arbtirary number of relative paths.
     
     /// Directory component.  An absolute path always has a non-empty directory
     /// component (the directory component of the root path is the root itself).
     public var dirname: String {
-        return _impl.dirname!
+        return _impl.dirname
     }
     
     /// Last path component (including the suffix, if any).  it is never empty.
@@ -153,36 +84,32 @@ public struct AbsolutePath {
     /// every directory has a parent (the parent directory of the root directory
     /// is considered to be the root directory itself).
     public var parentDirectory: AbsolutePath {
-        return isRoot ? self : AbsolutePath(_impl.dirname!)
+        return isRoot ? self : AbsolutePath(_impl.dirname)
     }
     
     /// True if the path is the root directory.
     public var isRoot: Bool {
         let chars = _impl.string.characters
-        return chars.count == 1 && chars.first == PathSeparatorCharacter
+        return chars.count == 1 && chars.first == pathSeparatorCharacter
     }
     
     /// Returns the absolute path with the relative path applied.
     public func join(_ subpath: RelativePath) -> AbsolutePath {
-        let slash = String(PathSeparatorCharacter)
-        return AbsolutePath(asString + slash + subpath.asString)
+        return AbsolutePath(self, subpath)
     }
     
     /// NOTE: We will want to add other methods here, such as a join() method
     ///       that takes an arbitrary number of parameters, etc.  Most likely
     ///       we will also make the `+` operator mean `join()`.
     
-    /// Root directory (whose string representation is just a path separator).
-    public static var root: AbsolutePath {
-        // FIXME: If this is called a lot, we should maybe cache the root path.
-        return AbsolutePath(String(PathSeparatorCharacter))
-    }
+    /// NOTE: We will want to add a method to return the lowest common ancestor
+    ///       path, and another to create a minimal relative path to get from
+    ///       one AbsolutePath to another.
     
-    /// Home directory of the effective user.
-    public static var home: AbsolutePath {
-        // FIXME: We need a real implementation here.
-        return AbsolutePath(gethomedir())
-    }
+    /// Root directory (whose string representation is just a path separator).
+    public static let root = AbsolutePath(String(pathSeparatorCharacter))
+    
+    // FIXME: We need to add a `home` property to represent the home directory.
     
     /// Normalized string representation (the normalization rules are described
     /// in the documentation of the initializer).  This string is never empty.
@@ -192,10 +119,10 @@ public struct AbsolutePath {
 }
 
 
-/// Represents a relative file system path.  A relative path is a string that
-/// doesn't start with a `/` or a `~` character, and holds a normalized string
-/// representation.  As with AbsolutePath, the normalization is strictly syn-
-/// tactic, and does not access the file system in any way.
+/// Represents a relative file system path.  A relative path never starts with
+/// a `/` character, and holds a normalized string representation.  As with
+/// AbsolutePath, the normalization is strictly syntactic, and does not access
+/// the file system in any way.
 public struct RelativePath {
     /// Private implementation details, shared with the AbsolutePath struct.
     private let _impl: PathImpl
@@ -216,72 +143,12 @@ public struct RelativePath {
     /// path components are symbolic links on disk.  However, the file system is
     /// never accessed in any way when initializing an AbsolutePath.
     public init(_ string: String) {
-        precondition(string.characters.first != PathSeparatorCharacter
-                  && string.characters.first != HomeDirectoryCharacter)
-        // Get a hold of the character view.
-        // FIXME: We need to investigate what is most performant here.
-        //        For example, is UTF-8 view more efficient, or unichars, etc?
-        let chars = string.characters
-        
-        // Split the character array into parts, folding components as we go.
-        // As we do so, we count the number of characters we'll end up with in
-        // the normalized string representation.
-        var parts: [String.CharacterView] = []
-        var capacity = 0
-        for part in chars.split(separator: PathSeparatorCharacter) {
-            switch part.count {
-              case 0:
-                // Ignore empty path components.
-                continue
-              case 1 where part.first == ".":
-                // Ignore `.` path components.
-                continue
-              case 2 where part.first == "." && part.last == ".":
-                // If at beginning, fall through to treat the `..` literally.
-                guard let prev = parts.last else {
-                    fallthrough
-                }
-                // If previous component is anything other than `..`, drop it.
-                if !(prev.count == 2 && prev.first == "." && prev.last == ".") {
-                    parts.removeLast()
-                    capacity -= prev.count
-                    continue
-                }
-                // Otherwise, fall through to treat the `..` literally.
-                fallthrough
-              default:
-                // Any other component gets appended.
-                parts.append(part)
-                capacity += part.count
-            }
-        }
-        capacity += max(parts.count - 1, 0)
-        
-        // Create an output buffer using the capacity we've calculated.
-        // FIXME: Determine whether this is the most efficient way to do it.
-        var result = ""
-        result.reserveCapacity(capacity)
-        
-        // Put the normalized parts back together again.
-        var iter = parts.makeIterator()
-        if let first = iter.next() {
-            result.append(contentsOf: first)
-            while let next = iter.next() {
-                result.append(PathSeparatorCharacter)
-                result.append(contentsOf: next)
-            }
-        }
-        
-        // Sanity-check the result (including the capacity we reserved).
-        assert(result.characters.count == capacity, "count: " +
-            "\(result.characters.count), cap: \(capacity)")
-
-        // Use the result (or `.` if it's empty) as our stored string.
-        _impl = PathImpl(string: result.isEmpty ? "." : String(result))
+        // Normalize the relative string and store it as our PathImpl.
+        _impl = PathImpl(string: normalize(relative: string))
     }
     
     /// Directory component.  For a relative path, this may be empty.
-    public var dirname: String? {
+    public var dirname: String {
         return _impl.dirname
     }
     
@@ -342,34 +209,226 @@ private struct PathImpl {
     private let string: String
     
     /// Private function that returns the directory part of the stored path
-    /// string (relying on the fact that it has been normalized).  Returns nil
-    /// if there is no directory part (which is the case iff there is no path
-    /// separator).
-    private var dirname: String? {
+    /// string (relying on the fact that it has been normalized).  Returns an
+    /// empty string if there is no directory part (which is the case if and
+    /// only if there is no path separator).
+    private var dirname: String {
+        // FIXME: This method seems too complicated; it should be simplified,
+        //        if possible, and certainly optimized (using UTF8View).
         let chars = string.characters
-        guard let idx = chars.rindex(of: PathSeparatorCharacter) else {
-            return nil
+        // Find the last path separator.
+        guard let idx = chars.rindex(of: pathSeparatorCharacter) else {
+            // No path separators, so the directory name is empty.
+            return ""
         }
-        return idx == chars.startIndex ? String(chars[idx])
-            : String(chars.prefix(upTo: idx))
+        // Check if it's the only one in the string.
+        if idx == chars.startIndex {
+            // Just one path separator, so the directory name is `/`.
+            return String(pathSeparatorCharacter)
+        }
+        // Otherwise, it's the string up to (but not including) the last path
+        // separator.
+        return String(chars.prefix(upTo: idx))
     }
     
     private var basename: String {
-        // FIXME: This needs to be rewritten.
-        guard !string.isEmpty else { return "." }
-        let parts = string.characters.split(separator: PathSeparatorCharacter)
-        guard !parts.isEmpty else { return "/" }
-        return String(parts.last!)
+        // FIXME: This method seems too complicated; it should be simplified,
+        //        if possible, and certainly optimized (using UTF8View).
+        let chars = string.characters
+        // Check for a special case of the root directory.
+        if chars.count == 1 && chars.first == pathSeparatorCharacter {
+            // Root directory, so the basename is a single path separator (the
+            // root directory is special in this regard).
+            return String(pathSeparatorCharacter)
+        }
+        // Find the last path separator.
+        guard let idx = chars.rindex(of: pathSeparatorCharacter) else {
+            // No path separators, so the basename is the whole string.
+            return string
+        }
+        // Otherwise, it's the string from (but not including) the last path
+        // separator.
+        return String(chars.suffix(from: chars.index(after: idx)))
     }
     
     private var suffix: String? {
-        // FIXME: This needs to be rewritten.
+        // FIXME: This method seems too complicated; it should be simplified,
+        //        if possible, and certainly optimized (using UTF8View).
         let chars = string.characters
-        guard chars.contains(".") else { return nil }
-        let parts = chars.split(separator: ".")
-        if let last = parts.last where parts.count > 1 { return String(last) }
+        // Find the last path separator, if any.
+        let sIdx = chars.rindex(of: pathSeparatorCharacter)
+        // Find the start of the basename.
+        let bIdx = (sIdx != nil) ? chars.index(after: sIdx!) : chars.startIndex
+        // Find the last `.` (if any), starting from the second character of
+        // the basename (a leading `.` does not make the whole path component
+        // a suffix).
+        let fIdx = chars.index(bIdx, offsetBy: 1, limitedBy: chars.endIndex)
+        if let idx = chars.rindex(of: ".", from: fIdx) {
+            // Unless it's just a `.` at the end, we have found a suffix.
+            if chars.distance(from: idx, to: chars.endIndex) > 1 {
+                return String(chars.suffix(from: idx))
+            }
+            else {
+                return nil
+            }
+        }
+        // If we get this far, there is no suffix.
         return nil
     }
+}
+
+
+// FIXME: We should consider whether to merge the two `normalize()` functions.
+// The argument for doing so is that some of the code is repeated; the argument
+// against doing so is that some of the details are different, and since any
+// given path is either absolute or relative, it's wasteful to keep checking
+// for whether it's relative or absolute.  Possibly we can do both by clever
+// use of generics that abstract away the differences.
+
+
+/// Private function that normalizes and returns an absolute string.  Asserts
+/// that `string` starts with a path separator.
+///
+/// The path string will be normalized by:
+/// - Collapsing `..` path components
+/// - Removing `.` path components
+/// - Removing any trailing path separator
+/// - Removing any redundant path separators
+///
+/// This string manipulation may change the meaning of a path if any of the
+/// path components are symbolic links on disk.  However, the file system is
+/// never accessed in any way as part of the normalization.
+private func normalize(absolute string: String) -> String {
+    // FIXME: We will also need to support a leading `~` for a home directory.
+    precondition(string.characters.first == pathSeparatorCharacter)
+    
+    // Get a hold of the character view.
+    // FIXME: Switch to use the UTF-8 view, which is more efficient.
+    let chars = string.characters
+    
+    // At this point we expect to have a path separator as first character.
+    assert(chars.first == pathSeparatorCharacter)
+    
+    // FIXME: Here we should also keep track of whether anything actually has
+    // to be changed in the string, and if not, just return the existing one.
+
+    // Split the character array into parts, folding components as we go.
+    // As we do so, we count the number of characters we'll end up with in
+    // the normalized string representation.
+    var parts: [String.CharacterView] = []
+    var capacity = 0
+    for part in chars.split(separator: pathSeparatorCharacter) {
+        switch part.count {
+          case 0:
+            // Ignore empty path components.
+            continue
+          case 1 where part.first == ".":
+            // Ignore `.` path components.
+            continue
+          case 2 where part.first == "." && part.last == ".":
+            // If there's a previous part, drop it; otherwise, do nothing.
+            if let prev = parts.last {
+                parts.removeLast()
+                capacity -= prev.count
+            }
+          default:
+            // Any other component gets appended.
+            parts.append(part)
+            capacity += part.count
+        }
+    }
+    capacity += max(parts.count, 1)
+    
+    // Create an output buffer using the capacity we've calculated.
+    // FIXME: Determine the most efficient way to reassemble a string.
+    var result = ""
+    result.reserveCapacity(capacity)
+    
+    // Put the normalized parts back together again.
+    var iter = parts.makeIterator()
+    result.append(pathSeparatorCharacter)
+    if let first = iter.next() {
+        result.append(contentsOf: first)
+        while let next = iter.next() {
+            result.append(pathSeparatorCharacter)
+            result.append(contentsOf: next)
+        }
+    }
+    
+    // Sanity-check the result (including the capacity we reserved).
+    assert(!result.isEmpty, "unexpected empty string")
+    assert(result.characters.count == capacity, "count: " +
+        "\(result.characters.count), cap: \(capacity)")
+    
+    // Use the result as our stored string.
+    return result
+}
+
+
+private func normalize(relative string: String) -> String {
+    precondition(string.characters.first != pathSeparatorCharacter)
+    // Get a hold of the character view.
+    // FIXME: Switch to use the UTF-8 view, which is more efficient.
+    let chars = string.characters
+    
+    // FIXME: Here we should also keep track of whether anything actually has
+    // to be changed in the string, and if not, just return the existing one.
+    
+    // Split the character array into parts, folding components as we go.
+    // As we do so, we count the number of characters we'll end up with in
+    // the normalized string representation.
+    var parts: [String.CharacterView] = []
+    var capacity = 0
+    for part in chars.split(separator: pathSeparatorCharacter) {
+        switch part.count {
+        case 0:
+            // Ignore empty path components.
+            continue
+        case 1 where part.first == ".":
+            // Ignore `.` path components.
+            continue
+        case 2 where part.first == "." && part.last == ".":
+            // If at beginning, fall through to treat the `..` literally.
+            guard let prev = parts.last else {
+                fallthrough
+            }
+            // If previous component is anything other than `..`, drop it.
+            if !(prev.count == 2 && prev.first == "." && prev.last == ".") {
+                parts.removeLast()
+                capacity -= prev.count
+                continue
+            }
+            // Otherwise, fall through to treat the `..` literally.
+            fallthrough
+        default:
+            // Any other component gets appended.
+            parts.append(part)
+            capacity += part.count
+        }
+    }
+    capacity += max(parts.count - 1, 0)
+    
+    // Create an output buffer using the capacity we've calculated.
+    // FIXME: Determine the most efficient way to reassemble a string.
+    var result = ""
+    result.reserveCapacity(capacity)
+    
+    // Put the normalized parts back together again.
+    var iter = parts.makeIterator()
+    if let first = iter.next() {
+        result.append(contentsOf: first)
+        while let next = iter.next() {
+            result.append(pathSeparatorCharacter)
+            result.append(contentsOf: next)
+        }
+    }
+    
+    // Sanity-check the result (including the capacity we reserved).
+    assert(result.characters.count == capacity, "count: " +
+        "\(result.characters.count), cap: \(capacity)")
+    
+    // If the result is empty, return `.`, otherwise we return it as a string.
+    return result.isEmpty ? "." : result
 }
 
 
@@ -377,97 +436,17 @@ private struct PathImpl {
 /// public place, but we'll need to debate the names, etc, etc.
 private extension String.CharacterView {
     
-    /// Returns the index of the last occurrence of `char`, or nil if none.
-    private func rindex(of char: Character) -> Index? {
+    /// Returns the index of the last occurrence of `char` or nil if none.  If
+    /// provided, the `start` index limits the search to a suffix of charview.
+    private func rindex(of char: Character, from start: Index? = nil) -> Index? {
         var idx = endIndex
-        while idx > startIndex {
+        let firstIdx = start ?? startIndex
+        while idx > firstIdx {
             idx = index(before: idx)
             if self[idx] == char {
                 return idx
             }
         }
         return nil
-    }
-}
-
-
-/// Private function that returns a string containing the home directory of the
-/// effective user.  This should definitely move out into a public place, but
-/// we'll need to debate the names, etc, etc.
-/// FIXME:  Should this function return an optional or throw an error if there
-/// is a problem with the current user id?
-private func gethomedir() -> String {
-    /// First respect the `HOME` environment variable, if it's set.
-    if let path = POSIX.getenv("HOME") {
-        return path
-    }
-    // Otherwise check effective user id, falling back on actual user id.
-    var uid = geteuid()
-    if uid == 0 { uid = getuid() }
-    // Look up the user in the account database.
-    let pwd = getpwuid(uid)
-    if let cdir = pwd?.pointee.pw_dir {
-        // We found the user, so construct a string from the pw_dir.
-        if let dir = String(validatingUTF8: cdir) {
-            return dir
-        }
-        // FIXME: How should we recover from bad UTF-8 in the home directory?
-        //        Should we just throw an error and punt the problem upwards?
-    }
-    // FIXME: What should we return if all else fails?
-    return "/tmp/~"
-}
-
-
-/// Private function that returns a string containing the home directory of the
-/// name user.  This should definitely move out into a public place, but we'll
-/// need to debate the names, etc, etc.
-/// FIXME:  Should this function return an optional or throw an error if there
-/// is no user with the given name?
-private func gethomedir(user: String) -> String {
-    // Look up the user in the account database.
-    let pwd = getpwnam(user)
-    if let cdir = pwd?.pointee.pw_dir {
-        // We found the user, so construct a string from the pw_dir.
-        if let dir = String(validatingUTF8: cdir) {
-            return dir
-        }
-        // FIXME: How should we recover from bad UTF-8 in the home directory?
-        //        Should we just throw an error and punt the problem upwards?
-    }
-    // FIXME: What should we return if all else fails?
-    return "/tmp/~\(user)"
-}
-
-
-/// Convenience properties that access the file system, making it convenient to
-/// get information about a file system entity at a particular path.  Note that
-/// none of these functions is allowed to mutate the file system.
-extension AbsolutePath {
-    // FIXME: Factor out a method to return the stat record, and then move the
-    //        other methods to the stat record.  That makes it easier to avoid
-    //        blithely stat:ing over and over again if multple properties are
-    //        checked (e.g. `isFile || isSymlink` etc).
-    
-    public var isDirectory: Bool {
-        var mystat = stat()
-        let rv = lstat(self.asString, &mystat)
-        return rv == 0 && (mystat.st_mode & S_IFMT) == S_IFDIR
-    }
-    
-    public var isFile: Bool {
-        var mystat = stat()
-        let rv = lstat(self.asString, &mystat)
-        return rv == 0 && (mystat.st_mode & S_IFMT) == S_IFREG
-    }
-        
-    public var isSymlink: Bool {
-        var mystat = stat()
-        let rv = lstat(self.asString, &mystat)
-        return rv == 0 && (mystat.st_mode & S_IFMT) == S_IFLNK
-    }
-    
-    public var exists: Bool {
-        return access(self.asString, F_OK) == 0
     }
 }

--- a/Tests/Basic/PathPerfTests.swift
+++ b/Tests/Basic/PathPerfTests.swift
@@ -12,11 +12,6 @@ import XCTest
 
 import Basic
 
-// FIXME: Performance tests are disabled for the time being because they have
-// too high an impact on overall testing time.
-//
-// See: https://bugs.swift.org/browse/SR-1354
-#if false
 
 class PathPerfTests: XCTestCase {
 
@@ -38,5 +33,3 @@ class PathPerfTests: XCTestCase {
         ("testJoinPerf_X100000",         testJoinPerf_X100000),
     ]
 }
-
-#endif

--- a/Tests/Basic/PathPerfTests.swift
+++ b/Tests/Basic/PathPerfTests.swift
@@ -1,0 +1,42 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+import Basic
+
+// FIXME: Performance tests are disabled for the time being because they have
+// too high an impact on overall testing time.
+//
+// See: https://bugs.swift.org/browse/SR-1354
+#if false
+
+class PathPerfTests: XCTestCase {
+
+    func testJoinPerf_X100000() {
+        let absPath = AbsolutePath("/hello/little")
+        let relPath = RelativePath("world")
+        let N = 100000
+        self.measure {
+            var lengths = 0
+            for _ in 0 ..< N {
+                let result = absPath.join(relPath)
+                lengths = lengths &+ result.asString.utf8.count
+            }
+            XCTAssertEqual(lengths, (absPath.asString.utf8.count + 1 + relPath.asString.utf8.count) &* N)
+        }
+    }
+
+    static var allTests = [
+        ("testJoinPerf_X100000",         testJoinPerf_X100000),
+    ]
+}
+
+#endif

--- a/Tests/Basic/PathPerfTests.swift
+++ b/Tests/Basic/PathPerfTests.swift
@@ -14,7 +14,8 @@ import Basic
 
 
 class PathPerfTests: XCTestCase {
-
+    
+    /// Tests creating very long AbsolutePaths by joining path components.
     func testJoinPerf_X100000() {
         let absPath = AbsolutePath("/hello/little")
         let relPath = RelativePath("world")
@@ -28,6 +29,8 @@ class PathPerfTests: XCTestCase {
             XCTAssertEqual(lengths, (absPath.asString.utf8.count + 1 + relPath.asString.utf8.count) &* N)
         }
     }
+    
+    // FIXME: We will obviously want a lot more tests here.
 
     static var allTests = [
         ("testJoinPerf_X100000",         testJoinPerf_X100000),

--- a/Tests/Basic/PathTests.swift
+++ b/Tests/Basic/PathTests.swift
@@ -99,13 +99,13 @@ class PathTests: XCTestCase {
         XCTAssertEqual(AbsolutePath("/ab/c//d/").dirname, "/ab/c")
         XCTAssertEqual(RelativePath("ab/c//d/").dirname, "ab/c")
         XCTAssertEqual(RelativePath("../a").dirname, "..")
-        XCTAssertEqual(RelativePath("../a/..").dirname, "")
-        XCTAssertEqual(RelativePath("a/..").dirname, "")
-        XCTAssertEqual(RelativePath("./..").dirname, "")
-        XCTAssertEqual(RelativePath("a/../////../////./////").dirname, "")
-        XCTAssertEqual(RelativePath("abc").dirname, "")
-        XCTAssertEqual(RelativePath("").dirname, "")
-        XCTAssertEqual(RelativePath(".").dirname, "")
+        XCTAssertEqual(RelativePath("../a/..").dirname, ".")
+        XCTAssertEqual(RelativePath("a/..").dirname, ".")
+        XCTAssertEqual(RelativePath("./..").dirname, ".")
+        XCTAssertEqual(RelativePath("a/../////../////./////").dirname, ".")
+        XCTAssertEqual(RelativePath("abc").dirname, ".")
+        XCTAssertEqual(RelativePath("").dirname, ".")
+        XCTAssertEqual(RelativePath(".").dirname, ".")
     }
     
     func testBaseNameExtraction() {

--- a/Tests/Basic/PathTests.swift
+++ b/Tests/Basic/PathTests.swift
@@ -91,7 +91,25 @@ class PathTests: XCTestCase {
         XCTAssertEqual(RelativePath("a/../////../////./////").asString, "..")
     }
         
+    func testDirectoryNameExtraction() {
+        XCTAssertEqual(AbsolutePath("/").dirname, "/")
+        XCTAssertEqual(AbsolutePath("/a").dirname, "/")
+        XCTAssertEqual(AbsolutePath("/./a").dirname, "/")
+        XCTAssertEqual(AbsolutePath("/../..").dirname, "/")
+        XCTAssertEqual(AbsolutePath("/ab/c//d/").dirname, "/ab/c")
+        XCTAssertEqual(RelativePath("ab/c//d/").dirname, "ab/c")
+        XCTAssertEqual(RelativePath("../a").dirname, "..")
+        XCTAssertEqual(RelativePath("../a/..").dirname, "")
+        XCTAssertEqual(RelativePath("a/..").dirname, "")
+        XCTAssertEqual(RelativePath("./..").dirname, "")
+        XCTAssertEqual(RelativePath("a/../////../////./////").dirname, "")
+        XCTAssertEqual(RelativePath("abc").dirname, "")
+        XCTAssertEqual(RelativePath("").dirname, "")
+        XCTAssertEqual(RelativePath(".").dirname, "")
+    }
+    
     func testBaseNameExtraction() {
+        XCTAssertEqual(AbsolutePath("/").basename, "/")
         XCTAssertEqual(AbsolutePath("/a").basename, "a")
         XCTAssertEqual(AbsolutePath("/./a").basename, "a")
         XCTAssertEqual(AbsolutePath("/../..").basename, "/")
@@ -100,10 +118,10 @@ class PathTests: XCTestCase {
         XCTAssertEqual(RelativePath("../a/..").basename, "..")
         XCTAssertEqual(RelativePath("a/..").basename, ".")
         XCTAssertEqual(RelativePath("./..").basename, "..")
-        XCTAssertEqual(RelativePath("a/..").basename, ".")
         XCTAssertEqual(RelativePath("a/../////../////./////").basename, "..")
         XCTAssertEqual(RelativePath("abc").basename, "abc")
         XCTAssertEqual(RelativePath("").basename, ".")
+        XCTAssertEqual(RelativePath(".").basename, ".")
     }
     
     func testSuffixExtraction() {

--- a/Tests/Basic/PathTests.swift
+++ b/Tests/Basic/PathTests.swift
@@ -146,6 +146,16 @@ class PathTests: XCTestCase {
         XCTAssertEqual(AbsolutePath("/bar/../foo/..//yabba/a/b").parentDirectory.parentDirectory, AbsolutePath("/yabba"))
     }
     
+    func testConcatenation() {
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("")).asString, "/")
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath(".")).asString, "/")
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("..")).asString, "/")
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("bar")).asString, "/bar")
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/bar"), RelativePath("../foo")).asString, "/foo")
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/bar"), RelativePath("../foo/..//")).asString, "/")
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/bar/../foo/..//yabba/"), RelativePath("a/b")).asString, "/yabba/a/b")
+    }
+    
     // FIXME: We also need tests for join() operations.
     
     // FIXME: We also need tests for dirname, basename, suffix, etc.
@@ -162,5 +172,6 @@ class PathTests: XCTestCase {
         ("testBaseNameExtraction",       testBaseNameExtraction),
         ("testSuffixExtraction",         testSuffixExtraction),
         ("testParentDirectory",          testParentDirectory),
+        ("testConcatenation",            testConcatenation),
     ]
 }

--- a/Tests/Basic/PathTests.swift
+++ b/Tests/Basic/PathTests.swift
@@ -1,0 +1,156 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import POSIX
+import Basic
+import Utility
+
+
+class PathTests: XCTestCase {
+    
+    func testBasics() {
+        XCTAssertEqual(AbsolutePath("/").asString, "/")
+        XCTAssertEqual(AbsolutePath("/a").asString, "/a")
+        XCTAssertEqual(AbsolutePath("/a/b/c").asString, "/a/b/c")
+        XCTAssertEqual(RelativePath(".").asString, ".")
+        XCTAssertEqual(RelativePath("a").asString, "a")
+        XCTAssertEqual(RelativePath("a/b/c").asString, "a/b/c")
+    }
+    
+    func testRepeatedPathSeparators() {
+        XCTAssertEqual(AbsolutePath("/ab//cd//ef").asString, "/ab/cd/ef")
+        XCTAssertEqual(AbsolutePath("/ab///cd//ef").asString, "/ab/cd/ef")
+        XCTAssertEqual(RelativePath("ab//cd//ef").asString, "ab/cd/ef")
+        XCTAssertEqual(RelativePath("ab//cd///ef").asString, "ab/cd/ef")
+    }
+    
+    func testTrailingPathSeparators() {
+        XCTAssertEqual(AbsolutePath("/ab/cd/ef/").asString, "/ab/cd/ef")
+        XCTAssertEqual(AbsolutePath("/ab/cd/ef//").asString, "/ab/cd/ef")
+        XCTAssertEqual(RelativePath("ab/cd/ef/").asString, "ab/cd/ef")
+        XCTAssertEqual(RelativePath("ab/cd/ef//").asString, "ab/cd/ef")
+    }
+    
+    func testDotPathComponents() {
+        XCTAssertEqual(AbsolutePath("/ab/././cd//ef").asString, "/ab/cd/ef")
+        XCTAssertEqual(AbsolutePath("/ab/./cd//ef/.").asString, "/ab/cd/ef")
+        XCTAssertEqual(RelativePath("ab/./cd/././ef").asString, "ab/cd/ef")
+        XCTAssertEqual(RelativePath("ab/./cd/ef/.").asString, "ab/cd/ef")
+    }
+    
+    func testDotDotPathComponents() {
+        XCTAssertEqual(AbsolutePath("/..").asString, "/")
+        XCTAssertEqual(AbsolutePath("/../../../../..").asString, "/")
+        XCTAssertEqual(AbsolutePath("/abc/..").asString, "/")
+        XCTAssertEqual(AbsolutePath("/abc/../..").asString, "/")
+        XCTAssertEqual(AbsolutePath("/../abc").asString, "/abc")
+        XCTAssertEqual(AbsolutePath("/../abc/..").asString, "/")
+        XCTAssertEqual(AbsolutePath("/../abc/../def").asString, "/def")
+        XCTAssertEqual(RelativePath("..").asString, "..")
+        XCTAssertEqual(RelativePath("../..").asString, "../..")
+        XCTAssertEqual(RelativePath(".././..").asString, "../..")
+        XCTAssertEqual(RelativePath("../abc/..").asString, "..")
+        XCTAssertEqual(RelativePath("../abc/.././").asString, "..")
+        XCTAssertEqual(RelativePath("abc/..").asString, ".")
+    }
+    
+    func testCombinationsAndEdgeCases() {
+        XCTAssertEqual(AbsolutePath("///").asString, "/")
+        XCTAssertEqual(AbsolutePath("/./").asString, "/")
+        XCTAssertEqual(RelativePath("").asString, ".")
+        XCTAssertEqual(RelativePath(".").asString, ".")
+        XCTAssertEqual(RelativePath("./abc").asString, "abc")
+        XCTAssertEqual(RelativePath("./abc/").asString, "abc")
+        XCTAssertEqual(RelativePath("./abc/../bar").asString, "bar")
+        XCTAssertEqual(RelativePath("foo/../bar").asString, "bar")
+        XCTAssertEqual(RelativePath("foo///..///bar///baz").asString, "bar/baz")
+        XCTAssertEqual(RelativePath("foo/../bar/./").asString, "bar")
+        XCTAssertEqual(RelativePath("../abc/def/").asString, "../abc/def")
+        XCTAssertEqual(RelativePath("././././.").asString, ".")
+        XCTAssertEqual(RelativePath("./././../.").asString, "..")
+        XCTAssertEqual(RelativePath("./").asString, ".")
+        XCTAssertEqual(RelativePath(".//").asString, ".")
+        XCTAssertEqual(RelativePath("./.").asString, ".")
+        XCTAssertEqual(RelativePath("././").asString, ".")
+        XCTAssertEqual(RelativePath("../").asString, "..")
+        XCTAssertEqual(RelativePath("../.").asString, "..")
+        XCTAssertEqual(RelativePath("./..").asString, "..")
+        XCTAssertEqual(RelativePath("./../.").asString, "..")
+        XCTAssertEqual(RelativePath("./////../////./////").asString, "..")
+        XCTAssertEqual(RelativePath("../a").asString, "../a")
+        XCTAssertEqual(RelativePath("../a/..").asString, "..")
+        XCTAssertEqual(RelativePath("a/..").asString, ".")
+        XCTAssertEqual(RelativePath("a/../////../////./////").asString, "..")
+    }
+        
+    func testBaseNameExtraction() {
+        XCTAssertEqual(AbsolutePath("/a").basename, "a")
+        XCTAssertEqual(AbsolutePath("/./a").basename, "a")
+        XCTAssertEqual(AbsolutePath("/../..").basename, "/")
+        XCTAssertEqual(RelativePath("../..").basename, "..")
+        XCTAssertEqual(RelativePath("../a").basename, "a")
+        XCTAssertEqual(RelativePath("../a/..").basename, "..")
+        XCTAssertEqual(RelativePath("a/..").basename, ".")
+        XCTAssertEqual(RelativePath("./..").basename, "..")
+        XCTAssertEqual(RelativePath("a/..").basename, ".")
+        XCTAssertEqual(RelativePath("a/../////../////./////").basename, "..")
+        XCTAssertEqual(RelativePath("abc").basename, "abc")
+        XCTAssertEqual(RelativePath("").basename, ".")
+    }
+    
+    func testSuffixExtraction() {
+        XCTAssertEqual(RelativePath("a").suffix, nil)
+        XCTAssertEqual(RelativePath("a.").suffix, nil)
+        XCTAssertEqual(RelativePath(".a").suffix, nil)
+        XCTAssertEqual(RelativePath("a.foo").suffix, "foo")
+        XCTAssertEqual(RelativePath(".a.foo").suffix, "foo")
+        XCTAssertEqual(RelativePath(".a.foo.bar").suffix, "bar")
+        XCTAssertEqual(RelativePath("a.foo.bar").suffix, "bar")
+        XCTAssertEqual(RelativePath(".a.foo.bar.baz").suffix, "baz")
+    }
+    
+    func testParentDirectory() {
+        XCTAssertEqual(AbsolutePath("/").parentDirectory, AbsolutePath("/"))
+        XCTAssertEqual(AbsolutePath("/").parentDirectory.parentDirectory, AbsolutePath("/"))
+        XCTAssertEqual(AbsolutePath("/bar").parentDirectory, AbsolutePath("/"))
+        XCTAssertEqual(AbsolutePath("/bar/../foo/..//").parentDirectory.parentDirectory, AbsolutePath("/"))
+        XCTAssertEqual(AbsolutePath("/bar/../foo/..//yabba/a/b").parentDirectory.parentDirectory, AbsolutePath("/yabba"))
+    }
+    
+    func testHomeDirectory() {
+        // Only run tests using HOME if it is defined.
+        // FIXME: This needs a lot more testing, especially that the environment variable HOME correctly overrides getpwuid()'s directory etc.
+        if POSIX.getenv("HOME") != nil {
+            XCTAssertEqual(AbsolutePath("~").asString, POSIX.getenv("HOME"))
+        }
+    }
+    
+    // FIXME: We also need tests for join() operations.
+    
+    // FIXME: We also need tests for dirname, basename, suffix, etc.
+    
+    // FIXME: We also need test for stat() operations.
+    
+    // FIXME: We also need performance tests for all of this.
+    
+    static var allTests = [
+        ("testBasics",                   testBasics),
+        ("testRepeatedPathSeparators",   testRepeatedPathSeparators),
+        ("testTrailingPathSeparators",   testTrailingPathSeparators),
+        ("testDotPathComponents",        testDotPathComponents),
+        ("testDotDotPathComponents",     testDotDotPathComponents),
+        ("testCombinationsAndEdgeCases", testCombinationsAndEdgeCases),
+        ("testBaseNameExtraction",       testBaseNameExtraction),
+        ("testSuffixExtraction",         testSuffixExtraction),
+        ("testParentDirectory",          testParentDirectory),
+        ("testHomeDirectory",            testHomeDirectory),
+    ]
+}

--- a/Tests/Basic/PathTests.swift
+++ b/Tests/Basic/PathTests.swift
@@ -110,11 +110,14 @@ class PathTests: XCTestCase {
         XCTAssertEqual(RelativePath("a").suffix, nil)
         XCTAssertEqual(RelativePath("a.").suffix, nil)
         XCTAssertEqual(RelativePath(".a").suffix, nil)
-        XCTAssertEqual(RelativePath("a.foo").suffix, "foo")
-        XCTAssertEqual(RelativePath(".a.foo").suffix, "foo")
-        XCTAssertEqual(RelativePath(".a.foo.bar").suffix, "bar")
-        XCTAssertEqual(RelativePath("a.foo.bar").suffix, "bar")
-        XCTAssertEqual(RelativePath(".a.foo.bar.baz").suffix, "baz")
+        XCTAssertEqual(RelativePath("").suffix, nil)
+        XCTAssertEqual(RelativePath(".").suffix, nil)
+        XCTAssertEqual(RelativePath("..").suffix, nil)
+        XCTAssertEqual(RelativePath("a.foo").suffix, ".foo")
+        XCTAssertEqual(RelativePath(".a.foo").suffix, ".foo")
+        XCTAssertEqual(RelativePath(".a.foo.bar").suffix, ".bar")
+        XCTAssertEqual(RelativePath("a.foo.bar").suffix, ".bar")
+        XCTAssertEqual(RelativePath(".a.foo.bar.baz").suffix, ".baz")
     }
     
     func testParentDirectory() {
@@ -125,22 +128,12 @@ class PathTests: XCTestCase {
         XCTAssertEqual(AbsolutePath("/bar/../foo/..//yabba/a/b").parentDirectory.parentDirectory, AbsolutePath("/yabba"))
     }
     
-    func testHomeDirectory() {
-        // Only run tests using HOME if it is defined.
-        // FIXME: This needs a lot more testing, especially that the environment variable HOME correctly overrides getpwuid()'s directory etc.
-        if POSIX.getenv("HOME") != nil {
-            XCTAssertEqual(AbsolutePath("~").asString, POSIX.getenv("HOME"))
-        }
-    }
-    
     // FIXME: We also need tests for join() operations.
     
     // FIXME: We also need tests for dirname, basename, suffix, etc.
     
     // FIXME: We also need test for stat() operations.
-    
-    // FIXME: We also need performance tests for all of this.
-    
+        
     static var allTests = [
         ("testBasics",                   testBasics),
         ("testRepeatedPathSeparators",   testRepeatedPathSeparators),
@@ -151,6 +144,5 @@ class PathTests: XCTestCase {
         ("testBaseNameExtraction",       testBaseNameExtraction),
         ("testSuffixExtraction",         testSuffixExtraction),
         ("testParentDirectory",          testParentDirectory),
-        ("testHomeDirectory",            testHomeDirectory),
     ]
 }


### PR DESCRIPTION
This will provide a more type safe and expressive path API than plain
strings.  Many more details are in the documentation of the types.

More extensive correctness and performance tests, as well as adoption,
to come.  There is still a fair amount of performance investigation and
tuning to do -- that can be addressed piecemeal, but the direction of
the API (in particular the distinction between absolute and relative
paths) is the most important part at this point.