### PR TITLE
[Basic] Add TerminalController class

### DIFF
--- a/Sources/Basic/TerminalController.swift
+++ b/Sources/Basic/TerminalController.swift
@@ -1,0 +1,136 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import libc
+import func POSIX.getenv
+
+/// A class to have better control on tty output streams: standard output and standard error.
+/// Allows operations like cursor movement and colored text output on tty.
+public final class TerminalController {
+
+    /// Terminal color choices.
+    public enum Color {
+        case noColor
+
+        case red
+        case green
+        case yellow
+        case cyan
+
+        case white
+        case black
+        case grey
+
+        /// Returns the color code which can be prefixed on a string to display it in that color.
+        fileprivate var string: String {
+            switch self {
+                case .noColor: return ""
+                case .red: return "\u{001B}[31m"
+                case .green: return "\u{001B}[32m"
+                case .yellow: return "\u{001B}[33m"
+                case .cyan: return "\u{001B}[36m"
+                case .white: return "\u{001B}[37m"
+                case .black: return "\u{001B}[30m"
+                case .grey: return "\u{001B}[30;1m"
+            }
+        }
+    }
+
+    /// Pointer to output stream to operate on.
+    private var stream: LocalFileOutputByteStream
+
+    /// Width of the terminal.
+    public let width: Int
+
+    /// Code to clear the line on a tty.
+    private let clearLineString = "\u{001B}[2K"
+
+    /// Code to end any currently active wrapping.
+    private let resetString = "\u{001B}[0m"
+
+    /// Code to make string bold.
+    private let boldString = "\u{001B}[1m"
+
+    /// Constructs the instance if the stream is a tty.
+    public init?(stream: LocalFileOutputByteStream) {
+        // Make sure this file stream is tty.
+        guard isatty(fileno(stream.fp)) != 0 else {
+            return nil
+        }
+        width = TerminalController.terminalWidth() ?? 80 // Assume default if we are not able to determine.
+        self.stream = stream
+    }
+
+    /// Tries to get the terminal width first using COLUMNS env variable and
+    /// if that fails ioctl method testing on stdout stream.
+    ///
+    /// - Returns: Current width of terminal if it was determinable.
+    public static func terminalWidth() -> Int? {
+        // Try to get from enviornment.
+        if let columns = POSIX.getenv("COLUMNS"), let width = Int(columns) {
+            return width
+        }
+
+        // Try determining using ioctl.
+        var ws = winsize()
+        if ioctl(1, UInt(TIOCGWINSZ), &ws) == 0 {
+            return Int(ws.ws_col)
+        }
+        return nil
+    }
+
+    /// Flushes the stream.
+    public func flush() {
+        stream.flush()
+    }
+
+    /// Clears the current line and moves the cursor to beginning of the line..
+    public func clearLine() {
+        stream <<< clearLineString <<< "\r"
+        flush()
+    }
+
+    /// Moves the cursor y columns up.
+    public func moveCursor(y: Int) {
+        stream <<< "\u{001B}[\(y)A"
+        flush()
+    }
+
+    /// Writes a string to the stream.
+    public func write(_ string: String, inColor color: Color = .noColor, bold: Bool = false) {
+        writeWrapped(string, inColor: color, bold: bold, stream: stream)
+        flush()
+    }
+
+    /// Inserts a new line character into the stream.
+    public func endLine() {
+        stream <<< "\n"
+        flush()
+    }
+
+    /// Wraps the string into the color mentioned.
+    public func wrap(_ string: String, inColor color: Color, bold: Bool = false) -> String {
+        let stream = BufferedOutputByteStream()
+        writeWrapped(string, inColor: color, bold: bold, stream: stream)
+        guard let string = stream.bytes.asString else {
+            fatalError("Couldn't get string value from stream.")
+        }
+        return string
+    }
+
+    private func writeWrapped(_ string: String, inColor color: Color, bold: Bool = false, stream: OutputByteStream) {
+        // Don't wrap if string is empty or color is no color.
+        guard !string.isEmpty && color != .noColor else {
+            stream <<< string
+            return
+        }
+        stream <<< color.string <<< (bold ? boldString : "") <<< string <<< resetString
+    }
+}

