### PR TITLE
First round of String -> Path transition

### DIFF
--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -268,10 +268,10 @@ public struct SwiftTestTool {
         // Run the correct tool.
       #if os(OSX)
         let tempFile = try TemporaryFile()
-        let args = [xctestHelperPath(), path, tempFile.path]
+        let args = [xctestHelperPath(), path, tempFile.path.asString]
         try system(args, environment: ["DYLD_FRAMEWORK_PATH": try platformFrameworksPath()])
         // Read the temporary file's content.
-        let data = try fopen(tempFile.path).readFileContents()
+        let data = try fopen(tempFile.path.asString).readFileContents()
       #else
         let args = [path, "--dump-tests-json"]
         let data = try popen(args)

--- a/Tests/Basic/FSProxyTests.swift
+++ b/Tests/Basic/FSProxyTests.swift
@@ -156,7 +156,7 @@ class FSProxyTests: XCTestCase {
 
     func testPseudoCreateDirectory() {
         let fs = PseudoFS()
-        let subdir = "/new-dir/subdir"
+        let subdir = AbsolutePath("/new-dir/subdir")
         try! fs.createDirectory(subdir, recursive: true)
         XCTAssert(fs.isDirectory(subdir))
 
@@ -165,13 +165,13 @@ class FSProxyTests: XCTestCase {
         XCTAssert(fs.isDirectory(subdir))
         
         // Check non-recursive subdir creation.
-        let subsubdir = Path.join(subdir, "new-subdir")
+        let subsubdir = subdir.appending("new-subdir")
         XCTAssert(!fs.isDirectory(subsubdir))
         try! fs.createDirectory(subsubdir, recursive: false)
         XCTAssert(fs.isDirectory(subsubdir))
         
         // Check non-recursive failing subdir case.
-        let newsubdir = "/very-new-dir/subdir"
+        let newsubdir = AbsolutePath("/very-new-dir/subdir")
         XCTAssert(!fs.isDirectory(newsubdir))
         XCTAssertThrows(FSProxyError.noEntry) {
             try fs.createDirectory(newsubdir, recursive: false)
@@ -179,14 +179,14 @@ class FSProxyTests: XCTestCase {
         XCTAssert(!fs.isDirectory(newsubdir))
         
         // Check directory creation over a file.
-        let filePath = "/mach_kernel"
+        let filePath = AbsolutePath("/mach_kernel")
         try! fs.writeFileContents(filePath, bytes: [0xCD, 0x0D])
         XCTAssert(fs.exists(filePath) && !fs.isDirectory(filePath))
         XCTAssertThrows(FSProxyError.notDirectory) {
             try fs.createDirectory(filePath, recursive: true)
         }
         XCTAssertThrows(FSProxyError.notDirectory) {
-            try fs.createDirectory(Path.join(filePath, "not-possible"), recursive: true)
+            try fs.createDirectory(filePath.appending("not-possible"), recursive: true)
         }
         XCTAssert(fs.exists(filePath) && !fs.isDirectory(filePath))
     }
@@ -196,7 +196,7 @@ class FSProxyTests: XCTestCase {
         try! fs.createDirectory("/new-dir/subdir", recursive: true)
 
         // Check read/write of a simple file.
-        let filePath = Path.join("/new-dir/subdir", "new-file.txt")
+        let filePath = AbsolutePath("/new-dir/subdir").appending("new-file.txt")
         XCTAssert(!fs.exists(filePath))
         try! fs.writeFileContents(filePath, bytes: "Hello, world!")
         XCTAssert(fs.exists(filePath))
@@ -227,15 +227,15 @@ class FSProxyTests: XCTestCase {
         
         // Check read/write into a non-directory.
         XCTAssertThrows(FSProxyError.notDirectory) {
-            _ = try fs.readFileContents(Path.join(filePath, "not-possible"))
+            _ = try fs.readFileContents(filePath.appending("not-possible"))
         }
         XCTAssertThrows(FSProxyError.notDirectory) {
-            try fs.writeFileContents(Path.join(filePath, "not-possible"), bytes: [])
+            try fs.writeFileContents(filePath.appending("not-possible"), bytes: [])
         }
         XCTAssert(fs.exists(filePath))
         
         // Check read/write into a missing directory.
-        let missingDir = "/does/not/exist"
+        let missingDir = AbsolutePath("/does/not/exist")
         XCTAssertThrows(FSProxyError.noEntry) {
             _ = try fs.readFileContents(missingDir)
         }

--- a/Tests/Basic/TemporaryFileTests.swift
+++ b/Tests/Basic/TemporaryFileTests.swift
@@ -15,7 +15,7 @@ import class Foundation.FileManager
 
 class TemporaryFileTests: XCTestCase {
     func testBasicReadWrite() throws {
-        let filePath: String
+        let filePath: AbsolutePath
         do {
             let file = try TemporaryFile(prefix: "myprefix", suffix: "mysuffix")
             // Make sure the filename contains our prefix and suffix.
@@ -23,7 +23,7 @@ class TemporaryFileTests: XCTestCase {
             XCTAssertTrue(file.path.basename.hasSuffix("mysuffix"))
 
             // Check if file is created.
-            XCTAssertTrue(file.path.isFile)
+            XCTAssertTrue(file.path.asString.isFile)
 
             // Try writing some data to the file.
             let stream = OutputByteStream()
@@ -41,31 +41,31 @@ class TemporaryFileTests: XCTestCase {
             filePath = file.path
         }
         // File should be deleted now.
-        XCTAssertFalse(filePath.isFile)
+        XCTAssertFalse(filePath.asString.isFile)
     }
 
     func testCanCreateUniqueTempFiles() throws {
-        let filePathOne: String
-        let filePathTwo: String
+        let filePathOne: AbsolutePath
+        let filePathTwo: AbsolutePath
         do {
             let fileOne = try TemporaryFile()
             let fileTwo = try TemporaryFile()
             // Check files exists.
-            XCTAssertTrue(fileOne.path.isFile)
-            XCTAssertTrue(fileTwo.path.isFile)
+            XCTAssertTrue(fileOne.path.asString.isFile)
+            XCTAssertTrue(fileTwo.path.asString.isFile)
             // Their paths should be different.
             XCTAssertTrue(fileOne.path != fileTwo.path)
 
             filePathOne = fileOne.path
             filePathTwo = fileTwo.path
         }
-        XCTAssertFalse(filePathOne.isFile)
-        XCTAssertFalse(filePathTwo.isFile)
+        XCTAssertFalse(filePathOne.asString.isFile)
+        XCTAssertFalse(filePathTwo.asString.isFile)
     }
 
     func testBasicTemporaryDirectory() throws {
         // Test can create and remove temp directory.
-        var path: String
+        var path: AbsolutePath
         do {
             let tempDir = try TemporaryDirectory()
             XCTAssertTrue(localFS.isDirectory(tempDir.path))
@@ -78,20 +78,20 @@ class TemporaryFileTests: XCTestCase {
             let tempDir = try TemporaryDirectory()
             XCTAssertTrue(localFS.isDirectory(tempDir.path))
             // Create a file inside the temp directory.
-            let filePath = AbsolutePath(tempDir.path).appending("somefile").asString
+            let filePath = tempDir.path.appending("somefile").asString
             try localFS.writeFileContents(filePath, bytes: ByteString())
             path = tempDir.path
         }
         XCTAssertTrue(localFS.isDirectory(path))
         // Cleanup.
-        try FileManager.default().removeItem(atPath: path)
+        try FileManager.default().removeItem(atPath: path.asString)
         XCTAssertFalse(localFS.isDirectory(path))
 
         // Test temp directory is removed when its not empty and removeTreeOnDeinit is enabled.
         do {
             let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
             XCTAssertTrue(localFS.isDirectory(tempDir.path))
-            let filePath = AbsolutePath(tempDir.path).appending("somefile").asString
+            let filePath = tempDir.path.appending("somefile").asString
             try localFS.writeFileContents(filePath, bytes: ByteString())
             path = tempDir.path
         }
@@ -99,8 +99,8 @@ class TemporaryFileTests: XCTestCase {
     }
 
     func testCanCreateUniqueTempDirectories() throws {
-        let pathOne: String
-        let pathTwo: String
+        let pathOne: AbsolutePath
+        let pathTwo: AbsolutePath
         do {
             let one = try TemporaryDirectory()
             let two = try TemporaryDirectory()

--- a/Tests/Functional/MiscellaneousTests.swift
+++ b/Tests/Functional/MiscellaneousTests.swift
@@ -369,7 +369,7 @@ class MiscellaneousTestCase: XCTestCase {
         XCTAssertTrue(localFS.isDirectory(tempDir.path))
 
         // Create a directory with non c99name.
-        let packageRoot = AbsolutePath(tempDir.path).appending("some-package").asString
+        let packageRoot = tempDir.path.appending("some-package").asString
         try localFS.createDirectory(packageRoot)
         XCTAssertTrue(localFS.isDirectory(packageRoot))
 


### PR DESCRIPTION
Among other things this adds temporary shims to FSProxy until all the
clients have been converted to use path types.

Note that during the conversion there are a lot of .asString calls that
are needed for POSIX functions and FileManager functions, but as we put
all of these on FSProxy (which takes Paths) a lot of these should end up
disappearing again.

So during the transition, the current path-based code looks a bit more
complicated than it will eventually look.  The end goal is for the path
operations to be type safe, elegant, and intuitive.