### PR TITLE
Add AbsolutePath.appending(component[s]:) methods

### DIFF
--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -133,12 +133,6 @@ public struct AbsolutePath {
         return AbsolutePath(self, subpath)
     }
     
-    /// Returns the absolute path with the contents of the string (interpreted
-    /// as a relative path, not a single path component) appended.
-    public func appending(_ str: String) -> AbsolutePath {
-        return AbsolutePath(self, str)
-    }
-    
     /// Returns the absolute path with an additional literal component appended.
     ///
     /// This method should only be used in cases where the input is guaranteed

--- a/Sources/Build/Buildable.swift
+++ b/Sources/Build/Buildable.swift
@@ -36,7 +36,7 @@ extension Module: Buildable {
                 }
 
                 let buildMeta = ClangModuleBuildMetadata(module: module, prefix: prefix, otherArgs: [])
-                let genModuleMap = buildMeta.buildDirectory.appending(module.moduleMap)
+                let genModuleMap = buildMeta.buildDirectory.appending(component: CModule.moduleMapFilename)
                 return ["-Xcc", "-fmodule-map-file=\(genModuleMap.asString)"]
             } else if let module = module as? CModule {
                 return ["-Xcc", "-fmodule-map-file=\(module.moduleMapPath.asString)"]

--- a/Sources/Build/Command.compile(ClangModule).swift
+++ b/Sources/Build/Command.compile(ClangModule).swift
@@ -53,7 +53,7 @@ struct ClangModuleBuildMetadata {
     let otherArgs: [String]
 
     /// Path to build directory for this module.
-    var buildDirectory: AbsolutePath { return prefix.appending(module.c99name + ".build") }
+    var buildDirectory: AbsolutePath { return prefix.appending(component: module.c99name + ".build") }
 
     /// Targets this module depends on.
     var inputs: [String] {
@@ -75,8 +75,8 @@ struct ClangModuleBuildMetadata {
     func compilePaths() -> [(filename: RelativePath, source: AbsolutePath, object: AbsolutePath, deps: AbsolutePath)] {
         return module.sources.relativePaths.map { source in
             let path = module.sources.root.appending(source)
-            let object = buildDirectory.appending(source.asString + ".o")
-            let deps = buildDirectory.appending(source.asString + ".d")
+            let object = buildDirectory.appending(RelativePath(source.asString + ".o"))
+            let deps = buildDirectory.appending(RelativePath(source.asString + ".d"))
             return (source, path, object, deps)
         }
     }

--- a/Sources/Build/Command.link(SwiftModule).swift
+++ b/Sources/Build/Command.link(SwiftModule).swift
@@ -61,7 +61,7 @@ extension Command {
 
             // TODO should be llbuild rules∫
             if conf == .debug {
-                let infoPlistPath = outpath.parentDirectory.parentDirectory.appending("Info.plist")
+                let infoPlistPath = outpath.parentDirectory.parentDirectory.appending(component: "Info.plist")
                 try localFileSystem.createDirectory(outpath.parentDirectory, recursive: true)
                 try localFileSystem.writeFileContents(infoPlistPath, bytes: ByteString(encodingAsUTF8: product.Info.plist))
             }
@@ -70,7 +70,7 @@ extension Command {
             //       parent directory of the first test module we can find.
             let firstTestModule = product.modules.flatMap{$0 as? SwiftModule}.filter{ $0.isTest }.first!
             let testDirectory = firstTestModule.sources.root.parentDirectory
-            let main = testDirectory.appending("LinuxMain.swift")
+            let main = testDirectory.appending(component: "LinuxMain.swift")
             args.append(main.asString)
             for module in product.modules {
                 args += module.XccFlags(prefix)

--- a/Sources/Build/PackageVersion.swift
+++ b/Sources/Build/PackageVersion.swift
@@ -15,7 +15,7 @@ import class Utility.Git
 import struct Utility.Path
 
 public func generateVersionData(_ rootDir: AbsolutePath, rootPackage: Package, externalPackages: [Package]) throws {
-    let dirPath = rootDir.appending(".build/versionData")
+    let dirPath = rootDir.appending(components: ".build", "versionData")
     try localFileSystem.createDirectory(dirPath, recursive: true)
 
     try saveRootPackage(dirPath, package: rootPackage)
@@ -72,6 +72,6 @@ func versionData(package: Package) -> String {
 }
 
 private func saveVersionData(_ dirPath: AbsolutePath, packageName: String, data: String) throws {
-    let filePath = dirPath.appending(packageName + ".swift")
+    let filePath = dirPath.appending(components: packageName + ".swift")
     try localFileSystem.writeFileContents(filePath, bytes: ByteString(encodingAsUTF8: data))
 }

--- a/Sources/Build/ToolProtocol.swift
+++ b/Sources/Build/ToolProtocol.swift
@@ -78,10 +78,10 @@ struct SwiftcTool: ToolProtocol {
 
     var outputs: [String]                   { return [module.targetName] + objects.map{ $0.asString } }
     var moduleName: String                  { return module.c99name }
-    var moduleOutputPath: AbsolutePath      { return prefix.appending(module.c99name + ".swiftmodule") }
+    var moduleOutputPath: AbsolutePath      { return prefix.appending(component: module.c99name + ".swiftmodule") }
     var importPaths: [AbsolutePath]         { return [prefix] }
-    var tempsPath: AbsolutePath             { return prefix.appending(module.c99name + ".build") }
-    var objects: [AbsolutePath]             { return module.sources.relativePaths.map{ tempsPath.appending($0.asString + ".o") } }
+    var tempsPath: AbsolutePath             { return prefix.appending(component: module.c99name + ".build") }
+    var objects: [AbsolutePath]             { return module.sources.relativePaths.map{ tempsPath.appending(RelativePath($0.asString + ".o")) } }
     var sources: [AbsolutePath]             { return module.sources.paths }
     var isLibrary: Bool                     { return module.type == .library }
     var enableWholeModuleOptimization: Bool {

--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -29,7 +29,7 @@ public func describe(_ prefix: AbsolutePath, _ conf: Configuration, _ modules: [
 
     let Xcc = flags.cCompilerFlags.flatMap{ ["-Xcc", $0] }
     let Xld = flags.linkerFlags.flatMap{ ["-Xlinker", $0] }
-    let prefix = prefix.appending(conf.dirname)
+    let prefix = prefix.appending(component: conf.dirname)
     try Utility.makeDirectories(prefix.asString)
     let swiftcArgs = flags.cCompilerFlags + flags.swiftCompilerFlags + verbosity.ccArgs
 

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -40,7 +40,7 @@ public struct Flag {
 
 private func getroot() -> AbsolutePath {
     var root = AbsolutePath(getcwd())
-    while !root.appending(Manifest.filename).asString.isFile {
+    while !root.appending(component: Manifest.filename).asString.isFile {
         root = root.parentDirectory
 
         guard root != "/" else {

--- a/Sources/Commands/init.swift
+++ b/Sources/Commands/init.swift
@@ -80,7 +80,7 @@ final class InitPackage {
     }
     
     private func writeManifestFile() throws {
-        let manifest = rootd.appending(Manifest.filename)
+        let manifest = rootd.appending(component: Manifest.filename)
         guard manifest.asString.exists == false else {
             throw InitError.manifestAlreadyExists
         }

--- a/Sources/Get/PackagesDirectory.swift
+++ b/Sources/Get/PackagesDirectory.swift
@@ -138,7 +138,7 @@ extension PackagesDirectory: Fetcher {
 
     func fetch(url: String) throws -> Fetchable {
         // Clone into a staging location, we will rename it once all versions are selected.
-        let dstdir = packagesPath.appending(url.basename)
+        let dstdir = packagesPath.appending(component: url.basename)
         if let repo = Git.Repo(path: dstdir), repo.origin == url {
             //TODO need to canonicalize the URL need URL struct
             return try RawClone(path: dstdir, manifestParser: manifestLoader.load)
@@ -153,7 +153,7 @@ extension PackagesDirectory: Fetcher {
     func finalize(_ fetchable: Fetchable) throws -> Manifest {
         switch fetchable {
         case let clone as RawClone:
-            let prefix = self.packagesPath.appending(RelativePath(clone.finalName))
+            let prefix = self.packagesPath.appending(component: clone.finalName)
             try Utility.makeDirectories(packagesPath.parentDirectory.asString)
             try rename(old: clone.path.asString, new: prefix.asString)
             //TODO don't reparse the manifest!

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -66,7 +66,7 @@ public final class ManifestLoader {
         }
 
         // Compute the actual input file path.
-        let path: AbsolutePath = inputPath.asString.isDirectory ? inputPath.appending(Manifest.filename) : inputPath
+        let path: AbsolutePath = inputPath.asString.isDirectory ? inputPath.appending(component: Manifest.filename) : inputPath
 
         // Validate that the file exists.
         guard path.asString.isFile else { throw PackageModel.Package.Error.noManifest(path.asString) }

--- a/Sources/PackageLoading/ModuleMapGeneration.swift
+++ b/Sources/PackageLoading/ModuleMapGeneration.swift
@@ -13,13 +13,10 @@ import Utility
 import PackageModel
 
 extension CModule {
-    
-    public var moduleMap: String {
-        return "module.modulemap"
-    }
+    public static let moduleMapFilename = "module.modulemap"
     
     public var moduleMapPath: AbsolutePath {
-        return path.appending(moduleMap)
+        return path.appending(component: CModule.moduleMapFilename)
     }
 }
 
@@ -82,7 +79,7 @@ extension ClangModule {
             return
         }
         
-        let walked = try localFileSystem.getDirectoryContents(includeDir).map{ includeDir.appending($0) }
+        let walked = try localFileSystem.getDirectoryContents(includeDir).map{ includeDir.appending(component: $0) }
         
         let files = walked.filter{ $0.asString.isFile && $0.suffix == ".h" }
         let dirs = walked.filter{ $0.asString.isDirectory }
@@ -94,7 +91,7 @@ extension ClangModule {
         //    directory
         // * `umbrella "path/to/include"` in all other cases
 
-        let umbrellaHeaderFlat = includeDir.appending(c99name + ".h")
+        let umbrellaHeaderFlat = includeDir.appending(component: c99name + ".h")
         if umbrellaHeaderFlat.asString.isFile {
             guard dirs.isEmpty else { throw ModuleMapError.unsupportedIncludeLayoutForModule(name) }
             try createModuleMap(inDir: wd, type: .header(umbrellaHeaderFlat), modulemapStyle: modulemapStyle)
@@ -102,13 +99,13 @@ extension ClangModule {
         }
         diagnoseInvalidUmbrellaHeader(includeDir)
 
-        let umbrellaHeader = includeDir.appending(c99name).appending(c99name + ".h")
+        let umbrellaHeader = includeDir.appending(components: c99name, c99name + ".h")
         if umbrellaHeader.asString.isFile {
             guard dirs.count == 1 && files.isEmpty else { throw ModuleMapError.unsupportedIncludeLayoutForModule(name) }
             try createModuleMap(inDir: wd, type: .header(umbrellaHeader), modulemapStyle: modulemapStyle)
             return
         }
-        diagnoseInvalidUmbrellaHeader(includeDir.appending(c99name))
+        diagnoseInvalidUmbrellaHeader(includeDir.appending(component: c99name))
 
         try createModuleMap(inDir: wd, type: .directory(includeDir), modulemapStyle: modulemapStyle)
     }
@@ -116,8 +113,8 @@ extension ClangModule {
     /// Warn user if in case module name and c99name are different and there is a
     /// `name.h` umbrella header.
     private func diagnoseInvalidUmbrellaHeader(_ path: AbsolutePath) {
-        let umbrellaHeader = path.appending(c99name + ".h")
-        let invalidUmbrellaHeader = path.appending(name + ".h")
+        let umbrellaHeader = path.appending(component: c99name + ".h")
+        let invalidUmbrellaHeader = path.appending(component: name + ".h")
         if c99name != name && invalidUmbrellaHeader.asString.isFile {
             print("warning: \(invalidUmbrellaHeader) should be renamed to \(umbrellaHeader) to be used as an umbrella header")
         }
@@ -130,7 +127,7 @@ extension ClangModule {
     
     private func createModuleMap(inDir wd: AbsolutePath, type: UmbrellaType, modulemapStyle: ModuleMapStyle) throws {
         try Utility.makeDirectories(wd.asString)
-        let moduleMapFile = wd.appending(self.moduleMap)
+        let moduleMapFile = wd.appending(component: CModule.moduleMapFilename)
         let moduleMap = try fopen(moduleMapFile.asString, mode: .write)
         defer { moduleMap.closeFile() }
         

--- a/Sources/PackageLoading/PackageExtensions.swift
+++ b/Sources/PackageLoading/PackageExtensions.swift
@@ -364,7 +364,7 @@ extension Package {
     }
 
     var excludedPaths: [AbsolutePath] {
-        return manifest.package.exclude.map { self.path.appending($0) }
+        return manifest.package.exclude.map { self.path.appending(RelativePath($0)) }
     }
     
     private var pkgConfigPath: RelativePath? {

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -8,8 +8,9 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basic
+
 @_exported import enum PackageDescription.ProductType
-import Utility
 
 public class Product {
     public let name: String
@@ -22,20 +23,20 @@ public class Product {
         self.modules = modules
     }
 
-    public var outname: String {
+    public var outname: RelativePath {
         switch type {
         case .Executable:
-            return name
+            return RelativePath(name)
         case .Library(.Static):
-            return "lib\(name).a"
+            return RelativePath("lib\(name).a")
         case .Library(.Dynamic):
-            return "lib\(name).\(Product.dynamicLibraryExtension)"
+            return RelativePath("lib\(name).\(Product.dynamicLibraryExtension)")
         case .Test:
             let base = "\(name).xctest"
             #if os(macOS)
-                return "\(base)/Contents/MacOS/\(name)"
+                return RelativePath("\(base)/Contents/MacOS/\(name)")
             #else
-                return base
+                return RelativePath(base)
             #endif
         }
     }

--- a/Sources/Utility/walk.swift
+++ b/Sources/Utility/walk.swift
@@ -120,11 +120,11 @@ public class RecursibleDirectoryContentsGenerator: IteratorProtocol, Sequence {
                 return nil
             }
             let name = entry.name ?? ""
-            let path = current.path.appending(name)
+            let path = current.path.appending(component: name)
             if path.asString.isDirectory && !path.asString.isSymlink {
                 towalk.append(path)
             }
-            return current.path.appending(name)
+            return current.path.appending(component: name)
         }
     }
 }

--- a/Sources/Xcodeproj/Module+PBXProj.swift
+++ b/Sources/Xcodeproj/Module+PBXProj.swift
@@ -85,7 +85,7 @@ func fileRef(inProjectRoot subpath: RelativePath, srcroot: AbsolutePath) -> (ref
 
 /// Returns the (refId, path) tuple for the Info.plist file for a particular module.
 func fileRef(ofInfoPlistFor module: XcodeModuleProtocol, srcroot: AbsolutePath) -> (refId: String, path: AbsolutePath) {
-    let path = srcroot.appending(module.infoPlistFileName)
+    let path = srcroot.appending(component: module.infoPlistFileName)
     let idSuffix = module.infoPlistFileName
     return (refId: "\(sourceGroupFileRefPrefix)\(idSuffix)", path: path)
 }
@@ -194,7 +194,7 @@ extension XcodeModuleProtocol  {
 
     private func getCommonBuildSettings(_ options: XcodeprojOptions, xcodeProjectPath: AbsolutePath) throws -> [String: String] {
         var buildSettings = [String: String]()
-        let plistPath = xcodeProjectPath.appending(infoPlistFileName)
+        let plistPath = xcodeProjectPath.appending(component: infoPlistFileName)
 
         if isTest {
             buildSettings["EMBEDDED_CONTENT_CONTAINS_SWIFT"] = "YES"
@@ -270,9 +270,9 @@ extension XcodeModuleProtocol  {
                 moduleMapPath = clangModule.moduleMapPath
             } else {
                 // Generate and drop the modulemap inside Xcodeproj folder.
-                let path = xcodeProjectPath.appending("GeneratedModuleMap").appending(clangModule.c99name)
+                let path = xcodeProjectPath.appending(components: "GeneratedModuleMap", clangModule.c99name)
                 try clangModule.generateModuleMap(inDir: path, modulemapStyle: .framework)
-                moduleMapPath = path.appending(clangModule.moduleMap)
+                moduleMapPath = path.appending(component: CModule.moduleMapFilename)
             }
 
             buildSettings["MODULEMAP_FILE"] = moduleMapPath.relative(to: xcodeProjectPath.parentDirectory).asString

--- a/Tests/Basic/PathTests.swift
+++ b/Tests/Basic/PathTests.swift
@@ -180,7 +180,12 @@ class PathTests: XCTestCase {
         XCTAssertEqual(AbsolutePath("/bar").appending(RelativePath("../foo")).asString, "/foo")
         XCTAssertEqual(AbsolutePath("/bar").appending(RelativePath("../foo/..//")).asString, "/")
         XCTAssertEqual(AbsolutePath("/bar/../foo/..//yabba/").appending(RelativePath("a/b")).asString, "/yabba/a/b")
-        
+
+        XCTAssertEqual(AbsolutePath("/").appending(component: "a").asString, "/a")
+        XCTAssertEqual(AbsolutePath("/a").appending(component: "b").asString, "/a/b")
+        XCTAssertEqual(AbsolutePath("/").appending(components: "a", "b").asString, "/a/b")
+        XCTAssertEqual(AbsolutePath("/a").appending(components: "b", "c").asString, "/a/b/c")
+
         let emptyString = ""
         XCTAssertEqual(AbsolutePath("/").appending(emptyString).asString, "/")
         let dotString = "."

--- a/Tests/Basic/PathTests.swift
+++ b/Tests/Basic/PathTests.swift
@@ -185,13 +185,6 @@ class PathTests: XCTestCase {
         XCTAssertEqual(AbsolutePath("/a").appending(component: "b").asString, "/a/b")
         XCTAssertEqual(AbsolutePath("/").appending(components: "a", "b").asString, "/a/b")
         XCTAssertEqual(AbsolutePath("/a").appending(components: "b", "c").asString, "/a/b/c")
-
-        let emptyString = ""
-        XCTAssertEqual(AbsolutePath("/").appending(emptyString).asString, "/")
-        let dotString = "."
-        XCTAssertEqual(AbsolutePath("/").appending(dotString).asString, "/")
-        let dotdotString = dotString + dotString
-        XCTAssertEqual(AbsolutePath("/").appending(dotdotString).asString, "/")
     }
     
     func testPathComponents() {

--- a/Tests/Build/PackageVersionDataTests.swift
+++ b/Tests/Build/PackageVersionDataTests.swift
@@ -56,7 +56,7 @@ final class PackageVersionDataTests: XCTestCase {
             let rootPkg = Package(manifest: m)
 
             try generateVersionData(dir, rootPackage:rootPkg, externalPackages: [package])
-            XCTAssertFileExists(dir.appending(".build/versionData/").appending(package.name + ".swift"))
+            XCTAssertFileExists(dir.appending(components: ".build", "versionData", package.name + ".swift"))
         }
     }
 

--- a/Tests/Functional/ClangModuleTests.swift
+++ b/Tests/Functional/ClangModuleTests.swift
@@ -25,25 +25,28 @@ class ClangModulesTestCase: XCTestCase {
     func testSingleModuleFlatCLibrary() {
         fixture(name: "ClangModules/CLibraryFlat") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("CLibraryFlat".soname))
+            let debugPath = prefix.appending(components: ".build", "debug")
+            XCTAssertFileExists(debugPath.appending(components: "CLibraryFlat".soname))
         }
     }
     
     func testSingleModuleCLibraryInSources() {
         fixture(name: "ClangModules/CLibrarySources") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("CLibrarySources".soname))
+            let debugPath = prefix.appending(components: ".build", "debug")
+            XCTAssertFileExists(debugPath.appending(component: "CLibrarySources".soname))
         }
     }
     
     func testMixedSwiftAndC() {
         fixture(name: "ClangModules/SwiftCMixed") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix.appending(".build/debug").appending("SeaLib".soname))
-            XCTAssertFileExists(prefix.appending(".build/debug").appending("SeaExec"))
-            var output = try popen([prefix.appending(".build/debug").appending("SeaExec").asString])
+            let debugPath = prefix.appending(components: ".build", "debug")
+            XCTAssertFileExists(debugPath.appending(component: "SeaLib".soname))
+            XCTAssertFileExists(debugPath.appending(component: "SeaExec"))
+            var output = try popen([debugPath.appending(component: "SeaExec").asString])
             XCTAssertEqual(output, "a = 5\n")
-            output = try popen([prefix.appending(".build/debug").appending("CExec").asString])
+            output = try popen([debugPath.appending(component: "CExec").asString])
             XCTAssertEqual(output, "5")
         }
     }
@@ -51,34 +54,38 @@ class ClangModulesTestCase: XCTestCase {
     func testExternalSimpleCDep() {
         fixture(name: "DependencyResolution/External/SimpleCDep") { prefix in
             XCTAssertBuilds(prefix.appending("Bar"))
-            XCTAssertFileExists(prefix.appending("Bar/.build/debug").appending("Bar"))
-            XCTAssertFileExists(prefix.appending("Bar/.build/debug").appending("Foo".soname))
-            XCTAssertDirectoryExists(prefix.appending("Bar/Packages/Foo-1.2.3"))
+            let debugPath = prefix.appending(components: "Bar", ".build", "debug")
+            XCTAssertFileExists(debugPath.appending(component: "Bar"))
+            XCTAssertFileExists(debugPath.appending(component: "Foo".soname))
+            XCTAssertDirectoryExists(prefix.appending(RelativePath("Bar/Packages/Foo-1.2.3")))
         }
     }
     
     func testiquoteDep() {
         fixture(name: "ClangModules/CLibraryiquote") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix.appending(".build/debug").appending("Foo".soname))
-            XCTAssertFileExists(prefix.appending(".build/debug").appending("Bar".soname))
-            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("Bar with spaces".soname))
+            let debugPath = prefix.appending(components: ".build", "debug")
+            XCTAssertFileExists(debugPath.appending(component: "Foo".soname))
+            XCTAssertFileExists(debugPath.appending(component: "Bar".soname))
+            XCTAssertFileExists(debugPath.appending(component: "Bar with spaces".soname))
         }
     }
     
     func testCUsingCDep() {
         fixture(name: "DependencyResolution/External/CUsingCDep") { prefix in
             XCTAssertBuilds(prefix.appending("Bar"))
-            XCTAssertFileExists(prefix.appending("Bar/.build/debug").appending("Foo".soname))
-            XCTAssertDirectoryExists(prefix.appending("Bar/Packages/Foo-1.2.3"))
+            let debugPath = prefix.appending(components: "Bar", ".build", "debug")
+            XCTAssertFileExists(debugPath.appending(component: "Foo".soname))
+            XCTAssertDirectoryExists(prefix.appending(RelativePath("Bar/Packages/Foo-1.2.3")))
         }
     }
     
     func testCExecutable() {
         fixture(name: "ValidLayouts/SingleModule/CExecutable") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix.appending(".build/debug/CExecutable"))
-            let output = try popen([prefix.appending(".build/debug/CExecutable").asString])
+            let debugPath = prefix.appending(components: ".build", "debug")
+            XCTAssertFileExists(debugPath.appending(component: "CExecutable"))
+            let output = try popen([debugPath.appending(component: "CExecutable").asString])
             XCTAssertEqual(output, "hello 5")
         }
     }
@@ -87,19 +94,21 @@ class ClangModulesTestCase: XCTestCase {
         //The C dependency "Foo" has different layout
         fixture(name: "DependencyResolution/External/CUsingCDep2") { prefix in
             XCTAssertBuilds(prefix.appending("Bar"))
-            XCTAssertFileExists(prefix.appending("Bar/.build/debug").appending("Foo".soname))
-            XCTAssertDirectoryExists(prefix.appending("Bar/Packages/Foo-1.2.3"))
+            let debugPath = prefix.appending(components: "Bar", ".build", "debug")
+            XCTAssertFileExists(debugPath.appending(component: "Foo".soname))
+            XCTAssertDirectoryExists(prefix.appending(RelativePath("Bar/Packages/Foo-1.2.3")))
         }
     }
     
     func testModuleMapGenerationCases() {
         fixture(name: "ClangModules/ModuleMapGenerationCases") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("UmbrellaHeader".soname))
-            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("FlatInclude".soname))
-            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("UmbellaModuleNameInclude".soname))
-            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("NoIncludeDir".soname))
-            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("Baz"))
+            let debugPath = prefix.appending(components: ".build", "debug")
+            XCTAssertFileExists(debugPath.appending(component: "UmbrellaHeader".soname))
+            XCTAssertFileExists(debugPath.appending(component: "FlatInclude".soname))
+            XCTAssertFileExists(debugPath.appending(component: "UmbellaModuleNameInclude".soname))
+            XCTAssertFileExists(debugPath.appending(component: "NoIncludeDir".soname))
+            XCTAssertFileExists(debugPath.appending(component: "Baz"))
         }
     }
 
@@ -107,7 +116,8 @@ class ClangModulesTestCase: XCTestCase {
         // Try building a fixture which needs extra flags to be able to build.
         fixture(name: "ClangModules/CDynamicLookup") { prefix in
             XCTAssertBuilds(prefix, Xld: ["-undefined", "dynamic_lookup"])
-            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("CDynamicLookup".soname))
+            let debugPath = prefix.appending(components: ".build", "debug")
+            XCTAssertFileExists(debugPath.appending(component: "CDynamicLookup".soname))
         }
     }
 

--- a/Tests/Functional/Utilities.swift
+++ b/Tests/Functional/Utilities.swift
@@ -41,7 +41,7 @@ func fixture(name fixtureSubpath: RelativePath, tags: [String] = [], file: Stati
         // The fixture contains either a checkout or just a Git directory.
         if fixtureDir.appending("Package.swift").asString.isFile {
             // It's a single package, so copy the whole directory as-is.
-            let dstDir = tmpDir.path.appending(copyName)
+            let dstDir = tmpDir.path.appending(component: copyName)
             try systemQuietly("cp", "-R", "-H", fixtureDir.asString, dstDir.asString)
             
             // Invoke the block, passing it the path of the copied fixture.
@@ -61,9 +61,9 @@ func fixture(name fixtureSubpath: RelativePath, tags: [String] = [], file: Stati
             
             // Copy each of the package directories and construct a git repo in it.
             for fileName in try! localFileSystem.getDirectoryContents(fixtureDir).sorted() {
-                let srcDir = fixtureDir.appending(fileName)
+                let srcDir = fixtureDir.appending(component: fileName)
                 guard srcDir.asString.isDirectory else { continue }
-                let dstDir = tmpDir.path.appending(fileName)
+                let dstDir = tmpDir.path.appending(component: fileName)
                 try systemQuietly("cp", "-R", "-H", srcDir.asString, dstDir.asString)
                 try systemQuietly([Git.tool, "-C", dstDir.asString, "init"])
                 try systemQuietly([Git.tool, "-C", dstDir.asString, "config", "user.email", "example@example.com"])
@@ -84,7 +84,7 @@ func fixture(name fixtureSubpath: RelativePath, tags: [String] = [], file: Stati
 /// Test-helper function that creates a new Git repository in a directory.  The new repository will contain exactly one empty file, and if a tag name is provided, a tag with that name will be created.
 func initGitRepo(_ dir: AbsolutePath, tag: String? = nil, file: StaticString = #file, line: UInt = #line) {
     do {
-        let file = dir.appending("file.swift")
+        let file = dir.appending(component: "file.swift")
         try systemQuietly(["touch", file.asString])
         try systemQuietly([Git.tool, "-C", dir.asString, "init"])
         try systemQuietly([Git.tool, "-C", dir.asString, "config", "user.email", "example@example.com"])

--- a/Tests/Functional/ValidLayoutTests.swift
+++ b/Tests/Functional/ValidLayoutTests.swift
@@ -22,14 +22,16 @@ class ValidLayoutsTestCase: XCTestCase {
     func testSingleModuleLibrary() {
         runLayoutFixture(name: "SingleModule/Library") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("Library.swiftmodule"))
+            let debugPath = prefix.appending(components: ".build", "debug")
+            XCTAssertFileExists(debugPath.appending("Library.swiftmodule"))
         }
     }
 
     func testSingleModuleExecutable() {
         runLayoutFixture(name: "SingleModule/Executable") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("Executable"))
+            let debugPath = prefix.appending(components: ".build", "debug")
+            XCTAssertFileExists(debugPath.appending("Executable"))
         }
     }
 
@@ -40,22 +42,25 @@ class ValidLayoutsTestCase: XCTestCase {
 
         runLayoutFixture(name: "SingleModule/CustomizedName") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("Bar.swiftmodule"))
+            let debugPath = prefix.appending(components: ".build", "debug")
+            XCTAssertFileExists(debugPath.appending("Bar.swiftmodule"))
         }
     }
 
     func testSingleModuleSubfolderWithSwiftSuffix() {
         fixture(name: "ValidLayouts/SingleModule/SubfolderWithSwiftSuffix", file: #file, line: #line) { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("Bar.swiftmodule"))
+            let debugPath = prefix.appending(components: ".build", "debug")
+            XCTAssertFileExists(debugPath.appending("Bar.swiftmodule"))
         }
     }
 
     func testMultipleModulesLibraries() {
         runLayoutFixture(name: "MultipleModules/Libraries") { prefix in
             XCTAssertBuilds(prefix)
+            let debugPath = prefix.appending(components: ".build", "debug")
             for x in ["Bar", "Baz", "Foo"] {
-                XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("\(x).swiftmodule"))
+                XCTAssertFileExists(debugPath.appending(component: "\(x).swiftmodule"))
             }
         }
     }
@@ -63,8 +68,9 @@ class ValidLayoutsTestCase: XCTestCase {
     func testMultipleModulesExecutables() {
         runLayoutFixture(name: "MultipleModules/Executables") { prefix in
             XCTAssertBuilds(prefix)
+            let debugPath = prefix.appending(components: ".build", "debug")
             for x in ["Bar", "Baz", "Foo"] {
-                let output = try popen([prefix.appending(".build").appending("debug").appending(x).asString])
+                let output = try popen([debugPath.appending(component: x).asString])
                 XCTAssertEqual(output, "\(x)\n")
             }
         }
@@ -79,10 +85,10 @@ class ValidLayoutsTestCase: XCTestCase {
         #endif
         
         fixture(name: "DependencyResolution/External/Complex", tags: tags) { prefix in
-            XCTAssertBuilds(prefix.appending("app"), configurations: [.Debug])
-            XCTAssertDirectoryExists(prefix.appending("app/Packages/DeckOfPlayingCards-1.2.3-beta5"))
-            XCTAssertDirectoryExists(prefix.appending("app/Packages/FisherYates-1.3.4-alpha.beta.gamma1"))
-            XCTAssertDirectoryExists(prefix.appending("app/Packages/PlayingCard-1.2.3+24"))
+            XCTAssertBuilds(prefix.appending(component: "app"), configurations: [.Debug])
+            XCTAssertDirectoryExists(prefix.appending(RelativePath("app/Packages/DeckOfPlayingCards-1.2.3-beta5")))
+            XCTAssertDirectoryExists(prefix.appending(RelativePath("app/Packages/FisherYates-1.3.4-alpha.beta.gamma1")))
+            XCTAssertDirectoryExists(prefix.appending(RelativePath("app/Packages/PlayingCard-1.2.3+24")))
         }
     }
 
@@ -120,10 +126,10 @@ extension ValidLayoutsTestCase {
         // 2. Move everything to a directory called "Sources"
         fixture(name: name, file: #file, line: line) { prefix in
             let files = try! localFileSystem.getDirectoryContents(prefix).filter{ $0.basename != "Package.swift" }
-            let dir = prefix.appending("Sources")
+            let dir = prefix.appending(component: "Sources")
             try Utility.makeDirectories(dir.asString)
             for file in files {
-                try rename(old: prefix.appending(file).asString, new: dir.appending(file).asString)
+                try rename(old: prefix.appending(component: file).asString, new: dir.appending(component: file).asString)
             }
             try body(prefix)
         }
@@ -134,9 +140,9 @@ extension ValidLayoutsTestCase {
             let dir = prefix.appending("Floobles")
             try Utility.makeDirectories(dir.asString)
             for file in files {
-                try rename(old: prefix.appending(file).asString, new: dir.appending(file).asString)
+                try rename(old: prefix.appending(component: file).asString, new: dir.appending(component: file).asString)
             }
-            try symlink(create: prefix.appending("Sources").asString, pointingAt: dir.asString, relativeTo: prefix.asString)
+            try symlink(create: prefix.appending(component: "Sources").asString, pointingAt: dir.asString, relativeTo: prefix.asString)
             try body(prefix)
         }
     }

--- a/Tests/Xcodeproj/FunctionalTests.swift
+++ b/Tests/Xcodeproj/FunctionalTests.swift
@@ -21,10 +21,10 @@ class FunctionalTests: XCTestCase {
     func testSingleModuleLibrary() {
         fixture(name: "ValidLayouts/SingleModule/Library") { prefix in
             XCTAssertXcodeprojGen(prefix)
-            let pbx = prefix.appending("Library.xcodeproj")
+            let pbx = prefix.appending(component: "Library.xcodeproj")
             XCTAssertDirectoryExists(pbx)
             XCTAssertXcodeBuild(project: pbx)
-            let build = prefix.appending("build").appending("Debug")
+            let build = prefix.appending(components: "build", "Debug")
             XCTAssertDirectoryExists(build.appending("Library.framework"))
         }
     }
@@ -33,23 +33,23 @@ class FunctionalTests: XCTestCase {
         fixture(name: "ClangModules/SwiftCMixed") { prefix in
             // This will also test Modulemap generation for xcodeproj.
             XCTAssertXcodeprojGen(prefix)
-            let pbx = prefix.appending("SwiftCMixed.xcodeproj")
+            let pbx = prefix.appending(component: "SwiftCMixed.xcodeproj")
             XCTAssertDirectoryExists(pbx)
             XCTAssertXcodeBuild(project: pbx)
-            let build = prefix.appending("build").appending("Debug")
-            XCTAssertDirectoryExists(build.appending("SeaLib.framework"))
-            XCTAssertFileExists(build.appending("SeaExec"))
-            XCTAssertFileExists(build.appending("CExec"))
+            let build = prefix.appending(components: "build", "Debug")
+            XCTAssertDirectoryExists(build.appending(component: "SeaLib.framework"))
+            XCTAssertFileExists(build.appending(component: "SeaExec"))
+            XCTAssertFileExists(build.appending(component: "CExec"))
         }
     }
 
     func testXcodeProjWithPkgConfig() {
         fixture(name: "Miscellaneous/PkgConfig") { prefix in
-            XCTAssertBuilds(prefix.appending("SystemModule"))
-            XCTAssertFileExists(prefix.appending("SystemModule").appending(".build").appending("debug").appending("libSystemModule.\(Product.dynamicLibraryExtension)"))
-            let pcFile = prefix.appending("libSystemModule.pc")
+            XCTAssertBuilds(prefix.appending(component: "SystemModule"))
+            XCTAssertFileExists(prefix.appending(components: "SystemModule", ".build", "debug", "libSystemModule.\(Product.dynamicLibraryExtension)"))
+            let pcFile = prefix.appending(component: "libSystemModule.pc")
             try! write(path: pcFile) { stream in
-                stream <<< "prefix=\(prefix.appending("SystemModule").asString)\n"
+                stream <<< "prefix=\(prefix.appending(component: "SystemModule").asString)\n"
                 stream <<< "exec_prefix=${prefix}\n"
                 stream <<< "libdir=${exec_prefix}/.build/debug\n"
                 stream <<< "includedir=${prefix}/Sources/include\n"
@@ -61,27 +61,27 @@ class FunctionalTests: XCTestCase {
                 stream <<< "Cflags: -I${includedir}\n"
                 stream <<< "Libs: -L${libdir} -lSystemModule\n"
             }
-            let moduleUser = prefix.appending("SystemModuleUser")
+            let moduleUser = prefix.appending(component: "SystemModuleUser")
             let env = ["PKG_CONFIG_PATH": prefix.asString]
             XCTAssertBuilds(moduleUser, env: env)
             XCTAssertXcodeprojGen(moduleUser, env: env)
-            let pbx = moduleUser.appending("SystemModuleUser.xcodeproj")
+            let pbx = moduleUser.appending(component: "SystemModuleUser.xcodeproj")
             XCTAssertDirectoryExists(pbx)
             XCTAssertXcodeBuild(project: pbx)
-            XCTAssertFileExists(moduleUser.appending("build").appending("Debug").appending("SystemModuleUser"))
+            XCTAssertFileExists(moduleUser.appending(components: "build", "Debug", "SystemModuleUser"))
         }
     }
 
     func testModuleNamesWithNonC99Names() {
         fixture(name: "Miscellaneous/PackageWithNonc99NameModules") { prefix in
             XCTAssertXcodeprojGen(prefix)
-            let pbx = prefix.appending("PackageWithNonc99NameModules.xcodeproj")
+            let pbx = prefix.appending(component: "PackageWithNonc99NameModules.xcodeproj")
             XCTAssertDirectoryExists(pbx)
             XCTAssertXcodeBuild(project: pbx)
-            let build = prefix.appending("build").appending("Debug")
-            XCTAssertDirectoryExists(build.appending("A_B.framework"))
-            XCTAssertDirectoryExists(build.appending("B_C.framework"))
-            XCTAssertDirectoryExists(build.appending("C_D.framework"))
+            let build = prefix.appending(components: "build", "Debug")
+            XCTAssertDirectoryExists(build.appending(component: "A_B.framework"))
+            XCTAssertDirectoryExists(build.appending(component: "B_C.framework"))
+            XCTAssertDirectoryExists(build.appending(component: "C_D.framework"))
         }
     }
     
@@ -104,14 +104,14 @@ class FunctionalTests: XCTestCase {
         }
         // Now we use a fixture for both the system library wrapper and the text executable.
         fixture(name: "Miscellaneous/SystemModules") { prefix in
-            XCTAssertBuilds(prefix.appending("TestExec"), Xld: ["-L/tmp/"])
-            XCTAssertFileExists(prefix.appending("TestExec").appending(".build").appending("debug").appending("TestExec"))
-            let fakeDir = prefix.appending("CFake")
+            XCTAssertBuilds(prefix.appending(component: "TestExec"), Xld: ["-L/tmp/"])
+            XCTAssertFileExists(prefix.appending(components: "TestExec", ".build", "debug", "TestExec"))
+            let fakeDir = prefix.appending(component: "CFake")
             XCTAssertDirectoryExists(fakeDir)
-            let execDir = prefix.appending("TestExec")
+            let execDir = prefix.appending(component: "TestExec")
             XCTAssertDirectoryExists(execDir)
             XCTAssertXcodeprojGen(execDir, flags: ["-Xlinker", "-L/tmp/"])
-            let proj = execDir.appending("TestExec.xcodeproj")
+            let proj = execDir.appending(component: "TestExec.xcodeproj")
             XCTAssertXcodeBuild(project: proj)
         }
     }

--- a/Tests/Xcodeproj/GenerateXcodeprojTests.swift
+++ b/Tests/Xcodeproj/GenerateXcodeprojTests.swift
@@ -31,7 +31,7 @@ class GenerateXcodeprojTests: XCTestCase {
             let outpath = try Xcodeproj.generate(dstdir: dstdir, projectName: projectName, srcroot: srcroot, modules: modules, externalModules: [], products: products, options: XcodeprojOptions())
 
             XCTAssertDirectoryExists(outpath)
-            XCTAssertEqual(outpath, dstdir.appending(projectName + ".xcodeproj"))
+            XCTAssertEqual(outpath, dstdir.appending(component: projectName + ".xcodeproj"))
 
             // We can only validate this on OS X.
             // Don't allow TOOLCHAINS to be overriden here, as it breaks the test below.


### PR DESCRIPTION
[Basic] Add AbsolutePath.appending(component[s]:) methods.  …
 - These are used to append literal components, not subpaths. This is a common
   operation and helps make explicit at the call sites when the expectation is
   that the append is not a full subpath.

[Basic] Eliminate AbsolutePath.appending(_:String)  …
 - It turns out that almost all clients of this method were in places where the
   individual components were well known. The result is a little more verbose,
   but it makes it much more explicit when the only thing being appended is a
   component (which can have semantic implications on the calling code, and so
   is useful to know).