### PR TITLE
[PackageDescription] Make Package `name` required.

### DIFF
--- a/Fixtures/DependencyResolution/Internal/Complex/Package.swift
+++ b/Fixtures/DependencyResolution/Internal/Complex/Package.swift
@@ -1,6 +1,7 @@
 import PackageDescription
 
 let package = Package(
+    name: "Complex",
     targets: [
         Target(
             name: "Foo",

--- a/Fixtures/DependencyResolution/Internal/Simple/Package.swift
+++ b/Fixtures/DependencyResolution/Internal/Simple/Package.swift
@@ -1,6 +1,8 @@
 import PackageDescription
 
-let package = Package(targets: [
-    Target(name: "Foo", dependencies: [.Target(name: "Bar")])
-])
+let package = Package(
+    name: "Simple",
+    targets: [
+        Target(name: "Foo", dependencies: [.Target(name: "Bar")])
+    ])
  

--- a/Fixtures/Miscellaneous/DependencyEdges/External/dep2/Package.swift
+++ b/Fixtures/Miscellaneous/DependencyEdges/External/dep2/Package.swift
@@ -1,6 +1,7 @@
 import PackageDescription
 
 let package = Package(
+    name: "dep2",
     dependencies: [
         .Package(url: "../dep1", versions: "1.1.0"..<"2.0.0"),
     ]

--- a/Fixtures/Miscellaneous/DependencyEdges/External/root/Package.swift
+++ b/Fixtures/Miscellaneous/DependencyEdges/External/root/Package.swift
@@ -1,6 +1,7 @@
 import PackageDescription
 
 let package = Package(
+    name: "root",
     dependencies: [
         .Package(url: "../dep2", majorVersion: 1)
     ]

--- a/Fixtures/Miscellaneous/DependencyEdges/Internal/Package.swift
+++ b/Fixtures/Miscellaneous/DependencyEdges/Internal/Package.swift
@@ -1,3 +1,3 @@
 import PackageDescription
 
-let package = Package(targets: [Target(name: "Foo", dependencies: ["Bar"])])
+let package = Package(name: "Internal", targets: [Target(name: "Foo", dependencies: ["Bar"])])

--- a/Fixtures/Miscellaneous/Spaces Fixture/Package.swift
+++ b/Fixtures/Miscellaneous/Spaces Fixture/Package.swift
@@ -1,5 +1,7 @@
 import PackageDescription
 
-let package = Package(targets: [
-    Target(name: "Module Name 2", dependencies: ["Module Name 1"])
-])
+let package = Package(
+    name: "Spaces Fixture",
+    targets: [
+        Target(name: "Module Name 2", dependencies: ["Module Name 1"])
+    ])

--- a/Fixtures/ModuleMaps/Direct/App/Package.swift
+++ b/Fixtures/ModuleMaps/Direct/App/Package.swift
@@ -1,5 +1,7 @@
 import PackageDescription
 
-let package = Package(dependencies: [
-     .Package(url: "../CFoo", majorVersion: 1),
-])
+let package = Package(
+    name: "App",
+    dependencies: [
+        .Package(url: "../CFoo", majorVersion: 1),
+    ])

--- a/Fixtures/ModuleMaps/Transitive/packageA/Package.swift
+++ b/Fixtures/ModuleMaps/Transitive/packageA/Package.swift
@@ -18,6 +18,7 @@
 import PackageDescription
 
 let package = Package(
+    name: "packageA",
     dependencies: [
         .Package(url: "../packageB", majorVersion: 1)
     ])

--- a/Fixtures/ModuleMaps/Transitive/packageB/Package.swift
+++ b/Fixtures/ModuleMaps/Transitive/packageB/Package.swift
@@ -18,6 +18,7 @@
 import PackageDescription
 
 let package = Package(
+    name: "packageB",
     targets: [ Target(name: "y")],
     dependencies: [
         .Package(url: "../packageC", majorVersion: 1)

--- a/Fixtures/ModuleMaps/Transitive/packageC/Package.swift
+++ b/Fixtures/ModuleMaps/Transitive/packageC/Package.swift
@@ -18,6 +18,7 @@
 import PackageDescription
 
 let package = Package(
+    name: "packageC",
     targets: [ Target(name: "x")],
     dependencies: [
         .Package(url: "../packageD", majorVersion: 1)

--- a/Fixtures/ValidLayouts/MadeValidWithExclude/Case1/Package.swift
+++ b/Fixtures/ValidLayouts/MadeValidWithExclude/Case1/Package.swift
@@ -1,5 +1,6 @@
 import PackageDescription
 
 let package = Package(
+    name: "Case1",
     exclude: ["InvalidSource.swift"]
 )

--- a/Fixtures/ValidLayouts/MadeValidWithExclude/Case2/Package.swift
+++ b/Fixtures/ValidLayouts/MadeValidWithExclude/Case2/Package.swift
@@ -1,5 +1,6 @@
 import PackageDescription
 
 let package = Package(
+    name: "Case2",
     exclude: ["InvalidSource1.swift", "Sources/InvalidSource2.swift"]
 )

--- a/Sources/PackageDescription/Package.swift
+++ b/Sources/PackageDescription/Package.swift
@@ -47,8 +47,8 @@ public final class Package {
         }
     }
     
-    /// The name of the package, if specified.
-    public let name: String?
+    /// The name of the package.
+    public let name: String
   
     /// pkgconfig name to use for C Modules. If present, swiftpm will try to search for
     /// <name>.pc file to get the additional flags needed for the system module.
@@ -70,7 +70,7 @@ public final class Package {
     public var exclude: [String]
 
     /// Construct a package.
-    public init(name: String? = nil, pkgConfig: String? = nil, providers: [SystemPackageProvider]? = nil, targets: [Target] = [], dependencies: [Dependency] = [], testDependencies: [Dependency] = [], exclude: [String] = []) {
+    public init(name: String, pkgConfig: String? = nil, providers: [SystemPackageProvider]? = nil, targets: [Target] = [], dependencies: [Dependency] = [], testDependencies: [Dependency] = [], exclude: [String] = []) {
         self.name = name
         self.pkgConfig = pkgConfig
         self.providers = providers
@@ -136,9 +136,7 @@ extension Package: TOMLConvertible {
     public func toTOML() -> String {
         var result = ""
         result += "[package]\n"
-        if let name = self.name {
-            result += "name = \"\(name)\"\n"
-        }
+        result += "name = \"\(name)\"\n"
         if let pkgConfig = self.pkgConfig {
             result += "pkgConfig = \"\(pkgConfig)\"\n"
         }

--- a/Sources/PackageLoading/JSONSerialization.swift
+++ b/Sources/PackageLoading/JSONSerialization.swift
@@ -40,9 +40,7 @@ extension Package.Dependency: JSONSerializable {
 extension Package: JSONSerializable {
     public func toJSON() -> JSON {
         var dict: [String: JSON] = [:]
-        if let name = self.name {
-            dict["name"] = .string(name)
-        }
+        dict["name"] = .string(name)
         if let pkgConfig = self.pkgConfig {
             dict["pkgConfig"] = .string(pkgConfig)
         }

--- a/Sources/PackageLoading/Manifest+parse.swift
+++ b/Sources/PackageLoading/Manifest+parse.swift
@@ -119,10 +119,7 @@ extension PackageDescription.Package {
         guard case .table(let topLevelTable) = item else { fatalError("unexpected item") }
         guard case .table(let table)? = topLevelTable.items["package"] else { fatalError("missing package") }
 
-        var name: String? = nil
-        if case .string(let value)? = table.items["name"] {
-            name = value
-        }
+        guard case .string(let name)? = table.items["name"] else { fatalError("missing 'name'") }
         
         var pkgConfig: String? = nil
         if case .string(let value)? = table.items["pkgConfig"] {

--- a/Tests/Build/PackageVersionDataTests.swift
+++ b/Tests/Build/PackageVersionDataTests.swift
@@ -19,7 +19,7 @@ import PackageDescription
 final class PackageVersionDataTests: XCTestCase {
 
     func makePackage(version: Version?) -> PackageModel.Package {
-        let m = Manifest(path: "/path", url: "https://github.com/testPkg", package: PackageDescription.Package(), products: [], version: version)
+        let m = Manifest(path: "/path", url: "https://github.com/testPkg", package: PackageDescription.Package(name: "a"), products: [], version: version)
         return Package(manifest: m)
     }
 
@@ -52,7 +52,7 @@ final class PackageVersionDataTests: XCTestCase {
         mktmpdir { dir in
             let package = makePackage(version: nil)
 
-            let m = Manifest(path: "/path", url: "https://github.com/rootPkg", package: PackageDescription.Package(), products: [], version: nil)
+            let m = Manifest(path: "/path", url: "https://github.com/rootPkg", package: PackageDescription.Package(name: "a"), products: [], version: nil)
             let rootPkg = Package(manifest: m)
 
             try generateVersionData(dir, rootPackage:rootPkg, externalPackages: [package])

--- a/Tests/Get/GitTests.swift
+++ b/Tests/Get/GitTests.swift
@@ -61,7 +61,7 @@ private func tryCloningRepoWithTag(_ tag: String?, shouldCrash: Bool) {
         _ = makeGitRepo(path, tag: tag)!
         do {
             _ = try RawClone(path: path, manifestParser: { _ throws in
-                return Manifest(path: path, url: path.asString, package: PackageDescription.Package(), products: [], version: nil)
+                return Manifest(path: path, url: path.asString, package: PackageDescription.Package(name: path.basename), products: [], version: nil)
             })
         } catch Get.Error.unversioned {
             done = shouldCrash

--- a/Tests/PackageLoading/SerializationTests.swift
+++ b/Tests/PackageLoading/SerializationTests.swift
@@ -39,13 +39,13 @@ class SerializationTests: XCTestCase {
     }
 
     func testEmptyTestDependencies() {
-        let p = Package(testDependencies: [])
+        let p = Package(name: "a", testDependencies: [])
         XCTAssertEqual(p.testDependencies, [])
     }
 
     func testTestDependencies() {
         let dependencies = [Package.Dependency.Package(url: "../TestingLib", majorVersion: 1)]
-        let p = Package(testDependencies: dependencies)
+        let p = Package(name: "a", testDependencies: dependencies)
         let pFromTOML = Package.fromTOML(parseTOML(p.toTOML()))
         XCTAssertEqual(pFromTOML.testDependencies, dependencies)
     }


### PR DESCRIPTION
 - Prior to this change, the name would be inferred from the context (i.e. path
   or URL) from which the package containing the manifest was loaded. However,
   this is both cumbersome in the code and problematic bwith regard to case
   normalization as nothing guarantees that the file path or git URL path
   matches the author's intended casing.

 - In addition, the feature itself seems rarely used and less explicit, so I
   think moving to make this parameter is a natural choice.