### PR TITLE
[Build] Fix regression in Xcc handling.

### DIFF
--- a/Fixtures/ValidLayouts/ExtraCommandLineFlags/Package.swift
+++ b/Fixtures/ValidLayouts/ExtraCommandLineFlags/Package.swift
@@ -1,0 +1,6 @@
+import PackageDescription
+
+let package = Package(
+    name: "ExtraCommandLineFlags",
+    targets: [
+        Target(name: "SwiftExec", dependencies: ["CLib"])])

--- a/Fixtures/ValidLayouts/ExtraCommandLineFlags/Sources/CLib/foo.c
+++ b/Fixtures/ValidLayouts/ExtraCommandLineFlags/Sources/CLib/foo.c
@@ -1,0 +1,3 @@
+#include "CLib.h"
+
+void foo(void) { }

--- a/Fixtures/ValidLayouts/ExtraCommandLineFlags/Sources/CLib/include/CLib.h
+++ b/Fixtures/ValidLayouts/ExtraCommandLineFlags/Sources/CLib/include/CLib.h
@@ -1,0 +1,6 @@
+// This is to check a -Xcc arg.
+#if !defined(EXTRA_C_DEFINE) || EXTRA_C_DEFINE != 2
+#error "unexpected compiler flags"
+#endif
+
+void foo(void);

--- a/Fixtures/ValidLayouts/ExtraCommandLineFlags/Sources/SwiftExec/main.swift
+++ b/Fixtures/ValidLayouts/ExtraCommandLineFlags/Sources/SwiftExec/main.swift
@@ -1,0 +1,9 @@
+import CLib
+
+// This is expected to be set with -Xswiftc.
+#if !EXTRA_SWIFTC_DEFINE
+doesNotCompile()
+#endif
+
+foo()
+

--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -27,11 +27,10 @@ public func describe(_ prefix: AbsolutePath, _ conf: Configuration, _ graph: Pac
         throw Error.onlyCModule(name: module.name)
     }
 
-    let Xcc = flags.cCompilerFlags.flatMap{ ["-Xcc", $0] }
     let Xld = flags.linkerFlags.flatMap{ ["-Xlinker", $0] }
     let prefix = prefix.appending(component: conf.dirname)
     try makeDirectories(prefix)
-    let swiftcArgs = flags.cCompilerFlags + flags.swiftCompilerFlags + verbosity.ccArgs
+    let swiftcArgs = flags.cCompilerFlags.flatMap{ ["-Xcc", $0] } + flags.swiftCompilerFlags + verbosity.ccArgs
 
     let SWIFT_EXEC = toolchain.SWIFT_EXEC
     let CC = getenv("CC") ?? "clang"
@@ -52,7 +51,7 @@ public func describe(_ prefix: AbsolutePath, _ conf: Configuration, _ graph: Pac
             if module.isTest { continue }
           #endif
             // FIXME: Find a way to eliminate `externalModules` from here.
-            let compile = try Command.compile(clangModule: module, externalModules: graph.externalModules, configuration: conf, prefix: prefix, CC: CC, otherArgs: Xcc + toolchain.platformArgsClang)
+            let compile = try Command.compile(clangModule: module, externalModules: graph.externalModules, configuration: conf, prefix: prefix, CC: CC, otherArgs: flags.cCompilerFlags + toolchain.platformArgsClang)
             commands += compile
             targets.append(compile, for: module)
 

--- a/Tests/Functional/ValidLayoutTests.swift
+++ b/Tests/Functional/ValidLayoutTests.swift
@@ -101,6 +101,15 @@ class ValidLayoutsTestCase: XCTestCase {
         }
     }
 
+    func testExtraCommandLineFlags() {
+        fixture(name: "ValidLayouts/ExtraCommandLineFlags") { prefix in
+            // This project is expected to require Xcc and Xswiftc overrides.
+            XCTAssertBuildFails(prefix)
+            XCTAssertBuildFails(prefix, Xcc: ["-DEXTRA_C_DEFINE=2"])
+            XCTAssertBuilds(prefix, Xcc: ["-DEXTRA_C_DEFINE=2"], Xswiftc: ["-DEXTRA_SWIFTC_DEFINE"])
+        }
+    }
+
     static var allTests = [
         ("testSingleModuleLibrary", testSingleModuleLibrary),
         ("testSingleModuleExecutable", testSingleModuleExecutable),


### PR DESCRIPTION
 - Noticed by Chris Bailey (see #507).

 - This also adds at least some test coverage of -Xcc and -Xswiftc.

 - This also fixes it so we don't quite the extra C flags when passing them to
   Clang (which would still work, because Clang ignores -Xcc, but was incorrect
   and produced a warning).