### PR TITLE
[Init] Handle case when directory name and c99name are not same.

### DIFF
--- a/Sources/Commands/init.swift
+++ b/Sources/Commands/init.swift
@@ -49,21 +49,18 @@ final class InitPackage {
     let pkgname: String
 
     /// The name of the example module to create.
-    var moduleName: String {
-        return pkgname
-    }
+    var moduleName: String
 
     /// The name of the example type to create (within the package).
     var typeName: String {
-        return pkgname
+        return moduleName
     }
     
     init(mode: InitMode) throws {
-        // Validate that the name is valid.
-        let _ = try c99name(name: rootd.basename)
-        
         self.mode = mode
         pkgname = rootd.basename
+        // Also validates that the name is valid.
+        moduleName = try c99name(name: rootd.basename)
     }
     
     func writePackageStructure() throws {
@@ -187,8 +184,8 @@ final class InitPackage {
     }
     
     private func writeTestFileStubs(testsPath: String) throws {
-        let testModule = Path.join(testsPath, moduleName)
-        print("Creating Tests/\(moduleName)/")
+        let testModule = Path.join(testsPath, pkgname)
+        print("Creating Tests/\(pkgname)/")
         try Utility.makeDirectories(testModule)
         
         try writePackageFile(Path.join(testModule, "\(moduleName)Tests.swift")) { stream in

--- a/Tests/Functional/MiscellaneousTests.swift
+++ b/Tests/Functional/MiscellaneousTests.swift
@@ -364,6 +364,22 @@ class MiscellaneousTestCase: XCTestCase {
         }
     }
 
+    func testInitPackageNonc99Directory() throws {
+        let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
+        XCTAssertTrue(localFS.isDirectory(tempDir.path))
+
+        // Create a directory with non c99name.
+        let packageRoot = AbsolutePath(tempDir.path).join(RelativePath("some-package")).asString
+        try localFS.createDirectory(packageRoot)
+        XCTAssertTrue(localFS.isDirectory(packageRoot))
+
+        // Run package init.
+        _ = try SwiftPMProduct.SwiftPackage.execute(["init"], chdir: packageRoot, env: [:], printIfError: true)
+        // Try building it.
+        XCTAssertBuilds(packageRoot)
+        XCTAssertFileExists(packageRoot, ".build/debug/some_package.swiftmodule")
+    }
+
     static var allTests = [
         ("testPrintsSelectedDependencyVersion", testPrintsSelectedDependencyVersion),
         ("testPackageWithNoSources", testPackageWithNoSources),
@@ -390,5 +406,6 @@ class MiscellaneousTestCase: XCTestCase {
         ("testExternalDependencyEdges2", testExternalDependencyEdges2),
         ("testProductWithNoModules", testProductWithNoModules),
         ("testProductWithMissingModules", testProductWithMissingModules),
+        ("testInitPackageNonc99Directory", testInitPackageNonc99Directory),
     ]
 }


### PR DESCRIPTION
Bug: https://bugs.swift.org/browse/SR-1862