### PR TITLE
[Basic] Rename FSProxy to FileSystem.

### DIFF
--- a/Sources/Basic/FileSystem.swift
+++ b/Sources/Basic/FileSystem.swift
@@ -12,7 +12,7 @@ import POSIX
 import libc
 
 
-public enum FSProxyError: ErrorProtocol {
+public enum FileSystemError: ErrorProtocol {
     /// Access to the path is denied.
     ///
     /// This is used when an operation cannot be completed because a component of
@@ -61,7 +61,7 @@ public enum FSProxyError: ErrorProtocol {
     case unknownOSError
 }
 
-private extension FSProxyError {
+private extension FileSystemError {
     init(errno: Int32) {
         switch errno {
         case libc.EACCES:
@@ -87,7 +87,7 @@ private extension FSProxyError {
 /// NOTE: All of these APIs are synchronous and can block.
 //
 // FIXME: Design an asynchronous story?
-public protocol FSProxy {
+public protocol FileSystem {
     /// Check whether the given path exists and is accessible.
     func exists(_ path: AbsolutePath) -> Bool
     
@@ -123,7 +123,7 @@ public protocol FSProxy {
 
 /// Convenience implementations (default arguments aren't permitted in protocol
 /// methods).
-public extension FSProxy {
+public extension FileSystem {
     /// Default implementation of createDirectory(_:)
     mutating func createDirectory(_ path: AbsolutePath) throws {
         try createDirectory(path, recursive: false)
@@ -131,7 +131,7 @@ public extension FSProxy {
 }
 
 /// Temporary shims during String -> Path transition.
-public extension FSProxy {
+public extension FileSystem {
     func exists(_ path: String) -> Bool {
         return exists(AbsolutePath(path))
     }
@@ -155,8 +155,8 @@ public extension FSProxy {
     }
 }
 
-/// Concrete FSProxy implementation which communicates with the local file system.
-private class LocalFS: FSProxy {
+/// Concrete FileSystem implementation which communicates with the local file system.
+private class LocalFileSystem: FileSystem {
     func exists(_ path: AbsolutePath) -> Bool {
         return (try? stat(path.asString)) != nil
     }
@@ -172,7 +172,7 @@ private class LocalFS: FSProxy {
     
     func getDirectoryContents(_ path: AbsolutePath) throws -> [String] {
         guard let dir = libc.opendir(path.asString) else {
-            throw FSProxyError(errno: errno)
+            throw FileSystemError(errno: errno)
         }
         defer { _ = libc.closedir(dir) }
         
@@ -184,7 +184,7 @@ private class LocalFS: FSProxy {
             if readdir_r(dir, &entry, &entryPtr) < 0 {
                 // FIXME: Are there ever situation where we would want to
                 // continue here?
-                throw FSProxyError(errno: errno)
+                throw FileSystemError(errno: errno)
             }
             
             // If the entry pointer is null, we reached the end of the directory.
@@ -197,7 +197,7 @@ private class LocalFS: FSProxy {
             
             // Add the entry to the result.
             guard let name = entry.name else {
-                throw FSProxyError.invalidEncoding
+                throw FileSystemError.invalidEncoding
             }
             
             // Ignore the pseudo-entries.
@@ -232,7 +232,7 @@ private class LocalFS: FSProxy {
             try createDirectory(path, recursive: false)
         } else {
             // Otherwise, we failed due to some other error. Report it.
-            throw FSProxyError(errno: errno)
+            throw FileSystemError(errno: errno)
         }
     }
     
@@ -240,7 +240,7 @@ private class LocalFS: FSProxy {
         // Open the file.
         let fp = fopen(path.asString, "rb")
         if fp == nil {
-            throw FSProxyError(errno: errno)
+            throw FileSystemError(errno: errno)
         }
         defer { fclose(fp) }
 
@@ -251,11 +251,11 @@ private class LocalFS: FSProxy {
             let n = fread(&tmpBuffer, 1, tmpBuffer.count, fp)
             if n < 0 {
                 if errno == EINTR { continue }
-                throw FSProxyError.ioError
+                throw FileSystemError.ioError
             }
             if n == 0 {
                 if ferror(fp) != 0 {
-                    throw FSProxyError.ioError
+                    throw FileSystemError.ioError
                 }
                 break
             }
@@ -269,7 +269,7 @@ private class LocalFS: FSProxy {
         // Open the file.
         let fp = fopen(path.asString, "wb")
         if fp == nil {
-            throw FSProxyError(errno: errno)
+            throw FileSystemError(errno: errno)
         }
         defer { fclose(fp) }
 
@@ -279,20 +279,20 @@ private class LocalFS: FSProxy {
             let n = fwrite(&contents, 1, contents.count, fp)
             if n < 0 {
                 if errno == EINTR { continue }
-                throw FSProxyError.ioError
+                throw FileSystemError.ioError
             }
             if n != contents.count {
-                throw FSProxyError.ioError
+                throw FileSystemError.ioError
             }
             break
         }
     }
 }
 
-/// Concrete FSProxy implementation which simulates an empty disk.
+/// Concrete FileSystem implementation which simulates an empty disk.
 //
 // FIXME: This class does not yet support concurrent mutation safely.
-public class PseudoFS: FSProxy {
+public class PseudoFS: FileSystem {
     private class Node {
         /// The actual node data.
         let contents: NodeContents
@@ -302,8 +302,8 @@ public class PseudoFS: FSProxy {
         }
     }
     private enum NodeContents {
-        case File(ByteString)
-        case Directory(DirectoryContents)
+        case file(ByteString)
+        case directory(DirectoryContents)
     }    
     private class DirectoryContents {
         var entries:  [String: Node]
@@ -317,7 +317,7 @@ public class PseudoFS: FSProxy {
     private var root: Node
 
     public init() {
-        root = Node(.Directory(DirectoryContents()))
+        root = Node(.directory(DirectoryContents()))
     }
 
     /// Get the node corresponding to get given path.
@@ -334,8 +334,8 @@ public class PseudoFS: FSProxy {
             }
 
             // If we didn't find a directory, this is an error.
-            guard case .Directory(let contents) = parent.contents else {
-                throw FSProxyError.notDirectory
+            guard case .directory(let contents) = parent.contents else {
+                throw FileSystemError.notDirectory
             }
 
             // Return the directory entry.
@@ -346,7 +346,7 @@ public class PseudoFS: FSProxy {
         return try getNodeInternal(path)
     }
 
-    // MARK: FSProxy Implementation
+    // MARK: FileSystem Implementation
     
     public func exists(_ path: AbsolutePath) -> Bool {
         do {
@@ -358,7 +358,7 @@ public class PseudoFS: FSProxy {
     
     public func isDirectory(_ path: AbsolutePath) -> Bool {
         do {
-            if case .Directory? = try getNode(path)?.contents {
+            if case .directory? = try getNode(path)?.contents {
                 return true
             }
             return false
@@ -369,10 +369,10 @@ public class PseudoFS: FSProxy {
     
     public func getDirectoryContents(_ path: AbsolutePath) throws -> [String] {
         guard let node = try getNode(path) else {
-            throw FSProxyError.noEntry
+            throw FileSystemError.noEntry
         }
-        guard case .Directory(let contents) = node.contents else {
-            throw FSProxyError.notDirectory
+        guard case .directory(let contents) = node.contents else {
+            throw FileSystemError.notDirectory
         }
 
         // FIXME: Perhaps we should change the protocol to allow lazy behavior.
@@ -393,22 +393,22 @@ public class PseudoFS: FSProxy {
                 return try createDirectory(path, recursive: false)
             } else {
                 // Otherwise, we failed.
-                throw FSProxyError.noEntry
+                throw FileSystemError.noEntry
             }
         }
 
         // Check that the parent is a directory.
-        guard case .Directory(let contents) = parent.contents else {
+        guard case .directory(let contents) = parent.contents else {
             // The parent isn't a directory, this is an error.
-            throw FSProxyError.notDirectory
+            throw FileSystemError.notDirectory
         }
         
         // Check if the node already exists.
         if let node = contents.entries[path.basename] {
             // Verify it is a directory.
-            guard case .Directory = node.contents else {
+            guard case .directory = node.contents else {
                 // The path itself isn't a directory, this is an error.
-                throw FSProxyError.notDirectory
+                throw FileSystemError.notDirectory
             }
 
             // We are done.
@@ -416,19 +416,19 @@ public class PseudoFS: FSProxy {
         }
 
         // Otherwise, the node does not exist, create it.
-        contents.entries[path.basename] = Node(.Directory(DirectoryContents()))
+        contents.entries[path.basename] = Node(.directory(DirectoryContents()))
     }
 
     public func readFileContents(_ path: AbsolutePath) throws -> ByteString {
         // Get the node.
         guard let node = try getNode(path) else {
-            throw FSProxyError.noEntry
+            throw FileSystemError.noEntry
         }
 
         // Check that the node is a file.
-        guard case .File(let contents) = node.contents else {
+        guard case .file(let contents) = node.contents else {
             // The path is a directory, this is an error.
-            throw FSProxyError.isDirectory
+            throw FileSystemError.isDirectory
         }
 
         // Return the file contents.
@@ -439,33 +439,33 @@ public class PseudoFS: FSProxy {
         // It is an error if this is the root node.
         let parentPath = path.parentDirectory
         guard path != parentPath else {
-            throw FSProxyError.isDirectory
+            throw FileSystemError.isDirectory
         }
             
         // Get the parent node.
         guard let parent = try getNode(parentPath) else {
-            throw FSProxyError.noEntry
+            throw FileSystemError.noEntry
         }
 
         // Check that the parent is a directory.
-        guard case .Directory(let contents) = parent.contents else {
+        guard case .directory(let contents) = parent.contents else {
             // The parent isn't a directory, this is an error.
-            throw FSProxyError.notDirectory
+            throw FileSystemError.notDirectory
         }
 
         // Check if the node exists.
         if let node = contents.entries[path.basename] {
             // Verify it is a file.
-            guard case .File = node.contents else {
+            guard case .file = node.contents else {
                 // The path is a directory, this is an error.
-                throw FSProxyError.isDirectory
+                throw FileSystemError.isDirectory
             }
         }
 
         // Write the file.
-        contents.entries[path.basename] = Node(.File(bytes))
+        contents.entries[path.basename] = Node(.file(bytes))
     }
 }
 
 /// Public access to the local FS proxy.
-public var localFS: FSProxy = LocalFS()
+public var localFileSystem: FileSystem = LocalFileSystem()

--- a/Sources/Basic/TemporaryFile.swift
+++ b/Sources/Basic/TemporaryFile.swift
@@ -43,7 +43,7 @@ private func determineTempDirectory(_ dir: AbsolutePath? = nil) -> AbsolutePath 
     // FIXME: Add other platform specific locations.
     let tmpDir = dir ?? cachedTempDirectory
     // FIXME: This is a runtime condition, so it should throw and not crash.
-    precondition(localFS.isDirectory(tmpDir))
+    precondition(localFileSystem.isDirectory(tmpDir))
     return tmpDir
 }
 
@@ -116,8 +116,9 @@ extension TemporaryFile: CustomStringConvertible {
     }
 }
 
-// FIXME: This isn't right place to declare this, probably POSIX or merge with FSProxyError?
 /// Contains the error which can be thrown while creating a directory using POSIX's mkdir.
+//
+// FIXME: This isn't right place to declare this, probably POSIX or merge with FileSystemError?
 public enum MakeDirectoryError: ErrorProtocol {
     /// The given path already exists as a directory, file or symbolic link.
     case pathExists

--- a/Sources/Build/Command.link(SwiftModule).swift
+++ b/Sources/Build/Command.link(SwiftModule).swift
@@ -63,8 +63,8 @@ extension Command {
             // TODO should be llbuild rules∫
             if conf == .debug {
                 let infoPlistPath = Path.join(outpath.parentDirectory.parentDirectory, "Info.plist")
-                try localFS.createDirectory(outpath.parentDirectory, recursive: true)
-                try localFS.writeFileContents(infoPlistPath, bytes: ByteString(encodingAsUTF8: product.Info.plist))
+                try localFileSystem.createDirectory(outpath.parentDirectory, recursive: true)
+                try localFileSystem.writeFileContents(infoPlistPath, bytes: ByteString(encodingAsUTF8: product.Info.plist))
             }
           #else
             // HACK: To get a path to LinuxMain.swift, we just grab the

--- a/Sources/Build/PackageVersion.swift
+++ b/Sources/Build/PackageVersion.swift
@@ -18,7 +18,7 @@ public func generateVersionData(_ rootDir: String, rootPackage: Package, externa
     precondition(rootDir.isAbsolute)
     
     let dirPath = Path.join(rootDir, ".build/versionData")
-    try localFS.createDirectory(dirPath, recursive: true)
+    try localFileSystem.createDirectory(dirPath, recursive: true)
 
     try saveRootPackage(dirPath, package: rootPackage)
     for (pkgName, data) in generateData(externalPackages) {
@@ -75,5 +75,5 @@ func versionData(package: Package) -> String {
 
 private func saveVersionData(_ dirPath: String, packageName: String, data: String) throws {
     let filePath = Path.join(dirPath, "\(packageName).swift")
-    try localFS.writeFileContents(filePath, bytes: ByteString(encodingAsUTF8: data))
+    try localFileSystem.writeFileContents(filePath, bytes: ByteString(encodingAsUTF8: data))
 }

--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -101,7 +101,7 @@ public func describe(_ prefix: String, _ conf: Configuration, _ modules: [Module
 private func write(path: String, write: (OutputByteStream) -> Void) throws -> String {
     let stream = OutputByteStream()
     write(stream)
-    try localFS.writeFileContents(path, bytes: stream.bytes)
+    try localFileSystem.writeFileContents(path, bytes: stream.bytes)
     return path
 }
 

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -191,8 +191,8 @@ public struct SwiftPackageTool: SwiftTool {
                             
             case .update:
                 // Attempt to ensure that none of the repositories are modified.
-                if localFS.exists(opts.path.packages) {
-                    for name in try localFS.getDirectoryContents(opts.path.packages) {
+                if localFileSystem.exists(opts.path.packages) {
+                    for name in try localFileSystem.getDirectoryContents(opts.path.packages) {
                         let item = opts.path.packages.appending(RelativePath(name))
 
                         // Only look at repositories.

--- a/Sources/Commands/init.swift
+++ b/Sources/Commands/init.swift
@@ -14,7 +14,7 @@ import POSIX
 
 import func Utility.makeDirectories
 
-private extension FSProxy {
+private extension FileSystem {
     /// Write to a file from a stream producer.
     mutating func writeFileContents(_ path: AbsolutePath, body: @noescape (OutputByteStream) -> ()) throws {
         let contents = OutputByteStream()
@@ -76,7 +76,7 @@ final class InitPackage {
 
     private func writePackageFile(_ path: AbsolutePath, body: @noescape (OutputByteStream) -> ()) throws {
         print("Creating \(path.relative(to: rootd).asString)")
-        try localFS.writeFileContents(path, body: body)
+        try localFileSystem.writeFileContents(path, body: body)
     }
     
     private func writeManifestFile() throws {

--- a/Sources/Get/PackagesDirectory.swift
+++ b/Sources/Get/PackagesDirectory.swift
@@ -30,10 +30,10 @@ class PackagesDirectory {
     /// The set of all repositories available within the `Packages` directory, by origin.
     fileprivate lazy var availableRepositories: [String: Git.Repo] = { [unowned self] in
         // FIXME: Lift this higher.
-        guard localFS.isDirectory(self.prefix) else { return [:] }
+        guard localFileSystem.isDirectory(self.prefix) else { return [:] }
 
         var result = Dictionary<String, Git.Repo>()
-        for name in try! localFS.getDirectoryContents(self.prefix) {
+        for name in try! localFileSystem.getDirectoryContents(self.prefix) {
             let prefix = self.prefix.appending(RelativePath(name))
             guard let repo = Git.Repo(path: prefix), let origin = repo.origin else { continue } // TODO: Warn user.
             result[origin] = repo

--- a/Sources/PackageLoading/Manifest+parse.swift
+++ b/Sources/PackageLoading/Manifest+parse.swift
@@ -95,7 +95,7 @@ private func parse(path manifestPath: String, swiftc: String, libdir: String) th
         throw ManifestParseError.invalidManifestFormat
     }
 
-    guard let toml = try localFS.readFileContents(filePath).asString else {
+    guard let toml = try localFileSystem.readFileContents(filePath).asString else {
         throw ManifestParseError.invalidEncoding
     }
     try Utility.removeFileTree(filePath) // Delete the temp file after reading it

--- a/Sources/PackageLoading/ModuleMapGeneration.swift
+++ b/Sources/PackageLoading/ModuleMapGeneration.swift
@@ -83,7 +83,7 @@ extension ClangModule {
             return
         }
         
-        let walked = try localFS.getDirectoryContents(includeDir).map{ Path.join(includeDir, $0) }
+        let walked = try localFileSystem.getDirectoryContents(includeDir).map{ Path.join(includeDir, $0) }
         
         let files = walked.filter{$0.isFile && $0.hasSuffix(".h")}
         let dirs = walked.filter{$0.isDirectory}

--- a/Sources/SourceControl/CheckoutManager.swift
+++ b/Sources/SourceControl/CheckoutManager.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import var Basic.localFS
+import var Basic.localFileSystem
 import struct Basic.ByteString
 import enum Basic.JSON
 import Utility
@@ -252,7 +252,7 @@ public class CheckoutManager {
             })
 
         // FIXME: This should write atomically.
-        try localFS.writeFileContents(statePath, bytes: JSON.dictionary(data).toBytes())
+        try localFileSystem.writeFileContents(statePath, bytes: JSON.dictionary(data).toBytes())
     }
 }
 

--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -133,7 +133,7 @@ func open(_ path: AbsolutePath, body: ((String) -> Void) throws -> Void) throws 
         }
     }
     // Write the real file.
-    try localFS.writeFileContents(path.asString, bytes: stream.bytes)
+    try localFileSystem.writeFileContents(path.asString, bytes: stream.bytes)
 }
 
 /// Finds directories that will be added as blue folder

--- a/Tests/Basic/TemporaryFileTests.swift
+++ b/Tests/Basic/TemporaryFileTests.swift
@@ -68,38 +68,38 @@ class TemporaryFileTests: XCTestCase {
         var path: AbsolutePath
         do {
             let tempDir = try TemporaryDirectory()
-            XCTAssertTrue(localFS.isDirectory(tempDir.path))
+            XCTAssertTrue(localFileSystem.isDirectory(tempDir.path))
             path = tempDir.path
         }
-        XCTAssertFalse(localFS.isDirectory(path))
+        XCTAssertFalse(localFileSystem.isDirectory(path))
 
         // Test temp directory is not removed when its not empty. 
         do {
             let tempDir = try TemporaryDirectory()
-            XCTAssertTrue(localFS.isDirectory(tempDir.path))
+            XCTAssertTrue(localFileSystem.isDirectory(tempDir.path))
             // Create a file inside the temp directory.
             let filePath = tempDir.path.appending("somefile").asString
-            try localFS.writeFileContents(filePath, bytes: ByteString())
+            try localFileSystem.writeFileContents(filePath, bytes: ByteString())
             path = tempDir.path
         }
-        XCTAssertTrue(localFS.isDirectory(path))
+        XCTAssertTrue(localFileSystem.isDirectory(path))
         // Cleanup.
       #if os(Linux)
         try FileManager.default().removeItem(atPath: path.asString)
       #else
         try FileManager.default.removeItem(atPath: path.asString)
       #endif
-        XCTAssertFalse(localFS.isDirectory(path))
+        XCTAssertFalse(localFileSystem.isDirectory(path))
 
         // Test temp directory is removed when its not empty and removeTreeOnDeinit is enabled.
         do {
             let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
-            XCTAssertTrue(localFS.isDirectory(tempDir.path))
+            XCTAssertTrue(localFileSystem.isDirectory(tempDir.path))
             let filePath = tempDir.path.appending("somefile").asString
-            try localFS.writeFileContents(filePath, bytes: ByteString())
+            try localFileSystem.writeFileContents(filePath, bytes: ByteString())
             path = tempDir.path
         }
-        XCTAssertFalse(localFS.isDirectory(path))
+        XCTAssertFalse(localFileSystem.isDirectory(path))
     }
 
     func testCanCreateUniqueTempDirectories() throws {
@@ -108,15 +108,15 @@ class TemporaryFileTests: XCTestCase {
         do {
             let one = try TemporaryDirectory()
             let two = try TemporaryDirectory()
-            XCTAssertTrue(localFS.isDirectory(one.path))
-            XCTAssertTrue(localFS.isDirectory(two.path))
+            XCTAssertTrue(localFileSystem.isDirectory(one.path))
+            XCTAssertTrue(localFileSystem.isDirectory(two.path))
             // Their paths should be different.
             XCTAssertTrue(one.path != two.path)
             pathOne = one.path
             pathTwo = two.path
         }
-        XCTAssertFalse(localFS.isDirectory(pathOne))
-        XCTAssertFalse(localFS.isDirectory(pathTwo))
+        XCTAssertFalse(localFileSystem.isDirectory(pathOne))
+        XCTAssertFalse(localFileSystem.isDirectory(pathTwo))
     }
 
     static var allTests = [

--- a/Tests/Basic/XCTestManifests.swift
+++ b/Tests/Basic/XCTestManifests.swift
@@ -14,20 +14,20 @@ import XCTest
 public func allTests() -> [XCTestCaseEntry] {
     return [
         testCase(ByteStringTests.allTests),
-        testCase(JSONTests.allTests),
-        testCase(FSProxyTests.allTests),
+        testCase(FileSystemTests.allTests),
         testCase(GraphAlgorithmsTests.allTests),
+        testCase(JSONTests.allTests),
         testCase(LazyCacheTests.allTests),
         testCase(LockTests.allTests),
-        testCase(OrderedSetTests.allTests),
         testCase(OptionParserTests.allTests),
+        testCase(OrderedSetTests.allTests),
         testCase(OutputByteStreamTests.allTests),
         testCase(PathTests.allTests),
+        testCase(StringConversionTests.allTests),
+        testCase(SyncronizedQueueTests.allTests),
         testCase(TOMLTests.allTests),
         testCase(TemporaryFileTests.allTests),
         testCase(ThreadTests.allTests),
-        testCase(StringConversionTests.allTests),
-        testCase(SyncronizedQueueTests.allTests),
     ]
 }
 #endif

--- a/Tests/Functional/MiscellaneousTests.swift
+++ b/Tests/Functional/MiscellaneousTests.swift
@@ -278,7 +278,7 @@ class MiscellaneousTestCase: XCTestCase {
             // llbuild does not realize the file has changed
             sleep(1)
 
-            try localFS.writeFileContents(prefix.appending("Bar/Bar.swift").asString, bytes: "public let bar = \"Goodbye\"\n")
+            try localFileSystem.writeFileContents(prefix.appending("Bar/Bar.swift").asString, bytes: "public let bar = \"Goodbye\"\n")
 
             XCTAssertBuilds(prefix)
             output = try popen(execpath)
@@ -302,7 +302,7 @@ class MiscellaneousTestCase: XCTestCase {
             // llbuild does not realize the file has changed
             sleep(1)
 
-            try localFS.writeFileContents(prefix.appending("app/Packages/FisherYates-1.2.3/src/Fisher-Yates_Shuffle.swift").asString, bytes: "public extension Collection{ func shuffle() -> [Iterator.Element] {return []} }\n\npublic extension MutableCollection where Index == Int { mutating func shuffleInPlace() { for (i, _) in enumerated() { self[i] = self[0] } }}\n\npublic let shuffle = true")
+            try localFileSystem.writeFileContents(prefix.appending("app/Packages/FisherYates-1.2.3/src/Fisher-Yates_Shuffle.swift").asString, bytes: "public extension Collection{ func shuffle() -> [Iterator.Element] {return []} }\n\npublic extension MutableCollection where Index == Int { mutating func shuffleInPlace() { for (i, _) in enumerated() { self[i] = self[0] } }}\n\npublic let shuffle = true")
 
             XCTAssertBuilds(prefix.appending("app"))
             output = try popen(execpath)
@@ -326,7 +326,7 @@ class MiscellaneousTestCase: XCTestCase {
             // llbuild does not realize the file has changed
             sleep(1)
 
-            try localFS.writeFileContents(prefix.appending("root/Packages/dep1-1.2.3/Foo.swift").asString, bytes: "public let foo = \"Goodbye\"")
+            try localFileSystem.writeFileContents(prefix.appending("root/Packages/dep1-1.2.3/Foo.swift").asString, bytes: "public let foo = \"Goodbye\"")
 
             XCTAssertBuilds(prefix.appending("root"))
             output = try popen(execpath)
@@ -366,12 +366,12 @@ class MiscellaneousTestCase: XCTestCase {
 
     func testInitPackageNonc99Directory() throws {
         let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
-        XCTAssertTrue(localFS.isDirectory(tempDir.path))
+        XCTAssertTrue(localFileSystem.isDirectory(tempDir.path))
 
         // Create a directory with non c99name.
         let packageRoot = tempDir.path.appending("some-package")
-        try localFS.createDirectory(packageRoot)
-        XCTAssertTrue(localFS.isDirectory(packageRoot))
+        try localFileSystem.createDirectory(packageRoot)
+        XCTAssertTrue(localFileSystem.isDirectory(packageRoot))
 
         // Run package init.
         _ = try SwiftPMProduct.SwiftPackage.execute(["init"], chdir: packageRoot, env: [:], printIfError: true)

--- a/Tests/Functional/Utilities.swift
+++ b/Tests/Functional/Utilities.swift
@@ -65,7 +65,7 @@ func fixture(name fixtureSubpath: RelativePath, tags: [String] = [], file: Stati
                 }
                 
                 // Copy each of the package directories and construct a git repo in it.
-                for fileName in try! localFS.getDirectoryContents(fixtureDir).sorted() {
+                for fileName in try! localFileSystem.getDirectoryContents(fixtureDir).sorted() {
                     let srcDir = fixtureDir.appending(fileName)
                     guard srcDir.asString.isDirectory else { continue }
                     let dstDir = tmpDir.appending(fileName)

--- a/Tests/Functional/ValidLayoutTests.swift
+++ b/Tests/Functional/ValidLayoutTests.swift
@@ -119,7 +119,7 @@ extension ValidLayoutsTestCase {
 
         // 2. Move everything to a directory called "Sources"
         fixture(name: name, file: #file, line: line) { prefix in
-            let files = try! localFS.getDirectoryContents(prefix).filter{ $0.basename != "Package.swift" }
+            let files = try! localFileSystem.getDirectoryContents(prefix).filter{ $0.basename != "Package.swift" }
             let dir = prefix.appending("Sources")
             try Utility.makeDirectories(dir.asString)
             for file in files {
@@ -130,7 +130,7 @@ extension ValidLayoutsTestCase {
 
         // 3. Symlink some other directory to a directory called "Sources"
         fixture(name: name, file: #file, line: line) { prefix in
-            let files = try! localFS.getDirectoryContents(prefix).filter{ $0.basename != "Package.swift" }
+            let files = try! localFileSystem.getDirectoryContents(prefix).filter{ $0.basename != "Package.swift" }
             let dir = prefix.appending("Floobles")
             try Utility.makeDirectories(dir.asString)
             for file in files {

--- a/Tests/Xcodeproj/FunctionalTests.swift
+++ b/Tests/Xcodeproj/FunctionalTests.swift
@@ -129,7 +129,7 @@ class FunctionalTests: XCTestCase {
 func write(path: AbsolutePath, write: (OutputByteStream) -> Void) throws {
     let stream = OutputByteStream()
     write(stream)
-    try localFS.writeFileContents(path, bytes: stream.bytes)
+    try localFileSystem.writeFileContents(path, bytes: stream.bytes)
 }
 
 func XCTAssertXcodeBuild(project: AbsolutePath, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
 - This is more appropriate given that we want it to be our pervasive, uniform
   API for accessing the file system. I'm not sure why I didn't just call it
   that in the first place...