### PR TITLE
Update for SE-0025 ('private' and 'fileprivate')

### DIFF
--- a/Fixtures/DependencyResolution/External/Complex/deck-of-playing-cards/src/Deck.swift
+++ b/Fixtures/DependencyResolution/External/Complex/deck-of-playing-cards/src/Deck.swift
@@ -12,7 +12,7 @@ import FisherYates
 import PlayingCard
 
 public struct Deck {
-    private var cards: [PlayingCard]
+    fileprivate var cards: [PlayingCard]
 
     public static func standard52CardDeck() -> Deck {
         let suits: [Suit] = [.Spades, .Hearts, .Diamonds, .Clubs]

--- a/Fixtures/DependencyResolution/External/IgnoreIndirectTests/deck-of-playing-cards/src/Deck.swift
+++ b/Fixtures/DependencyResolution/External/IgnoreIndirectTests/deck-of-playing-cards/src/Deck.swift
@@ -12,7 +12,7 @@ import FisherYates
 import PlayingCard
 
 public struct Deck {
-    private var cards: [PlayingCard]
+    fileprivate var cards: [PlayingCard]
 
     public static func standard52CardDeck() -> Deck {
         let suits: [Suit] = [.Spades, .Hearts, .Diamonds, .Clubs]

--- a/Sources/Basic/ByteString.swift
+++ b/Sources/Basic/ByteString.swift
@@ -23,7 +23,7 @@
 /// and then convert to a `ByteString` when complete.
 public struct ByteString: ArrayLiteralConvertible {
     /// The buffer contents.
-    private var _bytes: [UInt8]
+    fileprivate var _bytes: [UInt8]
 
     /// Create an empty byte string.
     public init() {

--- a/Sources/Basic/OrderedSet.swift
+++ b/Sources/Basic/OrderedSet.swift
@@ -15,8 +15,8 @@ public struct OrderedSet<E: Hashable>: Equatable, Collection {
     public typealias Index = Int
     public typealias Indices = CountableRange<Int>
 
-    private var array: [Element]
-    private var set: Set<Element>
+    fileprivate var array: [Element]
+    fileprivate var set: Set<Element>
     
     /// Creates an empty ordered set.
     public init() {

--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -311,13 +311,13 @@ public func ==(lhs: RelativePath, rhs: RelativePath) -> Bool {
 /// different.
 private struct PathImpl {
     /// Normalized string of the (absolute or relative) path.  Never empty.
-    private let string: String
+    fileprivate let string: String
     
     /// Private function that returns the directory part of the stored path
     /// string (relying on the fact that it has been normalized).  Returns a
     /// string consisting of just `.` if there is no directory part (which is
     /// the case if and only if there is no path separator).
-    private var dirname: String {
+    fileprivate var dirname: String {
         // FIXME: This method seems too complicated; it should be simplified,
         //        if possible, and certainly optimized (using UTF8View).
         let chars = string.characters
@@ -336,7 +336,7 @@ private struct PathImpl {
         return String(chars.prefix(upTo: idx))
     }
     
-    private var basename: String {
+    fileprivate var basename: String {
         // FIXME: This method seems too complicated; it should be simplified,
         //        if possible, and certainly optimized (using UTF8View).
         let chars = string.characters
@@ -356,7 +356,7 @@ private struct PathImpl {
         return String(chars.suffix(from: chars.index(after: idx)))
     }
     
-    private var suffix: String? {
+    fileprivate var suffix: String? {
         // FIXME: This method seems too complicated; it should be simplified,
         //        if possible, and certainly optimized (using UTF8View).
         let chars = string.characters
@@ -585,11 +585,11 @@ private func normalize(relative string: String) -> String {
 
 /// Private functions for use by the path logic.  These should move out into a
 /// public place, but we'll need to debate the names, etc, etc.
-private extension String.CharacterView {
+extension String.CharacterView {
     
     /// Returns the index of the last occurrence of `char` or nil if none.  If
     /// provided, the `start` index limits the search to a suffix of charview.
-    private func rindex(of char: Character, from start: Index? = nil) -> Index? {
+    fileprivate func rindex(of char: Character, from start: Index? = nil) -> Index? {
         var idx = endIndex
         let firstIdx = start ?? startIndex
         while idx > firstIdx {

--- a/Sources/Basic/TOML.swift
+++ b/Sources/Basic/TOML.swift
@@ -137,7 +137,7 @@ private extension UInt8 {
 ///
 /// This implementation doesn't yet support multi-line strings.
 private struct Lexer {
-    private enum Token {
+    fileprivate enum Token {
         /// Any comment.
         case comment
         /// Any whitespace.

--- a/Sources/Get/Package.swift
+++ b/Sources/Get/Package.swift
@@ -32,7 +32,7 @@ extension Package: Fetchable {
         return manifest.package.dependencies.map{ ($0.url, $0.versionRange) }
     }
 
-    private var versionString: String.CharacterView {
+    fileprivate var versionString: String.CharacterView {
         return path.basename.characters.dropFirst(name.characters.count + 1)
     }
 

--- a/Sources/Get/PackagesDirectory.swift
+++ b/Sources/Get/PackagesDirectory.swift
@@ -29,7 +29,7 @@ class PackagesDirectory {
     }
     
     /// The set of all repositories available within the `Packages` directory, by origin.
-    private lazy var availableRepositories: [String: Git.Repo] = { [unowned self] in
+    fileprivate lazy var availableRepositories: [String: Git.Repo] = { [unowned self] in
         // FIXME: Lift this higher.
         guard localFS.isDirectory(self.prefix) else { return [:] }
 

--- a/Sources/PackageLoading/Manifest+parse.swift
+++ b/Sources/PackageLoading/Manifest+parse.swift
@@ -200,7 +200,7 @@ extension PackageDescription.Package.Dependency {
 }
 
 extension PackageDescription.SystemPackageProvider {
-    private static func fromTOML(_ item: TOMLItem) -> PackageDescription.SystemPackageProvider {
+    fileprivate static func fromTOML(_ item: TOMLItem) -> PackageDescription.SystemPackageProvider {
         guard case .table(let table) = item else { fatalError("unexpected item") }
         guard case .string(let name)? = table.items["name"] else { fatalError("missing name") }
         guard case .string(let value)? = table.items["value"] else { fatalError("missing value") }
@@ -216,7 +216,7 @@ extension PackageDescription.SystemPackageProvider {
 }
 
 extension PackageDescription.Target {
-    private static func fromTOML(_ item: TOMLItem) -> PackageDescription.Target {
+    fileprivate static func fromTOML(_ item: TOMLItem) -> PackageDescription.Target {
         // This is a private API, currently, so we do not currently try and
         // validate the input.
         guard case .table(let table) = item else { fatalError("unexpected item") }
@@ -236,7 +236,7 @@ extension PackageDescription.Target {
 }
 
 extension PackageDescription.Target.Dependency {
-    private static func fromTOML(_ item: TOMLItem) -> PackageDescription.Target.Dependency {
+    fileprivate static func fromTOML(_ item: TOMLItem) -> PackageDescription.Target.Dependency {
         guard case .string(let name) = item else { fatalError("unexpected item") }
         return .Target(name: name)
     }

--- a/Sources/PackageLoading/Module+PkgConfig.swift
+++ b/Sources/PackageLoading/Module+PkgConfig.swift
@@ -54,7 +54,7 @@ extension ModuleProtocol {
 }
 
 private extension SystemPackageProvider {
-    private var installText: String {
+    fileprivate var installText: String {
         switch self {
         case .Brew(let name):
             return "    brew install \(name)\n"

--- a/Sources/PackageLoading/PackageExtensions.swift
+++ b/Sources/PackageLoading/PackageExtensions.swift
@@ -237,7 +237,7 @@ extension Package {
         return modules
     }
     
-    private func modulify(_ path: String, name: String, isTest: Bool) throws -> Module {
+    fileprivate func modulify(_ path: String, name: String, isTest: Bool) throws -> Module {
         let walked = walk(path, recursing: shouldConsiderDirectory).map{ $0 }
         
         let cSources = walked.filter{ isValidSource($0, validExtensions: SupportedLanguageExtension.cFamilyExtensions) }

--- a/Sources/SourceControl/CheckoutManager.swift
+++ b/Sources/SourceControl/CheckoutManager.swift
@@ -38,19 +38,19 @@ public class CheckoutManager {
         ///
         /// This is intentionally hidden from the clients so that the manager is
         /// allowed to move repositories transparently.
-        private let subpath: String
+        fileprivate let subpath: String
 
         /// The status of the repository.
-        private var status: Status = .uninitialized
+        fileprivate var status: Status = .uninitialized
 
         /// Create a handle.
-        private init(manager: CheckoutManager, subpath: String) {
+        fileprivate init(manager: CheckoutManager, subpath: String) {
             self.manager = manager
             self.subpath = subpath
         }
 
         /// Create a handle from JSON data.
-        private init?(manager: CheckoutManager, json data: JSON) {
+        fileprivate init?(manager: CheckoutManager, json data: JSON) {
             guard case let .dictionary(contents) = data,
                   case let .string(subpath)? = contents["subpath"],
                   case let .string(statusString)? = contents["status"],
@@ -89,7 +89,7 @@ public class CheckoutManager {
 
         // MARK: Persistence
 
-        private func toJSON() -> JSON {
+        fileprivate func toJSON() -> JSON {
             return .dictionary([
                     "status": .string(status.rawValue),
                     "subpath": .string(subpath)

--- a/Sources/Utility/Path.swift
+++ b/Sources/Utility/Path.swift
@@ -278,7 +278,7 @@ extension String {
     }
 
     /// - Returns: Ensures single path separators in a path string, and removes trailing slashes.
-    private var onesep: String {
+    fileprivate var onesep: String {
         // Fast path, for already clean strings.
         //
         // It would be more efficient to avoid scrubbing every string that

--- a/Sources/Utility/walk.swift
+++ b/Sources/Utility/walk.swift
@@ -62,9 +62,9 @@ public func walk(_ paths: String..., recursing: (String) -> Bool) -> RecursibleD
 */
 private class DirectoryContentsGenerator: IteratorProtocol {
     private let dirptr: DirHandle?
-    private let path: String
+    fileprivate let path: String
 
-    private init(path: String) {
+    fileprivate init(path: String) {
         let path = path.normpath
         dirptr = libc.opendir(path)
         self.path = path

--- a/Tests/Functional/ClangModuleTests.swift
+++ b/Tests/Functional/ClangModuleTests.swift
@@ -14,7 +14,7 @@ import PackageModel
 import Utility
 
 extension String {
-    private var soname: String {
+    fileprivate var soname: String {
         return "lib\(self).\(Product.dynamicLibraryExtension)"
     }
 }

--- a/Tests/Get/VersionGraphTests.swift
+++ b/Tests/Get/VersionGraphTests.swift
@@ -376,7 +376,7 @@ private func ==(lhs: MockCheckout, rhs: MockCheckout) -> Bool {
 }
 
 private class _MockFetcher: Fetcher {
-    private typealias T = MockCheckout
+    typealias T = MockCheckout
 
     func find(url: String) throws -> Fetchable? {
         return nil

--- a/Tests/PackageLoading/ModuleDependencyTests.swift
+++ b/Tests/PackageLoading/ModuleDependencyTests.swift
@@ -170,11 +170,11 @@ class ModuleDependencyTests: XCTestCase {
 }
 
 private extension Module {
-    private func depends(on target: Module) {
+    fileprivate func depends(on target: Module) {
         dependencies.append(target)
     }
     
-    private var recursiveDeps: [Module] {
+    fileprivate var recursiveDeps: [Module] {
         // FIXME: Eliminate this, it is a bad historical artifact.
         return recursiveDependencies.reversed()
     }


### PR DESCRIPTION
[SE-0025](https://github.com/apple/swift-evolution/blob/master/proposals/0025-scoped-access-level.md) makes `private` restrict access to a lexical scope; the Swift 2 behavior is now named `fileprivate`. At the time of this pull request, the compiler treats both `private` and `fileprivate` as having `fileprivate` semantics, but that will soon change.

Supersedes #410; the latest amendment to SE-0025 permits some accesses that the original model (or at least our interpretation of it) would have forbidden. I made my changes by hand without compiler aid, though, so it's possible I missed a case.