### PR TITLE
[Xcodeproj] Correct LastKnownFileType for C family sources.

### DIFF
--- a/Sources/PackageModel/Module.swift
+++ b/Sources/PackageModel/Module.swift
@@ -16,6 +16,7 @@
 */
 
 @_exported import enum PackageDescription.SystemPackageProvider
+import struct Basic.RelativePath
 
 public protocol ModuleProtocol {
     var name: String { get }
@@ -80,7 +81,7 @@ extension ModuleTypeProtocol {
 
 
 public protocol XcodeModuleProtocol: ModuleProtocol, ModuleTypeProtocol {
-    var fileType: String { get }
+    func fileType(forSource source: RelativePath) -> String
 }
 
 extension Module: Hashable, Equatable {
@@ -101,8 +102,9 @@ public class SwiftModule: Module {
 }
 
 extension SwiftModule: XcodeModuleProtocol {
-    public var fileType: String {
-        return "sourcecode.swift"
+    public func fileType(forSource source: RelativePath) -> String {
+        // SwiftModules only has one type of source so just always return this.
+        return SupportedLanguageExtension.swift.xcodeFileType
     }
 }
 
@@ -129,9 +131,35 @@ public class ClangModule: CModule {
     }
 }
 
+private extension SupportedLanguageExtension {
+    var xcodeFileType: String {
+        switch self {
+        case c:
+            return "sourcecode.c.c"
+        case m:
+            return "sourcecode.c.objc"
+        case cxx, cc, cpp:
+            return "sourcecode.cpp.cpp"
+        case mm:
+            return "sourcecode.cpp.objcpp"
+        case swift:
+            return "sourcecode.swift"
+        }
+    }
+}
+
 extension ClangModule: XcodeModuleProtocol {
-    public var fileType: String {
-        return "sourcecode.c.c"
+    public func fileType(forSource source: RelativePath) -> String {
+        guard let suffix = source.suffix else {
+            fatalError("Source \(source) doesn't have an extension in ClangModule \(name)")
+        }
+        // Suffix includes `.` so drop it.
+        assert(suffix.hasPrefix("."))
+        let fileExtension = String(suffix.characters.dropFirst())
+        guard let ext = SupportedLanguageExtension(rawValue: fileExtension) else {
+            fatalError("Unknown source extension \(source) in ClangModule \(name)")
+        }
+        return ext.xcodeFileType
     }
 }
 

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -11,6 +11,7 @@
 import POSIX
 import PackageModel
 import Utility
+import struct Basic.RelativePath
 
 // FIXME: escaping
 
@@ -96,7 +97,7 @@ public func pbxproj(srcroot: String, projectRoot: String, xcodeprojPath: String,
         for (ref, path) in sourceFileRefPaths {
             print("        \(ref) = {")
             print("            isa = PBXFileReference;")
-            print("            lastKnownFileType = \(module.fileType);")
+            print("            lastKnownFileType = \(module.fileType(forSource: RelativePath(path)));")
             print("            name = '\(Path(path).relative(to: module.sources.root))';")
             print("            sourceTree = '<group>';")
             print("        };")


### PR DESCRIPTION
The file type was sourcecode.c.c for all types of C family sources
causing build failure in generated Xcode project.

Bug: https://bugs.swift.org/browse/SR-1654