### PR TITLE
Wrap -Xcc -fblocks usage with -Xswiftc when building Swift PM

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -821,7 +821,7 @@ def main():
         cmd.extend(["-Xswiftc", "-I{}".format(os.path.join(args.libdispatch_build_dir,
                                              "src"))])
         cmd.extend(["-Xswiftc", "-I{}".format(args.libdispatch_source_dir)])
-        cmd.extend(["-Xcc", "-fblocks"])
+        cmd.extend(["-Xswiftc", "-Xcc", "-Xswiftc", "-fblocks"])
 
     if args.release:
         cmd.extend(["--configuration", "release"])


### PR DESCRIPTION
A recent change to Swift PM means that the passing of `-Xcc -fblocks` as part of the Swift compile args no longer works. Each term now needs to be delimited with the use of `-Xswiftc`.

This fixes the build break that can be seen in the Dispatch CI here:
https://ci.swift.org/view/All/job/oss-swift-incremental-RA-libdispatch-linux-ubuntu-15_10/676/

```
Compile Swift Module 'PackageDescription' (6 sources)
Compile Swift Module 'swiftpm_xctest_helper' (1 sources)
Compile Swift Module 'libc' (2 sources)
<unknown>:0: error: unknown argument: '-fblocks'
<unknown>:0: error: unknown argument: '-fblocks'
<unknown>:0: error: unknown argument: '-fblocks'
```