### PR TITLE
Fix for [SR-1946] `swift test` fails to recognize --build-path argument

### DIFF
--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -70,6 +70,7 @@ private func ==(lhs: Mode, rhs: Mode) -> Bool {
 private enum TestToolFlag: Argument {
     case chdir(String)
     case skipBuild
+    case buildPath(String)
 
     init?(argument: String, pop: () -> String?) throws {
         switch argument {
@@ -78,6 +79,9 @@ private enum TestToolFlag: Argument {
             self = .chdir(path)
         case "--skip-build":
             self = .skipBuild
+        case "--build-path":
+            guard let path = pop() else { throw OptionParserError.expectedAssociatedValue(argument) }
+            self = .buildPath(path)
         default:
             return nil
         }
@@ -199,6 +203,8 @@ public struct SwiftTestTool: SwiftTool {
                 opts.chdir = path
             case .skipBuild:
                 opts.buildTests = false
+            case .buildPath(let buildPath): ()
+                opts.path.build = buildPath
             }
         }
 

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -203,7 +203,7 @@ public struct SwiftTestTool: SwiftTool {
                 opts.chdir = path
             case .skipBuild:
                 opts.buildTests = false
-            case .buildPath(let buildPath): ()
+            case .buildPath(let buildPath):
                 opts.path.build = buildPath
             }
         }


### PR DESCRIPTION
https://bugs.swift.org/browse/SR-1946

The flag was not accounted for in TestToolFlag so I added the cases and set opts.path.build the same way it is in a normal `swift build` invocation.

After this change I was successfully able to `swift build` to an explicitly specified build directory and run `swift test` with the same.