### PR TITLE
[Build] Use actual output path instead of virtual nodes.

### DIFF
--- a/Sources/Build/Buildable.swift
+++ b/Sources/Build/Buildable.swift
@@ -12,7 +12,6 @@ import PackageModel
 import struct Utility.Path
 
 protocol Buildable {
-    var targetName: String { get }
     var isTest: Bool { get }
 }
 
@@ -44,10 +43,6 @@ extension Module: Buildable {
             }
         }
     }
-
-    var targetName: String {
-        return "<\(name).module>"
-    }
 }
 
 extension Product: Buildable {
@@ -56,18 +51,5 @@ extension Product: Buildable {
             return true
         }
         return false
-    }
-
-    var targetName: String {
-        switch type {
-        case .Library(.Dynamic):
-            return "<\(name).dylib>"
-        case .Test:
-            return "<\(name).test>"
-        case .Library(.Static):
-            return "<\(name).a>"
-        case .Executable:
-            return "<\(name).exe>"
-        }
     }
 }

--- a/Sources/Build/Command.compile(ClangModule).swift
+++ b/Sources/Build/Command.compile(ClangModule).swift
@@ -59,10 +59,11 @@ struct ClangModuleBuildMetadata {
         return module.recursiveDependencies.flatMap { module in
             switch module {
             case let module as ClangModule:
-                 let product = Product(name: module.name, type: .Library(.Dynamic), modules: [module])
-                return product.targetName
-            case let module as CModule:
-                return module.targetName
+                let product = Product(name: module.name, type: .Library(.Dynamic), modules: [module])
+                return product.outpath(prefix)
+            case is CModule:
+                // There is no actual input dependency in case of CModule, necessary flags are appended in Module.XccFlags(_:) method.
+                return nil
             default:
                 fatalError("ClangModule \(self.module) can't have \(module) as a dependency.")
             }

--- a/Sources/Build/Command.compile(SwiftModule).swift
+++ b/Sources/Build/Command.compile(SwiftModule).swift
@@ -29,6 +29,6 @@ extension Command {
         #endif
 
         let tool = SwiftcTool(module: module, prefix: prefix, otherArgs: args + otherArgs, executable: SWIFT_EXEC, conf: conf)
-        return Command(node: module.targetName, tool: tool)
+        return Command(node: tool.moduleOutputPath, tool: tool)
     }
 }

--- a/Sources/Build/Command.link(ClangModule).swift
+++ b/Sources/Build/Command.link(ClangModule).swift
@@ -44,14 +44,14 @@ extension Command {
             fatalError("Can't build \(product.name), \(product.type) is not yet supported.")
         }
 
-        let productPath = Path.join(prefix, product.outname)
+        let productPath = product.outpath(prefix)
         args += ["-o", productPath]
         
         let shell = ShellTool(description: "Linking \(product.name)",
                               inputs: objects + inputs,
-                              outputs: [productPath, product.targetName],
+                              outputs: [productPath],
                               args: [CC] + args)
         
-        return Command(node: product.targetName, tool: shell)
+        return Command(node: productPath, tool: shell)
     }
 }

--- a/Sources/Build/Command.link(SwiftModule).swift
+++ b/Sources/Build/Command.link(SwiftModule).swift
@@ -26,7 +26,7 @@ extension Command {
         
         var objects = buildables.flatMap { SwiftcTool(module: $0, prefix: prefix, otherArgs: [], executable: SWIFT_EXEC, conf: conf).objects }
 
-        let outpath = Path.join(prefix, product.outname)
+        let outpath = product.outpath(prefix)
 
         var args: [String]
         switch product.type {
@@ -44,9 +44,7 @@ extension Command {
           #endif
 
         case .Library(.Static):
-            let inputs = buildables.map{ $0.targetName } + objects
-            let outputs = [product.targetName, outpath]
-            return Command(node: product.targetName, tool: ArchiveTool(inputs: inputs, outputs: outputs))
+            return Command(node: outpath, tool: ArchiveTool(inputs: objects, outputs: [outpath]))
         }
 
         switch product.type {
@@ -101,9 +99,9 @@ extension Command {
         let shell = ShellTool(
             description: "Linking \(outpath.prettyPath)",
             inputs: objects,
-            outputs: [product.targetName, outpath],
+            outputs: [outpath],
             args: args)
 
-        return Command(node: product.targetName, tool: shell)
+        return Command(node: outpath, tool: shell)
     }
 }

--- a/Sources/Build/misc.swift
+++ b/Sources/Build/misc.swift
@@ -62,6 +62,16 @@ extension ClangModule {
 }
 
 extension Product {
+    /// Creates output path of a product by appending working directory and product outname.
+    ///
+    /// - Parameters:
+    ///     - prefix: Working directory in which product will be created.
+    ///
+    /// - Returns: Output path of the product.
+    func outpath(_ prefix: String) -> String {
+        return Path.join(prefix, outname)
+    }
+
     /// Returns true iff all the modules in this product are ClangModules. 
     var containsOnlyClangModules: Bool {
         return modules.filter{ $0 is ClangModule }.count == modules.count


### PR DESCRIPTION
Removes the use of virtual nodes when generating llbuild manifest file.
using virtual nodes might cause issues in incremental builds.

Bug: https://bugs.swift.org/browse/SR-1708