### PR TITLE
[Build] Fix modules cache path for ClangModules

### DIFF
--- a/Sources/Build/misc.swift
+++ b/Sources/Build/misc.swift
@@ -155,7 +155,7 @@ extension ClangModule: ClangModuleCachable {
         // so it doesn't become painfully slow.
         if let _ = getenv("IS_SWIFTPM_TEST") { return [] }
         let moduleCachePath = moduleCacheDir(prefix: prefix)
-        return ["-fmodules-cache-path=\(moduleCachePath)"]
+        return ["-fmodules-cache-path=" + moduleCachePath.asString]
     }
 }
 


### PR DESCRIPTION
Incorrect path was being passed to due string interpolation:

fmodules-cache-path=AbsolutePath(_impl: Basic.(PathImpl in _F37600050464D58680C1E5753557C388)(string:\"/path/to/.build/debug/ModuleCache\"))