### PR TITLE
Nitpicky description strings

### DIFF
--- a/Sources/Utility/Error.swift
+++ b/Sources/Utility/Error.swift
@@ -24,12 +24,12 @@ extension Error: CustomStringConvertible {
         case .obsoleteGitVersion:
             return "Git 2.0 or higher is required. Please update git and retry."
         case .unknownGitError:
-            return "Failed to invoke git command. Please try updating git"
-        case .unicodeDecodingError: return "Could not decode input file into unicode"
-        case .unicodeEncodingError: return "Could not encode string into unicode"
-        case .couldNotCreateFile(let path): return "Could not create file: \(path)"
-        case .fileDoesNotExist(let path): return "File does not exist: \(path)"
-        case .invalidPlatformPath: return "Invalid platform path"
+            return "Failed to invoke git command. Please try updating git."
+        case .unicodeDecodingError: return "Could not decode input file into unicode."
+        case .unicodeEncodingError: return "Could not encode string into unicode."
+        case .couldNotCreateFile(let path): return "Could not create file: \(path)."
+        case .fileDoesNotExist(let path): return "File does not exist: \(path)."
+        case .invalidPlatformPath: return "Invalid platform path."
         }
     }
 }


### PR DESCRIPTION
If the description in the `.obsoleteGitVersion` case has periods in the *description* string, the rest of the cases should as well (for consistency).

Nit-picky, I know, but it's for the best :)