### PR TITLE
Rename AbsolutePath's `join` method to `appending`

### DIFF
--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -109,17 +109,16 @@ public struct AbsolutePath {
     }
     
     /// Returns the absolute path with the relative path applied.
-    public func join(_ subpath: RelativePath) -> AbsolutePath {
+    public func appending(_ subpath: RelativePath) -> AbsolutePath {
         return AbsolutePath(self, subpath)
     }
     
-    /// NOTE: We will want to add other methods here, such as a join() method
+    /// NOTE: We will want to add other methods, such as an appending() method
     ///       that takes an arbitrary number of parameters, etc.  Most likely
-    ///       we will also make the `+` operator mean `join()`.
+    ///       we will also make the `+` operator mean `appending()`.
     
     /// NOTE: We will want to add a method to return the lowest common ancestor
-    ///       path, and another to create a minimal relative path to get from
-    ///       one AbsolutePath to another.
+    ///       path.
     
     /// Root directory (whose string representation is just a path separator).
     public static let root = AbsolutePath(String(pathSeparatorCharacter))
@@ -369,7 +368,7 @@ extension AbsolutePath {
             relComps.append(contentsOf: newPathComps)
             result = RelativePath(relComps.joined(separator: "/"))
         }
-        assert(base.join(result) == self)
+        assert(base.appending(result) == self)
         return result
     }
 }

--- a/Tests/Basic/PathTests.swift
+++ b/Tests/Basic/PathTests.swift
@@ -155,6 +155,15 @@ class PathTests: XCTestCase {
         XCTAssertEqual(AbsolutePath(AbsolutePath("/bar"), RelativePath("../foo")).asString, "/foo")
         XCTAssertEqual(AbsolutePath(AbsolutePath("/bar"), RelativePath("../foo/..//")).asString, "/")
         XCTAssertEqual(AbsolutePath(AbsolutePath("/bar/../foo/..//yabba/"), RelativePath("a/b")).asString, "/yabba/a/b")
+        
+        XCTAssertEqual(AbsolutePath("/").appending(RelativePath("")).asString, "/")
+        XCTAssertEqual(AbsolutePath("/").appending(RelativePath(".")).asString, "/")
+        XCTAssertEqual(AbsolutePath("/").appending(RelativePath("..")).asString, "/")
+        XCTAssertEqual(AbsolutePath("/").appending(RelativePath("bar")).asString, "/bar")
+        XCTAssertEqual(AbsolutePath("/foo/bar").appending(RelativePath("..")).asString, "/foo")
+        XCTAssertEqual(AbsolutePath("/bar").appending(RelativePath("../foo")).asString, "/foo")
+        XCTAssertEqual(AbsolutePath("/bar").appending(RelativePath("../foo/..//")).asString, "/")
+        XCTAssertEqual(AbsolutePath("/bar/../foo/..//yabba/").appending(RelativePath("a/b")).asString, "/yabba/a/b")
     }
     
     func testPathComponents() {

--- a/Tests/Basic/TemporaryFileTests.swift
+++ b/Tests/Basic/TemporaryFileTests.swift
@@ -78,7 +78,7 @@ class TemporaryFileTests: XCTestCase {
             let tempDir = try TemporaryDirectory()
             XCTAssertTrue(localFS.isDirectory(tempDir.path))
             // Create a file inside the temp directory.
-            let filePath = AbsolutePath(tempDir.path).join(RelativePath("somefile")).asString
+            let filePath = AbsolutePath(tempDir.path).appending(RelativePath("somefile")).asString
             try localFS.writeFileContents(filePath, bytes: ByteString())
             path = tempDir.path
         }
@@ -91,7 +91,7 @@ class TemporaryFileTests: XCTestCase {
         do {
             let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
             XCTAssertTrue(localFS.isDirectory(tempDir.path))
-            let filePath = AbsolutePath(tempDir.path).join(RelativePath("somefile")).asString
+            let filePath = AbsolutePath(tempDir.path).appending(RelativePath("somefile")).asString
             try localFS.writeFileContents(filePath, bytes: ByteString())
             path = tempDir.path
         }

--- a/Tests/Functional/MiscellaneousTests.swift
+++ b/Tests/Functional/MiscellaneousTests.swift
@@ -369,7 +369,7 @@ class MiscellaneousTestCase: XCTestCase {
         XCTAssertTrue(localFS.isDirectory(tempDir.path))
 
         // Create a directory with non c99name.
-        let packageRoot = AbsolutePath(tempDir.path).join(RelativePath("some-package")).asString
+        let packageRoot = AbsolutePath(tempDir.path).appending(RelativePath("some-package")).asString
         try localFS.createDirectory(packageRoot)
         XCTAssertTrue(localFS.isDirectory(packageRoot))
 


### PR DESCRIPTION
Rename AbsolutePath's `join` method to `appending` to better match the
semantics ("join" is usually applied to a collection to combine all of
its elements, while "append" is usually applied to one thing, such as a
string or collection, to tack another thing onto the end of it).

The `-ing` suffix also makes the name more inline with Swift 3 naming.