### PR TITLE
[Basic] Export existing `rindex` method.

### DIFF
--- a/Sources/Basic/CollectionAlgorithms.swift
+++ b/Sources/Basic/CollectionAlgorithms.swift
@@ -1,0 +1,30 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+extension BidirectionalCollection where Iterator.Element : Comparable {
+    /// Returns the index of the last occurrence of `element` or nil if none.
+    ///
+    /// - Parameters:
+    ///   - start: If provided, the `start` index limits the search to a suffix of the collection.
+    //
+    // FIXME: This probably shouldn't take the `from` parameter, the pattern in
+    // the standard library is to use slices for that.
+    public func rindex(of element: Iterator.Element, from start: Index? = nil) -> Index? {
+        let firstIdx = start ?? startIndex
+        var i = endIndex
+        while i > firstIdx {
+            self.formIndex(before: &i)
+            if self[i] == element {
+                return i
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -581,23 +581,3 @@ private func normalize(relative string: String) -> String {
     // If the result is empty, return `.`, otherwise we return it as a string.
     return result.isEmpty ? "." : result
 }
-
-
-/// Private functions for use by the path logic.  These should move out into a
-/// public place, but we'll need to debate the names, etc, etc.
-extension String.CharacterView {
-    
-    /// Returns the index of the last occurrence of `char` or nil if none.  If
-    /// provided, the `start` index limits the search to a suffix of charview.
-    fileprivate func rindex(of char: Character, from start: Index? = nil) -> Index? {
-        var idx = endIndex
-        let firstIdx = start ?? startIndex
-        while idx > firstIdx {
-            idx = index(before: idx)
-            if self[idx] == char {
-                return idx
-            }
-        }
-        return nil
-    }
-}

--- a/Tests/Basic/CollectionAlgorithmsTests.swift
+++ b/Tests/Basic/CollectionAlgorithmsTests.swift
@@ -1,0 +1,28 @@
+/*
+This source file is part of the Swift.org open source project
+
+Copyright 2016 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See http://swift.org/LICENSE.txt for license information
+See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+import Basic
+
+class CollectionAlgorithmsTests: XCTestCase {
+    func testRIndex() {
+        var str = "hello"
+        XCTAssertEqual(str.characters.rindex(of: "h"), str.startIndex)
+        XCTAssertEqual(str.characters.rindex(of: "h", from: str.index(after: str.startIndex)), nil)
+        XCTAssertEqual(str.characters.rindex(of: "o"), str.characters.index(of: "o"))
+        XCTAssertEqual(str.characters.rindex(of: "l"), str.index(after: str.characters.index(where: { $0 == "l" })!))
+        XCTAssertEqual(str.characters.rindex(of: "x"), nil)
+    }
+
+    static var allTests = [
+        ("testRIndex", testRIndex),
+    ]
+}

--- a/Tests/Basic/XCTestManifests.swift
+++ b/Tests/Basic/XCTestManifests.swift
@@ -14,6 +14,7 @@ import XCTest
 public func allTests() -> [XCTestCaseEntry] {
     return [
         testCase(ByteStringTests.allTests),
+        testCase(CollectionAlgorithmsTests.allTests),
         testCase(FileSystemTests.allTests),
         testCase(GraphAlgorithmsTests.allTests),
         testCase(JSONTests.allTests),


### PR DESCRIPTION
 - We still need to figure out where we ultimately want this to live and be
   called, but for now I just need it somewhere above.