### PR TITLE
[PackageLoading] Remove support for loading empty Package.swift

### DIFF
--- a/Fixtures/ClangModules/CDynamicLookup/Package.swift
+++ b/Fixtures/ClangModules/CDynamicLookup/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "CDynamicLookup"
+)

--- a/Fixtures/ClangModules/CLibraryFlat/Package.swift
+++ b/Fixtures/ClangModules/CLibraryFlat/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "CLibraryFlat"
+)

--- a/Fixtures/ClangModules/CLibrarySources/Package.swift
+++ b/Fixtures/ClangModules/CLibrarySources/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "CLibrarySources"
+)

--- a/Fixtures/DependencyResolution/External/CUsingCDep/Foo/Package.swift
+++ b/Fixtures/DependencyResolution/External/CUsingCDep/Foo/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "Foo"
+)

--- a/Fixtures/DependencyResolution/External/CUsingCDep2/Foo/Package.swift
+++ b/Fixtures/DependencyResolution/External/CUsingCDep2/Foo/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "Foo"
+)

--- a/Fixtures/DependencyResolution/External/Complex/FisherYates/Package.swift
+++ b/Fixtures/DependencyResolution/External/Complex/FisherYates/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "FisherYates"
+)

--- a/Fixtures/DependencyResolution/External/Complex/PlayingCard/Package.swift
+++ b/Fixtures/DependencyResolution/External/Complex/PlayingCard/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "PlayingCard"
+)

--- a/Fixtures/DependencyResolution/External/IgnoreIndirectTests/FisherYates/Package.swift
+++ b/Fixtures/DependencyResolution/External/IgnoreIndirectTests/FisherYates/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "FisherYates"
+)

--- a/Fixtures/DependencyResolution/External/IgnoreIndirectTests/PlayingCard/Package.swift
+++ b/Fixtures/DependencyResolution/External/IgnoreIndirectTests/PlayingCard/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "PlayingCard"
+)

--- a/Fixtures/DependencyResolution/External/Simple/Foo/Package.swift
+++ b/Fixtures/DependencyResolution/External/Simple/Foo/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "Foo"
+)

--- a/Fixtures/DependencyResolution/External/SimpleCDep/Foo/Package.swift
+++ b/Fixtures/DependencyResolution/External/SimpleCDep/Foo/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "Foo"
+)

--- a/Fixtures/Miscellaneous/DependencyEdges/External/dep1/Package.swift
+++ b/Fixtures/Miscellaneous/DependencyEdges/External/dep1/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "dep1"
+)

--- a/Fixtures/Miscellaneous/Empty/Package.swift
+++ b/Fixtures/Miscellaneous/Empty/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "Empty"
+)

--- a/Fixtures/Miscellaneous/ExactDependencies/FooLib2/Package.swift
+++ b/Fixtures/Miscellaneous/ExactDependencies/FooLib2/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "FooLib2"
+)

--- a/Fixtures/Miscellaneous/PkgConfig/SystemModule/Package.swift
+++ b/Fixtures/Miscellaneous/PkgConfig/SystemModule/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "SystemModule"
+)

--- a/Fixtures/ModuleMaps/Direct/CFoo/Package.swift
+++ b/Fixtures/ModuleMaps/Direct/CFoo/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "CFoo"
+)

--- a/Fixtures/ValidLayouts/MultipleModules/Executables/Package.swift
+++ b/Fixtures/ValidLayouts/MultipleModules/Executables/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "Executables"
+)

--- a/Fixtures/ValidLayouts/MultipleModules/Libraries/Package.swift
+++ b/Fixtures/ValidLayouts/MultipleModules/Libraries/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "Libraries"
+)

--- a/Fixtures/ValidLayouts/SingleModule/Executable/Package.swift
+++ b/Fixtures/ValidLayouts/SingleModule/Executable/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "Executable"
+)

--- a/Fixtures/ValidLayouts/SingleModule/Library/Package.swift
+++ b/Fixtures/ValidLayouts/SingleModule/Library/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "Library"
+)


### PR DESCRIPTION
I couldn't find any reference in documentation...
Bug: https://bugs.swift.org/browse/SR-1839