### PR TITLE
[SR-1740] SwiftPM generates excess targets in schemes

### DIFF
--- a/Sources/PackageLoading/transmute.swift
+++ b/Sources/PackageLoading/transmute.swift
@@ -66,6 +66,12 @@ public func transmute(_ rootPackage: Package, externalPackages: [Package]) throw
 
                 modules += testModules.map{$0}
             }
+        } else {
+            // filter out non library packages from dependencies
+            modules = modules
+                .flatMap { $0 as? ModuleTypeProtocol }
+                .filter { $0.type == .library }
+                .flatMap { $0 as? Module }
         }
 
         map[package] = modules


### PR DESCRIPTION
Attempts to solve bug SR-1740 https://bugs.swift.org/browse/SR-1740 by removing non library packages from dependencies' targets in the `transmute` method.