### PR TITLE
[Utility] Migrate ad hoc `walk` clients to use localFS.

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -192,22 +192,26 @@ public struct SwiftPackageTool {
                             
             case .update:
                 // Attempt to ensure that none of the repositories are modified.
-                for item in walk(opts.path.Packages, recursively: false) {
-                    // Only look at repositories.
-                    guard Path.join(item, ".git").exists else { continue }
+                if localFS.exists(opts.path.Packages) {
+                    for name in try localFS.getDirectoryContents(opts.path.Packages) {
+                        let item = Path.join(opts.path.Packages, name)
 
-                    // If there is a staged or unstaged diff, don't remove the
-                    // tree. This won't detect new untracked files, but it is
-                    // just a safety measure for now.
-                    let diffArgs = ["--no-ext-diff", "--quiet", "--exit-code"]
-                    do {
-                        _ = try Git.runPopen([Git.tool, "-C", item, "diff"] + diffArgs)
-                        _ = try Git.runPopen([Git.tool, "-C", item, "diff", "--cached"] + diffArgs)
-                    } catch {
-                        throw Error.repositoryHasChanges(item)
+                        // Only look at repositories.
+                        guard Path.join(item, ".git").exists else { continue }
+
+                        // If there is a staged or unstaged diff, don't remove the
+                        // tree. This won't detect new untracked files, but it is
+                        // just a safety measure for now.
+                        let diffArgs = ["--no-ext-diff", "--quiet", "--exit-code"]
+                        do {
+                            _ = try Git.runPopen([Git.tool, "-C", item, "diff"] + diffArgs)
+                            _ = try Git.runPopen([Git.tool, "-C", item, "diff", "--cached"] + diffArgs)
+                        } catch {
+                            throw Error.repositoryHasChanges(item)
+                        }
                     }
+                    try Utility.removeFileTree(opts.path.Packages)
                 }
-                try Utility.removeFileTree(opts.path.Packages)
                 fallthrough
                 
             case .fetch:

--- a/Sources/Get/PackagesDirectory.swift
+++ b/Sources/Get/PackagesDirectory.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basic
 import PackageModel
 import Utility
 
@@ -29,8 +30,12 @@ class PackagesDirectory {
     
     /// The set of all repositories available within the `Packages` directory, by origin.
     private lazy var availableRepositories: [String: Git.Repo] = { [unowned self] in
+        // FIXME: Lift this higher.
+        guard localFS.isDirectory(self.prefix) else { return [:] }
+
         var result = Dictionary<String, Git.Repo>()
-        for prefix in walk(self.prefix, recursively: false) {
+        for name in try! localFS.getDirectoryContents(self.prefix) {
+            let prefix = Path.join(self.prefix, name)
             guard let repo = Git.Repo(path: prefix), origin = repo.origin else { continue } // TODO: Warn user.
             result[origin] = repo
         }

--- a/Sources/PackageLoading/ModuleMapGeneration.swift
+++ b/Sources/PackageLoading/ModuleMapGeneration.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+import Basic
 import Utility
 import PackageModel
 
@@ -78,7 +79,7 @@ extension ClangModule {
             return
         }
         
-        let walked = walk(includeDir, recursively: false).map{$0}
+        let walked = try localFS.getDirectoryContents(includeDir).map{ Path.join(includeDir, $0) }
         
         let files = walked.filter{$0.isFile && $0.hasSuffix(".h")}
         let dirs = walked.filter{$0.isDirectory}

--- a/Sources/PackageLoading/transmute.swift
+++ b/Sources/PackageLoading/transmute.swift
@@ -39,14 +39,32 @@ public func transmute(_ rootPackage: Package, externalPackages: [Package]) throw
 
             // Set dependencies for test modules.
             for case let testModule as SwiftModule in testModules {
-                if testModule.basename == "Functional" {
+                if testModule.basename == "Utility" {
+                    // FIXME: The Utility tests currently have a layering
+                    // violation and a dependency on Basic for infrastructure.
+                    testModule.dependencies = modules.filter{
+                        switch $0.name {
+                        case "Basic", "Utility":
+                            return true
+                        default:
+                            return false
+                        }
+                    }
+                } else if testModule.basename == "Functional" {
                     // FIXME: swiftpm's own Functional tests module does not
                     //        follow the normal rules--there is no corresponding
                     //        'Sources/Functional' module to depend upon. For the
                     //        time being, assume test modules named 'Functional'
                     //        depend upon 'Utility', and hope that no users define
                     //        test modules named 'Functional'.
-                    testModule.dependencies = modules.filter{ $0.name == "Utility" }
+                    testModule.dependencies = modules.filter{
+                        switch $0.name {
+                        case "Basic", "Utility":
+                            return true
+                        default:
+                            return false
+                        }
+                    }
                 } else if testModule.basename == "PackageLoading" {
                     // FIXME: Turns out PackageLoadingTests violate encapsulation :(
                     testModule.dependencies = modules.filter{

--- a/Tests/Functional/Utilities.swift
+++ b/Tests/Functional/Utilities.swift
@@ -10,6 +10,7 @@
 
 import func XCTest.XCTFail
 
+import Basic
 import POSIX
 import Utility
 
@@ -51,7 +52,8 @@ func fixture(name fixtureName: String, tags: [String] = [], file: StaticString =
                     }
                 }
 
-                for d in walk(rootd, recursively: false).sorted() {
+                for name in try! localFS.getDirectoryContents(rootd).sorted() {
+                    let d = Path.join(rootd, name)
                     guard d.isDirectory else { continue }
                     let dstdir = Path.join(prefix, d.basename).normpath
                     try systemQuietly("cp", "-R", try realpath(d), dstdir)

--- a/Tests/Functional/ValidLayoutTests.swift
+++ b/Tests/Functional/ValidLayoutTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import Basic
 import Utility
 
 import func POSIX.symlink
@@ -107,7 +108,7 @@ class ValidLayoutsTestCase: XCTestCase {
 }
 
 
-//MARK: Utility
+// MARK: Utility
 
 extension ValidLayoutsTestCase {
     func runLayoutFixture(name: String, line: UInt = #line, body: @noescape(String) throws -> Void) {
@@ -118,24 +119,22 @@ extension ValidLayoutsTestCase {
 
         // 2. Move everything to a directory called "Sources"
         fixture(name: name, file: #file, line: line) { prefix in
-            let files = walk(prefix, recursively: false).filter{ $0.basename != "Package.swift" }
+            let files = try! localFS.getDirectoryContents(prefix).filter{ $0.basename != "Package.swift" }
             let dir = Path.join(prefix, "Sources")
             try Utility.makeDirectories(dir)
             for file in files {
-                let tip = Path(file).relative(to: prefix)
-                try rename(old: file, new: Path.join(dir, tip))
+                try rename(old: Path.join(prefix, file), new: Path.join(dir, file))
             }
             try body(prefix)
         }
 
         // 3. Symlink some other directory to a directory called "Sources"
         fixture(name: name, file: #file, line: line) { prefix in
-            let files = walk(prefix, recursively: false).filter{ $0.basename != "Package.swift" }
+            let files = try! localFS.getDirectoryContents(prefix).filter{ $0.basename != "Package.swift" }
             let dir = Path.join(prefix, "Floobles")
             try Utility.makeDirectories(dir)
             for file in files {
-                let tip = Path(file).relative(to: prefix)
-                try rename(old: file, new: Path.join(dir, tip))
+                try rename(old: Path.join(prefix, file), new: Path.join(dir, file))
             }
             try symlink(create: "\(prefix)/Sources", pointingAt: dir, relativeTo: prefix)
             try body(prefix)


### PR DESCRIPTION
 - This just migrates clients outside the core convention system which only
   needed individual directory listings over.

 - This reapplies 4f3e7042 with a fix to add the additional hard coded
   test dependency for `Functional` on `Basic` which is required
   currently pending real support for specifying dependencies of test
   modules.