### PR TITLE
Rename *LiteralConvertible conformances to ExpressibleBy*Literal

### DIFF
--- a/Fixtures/DependencyResolution/External/Complex/deck-of-playing-cards/src/Deck.swift
+++ b/Fixtures/DependencyResolution/External/Complex/deck-of-playing-cards/src/Deck.swift
@@ -43,9 +43,9 @@ public struct Deck {
     }
 }
 
-// MARK: - ArrayLiteralConvertible
+// MARK: - ExpressibleByArrayLiteral
 
-extension Deck : ArrayLiteralConvertible {
+extension Deck : ExpressibleByArrayLiteral {
     public init(arrayLiteral elements: PlayingCard...) {
         self.init(elements)
     }

--- a/Fixtures/DependencyResolution/External/IgnoreIndirectTests/deck-of-playing-cards/src/Deck.swift
+++ b/Fixtures/DependencyResolution/External/IgnoreIndirectTests/deck-of-playing-cards/src/Deck.swift
@@ -43,9 +43,9 @@ public struct Deck {
     }
 }
 
-// MARK: - ArrayLiteralConvertible
+// MARK: - ExpressibleByArrayLiteral
 
-extension Deck : ArrayLiteralConvertible {
+extension Deck : ExpressibleByArrayLiteral {
     public init(arrayLiteral elements: PlayingCard...) {
         self.init(elements)
     }

--- a/Sources/Basic/ByteString.swift
+++ b/Sources/Basic/ByteString.swift
@@ -21,7 +21,7 @@
 /// strings or and by eliminating wasted space in growable arrays). For
 /// construction of byte arrays, clients should use the `OutputByteStream` class
 /// and then convert to a `ByteString` when complete.
-public struct ByteString: ArrayLiteralConvertible {
+public struct ByteString: ExpressibleByArrayLiteral {
     /// The buffer contents.
     fileprivate var _bytes: [UInt8]
 
@@ -119,7 +119,7 @@ extension ByteString: ByteStreamable {
 }
 
 /// StringLiteralConvertable conformance for a ByteString.
-extension ByteString: StringLiteralConvertible {
+extension ByteString: ExpressibleByStringLiteral {
     public typealias UnicodeScalarLiteralType = StringLiteralType
     public typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
 

--- a/Sources/Basic/OrderedSet.swift
+++ b/Sources/Basic/OrderedSet.swift
@@ -79,7 +79,7 @@ public struct OrderedSet<E: Hashable>: Equatable, Collection {
     }
 }
 
-extension OrderedSet: ArrayLiteralConvertible {
+extension OrderedSet: ExpressibleByArrayLiteral {
     /// Create an instance initialized with `elements`.
     ///
     /// If an element occurs more than once in `element`, only the first one

--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -158,9 +158,9 @@ public struct AbsolutePath {
     }
 }
 
-/// Adoption of the StringLiteralConvertible protocol allows literal strings
+/// Adoption of the ExpressibleByStringLiteral protocol allows literal strings
 /// to be implicitly converted to AbsolutePaths.
-extension AbsolutePath : StringLiteralConvertible {
+extension AbsolutePath : ExpressibleByStringLiteral {
     public typealias UnicodeScalarLiteralType = StringLiteralType
     public typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
     public init(stringLiteral value: String) {
@@ -245,9 +245,9 @@ public struct RelativePath {
     }
 }
 
-/// Adoption of the StringLiteralConvertible protocol allows literal strings
+/// Adoption of the ExpressibleByStringLiteral protocol allows literal strings
 /// to be implicitly converted to RelativePaths.
-extension RelativePath : StringLiteralConvertible {
+extension RelativePath : ExpressibleByStringLiteral {
     public typealias UnicodeScalarLiteralType = StringLiteralType
     public typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
     public init(stringLiteral value: String) {

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -53,9 +53,9 @@ extension Target: TOMLConvertible {
     }
 }
 
-// MARK: StringLiteralConvertible
+// MARK: ExpressibleByStringLiteral
 
-extension Target.Dependency : StringLiteralConvertible {
+extension Target.Dependency : ExpressibleByStringLiteral {
   public init(unicodeScalarLiteral value: String) {
     self = .Target(name: value)
   }

--- a/Sources/PackageDescription/Version+StringLiteralConvertible.swift
+++ b/Sources/PackageDescription/Version+StringLiteralConvertible.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-extension Version: StringLiteralConvertible {
+extension Version: ExpressibleByStringLiteral {
 
     public init(stringLiteral value: String) {
         self.init(value.characters)!

--- a/Tests/Basic/ByteStringTests.swift
+++ b/Tests/Basic/ByteStringTests.swift
@@ -30,7 +30,7 @@ class ByteStringTests: XCTestCase {
 
         XCTAssertEqual(ByteString("A").contents, [65])
 
-        // Test StringLiteralConvertible initialization.
+        // Test ExpressibleByStringLiteral initialization.
         XCTAssertEqual(ByteString([65]), "A")
     }
 


### PR DESCRIPTION
In accordance with SE-0115 and apple/swift#3474.