### PR TITLE
Fix warnings introduced by SE-0099

### DIFF
--- a/Sources/PackageLoading/Manifest+parse.swift
+++ b/Sources/PackageLoading/Manifest+parse.swift
@@ -176,19 +176,19 @@ extension PackageDescription.Package {
 
 extension PackageDescription.Package.Dependency {
     static func fromTOML(_ item: TOMLItem, baseURL: String?) -> PackageDescription.Package.Dependency {
-        guard case .array(let array) = item where array.items.count == 3 else {
+        guard case .array(let array) = item, array.items.count == 3 else {
             fatalError("Unexpected TOMLItem")
         }
         guard case .string(let url) = array.items[0],
               case .string(let vv1) = array.items[1],
               case .string(let vv2) = array.items[2],
-              let v1 = Version(vv1), v2 = Version(vv2)
+              let v1 = Version(vv1), let v2 = Version(vv2)
         else {
             fatalError("Unexpected TOMLItem")
         }
 
         func fixURL() -> String {
-            if let baseURL = baseURL where URL.scheme(url) == nil {
+            if let baseURL = baseURL, URL.scheme(url) == nil {
                 return Path.join(baseURL, url).normpath
             } else {
                 return url

--- a/Sources/PackageLoading/PackageExtensions.swift
+++ b/Sources/PackageLoading/PackageExtensions.swift
@@ -134,7 +134,7 @@ extension Package {
                     guard let dependency = moduleForName(name) else {
                         throw ModuleError.modulesNotFound([name])
                     }
-                    if let moduleType = dependency as? ModuleTypeProtocol where moduleType.type != .library {
+                    if let moduleType = dependency as? ModuleTypeProtocol, moduleType.type != .library {
                         throw ModuleError.executableAsDependency("\(module.name) cannot have an executable \(name) as a dependency")
                     }
                     return dependency

--- a/Sources/PackageLoading/transmute.swift
+++ b/Sources/PackageLoading/transmute.swift
@@ -145,8 +145,7 @@ private func recursiveDependencies(_ modules: [Module]) throws -> [Module] {
         } else {
             guard let index = set.index(of: top),
                   let moduleInSet = set[index] as? ModuleTypeProtocol,
-                  let module = top as? ModuleTypeProtocol
-                      where module.sources.root != moduleInSet.sources.root else {
+                  let module = top as? ModuleTypeProtocol, module.sources.root != moduleInSet.sources.root else {
                 continue;
             }
 

--- a/Sources/Xcodeproj/Module+PBXProj.swift
+++ b/Sources/Xcodeproj/Module+PBXProj.swift
@@ -264,7 +264,7 @@ extension XcodeModuleProtocol  {
         buildSettings["FRAMEWORK_SEARCH_PATHS"] = Path.join("$(PLATFORM_DIR)", "Developer/Library/Frameworks")
 
         // Generate modulemap for a ClangModule if not provided by user and add to build settings.
-        if case let clangModule as ClangModule = self where clangModule.type == .library {
+        if case let clangModule as ClangModule = self, clangModule.type == .library {
             buildSettings["DEFINES_MODULE"] = "YES"
             let moduleMapPath: AbsolutePath
             // If user provided the modulemap no need to generate.


### PR DESCRIPTION
Many "where" and other condition clauses have been replaced by commas. Apply the compiler fix-its to fix the warnings.

For details on the proposal, see: https://github.com/apple/swift-evolution/blob/master/proposals/0099-conditionclauses.md