### PR TITLE
[Basic] Implement FileOutputByteStream for Local and in-mem fs

### DIFF
--- a/Sources/Basic/FileSystem.swift
+++ b/Sources/Basic/FileSystem.swift
@@ -60,7 +60,7 @@ public enum FileSystemError: Swift.Error {
     case unknownOSError
 }
 
-private extension FileSystemError {
+extension FileSystemError {
     init(errno: Int32) {
         switch errno {
         case libc.EACCES:

--- a/Sources/Basic/JSON.swift
+++ b/Sources/Basic/JSON.swift
@@ -92,7 +92,9 @@ public func ==(lhs: JSON, rhs: JSON) -> Bool {
 extension JSON {
     /// Encode a JSON item into a string of bytes.
     public func toBytes() -> ByteString {
-        return (OutputByteStream() <<< self).bytes
+        let stream = InMemoryOutputByteStream()
+        stream <<< self
+        return stream.bytes
     }
     
     /// Encode a JSON item into a JSON string

--- a/Sources/Basic/OutputByteStream.swift
+++ b/Sources/Basic/OutputByteStream.swift
@@ -57,12 +57,6 @@ public class OutputByteStream: OutputStream {
         return buffer.count
     }
 
-    /// The current contents of the output stream.
-    // FIXME: Remove this once all dependencies are migrated to InMemoryOutputByteStream.
-    public var bytes: ByteString {
-        return ByteString(self.buffer)
-    }
-    
     // MARK: Data Output API
 
     public func flush() {
@@ -410,7 +404,7 @@ public struct Format {
 public final class InMemoryOutputByteStream: OutputByteStream {
 
     /// The contents of the output stream.
-    override public var bytes: ByteString {
+    public var bytes: ByteString {
         return ByteString(self.buffer)
     }
 }

--- a/Sources/Basic/OutputByteStream.swift
+++ b/Sources/Basic/OutputByteStream.swift
@@ -44,7 +44,7 @@ public protocol ByteStreamable {
 /// space.
 public class OutputByteStream: OutputStream {
     /// The data buffer.
-    private var buffer: [UInt8]
+    var buffer: [UInt8]
     
     public init() {
         self.buffer = []

--- a/Sources/Basic/OutputByteStream.swift
+++ b/Sources/Basic/OutputByteStream.swift
@@ -58,6 +58,7 @@ public class OutputByteStream: OutputStream {
     }
 
     /// The current contents of the output stream.
+    // FIXME: Remove this once all dependencies are migrated to InMemoryOutputByteStream.
     public var bytes: ByteString {
         return ByteString(self.buffer)
     }
@@ -402,6 +403,15 @@ public struct Format {
     /// Write the input list to the stream (after applying a transform to each item) with the given separator between items.
     static public func asSeparatedList<T>(_ items: [T], transform: (T) -> ByteStreamable, separator: String) -> ByteStreamable {
         return TransformedSeparatedListStreamable(items: items, transform: transform, separator: separator)
+    }
+}
+
+/// Represents a stream which operates in memory.
+public final class InMemoryOutputByteStream: OutputByteStream {
+
+    /// The contents of the output stream.
+    override public var bytes: ByteString {
+        return ByteString(self.buffer)
     }
 }
 

--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -102,9 +102,9 @@ public func describe(_ prefix: AbsolutePath, _ conf: Configuration, _ graph: Pac
 }
 
 private func write(path: AbsolutePath, write: (OutputByteStream) -> Void) throws -> AbsolutePath {
-    let stream = OutputByteStream()
+    let stream = try localFileSystem.openFileOutputStream(path)
     write(stream)
-    try localFileSystem.writeFileContents(path, bytes: stream.bytes)
+    try stream.close()
     return path
 }
 

--- a/Sources/Commands/init.swift
+++ b/Sources/Commands/init.swift
@@ -15,10 +15,10 @@ import POSIX
 private extension FileSystem {
     /// Write to a file from a stream producer.
     mutating func writeFileContents(_ path: AbsolutePath, body: @noescape (OutputByteStream) -> ()) throws {
-        let contents = OutputByteStream()
-        body(contents)
         try createDirectory(path.parentDirectory, recursive: true)
-        try writeFileContents(path, bytes: contents.bytes)
+        let stream = try openFileOutputStream(path)
+        body(stream)
+        try stream.close()
     }
 }
 

--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -123,7 +123,7 @@ import class Foundation.NSData
 /// Writes the contents to the file specified.
 /// Doesn't re-writes the file in case the new and old contents of file are same.
 func open(_ path: AbsolutePath, body: ((String) -> Void) throws -> Void) throws {
-    let stream = OutputByteStream()
+    let stream = InMemoryOutputByteStream()
     try body { line in
         stream <<< line
         stream <<< "\n"

--- a/Tests/Basic/ByteStringTests.swift
+++ b/Tests/Basic/ByteStringTests.swift
@@ -63,7 +63,7 @@ class ByteStringTests: XCTestCase {
     }
 
     func testByteStreamable() {
-        let s = OutputByteStream()
+        let s = InMemoryOutputByteStream()
         s <<< ByteString([1, 2, 3])
         XCTAssertEqual(s.bytes, [1, 2, 3])
     }

--- a/Tests/Basic/FileSystemTests.swift
+++ b/Tests/Basic/FileSystemTests.swift
@@ -260,7 +260,26 @@ class FileSystemTests: XCTestCase {
         try rerootedFileSystem.createDirectory("/subdir2")
         XCTAssert(baseFileSystem.isDirectory("/base/rootIsHere/subdir2"))
     }
-    
+
+    func testLocalFileOutputByteStream() throws {
+        let fs = Basic.localFileSystem
+        let tempFile = try TemporaryFile()
+        let path = tempFile.path
+        let stream = try fs.openFileOutputStream(path)
+        stream <<< "Hello, World!"
+        stream.flush()
+        XCTAssertEqual(try fs.readFileContents(path), "Hello, World!")
+    }
+
+    func testInMemoryFileOutputByteStream() throws {
+        let fs = InMemoryFileSystem()
+        let path = AbsolutePath("/file")
+        let stream = try fs.openFileOutputStream(path)
+        stream <<< "Hello, World!"
+        stream.flush()
+        XCTAssertEqual(try fs.readFileContents(path), "Hello, World!")
+    }
+
     static var allTests = [
         ("testLocalBasics", testLocalBasics),
         ("testLocalCreateDirectory", testLocalCreateDirectory),
@@ -269,5 +288,7 @@ class FileSystemTests: XCTestCase {
         ("testInMemoryCreateDirectory", testInMemoryCreateDirectory),
         ("testInMemoryReadWriteFile", testInMemoryReadWriteFile),
         ("testRootedFileSystem", testRootedFileSystem),
+        ("testLocalFileOutputByteStream", testLocalFileOutputByteStream),
+        ("testInMemoryFileOutputByteStream", testInMemoryFileOutputByteStream),
     ]
 }

--- a/Tests/Basic/OutputByteStreamTests.swift
+++ b/Tests/Basic/OutputByteStreamTests.swift
@@ -112,10 +112,29 @@ class OutputByteStreamTests: XCTestCase {
         }
     }
 
+    func testLocalFileStream() throws {
+        let tempFile = try TemporaryFile()
+
+        func read() -> String? {
+            return try! localFileSystem.readFileContents(tempFile.path).asString
+        }
+
+        let stream = try LocalFileOutputByteStream(tempFile.path)
+        stream <<< "Hello"
+        stream.flush()
+        XCTAssertEqual(read(), "Hello")
+
+        stream <<< " World"
+        try stream.close()
+
+        XCTAssertEqual(read(), "Hello World")
+    }
+
     static var allTests = [
         ("testBasics", testBasics),
         ("testStreamOperator", testStreamOperator),
         ("testJSONEncoding", testJSONEncoding),
         ("testFormattedOutput", testFormattedOutput),
+        ("testLocalFileStream", testLocalFileStream),
     ]
 }

--- a/Tests/Basic/OutputByteStreamTests.swift
+++ b/Tests/Basic/OutputByteStreamTests.swift
@@ -24,10 +24,9 @@ class OutputByteStreamTests: XCTestCase {
         
         let streamable: Streamable = Character("!")
         stream.write(streamable)
-
-        stream.flush()
         
         XCTAssertEqual(stream.position, "Hello, world!".utf8.count)
+        stream.flush()
         XCTAssertEqual(stream.bytes, "Hello, world!")
     }
     

--- a/Tests/Basic/OutputByteStreamTests.swift
+++ b/Tests/Basic/OutputByteStreamTests.swift
@@ -112,6 +112,12 @@ class OutputByteStreamTests: XCTestCase {
         }
     }
 
+    func testInMemoryOutputByteStream() {
+        let stream = InMemoryOutputByteStream()
+        stream.write("Hello")
+        XCTAssertEqual(stream.bytes, "Hello")
+    }
+
     func testLocalFileStream() throws {
         let tempFile = try TemporaryFile()
 
@@ -135,6 +141,7 @@ class OutputByteStreamTests: XCTestCase {
         ("testStreamOperator", testStreamOperator),
         ("testJSONEncoding", testJSONEncoding),
         ("testFormattedOutput", testFormattedOutput),
+        ("testInMemoryOutputByteStream", testInMemoryOutputByteStream),
         ("testLocalFileStream", testLocalFileStream),
     ]
 }

--- a/Tests/Basic/TemporaryFileTests.swift
+++ b/Tests/Basic/TemporaryFileTests.swift
@@ -26,7 +26,7 @@ class TemporaryFileTests: XCTestCase {
             XCTAssertTrue(file.path.asString.isFile)
 
             // Try writing some data to the file.
-            let stream = OutputByteStream()
+            let stream = InMemoryOutputByteStream()
             stream <<< "foo"
             stream <<< "bar"
             stream <<< "baz"

--- a/Tests/Xcodeproj/FunctionalTests.swift
+++ b/Tests/Xcodeproj/FunctionalTests.swift
@@ -125,9 +125,9 @@ class FunctionalTests: XCTestCase {
 }
 
 func write(path: AbsolutePath, write: (OutputByteStream) -> Void) throws {
-    let stream = OutputByteStream()
+    let stream = try localFileSystem.openFileOutputStream(path)
     write(stream)
-    try localFileSystem.writeFileContents(path, bytes: stream.bytes)
+    try stream.close()
 }
 
 func XCTAssertXcodeBuild(project: AbsolutePath, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
This adds an interface to FileSystem protocol which creates file stream
for a file which can be written to using OutputByteStream methods.
Currently file is actually written to when flush() or close() is called.