### PR TITLE
Link to issue tracker in contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+DON'T MERGE THIS, SEE PR DESCRIPTION
 By submitting a pull request, you represent that you have the right to license
 your contribution to Apple and the community, and agree by submitting the patch
 that your contributions are licensed under the [Swift

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,3 @@
-DON'T MERGE THIS, SEE PR DESCRIPTION
 By submitting a pull request, you represent that you have the right to license
 your contribution to Apple and the community, and agree by submitting the patch
 that your contributions are licensed under the [Swift
@@ -9,3 +8,7 @@ license](https://swift.org/LICENSE.txt).
 Before submitting the pull request, please make sure you have tested your
 changes and that they follow the Swift project [guidelines for contributing
 code](https://swift.org/contributing/#contributing-code).
+
+---
+
+Issues are tracked using https://bugs.swift.org/


### PR DESCRIPTION
It would be useful to enable the issue tracker on GitHub, rather than only accepting PR's.