### PR TITLE
[Utility] Migrate to simpler FileHandle extension.

### DIFF
--- a/Sources/SourceControl/CheckoutManager.swift
+++ b/Sources/SourceControl/CheckoutManager.swift
@@ -203,8 +203,7 @@ public class CheckoutManager {
         //
         // FIXME: Build out improved file reading support.
         try fopen(statePath) { handle in
-            let data = try handle.enumerate().joined(separator: "\n")
-            let json = try JSON(bytes: ByteString(encodingAsUTF8: data))
+            let json = try JSON(bytes: ByteString(encodingAsUTF8: try handle.readFileContents()))
 
             // Load the state from JSON.
             guard case let .dictionary(contents) = json,

--- a/Sources/Utility/File.swift
+++ b/Sources/Utility/File.swift
@@ -49,24 +49,11 @@ public func fputs(_ bytes: [UInt8], _ handle: FileHandle) throws {
     handle.write(Data(bytes: bytes))
 }
 
-
-extension FileHandle: Sequence {
-    public func enumerate(separatedBy separator: String = "\n") throws -> IndexingIterator<[String]> {
+extension FileHandle {
+    public func readFileContents() throws -> String {
         guard let contents = String(data: readDataToEndOfFile(), encoding: NSUTF8StringEncoding) else {
             throw Error.unicodeDecodingError
         }
-
-        if contents == "" {
-            return [].makeIterator()
-        }
-
-        return contents.components(separatedBy: separator).makeIterator()
-    }
-
-    public func makeIterator() -> IndexingIterator<[String]> {
-        guard let iterator = try? enumerate() else {
-            return [].makeIterator()
-        }
-        return iterator
+        return contents
     }
 }

--- a/Sources/Utility/PkgConfig.swift
+++ b/Sources/Utility/PkgConfig.swift
@@ -126,7 +126,7 @@ struct PkgConfigParser {
         }
         
         let file = try fopen(self.pcFile, mode: .read)
-        for line in file {
+        for line in try file.readFileContents().components(separatedBy: "\n") {
             // Remove commented or any trailing comment from the line.
             let uncommentedLine = removeComment(line: line)
             // Ignore any empty or whitespace line.

--- a/Tests/Utility/FileTests.swift
+++ b/Tests/Utility/FileTests.swift
@@ -25,8 +25,7 @@ class FileTests: XCTestCase {
     func testOpenFile() {
         do {
             let file = try loadInputFile("empty_file")
-            var generator = try file.enumerate()
-            XCTAssertNil(generator.next())
+            XCTAssertEqual(try file.readFileContents(), "")
         } catch {
             XCTFail("The file should be opened without problem")
         }
@@ -35,7 +34,7 @@ class FileTests: XCTestCase {
     func testOpenFileFail() {
         do {
             let file = try loadInputFile("file_not_existing")
-            let _ = try file.enumerate()
+            let _ = try file.readFileContents()
             XCTFail("The file should not be opened since it is not existing")
         } catch {
             
@@ -45,7 +44,7 @@ class FileTests: XCTestCase {
     func testReadRegularTextFile() {
         do {
             let file = try loadInputFile("regular_text_file")
-            var generator = try file.enumerate()
+            var generator = try file.readFileContents().components(separatedBy: "\n").makeIterator()
             XCTAssertEqual(generator.next(), "Hello world")
             XCTAssertEqual(generator.next(), "It is a regular text file.")
             XCTAssertEqual(generator.next(), "")
@@ -58,7 +57,7 @@ class FileTests: XCTestCase {
     func testReadRegularTextFileWithSeparator() {
         do {
             let file = try loadInputFile("regular_text_file")
-            var generator = try file.enumerate(separatedBy: " ")
+            var generator = try file.readFileContents().components(separatedBy: " ").makeIterator()
             XCTAssertEqual(generator.next(), "Hello")
             XCTAssertEqual(generator.next(), "world\nIt")
             XCTAssertEqual(generator.next(), "is")


### PR DESCRIPTION
 - We don't need line-based iteration that often, and some clients were abusing
   this API to then gratuitously reconstitute the string. Instead, just provide
   a method to read the contents as a String.