### PR TITLE
Convert the rest of the source base to use AbsolutePath and RelativePath instead of strings

### DIFF
--- a/Sources/Build/PackageVersion.swift
+++ b/Sources/Build/PackageVersion.swift
@@ -27,7 +27,7 @@ public func generateVersionData(_ rootDir: String, rootPackage: Package, externa
 }
 
 func saveRootPackage(_ dirPath: String, package: Package) throws {
-    guard let repo = Git.Repo(path: package.path) else { return }
+    guard let repo = Git.Repo(path: AbsolutePath(package.path.abspath)) else { return }
     var data = versionData(package: package)
     data += "public let sha: String? = "
 

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -140,15 +140,14 @@ public struct SwiftBuildTool: SwiftTool {
                 try chdir(dir.asString)
             }
             
-            /// FIXME: This can't path string be converted to an AbsolutePath until lower-level APIs have been converted.
-            func parseManifest(path: String, baseURL: String) throws -> Manifest {
+            func parseManifest(path: AbsolutePath, baseURL: String) throws -> Manifest {
                 let swiftc = ToolDefaults.SWIFT_EXEC.asString
                 let libdir = ToolDefaults.libdir.asString
-                return try Manifest(path: path, baseURL: baseURL, swiftc: swiftc, libdir: libdir)
+                return try Manifest(path: path.asString, baseURL: baseURL, swiftc: swiftc, libdir: libdir)
             }
             
             func fetch(_ root: AbsolutePath) throws -> (rootPackage: Package, externalPackages:[Package]) {
-                let manifest = try parseManifest(path: root.asString, baseURL: root.asString)
+                let manifest = try parseManifest(path: root, baseURL: root.asString)
                 if opts.ignoreDependencies {
                     return (Package(manifest: manifest, url: manifest.path.parentDirectory), [])
                 } else {

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -169,14 +169,14 @@ public struct SwiftPackageTool: SwiftTool {
                 try chdir(dir.asString)
             }
         
-            func parseManifest(path: String, baseURL: String) throws -> Manifest {
+            func parseManifest(path: AbsolutePath, baseURL: String) throws -> Manifest {
                 let swiftc = ToolDefaults.SWIFT_EXEC.asString
                 let libdir = ToolDefaults.libdir.asString
-                return try Manifest(path: path, baseURL: baseURL, swiftc: swiftc, libdir: libdir)
+                return try Manifest(path: path.asString, baseURL: baseURL, swiftc: swiftc, libdir: libdir)
             }
             
             func fetch(_ root: AbsolutePath) throws -> (rootPackage: Package, externalPackages:[Package]) {
-                let manifest = try parseManifest(path: root.asString, baseURL: root.asString)
+                let manifest = try parseManifest(path: root, baseURL: root.asString)
                 if opts.ignoreDependencies {
                     return (Package(manifest: manifest, url: manifest.path.parentDirectory), [])
                 } else {
@@ -262,7 +262,7 @@ public struct SwiftPackageTool: SwiftTool {
                 
             case .dumpPackage:
                 let root = opts.inputPath ?? opts.path.root
-                let manifest = try parseManifest(path: root.asString, baseURL: root.asString)
+                let manifest = try parseManifest(path: root, baseURL: root.asString)
                 let package = manifest.package
                 let json = try jsonString(package: package)
                 print(json)

--- a/Sources/Get/Git.swift
+++ b/Sources/Get/Git.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basic
 import struct PackageDescription.Version
 import func POSIX.realpath
 import func POSIX.getenv
@@ -16,7 +17,7 @@ import class Foundation.ProcessInfo
 import Utility
 
 extension Git {
-    class func clone(_ url: String, to dstdir: String) throws -> Repo {
+    class func clone(_ url: String, to dstdir: AbsolutePath) throws -> Repo {
         // canonicalize URL
         var url = url
         if URL.scheme(url) == nil {
@@ -32,13 +33,13 @@ extension Git {
             try system(Git.tool, "clone",
                        "--recursive",   // get submodules too so that developers can use these if they so choose
                 "--depth", "10",
-                url, dstdir, environment: env, message: "Cloning \(url)")
+                url, dstdir.asString, environment: env, message: "Cloning \(url)")
         } catch POSIX.Error.exitStatus {
             // Git 2.0 or higher is required
             if Git.majorVersionNumber < 2 {
                 throw Utility.Error.obsoleteGitVersion
             } else {
-                throw Error.gitCloneFailure(url, dstdir)
+                throw Error.gitCloneFailure(url, dstdir.asString)
             }
         }
 
@@ -48,7 +49,7 @@ extension Git {
 
 extension Git.Repo {
     var versions: [Version] {
-        let out = (try? Git.runPopen([Git.tool, "-C", path, "tag", "-l"])) ?? ""
+        let out = (try? Git.runPopen([Git.tool, "-C", path.asString, "tag", "-l"])) ?? ""
         let tags = out.characters.split(separator: "\n")
         let versions = tags.flatMap(Version.init).sorted()
         if !versions.isEmpty {

--- a/Sources/Get/Package.swift
+++ b/Sources/Get/Package.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basic
 import struct PackageDescription.Version
 import PackageModel
 import Utility
@@ -15,8 +16,8 @@ import Utility
 extension Package {
     // FIXME we *always* have a manifest, don't reparse it
 
-    static func make(repo: Git.Repo, manifestParser: (path: String, url: String) throws -> Manifest) throws -> Package? {
-        guard let origin = repo.origin else { throw Error.noOrigin(repo.path) }
+    static func make(repo: Git.Repo, manifestParser: (path: AbsolutePath, url: String) throws -> Manifest) throws -> Package? {
+        guard let origin = repo.origin else { throw Error.noOrigin(repo.path.asString) }
         let manifest = try manifestParser(path: repo.path, url: origin)
         let pkg = Package(manifest: manifest, url: origin)
         if let version = Version(pkg.versionString) {

--- a/Sources/Get/get().swift
+++ b/Sources/Get/get().swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basic
 import class PackageModel.Package
 import PackageModel
 import Utility
@@ -17,14 +18,14 @@ import Utility
  - Throws: Error.InvalidDependencyGraph
  - Returns: The modules that this manifest requires building
 */
-public func get(_ manifest: Manifest, manifestParser: (path: String, url: String) throws -> Manifest) throws -> (rootPackage: Package, externalPackages:[Package]) {
-    let dir = Path.join(manifest.path.parentDirectory, "Packages")
+public func get(_ manifest: Manifest, manifestParser: (path: AbsolutePath, url: String) throws -> Manifest) throws -> (rootPackage: Package, externalPackages:[Package]) {
+    let dir = AbsolutePath(manifest.path.parentDirectory).appending("Packages")
     let box = PackagesDirectory(prefix: dir, manifestParser: manifestParser)
 
     //TODO don't lose the dependency information during the Fetcher process!
     
     let rootPackage = Package(manifest: manifest, url: manifest.path.parentDirectory)
-    rootPackage.version = Git.Repo(path: rootPackage.path)?.versions.last
+    rootPackage.version = Git.Repo(path: AbsolutePath(rootPackage.path))?.versions.last
     let extPackages = try box.recursivelyFetch(manifest.dependencies)
     
     let pkgs = extPackages + [rootPackage]

--- a/Sources/PackageLoading/Manifest+parse.swift
+++ b/Sources/PackageLoading/Manifest+parse.swift
@@ -98,7 +98,7 @@ private func parse(path manifestPath: String, swiftc: String, libdir: String) th
     guard let toml = try localFS.readFileContents(filePath).asString else {
         throw ManifestParseError.invalidEncoding
     }
-    try Utility.removeFileTree(filePath) //Delete the temp file after reading it
+    try Utility.removeFileTree(filePath) // Delete the temp file after reading it
 
     return toml != "" ? toml : nil
 }

--- a/Tests/Build/DescribeTests.swift
+++ b/Tests/Build/DescribeTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import Basic
 import Build
 import Utility
 import POSIX
@@ -27,7 +28,7 @@ final class DescribeTests: XCTestCase {
 
             try POSIX.mkdtemp("spm-tests") { prefix in
                 defer { _ = try? Utility.removeFileTree(prefix) }
-                let _ = try describe(Path.join(prefix, "foo"), .debug, [], [], [], Xcc: [], Xld: [], Xswiftc: [], toolchain: InvalidToolchain())
+                let _ = try describe(prefix.appending("foo"), .debug, [], [], [], Xcc: [], Xld: [], Xswiftc: [], toolchain: InvalidToolchain())
                 XCTFail("This call should throw")
             }
         } catch Build.Error.noModules {

--- a/Tests/Build/PackageVersionDataTests.swift
+++ b/Tests/Build/PackageVersionDataTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import Basic
 import PackageModel
 import PackageDescription
 
@@ -56,8 +57,8 @@ final class PackageVersionDataTests: XCTestCase {
             let m = Manifest(path: "path", package: PackageDescription.Package(), products: [])
             let rootPkg = Package(manifest: m, url: "https://github.com/rootPkg")
 
-            try generateVersionData(dir, rootPackage:rootPkg, externalPackages: [package])
-            XCTAssertFileExists(dir, ".build/versionData/", "\(package.name).swift")
+            try generateVersionData(dir.asString, rootPackage:rootPkg, externalPackages: [package])
+            XCTAssertFileExists(dir.appending(".build/versionData/").appending(package.name + ".swift"))
         }
     }
 

--- a/Tests/Functional/ClangModuleTests.swift
+++ b/Tests/Functional/ClangModuleTests.swift
@@ -10,10 +10,12 @@
 
 import XCTest
 
+import Basic
 import PackageModel
 import Utility
 
 extension String {
+    // FIXME: It doesn't seem right for this to be an extension on String; it isn't inherent "string behavior".
     private var soname: String {
         return "lib\(self).\(Product.dynamicLibraryExtension)"
     }
@@ -23,63 +25,60 @@ class ClangModulesTestCase: XCTestCase {
     func testSingleModuleFlatCLibrary() {
         fixture(name: "ClangModules/CLibraryFlat") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix, ".build", "debug", "CLibraryFlat".soname)
+            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("CLibraryFlat".soname))
         }
     }
     
     func testSingleModuleCLibraryInSources() {
         fixture(name: "ClangModules/CLibrarySources") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix, ".build", "debug", "CLibrarySources".soname)
+            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("CLibrarySources".soname))
         }
     }
     
     func testMixedSwiftAndC() {
         fixture(name: "ClangModules/SwiftCMixed") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix, ".build", "debug", "SeaLib".soname)
-            let exec = ".build/debug/SeaExec"
-            XCTAssertFileExists(prefix, exec)
-            var output = try popen([Path.join(prefix, exec)])
+            XCTAssertFileExists(prefix.appending(".build/debug").appending("SeaLib".soname))
+            XCTAssertFileExists(prefix.appending(".build/debug").appending("SeaExec"))
+            var output = try popen([prefix.appending(".build/debug").appending("SeaExec").asString])
             XCTAssertEqual(output, "a = 5\n")
-            let cExec = ".build/debug/CExec"
-            output = try popen([Path.join(prefix, cExec)])
+            output = try popen([prefix.appending(".build/debug").appending("CExec").asString])
             XCTAssertEqual(output, "5")
         }
     }
     
     func testExternalSimpleCDep() {
         fixture(name: "DependencyResolution/External/SimpleCDep") { prefix in
-            XCTAssertBuilds(prefix, "Bar")
-            XCTAssertFileExists(prefix, "Bar/.build/debug/Bar")
-            XCTAssertFileExists(prefix, "Bar/.build/debug", "Foo".soname)
-            XCTAssertDirectoryExists(prefix, "Bar/Packages/Foo-1.2.3")
+            XCTAssertBuilds(prefix.appending("Bar"))
+            XCTAssertFileExists(prefix.appending("Bar/.build/debug").appending("Bar"))
+            XCTAssertFileExists(prefix.appending("Bar/.build/debug").appending("Foo".soname))
+            XCTAssertDirectoryExists(prefix.appending("Bar/Packages/Foo-1.2.3"))
         }
     }
     
     func testiquoteDep() {
         fixture(name: "ClangModules/CLibraryiquote") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix, ".build", "debug", "Foo".soname)
-            XCTAssertFileExists(prefix, ".build", "debug", "Bar".soname)
-            XCTAssertFileExists(prefix, ".build", "debug", "Bar with spaces".soname)
+            XCTAssertFileExists(prefix.appending(".build/debug").appending("Foo".soname))
+            XCTAssertFileExists(prefix.appending(".build/debug").appending("Bar".soname))
+            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("Bar with spaces".soname))
         }
     }
     
     func testCUsingCDep() {
         fixture(name: "DependencyResolution/External/CUsingCDep") { prefix in
-            XCTAssertBuilds(prefix, "Bar")
-            XCTAssertFileExists(prefix, "Bar/.build/debug", "Foo".soname)
-            XCTAssertDirectoryExists(prefix, "Bar/Packages/Foo-1.2.3")
+            XCTAssertBuilds(prefix.appending("Bar"))
+            XCTAssertFileExists(prefix.appending("Bar/.build/debug").appending("Foo".soname))
+            XCTAssertDirectoryExists(prefix.appending("Bar/Packages/Foo-1.2.3"))
         }
     }
     
     func testCExecutable() {
         fixture(name: "ValidLayouts/SingleModule/CExecutable") { prefix in
             XCTAssertBuilds(prefix)
-            let exec = ".build/debug/CExecutable"
-            XCTAssertFileExists(prefix, exec)
-            let output = try popen([Path.join(prefix, exec)])
+            XCTAssertFileExists(prefix.appending(".build/debug/CExecutable"))
+            let output = try popen([prefix.appending(".build/debug/CExecutable").asString])
             XCTAssertEqual(output, "hello 5")
         }
     }
@@ -87,20 +86,20 @@ class ClangModulesTestCase: XCTestCase {
     func testCUsingCDep2() {
         //The C dependency "Foo" has different layout
         fixture(name: "DependencyResolution/External/CUsingCDep2") { prefix in
-            XCTAssertBuilds(prefix, "Bar")
-            XCTAssertFileExists(prefix, "Bar/.build/debug", "Foo".soname)
-            XCTAssertDirectoryExists(prefix, "Bar/Packages/Foo-1.2.3")
+            XCTAssertBuilds(prefix.appending("Bar"))
+            XCTAssertFileExists(prefix.appending("Bar/.build/debug").appending("Foo".soname))
+            XCTAssertDirectoryExists(prefix.appending("Bar/Packages/Foo-1.2.3"))
         }
     }
     
     func testModuleMapGenerationCases() {
         fixture(name: "ClangModules/ModuleMapGenerationCases") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix, ".build", "debug", "UmbrellaHeader".soname)
-            XCTAssertFileExists(prefix, ".build", "debug", "FlatInclude".soname)
-            XCTAssertFileExists(prefix, ".build", "debug", "UmbellaModuleNameInclude".soname)
-            XCTAssertFileExists(prefix, ".build", "debug", "NoIncludeDir".soname)
-            XCTAssertFileExists(prefix, ".build", "debug", "Baz")
+            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("UmbrellaHeader".soname))
+            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("FlatInclude".soname))
+            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("UmbellaModuleNameInclude".soname))
+            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("NoIncludeDir".soname))
+            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("Baz"))
         }
     }
 
@@ -108,7 +107,7 @@ class ClangModulesTestCase: XCTestCase {
         // Try building a fixture which needs extra flags to be able to build.
         fixture(name: "ClangModules/CDynamicLookup") { prefix in
             XCTAssertBuilds(prefix, Xld: ["-undefined", "dynamic_lookup"])
-            XCTAssertFileExists(prefix, ".build", "debug", "CDynamicLookup".soname)
+            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("CDynamicLookup".soname))
         }
     }
 

--- a/Tests/Functional/DependencyResolutionTests.swift
+++ b/Tests/Functional/DependencyResolutionTests.swift
@@ -9,6 +9,7 @@
 */
 
 import XCTest
+import Basic
 import func POSIX.popen
 
 class DependencyResolutionTestCase: XCTestCase {
@@ -16,7 +17,7 @@ class DependencyResolutionTestCase: XCTestCase {
         fixture(name: "DependencyResolution/Internal/Simple") { prefix in
             XCTAssertBuilds(prefix)
 
-            let output = try popen(["\(prefix)/.build/debug/Foo"])
+            let output = try popen([prefix.appending(".build/debug/Foo").asString])
             XCTAssertEqual(output, "Foo\nBar\n")
         }
     }
@@ -31,16 +32,16 @@ class DependencyResolutionTestCase: XCTestCase {
         fixture(name: "DependencyResolution/Internal/Complex") { prefix in
             XCTAssertBuilds(prefix)
 
-            let output = try popen(["\(prefix)/.build/debug/Foo"])
+            let output = try popen([prefix.appending(".build/debug/Foo").asString])
             XCTAssertEqual(output, "meiow Baz\n")
         }
     }
 
     func testExternalSimple() {
         fixture(name: "DependencyResolution/External/Simple") { prefix in
-            XCTAssertBuilds(prefix, "Bar")
-            XCTAssertFileExists(prefix, "Bar/.build/debug/Bar")
-            XCTAssertDirectoryExists(prefix, "Bar/Packages/Foo-1.2.3")
+            XCTAssertBuilds(prefix.appending("Bar"))
+            XCTAssertFileExists(prefix.appending("Bar/.build/debug/Bar"))
+            XCTAssertDirectoryExists(prefix.appending("Bar/Packages/Foo-1.2.3"))
         }
     }
 
@@ -52,15 +53,15 @@ class DependencyResolutionTestCase: XCTestCase {
 
     func testExternalComplex() {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
-            XCTAssertBuilds(prefix, "app")
-            let output = try POSIX.popen(["\(prefix)/app/.build/debug/Dealer"])
+            XCTAssertBuilds(prefix.appending("app"))
+            let output = try POSIX.popen([prefix.appending("app/.build/debug/Dealer").asString])
             XCTAssertEqual(output, "♣︎K\n♣︎Q\n♣︎J\n♣︎10\n♣︎9\n♣︎8\n♣︎7\n♣︎6\n♣︎5\n♣︎4\n")
         }
     }
 
     func testIndirectTestsDontBuild() {
         fixture(name: "DependencyResolution/External/IgnoreIndirectTests") { prefix in
-            XCTAssertBuilds(prefix, "app")
+            XCTAssertBuilds(prefix.appending("app"))
         }
     }
 

--- a/Tests/Functional/InvalidLayoutTests.swift
+++ b/Tests/Functional/InvalidLayoutTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import Basic
 import Utility
 
 class InvalidLayoutsTestCase: XCTestCase {
@@ -32,7 +33,7 @@ class InvalidLayoutsTestCase: XCTestCase {
         */
         fixture(name: "InvalidLayouts/Generic1") { prefix in
             XCTAssertBuildFails(prefix)
-            try Utility.removeFileTree("\(prefix)/main.swift")
+            try Utility.removeFileTree(prefix.appending("main.swift").asString)
             XCTAssertBuilds(prefix)
         }
     }
@@ -47,7 +48,7 @@ class InvalidLayoutsTestCase: XCTestCase {
         */
         fixture(name: "InvalidLayouts/Generic2") { prefix in
             XCTAssertBuildFails(prefix)
-            try Utility.removeFileTree("\(prefix)/main.swift")
+            try Utility.removeFileTree(prefix.appending("main.swift").asString)
             XCTAssertBuilds(prefix)
         }
     }
@@ -62,7 +63,7 @@ class InvalidLayoutsTestCase: XCTestCase {
         */
         fixture(name: "InvalidLayouts/Generic3") { prefix in
             XCTAssertBuildFails(prefix)
-            try Utility.removeFileTree("\(prefix)/Sources/main.swift")
+            try Utility.removeFileTree(prefix.appending("Sources").appending("main.swift").asString)
             XCTAssertBuilds(prefix)
         }
     }
@@ -77,7 +78,7 @@ class InvalidLayoutsTestCase: XCTestCase {
         */
         fixture(name: "InvalidLayouts/Generic4") { prefix in
             XCTAssertBuildFails(prefix)
-            try Utility.removeFileTree("\(prefix)/main.swift")
+            try Utility.removeFileTree(prefix.appending("main.swift").asString)
             XCTAssertBuilds(prefix)
         }
     }
@@ -99,8 +100,8 @@ class InvalidLayoutsTestCase: XCTestCase {
             // determineTargets() but also we are saying: this
             // layout is only for *very* simple projects.
 
-            try Utility.removeFileTree("\(prefix)/Foo/Foo.swift")
-            try Utility.removeFileTree("\(prefix)/Foo")
+            try Utility.removeFileTree(prefix.appending("Foo").appending("Foo.swift").asString)
+            try Utility.removeFileTree(prefix.appending("Foo").asString)
             XCTAssertBuilds(prefix)
         }
     }

--- a/Tests/Functional/MiscellaneousTests.swift
+++ b/Tests/Functional/MiscellaneousTests.swift
@@ -25,7 +25,7 @@ class MiscellaneousTestCase: XCTestCase {
         // the selected version of the package
 
         fixture(name: "DependencyResolution/External/Simple", tags: ["1.3.5"]) { prefix in
-            let output = try executeSwiftBuild("\(prefix)/Bar")
+            let output = try executeSwiftBuild(prefix.appending("Bar"))
             let lines = output.characters.split(separator: "\n").map(String.init)
             XCTAssertTrue(lines.contains("Resolved version: 1.3.5"))
         }
@@ -45,8 +45,8 @@ class MiscellaneousTestCase: XCTestCase {
         // Tests a package with no source files but dependency, dependency should build.
 
         fixture(name: "Miscellaneous/ExactDependencies") { prefix in
-            XCTAssertBuilds(prefix, "EmptyWithDependency")
-            XCTAssertFileExists(prefix, "EmptyWithDependency/.build/debug/FooLib2.swiftmodule")
+            XCTAssertBuilds(prefix.appending("EmptyWithDependency"))
+            XCTAssertFileExists(prefix.appending("EmptyWithDependency/.build/debug/FooLib2.swiftmodule"))
         }
     }
 
@@ -56,9 +56,9 @@ class MiscellaneousTestCase: XCTestCase {
 
         fixture(name: "Miscellaneous/ExcludeDiagnostic1") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix, ".build", "debug", "BarLib.swiftmodule")
-            XCTAssertFileExists(prefix, ".build", "debug", "FooBarLib.swiftmodule")
-            XCTAssertNoSuchPath(prefix, ".build", "debug", "FooLib.swiftmodule")
+            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("BarLib.swiftmodule"))
+            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("FooBarLib.swiftmodule"))
+            XCTAssertNoSuchPath(prefix.appending(".build").appending("debug").appending("FooLib.swiftmodule"))
         }
     }
 
@@ -78,11 +78,11 @@ class MiscellaneousTestCase: XCTestCase {
         // Refs: https://bugs.swift.org/browse/SR-688
 
         fixture(name: "Miscellaneous/ExcludeDiagnostic3") { prefix in
-            XCTAssertBuilds(prefix, "App")
-            XCTAssertFileExists(prefix, "App", ".build", "debug", "App")
-            XCTAssertFileExists(prefix, "App", ".build", "debug", "top")
-            XCTAssertFileExists(prefix, "App", ".build", "debug", "bottom.swiftmodule")
-            XCTAssertNoSuchPath(prefix, "App", ".build", "debug", "some")
+            XCTAssertBuilds(prefix.appending("App"))
+            XCTAssertFileExists(prefix.appending("App").appending(".build").appending("debug").appending("App"))
+            XCTAssertFileExists(prefix.appending("App").appending(".build").appending("debug").appending("top"))
+            XCTAssertFileExists(prefix.appending("App").appending(".build").appending("debug").appending("bottom.swiftmodule"))
+            XCTAssertNoSuchPath(prefix.appending("App").appending(".build").appending("debug").appending("some"))
         }
     }
     
@@ -92,7 +92,7 @@ class MiscellaneousTestCase: XCTestCase {
         
         fixture(name: "Miscellaneous/ExcludeDiagnostic4") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix, ".build", "debug", "FooPackage.swiftmodule")
+            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("FooPackage.swiftmodule"))
         }
     }
     
