### PR TITLE
Account for planned changes in the Swift stdlib

### DIFF
--- a/Sources/Get/Range.swift
+++ b/Sources/Get/Range.swift
@@ -11,7 +11,7 @@
 import PackageDescription
 
 // FIXME: workaround for inability to constrain the extension to `Bound == Version`.
-protocol _VersionProtocol {}
+protocol _VersionProtocol : Comparable {}
 extension Version : _VersionProtocol {}
 
 extension Range where Bound : _VersionProtocol {


### PR DESCRIPTION
As shown in https://github.com/apple/swift/pull/3325 we are working on
dropping the Comparable requirement from Range Bounds.  Unfortunately
something in SwiftPM is currently depending on that requirement:

https://ci.swift.org/job/swift-PR-osx/2176/consoleFull#942983736ee1a197b-acac-4b17-83cf-a53b95139a76

I believe this patch will allow us to continue with testing without disturbing SwiftPM development