### PR TITLE
[ClangModule] Shell escape arguments passed to clang command.

### DIFF
--- a/Fixtures/ClangModules/SwiftCMixed/Sources/SeaLib with spaces/Foo.c
+++ b/Fixtures/ClangModules/SwiftCMixed/Sources/SeaLib with spaces/Foo.c
@@ -1,0 +1,3 @@
+int foo(int a) {
+    return a;
+}

--- a/Fixtures/ClangModules/SwiftCMixed/Sources/SeaLib with spaces/include/Foo.h
+++ b/Fixtures/ClangModules/SwiftCMixed/Sources/SeaLib with spaces/include/Foo.h
@@ -1,0 +1,1 @@
+int foo(int a);

--- a/Sources/Basic/ShellEscapedString.swift
+++ b/Sources/Basic/ShellEscapedString.swift
@@ -1,0 +1,52 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+private let whitelist: Set<Character> = {
+    Set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_/:@#%+=.,".characters.map{$0})
+}()
+
+public extension String {
+
+    /// Creates a shell escaped string. If the string does not need escaping, returns the original string.
+    /// Otherwise escapes using single quotes. For eg: hello -> hello, hello$world -> 'hello$world', input A -> 'input A'
+    ///
+    /// - Returns: Shell escaped string.
+    public func shellEscaped() -> String {
+        // If all the characters in the string are in whitelist then no need to escape.
+        guard let pos = characters.index(where: { !whitelist.contains($0) }) else {
+            return self
+        }
+
+        // If there are no single quotes then we can just wrap the string around single quotes.
+        guard let singleQuotePos = characters[pos..<characters.endIndex].index(of: "'") else {
+            return "'" + self + "'"
+        }
+
+        // Otherwise iterate and escape all the single quotes.
+        var newString = "'" + String(characters[characters.startIndex..<singleQuotePos])
+
+        for char in characters[singleQuotePos..<characters.endIndex] {
+            if char == "'" {
+                newString += "\\'"
+            } else {
+                newString += String(char)
+            }
+        }
+
+        newString += "'"
+
+        return newString
+    }
+
+    /// Shell escapes the current string. This method is mutating version of shellEscaped().
+    public mutating func shellEscape() {
+        self = shellEscaped()
+    }
+}

--- a/Sources/Build/ToolProtocol.swift
+++ b/Sources/Build/ToolProtocol.swift
@@ -128,7 +128,7 @@ struct ClangTool: ToolProtocol {
         stream <<< "    inputs: " <<< Format.asJSON(inputs) <<< "\n"
         stream <<< "    outputs: " <<< Format.asJSON(outputs) <<< "\n"
         // FIXME: This does not work for paths with spaces.
-        stream <<< "    args: " <<< Format.asJSON(args.joined(separator: " ")) <<< "\n"
+        stream <<< "    args: " <<< Format.asJSON(args.map{ $0.shellEscaped() }.joined(separator: " ")) <<< "\n"
         if let deps = deps {
             stream <<< "    deps: " <<< Format.asJSON(deps) <<< "\n"
         }

--- a/Tests/Basic/ShellEscapedTests.swift
+++ b/Tests/Basic/ShellEscapedTests.swift
@@ -1,0 +1,44 @@
+/*
+This source file is part of the Swift.org open source project
+
+Copyright 2016 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See http://swift.org/LICENSE.txt for license information
+See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import Basic
+
+class ShellEscapedTests: XCTestCase {
+
+    func testShellEscaped() {
+
+        var str = "hello"
+        XCTAssertEqual("hello", str.shellEscaped())
+
+        str = "hello world"
+        XCTAssertEqual("'hello world'", str.shellEscaped())
+
+        str = "hello 'world"
+        str.shellEscape()
+        XCTAssertEqual("'hello \\'world'", str)
+
+        str = "hello world swift"
+        XCTAssertEqual("'hello world swift'", str.shellEscaped())
+
+        str = "hello?world"
+        XCTAssertEqual("'hello?world'", str.shellEscaped())
+
+        str = "hello\nworld"
+        XCTAssertEqual("'hello\nworld'", str.shellEscaped())
+
+        str = "hello\nA\"B C>D*[$;()^><"
+        XCTAssertEqual("'hello\nA\"B C>D*[$;()^><'", str.shellEscaped())
+    }
+
+    static var allTests = [
+        ("testShellEscaped", testShellEscaped),
+    ]
+}

--- a/Tests/Basic/XCTestManifests.swift
+++ b/Tests/Basic/XCTestManifests.swift
@@ -25,6 +25,7 @@ public func allTests() -> [XCTestCaseEntry] {
         testCase(PathTests.allTests),
         testCase(TOMLTests.allTests),
         testCase(TemporaryFileTests.allTests),
+        testCase(ShellEscapedTests.allTests),
     ]
 }
 #endif


### PR DESCRIPTION
Bug: https://bugs.swift.org/browse/SR-1904

dependes on https://github.com/apple/swift-package-manager/pull/446