### PR TITLE
SR-1188 -- Improve error messages for package definitions

### DIFF
--- a/Sources/Basic/FixableError.swift
+++ b/Sources/Basic/FixableError.swift
@@ -1,0 +1,23 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+public protocol FixableError: CustomStringConvertible {
+    var error: String { get }
+    var fix: String? { get }
+}
+
+extension FixableError {
+    public var description: String {
+        switch fix {
+        case let fix?: return "\(error) fix: \(fix)"
+        case .none: return error
+        }
+    }
+}

--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -77,7 +77,7 @@ extension Error: CustomStringConvertible {
 
 private func print(error: Any) {
     if ColorWrap.isAllowed(for: .stdErr) {
-        let message = String(error).replacingOccurrences(of: " fix:", with: ColorWrap.wrap("\nfix:", with: .Green, for: .stdErr))
+        let message = String(error).replacingOccurrences(of: " fix:", with: ColorWrap.wrap("\nfix:", with: .Yellow, for: .stdErr))
         print(ColorWrap.wrap("error:", with: .Red, for: .stdErr), message, to: &stderr)
     } else {
         let cmd = Process.arguments.first?.basename ?? "SwiftPM"

--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -77,9 +77,11 @@ extension Error: CustomStringConvertible {
 
 private func print(error: Any) {
     if ColorWrap.isAllowed(for: .stdErr) {
-        print(ColorWrap.wrap("error:", with: .Red, for: .stdErr), error, to: &stderr)
+        let message = String(error).replacingOccurrences(of: " fix:", with: ColorWrap.wrap("\nfix:", with: .Green, for: .stdErr))
+        print(ColorWrap.wrap("error:", with: .Red, for: .stdErr), message, to: &stderr)
     } else {
         let cmd = Process.arguments.first?.basename ?? "SwiftPM"
-        print("\(cmd): error:", error, to: &stderr)
+        let message = String(error).replacingOccurrences(of: "fix:", with: "\nfix:")
+        print("\(cmd): error:", message, to: &stderr)
     }
 }

--- a/Sources/PackageLoading/PackageExtensions.swift
+++ b/Sources/PackageLoading/PackageExtensions.swift
@@ -1,4 +1,4 @@
->>/*
+/*
  This source file is part of the Swift.org open source project
 
  Copyright 2015 - 2016 Apple Inc. and the Swift project authors

--- a/Sources/PackageLoading/PackageExtensions.swift
+++ b/Sources/PackageLoading/PackageExtensions.swift
@@ -29,13 +29,13 @@ extension ModuleError: CustomStringConvertible {
     public var description: String {
         switch self {
         case .noModules(let package):
-            return "the package \(package) contains no modules"
+            return "the package \(package) contains no modules. fix: create at least one module."
         case .modulesNotFound(let modules):
-            return "these referenced modules could not be found: " + modules.joined(separator: ", ")
+            return "these referenced modules could not be found: " + modules.joined(separator: ", ") + ". fix: reference only valid modules."
         case .invalidLayout(let type):
             return "the package has an unsupported layout, \(type)"
         case .executableAsDependency(let module, let dependency):
-            return "the target \(module) cannot have the executable \(dependency) as a dependency"
+            return "the target \(module) cannot have the executable \(dependency) as a dependency. fix: move the shared logic inside a library, which can be referenced from both the target and the executable."
         }
     }
 }
@@ -44,9 +44,9 @@ extension InvalidLayoutType: CustomStringConvertible {
     public var description: String {
         switch self {
         case .multipleSourceRoots(let paths):
-            return "multiple source roots found: " + paths.joined(separator: ", ")
+            return "multiple source roots found: " + paths.joined(separator: ", ") + ". fix: remove the extra source roots, or add them to the source root exclude list."
         case .invalidLayout(let paths):
-            return "unexpected source file(s) found: " + paths.joined(separator: ", ")
+            return "unexpected source file(s) found: " + paths.joined(separator: ", ") + ". fix: move the file(s) inside a module."
         }
     }
 }
@@ -64,11 +64,11 @@ extension Module.Error: CustomStringConvertible {
     var description: String {
         switch self {
         case .noSources(let path):
-            return "the module at \(path) does not contain any source files"
+            return "the module at \(path) does not contain any source files. fix: either remove the module folder, or add a source file to the module."
         case .mixedSources(let path):
-            return "the module at \(path) contains mixed language source files"
+            return "the module at \(path) contains mixed language source files. fix: use only a single language within a module."
         case .duplicateModule(let name):
-            return "multiple modules with the name \(name) found; modules should have a unique name, accross dependencies"
+            return "multiple modules with the name \(name) found. fix: modules should have a unique name, accross dependencies."
         }
     }
 }
@@ -85,9 +85,9 @@ extension Product.Error: CustomStringConvertible {
     var description: String {
         switch self {
         case .noModules(let product):
-            return "the product named \(product) doesn't reference any modules"
+            return "the product named \(product) doesn't reference any modules. fix: reference one or more modules from the product."
         case .moduleNotFound(let product, let module):
-            return "the product named \(product) references a module that could not be found: \(module)"
+            return "the product named \(product) references a module that could not be found: \(module). fix: reference only valid modules from the product."
         }
     }
 }

--- a/Sources/Utility/ColorWrap.swift
+++ b/Sources/Utility/ColorWrap.swift
@@ -67,7 +67,7 @@ public enum ColorWrap {
     }
 
     public enum Color {
-        case Red, Blue
+        case Red, Green, Blue
     }
 }
 
@@ -79,10 +79,12 @@ extension String {
         let CSI = "\(ESC)["
 
         switch color {
-        case .Blue:
-            return "\(CSI)34m\(self)\(CSI)0m"
         case .Red:
             return "\(CSI)31m\(self)\(CSI)0m"
+        case .Green:
+            return "\(CSI)32m\(self)\(CSI)0m"
+        case .Blue:
+            return "\(CSI)34m\(self)\(CSI)0m"
         }
     }
 }

--- a/Sources/Utility/ColorWrap.swift
+++ b/Sources/Utility/ColorWrap.swift
@@ -67,7 +67,7 @@ public enum ColorWrap {
     }
 
     public enum Color {
-        case Red, Green, Blue
+        case Red, Green, Yellow, Blue
     }
 }
 
@@ -83,6 +83,8 @@ extension String {
             return "\(CSI)31m\(self)\(CSI)0m"
         case .Green:
             return "\(CSI)32m\(self)\(CSI)0m"
+        case .Yellow:
+            return "\(CSI)33m\(self)\(CSI)0m"
         case .Blue:
             return "\(CSI)34m\(self)\(CSI)0m"
         }

--- a/Tests/Functional/MiscellaneousTests.swift
+++ b/Tests/Functional/MiscellaneousTests.swift
@@ -353,8 +353,7 @@ class MiscellaneousTestCase: XCTestCase {
     
     func testProductWithMissingModules() {
         fixture(name: "Miscellaneous/ProductWithMissingModules") { prefix in
-            XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix, ".build/debug/libBar.a")
+            XCTAssertBuildFails(prefix)
         }
     }
 


### PR DESCRIPTION
Products referencing unknown modules will now produce an error instead of a warning. A missing module should be considered an error in the product definition.

Examples of the error messages:
```
swift-build: error: the target mylib cannot have the executable myexe as a dependency
swift-build: error: these referenced modules could not be found: lib2
swift-build: error: the package has an unsupported layout, unexpected source file(s) found: /tmp/test.c
swift-build: error: the package has an unsupported layout, multiple source roots found: /tmp/Sources, /tmp/src
swift-build: error: the module at /tmp/Sources/lib does not contain any source files
swift-build: error: the module at /tmp/Sources/lib contains mixed language source files
swift-build: error: multiple modules with the name CSV found; modules should have a unique name, accross dependencies
swift-build: error: the product named test references a module that could not be found: CSV
swift-build: error: the product named test doesn't reference any modules
```