@@ -102,7 +102,7 @@ class MiscellaneousTestCase: XCTestCase {
         
         fixture(name: "Miscellaneous/ExcludeDiagnostic5") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix, ".build", "debug", "FooPackage.swiftmodule")
+            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("FooPackage.swiftmodule"))
         }
     }
 
@@ -110,10 +110,10 @@ class MiscellaneousTestCase: XCTestCase {
     #if false
         //FIXME disabled pending no more magic
         fixture(name: "TestDependencies/Simple") { prefix in
-            XCTAssertBuilds(prefix, "App")
-            XCTAssertDirectoryExists(prefix, "App/Packages/TestingLib-1.2.3")
-            XCTAssertFileExists(prefix, "App/.build/debug/Foo.swiftmodule")
-            XCTAssertFileExists(prefix, "App/.build/debug/TestingLib.swiftmodule")
+            XCTAssertBuilds(prefix.appending("App"))
+            XCTAssertDirectoryExists(prefix.appending("App/Packages/TestingLib-1.2.3"))
+            XCTAssertFileExists(prefix.appending("App/.build/debug/Foo.swiftmodule"))
+            XCTAssertFileExists(prefix.appending("App/.build/debug/TestingLib.swiftmodule"))
         }
     #endif
     }
@@ -125,19 +125,19 @@ class MiscellaneousTestCase: XCTestCase {
         // verifies that testDependencies of dependencies are not fetched or built
 
         fixture(name: "TestDependencies/Complex") { prefix in
-            XCTAssertBuilds(prefix, "App")
+            XCTAssertBuilds(prefix.appending("App"))
 
-            XCTAssertDirectoryExists(prefix, "App/Packages/TestingLib-1.2.3")
-            XCTAssertDirectoryExists(prefix, "App/Packages/Foo-1.2.3")
+            XCTAssertDirectoryExists(prefix.appending("App/Packages/TestingLib-1.2.3"))
+            XCTAssertDirectoryExists(prefix.appending("App/Packages/Foo-1.2.3"))
 
-            XCTAssertFileExists(prefix, "App/.build/debug/App")
-            XCTAssertFileExists(prefix, "App/.build/debug/Foo.swiftmodule")
-            XCTAssertFileExists(prefix, "App/.build/debug/TestingLib.swiftmodule")
+            XCTAssertFileExists(prefix.appending("App/.build/debug/App"))
+            XCTAssertFileExists(prefix.appending("App/.build/debug/Foo.swiftmodule"))
+            XCTAssertFileExists(prefix.appending("App/.build/debug/TestingLib.swiftmodule"))
 
-            XCTAssertNoSuchPath(prefix, "App/Packages/PrivateFooLib-1.2.3")
-            XCTAssertNoSuchPath(prefix, "App/Packages/TestingFooLib-1.2.3")
-            XCTAssertNoSuchPath(prefix, "App/.build/debug/PrivateFooLib.swiftmodule")
-            XCTAssertNoSuchPath(prefix, "App/.build/debug/TestingFooLib.swiftmodule")
+            XCTAssertNoSuchPath(prefix.appending("App/Packages/PrivateFooLib-1.2.3"))
+            XCTAssertNoSuchPath(prefix.appending("App/Packages/TestingFooLib-1.2.3"))
+            XCTAssertNoSuchPath(prefix.appending("App/.build/debug/PrivateFooLib.swiftmodule"))
+            XCTAssertNoSuchPath(prefix.appending("App/.build/debug/TestingFooLib.swiftmodule"))
         }
 #endif
     }
