### PR TITLE
Hoist the Utility module above Basic, now that path support is in Basic

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,14 +37,13 @@ let package = Package(
             name: "POSIX",
             dependencies: ["libc"]),
         Target(
-            /** Abstractions for common operations, should migrate to Basic */
-            name: "Utility",
-            dependencies: ["POSIX"]),
-        Target(
             /** Basic support library */
             name: "Basic",
-            dependencies: ["libc", "POSIX", "Utility"]),
-            // FIXME: Eliminate the dependency on Utility above once we have Path.
+            dependencies: ["libc", "POSIX"]),
+        Target(
+            /** Abstractions for common operations, should migrate to Basic */
+            name: "Utility",
+            dependencies: ["POSIX", "Basic"]),
         Target(
             /** Source control operations */
             name: "SourceControl",

--- a/Sources/PackageLoading/transmute.swift
+++ b/Sources/PackageLoading/transmute.swift
@@ -40,9 +40,9 @@ public func transmute(_ rootPackage: Package, externalPackages: [Package]) throw
 
             // Set dependencies for test modules.
             for case let testModule as SwiftModule in testModules {
-                if testModule.basename == "Utility" {
-                    // FIXME: The Utility tests currently have a layering
-                    // violation and a dependency on Basic for infrastructure.
+                if testModule.basename == "Basic" {
+                    // FIXME: The Basic tests currently have a layering
+                    // violation and a dependency on Utility for infrastructure.
                     testModule.dependencies = modules.filter{
                         switch $0.name {
                         case "Basic", "Utility":


### PR DESCRIPTION
Flip the layering of Basic and Utility, now that the last reference has been removed.  Basic is where new general-purpose support is to be added, and as things from Utility get cleaned up, they may be moved down to Basic if they are deemed suitable of that.