### PR TITLE
[Basic] Capture self weakly in thread task.

### DIFF
--- a/Tests/Basic/ThreadTests.swift
+++ b/Tests/Basic/ThreadTests.swift
@@ -49,8 +49,27 @@ class ThreadTests: XCTestCase {
         XCTAssertTrue(finishedTwo)
     }
 
+    func testNotDeinitBeforeExecutingTask() {
+        var finishedCondition = Condition()
+        var finished = false
+
+        Thread {
+            finished = true
+            finishedCondition.signal()
+        }.start()
+
+        finishedCondition.lock()
+        while !finished {
+            finishedCondition.wait()
+        }
+        finishedCondition.unlock()
+
+        XCTAssertTrue(finished)
+    }
+
     static var allTests = [
         ("testSingleThread", testSingleThread),
         ("testMultipleThread", testMultipleThread),
+        ("testNotDeinitBeforeExecutingTask", testNotDeinitBeforeExecutingTask),
     ]
 }


### PR DESCRIPTION
Unowned results in trap in case Thread object is deinited before the
task is run. Ignore the use of finishedCondition in case Thread is
deinited and just run the task.