### PR TITLE
SR-1861 -- Improve error message if building system module package

### DIFF
--- a/Sources/Build/Error.swift
+++ b/Sources/Build/Error.swift
@@ -10,4 +10,16 @@
 
 public enum Error: ErrorProtocol {
     case noModules
+    case noProducts
+}
+
+extension Error: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .noModules:
+            return "no modules found"
+        case .noProducts:
+            return "no products found (note: modulemaps cannot be build)"
+        }
+    }
 }

--- a/Sources/Build/Error.swift
+++ b/Sources/Build/Error.swift
@@ -10,7 +10,7 @@
 
 public enum Error: ErrorProtocol {
     case noModules
-    case cModule(name: String)
+    case onlyCModule(name: String)
 }
 
 extension Error: CustomStringConvertible {
@@ -18,7 +18,7 @@ extension Error: CustomStringConvertible {
         switch self {
         case .noModules:
             return "no modules found."
-        case .cModule(let name):
+        case .onlyCModule(let name):
             return "system module package \(name) found. To use this system module package, include it in another project."
         }
     }

--- a/Sources/Build/Error.swift
+++ b/Sources/Build/Error.swift
@@ -8,18 +8,30 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import protocol Basic.FixableError
+import struct PackageModel.Manifest
+
 public enum Error: ErrorProtocol {
     case noModules
     case onlyCModule(name: String)
 }
 
-extension Error: CustomStringConvertible {
-    public var description: String {
+extension Error: FixableError {
+    public var error: String {
         switch self {
         case .noModules:
-            return "no modules found."
+            return "no modules found"
         case .onlyCModule(let name):
-            return "system module package \(name) found. To use this system module package, include it in another project."
+            return "only system module package \(name) found"
+        }
+    }
+
+    public var fix: String? {
+        switch self {
+            case .noModules:
+                return "define a module inside \(Manifest.filename)"
+            case .onlyCModule:
+                return "to use this system module package, include it in another project"
         }
     }
 }

--- a/Sources/Build/Error.swift
+++ b/Sources/Build/Error.swift
@@ -10,16 +10,16 @@
 
 public enum Error: ErrorProtocol {
     case noModules
-    case noProducts
+    case cModule(name: String)
 }
 
 extension Error: CustomStringConvertible {
     public var description: String {
         switch self {
         case .noModules:
-            return "no modules found"
-        case .noProducts:
-            return "no products found (note: modulemaps cannot be build)"
+            return "no modules found."
+        case .cModule(let name):
+            return "system module package \(name) found. To use this system module package, include it in another project."
         }
     }
 }

--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -24,6 +24,10 @@ public func describe(_ prefix: String, _ conf: Configuration, _ modules: [Module
         throw Error.noModules
     }
 
+    if modules.count == 1, let module = modules.first as? CModule {
+        throw Error.cModule(name: module.name)
+    }
+
     let Xcc = Xcc.flatMap{ ["-Xcc", $0] }
     let Xld = Xld.flatMap{ ["-Xlinker", $0] }
     let prefix = Path.join(prefix, conf.dirname)
@@ -78,10 +82,6 @@ public func describe(_ prefix: String, _ conf: Configuration, _ modules: [Module
 
         commands.append(command)
         targets.append([command], for: product)
-    }
-
-    guard commands.count > 0 else {
-        throw Error.noProducts
     }
 
     return try! write(path: "\(prefix).yaml") { stream in

--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -24,7 +24,7 @@ public func describe(_ prefix: String, _ conf: Configuration, _ modules: [Module
         throw Error.noModules
     }
 
-    if modules.count == 1, let module = modules.first as? CModule {
+    if modules.count == 1, let module = modules.first as? CModule, !(module is ClangModule) {
         throw Error.onlyCModule(name: module.name)
     }
 

--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -25,7 +25,7 @@ public func describe(_ prefix: String, _ conf: Configuration, _ modules: [Module
     }
 
     if modules.count == 1, let module = modules.first as? CModule {
-        throw Error.cModule(name: module.name)
+        throw Error.onlyCModule(name: module.name)
     }
 
     let Xcc = Xcc.flatMap{ ["-Xcc", $0] }

--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -80,6 +80,10 @@ public func describe(_ prefix: String, _ conf: Configuration, _ modules: [Module
         targets.append([command], for: product)
     }
 
+    guard commands.count > 0 else {
+        throw Error.noProducts
+    }
+
     return try! write(path: "\(prefix).yaml") { stream in
         stream <<< "client:\n"
         stream <<< "  name: swift-build\n"

--- a/Tests/Build/DescribeTests.swift
+++ b/Tests/Build/DescribeTests.swift
@@ -35,7 +35,7 @@ final class DescribeTests: XCTestCase {
         }
     }
 
-    func testDescribingNoProductsThrows() {
+    func testDescribingCModuleThrows() {
         do {
             struct InvalidToolchain: Toolchain {
                 var platformArgsClang: [String] { fatalError() }
@@ -48,16 +48,16 @@ final class DescribeTests: XCTestCase {
             let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
             _ = try describe(tempDir.path.appending("foo").asString, .debug, [CModule(name: "MyCModule", path: "")], [], [], Xcc: [], Xld: [], Xswiftc: [], toolchain: InvalidToolchain())
             XCTFail("This call should throw")
-        } catch Build.Error.noProducts {
+        } catch Build.Error.cModule (let name) {
             XCTAssert(true, "This error should be thrown")
+            XCTAssertEqual(name, "MyCModule")
         } catch {
-            print(error)
             XCTFail("No other error should be thrown")
         }
     }
 
     static var allTests = [
         ("testDescribingNoModulesThrows", testDescribingNoModulesThrows),
-        ("testDescribingNoProductsThrows", testDescribingNoProductsThrows),
+        ("testDescribingCModuleThrows", testDescribingCModuleThrows),
     ]
 }

--- a/Tests/Build/DescribeTests.swift
+++ b/Tests/Build/DescribeTests.swift
@@ -13,8 +13,6 @@ import XCTest
 import Basic
 import PackageModel
 import Build
-import Utility
-import POSIX
 
 final class DescribeTests: XCTestCase {
     func testDescribingNoModulesThrows() {
@@ -27,11 +25,9 @@ final class DescribeTests: XCTestCase {
                 var clang: String { fatalError() }
             }
 
-            try POSIX.mkdtemp("spm-tests") { prefix in
-                defer { _ = try? Utility.removeFileTree(prefix) }
-                let _ = try describe(prefix.appending("foo"), .debug, [], [], [], Xcc: [], Xld: [], Xswiftc: [], toolchain: InvalidToolchain())
-                XCTFail("This call should throw")
-            }
+            let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
+            _ = try describe(tempDir.path.appending("foo").asString, .debug, [], [], [], Xcc: [], Xld: [], Xswiftc: [], toolchain: InvalidToolchain())
+            XCTFail("This call should throw")
         } catch Build.Error.noModules {
             XCTAssert(true, "This error should be thrown")
         } catch {
@@ -49,11 +45,9 @@ final class DescribeTests: XCTestCase {
                 var clang: String { fatalError() }
             }
 
-            try POSIX.mkdtemp("spm-tests") { prefix in
-                defer { _ = try? Utility.removeFileTree(prefix) }
-                let _ = try describe(Path.join(prefix, "foo"), .debug, [CModule(name: "MyCModule", path: "")], [], [], Xcc: [], Xld: [], Xswiftc: [], toolchain: InvalidToolchain())
-                XCTFail("This call should throw")
-            }
+            let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
+            _ = try describe(tempDir.path.appending("foo").asString, .debug, [CModule(name: "MyCModule", path: "")], [], [], Xcc: [], Xld: [], Xswiftc: [], toolchain: InvalidToolchain())
+            XCTFail("This call should throw")
         } catch Build.Error.noProducts {
             XCTAssert(true, "This error should be thrown")
         } catch {

--- a/Tests/Build/DescribeTests.swift
+++ b/Tests/Build/DescribeTests.swift
@@ -15,16 +15,16 @@ import PackageModel
 import Build
 
 final class DescribeTests: XCTestCase {
+    struct InvalidToolchain: Toolchain {
+        var platformArgsClang: [String] { fatalError() }
+        var platformArgsSwiftc: [String] { fatalError() }
+        var sysroot: String?  { fatalError() }
+        var SWIFT_EXEC: String { fatalError() }
+        var clang: String { fatalError() }
+    }
+
     func testDescribingNoModulesThrows() {
         do {
-            struct InvalidToolchain: Toolchain {
-                var platformArgsClang: [String] { fatalError() }
-                var platformArgsSwiftc: [String] { fatalError() }
-                var sysroot: String?  { fatalError() }
-                var SWIFT_EXEC: String { fatalError() }
-                var clang: String { fatalError() }
-            }
-
             let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
             _ = try describe(tempDir.path.appending("foo").asString, .debug, [], [], [], Xcc: [], Xld: [], Xswiftc: [], toolchain: InvalidToolchain())
             XCTFail("This call should throw")
@@ -37,18 +37,10 @@ final class DescribeTests: XCTestCase {
 
     func testDescribingCModuleThrows() {
         do {
-            struct InvalidToolchain: Toolchain {
-                var platformArgsClang: [String] { fatalError() }
-                var platformArgsSwiftc: [String] { fatalError() }
-                var sysroot: String?  { fatalError() }
-                var SWIFT_EXEC: String { return "" }
-                var clang: String { fatalError() }
-            }
-
             let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
             _ = try describe(tempDir.path.appending("foo").asString, .debug, [CModule(name: "MyCModule", path: "")], [], [], Xcc: [], Xld: [], Xswiftc: [], toolchain: InvalidToolchain())
             XCTFail("This call should throw")
-        } catch Build.Error.cModule (let name) {
+        } catch Build.Error.onlyCModule (let name) {
             XCTAssert(true, "This error should be thrown")
             XCTAssertEqual(name, "MyCModule")
         } catch {


### PR DESCRIPTION
Will throw a helpful error if a modulemap is being build. See also [SR-1861](https://bugs.swift.org/browse/SR-1861). Also improves the error message if no modules are defined.