### PR TITLE
[PackageModel] Remove `String.soname` extension.

### DIFF
--- a/Sources/PackageLoading/transmute.swift
+++ b/Sources/PackageLoading/transmute.swift
@@ -59,7 +59,7 @@ public func transmute(_ rootPackage: Package, externalPackages: [Package]) throw
                     //        test modules named 'Functional'.
                     testModule.dependencies = modules.filter{
                         switch $0.name {
-                        case "Basic", "Utility":
+                        case "Basic", "Utility", "PackageModel":
                             return true
                         default:
                             return false

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -29,7 +29,7 @@ public class Product {
         case .Library(.Static):
             return "lib\(name).a"
         case .Library(.Dynamic):
-            return name.soname
+            return "lib\(name).\(Product.dynamicLibraryExtension)"
         case .Test:
             let base = "\(name).xctest"
             #if os(OSX)
@@ -39,6 +39,14 @@ public class Product {
             #endif
         }
     }
+
+    // FIXME: This needs to be come from a toolchain object, not the host
+    // configuration.
+#if os(OSX)
+    public static let dynamicLibraryExtension = "dylib"
+#else
+    public static let dynamicLibraryExtension = "so"
+#endif
 }
 
 extension Product: CustomStringConvertible {

--- a/Sources/Utility/misc.swift
+++ b/Sources/Utility/misc.swift
@@ -24,16 +24,3 @@ import Foundation
 #else
     // ERROR: Unsupported platform
 #endif
-
-extension String {
-    /// Returns shared dynamic library name of a string by 
-    /// appending lib prefix and file extension `dylib` for OSX
-    /// and `so` for Linux.
-    public var soname: String {
-      #if os(OSX)
-        return "lib\(self).dylib"
-      #else
-        return "lib\(self).so"
-      #endif
-    }
-}

--- a/Tests/Functional/ClangModuleTests.swift
+++ b/Tests/Functional/ClangModuleTests.swift
@@ -10,7 +10,14 @@
 
 import XCTest
 
+import PackageModel
 import Utility
+
+extension String {
+    private var soname: String {
+        return "lib\(self).\(Product.dynamicLibraryExtension)"
+    }
+}
 
 class ClangModulesTestCase: XCTestCase {
     func testSingleModuleFlatCLibrary() {

--- a/Tests/Xcodeproj/FunctionalTests.swift
+++ b/Tests/Xcodeproj/FunctionalTests.swift
@@ -47,7 +47,7 @@ class FunctionalTests: XCTestCase {
     func testXcodeProjWithPkgConfig() {
         fixture(name: "Miscellaneous/PkgConfig") { prefix in
             XCTAssertBuilds(prefix, "SystemModule")
-            XCTAssertFileExists(prefix, "SystemModule", ".build", "debug", "SystemModule".soname)
+            XCTAssertFileExists(prefix, "SystemModule", ".build", "debug", "libSystemModule.\(Product.dynamicLibraryExtension)")
             let pcFile = Path.join(prefix, "libSystemModule.pc")
             try! write(path: pcFile) { stream in
                 stream <<< "prefix=\(Path.join(prefix, "SystemModule"))\n"


### PR DESCRIPTION
 - This shouldn't be general purpose, it should only be exposed via the Product.