### PR TITLE
Make Path types support StringLiteralConvertible

### DIFF
--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -147,6 +147,22 @@ public struct AbsolutePath {
     }
 }
 
+/// Adoption of the StringLiteralConvertible protocol allows literal strings
+/// to be implicitly converted to AbsolutePaths.
+extension AbsolutePath : StringLiteralConvertible {
+    public typealias UnicodeScalarLiteralType = StringLiteralType
+    public typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
+    public init(extendedGraphemeClusterLiteral value: String) {
+        self.init(stringLiteral: value)
+    }
+    public init(unicodeScalarLiteral value: String) {
+        self.init(stringLiteral: value)
+    }
+}
+
 
 /// Represents a relative file system path.  A relative path never starts with
 /// a `/` character, and holds a normalized string representation.  As with
@@ -218,6 +234,21 @@ public struct RelativePath {
     }
 }
 
+/// Adoption of the StringLiteralConvertible protocol allows literal strings
+/// to be implicitly converted to RelativePaths.
+extension RelativePath : StringLiteralConvertible {
+    public typealias UnicodeScalarLiteralType = StringLiteralType
+    public typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
+    public init(extendedGraphemeClusterLiteral value: String) {
+        self.init(stringLiteral: value)
+    }
+    public init(unicodeScalarLiteral value: String) {
+        self.init(stringLiteral: value)
+    }
+}
 
 // Make absolute paths Hashable.
 extension AbsolutePath : Hashable {

--- a/Tests/Basic/PathTests.swift
+++ b/Tests/Basic/PathTests.swift
@@ -25,6 +25,13 @@ class PathTests: XCTestCase {
         XCTAssertEqual(RelativePath("a/b/c").asString, "a/b/c")
     }
     
+    func testStringLiteralInitialization() {
+        let abs: AbsolutePath = "/"
+        XCTAssertEqual(abs.asString, "/")
+        let rel: RelativePath = "."
+        XCTAssertEqual(rel.asString, ".")
+    }
+    
     func testRepeatedPathSeparators() {
         XCTAssertEqual(AbsolutePath("/ab//cd//ef").asString, "/ab/cd/ef")
         XCTAssertEqual(AbsolutePath("/ab///cd//ef").asString, "/ab/cd/ef")
@@ -212,6 +219,7 @@ class PathTests: XCTestCase {
         
     static var allTests = [
         ("testBasics",                   testBasics),
+        ("testStringLiteralInitialization", testStringLiteralInitialization),
         ("testRepeatedPathSeparators",   testRepeatedPathSeparators),
         ("testTrailingPathSeparators",   testTrailingPathSeparators),
         ("testDotPathComponents",        testDotPathComponents),

--- a/Tests/Basic/TemporaryFileTests.swift
+++ b/Tests/Basic/TemporaryFileTests.swift
@@ -78,7 +78,7 @@ class TemporaryFileTests: XCTestCase {
             let tempDir = try TemporaryDirectory()
             XCTAssertTrue(localFS.isDirectory(tempDir.path))
             // Create a file inside the temp directory.
-            let filePath = AbsolutePath(tempDir.path).appending(RelativePath("somefile")).asString
+            let filePath = AbsolutePath(tempDir.path).appending("somefile").asString
             try localFS.writeFileContents(filePath, bytes: ByteString())
             path = tempDir.path
         }
@@ -91,7 +91,7 @@ class TemporaryFileTests: XCTestCase {
         do {
             let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
             XCTAssertTrue(localFS.isDirectory(tempDir.path))
-            let filePath = AbsolutePath(tempDir.path).appending(RelativePath("somefile")).asString
+            let filePath = AbsolutePath(tempDir.path).appending("somefile").asString
             try localFS.writeFileContents(filePath, bytes: ByteString())
             path = tempDir.path
         }

--- a/Tests/Functional/MiscellaneousTests.swift
+++ b/Tests/Functional/MiscellaneousTests.swift
@@ -369,7 +369,7 @@ class MiscellaneousTestCase: XCTestCase {
         XCTAssertTrue(localFS.isDirectory(tempDir.path))
 
         // Create a directory with non c99name.
-        let packageRoot = AbsolutePath(tempDir.path).appending(RelativePath("some-package")).asString
+        let packageRoot = AbsolutePath(tempDir.path).appending("some-package").asString
         try localFS.createDirectory(packageRoot)
         XCTAssertTrue(localFS.isDirectory(packageRoot))
 


### PR DESCRIPTION
Make Path types support StringLiteralConvertible to cut down on needless verbosity at call sites when the meaning is clear.