### PR TITLE
Rename OutputStream to TextOutputStream [SE-0086]

### DIFF
--- a/Sources/Basic/OutputByteStream.swift
+++ b/Sources/Basic/OutputByteStream.swift
@@ -40,7 +40,7 @@ public protocol ByteStreamable {
 ///
 /// would write each item in the list to the stream, separating them with a
 /// space.
-public class OutputByteStream: OutputStream {
+public class OutputByteStream: TextOutputStream {
     /// The data buffer.
     private var buffer: [UInt8]
     

--- a/Sources/Utility/Verbosity.swift
+++ b/Sources/Utility/Verbosity.swift
@@ -43,11 +43,11 @@ public var verbosity = Verbosity.concise
 import func libc.fputs
 import var libc.stderr
 
-public class StandardErrorOutputStream: OutputStream {
+public class StandardErrorOutputStream: TextOutputStream {
     public func write(_ string: String) {
         // Silently ignore write failures here.
         //
-        // FIXME: We would like to throw this error, but can't given the design of `OutputStream`.
+        // FIXME: We would like to throw this error, but can't given the design of `TextOutputStream`.
         _ = libc.fputs(string, libc.stderr)
     }
 }


### PR DESCRIPTION
This is part of the changes for [Swift PR 3576](https://github.com/apple/swift/pull/3576).