### PR TITLE
Path adoption in the Commands target

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -8,21 +8,22 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basic
 import POSIX
 import PackageModel
 import Utility
 
 public class Options {
-    public var chdir: String?
+    public var chdir: AbsolutePath?
     public var path = Path()
 
     public class Path {
         public lazy var root = getroot()
-        public var Packages: String { return Utility.Path.join(self.root, "Packages") }
+        public var packages: AbsolutePath { return root.appending("Packages") }
 
-        public var build: String {
-            get { return _build ?? Utility.Path.join(getroot(), ".build") }
-            set { _build = newValue }
+        public var build: AbsolutePath {
+            get { return _build != nil ? AbsolutePath(_build!) : getroot().appending(".build") }
+            set { _build = newValue.asString }
         }
 
         private var _build = getenv("SWIFT_BUILD_PATH")
@@ -37,9 +38,9 @@ public struct Flag {
     public static let C = "-C"
 }
 
-private func getroot() -> String {
-    var root = getcwd()
-    while !Path.join(root, Manifest.filename).isFile {
+private func getroot() -> AbsolutePath {
+    var root = AbsolutePath(getcwd())
+    while !root.appending(RelativePath(Manifest.filename)).asString.isFile {
         root = root.parentDirectory
 
         guard root != "/" else {

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -26,7 +26,7 @@ public class Options {
             set { _build = newValue.asString }
         }
 
-        private var _build = getenv("SWIFT_BUILD_PATH")
+        private var _build = getenv("SWIFT_BUILD_PATH")?.abspath
     }
 
     public init()

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -81,7 +81,7 @@ private enum BuildToolFlag: Argument {
         
         switch argument {
         case Flag.chdir, Flag.C:
-            self = try .chdir(AbsolutePath(forcePop()))
+            self = try .chdir(AbsolutePath(forcePop().abspath))
         case "--verbose", "-v":
             self = .verbose(1)
         case "-Xcc":
@@ -91,7 +91,7 @@ private enum BuildToolFlag: Argument {
         case "-Xswiftc":
             self = try .xswiftc(forcePop())
         case "--build-path":
-            self = try .buildPath(AbsolutePath(forcePop()))
+            self = try .buildPath(AbsolutePath(forcePop().abspath))
         case "--build-tests":
             self = .buildTests
         case "--color":
@@ -103,7 +103,7 @@ private enum BuildToolFlag: Argument {
         case "--ignore-dependencies":
             self = .ignoreDependencies
         case "--xcconfig-overrides":
-            self = try .xcconfigOverrides(AbsolutePath(forcePop()))
+            self = try .xcconfigOverrides(AbsolutePath(forcePop().abspath))
         default:
             return nil
         }
@@ -173,10 +173,10 @@ public struct SwiftBuildTool: SwiftTool {
                 fallthrough
         
             case .clean(.build):
-                let artifacts = ["debug", "release"].map{ AbsolutePath(opts.path.build, $0) }.map{ ($0, "\($0).yaml") }
+                let artifacts = ["debug", "release"].map{ AbsolutePath(opts.path.build, $0) }.map{ ($0, AbsolutePath("\($0.asString).yaml")) }
                 for (dir, yml) in artifacts {
                     if dir.asString.isDirectory { try Utility.removeFileTree(dir.asString) }
-                    if yml.abspath.isFile { try Utility.removeFileTree(yml) }
+                    if yml.asString.isFile { try Utility.removeFileTree(yml.asString) }
                 }
         
                 let db = opts.path.build.appending("build.db")

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -103,15 +103,15 @@ private enum PackageToolFlag: Argument {
 
         switch argument {
         case Flag.chdir, Flag.C:
-            self = try .chdir(AbsolutePath(forcePop()))
+            self = try .chdir(AbsolutePath(forcePop().abspath))
         case "--type":
             self = try .initMode(forcePop())
         case "--format":
             self = try .showDepsMode(forcePop())
         case "--output":
-            self = try .outputPath(AbsolutePath(forcePop()))
+            self = try .outputPath(AbsolutePath(forcePop().abspath))
         case "--input":
-            self = try .inputPath(AbsolutePath(forcePop()))
+            self = try .inputPath(AbsolutePath(forcePop().abspath))
         case "--verbose", "-v":
             self = .verbose(1)
         case "--color":
@@ -129,7 +129,7 @@ private enum PackageToolFlag: Argument {
         case "-Xswiftc":
             self = try .xswiftc(forcePop())
         case "--xcconfig-overrides":
-            self = try .xcconfigOverrides(AbsolutePath(forcePop()))
+            self = try .xcconfigOverrides(AbsolutePath(forcePop().abspath))
         default:
             return nil
         }

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -83,14 +83,14 @@ private enum Mode: Argument, Equatable, CustomStringConvertible {
 private enum PackageToolFlag: Argument {
     case initMode(String)
     case showDepsMode(String)
-    case inputPath(String)
-    case outputPath(String)
-    case chdir(String)
+    case inputPath(AbsolutePath)
+    case outputPath(AbsolutePath)
+    case chdir(AbsolutePath)
     case colorMode(ColorWrap.Mode)
     case xcc(String)
     case xld(String)
     case xswiftc(String)
-    case xcconfigOverrides(String)
+    case xcconfigOverrides(AbsolutePath)
     case ignoreDependencies
     case verbose(Int)
 
@@ -103,15 +103,15 @@ private enum PackageToolFlag: Argument {
 
         switch argument {
         case Flag.chdir, Flag.C:
-            self = try .chdir(forcePop())
+            self = try .chdir(AbsolutePath(forcePop()))
         case "--type":
             self = try .initMode(forcePop())
         case "--format":
             self = try .showDepsMode(forcePop())
         case "--output":
-            self = try .outputPath(forcePop())
+            self = try .outputPath(AbsolutePath(forcePop()))
         case "--input":
-            self = try .inputPath(forcePop())
+            self = try .inputPath(AbsolutePath(forcePop()))
         case "--verbose", "-v":
             self = .verbose(1)
         case "--color":
@@ -129,7 +129,7 @@ private enum PackageToolFlag: Argument {
         case "-Xswiftc":
             self = try .xswiftc(forcePop())
         case "--xcconfig-overrides":
-            self = try .xcconfigOverrides(forcePop())
+            self = try .xcconfigOverrides(AbsolutePath(forcePop()))
         default:
             return nil
         }
@@ -139,14 +139,14 @@ private enum PackageToolFlag: Argument {
 private class PackageToolOptions: Options {
     var initMode: InitMode = InitMode.library
     var showDepsMode: ShowDependenciesMode = ShowDependenciesMode.text
-    var inputPath: String? = nil
-    var outputPath: String? = nil
+    var inputPath: AbsolutePath? = nil
+    var outputPath: AbsolutePath? = nil
     var verbosity: Int = 0
     var colorMode: ColorWrap.Mode = .Auto
     var Xcc: [String] = []
     var Xld: [String] = []
     var Xswiftc: [String] = []
-    var xcconfigOverrides: String? = nil
+    var xcconfigOverrides: AbsolutePath? = nil
     var ignoreDependencies: Bool = false
 }
 
@@ -166,17 +166,17 @@ public struct SwiftPackageTool: SwiftTool {
             colorMode = opts.colorMode
         
             if let dir = opts.chdir {
-                try chdir(dir)
+                try chdir(dir.asString)
             }
         
             func parseManifest(path: String, baseURL: String) throws -> Manifest {
-                let swiftc = ToolDefaults.SWIFT_EXEC
-                let libdir = ToolDefaults.libdir
+                let swiftc = ToolDefaults.SWIFT_EXEC.asString
+                let libdir = ToolDefaults.libdir.asString
                 return try Manifest(path: path, baseURL: baseURL, swiftc: swiftc, libdir: libdir)
             }
             
-            func fetch(_ root: String) throws -> (rootPackage: Package, externalPackages:[Package]) {
-                let manifest = try parseManifest(path: root, baseURL: root)
+            func fetch(_ root: AbsolutePath) throws -> (rootPackage: Package, externalPackages:[Package]) {
+                let manifest = try parseManifest(path: root.asString, baseURL: root.asString)
                 if opts.ignoreDependencies {
                     return (Package(manifest: manifest, url: manifest.path.parentDirectory), [])
                 } else {
@@ -191,25 +191,25 @@ public struct SwiftPackageTool: SwiftTool {
                             
             case .update:
                 // Attempt to ensure that none of the repositories are modified.
-                if localFS.exists(opts.path.Packages) {
-                    for name in try localFS.getDirectoryContents(opts.path.Packages) {
-                        let item = Path.join(opts.path.Packages, name)
+                if localFS.exists(opts.path.packages) {
+                    for name in try localFS.getDirectoryContents(opts.path.packages) {
+                        let item = opts.path.packages.appending(RelativePath(name))
 
                         // Only look at repositories.
-                        guard Path.join(item, ".git").exists else { continue }
+                        guard item.appending(".git").asString.exists else { continue }
 
                         // If there is a staged or unstaged diff, don't remove the
                         // tree. This won't detect new untracked files, but it is
                         // just a safety measure for now.
                         let diffArgs = ["--no-ext-diff", "--quiet", "--exit-code"]
                         do {
-                            _ = try Git.runPopen([Git.tool, "-C", item, "diff"] + diffArgs)
-                            _ = try Git.runPopen([Git.tool, "-C", item, "diff", "--cached"] + diffArgs)
+                            _ = try Git.runPopen([Git.tool, "-C", item.asString, "diff"] + diffArgs)
+                            _ = try Git.runPopen([Git.tool, "-C", item.asString, "diff", "--cached"] + diffArgs)
                         } catch {
-                            throw Error.repositoryHasChanges(item)
+                            throw Error.repositoryHasChanges(item.asString)
                         }
                     }
-                    try Utility.removeFileTree(opts.path.Packages)
+                    try Utility.removeFileTree(opts.path.packages.asString)
                 }
                 fallthrough
                 
@@ -241,11 +241,11 @@ public struct SwiftPackageTool: SwiftTool {
                 let externalXcodeModules  = externalModules.flatMap { $0 as? XcodeModuleProtocol }
         
                 let projectName: String
-                let dstdir: String
+                let dstdir: AbsolutePath
                 let packageName = rootPackage.name
         
                 switch opts.outputPath {
-                case let outpath? where outpath.hasSuffix(".xcodeproj"):
+                case let outpath? where outpath.suffix == ".xcodeproj":
                     // if user specified path ending with .xcodeproj, use that
                     projectName = String(outpath.basename.characters.dropLast(10))
                     dstdir = outpath.parentDirectory
@@ -256,13 +256,13 @@ public struct SwiftPackageTool: SwiftTool {
                     dstdir = opts.path.root
                     projectName = packageName
                 }
-                let outpath = try Xcodeproj.generate(dstdir: dstdir.abspath, projectName: projectName, srcroot: opts.path.root, modules: xcodeModules, externalModules: externalXcodeModules, products: products, options: opts)
+                let outpath = try Xcodeproj.generate(dstdir: dstdir.asString, projectName: projectName, srcroot: opts.path.root.asString, modules: xcodeModules, externalModules: externalXcodeModules, products: products, options: opts)
         
                 print("generated:", outpath.prettyPath)
                 
             case .dumpPackage:
                 let root = opts.inputPath ?? opts.path.root
-                let manifest = try parseManifest(path: root, baseURL: root)
+                let manifest = try parseManifest(path: root.asString, baseURL: root.asString)
                 let package = manifest.package
                 let json = try jsonString(package: package)
                 print(json)

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -76,7 +76,7 @@ private enum TestToolFlag: Argument {
         switch argument {
         case "--chdir", "-C":
             guard let path = pop() else { throw OptionParserError.expectedAssociatedValue(argument) }
-            self = .chdir(AbsolutePath(path))
+            self = .chdir(AbsolutePath(path.abspath))
         case "--skip-build":
             self = .skipBuild
         case "--build-path":
@@ -172,7 +172,7 @@ public struct SwiftTestTool: SwiftTool {
                 throw TestError.testsExecutableNotFound
             }
 
-            return AbsolutePath(path)
+            return AbsolutePath(path.abspath)
         }
     }
 

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -279,7 +279,7 @@ public struct SwiftTestTool: SwiftTool {
         // Read the temporary file's content.
         let data = try fopen(tempFile.path.asString).readFileContents()
       #else
-        let args = [path, "--dump-tests-json"]
+        let args = [path.asString, "--dump-tests-json"]
         let data = try popen(args)
       #endif
         // Parse json and return TestSuites.

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -68,7 +68,7 @@ private func ==(lhs: Mode, rhs: Mode) -> Bool {
 }
 
 private enum TestToolFlag: Argument {
-    case chdir(String)
+    case chdir(AbsolutePath)
     case skipBuild
     case buildPath(String)
 
@@ -76,7 +76,7 @@ private enum TestToolFlag: Argument {
         switch argument {
         case "--chdir", "-C":
             guard let path = pop() else { throw OptionParserError.expectedAssociatedValue(argument) }
-            self = .chdir(path)
+            self = .chdir(AbsolutePath(path))
         case "--skip-build":
             self = .skipBuild
         case "--build-path":
@@ -105,7 +105,7 @@ public struct SwiftTestTool: SwiftTool {
             let (mode, opts) = try parseOptions(commandLineArguments: args)
         
             if let dir = opts.chdir {
-                try chdir(dir)
+                try chdir(dir.asString)
             }
         
             switch mode {
@@ -125,9 +125,9 @@ public struct SwiftTestTool: SwiftTool {
                 }
 
             case .run(let specifier):
-                let yamlPath = Path.join(opts.path.build, "\(configuration).yaml")
+                let yamlPath = opts.path.build.appending(RelativePath("\(configuration).yaml"))
                 if opts.buildTests {
-                    try build(YAMLPath: yamlPath, target: "test")
+                    try build(yamlPath: yamlPath, target: "test")
                 }
                 let success = try test(path: determineTestPath(opts: opts), xctestArg: specifier)
                 exit(success ? 0 : 1)
@@ -152,18 +152,18 @@ public struct SwiftTestTool: SwiftTool {
     /// - Throws: TestError
     ///
     /// - Returns: Path to XCTest bundle (OSX) or executable (Linux).
-    private func determineTestPath(opts: Options) throws -> String {
+    private func determineTestPath(opts: Options) throws -> AbsolutePath {
 
         //FIXME better, ideally without parsing manifest since
         // that makes us depend on the whole Manifest system
 
         let packageName = opts.path.root.basename  //FIXME probably not true
-        let maybePath = Path.join(opts.path.build, configuration, "\(packageName)Tests.xctest")
+        let maybePath = opts.path.build.appending(RelativePath(configuration)).appending(RelativePath("\(packageName)Tests.xctest"))
 
-        if maybePath.exists {
+        if maybePath.asString.exists {
             return maybePath
         } else {
-            let possiblePaths = walk(opts.path.build).filter {
+            let possiblePaths = walk(opts.path.build.asString).filter {
                 $0.basename != "Package.xctest" &&   // this was our hardcoded name, may still exist if no clean
                 $0.hasSuffix(".xctest")
             }
@@ -172,7 +172,7 @@ public struct SwiftTestTool: SwiftTool {
                 throw TestError.testsExecutableNotFound
             }
 
-            return path
+            return AbsolutePath(path)
         }
     }
 
@@ -211,24 +211,24 @@ public struct SwiftTestTool: SwiftTool {
         return (mode ?? .run(nil), opts)
     }
 
-    private func test(path: String, xctestArg: String? = nil) throws -> Bool {
-        guard path.isValidTest else {
+    private func test(path: AbsolutePath, xctestArg: String? = nil) throws -> Bool {
+        guard isValidTestPath(path) else {
             throw TestError.testsExecutableNotFound
         }
 
         var args: [String] = []
-#if os(OSX)
+      #if os(OSX)
         args = ["xcrun", "xctest"]
         if let xctestArg = xctestArg {
             args += ["-XCTest", xctestArg]
         }
-        args += [path]
-#else
-        args += [path]
+        args += [path.asString]
+      #else
+        args += [path.asString]
         if let xctestArg = xctestArg {
             args += [xctestArg]
         }
-#endif
+      #endif
 
         // Execute the XCTest with inherited environment as it is convenient to pass senstive
         // information like username, password etc to test cases via enviornment variables.
@@ -240,18 +240,18 @@ public struct SwiftTestTool: SwiftTool {
     /// Note: It is a fatalError if we are not able to locate the tool.
     ///
     /// - Returns: Path to XCTestHelper tool.
-    private func xctestHelperPath() -> String {
+    private func xctestHelperPath() -> AbsolutePath {
         let xctestHelperBin = "swiftpm-xctest-helper"
-        let binDirectory = Process.arguments.first!.abspath.parentDirectory
+        let binDirectory = AbsolutePath(Process.arguments.first!.abspath).parentDirectory
         // XCTestHelper tool is installed in libexec.
-        let maybePath = Path.join(binDirectory, "../libexec/swift/pm/", xctestHelperBin)
-        if maybePath.isFile {
+        let maybePath = binDirectory.appending("../libexec/swift/pm/").appending(RelativePath(xctestHelperBin))
+        if maybePath.asString.isFile {
             return maybePath
         }
         // This will be true during swiftpm developement.
         // FIXME: Factor all of the development-time resource location stuff into a common place.
-        let path = Path.join(binDirectory, xctestHelperBin)
-        if path.isFile {
+        let path = binDirectory.appending(RelativePath(xctestHelperBin))
+        if path.asString.isFile {
             return path 
         }
         fatalError("XCTestHelper binary not found.") 
@@ -267,14 +267,14 @@ public struct SwiftTestTool: SwiftTool {
     /// - Throws: TestError, SystemError, Utility.Errror
     ///
     /// - Returns: Array of TestSuite
-    private func getTestSuites(path: String) throws -> [TestSuite] {
+    private func getTestSuites(path: AbsolutePath) throws -> [TestSuite] {
         // Make sure tests are present.
-        guard path.isValidTest else { throw TestError.testsExecutableNotFound }
+        guard isValidTestPath(path) else { throw TestError.testsExecutableNotFound }
 
         // Run the correct tool.
       #if os(OSX)
         let tempFile = try TemporaryFile()
-        let args = [xctestHelperPath(), path, tempFile.path.asString]
+        let args = [xctestHelperPath().asString, path.asString, tempFile.path.asString]
         try system(args, environment: ["DYLD_FRAMEWORK_PATH": try platformFrameworksPath()])
         // Read the temporary file's content.
         let data = try fopen(tempFile.path.asString).readFileContents()
@@ -287,14 +287,12 @@ public struct SwiftTestTool: SwiftTool {
     }
 }
 
-private extension String {
-    var isValidTest: Bool {
-        #if os(OSX)
-            return isDirectory  // ${foo}.xctest is dir on OSX
-        #else
-            return isFile       // otherwise ${foo}.xctest is executable file
-        #endif
-    }
+private func isValidTestPath(_ path: AbsolutePath) -> Bool {
+  #if os(OSX)
+    return path.asString.isDirectory  // ${foo}.xctest is dir on OSX
+  #else
+    return path.asString.isFile       // otherwise ${foo}.xctest is executable file
+  #endif
 }
 
 /// A struct to hold the XCTestSuite data.

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -70,7 +70,7 @@ private func ==(lhs: Mode, rhs: Mode) -> Bool {
 private enum TestToolFlag: Argument {
     case chdir(AbsolutePath)
     case skipBuild
-    case buildPath(String)
+    case buildPath(AbsolutePath)
 
     init?(argument: String, pop: () -> String?) throws {
         switch argument {
@@ -81,7 +81,7 @@ private enum TestToolFlag: Argument {
             self = .skipBuild
         case "--build-path":
             guard let path = pop() else { throw OptionParserError.expectedAssociatedValue(argument) }
-            self = .buildPath(path)
+            self = .buildPath(AbsolutePath(path.abspath))
         default:
             return nil
         }

--- a/Sources/Commands/ToolDefaults.swift
+++ b/Sources/Commands/ToolDefaults.swift
@@ -8,21 +8,22 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basic
 import PackageModel
-import Utility
 import POSIX
 
 struct ToolDefaults {
-#if Xcode
+  #if Xcode
     // when in Xcode we are built with same toolchain as we will run
     // this is not a production ready mode
 
-    static let SWIFT_EXEC = getenv("SWIFT_EXEC")!.abspath
-    static let llbuild = Path.join(getenv("SWIFT_EXEC")!, "../swift-build-tool").abspath
-    static let libdir = argv0.parentDirectory
-#else
-    static let SWIFT_EXEC = Path.join(argv0, "../swiftc").abspath
-    static let llbuild = Path.join(argv0, "../swift-build-tool").abspath
-    static let libdir = Path.join(argv0, "../../lib/swift/pm").abspath
-#endif
+    // FIXME: This isn't correct; we need to handle a missing SWIFT_EXEC.
+    static let SWIFT_EXEC = AbsolutePath(getenv("SWIFT_EXEC")!.abspath)
+    static let llbuild = AbsolutePath(getenv("SWIFT_EXEC")!.abspath).appending("../swift-build-tool")
+    static let libdir = AbsolutePath(argv0).parentDirectory
+  #else
+    static let SWIFT_EXEC = AbsolutePath(argv0).appending("../swiftc")
+    static let llbuild = AbsolutePath(argv0).appending("../swift-build-tool")
+    static let libdir = AbsolutePath(argv0).appending("../../lib/swift/pm")
+  #endif
 }

--- a/Sources/Commands/ToolDefaults.swift
+++ b/Sources/Commands/ToolDefaults.swift
@@ -20,10 +20,10 @@ struct ToolDefaults {
     // FIXME: This isn't correct; we need to handle a missing SWIFT_EXEC.
     static let SWIFT_EXEC = AbsolutePath(getenv("SWIFT_EXEC")!.abspath)
     static let llbuild = AbsolutePath(getenv("SWIFT_EXEC")!.abspath).appending("../swift-build-tool")
-    static let libdir = AbsolutePath(argv0).parentDirectory
+    static let libdir = AbsolutePath(argv0.abspath).parentDirectory
   #else
-    static let SWIFT_EXEC = AbsolutePath(argv0).appending("../swiftc")
-    static let llbuild = AbsolutePath(argv0).appending("../swift-build-tool")
-    static let libdir = AbsolutePath(argv0).appending("../../lib/swift/pm")
+    static let SWIFT_EXEC = AbsolutePath(argv0.abspath).appending("../swiftc")
+    static let llbuild = AbsolutePath(argv0.abspath).appending("../swift-build-tool")
+    static let libdir = AbsolutePath(argv0.abspath).appending("../../lib/swift/pm")
   #endif
 }

--- a/Sources/Commands/build().swift
+++ b/Sources/Commands/build().swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basic
 import PackageModel
 import Utility
 
@@ -15,9 +16,9 @@ import func POSIX.getenv
 import func POSIX.exit
 
 // Builds the default target in the llbuild manifest unless specified.
-public func build(YAMLPath: String, target: String? = nil) throws {
+public func build(yamlPath: AbsolutePath, target: String? = nil) throws {
     do {
-        var args = [ToolDefaults.llbuild, "-f", YAMLPath]
+        var args = [ToolDefaults.llbuild.asString, "-f", yamlPath.asString]
         if let target = target {
             args += [target]
         }
@@ -30,10 +31,10 @@ public func build(YAMLPath: String, target: String? = nil) throws {
         // out its own error conditions and then try
         // to infer what happened afterwards.
 
-        if YAMLPath.isFile {
+        if yamlPath.asString.isFile {
             throw error
         } else {
-            throw Error.buildYAMLNotFound(YAMLPath)
+            throw Error.buildYAMLNotFound(yamlPath.asString)
         }
     }
 }

--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -26,7 +26,7 @@ public protocol XcodeprojOptions {
     /// If provided, a path to an xcconfig file to be included by the project.
     ///
     /// This allows the client to override settings defined in the project itself.
-    var xcconfigOverrides: String? { get }
+    var xcconfigOverrides: AbsolutePath? { get }
 }
 
 /**

--- a/Tests/Xcodeproj/GenerateXcodeprojTests.swift
+++ b/Tests/Xcodeproj/GenerateXcodeprojTests.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basic
 import func POSIX.mkdtemp
 import PackageModel
 import Xcodeproj
@@ -32,7 +33,7 @@ class GenerateXcodeprojTests: XCTestCase {
                 let Xcc = [String]()
                 let Xld = [String]()
                 let Xswiftc = [String]()
-                let xcconfigOverrides: String? = nil
+                let xcconfigOverrides: AbsolutePath? = nil
             }
             let outpath = try Xcodeproj.generate(dstdir: dstdir, projectName: projectName, srcroot: srcroot, modules: modules, externalModules: [], products: products, options: Options())
 


### PR DESCRIPTION
Adopted AbsolutePath/RelativePath APIs in the Commands target.  Many of the `.asString` conversions in this check-in will eventually be removed again, once the adoption reaches lower-level APIs.