### PR TITLE
[Get] Change resolution to operate on Manifests.

### DIFF
--- a/Sources/Get/Manifest+Fetchable.swift
+++ b/Sources/Get/Manifest+Fetchable.swift
@@ -12,13 +12,13 @@ import PackageModel
 
 import struct PackageDescription.Version
 
-extension Package: Fetchable {
+extension Manifest: Fetchable {
     var children: [(String, Range<Version>)] {
-        return manifest.package.dependencies.map{ ($0.url, $0.versionRange) }
+        return package.dependencies.map{ ($0.url, $0.versionRange) }
     }
 
     var currentVersion: Version {
-        return self.version!
+        return version!
     }
 
     func constrain(to versionRange: Range<Version>) -> Version? {
@@ -30,6 +30,6 @@ extension Package: Fetchable {
     }
 
     func setCurrentVersion(_ newValue: Version) throws {
-        throw Get.Error.invalidDependencyGraph(url)
+        throw Get.Error.invalidDependencyGraph(path)
     }
 }

--- a/Sources/Get/RawClone.swift
+++ b/Sources/Get/RawClone.swift
@@ -14,13 +14,12 @@ import Utility
 
 import struct PackageDescription.Version
 
-/**
- Initially we clone into a non-final form because we may need to
- adjust the dependency graph due to further specifications as
- we clone more repositories. This is the non-final form. Once
- `recursivelyFetch` completes we finalize these clones into our
- Sandbox.
- */
+/// A clone of a repository which is not yet fully loaded.
+///
+/// Initially we clone into a non-final form because we may need to adjust the
+/// dependency graph due to further specifications as we clone more
+/// repositories. This is the non-final form. Once `recursivelyFetch` completes
+/// we finalize these clones into the `PackagesDirectory`.
 class RawClone: Fetchable {
     let path: AbsolutePath
     let manifestParser: (path: AbsolutePath, url: String, version: Version?) throws -> Manifest

--- a/Sources/PackageModel/Package.swift
+++ b/Sources/PackageModel/Package.swift
@@ -14,7 +14,7 @@ import struct PackageDescription.Version
 /// The basic package representation.
 ///
 /// The package manager conceptually works with five different kinds of
-/// packages:
+/// packages, of which this is only one:
 ///
 /// 1. Informally, the repository containing a package can be thought of in some
 /// sense as the "package". However, this isn't accurate, because the actual
@@ -28,11 +28,10 @@ import struct PackageDescription.Version
 /// that specification is primarily used to load the package (see the
 /// `PackageLoading` module).
 ///
-/// 3. A partially loaded `PackageModel.Package` (i.e. the type here) is used
-/// during package dependency resolution; it has a loaded manifest but has not
-/// had its dependencies populated (or the conventions evaluated to construct
-/// `Module` instances). This is what is generally in use within the algorithm
-/// inside of the `Get` module, and could probably be replaced by `Manifest`.
+/// 3. A loaded `PackageModel.Manifest` is an abstract representation of a
+/// package, and is used during package dependency resolution. It contains the
+/// loaded PackageDescription and information necessary for dependency
+/// resolution, but nothing else.
 ///
 /// 4. A loaded `PackageModel.Package` which has had dependencies loaded and
 /// resolved. This is the result after `Get.get()`.


### PR DESCRIPTION
 - This changes the bulk of the current package resolution logic to operate only
   in terms of parsed `Manifest` instances, and not using `Package`
   instances. As per the comments in `PackageModel.Package`, this is an attempt
   to align the currently used notions of what a package is with the types used.