### PR TITLE
Adapt Xcode project generation code to Path types

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -256,9 +256,9 @@ public struct SwiftPackageTool: SwiftTool {
                     dstdir = opts.path.root
                     projectName = packageName
                 }
-                let outpath = try Xcodeproj.generate(dstdir: dstdir.asString, projectName: projectName, srcroot: opts.path.root.asString, modules: xcodeModules, externalModules: externalXcodeModules, products: products, options: opts)
+                let outpath = try Xcodeproj.generate(dstdir: dstdir, projectName: projectName, srcroot: opts.path.root, modules: xcodeModules, externalModules: externalXcodeModules, products: products, options: opts)
         
-                print("generated:", outpath.prettyPath)
+                print("generated:", outpath.asString.prettyPath)
                 
             case .dumpPackage:
                 let root = opts.inputPath ?? opts.path.root

--- a/Sources/Commands/UserToolchain.swift
+++ b/Sources/Commands/UserToolchain.swift
@@ -10,8 +10,8 @@
 
 import POSIX
 
+import Basic
 import protocol Build.Toolchain
-import struct Utility.Path
 
 #if os(OSX)
     private let whichClangArgs = ["xcrun", "--find", "clang"]
@@ -41,7 +41,7 @@ struct UserToolchain: Toolchain {
         do {
             SWIFT_EXEC = getenv("SWIFT_EXEC")
                 // use the swiftc installed alongside ourselves
-                ?? Path.join(Process.arguments[0], "../swiftc").abspath
+                ?? AbsolutePath(Process.arguments[0].abspath).appending("../swiftc").asString
 
             clang = try getenv("CC") ?? POSIX.popen(whichClangArgs).chomp()
 

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -8,14 +8,16 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basic
 import POSIX
 import PackageModel
 import Utility
-import struct Basic.RelativePath
+
 
 // FIXME: escaping
 
-public func pbxproj(srcroot: String, projectRoot: String, xcodeprojPath: String, modules: [XcodeModuleProtocol], externalModules: [XcodeModuleProtocol], products _: [Product], options: XcodeprojOptions, printer print: (String) -> Void) throws {
+
+public func pbxproj(srcroot: AbsolutePath, projectRoot: AbsolutePath, xcodeprojPath: AbsolutePath, modules: [XcodeModuleProtocol], externalModules: [XcodeModuleProtocol], products _: [Product], options: XcodeprojOptions, printer print: (String) -> Void) throws {
     // let rootModulesSet = Set(modules).subtract(Set(externalModules))
     let rootModulesSet = modules
     let nonTestRootModules = rootModulesSet.filter{ !$0.isTest }
@@ -48,39 +50,41 @@ public func pbxproj(srcroot: String, projectRoot: String, xcodeprojPath: String,
 
 ////// Package.swift file
     let packageSwift = fileRef(inProjectRoot: "Package.swift", srcroot: srcroot)
-    print("        \(packageSwift.0) = {")
+    print("        \(packageSwift.refId) = {")
     print("            isa = PBXFileReference;")
     print("            lastKnownFileType = sourcecode.swift;")
-    print("            name = '\(packageSwift.1)';")
-    print("            path = '\(Path(packageSwift.2).relative(to: projectRoot))';")
+    print("            path = '\(packageSwift.path.relative(to: projectRoot).asString)';")
     print("            sourceTree = '<group>';")
     print("        };")
 
 ////// root group
     print("        \(rootGroupReference) = {")
     print("            isa = PBXGroup;")
-    print("            children = (\(packageSwift.0), \(configsGroupReference), \(sourcesGroupReference), \(dependenciesGroupReference), \(testsGroupReference), \(productsGroupReference));")
+    print("            children = (\(packageSwift.refId), \(configsGroupReference), \(sourcesGroupReference), \(dependenciesGroupReference), \(testsGroupReference), \(productsGroupReference));")
     print("            sourceTree = '<group>';")
     print("        };")
 
 ////// modules group
     for module in modules {
-
-        let sourceFileRefPaths = fileRefs(forModuleSources: module, srcroot: srcroot)
-        var sourceRefs = sourceFileRefPaths.map{$0.0}
+        // Base directory for source files belonging to the module.
+        let moduleRoot = AbsolutePath(module.sources.root)
+        
+        // Contruct an array of (refId, path, bflId) tuples for all the source files in the model.  The reference id is for the PBXFileReference in the group hierarchy, and the build file id is for the PBXBuildFile in the CompileSources build phase.
+        let sourceFileRefs = fileRefs(forModuleSources: module, srcroot: srcroot)
+        
+        // Make an array of all the source file reference ids to add to the main group.
+        var sourceRefIds = sourceFileRefs.map{ $0.refId }
 
         ////// Info.plist file reference if this a framework target
         if module.isLibrary {
-            let (ref, path, name) = fileRef(ofInfoPlistFor: module, inDirectory: xcodeprojPath)
-            print("        \(ref) = {")
+            let infoPlistFileRef = fileRef(ofInfoPlistFor: module, srcroot: xcodeprojPath)
+            print("        \(infoPlistFileRef.refId) = {")
             print("            isa = PBXFileReference;")
             print("            lastKnownFileType = text.plist.xml;")
-            print("            name = '\(name)';")
-            print("            path = '\(Path(path).relative(to: projectRoot))';")
+            print("            path = '\(infoPlistFileRef.path.relative(to: projectRoot).asString)';")
             print("            sourceTree = SOURCE_ROOT;")
             print("        };")
-
-            sourceRefs.append(ref)
+            sourceRefIds.append(infoPlistFileRef.refId)
         }
 
 
@@ -88,17 +92,18 @@ public func pbxproj(srcroot: String, projectRoot: String, xcodeprojPath: String,
         print("        \(module.groupReference) = {")
         print("            isa = PBXGroup;")
         print("            name = \(module.name);")
-        print("            path = '\(Path(module.sources.root).relative(to: projectRoot))';")
+        print("            path = '\(moduleRoot.relative(to: projectRoot).asString)';")
         print("            sourceTree = '<group>';")
-        print("            children = (" + sourceRefs.joined(separator: ", ") + ");")
+        print("            children = (" + sourceRefIds.joined(separator: ", ") + ");")
         print("        };")
 
         // the contents of the “Project Navigator” group for this module
-        for (ref, path) in sourceFileRefPaths {
-            print("        \(ref) = {")
+        for fileRef in sourceFileRefs {
+            let path = fileRef.path.relative(to: moduleRoot)
+            print("        \(fileRef.refId) = {")
             print("            isa = PBXFileReference;")
-            print("            lastKnownFileType = \(module.fileType(forSource: RelativePath(path)));")
-            print("            name = '\(Path(path).relative(to: module.sources.root))';")
+            print("            lastKnownFileType = \(module.fileType(forSource: path));")
+            print("            name = '\(fileRef.path.asString)';")
             print("            sourceTree = '<group>';")
             print("        };")
         }
@@ -127,15 +132,15 @@ public func pbxproj(srcroot: String, projectRoot: String, xcodeprojPath: String,
         // sources build phase
         print("        \(module.compilePhaseReference) = {")
         print("            isa = PBXSourcesBuildPhase;")
-        print("            files = (\(fileRefs(forCompilePhaseSourcesInModule: module, srcroot: srcroot).map{$1}.joined(separator: ", ")));")
+        print("            files = (\(sourceFileRefs.map{ $0.bflId }.joined(separator: ", ")));")
         print("            runOnlyForDeploymentPostprocessing = 0;")
         print("        };")
 
         // the fileRefs for the children in the build phases
-        for (ref1, ref2) in fileRefs(forCompilePhaseSourcesInModule: module, srcroot: srcroot) {
-            print("        \(ref2) = {")
+        for fileRef in sourceFileRefs {
+            print("        \(fileRef.bflId) = {")
             print("            isa = PBXBuildFile;")
-            print("            fileRef = \(ref1);")
+            print("            fileRef = \(fileRef.refId);")
             print("        };")
         }
 
@@ -186,9 +191,9 @@ public func pbxproj(srcroot: String, projectRoot: String, xcodeprojPath: String,
     // The project-level xcconfig files.
     //
     // FIXME: Generate these into a sane path.
-    let projectXCConfig = fileRef(inProjectRoot: Path.join(xcodeprojPath.basename, "Configs", "Project.xcconfig"), srcroot: Path.join(srcroot, projectRoot))
-    try Utility.makeDirectories(projectXCConfig.2.parentDirectory)
-    try open(projectXCConfig.2) { print in
+    let projectXCConfig = fileRef(inProjectRoot: RelativePath("\(xcodeprojPath.basename)/Configs/Project.xcconfig"), srcroot: srcroot)
+    try Utility.makeDirectories(projectXCConfig.path.parentDirectory.asString)
+    try open(projectXCConfig.path) { print in
         // Set the standard PRODUCT_NAME.
         print("PRODUCT_NAME = $(TARGET_NAME)")
         
@@ -250,18 +255,17 @@ public func pbxproj(srcroot: String, projectRoot: String, xcodeprojPath: String,
     }
     let configs = [projectXCConfig]
     for configInfo in configs {
-        print("        \(configInfo.0) = {")
+        print("        \(configInfo.refId) = {")
         print("            isa = PBXFileReference;")
         print("            lastKnownFileType = text.xcconfig;")
-        print("            name = '\(configInfo.1.basename)';")
-        print("            path = '\(Path(configInfo.2).relative(to: projectRoot))';")
+        print("            path = '\(configInfo.path.relative(to: projectRoot).asString)';")
         print("            sourceTree = '<group>';")
         print("        };")
     }
     
     print("        \(configsGroupReference) = {")
     print("            isa = PBXGroup;")
-    print("            children = (" + configs.map{ $0.0 }.joined(separator: ", ") + ");")
+    print("            children = (" + configs.map{ $0.refId }.joined(separator: ", ") + ");")
     print("            name = Configs;")
     print("            sourceTree = '<group>';")
     print("        };")

--- a/Tests/Xcodeproj/GenerateXcodeprojTests.swift
+++ b/Tests/Xcodeproj/GenerateXcodeprojTests.swift
@@ -20,8 +20,9 @@ import XCTest
 class GenerateXcodeprojTests: XCTestCase {
     func testXcodeBuildCanParseIt() {
         mktmpdir { dstdir in
+            let dstdir = AbsolutePath(dstdir)
             func dummy() throws -> [XcodeModuleProtocol] {
-                return [try SwiftModule(name: "DummyModuleName", sources: Sources(paths: [], root: dstdir))]
+                return [try SwiftModule(name: "DummyModuleName", sources: Sources(paths: [], root: dstdir.asString))]
             }
 
             let projectName = "DummyProjectName"
@@ -37,12 +38,12 @@ class GenerateXcodeprojTests: XCTestCase {
             }
             let outpath = try Xcodeproj.generate(dstdir: dstdir, projectName: projectName, srcroot: srcroot, modules: modules, externalModules: [], products: products, options: Options())
 
-            XCTAssertDirectoryExists(outpath)
-            XCTAssertEqual(outpath, Path.join(dstdir, "\(projectName).xcodeproj"))
+            XCTAssertDirectoryExists(outpath.asString)
+            XCTAssertEqual(outpath, dstdir.appending(RelativePath("\(projectName).xcodeproj")))
 
             // We can only validate this on OS X.
             // Don't allow TOOLCHAINS to be overriden here, as it breaks the test below.
-            let output = try popen(["env", "-u", "TOOLCHAINS", "xcodebuild", "-list", "-project", outpath]).chomp()
+            let output = try popen(["env", "-u", "TOOLCHAINS", "xcodebuild", "-list", "-project", outpath.asString]).chomp()
 
             let expectedOutput = "Information about project \"DummyProjectName\":\n    Targets:\n        DummyModuleName\n\n    Build Configurations:\n        Debug\n        Release\n\n    If no build configuration is specified and -scheme is not passed then \"Debug\" is used.\n\n    Schemes:\n        DummyProjectName\n".chomp()
 


### PR DESCRIPTION
Path adoption continues with the Xcode project generation.  As before, it is in general a fairly mechanical transformation, but I did simplify some of the helper functions for project generation, but there were some ambiguities and misnomers that made things unclear otherwise.  But I've tried to keep the diffs strictly localized to converting from Strings to AbsolutePaths / RelativePaths, as appropriate.