@@ -149,10 +149,10 @@ class MiscellaneousTestCase: XCTestCase {
         // are not passed into the build-command.
 
         fixture(name: "Miscellaneous/ExactDependencies") { prefix in
-            XCTAssertBuilds(prefix, "app")
-            XCTAssertFileExists(prefix, "app/.build/debug/FooExec")
-            XCTAssertFileExists(prefix, "app/.build/debug/FooLib1.swiftmodule")
-            XCTAssertFileExists(prefix, "app/.build/debug/FooLib2.swiftmodule")
+            XCTAssertBuilds(prefix.appending("app"))
+            XCTAssertFileExists(prefix.appending("app/.build/debug/FooExec"))
+            XCTAssertFileExists(prefix.appending("app/.build/debug/FooLib1.swiftmodule"))
+            XCTAssertFileExists(prefix.appending("app/.build/debug/FooLib2.swiftmodule"))
         }
     }
 
@@ -163,15 +163,15 @@ class MiscellaneousTestCase: XCTestCase {
         // should immediately exit with exit-status: `0`
 
         fixture(name: "DependencyResolution/External/Complex") { prefix in
-            XCTAssertBuilds(prefix, "app")
-            XCTAssertBuilds(prefix, "app")
-            XCTAssertBuilds(prefix, "app")
+            XCTAssertBuilds(prefix.appending("app"))
+            XCTAssertBuilds(prefix.appending("app"))
+            XCTAssertBuilds(prefix.appending("app"))
         }
     }
 
     func testDependenciesWithVPrefixTagsWork() {
         fixture(name: "DependencyResolution/External/Complex", tags: ["v1.2.3"]) { prefix in
-            XCTAssertBuilds(prefix, "app")
+            XCTAssertBuilds(prefix.appending("app"))
         }
     }
 
