### PR TITLE
[PackageModel] Move `url` into Manifest.

### DIFF
--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -150,7 +150,7 @@ public struct SwiftBuildTool: SwiftTool {
             func fetch(_ root: AbsolutePath) throws -> (rootPackage: Package, externalPackages:[Package]) {
                 let manifest = try parseManifest(path: root, baseURL: root.asString, version: nil)
                 if opts.ignoreDependencies {
-                    return (Package(manifest: manifest, url: manifest.path.parentDirectory), [])
+                    return (Package(manifest: manifest), [])
                 } else {
                     return try get(manifest, manifestParser: parseManifest)
                 }

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -179,7 +179,7 @@ public struct SwiftPackageTool: SwiftTool {
             func fetch(_ root: AbsolutePath) throws -> (rootPackage: Package, externalPackages:[Package]) {
                 let manifest = try parseManifest(path: root, baseURL: root.asString, version: nil)
                 if opts.ignoreDependencies {
-                    return (Package(manifest: manifest, url: manifest.path.parentDirectory), [])
+                    return (Package(manifest: manifest), [])
                 } else {
                     return try get(manifest, manifestParser: parseManifest)
                 }

--- a/Sources/Get/PackagesDirectory.swift
+++ b/Sources/Get/PackagesDirectory.swift
@@ -78,7 +78,7 @@ extension PackagesDirectory: Fetcher {
         }
 
         let manifest = try manifestParser(path: repo.path, url: origin, version: version)
-        return Package(manifest: manifest, url: origin)
+        return Package(manifest: manifest)
     }
     
     func find(url: String) throws -> Fetchable? {

--- a/Sources/Get/get().swift
+++ b/Sources/Get/get().swift
@@ -24,7 +24,7 @@ public func get(_ manifest: Manifest, manifestParser: (path: AbsolutePath, url: 
 
     //TODO don't lose the dependency information during the Fetcher process!
 
-    let rootPackage = Package(manifest: manifest, url: manifest.path.parentDirectory)
+    let rootPackage = Package(manifest: manifest)
     let extPackages = try box.recursivelyFetch(manifest.dependencies)
     
     let pkgs = extPackages + [rootPackage]

--- a/Sources/PackageLoading/Manifest+parse.swift
+++ b/Sources/PackageLoading/Manifest+parse.swift
@@ -52,7 +52,7 @@ extension Manifest {
         let package = PackageDescription.Package.fromTOML(toml, baseURL: baseURL)
         let products = PackageDescription.Product.fromTOML(toml)
 
-        self.init(path: path, package: package, products: products, version: version)
+        self.init(path: path, url: baseURL, package: package, products: products, version: version)
     }
 }
 

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -27,6 +27,12 @@ public struct Manifest {
     // to the repository state, it shouldn't matter where it is.
     public let path: String
 
+    /// The repository URL the manifest was loaded from.
+    //
+    // FIXME: This doesn't belong here, we want the Manifest to be purely tied
+    // to the repository state, it shouldn't matter where it is.
+    public let url: String
+
     /// The raw package description.
     public let package: PackageDescription.Package
 
@@ -36,8 +42,9 @@ public struct Manifest {
     /// The version this package was loaded from, if known.
     public let version: Version?
 
-    public init(path: String, package: PackageDescription.Package, products: [PackageDescription.Product], version: Version?) {
+    public init(path: String, url: String, package: PackageDescription.Package, products: [PackageDescription.Product], version: Version?) {
         self.path = path
+        self.url = url
         self.package = package
         self.products = products
         self.version = version

--- a/Tests/Build/PackageVersionDataTests.swift
+++ b/Tests/Build/PackageVersionDataTests.swift
@@ -19,8 +19,8 @@ import PackageDescription
 final class PackageVersionDataTests: XCTestCase {
 
     func makePackage(version: Version?) -> PackageModel.Package {
-        let m = Manifest(path: "path", package: PackageDescription.Package(), products: [], version: version)
-        return Package(manifest: m, url: "https://github.com/testPkg")
+        let m = Manifest(path: "path", url: "https://github.com/testPkg", package: PackageDescription.Package(), products: [], version: version)
+        return Package(manifest: m)
     }
 
     func testPackageData(_ package: PackageModel.Package, url: String, version: Version?) {
@@ -52,8 +52,8 @@ final class PackageVersionDataTests: XCTestCase {
         mktmpdir { dir in
             let package = makePackage(version: nil)
 
-            let m = Manifest(path: "path", package: PackageDescription.Package(), products: [], version: nil)
-            let rootPkg = Package(manifest: m, url: "https://github.com/rootPkg")
+            let m = Manifest(path: "path", url: "https://github.com/rootPkg", package: PackageDescription.Package(), products: [], version: nil)
+            let rootPkg = Package(manifest: m)
 
             try generateVersionData(dir.asString, rootPackage:rootPkg, externalPackages: [package])
             XCTAssertFileExists(dir.appending(".build/versionData/").appending(package.name + ".swift"))

--- a/Tests/Get/GitTests.swift
+++ b/Tests/Get/GitTests.swift
@@ -61,7 +61,7 @@ private func tryCloningRepoWithTag(_ tag: String?, shouldCrash: Bool) {
         _ = makeGitRepo(path, tag: tag)!
         do {
             _ = try RawClone(path: path, manifestParser: { _ throws in
-                return Manifest(path: path.asString, package: PackageDescription.Package(), products: [], version: nil)
+                return Manifest(path: path.asString, url: path.asString, package: PackageDescription.Package(), products: [], version: nil)
             })
         } catch Get.Error.unversioned {
             done = shouldCrash

--- a/Tests/PackageLoading/ConventionTests.swift
+++ b/Tests/PackageLoading/ConventionTests.swift
@@ -89,8 +89,8 @@ private func fixture(files: [RelativePath], body: @noescape (AbsolutePath) throw
 /// Check the behavior of a test project with the given file paths.
 private func fixture(files: [RelativePath], file: StaticString = #file, line: UInt = #line, body: @noescape (PackageModel.Package, [Module]) throws -> ()) throws {
     fixture(files: files) { (prefix: AbsolutePath) in
-        let manifest = Manifest(path: prefix.appending("Package.swift").asString, package: Package(name: "name"), products: [], version: nil)
-        let package = Package(manifest: manifest, url: prefix.asString)
+        let manifest = Manifest(path: prefix.appending("Package.swift").asString, url: prefix.asString, package: Package(name: "name"), products: [], version: nil)
+        let package = Package(manifest: manifest)
         let modules = try package.modules()
         try body(package, modules)
     }

--- a/Tests/PackageLoading/ManifestTests.swift
+++ b/Tests/PackageLoading/ManifestTests.swift
@@ -98,7 +98,7 @@ class ManifestTests: XCTestCase {
         fixture(name: "Miscellaneous/PackageWithInvalidTargets") { (prefix: AbsolutePath) in
             do {
                 let manifest = try Manifest(path: prefix.appending("Package.swift").asString, baseURL: prefix.asString, swiftc: swiftc.asString, libdir: libdir.asString, version: nil)
-                let package = Package(manifest: manifest, url: prefix.asString)
+                let package = Package(manifest: manifest)
 
                 let _ = try package.modules()
 


### PR DESCRIPTION
 - As with `version`, I'm not sure this belongs in either place, but of the
   two I would rather it be with the Manifest.

 - Also, document the various notions of `Package` that are currently in use...