### PR TITLE
[PackageModel] Switch Module.recursiveDependencies to be well defined.

### DIFF
--- a/Tests/PackageModel/ModuleTests.swift
+++ b/Tests/PackageModel/ModuleTests.swift
@@ -1,0 +1,29 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+@testable import PackageModel
+
+class ModuleTests: XCTestCase {
+    /// Check that module dependencies appear in build order.
+    func testDependencyOrder() throws {
+        let a = try Module(name: "a")
+        let b = try Module(name: "b")
+        let c = try Module(name: "c")
+        a.dependencies.append(b)
+        b.dependencies.append(c)
+        XCTAssertEqual(a.recursiveDependencies, [c, b])
+    }
+
+    static var allTests = [
+        ("testDependencyOrder", testDependencyOrder),
+    ]
+}

--- a/Tests/PackageModel/XCTestManifests.swift
+++ b/Tests/PackageModel/XCTestManifests.swift
@@ -14,6 +14,7 @@ import XCTest
 public func allTests() -> [XCTestCaseEntry] {
     return [
         testCase(c99nameTests.allTests),
+        testCase(ModuleTests.allTests),
         testCase(PackageNameTests.allTests),
     ]
 }


### PR DESCRIPTION
 - The results were previously unordered w.r.t. the dependency build order, this
   makes them always appear in build order.

 - I don't *think* anything was necessarily broken because of the previous
   order, but it is better to have it be well defined; this also eliminates some
   copy-paste code.