--- a/Sources/Utility/ProgressBar.swift
+++ b/Sources/Utility/ProgressBar.swift
@@ -1,0 +1,110 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Basic
+
+/// A protocol to operate on terminal based progress bars.
+public protocol ProgressBarProtocol {
+    func update(percent: Int, text: String)
+    func complete()
+}
+
+/// Simple ProgressBar which shows the update text in new lines.
+public final class SimpleProgressBar: ProgressBarProtocol {
+    private let header: String
+    private var isClear: Bool
+    private var stream: OutputByteStream
+
+    init(stream: OutputByteStream, header: String) {
+        self.stream = stream
+        self.header = header
+        self.isClear = true
+    }
+
+    public func update(percent: Int, text: String) {
+        if isClear {
+            stream <<< header
+            stream <<< "\n"
+            stream.flush()
+            isClear = false
+        }
+
+        stream <<< "\(percent)%: " <<< text
+        stream <<< "\n"
+        stream.flush()
+    }
+
+    public func complete() {
+    }
+}
+
+/// Three line progress bar with header, redraws on each update.
+public final class ProgressBar: ProgressBarProtocol {
+    private let term: TerminalController
+    private let header: String
+    private var isClear: Bool // true if haven't drawn anything yet.
+
+    init(term: TerminalController, header: String) {
+        self.term = term
+        self.header = header
+        self.isClear = true
+    }
+
+    public func update(percent: Int, text: String) {
+        if isClear {
+            let spaceCount = (term.width/2 - header.utf8.count/2)
+            term.write(" ".repeating(n: spaceCount))
+            term.write(header, inColor: .cyan, bold: true)
+            term.endLine()
+            isClear = false
+        }
+
+        term.clearLine()
+        let percentString = percent < 10 ? " \(percent)" : "\(percent)"
+        let prefix = "\(percentString)% " + term.wrap("[", inColor: .green, bold: true)
+        term.write(prefix)
+
+        let barWidth = term.width - prefix.utf8.count
+        let n = Int(Double(barWidth) * Double(percent)/100.0)
+
+        term.write("=".repeating(n: n) + "-".repeating(n: barWidth - n), inColor: .green)
+        term.write("]", inColor: .green, bold: true)
+        term.endLine()
+
+        term.clearLine()
+        term.write(text)
+
+        term.moveCursor(y: 1)
+    }
+
+    public func complete() {
+        term.endLine()
+    }
+}
+
+/// Creates colored or simple progress bar based on the provided output stream.
+public func createProgressBar(forStream stream: OutputByteStream, header: String) -> ProgressBarProtocol {
+    if let stdStream = stream as? LocalFileOutputByteStream, let term = TerminalController(stream: stdStream) {
+        return ProgressBar(term: term, header: header)
+    }
+    return SimpleProgressBar(stream: stream, header: header)
+}
+
+private extension String {
+    /// Repeats self n times. If n is less than zero, returns the same string.
+    func repeating(n: Int) -> String {
+        guard n > 0 else { return self }
+        var str = ""
+        for _ in 0..<n {
+            str = str + self
+        }
+        return str
+    }
+}

--- a/Tests/BasicTests/TerminalControllerTests.swift
+++ b/Tests/BasicTests/TerminalControllerTests.swift
@@ -1,0 +1,83 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+@testable import Basic
+import libc
+
+final class PseudoTerminal {
+    let master: Int32
+    let slave: Int32
+    var outStream: LocalFileOutputByteStream
+
+    init?(){
+        var master: Int32 = 0
+        var slave: Int32 = 0
+        if openpty(&master, &slave, nil, nil, nil) != 0 {
+            return nil
+        }
+        guard let outStream = try? LocalFileOutputByteStream(filePointer: fdopen(slave, "w")) else {
+            return nil
+        }
+        self.outStream = outStream
+        self.master = master
+        self.slave = slave
+    }
+
+    func readMaster(maxChars n: Int = 1000) -> String? {
+        var buf: [CChar] = [CChar](repeating: 0, count: n)
+        if read(master, &buf, n) <= 0 {
+            return nil
+        }
+        return String(cString: buf)
+    }
+
+    func close() {
+        _ = libc.close(slave)
+        _ = libc.close(master)
+    }
+}
+
+final class TerminalControllerTests: XCTestCase {
+    func testBasic() {
+        guard let pty = PseudoTerminal(), let term = TerminalController(stream: pty.outStream) else {
+            XCTFail("Couldn't create pseudo terminal.")
+            return
+        }
+
+        // Test red color.
+        term.write("hello", inColor: .red)
+        XCTAssertEqual(pty.readMaster(), "\u{1B}[31mhello\u{1B}[0m")
+
+        // Test clearLine.
+        term.clearLine()
+        XCTAssertEqual(pty.readMaster(), "\u{1B}[2K\r")
+
+        // Test endline.
+        term.endLine()
+        XCTAssertEqual(pty.readMaster(), "\r\n")
+
+        // Test move cursor.
+        term.moveCursor(y: 3)
+        XCTAssertEqual(pty.readMaster(), "\u{1B}[3A")
+
+        // Test color wrapping.
+        var wrapped = term.wrap("hello", inColor: .noColor)
+        XCTAssertEqual(wrapped, "hello")
+
+        wrapped = term.wrap("green", inColor: .green)
+        XCTAssertEqual(wrapped, "\u{001B}[32mgreen\u{001B}[0m")
+        pty.close()
+    }
+
+    static var allTests = [
+        ("testBasic", testBasic),
+    ]
+}

