### PR TITLE
[PackageModel] Move `version` into Manifest.

### DIFF
--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -23,6 +23,7 @@ import VersionInfo
 import enum Build.Configuration
 import enum Utility.ColorWrap
 import protocol Build.Toolchain
+import struct PackageDescription.Version
 
 import func POSIX.chdir
 
@@ -140,16 +141,16 @@ public struct SwiftBuildTool: SwiftTool {
                 try chdir(dir.asString)
             }
             
-            func parseManifest(path: AbsolutePath, baseURL: String) throws -> Manifest {
+            func parseManifest(path: AbsolutePath, baseURL: String, version: Version?) throws -> Manifest {
                 let swiftc = ToolDefaults.SWIFT_EXEC.asString
                 let libdir = ToolDefaults.libdir.asString
-                return try Manifest(path: path.asString, baseURL: baseURL, swiftc: swiftc, libdir: libdir)
+                return try Manifest(path: path.asString, baseURL: baseURL, swiftc: swiftc, libdir: libdir, version: version)
             }
             
             func fetch(_ root: AbsolutePath) throws -> (rootPackage: Package, externalPackages:[Package]) {
-                let manifest = try parseManifest(path: root, baseURL: root.asString)
+                let manifest = try parseManifest(path: root, baseURL: root.asString, version: nil)
                 if opts.ignoreDependencies {
-                    return (Package(manifest: manifest, url: manifest.path.parentDirectory, version: nil), [])
+                    return (Package(manifest: manifest, url: manifest.path.parentDirectory), [])
                 } else {
                     return try get(manifest, manifestParser: parseManifest)
                 }

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -23,6 +23,7 @@ import VersionInfo
 import enum Build.Configuration
 import enum Utility.ColorWrap
 import protocol Build.Toolchain
+import struct PackageDescription.Version
 
 import func POSIX.chdir
 
@@ -169,16 +170,16 @@ public struct SwiftPackageTool: SwiftTool {
                 try chdir(dir.asString)
             }
         
-            func parseManifest(path: AbsolutePath, baseURL: String) throws -> Manifest {
+            func parseManifest(path: AbsolutePath, baseURL: String, version: Version?) throws -> Manifest {
                 let swiftc = ToolDefaults.SWIFT_EXEC.asString
                 let libdir = ToolDefaults.libdir.asString
-                return try Manifest(path: path.asString, baseURL: baseURL, swiftc: swiftc, libdir: libdir)
+                return try Manifest(path: path.asString, baseURL: baseURL, swiftc: swiftc, libdir: libdir, version: version)
             }
             
             func fetch(_ root: AbsolutePath) throws -> (rootPackage: Package, externalPackages:[Package]) {
-                let manifest = try parseManifest(path: root, baseURL: root.asString)
+                let manifest = try parseManifest(path: root, baseURL: root.asString, version: nil)
                 if opts.ignoreDependencies {
-                    return (Package(manifest: manifest, url: manifest.path.parentDirectory, version: nil), [])
+                    return (Package(manifest: manifest, url: manifest.path.parentDirectory), [])
                 } else {
                     return try get(manifest, manifestParser: parseManifest)
                 }
@@ -262,7 +263,7 @@ public struct SwiftPackageTool: SwiftTool {
                 
             case .dumpPackage:
                 let root = opts.inputPath ?? opts.path.root
-                let manifest = try parseManifest(path: root, baseURL: root.asString)
+                let manifest = try parseManifest(path: root, baseURL: root.asString, version: nil)
                 let package = manifest.package
                 let json = try jsonString(package: package)
                 print(json)

--- a/Sources/Get/PackagesDirectory.swift
+++ b/Sources/Get/PackagesDirectory.swift
@@ -20,9 +20,9 @@ import func POSIX.rename
  */
 class PackagesDirectory {
     let prefix: AbsolutePath
-    let manifestParser: (path: AbsolutePath, url: String) throws -> Manifest
+    let manifestParser: (path: AbsolutePath, url: String, version: Version?) throws -> Manifest
 
-    init(prefix: AbsolutePath, manifestParser: (path: AbsolutePath, url: String) throws -> Manifest) {
+    init(prefix: AbsolutePath, manifestParser: (path: AbsolutePath, url: String, version: Version?) throws -> Manifest) {
         self.prefix = prefix
         self.manifestParser = manifestParser
     }
@@ -76,9 +76,9 @@ extension PackagesDirectory: Fetcher {
         guard let version = extractPackageVersion(repo.path.basename) else {
             return nil
         }
-        
-        let manifest = try manifestParser(path: repo.path, url: origin)
-        return Package(manifest: manifest, url: origin, version: version)
+
+        let manifest = try manifestParser(path: repo.path, url: origin, version: version)
+        return Package(manifest: manifest, url: origin)
     }
     
     func find(url: String) throws -> Fetchable? {

--- a/Sources/Get/get().swift
+++ b/Sources/Get/get().swift
@@ -18,17 +18,13 @@ import Utility
  - Throws: Error.InvalidDependencyGraph
  - Returns: The modules that this manifest requires building
 */
-public func get(_ manifest: Manifest, manifestParser: (path: AbsolutePath, url: String) throws -> Manifest) throws -> (rootPackage: Package, externalPackages:[Package]) {
+public func get(_ manifest: Manifest, manifestParser: (path: AbsolutePath, url: String, version: Version?) throws -> Manifest) throws -> (rootPackage: Package, externalPackages:[Package]) {
     let dir = AbsolutePath(manifest.path.parentDirectory).appending("Packages")
     let box = PackagesDirectory(prefix: dir, manifestParser: manifestParser)
 
     //TODO don't lose the dependency information during the Fetcher process!
 
-    // FIXME: We shouldn't need to reconstruct the Repo here. Also, this
-    // assignment of a "version" is bogus -- this is really on the version of
-    // the package if the root package sources are at that tag and unmodified.
-    let rootPackageVersion = Git.Repo(path: AbsolutePath(manifest.path.parentDirectory))?.versions.last
-    let rootPackage = Package(manifest: manifest, url: manifest.path.parentDirectory, version: rootPackageVersion)
+    let rootPackage = Package(manifest: manifest, url: manifest.path.parentDirectory)
     let extPackages = try box.recursivelyFetch(manifest.dependencies)
     
     let pkgs = extPackages + [rootPackage]

--- a/Sources/PackageLoading/Manifest+parse.swift
+++ b/Sources/PackageLoading/Manifest+parse.swift
@@ -28,7 +28,7 @@ extension Manifest {
     /// Create a manifest by loading from the given path.
     ///
     /// - path: The path to the manifest file or directory containing `Package.swift`.
-    public init(path inputPath: String, baseURL: String, swiftc: String, libdir: String) throws {
+    public init(path inputPath: String, baseURL: String, swiftc: String, libdir: String, version: Version?) throws {
         guard baseURL.chuzzle() != nil else { fatalError() }  //TODO
 
         // Canonicalize the URL.
@@ -52,7 +52,7 @@ extension Manifest {
         let package = PackageDescription.Package.fromTOML(toml, baseURL: baseURL)
         let products = PackageDescription.Product.fromTOML(toml)
 
-        self.init(path: path, package: package, products: products)
+        self.init(path: path, package: package, products: products, version: version)
     }
 }
 

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -18,20 +18,28 @@ import PackageDescription
  files, and the tools for working with the manifest.
 */
 public struct Manifest {
+    /// The standard filename for the manifest.
+    public static var filename = "Package.swift"
+
+    /// The path of the manifest file.
+    //
+    // FIXME: This doesn't belong here, we want the Manifest to be purely tied
+    // to the repository state, it shouldn't matter where it is.
     public let path: String
+
+    /// The raw package description.
     public let package: PackageDescription.Package
+
+    /// The raw product descriptions.
     public let products: [PackageDescription.Product]
 
+    /// The version this package was loaded from, if known.
+    public let version: Version?
 
-    public init(path: String, package: PackageDescription.Package, products: [PackageDescription.Product]) {
+    public init(path: String, package: PackageDescription.Package, products: [PackageDescription.Product], version: Version?) {
         self.path = path
         self.package = package
         self.products = products
+        self.version = version
     }
-
-    // this is here because we need a strictly narrow module for constants
-    // when we lose libc because Swift proper gets a CPOSIX then we can
-    // rename this module to Constants
-
-    public static var filename: String { return "Package.swift" }
 }

--- a/Sources/PackageModel/Package.swift
+++ b/Sources/PackageModel/Package.swift
@@ -16,6 +16,8 @@ public final class Package {
     public let name: String
     
     /// The URL the package was loaded from.
+    //
+    // FIXME: This probably doesn't belong here...
     public let url: String
     
     /// The local path of the package.
@@ -25,19 +27,22 @@ public final class Package {
     public let manifest: Manifest
 
     /// The version this package was loaded from, if known.
-    public let version: Version?
+    //
+    // FIXME: Eliminate this method forward.
+    public var version: Version? {
+        return manifest.version
+    }
 
     /// The resolved dependencies of the package.
     ///
     /// This value is only available once package loading is complete.
     public var dependencies: [Package] = []
 
-    public init(manifest: Manifest, url: String, version: Version?) {
+    public init(manifest: Manifest, url: String) {
         self.url = url
         self.manifest = manifest
         self.path = manifest.path.parentDirectory
         self.name = manifest.package.name ?? Package.nameForURL(url)
-        self.version = version
     }
 
     public enum Error: Swift.Error {

--- a/Tests/Build/PackageVersionDataTests.swift
+++ b/Tests/Build/PackageVersionDataTests.swift
@@ -19,8 +19,8 @@ import PackageDescription
 final class PackageVersionDataTests: XCTestCase {
 
     func makePackage(version: Version?) -> PackageModel.Package {
-        let m = Manifest(path: "path", package: PackageDescription.Package(), products: [])
-        return Package(manifest: m, url: "https://github.com/testPkg", version: version)
+        let m = Manifest(path: "path", package: PackageDescription.Package(), products: [], version: version)
+        return Package(manifest: m, url: "https://github.com/testPkg")
     }
 
     func testPackageData(_ package: PackageModel.Package, url: String, version: Version?) {
@@ -52,8 +52,8 @@ final class PackageVersionDataTests: XCTestCase {
         mktmpdir { dir in
             let package = makePackage(version: nil)
 
-            let m = Manifest(path: "path", package: PackageDescription.Package(), products: [])
-            let rootPkg = Package(manifest: m, url: "https://github.com/rootPkg", version: nil)
+            let m = Manifest(path: "path", package: PackageDescription.Package(), products: [], version: nil)
+            let rootPkg = Package(manifest: m, url: "https://github.com/rootPkg")
 
             try generateVersionData(dir.asString, rootPackage:rootPkg, externalPackages: [package])
             XCTAssertFileExists(dir.appending(".build/versionData/").appending(package.name + ".swift"))

--- a/Tests/Get/GetTests.swift
+++ b/Tests/Get/GetTests.swift
@@ -25,7 +25,7 @@ class GetTests: XCTestCase {
         mktmpdir { tmpdir in
             guard let repo = makeGitRepo(tmpdir, tag: "0.1.0") else { return XCTFail() }
             try systemQuietly([Git.tool, "-C", repo.path.asString, "remote", "add", "origin", repo.path.asString])
-            let clone = try RawClone(path: repo.path, manifestParser: { _,_ throws -> Manifest in
+            let clone = try RawClone(path: repo.path, manifestParser: { _,_,_ throws -> Manifest in
                 throw Package.Error.noManifest(tmpdir.asString)
             })
             XCTAssertEqual(clone.children.count, 0)

--- a/Tests/Get/GitTests.swift
+++ b/Tests/Get/GitTests.swift
@@ -61,7 +61,7 @@ private func tryCloningRepoWithTag(_ tag: String?, shouldCrash: Bool) {
         _ = makeGitRepo(path, tag: tag)!
         do {
             _ = try RawClone(path: path, manifestParser: { _ throws in
-                return Manifest(path: path.asString, package: PackageDescription.Package(), products: [])
+                return Manifest(path: path.asString, package: PackageDescription.Package(), products: [], version: nil)
             })
         } catch Get.Error.unversioned {
             done = shouldCrash

--- a/Tests/PackageLoading/ConventionTests.swift
+++ b/Tests/PackageLoading/ConventionTests.swift
@@ -89,8 +89,8 @@ private func fixture(files: [RelativePath], body: @noescape (AbsolutePath) throw
 /// Check the behavior of a test project with the given file paths.
 private func fixture(files: [RelativePath], file: StaticString = #file, line: UInt = #line, body: @noescape (PackageModel.Package, [Module]) throws -> ()) throws {
     fixture(files: files) { (prefix: AbsolutePath) in
-        let manifest = Manifest(path: prefix.appending("Package.swift").asString, package: Package(name: "name"), products: [])
-        let package = Package(manifest: manifest, url: prefix.asString, version: nil)
+        let manifest = Manifest(path: prefix.appending("Package.swift").asString, package: Package(name: "name"), products: [], version: nil)
+        let package = Package(manifest: manifest, url: prefix.asString)
         let modules = try package.modules()
         try body(package, modules)
     }

--- a/Tests/PackageLoading/ManifestTests.swift
+++ b/Tests/PackageLoading/ManifestTests.swift
@@ -55,7 +55,7 @@ class ManifestTests: XCTestCase {
     private func loadManifest(_ inputName: RelativePath, line: UInt = #line, body: (Manifest) -> Void) {
         do {
             let input = AbsolutePath(#file).appending("../Inputs").appending(inputName)
-            body(try Manifest(path: input.asString, baseURL: input.parentDirectory.asString, swiftc: swiftc.asString, libdir: libdir.asString))
+            body(try Manifest(path: input.asString, baseURL: input.parentDirectory.asString, swiftc: swiftc.asString, libdir: libdir.asString, version: nil))
         } catch {
             XCTFail("Unexpected error: \(error)", file: #file, line: line)
         }
@@ -90,15 +90,15 @@ class ManifestTests: XCTestCase {
     }
 
     func testNoManifest() {
-        let foo = try? Manifest(path: "/non-existent-file", baseURL: "/", swiftc: swiftc.asString, libdir: libdir.asString)
+        let foo = try? Manifest(path: "/non-existent-file", baseURL: "/", swiftc: swiftc.asString, libdir: libdir.asString, version: nil)
         XCTAssertNil(foo)
     }
 
     func testInvalidTargetName() {
         fixture(name: "Miscellaneous/PackageWithInvalidTargets") { (prefix: AbsolutePath) in
             do {
-                let manifest = try Manifest(path: prefix.appending("Package.swift").asString, baseURL: prefix.asString, swiftc: swiftc.asString, libdir: libdir.asString)
-                let package = Package(manifest: manifest, url: prefix.asString, version: nil)
+                let manifest = try Manifest(path: prefix.appending("Package.swift").asString, baseURL: prefix.asString, swiftc: swiftc.asString, libdir: libdir.asString, version: nil)
+                let package = Package(manifest: manifest, url: prefix.asString)
 
                 let _ = try package.modules()
 


### PR DESCRIPTION
 - I am not sure that either the Package or the Manifest should know about what
   version they were loaded from, but of the two the Manifest is the better one
   to own this information since it is the model object most directly
   constructed from the repository.