### PR TITLE
Switch from string-based `realpath()`

### DIFF
--- a/Sources/Basic/PathShims.swift
+++ b/Sources/Basic/PathShims.swift
@@ -51,9 +51,11 @@ public func exists(_ path: AbsolutePath) -> Bool {
 public func resolveSymlinks(_ path: AbsolutePath) -> AbsolutePath {
     let pathStr = path.asString
   #if os(Linux)
-    let resolvedPathStr = pathStr.resolvingSymlinksInPath()
+    // FIXME: This is really unfortunate but seems to be the only way to invoke this functionality on Linux.
+    let url = URL(fileURLWithPath: pathStr)
+    guard let resolvedPathStr = (try? url.resolvingSymlinksInPath())?.path else { return path }
   #else
-    // FIXME: It's unfortunate to have to case to NSString here but apparently the String method is deprecated.
+    // FIXME: It's unfortunate to have to cast to NSString here but apparently the String method is deprecated.
     let resolvedPathStr = (pathStr as NSString).resolvingSymlinksInPath
   #endif
     // FIXME: We should measure if it's really more efficient to compare the strings first.

--- a/Sources/Basic/PathShims.swift
+++ b/Sources/Basic/PathShims.swift
@@ -49,7 +49,15 @@ public func exists(_ path: AbsolutePath) -> Bool {
 
 /// Returns the "real path" corresponding to `path` by resolving any symbolic links.
 public func resolveSymlinks(_ path: AbsolutePath) -> AbsolutePath {
-    return AbsolutePath((path.asString as NSString).resolvingSymlinksInPath)
+    let pathStr = path.asString
+  #if os(Linux)
+    let resolvedPathStr = pathStr.resolvingSymlinksInPath()
+  #else
+    // FIXME: It's unfortunate to have to case to NSString here but apparently the String method is deprecated.
+    let resolvedPathStr = (pathStr as NSString).resolvingSymlinksInPath
+  #endif
+    // FIXME: We should measure if it's really more efficient to compare the strings first.
+    return (resolvedPathStr == pathStr) ? path : AbsolutePath(resolvedPathStr)
 }
 
 public func mkdir(_ path: AbsolutePath, permissions mode: mode_t = S_IRWXU|S_IRWXG|S_IRWXO, recursive: Bool = true) throws {

--- a/Sources/Basic/PathShims.swift
+++ b/Sources/Basic/PathShims.swift
@@ -10,6 +10,7 @@
 
 import libc
 import POSIX
+import Foundation
 
 
 /// This file contains temporary shim functions for use during the adoption of
@@ -46,8 +47,9 @@ public func exists(_ path: AbsolutePath) -> Bool {
     return access(path.asString, F_OK) == 0
 }
 
-public func realpath(_ path: AbsolutePath) throws -> AbsolutePath {
-    return try AbsolutePath(realpath(path.asString))
+/// Returns the "real path" corresponding to `path` by resolving any symbolic links.
+public func resolveSymlinks(_ path: AbsolutePath) -> AbsolutePath {
+    return AbsolutePath((path.asString as NSString).resolvingSymlinksInPath)
 }
 
 public func mkdir(_ path: AbsolutePath, permissions mode: mode_t = S_IRWXU|S_IRWXG|S_IRWXO, recursive: Bool = true) throws {

--- a/Sources/Utility/Git.swift
+++ b/Sources/Utility/Git.swift
@@ -19,8 +19,7 @@ public class Git {
         public let path: AbsolutePath
 
         public init?(path: AbsolutePath) {
-            guard let realroot = try? AbsolutePath(realpath(path.asString)) else { return nil }
-            self.path = realroot
+            self.path = resolveSymlinks(path)
             guard path.appending(".git").asString.isDirectory else { return nil }
         }
 

--- a/Tests/Basic/PathShimTests.swift
+++ b/Tests/Basic/PathShimTests.swift
@@ -1,0 +1,49 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+import Basic
+import POSIX
+import Utility
+
+class PathShimTests : XCTestCase {
+
+    func testResolvingSymlinks() {
+        // Make sure the root path resolves to itself.
+        XCTAssertEqual(resolveSymlinks(AbsolutePath.root), AbsolutePath.root)
+        
+        // For the rest of the tests we'll need a temporary directory.
+        let tmpDir = try! TemporaryDirectory(removeTreeOnDeinit: true)
+        
+        // Create a symbolic link and directory.
+        let slnkPath = tmpDir.path.appending("slnk")
+        let fldrPath = tmpDir.path.appending("fldr")
+        
+        // Create a symbolic link pointing at the (so far non-existent) directory.
+        try! symlink(create: slnkPath.asString, pointingAt: fldrPath.asString, relativeTo: tmpDir.path.asString)
+        
+        // Resolving the symlink should not yet change anything.
+        XCTAssertEqual(resolveSymlinks(slnkPath), slnkPath)
+        
+        // Create a directory to be the referent of the symbolic link.
+        try! Utility.makeDirectories(fldrPath.asString)
+        
+        // Resolving the symlink should now point at the directory.
+        XCTAssertEqual(resolveSymlinks(slnkPath), fldrPath)
+        
+        // Resolving the directory should still not change anything.
+        XCTAssertEqual(resolveSymlinks(fldrPath), fldrPath)
+    }
+    
+    static var allTests = [
+        ("testResolvingSymlinks",  testResolvingSymlinks),
+    ]
+}

--- a/Tests/Commands/PackageToolTests.swift
+++ b/Tests/Commands/PackageToolTests.swift
@@ -78,7 +78,7 @@ final class PackageToolTests: XCTestCase {
             guard case let .string(name)? = contents["name"] else { XCTFail("unexpected result"); return }
             XCTAssertEqual(name, "Dealer")
             guard case let .string(path)? = contents["path"] else { XCTFail("unexpected result"); return }
-            XCTAssertEqual(path, try realpath(packageRoot).asString)
+            XCTAssertEqual(resolveSymlinks(AbsolutePath(path)), resolveSymlinks(packageRoot))
         }
     }
     

--- a/Tests/Utility/PathTests.swift
+++ b/Tests/Utility/PathTests.swift
@@ -121,15 +121,15 @@ class WalkTests: XCTestCase {
 
     func testSymlinksNotWalked() {
         mktmpdir { root in
-            let root = try realpath(root)  // FIXME: it would be better to not need this, but we end up relying on /tmp -> /private/tmp.
+            let root = resolveSymlinks(root)  // FIXME: it would be better to not need this, but we end up relying on /tmp -> /private/tmp.
             
             try Utility.makeDirectories(root.appending("foo").asString)
             try Utility.makeDirectories(root.appending("bar/baz/goo").asString)
             try symlink(create: root.appending("foo/symlink").asString, pointingAt: root.appending("bar").asString, relativeTo: root.asString)
 
             XCTAssertTrue(root.appending("foo/symlink").asString.isSymlink)
-            XCTAssertEqual(try! realpath(root.appending("foo/symlink").asString), root.appending("bar").asString)
-            XCTAssertTrue(try! realpath(root.appending("foo/symlink/baz").asString).isDirectory)
+            XCTAssertEqual(resolveSymlinks(root.appending("foo/symlink")), root.appending("bar"))
+            XCTAssertTrue(resolveSymlinks(root.appending("foo/symlink/baz")).asString.isDirectory)
 
             let results = walk(root.appending("foo")).map{ $0 }
 

--- a/Tests/Utility/RmtreeTests.swift
+++ b/Tests/Utility/RmtreeTests.swift
@@ -17,15 +17,15 @@ import Utility
 class RmtreeTests: XCTestCase {
     func testDoesNotFollowSymlinks() {
         mktmpdir { root in
-            let root = try realpath(root)  // FIXME: it would be better to not need this, but we end up relying on /tmp -> /private/tmp.
+            let root = resolveSymlinks(root)  // FIXME: it would be better to not need this, but we end up relying on /tmp -> /private/tmp.
             
             try Utility.makeDirectories(root.appending("foo").asString)
             try Utility.makeDirectories(root.appending("bar/baz/goo").asString)
             try symlink(create: root.appending("foo/symlink").asString, pointingAt: root.appending("bar").asString, relativeTo: root.asString)
             
             XCTAssertTrue(root.appending("foo/symlink").asString.isSymlink)
-            XCTAssertEqual(try! realpath(root.appending("foo/symlink").asString), root.appending("bar").asString)
-            XCTAssertTrue(try! realpath(root.appending("foo/symlink/baz").asString).isDirectory)
+            XCTAssertEqual(resolveSymlinks(root.appending("foo").appending("symlink")), root.appending("bar"))
+            XCTAssertTrue(resolveSymlinks(root.appending("foo").appending("symlink").appending("baz")).asString.isDirectory)
 
             try Utility.removeFileTree(root.appending("foo").asString)
 


### PR DESCRIPTION
Switch from string-based `realpath()` to the AbsolutePath-based `resolveSymlinks()`.  We give the path-based function a separate name from the string-based one to reduce confusion.

We do not yet change the locations that operate on URLs, however.