--- a/Tests/BasicTests/XCTestManifests.swift
+++ b/Tests/BasicTests/XCTestManifests.swift
@@ -32,6 +32,7 @@ public func allTests() -> [XCTestCaseEntry] {
         testCase(SyncronizedQueueTests.allTests),
         testCase(TOMLTests.allTests),
         testCase(TemporaryFileTests.allTests),
+        testCase(TerminalControllerTests.allTests),
         testCase(ThreadTests.allTests),
         testCase(WalkTests.allTests),
     ]

--- a/Tests/UtilityTests/ProgressBarTests.swift
+++ b/Tests/UtilityTests/ProgressBarTests.swift
@@ -1,0 +1,98 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import Utility
+import libc
+@testable import Basic
+
+typealias Thread = Basic.Thread
+
+// FIXME: Copied from BasicTests, move to TestSupport once available.
+final class PseudoTerminal {
+    let master: Int32
+    let slave: Int32
+    var outStream: LocalFileOutputByteStream
+
+    init?(){
+        var master: Int32 = 0
+        var slave: Int32 = 0
+        if openpty(&master, &slave, nil, nil, nil) != 0 {
+            return nil
+        }
+        guard let outStream = try? LocalFileOutputByteStream(filePointer: fdopen(slave, "w")) else {
+            return nil
+        }
+        self.outStream = outStream
+        self.master = master
+        self.slave = slave
+    }
+
+    func readMaster(maxChars n: Int = 1000) -> String? {
+        var buf: [CChar] = [CChar](repeating: 0, count: n)
+        if read(master, &buf, n) <= 0 {
+            return nil
+        }
+        return String(cString: buf)
+    }
+
+    func close() {
+        _ = libc.close(slave)
+    }
+
+    deinit {
+        _ = libc.close(master)
+    }
+}
+
+final class ProgressBarTests: XCTestCase {
+    func testProgressBar() {
+        guard let pty = PseudoTerminal() else {
+            XCTFail("Couldn't create pseudo terminal.")
+            return
+        }
+
+        // Test progress bar when writing to a non tty stream.
+        let outStream = BufferedOutputByteStream()
+        var bar = createProgressBar(forStream: outStream, header: "test")
+        XCTAssertTrue(bar is SimpleProgressBar)
+
+        runProgressBar(bar)
+        XCTAssertEqual(outStream.bytes.asString, "test\n0%: 0\n1%: 1\n2%: 2\n3%: 3\n4%: 4\n5%: 5\n")
+
+        // Test progress bar when writing a tty stream.
+        bar = createProgressBar(forStream: pty.outStream, header: "TestHeader")
+        XCTAssertTrue(bar is ProgressBar)
+
+        var output = ""
+        let thread = Thread {
+            while let out = pty.readMaster() {
+                output += out
+            }
+        }
+        thread.start()
+        runProgressBar(bar)
+        pty.close()
+        // Make sure to read the complete output before checking it.
+        thread.join()
+        XCTAssertTrue(output.chuzzle()?.hasPrefix("\u{1B}[36m\u{1B}[1mTestHeader\u{1B}[0m") ?? false)
+    }
+
+    private func runProgressBar(_ bar: ProgressBarProtocol) {
+        for i in 0...5 {
+            bar.update(percent: i, text: String(i))
+        }
+        bar.complete()
+    }
+
+    static var allTests = [
+        ("testProgressBar", testProgressBar),
+    ]
+}

--- a/Tests/UtilityTests/XCTestManifests.swift
+++ b/Tests/UtilityTests/XCTestManifests.swift
@@ -16,6 +16,7 @@ public func allTests() -> [XCTestCaseEntry] {
         testCase(CollectionTests.allTests),
         testCase(GitUtilityTests.allTests),
         testCase(PkgConfigParserTests.allTests),
+        testCase(ProgressBarTests.allTests),
         testCase(ShellTests.allTests),
         testCase(StringTests.allTests),
         testCase(URLTests.allTests),


### PR DESCRIPTION
I was able to implement a lit-style progress bar without using curses (yay!). Currently how it works is `TerminalController` takes any object conforming to `OutputStream` and exposes APIs to perform operations like write with colour and cursor movement on it. If the output stream is not a tty then TerminalController will ignore the tty operations and write in plain text. This PR is not fully complete yet, needs tests and some calculation fixing but works. I want to get feedback for the APIs and direction.
