### PR TITLE
Add AbsolutePath methods that take strings, based on experience in converting project source base

### DIFF
--- a/Sources/Basic/OptionParser.swift
+++ b/Sources/Basic/OptionParser.swift
@@ -67,7 +67,7 @@ public func parseOptions<Mode, Flag where Mode: Argument, Mode: Equatable, Flag:
             }
             mode = mkmode
 
-            if let value = value where !popped {
+            if let value = value, !popped {
                 throw OptionParserError.unexpectedAssociatedValue(arg, value)
             }
         } else {
@@ -115,7 +115,7 @@ public func parseOptions<Mode, Flag where Mode: Argument, Mode: Equatable, Flag:
           throw OptionParserError.unknownArgument(arg)
         }
 
-        if let value = value where !popped {
+        if let value = value, !popped {
             throw OptionParserError.unexpectedAssociatedValue(arg, value)
         }
     }

--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -274,6 +274,21 @@ public func ==(lhs: AbsolutePath, rhs: AbsolutePath) -> Bool {
     return lhs.asString == rhs.asString
 }
 
+// Make absolute paths Comparable.
+extension AbsolutePath : Comparable { }
+public func <(lhs: AbsolutePath, rhs: AbsolutePath) -> Bool {
+    return lhs.asString < rhs.asString
+}
+public func <=(lhs: AbsolutePath, rhs: AbsolutePath) -> Bool {
+    return lhs.asString <= rhs.asString
+}
+public func >=(lhs: AbsolutePath, rhs: AbsolutePath) -> Bool {
+    return lhs.asString >= rhs.asString
+}
+public func >(lhs: AbsolutePath, rhs: AbsolutePath) -> Bool {
+    return lhs.asString > rhs.asString
+}
+
 
 // Make relative paths Hashable.
 extension RelativePath : Hashable {

--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -74,6 +74,11 @@ public struct AbsolutePath {
         _impl = PathImpl(string: absStr)
     }
     
+    /// Convenience initializer that appends a string to a relative path.
+    public init(_ absPath: AbsolutePath, _ relStr: String) {
+        self.init(absPath, RelativePath(relStr))
+    }
+    
     /// NOTE: We will want to add other initializers, such as ones that take
     ///       an arbtirary number of relative paths.
     
@@ -111,6 +116,12 @@ public struct AbsolutePath {
     /// Returns the absolute path with the relative path applied.
     public func appending(_ subpath: RelativePath) -> AbsolutePath {
         return AbsolutePath(self, subpath)
+    }
+    
+    /// Returns the absolute path with the contents of the string (interpreted
+    /// as a relative path, not a single path component) appended.
+    public func appending(_ str: String) -> AbsolutePath {
+        return AbsolutePath(self, str)
     }
     
     /// NOTE: We will want to add other methods, such as an appending() method

--- a/Sources/Basic/TOML.swift
+++ b/Sources/Basic/TOML.swift
@@ -248,7 +248,7 @@ private struct Lexer {
         // Whitespace.
         case let c where c.isSpace():
             // Scan to the end of the whitespace
-            while let c = look() where c.isSpace() {
+            while let c = look() , c.isSpace() {
                 let _ = eat()
             }
             return .whitespace
@@ -276,7 +276,7 @@ private struct Lexer {
         // numbers are valid identifiers but should be reconfigured as such.
         case let c where c.isNumberInitialChar():
             // Scan to the end of the number.
-            while let c = look() where c.isNumberChar() {
+            while let c = look(), c.isNumberChar() {
                 let _ = eat()
             }
             return .number(value: String(utf8[startIndex..<index]))
@@ -284,7 +284,7 @@ private struct Lexer {
         // Identifiers.
         case let c where c.isIdentifierChar():
             // Scan to the end of the identifier.
-            while let c = look() where c.isIdentifierChar() {
+            while let c = look(), c.isIdentifierChar() {
                 let _ = eat()
             }
 

--- a/Sources/Get/PackagesDirectory.swift
+++ b/Sources/Get/PackagesDirectory.swift
@@ -36,7 +36,7 @@ class PackagesDirectory {
         var result = Dictionary<String, Git.Repo>()
         for name in try! localFS.getDirectoryContents(self.prefix) {
             let prefix = Path.join(self.prefix, name)
-            guard let repo = Git.Repo(path: prefix), origin = repo.origin else { continue } // TODO: Warn user.
+            guard let repo = Git.Repo(path: prefix), let origin = repo.origin else { continue } // TODO: Warn user.
             result[origin] = repo
         }
         return result
@@ -55,7 +55,7 @@ extension PackagesDirectory: Fetcher {
 
     func fetch(url: String) throws -> Fetchable {
         let dstdir = Path.join(prefix, Package.nameForURL(url))
-        if let repo = Git.Repo(path: dstdir) where repo.origin == url {
+        if let repo = Git.Repo(path: dstdir), repo.origin == url {
             //TODO need to canonicalize the URL need URL struct
             return try RawClone(path: dstdir, manifestParser: manifestParser)
         }

--- a/Sources/PackageDescription/Package.swift
+++ b/Sources/PackageDescription/Package.swift
@@ -90,7 +90,7 @@ public final class Package {
         // See https://bugs.swift.org/browse/SR-1119.
         if Process.argc > 0 {
             if let fileNoOptIndex = Process.arguments.index(of: "-fileno"),
-                   fileNo = Int32(Process.arguments[fileNoOptIndex + 1]) {
+                   let fileNo = Int32(Process.arguments[fileNoOptIndex + 1]) {
                 dumpPackageAtExit(self, fileNo: fileNo)
             }
         }

--- a/Sources/PackageLoading/Module+PkgConfig.swift
+++ b/Sources/PackageLoading/Module+PkgConfig.swift
@@ -43,7 +43,7 @@ extension ModuleProtocol {
             }
             catch PkgConfigError.couldNotFindConfigFile {
                 if let providers = module.providers,
-                    provider = SystemPackageProvider.providerForCurrentPlatform(providers: providers) {
+                    let provider = SystemPackageProvider.providerForCurrentPlatform(providers: providers) {
                     print("note: you may be able to install \(pkgConfigName) using your system-packager:\n")
                     print(provider.installText)
                 }

--- a/Sources/Utility/Path.swift
+++ b/Sources/Utility/Path.swift
@@ -239,7 +239,7 @@ extension String {
         guard isFile else { return nil }
         guard characters.contains(".") else { return nil }
         let parts = characters.split(separator: ".")
-        if let last = parts.last where parts.count > 1 { return String(last) }
+        if let last = parts.last, parts.count > 1 { return String(last) }
         return nil
     }
 

--- a/Sources/Utility/PkgConfig.swift
+++ b/Sources/Utility/PkgConfig.swift
@@ -187,7 +187,7 @@ struct PkgConfigParser {
                 // Encountered a seperator, use the token.
                 if separators.contains(String(char)) {
                     // If next character is a space skip.
-                    if let peeked = peek(idx: idx+1) where peeked == " " { continue }
+                    if let peeked = peek(idx: idx+1), peeked == " " { continue }
                     // Append to array of tokens and reset token variable.
                     tokens.append(token)
                     token = ""

--- a/Sources/swiftpm-xctest-helper/main.swift
+++ b/Sources/swiftpm-xctest-helper/main.swift
@@ -30,7 +30,7 @@ func run() throws {
 
     // Note that the bundle might write to stdout while it is being loaded, but we don't try to handle that here.
     // Instead the client should decide what to do with any extra output from this tool.
-    guard let bundle = Bundle(path: bundlePath) where bundle.load() else {
+    guard let bundle = Bundle(path: bundlePath), bundle.load() else {
         throw Error.unableToLoadBundle(bundlePath)
     }
     let suite = XCTestSuite.default()

--- a/Tests/Basic/OptionParserTests.swift
+++ b/Tests/Basic/OptionParserTests.swift
@@ -168,7 +168,7 @@ enum Flag: Argument, Equatable {
             guard let str = pop() else { throw OptionParserError.expectedAssociatedValue("") }
             self = .F(str)
         case "--G":
-            guard let str = pop(), int = Int(str) else { throw OptionParserError.expectedAssociatedValue("") }
+            guard let str = pop(), let int = Int(str) else { throw OptionParserError.expectedAssociatedValue("") }
             self = .G(int)
         case "-H":
             self = .H

--- a/Tests/Basic/PathTests.swift
+++ b/Tests/Basic/PathTests.swift
@@ -234,16 +234,17 @@ class PathTests: XCTestCase {
     // FIXME: We also need test for stat() operations.
         
     static var allTests = [
-        ("testBasics",                   testBasics),
+        ("testBasics",                      testBasics),
+        ("testStringInitialization",        testStringInitialization),
         ("testStringLiteralInitialization", testStringLiteralInitialization),
-        ("testRepeatedPathSeparators",   testRepeatedPathSeparators),
-        ("testTrailingPathSeparators",   testTrailingPathSeparators),
-        ("testDotPathComponents",        testDotPathComponents),
-        ("testDotDotPathComponents",     testDotDotPathComponents),
-        ("testCombinationsAndEdgeCases", testCombinationsAndEdgeCases),
-        ("testBaseNameExtraction",       testBaseNameExtraction),
-        ("testSuffixExtraction",         testSuffixExtraction),
-        ("testParentDirectory",          testParentDirectory),
-        ("testConcatenation",            testConcatenation),
+        ("testRepeatedPathSeparators",      testRepeatedPathSeparators),
+        ("testTrailingPathSeparators",      testTrailingPathSeparators),
+        ("testDotPathComponents",           testDotPathComponents),
+        ("testDotDotPathComponents",        testDotDotPathComponents),
+        ("testCombinationsAndEdgeCases",    testCombinationsAndEdgeCases),
+        ("testBaseNameExtraction",          testBaseNameExtraction),
+        ("testSuffixExtraction",            testSuffixExtraction),
+        ("testParentDirectory",             testParentDirectory),
+        ("testConcatenation",               testConcatenation),
     ]
 }

--- a/Tests/Basic/PathTests.swift
+++ b/Tests/Basic/PathTests.swift
@@ -227,6 +227,15 @@ class PathTests: XCTestCase {
         XCTAssertEqual(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/b/c/d")), RelativePath("../../../a/b/c/d"));
     }
     
+    func testComparison() {
+        XCTAssertTrue(AbsolutePath("/") <= AbsolutePath("/"));
+        XCTAssertTrue(AbsolutePath("/abc") < AbsolutePath("/def"));
+        XCTAssertTrue(AbsolutePath("/2") <= AbsolutePath("/2.1"));
+        XCTAssertTrue(AbsolutePath("/3.1") > AbsolutePath("/2"));
+        XCTAssertTrue(AbsolutePath("/2") >= AbsolutePath("/2"));
+        XCTAssertTrue(AbsolutePath("/2.1") >= AbsolutePath("/2"));
+    }
+    
     // FIXME: We also need tests for join() operations.
     
     // FIXME: We also need tests for dirname, basename, suffix, etc.
@@ -246,5 +255,6 @@ class PathTests: XCTestCase {
         ("testSuffixExtraction",            testSuffixExtraction),
         ("testParentDirectory",             testParentDirectory),
         ("testConcatenation",               testConcatenation),
+        ("testComparison",                  testComparison),
     ]
 }

--- a/Tests/Basic/PathTests.swift
+++ b/Tests/Basic/PathTests.swift
@@ -25,6 +25,15 @@ class PathTests: XCTestCase {
         XCTAssertEqual(RelativePath("a/b/c").asString, "a/b/c")
     }
     
+    func testStringInitialization() {
+        let abs1: AbsolutePath = "/"
+        let abs2 = AbsolutePath(abs1, ".")
+        XCTAssertEqual(abs1, abs2)
+        let rel3 = "."
+        let abs3 = AbsolutePath(abs2, rel3)
+        XCTAssertEqual(abs2, abs3)
+    }
+    
     func testStringLiteralInitialization() {
         let abs: AbsolutePath = "/"
         XCTAssertEqual(abs.asString, "/")
@@ -171,6 +180,13 @@ class PathTests: XCTestCase {
         XCTAssertEqual(AbsolutePath("/bar").appending(RelativePath("../foo")).asString, "/foo")
         XCTAssertEqual(AbsolutePath("/bar").appending(RelativePath("../foo/..//")).asString, "/")
         XCTAssertEqual(AbsolutePath("/bar/../foo/..//yabba/").appending(RelativePath("a/b")).asString, "/yabba/a/b")
+        
+        let emptyString = ""
+        XCTAssertEqual(AbsolutePath("/").appending(emptyString).asString, "/")
+        let dotString = "."
+        XCTAssertEqual(AbsolutePath("/").appending(dotString).asString, "/")
+        let dotdotString = dotString + dotString
+        XCTAssertEqual(AbsolutePath("/").appending(dotdotString).asString, "/")
     }
     
     func testPathComponents() {

--- a/Tests/Basic/ThreadTests.swift
+++ b/Tests/Basic/ThreadTests.swift
@@ -52,7 +52,7 @@ class ThreadTests: XCTestCase {
     }
 
     func testNotDeinitBeforeExecutingTask() {
-        var finishedCondition = Condition()
+        let finishedCondition = Condition()
         var finished = false
 
         Thread {


### PR DESCRIPTION
Add an `AbsolutePath` initializer and appender method that cut down on the amount of pointless boilerplate code at call sites.  This is based on experience with what the source base looks like after converting to AboslutePath.