### PR TITLE
Handle invalid Package.swift manifest format error

### DIFF
--- a/Sources/PackageLoading/Manifest+parse.swift
+++ b/Sources/PackageLoading/Manifest+parse.swift
@@ -20,6 +20,8 @@ private enum ManifestParseError: ErrorProtocol {
     case emptyManifestFile
     /// The manifest had a string encoding error.
     case invalidEncoding
+    /// The manifest contains invalid format.
+    case invalidManifestFormat
 }
 
 extension Manifest {
@@ -86,7 +88,12 @@ private func parse(path manifestPath: String, swiftc: String, libdir: String) th
 
     //Pass the fd in arguments
     cmd += ["-fileno", "\(fp.fileDescriptor)"]
-    try system(cmd)
+    do {
+        try system(cmd)
+    } catch {
+        print("Can't parse Package.swift manifest file because it contains invalid format. Fix Package.swift file format and try again.")
+        throw ManifestParseError.invalidManifestFormat
+    }
 
     guard let toml = try localFS.readFileContents(filePath).asString else {
         throw ManifestParseError.invalidEncoding


### PR DESCRIPTION
Add error handling and descriptive message for invalid `Package.swift` manifest file. Right now user gets error with stack trace from swiftc.  Maybe we should hide it in future if it's possible. 

Example of  stack trace: 
```
Current stack trace:
0    libswiftCore.dylib                 0x000000010ad34370 swift_reportError + 125
1    libswiftCore.dylib                 0x000000010ad50f90 _swift_stdlib_reportFatalError + 61
2    libswiftCore.dylib                 0x000000010acfdfe0 partial apply for thunk + 63
3    libswiftCore.dylib                 0x000000010ab57c50 specialized StaticString.withUTF8Buffer<A> (invoke : (UnsafeBufferPointer<UInt8>) -> A) -> A + 351
4    libswiftCore.dylib                 0x000000010acc6320 partial apply for (_fatalErrorMessage(StaticString, StaticString, StaticString, UInt, flags : UInt32) -> ()).(closure #2) + 158
5    libswiftCore.dylib                 0x000000010acfdfe0 partial apply for thunk + 63
6    libswiftCore.dylib                 0x000000010ad03e20 partial apply for thunk + 14
7    libswiftCore.dylib                 0x000000010ab57c50 specialized StaticString.withUTF8Buffer<A> (invoke : (UnsafeBufferPointer<UInt8>) -> A) -> A + 351
8    libswiftCore.dylib                 0x000000010ac86b40 specialized _fatalErrorMessage(StaticString, StaticString, StaticString, UInt, flags : UInt32) -> () + 143
9    libPackageDescription.dylib        0x000000010ab0b5e0 Version.init(stringLiteral : String) -> Version + 229
11   swift                              0x0000000103f9b250 llvm::MCJIT::runFunction(llvm::Function*, llvm::ArrayRef<llvm::GenericValue>) + 915
12   swift                              0x0000000103f9df30 llvm::ExecutionEngine::runFunctionAsMain(llvm::Function*, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, char const* const*) + 1267
13   swift                              0x0000000103b56190 swift::RunImmediately(swift::CompilerInstance&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, swift::IRGenOptions&, swift::SILOptions const&) + 2775
14   swift                              0x0000000103b4c530 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) + 15890
15   swift                              0x0000000103b4a750 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2895
16   swift                              0x0000000103b0d450 main + 2448
17   libdyld.dylib                      0x00007fff98a2e5ac start + 1
0  swift                       0x00000001067b500b llvm::sys::PrintStackTrace(llvm::raw_ostream&) + 43
1  swift                       0x00000001067b4256 llvm::sys::RunSignalHandlers() + 70
2  swift                       0x00000001067b575f SignalHandler(int) + 383
3  libsystem_platform.dylib    0x00007fff95be552a _sigtramp + 26
4  libsystem_platform.dylib    0x000000000000ffff _sigtramp + 1782754031
5  libPackageDescription.dylib 0x000000010ab0b6c5 _TFV18PackageDescription7VersionCfT13stringLiteralSS_S0_ + 229
6  libPackageDescription.dylib 0x000000010b44a130 _TFV18PackageDescription7VersionCfT13stringLiteralSS_S0_ + 9694032
7  swift                       0x0000000103f9b5e3 llvm::MCJIT::runFunction(llvm::Function*, llvm::ArrayRef<llvm::GenericValue>) + 915
8  swift                       0x0000000103f9e423 llvm::ExecutionEngine::runFunctionAsMain(llvm::Function*, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, char const* const*) + 1267
9  swift                       0x0000000103b56c67 swift::RunImmediately(swift::CompilerInstance&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, swift::IRGenOptions&, swift::SILOptions const&) + 2775
10 swift                       0x0000000103b50342 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*) + 15890
11 swift                       0x0000000103b4b29f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2895
12 swift                       0x0000000103b0dde0 main + 2448
13 libdyld.dylib               0x00007fff98a2e5ad start + 1
Stack dump:
```