@@ -212,15 +212,15 @@ class MiscellaneousTestCase: XCTestCase {
 
     func testCanBuildIfADependencyAlreadyCheckedOut() {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
-            try systemQuietly(Git.tool, "clone", Path.join(prefix, "deck-of-playing-cards"), Path.join(prefix, "app/Packages/DeckOfPlayingCards-1.2.3"))
-            XCTAssertBuilds(prefix, "app")
+            try systemQuietly(Git.tool, "clone", prefix.appending("deck-of-playing-cards").asString, prefix.appending("app/Packages/DeckOfPlayingCards-1.2.3").asString)
+            XCTAssertBuilds(prefix.appending("app"))
         }
     }
 
     func testCanBuildIfADependencyClonedButThenAborted() {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
-            try systemQuietly(Git.tool, "clone", Path.join(prefix, "deck-of-playing-cards"), Path.join(prefix, "app/Packages/DeckOfPlayingCards"))
-            XCTAssertBuilds(prefix, "app", configurations: [.Debug])
+            try systemQuietly(Git.tool, "clone", prefix.appending("deck-of-playing-cards").asString, prefix.appending("app/Packages/DeckOfPlayingCards").asString)
+            XCTAssertBuilds(prefix.appending("app"), configurations: [.Debug])
         }
     }
 
@@ -228,31 +228,31 @@ class MiscellaneousTestCase: XCTestCase {
     // valid provided the selected version tag has a Package.swift
     func testTipHasNoPackageSwift() {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
-            let path = Path.join(prefix, "FisherYates")
+            let path = prefix.appending("FisherYates")
 
             // required for some Linux configurations
-            try systemQuietly(Git.tool, "-C", path, "config", "user.email", "example@example.com")
-            try systemQuietly(Git.tool, "-C", path, "config", "user.name", "Example Example")
+            try systemQuietly(Git.tool, "-C", path.asString, "config", "user.email", "example@example.com")
+            try systemQuietly(Git.tool, "-C", path.asString, "config", "user.name", "Example Example")
 
-            try systemQuietly(Git.tool, "-C", path, "rm", "Package.swift")
-            try systemQuietly(Git.tool, "-C", path, "commit", "-mwip")
+            try systemQuietly(Git.tool, "-C", path.asString, "rm", "Package.swift")
+            try systemQuietly(Git.tool, "-C", path.asString, "commit", "-mwip")
 
-            XCTAssertBuilds(prefix, "app")
+            XCTAssertBuilds(prefix.appending("app"))
         }
     }
 
     // if a tag does not have a valid Package.swift, the build fails
     func testFailsIfVersionTagHasNoPackageSwift() {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
-            let path = Path.join(prefix, "FisherYates")
+            let path = prefix.appending("FisherYates")
 
-            try systemQuietly(Git.tool, "-C", path, "config", "user.email", "example@example.com")
-            try systemQuietly(Git.tool, "-C", path, "config", "user.name", "Example McExample")
-            try systemQuietly(Git.tool, "-C", path, "rm", "Package.swift")
-            try systemQuietly(Git.tool, "-C", path, "commit", "--message", "wip")
-            try systemQuietly(Git.tool, "-C", path, "tag", "--force", "1.2.3")
+            try systemQuietly(Git.tool, "-C", path.asString, "config", "user.email", "example@example.com")
+            try systemQuietly(Git.tool, "-C", path.asString, "config", "user.name", "Example McExample")
+            try systemQuietly(Git.tool, "-C", path.asString, "rm", "Package.swift")
+            try systemQuietly(Git.tool, "-C", path.asString, "commit", "--message", "wip")
+            try systemQuietly(Git.tool, "-C", path.asString, "tag", "--force", "1.2.3")
 
-            XCTAssertBuildFails(prefix, "app")
+            XCTAssertBuildFails(prefix.appending("app"))
         }
     }
 
