### PR TITLE
Add a method to construct a RelativePath to get from one AbsolutePath to another

### DIFF
--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -327,6 +327,51 @@ private struct PathImpl {
 }
 
 
+extension AbsolutePath {
+    /// Returns a relative path that, when concatenated to `base`, yields the
+    /// callee path itself.  If `base` is not an ancestor of the callee, the
+    /// returned path will begin with one or more `..` path components.
+    ///
+    /// Because both paths are absolute, they always have a common ancestor
+    /// (the root path, if nothing else).  Therefore, any path can be made
+    /// relative to any other path by using a sufficient number of `..` path
+    /// components.
+    ///
+    /// This method is strictly syntactic and does not access the file system
+    /// in any way.  Therefore, it does not take symbolic links into account.
+    public func relative(to base: AbsolutePath) -> RelativePath {
+        // Split the two paths into their components.
+        // FIXME: The is needs to be optimized to avoid unncessary copying.
+        let pathComps = self.components
+        let baseComps = base.components
+        
+        // It's common for the base to be an ancestor, so try that first.
+        if pathComps.starts(with: baseComps) {
+            // Special case, which is a plain path without `..` components.  It
+            // might be an empty path (when self and the base are equal).
+            let relComps = pathComps.dropFirst(baseComps.count)
+            return RelativePath(relComps.joined(separator: "/"))
+        }
+        else {
+            // General case, in which we might well need `..` components to go
+            // "up" before we can go "down" the directory tree.
+            var newPathComps = ArraySlice(pathComps)
+            var newBaseComps = ArraySlice(baseComps)
+            while newPathComps.prefix(1) == newBaseComps.prefix(1) {
+                // First component matches, so drop it.
+                newPathComps = newPathComps.dropFirst()
+                newBaseComps = newBaseComps.dropFirst()
+            }
+            // Now construct a path consisting of as many `..`s as are in the
+            // `newBaseComps` followed by what remains in `newPathComps`.
+            var relComps = Array(repeating: "..", count: newBaseComps.count)
+            relComps.append(contentsOf: newPathComps)
+            return RelativePath(relComps.joined(separator: "/"))
+        }
+    }
+}
+
+
 // FIXME: We should consider whether to merge the two `normalize()` functions.
 // The argument for doing so is that some of the code is repeated; the argument
 // against doing so is that some of the details are different, and since any

--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -340,6 +340,7 @@ extension AbsolutePath {
     /// This method is strictly syntactic and does not access the file system
     /// in any way.  Therefore, it does not take symbolic links into account.
     public func relative(to base: AbsolutePath) -> RelativePath {
+        let result: RelativePath
         // Split the two paths into their components.
         // FIXME: The is needs to be optimized to avoid unncessary copying.
         let pathComps = self.components
@@ -350,7 +351,7 @@ extension AbsolutePath {
             // Special case, which is a plain path without `..` components.  It
             // might be an empty path (when self and the base are equal).
             let relComps = pathComps.dropFirst(baseComps.count)
-            return RelativePath(relComps.joined(separator: "/"))
+            result = RelativePath(relComps.joined(separator: "/"))
         }
         else {
             // General case, in which we might well need `..` components to go
@@ -366,8 +367,10 @@ extension AbsolutePath {
             // `newBaseComps` followed by what remains in `newPathComps`.
             var relComps = Array(repeating: "..", count: newBaseComps.count)
             relComps.append(contentsOf: newPathComps)
-            return RelativePath(relComps.joined(separator: "/"))
+            result = RelativePath(relComps.joined(separator: "/"))
         }
+        assert(base.join(result) == self)
+        return result
     }
 }
 

--- a/Tests/Basic/PathTests.swift
+++ b/Tests/Basic/PathTests.swift
@@ -185,6 +185,16 @@ class PathTests: XCTestCase {
         XCTAssertEqual(RelativePath("abc").components, ["abc"])
     }
     
+    func testRelativePathFromAbsolutePaths() {
+        XCTAssertEqual(AbsolutePath("/").relative(to: AbsolutePath("/")), RelativePath("."));
+        XCTAssertEqual(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/")), RelativePath("a/b/c/d"));
+        XCTAssertEqual(AbsolutePath("/").relative(to: AbsolutePath("/a/b/c")), RelativePath("../../.."));
+        XCTAssertEqual(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/a/b")), RelativePath("c/d"));
+        XCTAssertEqual(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/a/b/c")), RelativePath("d"));
+        XCTAssertEqual(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/a/c/d")), RelativePath("../../b/c/d"));
+        XCTAssertEqual(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/b/c/d")), RelativePath("../../../a/b/c/d"));
+    }
+    
     // FIXME: We also need tests for join() operations.
     
     // FIXME: We also need tests for dirname, basename, suffix, etc.


### PR DESCRIPTION
This is needed by some parts of the SwiftPM source code in order to switch them over to AbsolutePath and RelativePath.  There was such a method for strings, but this makes it type-safe.