@@ -268,7 +268,7 @@ class MiscellaneousTestCase: XCTestCase {
     */
     func testInternalDependencyEdges() {
         fixture(name: "Miscellaneous/DependencyEdges/Internal") { prefix in
-            let execpath = [Path.join(prefix, ".build/debug/Foo")]
+            let execpath = [prefix.appending(".build/debug/Foo").asString]
 
             XCTAssertBuilds(prefix)
             var output = try popen(execpath)
@@ -278,7 +278,7 @@ class MiscellaneousTestCase: XCTestCase {
             // llbuild does not realize the file has changed
             sleep(1)
 
-            try localFS.writeFileContents(Path.join(prefix, "Bar/Bar.swift"), bytes: "public let bar = \"Goodbye\"\n")
+            try localFS.writeFileContents(prefix.appending("Bar/Bar.swift").asString, bytes: "public let bar = \"Goodbye\"\n")
 
             XCTAssertBuilds(prefix)
             output = try popen(execpath)
@@ -292,9 +292,9 @@ class MiscellaneousTestCase: XCTestCase {
     */
     func testExternalDependencyEdges1() {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
-            let execpath = [Path.join(prefix, "app/.build/debug/Dealer")]
+            let execpath = [prefix.appending("app/.build/debug/Dealer").asString]
 
-            XCTAssertBuilds(prefix, "app")
+            XCTAssertBuilds(prefix.appending("app"))
             var output = try popen(execpath)
             XCTAssertEqual(output, "♣︎K\n♣︎Q\n♣︎J\n♣︎10\n♣︎9\n♣︎8\n♣︎7\n♣︎6\n♣︎5\n♣︎4\n")
 
@@ -302,9 +302,9 @@ class MiscellaneousTestCase: XCTestCase {
             // llbuild does not realize the file has changed
             sleep(1)
 
-            try localFS.writeFileContents(Path.join(prefix, "app/Packages/FisherYates-1.2.3/src/Fisher-Yates_Shuffle.swift"), bytes: "public extension Collection{ func shuffle() -> [Iterator.Element] {return []} }\n\npublic extension MutableCollection where Index == Int { mutating func shuffleInPlace() { for (i, _) in enumerated() { self[i] = self[0] } }}\n\npublic let shuffle = true")
+            try localFS.writeFileContents(prefix.appending("app/Packages/FisherYates-1.2.3/src/Fisher-Yates_Shuffle.swift").asString, bytes: "public extension Collection{ func shuffle() -> [Iterator.Element] {return []} }\n\npublic extension MutableCollection where Index == Int { mutating func shuffleInPlace() { for (i, _) in enumerated() { self[i] = self[0] } }}\n\npublic let shuffle = true")
 
-            XCTAssertBuilds(prefix, "app")
+            XCTAssertBuilds(prefix.appending("app"))
             output = try popen(execpath)
             XCTAssertEqual(output, "♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n")
         }
@@ -316,9 +316,9 @@ class MiscellaneousTestCase: XCTestCase {
      */
     func testExternalDependencyEdges2() {
         fixture(name: "Miscellaneous/DependencyEdges/External") { prefix in
-            let execpath = [Path.join(prefix, "root/.build/debug/dep2")]
+            let execpath = [prefix.appending("root/.build/debug/dep2").asString]
 
-            XCTAssertBuilds(prefix, "root")
+            XCTAssertBuilds(prefix.appending("root"))
             var output = try popen(execpath)
             XCTAssertEqual(output, "Hello\n")
 
@@ -326,9 +326,9 @@ class MiscellaneousTestCase: XCTestCase {
             // llbuild does not realize the file has changed
             sleep(1)
 
-            try localFS.writeFileContents(Path.join(prefix, "root/Packages/dep1-1.2.3/Foo.swift"), bytes: "public let foo = \"Goodbye\"")
+            try localFS.writeFileContents(prefix.appending("root/Packages/dep1-1.2.3/Foo.swift").asString, bytes: "public let foo = \"Goodbye\"")
 
-            XCTAssertBuilds(prefix, "root")
+            XCTAssertBuilds(prefix.appending("root"))
             output = try popen(execpath)
             XCTAssertEqual(output, "Goodbye\n")
         }
@@ -337,11 +337,11 @@ class MiscellaneousTestCase: XCTestCase {
     func testProducts() {
         fixture(name: "Products/StaticLibrary") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix, ".build/debug/libProductName.a")
+            XCTAssertFileExists(prefix.appending(".build/debug/libProductName.a"))
         }
         fixture(name: "Products/DynamicLibrary") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix, ".build/debug/libProductName.dylib")
+            XCTAssertFileExists(prefix.appending(".build/debug/libProductName.dylib"))
         }
     }
     
@@ -360,7 +360,7 @@ class MiscellaneousTestCase: XCTestCase {
     func testSpaces() {
         fixture(name: "Miscellaneous/Spaces Fixture") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix, ".build/debug/Module_Name_1.build/Foo.swift.o")
+            XCTAssertFileExists(prefix.appending(".build/debug/Module_Name_1.build/Foo.swift.o"))
         }
     }
 
@@ -369,7 +369,7 @@ class MiscellaneousTestCase: XCTestCase {
         XCTAssertTrue(localFS.isDirectory(tempDir.path))
 
         // Create a directory with non c99name.
-        let packageRoot = tempDir.path.appending("some-package").asString
+        let packageRoot = tempDir.path.appending("some-package")
         try localFS.createDirectory(packageRoot)
         XCTAssertTrue(localFS.isDirectory(packageRoot))
 
@@ -377,7 +377,7 @@ class MiscellaneousTestCase: XCTestCase {
         _ = try SwiftPMProduct.SwiftPackage.execute(["init"], chdir: packageRoot, env: [:], printIfError: true)
         // Try building it.
         XCTAssertBuilds(packageRoot)
-        XCTAssertFileExists(packageRoot, ".build/debug/some_package.swiftmodule")
+        XCTAssertFileExists(packageRoot.appending(".build/debug/some_package.swiftmodule"))
     }
 
     static var allTests = [

--- a/Tests/Functional/ModuleMapTests.swift
+++ b/Tests/Functional/ModuleMapTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import Basic
 import Utility
 
 import func POSIX.popen
@@ -22,17 +23,17 @@ private let dylib = "so"
 
 class ModuleMapsTestCase: XCTestCase {
 
-    private func fixture(name: String, CModuleName: String, rootpkg: String, body: (String, [String]) throws -> Void) {
+    private func fixture(name: RelativePath, cModuleName: String, rootpkg: String, body: (AbsolutePath, [String]) throws -> Void) {
         FunctionalTestSuite.fixture(name: name) { prefix in
-            let input = Path.join(prefix, CModuleName, "C/foo.c")
-            let outdir = Path.join(prefix, rootpkg, ".build/debug")
-            try Utility.makeDirectories(outdir)
-            let output = Path.join(outdir, "libfoo.\(dylib)")
-            try systemQuietly(["clang", "-shared", input, "-o", output])
+            let input = prefix.appending(cModuleName).appending("C").appending("foo.c")
+            let outdir = prefix.appending(rootpkg).appending(".build/debug")
+            try Utility.makeDirectories(outdir.asString)
+            let output = outdir.appending("libfoo.\(dylib)")
+            try systemQuietly(["clang", "-shared", input.asString, "-o", output.asString])
 
-            var Xld = ["-L", outdir]
+            var Xld = ["-L", outdir.asString]
         #if os(Linux)
-            Xld += ["-rpath", outdir]
+            Xld += ["-rpath", outdir.asString]
         #endif
 
             try body(prefix, Xld)
@@ -40,25 +41,25 @@ class ModuleMapsTestCase: XCTestCase {
     }
 
     func testDirectDependency() {
-        fixture(name: "ModuleMaps/Direct", CModuleName: "CFoo", rootpkg: "App") { prefix, Xld in
+        fixture(name: "ModuleMaps/Direct", cModuleName: "CFoo", rootpkg: "App") { prefix, Xld in
 
-            XCTAssertBuilds(prefix, "App", Xld: Xld)
+            XCTAssertBuilds(prefix.appending("App"), Xld: Xld)
 
-            let debugout = try popen([Path.join(prefix, "App/.build/debug/App")])
+            let debugout = try popen([prefix.appending("App/.build/debug/App").asString])
             XCTAssertEqual(debugout, "123\n")
-            let releaseout = try popen([Path.join(prefix, "App/.build/release/App")])
+            let releaseout = try popen([prefix.appending("App/.build/release/App").asString])
             XCTAssertEqual(releaseout, "123\n")
         }
     }
 
     func testTransitiveDependency() {
-        fixture(name: "ModuleMaps/Transitive", CModuleName: "packageD", rootpkg: "packageA") { prefix, Xld in
+        fixture(name: "ModuleMaps/Transitive", cModuleName: "packageD", rootpkg: "packageA") { prefix, Xld in
 
-            XCTAssertBuilds(prefix, "packageA", Xld: Xld)
+            XCTAssertBuilds(prefix.appending("packageA"), Xld: Xld)
 
             func verify(_ conf: String, file: StaticString = #file, line: UInt = #line) throws {
                 let expectedOutput = "calling Y.bar()\nY.bar() called\nX.foo() called\n123\n"
-                let out = try popen([Path.join(prefix, "packageA/.build", conf, "packageA")])
+                let out = try popen([prefix.appending("packageA").appending(".build").appending(conf).appending("packageA").asString])
                 XCTAssertEqual(out, expectedOutput)
             }
 

--- a/Tests/Functional/SwiftPMXCTestHelperTests.swift
+++ b/Tests/Functional/SwiftPMXCTestHelperTests.swift
@@ -10,6 +10,7 @@
 
 #if os(OSX)
 
+import Basic
 import XCTest
 import Utility
 
@@ -18,7 +19,7 @@ class SwiftPMXCTestHelperTests: XCTestCase {
         fixture(name: "Miscellaneous/SwiftPMXCTestHelper") { prefix in
             // Build the package.
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix, ".build", "debug", "SwiftPMXCTestHelper.swiftmodule")
+            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("SwiftPMXCTestHelper.swiftmodule"))
             // Run swift-test on package.
             XCTAssertSwiftTest(prefix)
             // Expected output dictionary.
@@ -35,19 +36,18 @@ class SwiftPMXCTestHelperTests: XCTestCase {
               ]]]
             ] as NSDictionary
             // Run the XCTest helper tool and check result.
-            XCTAssertXCTestHelper(prefix, ".build", "debug", "SwiftPMXCTestHelperTests.xctest", testCases: testCases)
+            XCTAssertXCTestHelper(prefix.appending(".build").appending("debug").appending("SwiftPMXCTestHelperTests.xctest"), testCases: testCases)
         }
     }
 }
 
-func XCTAssertXCTestHelper(_ bundlePath: String..., testCases: NSDictionary) {
+func XCTAssertXCTestHelper(_ bundlePath: AbsolutePath, testCases: NSDictionary) {
     do {
-        let bundle = Path.join(bundlePath)
         let env = ["DYLD_FRAMEWORK_PATH": try platformFrameworksPath()]
-        let outputFile = Path.join(bundle.parentDirectory, "tests.txt")
-        let _ = try SwiftPMProduct.XCTestHelper.execute([bundle, outputFile], env: env, printIfError: true)
-        guard let data = NSData(contentsOfFile: outputFile) else {
-            XCTFail("No output found in : \(outputFile)"); return;
+        let outputFile = bundlePath.parentDirectory.appending("tests.txt")
+        let _ = try SwiftPMProduct.XCTestHelper.execute([bundlePath.asString, outputFile.asString], env: env, printIfError: true)
+        guard let data = NSData(contentsOfFile: outputFile.asString) else {
+            XCTFail("No output found in : \(outputFile.asString)"); return;
         }
         let json = try JSONSerialization.jsonObject(with: data as Data, options: [])
         XCTAssertTrue(json.isEqual(testCases), "\(json) is not equal to \(testCases)")

--- a/Tests/Functional/Utilities.swift
+++ b/Tests/Functional/Utilities.swift
@@ -19,28 +19,40 @@ import class Foundation.Bundle
 #endif
 
 
-func fixture(name fixtureName: String, tags: [String] = [], file: StaticString = #file, line: UInt = #line, body: @noescape(String) throws -> Void) {
-
-    func gsub(_ input: String) -> String {
-        return input.characters.split(separator: "/").map(String.init).joined(separator: "_")
-    }
-
+/// Test-helper function that runs a block of code on a copy of a test fixture package.  The copy is made into a temporary directory, and the block is given a path to that directory.  The block is permitted to modify the copy.  The temporary copy is deleted after the block returns.
+func fixture(name fixtureSubpath: RelativePath, tags: [String] = [], file: StaticString = #file, line: UInt = #line, body: @noescape(AbsolutePath) throws -> Void) {
     do {
-        try POSIX.mkdtemp(gsub(fixtureName)) { prefix in
-            defer { _ = try? Utility.removeFileTree(prefix) }
-
-            let rootd = Path.join(#file, "../../../Fixtures", fixtureName).normpath
-
-            guard rootd.isDirectory else {
-                XCTFail("No such fixture: \(rootd)", file: file, line: line)
+        // Make a suitable test directory name from the fixture subpath.
+        let copyName = fixtureSubpath.components.joined(separator: "_")
+        
+        // Create a temporary directory for the duration of the block.
+        try POSIX.mkdtemp(copyName) { tmpDir in
+            let tmpDir = AbsolutePath(tmpDir)
+            
+            // Schedule removal of the temporary directory, no matter what happens.
+            defer { _ = try? Utility.removeFileTree(tmpDir.asString) }
+            
+            // Construct the expected path of the fixture.
+            // FIXME: This seems quite hacky; we should provide some control over where fixtures are found.
+            let fixtureDir = AbsolutePath(#file).appending("../../../Fixtures").appending(fixtureSubpath)
+            
+            // Check that the fixture is really there.
+            guard fixtureDir.asString.isDirectory else {
+                XCTFail("No such fixture: \(fixtureDir.asString)", file: file, line: line)
                 return
             }
-
-            if Path.join(rootd, "Package.swift").isFile {
-                let dstdir = Path.join(prefix, rootd.basename).normpath
-                try systemQuietly("cp", "-R", rootd, dstdir)
-                try body(dstdir)
-            } else {
+            
+            // The fixture contains either a checkout or just a Git directory.
+            if fixtureDir.appending("Package.swift").asString.isFile {
+                // It's a single package, so copy the whole directory as-is.
+                let dstDir = tmpDir.appending(copyName)
+                try systemQuietly("cp", "-R", "-H", fixtureDir.asString, dstDir.asString)
+                
+                // Invoke the block, passing it the path of the copied fixture.
+                try body(dstDir)
+            }
+            else {
+                // Not a single package, so we expect it to be a directory of packages.
                 var versions = tags
                 func popVersion() -> String {
                     if versions.isEmpty {
@@ -51,38 +63,44 @@ func fixture(name fixtureName: String, tags: [String] = [], file: StaticString =
                         return versions.removeFirst()
                     }
                 }
-
-                for name in try! localFS.getDirectoryContents(rootd).sorted() {
-                    let d = Path.join(rootd, name)
-                    guard d.isDirectory else { continue }
-                    let dstdir = Path.join(prefix, d.basename).normpath
-                    try systemQuietly("cp", "-R", try realpath(d), dstdir)
-                    try systemQuietly([Git.tool, "-C", dstdir, "init"])
-                    try systemQuietly([Git.tool, "-C", dstdir, "config", "user.email", "example@example.com"])
-                    try systemQuietly([Git.tool, "-C", dstdir, "config", "user.name", "Example Example"])
-                    try systemQuietly([Git.tool, "-C", dstdir, "add", "."])
-                    try systemQuietly([Git.tool, "-C", dstdir, "commit", "-m", "msg"])
-                    try systemQuietly([Git.tool, "-C", dstdir, "tag", popVersion()])
+                
+                // Copy each of the package directories and construct a git repo in it.
+                for fileName in try! localFS.getDirectoryContents(fixtureDir).sorted() {
+                    let srcDir = fixtureDir.appending(fileName)
+                    guard srcDir.asString.isDirectory else { continue }
+                    let dstDir = tmpDir.appending(fileName)
+                    try systemQuietly("cp", "-R", "-H", srcDir.asString, dstDir.asString)
+                    try systemQuietly([Git.tool, "-C", dstDir.asString, "init"])
+                    try systemQuietly([Git.tool, "-C", dstDir.asString, "config", "user.email", "example@example.com"])
+                    try systemQuietly([Git.tool, "-C", dstDir.asString, "config", "user.name", "Example Example"])
+                    try systemQuietly([Git.tool, "-C", dstDir.asString, "add", "."])
+                    try systemQuietly([Git.tool, "-C", dstDir.asString, "commit", "-m", "msg"])
+                    try systemQuietly([Git.tool, "-C", dstDir.asString, "tag", popVersion()])
                 }
-                try body(prefix)
+                
+                // Invoke the block, passing it the path of the copied fixture.
+                try body(tmpDir)
             }
+            
+            // Regardless of how the block ends, the temporary directory will be removed.
         }
     } catch {
         XCTFail("\(error)", file: file, line: line)
     }
 }
 
-func initGitRepo(_ dstdir: String, tag: String? = nil, file: StaticString = #file, line: UInt = #line) {
+/// Test-helper function that creates a new Git repository in a directory.  The new repository will contain exactly one empty file, and if a tag name is provided, a tag with that name will be created.
+func initGitRepo(_ dir: AbsolutePath, tag: String? = nil, file: StaticString = #file, line: UInt = #line) {
     do {
-        let file = Path.join(dstdir, "file.swift")
-        try systemQuietly(["touch", file])
-        try systemQuietly([Git.tool, "-C", dstdir, "init"])
-        try systemQuietly([Git.tool, "-C", dstdir, "config", "user.email", "example@example.com"])
-        try systemQuietly([Git.tool, "-C", dstdir, "config", "user.name", "Example Example"])
-        try systemQuietly([Git.tool, "-C", dstdir, "add", "."])
-        try systemQuietly([Git.tool, "-C", dstdir, "commit", "-m", "msg"])
+        let file = dir.appending("file.swift")
+        try systemQuietly(["touch", file.asString])
+        try systemQuietly([Git.tool, "-C", dir.asString, "init"])
+        try systemQuietly([Git.tool, "-C", dir.asString, "config", "user.email", "example@example.com"])
+        try systemQuietly([Git.tool, "-C", dir.asString, "config", "user.name", "Example Example"])
+        try systemQuietly([Git.tool, "-C", dir.asString, "add", "."])
+        try systemQuietly([Git.tool, "-C", dir.asString, "commit", "-m", "msg"])
         if let tag = tag {
-            try systemQuietly([Git.tool, "-C", dstdir, "tag", tag])
+            try systemQuietly([Git.tool, "-C", dir.asString, "tag", tag])
         }
     }
     catch {
@@ -107,19 +125,19 @@ enum SwiftPMProduct {
     case XCTestHelper
 
     /// Path to currently built binary.
-    var path: String {
+    var path: AbsolutePath {
       #if os(OSX)
         for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
-            return Path.join(bundle.bundlePath.parentDirectory, exec)
+            return AbsolutePath(bundle.bundlePath).parentDirectory.appending(self.exec)
         }
         fatalError()
       #else
-        return Path.join(Process.arguments.first!.abspath.parentDirectory, exec)
+        return AbsolutePath(Process.arguments.first!.abspath).parentDirectory.appending(self.exec)
       #endif
     }
 
     /// Executable name.
-    var exec: String {
+    var exec: RelativePath {
         switch self {
         case SwiftBuild:
             return "swift-build"
@@ -143,12 +161,12 @@ extension SwiftPMProduct {
     ///         - printIfError: Print the output on non-zero exit.
     ///
     /// - Returns: The output of the process.
-    func execute(_ args: [String], chdir: String? = nil, env: [String: String], printIfError: Bool = false) throws -> String {
+    func execute(_ args: [String], chdir: AbsolutePath? = nil, env: [String: String], printIfError: Bool = false) throws -> String {
         var out = ""
         do {
-            var theArgs = [path]
+            var theArgs = [path.asString]
             if let chdir = chdir {
-                theArgs += ["--chdir", chdir]
+                theArgs += ["--chdir", chdir.asString]
             }
             try POSIX.popen(theArgs + args, redirectStandardError: true, environment: env) {
                 out += $0
@@ -158,7 +176,7 @@ extension SwiftPMProduct {
             if printIfError {
                 print("output:", out)
                 print("SWIFT_EXEC:", env["SWIFT_EXEC"] ?? "nil")
-                print(exec + ":", path)
+                print(exec.asString + ":", path.asString)
             }
             throw error
         }
@@ -166,7 +184,7 @@ extension SwiftPMProduct {
 }
 
 @discardableResult
-func executeSwiftBuild(_ chdir: String, configuration: Configuration = .Debug, printIfError: Bool = false, Xld: [String] = [], env: [String: String] = [:]) throws -> String {
+func executeSwiftBuild(_ chdir: AbsolutePath, configuration: Configuration = .Debug, printIfError: Bool = false, Xld: [String] = [], env: [String: String] = [:]) throws -> String {
     var args = ["--configuration"]
     switch configuration {
     case .Debug:
@@ -185,10 +203,11 @@ func executeSwiftBuild(_ chdir: String, configuration: Configuration = .Debug, p
     return try swiftBuild.execute(args, chdir: chdir, env: env, printIfError: printIfError)
 }
 
-func mktmpdir(_ file: StaticString = #file, line: UInt = #line, body: @noescape(String) throws -> Void) {
+func mktmpdir(_ file: StaticString = #file, line: UInt = #line, body: @noescape(AbsolutePath) throws -> Void) {
     do {
         try POSIX.mkdtemp("spm-tests") { dir in
-            defer { _ = try? Utility.removeFileTree(dir) }
+            let dir = AbsolutePath(dir)
+            defer { _ = try? Utility.removeFileTree(dir.asString) }
             try body(dir)
         }
     } catch {
@@ -196,32 +215,28 @@ func mktmpdir(_ file: StaticString = #file, line: UInt = #line, body: @noescape(
     }
 }
 
-func XCTAssertBuilds(_ paths: String..., configurations: Set<Configuration> = [.Debug, .Release], file: StaticString = #file, line: UInt = #line, Xld: [String] = [], env: [String: String] = [:]) {
-    let prefix = Path.join(paths)
-
+func XCTAssertBuilds(_ path: AbsolutePath, configurations: Set<Configuration> = [.Debug, .Release], file: StaticString = #file, line: UInt = #line, Xld: [String] = [], env: [String: String] = [:]) {
     for conf in configurations {
         do {
             print("    Building \(conf)")
-            _ = try executeSwiftBuild(prefix, configuration: conf, printIfError: true, Xld: Xld, env: env)
+            _ = try executeSwiftBuild(path, configuration: conf, printIfError: true, Xld: Xld, env: env)
         } catch {
             XCTFail("`swift build -c \(conf)' failed:\n\n\(error)\n", file: file, line: line)
         }
     }
 }
 
-func XCTAssertSwiftTest(_ paths: String..., file: StaticString = #file, line: UInt = #line, env: [String: String] = [:]) {
-    let prefix = Path.join(paths)
+func XCTAssertSwiftTest(_ path: AbsolutePath, file: StaticString = #file, line: UInt = #line, env: [String: String] = [:]) {
     do {
-        _ = try SwiftPMProduct.SwiftTest.execute([], chdir: prefix, env: env, printIfError: true)
+        _ = try SwiftPMProduct.SwiftTest.execute([], chdir: path, env: env, printIfError: true)
     } catch {
         XCTFail("`swift test' failed:\n\n\(error)\n", file: file, line: line)
     }
 }
 
-func XCTAssertBuildFails(_ paths: String..., file: StaticString = #file, line: UInt = #line) {
-    let prefix = Path.join(paths)
+func XCTAssertBuildFails(_ path: AbsolutePath, file: StaticString = #file, line: UInt = #line) {
     do {
-        _ = try executeSwiftBuild(prefix)
+        _ = try executeSwiftBuild(path)
 
         XCTFail("`swift build' succeeded but should have failed", file: file, line: line)
 
@@ -232,24 +247,21 @@ func XCTAssertBuildFails(_ paths: String..., file: StaticString = #file, line: U
     }
 }
 
-func XCTAssertFileExists(_ paths: String..., file: StaticString = #file, line: UInt = #line) {
-    let path = Path.join(paths)
-    if !path.isFile {
-        XCTFail("Expected file doesn’t exist: \(path)", file: file, line: line)
+func XCTAssertFileExists(_ path: AbsolutePath, file: StaticString = #file, line: UInt = #line) {
+    if !path.asString.isFile {
+        XCTFail("Expected file doesn’t exist: \(path.asString)", file: file, line: line)
     }
 }
 
-func XCTAssertDirectoryExists(_ paths: String..., file: StaticString = #file, line: UInt = #line) {
-    let path = Path.join(paths)
-    if !path.isDirectory {
-        XCTFail("Expected directory doesn’t exist: \(path)", file: file, line: line)
+func XCTAssertDirectoryExists(_ path: AbsolutePath, file: StaticString = #file, line: UInt = #line) {
+    if !path.asString.isDirectory {
+        XCTFail("Expected directory doesn’t exist: \(path.asString)", file: file, line: line)
     }
 }
 
-func XCTAssertNoSuchPath(_ paths: String..., file: StaticString = #file, line: UInt = #line) {
-    let path = Path.join(paths)
-    if path.exists {
-        XCTFail("path exists but should not: \(path)", file: file, line: line)
+func XCTAssertNoSuchPath(_ path: AbsolutePath, file: StaticString = #file, line: UInt = #line) {
+    if path.asString.exists {
+        XCTFail("path exists but should not: \(path.asString)", file: file, line: line)
     }
 }
     

--- a/Tests/Get/GetTests.swift
+++ b/Tests/Get/GetTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import Basic
 import Utility
 
 import struct PackageModel.Manifest
@@ -23,9 +24,9 @@ class GetTests: XCTestCase {
     func testRawCloneDoesNotCrashIfManifestIsNotPresent() {
         mktmpdir { tmpdir in
             guard let repo = makeGitRepo(tmpdir, tag: "0.1.0") else { return XCTFail() }
-            try systemQuietly([Git.tool, "-C", repo.path, "remote", "add", "origin", repo.path])
+            try systemQuietly([Git.tool, "-C", repo.path.asString, "remote", "add", "origin", repo.path.asString])
             let clone = try RawClone(path: repo.path, manifestParser: { _,_ throws -> Manifest in
-                throw Package.Error.noManifest(tmpdir)
+                throw Package.Error.noManifest(tmpdir.asString)
             })
             XCTAssertEqual(clone.children.count, 0)
         }
@@ -67,11 +68,11 @@ class GetTests: XCTestCase {
 
     func testGitRepoInitialization() {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
-            XCTAssertNotNil(Git.Repo(path: Path.join(prefix, "app")))
+            XCTAssertNotNil(Git.Repo(path: prefix.appending("app")))
         }
 
         XCTAssertNil(Git.Repo(path: #file))
-        XCTAssertNil(Git.Repo(path: #file.parentDirectory))
+        XCTAssertNil(Git.Repo(path: AbsolutePath(#file).parentDirectory))
     }
 
     static var allTests = [

--- a/Tests/Get/GitTests.swift
+++ b/Tests/Get/GitTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import Basic
 @testable import Get
 import struct PackageModel.Manifest
 import struct Utility.Path
@@ -49,7 +50,7 @@ class GitTests: XCTestCase {
 
 //MARK: - Helpers
 
-func makeGitRepo(_ dstdir: String, tag: String? = nil, file: StaticString = #file, line: UInt = #line) -> Git.Repo? {
+func makeGitRepo(_ dstdir: AbsolutePath, tag: String? = nil, file: StaticString = #file, line: UInt = #line) -> Git.Repo? {
     initGitRepo(dstdir, tag: tag)
     return Git.Repo(path: dstdir)
 }
@@ -60,7 +61,7 @@ private func tryCloningRepoWithTag(_ tag: String?, shouldCrash: Bool) {
         _ = makeGitRepo(path, tag: tag)!
         do {
             _ = try RawClone(path: path, manifestParser: { _ throws in
-                return Manifest(path: path, package: PackageDescription.Package(), products: [])
+                return Manifest(path: path.asString, package: PackageDescription.Package(), products: [])
             })
         } catch Error.unversioned {
             done = shouldCrash

--- a/Tests/PackageLoading/ConventionTests.swift
+++ b/Tests/PackageLoading/ConventionTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import Basic
 import PackageDescription
 import PackageModel
 import Utility
@@ -19,7 +20,7 @@ import Utility
 /// Tests for the handling of source layout conventions.
 class ConventionTests: XCTestCase {
     /// Parse the given test files according to the conventions, and check the result.
-    private func test<T: Module>(files: [String], file: StaticString = #file, line: UInt = #line, body: (T) throws -> ()) {
+    private func test<T: Module>(files: [RelativePath], file: StaticString = #file, line: UInt = #line, body: (T) throws -> ()) {
         do {
             try fixture(files: files) { (package, modules) in 
                 XCTAssertEqual(modules.count, 1)
@@ -51,10 +52,10 @@ class ConventionTests: XCTestCase {
     }
 
     func testResolvesSingleSwiftModule() throws {
-        let files = ["Foo.swift"]
+        let files: [RelativePath] = ["Foo.swift"]
         test(files: files) { (module: SwiftModule) in 
             XCTAssertEqual(module.sources.paths.count, files.count)
-            XCTAssertEqual(Set(module.sources.relativePaths), Set(files))
+            XCTAssertEqual(Set(module.sources.relativePaths.map{ RelativePath($0) }), Set(files))
         }
     }
 
@@ -75,21 +76,21 @@ class ConventionTests: XCTestCase {
 }
 
 /// Create a test fixture with empty files at the given paths.
-private func fixture(files: [String], body: @noescape (String) throws -> ()) {
+private func fixture(files: [RelativePath], body: @noescape (AbsolutePath) throws -> ()) {
     mktmpdir { prefix in
-        try Utility.makeDirectories(prefix)
+        try Utility.makeDirectories(prefix.asString)
         for file in files {
-            try system("touch", Path.join(prefix, file))
+            try system("touch", prefix.appending(file).asString)
         }
         try body(prefix)
     }
 }
 
 /// Check the behavior of a test project with the given file paths.
-private func fixture(files: [String], file: StaticString = #file, line: UInt = #line, body: @noescape (PackageModel.Package, [Module]) throws -> ()) throws {
-    fixture(files: files) { (prefix: String) in
-        let manifest = Manifest(path: Path.join(prefix, "Package.swift"), package: Package(name: "name"), products: [])
-        let package = Package(manifest: manifest, url: prefix)
+private func fixture(files: [RelativePath], file: StaticString = #file, line: UInt = #line, body: @noescape (PackageModel.Package, [Module]) throws -> ()) throws {
+    fixture(files: files) { (prefix: AbsolutePath) in
+        let manifest = Manifest(path: prefix.appending("Package.swift").asString, package: Package(name: "name"), products: [])
+        let package = Package(manifest: manifest, url: prefix.asString)
         let modules = try package.modules()
         try body(package, modules)
     }

--- a/Tests/PackageLoading/ManifestTests.swift
+++ b/Tests/PackageLoading/ManifestTests.swift
@@ -49,7 +49,7 @@ class ManifestTests: XCTestCase {
     let libdir = bundleRoot()
 #else
     let libdir = AbsolutePath(Process.arguments.first!.parentDirectory.abspath)
-    let swiftc = AbsolutePath(Process.arguments.first!.abspath, "../swiftc")
+    let swiftc = AbsolutePath(Process.arguments.first!.abspath).appending("../swiftc")
 #endif
 
     private func loadManifest(_ inputName: RelativePath, line: UInt = #line, body: (Manifest) -> Void) {

--- a/Tests/SourceControl/GitRepositoryTests.swift
+++ b/Tests/SourceControl/GitRepositoryTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import Basic
 import SourceControl
 import Utility
 
@@ -19,21 +20,22 @@ class GitRepositoryTests: XCTestCase {
     /// Test the basic provider functions.
     func testProvider() {
         try! POSIX.mkdtemp(#function) { path in
-            let testRepoPath = Path.join(path, "test-repo")
-            try! Utility.makeDirectories(testRepoPath)
+            let path = AbsolutePath(path)
+            let testRepoPath = path.appending("test-repo")
+            try! Utility.makeDirectories(testRepoPath.asString)
             initGitRepo(testRepoPath, tag: "1.2.3")
 
             // Test the provider.
-            let testCheckoutPath = Path.join(path, "checkout")
+            let testCheckoutPath = path.appending("checkout")
             let provider = GitRepositoryProvider()
-            let repoSpec = RepositorySpecifier(url: testRepoPath)
-            try! provider.fetch(repository: repoSpec, to: testCheckoutPath)
+            let repoSpec = RepositorySpecifier(url: testRepoPath.asString)
+            try! provider.fetch(repository: repoSpec, to: testCheckoutPath.asString)
 
             // Verify the checkout was made.
-            XCTAssert(testCheckoutPath.exists)
+            XCTAssert(testCheckoutPath.asString.exists)
 
             // Test the repository interface.
-            let repository = provider.open(repository: repoSpec, at: testCheckoutPath)
+            let repository = provider.open(repository: repoSpec, at: testCheckoutPath.asString)
             XCTAssertEqual(repository.tags, ["1.2.3"])
         }
     }

--- a/Tests/Utility/GitTests.swift
+++ b/Tests/Utility/GitTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import Basic
 @testable import Utility
 
 class GitMoc: Git {
@@ -36,7 +37,7 @@ class GitUtilityTests: XCTestCase {
     
     func testHeadSha() {
         mktmpdir { dir in
-            initGitRepo(dir)            
+            initGitRepo(dir)
             let sha = Git.Repo(path: dir)?.sha
             checkSha(sha!)
         }
@@ -44,7 +45,7 @@ class GitUtilityTests: XCTestCase {
     
     func testVersionSha() {
         mktmpdir { dir in
-            initGitRepo(dir, tag: "0.1.0") 
+            initGitRepo(dir, tag: "0.1.0")
             let sha = try Git.Repo(path: dir)?.versionSha(tag: "0.1.0")
             checkSha(sha!)
         }
@@ -69,8 +70,8 @@ class GitUtilityTests: XCTestCase {
             let repo = Git.Repo(path: dir)!
             XCTAssertFalse(repo.hasLocalChanges)
 
-            let filePath = Path.join(dir, "file2.swift")
-            try systemQuietly(["touch", filePath])
+            let filePath = dir.appending("file2.swift")
+            try systemQuietly(["touch", filePath.asString])
 
             XCTAssertTrue(repo.hasLocalChanges)
         }
@@ -84,12 +85,12 @@ class GitUtilityTests: XCTestCase {
         XCTAssertEqual(sha.characters.count, 40)
     }
     
-    func commit(_ dstdir: String, file: String) throws {
-        let filePath = Path.join(dstdir, file)
-        try systemQuietly(["touch", filePath])
+    func commit(_ dstdir: AbsolutePath, file: RelativePath) throws {
+        let filePath = dstdir.appending(file)
+        try systemQuietly(["touch", filePath.asString])
 
-        try systemQuietly([Git.tool, "-C", dstdir, "add", "."])
-        try systemQuietly([Git.tool, "-C", dstdir, "commit", "-m", "msg"])
+        try systemQuietly([Git.tool, "-C", dstdir.asString, "add", "."])
+        try systemQuietly([Git.tool, "-C", dstdir.asString, "commit", "-m", "msg"])
     }
 
     static var allTests = [

--- a/Tests/Xcodeproj/GenerateXcodeprojTests.swift
+++ b/Tests/Xcodeproj/GenerateXcodeprojTests.swift
@@ -20,7 +20,6 @@ import XCTest
 class GenerateXcodeprojTests: XCTestCase {
     func testXcodeBuildCanParseIt() {
         mktmpdir { dstdir in
-            let dstdir = AbsolutePath(dstdir)
             func dummy() throws -> [XcodeModuleProtocol] {
                 return [try SwiftModule(name: "DummyModuleName", sources: Sources(paths: [], root: dstdir.asString))]
             }
@@ -38,8 +37,8 @@ class GenerateXcodeprojTests: XCTestCase {
             }
             let outpath = try Xcodeproj.generate(dstdir: dstdir, projectName: projectName, srcroot: srcroot, modules: modules, externalModules: [], products: products, options: Options())
 
-            XCTAssertDirectoryExists(outpath.asString)
-            XCTAssertEqual(outpath, dstdir.appending(RelativePath("\(projectName).xcodeproj")))
+            XCTAssertDirectoryExists(outpath)
+            XCTAssertEqual(outpath, dstdir.appending(projectName + ".xcodeproj"))
 
             // We can only validate this on OS X.
             // Don't allow TOOLCHAINS to be overriden here, as it breaks the test below.


### PR DESCRIPTION
There may be a few more places that should be converted but this should be by far the most of them.