### PR TITLE
[Basic] Make OutputByteStream subclassable

### DIFF
--- a/Sources/Basic/FileSystem.swift
+++ b/Sources/Basic/FileSystem.swift
@@ -219,7 +219,7 @@ private class LocalFileSystem: FileSystem {
         defer { fclose(fp) }
 
         // Read the data one block at a time.
-        let data = OutputByteStream()
+        let data = BufferedOutputByteStream()
         var tmpBuffer = [UInt8](repeating: 0, count: 1 << 12)
         while true {
             let n = fread(&tmpBuffer, 1, tmpBuffer.count, fp)

--- a/Sources/Basic/JSON.swift
+++ b/Sources/Basic/JSON.swift
@@ -92,7 +92,9 @@ public func ==(lhs: JSON, rhs: JSON) -> Bool {
 extension JSON {
     /// Encode a JSON item into a string of bytes.
     public func toBytes() -> ByteString {
-        return (OutputByteStream() <<< self).bytes
+        let stream = BufferedOutputByteStream()
+        stream <<< self
+        return stream.bytes
     }
     
     /// Encode a JSON item into a JSON string

--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -102,7 +102,7 @@ public func describe(_ prefix: AbsolutePath, _ conf: Configuration, _ graph: Pac
 }
 
 private func write(path: AbsolutePath, write: (OutputByteStream) -> Void) throws -> AbsolutePath {
-    let stream = OutputByteStream()
+    let stream = BufferedOutputByteStream()
     write(stream)
     try localFileSystem.writeFileContents(path, bytes: stream.bytes)
     return path

--- a/Sources/Commands/init.swift
+++ b/Sources/Commands/init.swift
@@ -15,7 +15,7 @@ import POSIX
 private extension FileSystem {
     /// Write to a file from a stream producer.
     mutating func writeFileContents(_ path: AbsolutePath, body: @noescape (OutputByteStream) -> ()) throws {
-        let contents = OutputByteStream()
+        let contents = BufferedOutputByteStream()
         body(contents)
         try createDirectory(path.parentDirectory, recursive: true)
         try writeFileContents(path, bytes: contents.bytes)

--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -119,7 +119,7 @@ public func generate(dstdir: AbsolutePath, projectName: String, graph: PackageGr
 /// This method doesn't rewrite the file in case the new and old contents of
 /// file are same.
 func open(_ path: AbsolutePath, body: ((String) -> Void) throws -> Void) throws {
-    let stream = OutputByteStream()
+    let stream = BufferedOutputByteStream()
     try body { line in
         stream <<< line
         stream <<< "\n"

--- a/Tests/Basic/ByteStringTests.swift
+++ b/Tests/Basic/ByteStringTests.swift
@@ -63,7 +63,7 @@ class ByteStringTests: XCTestCase {
     }
 
     func testByteStreamable() {
-        let s = OutputByteStream()
+        let s = BufferedOutputByteStream()
         s <<< ByteString([1, 2, 3])
         XCTAssertEqual(s.bytes, [1, 2, 3])
     }

--- a/Tests/Basic/OutputByteStreamPerfTests.swift
+++ b/Tests/Basic/OutputByteStreamPerfTests.swift
@@ -46,7 +46,7 @@ class OutputByteStreamPerfTests: XCTestCase {
         let sequence = ByteSequence()
         measure {
             for _ in 0..<10 {
-                let stream = OutputByteStream()
+                let stream = BufferedOutputByteStream()
                 for _ in 0..<(1 << 16) {
                     stream <<< sequence
                 }
@@ -59,7 +59,7 @@ class OutputByteStreamPerfTests: XCTestCase {
         let byte = UInt8(0)
         measure {
             for _ in 0..<10 {
-                let stream = OutputByteStream()
+                let stream = BufferedOutputByteStream()
                 for _ in 0..<(1 << 20) {
                     stream <<< byte
                 }
@@ -71,7 +71,7 @@ class OutputByteStreamPerfTests: XCTestCase {
     func test1MBOfCharacters_X1() {
         measure {
             for _ in 0..<1 {
-                let stream = OutputByteStream()
+                let stream = BufferedOutputByteStream()
                 for _ in 0..<(1 << 20) {
                     stream <<< Character("X")
                 }
@@ -86,7 +86,7 @@ class OutputByteStreamPerfTests: XCTestCase {
         
         measure {
             for _ in 0..<100 {
-                let stream = OutputByteStream()
+                let stream = BufferedOutputByteStream()
                 for _ in 0..<(1 << 16) {
                     stream <<< bytes16
                 }
@@ -103,7 +103,7 @@ class OutputByteStreamPerfTests: XCTestCase {
 
         measure {
             for _ in 0..<100 {
-                let stream = OutputByteStream()
+                let stream = BufferedOutputByteStream()
                 for _ in 0..<(1 << 16) {
                     stream <<< bytes16
                 }
@@ -118,7 +118,7 @@ class OutputByteStreamPerfTests: XCTestCase {
         
         measure {
             for _ in 0..<1000 {
-                let stream = OutputByteStream()
+                let stream = BufferedOutputByteStream()
                 for _ in 0..<(1 << 10) {
                     stream <<< bytes1k
                 }
@@ -133,7 +133,7 @@ class OutputByteStreamPerfTests: XCTestCase {
         
         measure {
             for _ in 0..<10 {
-                let stream = OutputByteStream()
+                let stream = BufferedOutputByteStream()
                 for _ in 0..<(1 << 16) {
                     stream <<< string16
                 }
@@ -148,7 +148,7 @@ class OutputByteStreamPerfTests: XCTestCase {
         
         measure {
             for _ in 0..<100 {
-                let stream = OutputByteStream()
+                let stream = BufferedOutputByteStream()
                 for _ in 0..<(1 << 10) {
                     stream <<< bytes1k
                 }
@@ -163,7 +163,7 @@ class OutputByteStreamPerfTests: XCTestCase {
         
         measure {
             for _ in 0..<10 {
-                let stream = OutputByteStream()
+                let stream = BufferedOutputByteStream()
                 for _ in 0..<(1 << 16) {
                     stream.writeJSONEscaped(string16)
                 }
@@ -182,7 +182,7 @@ class OutputByteStreamPerfTests: XCTestCase {
         let listOfThings: [Thing] = listOfStrings.map(Thing.init)
         measure {
             for _ in 0..<10 {
-                let stream = OutputByteStream()
+                let stream = BufferedOutputByteStream()
                 for _ in 0..<(1 << 10) {
                     for string in listOfStrings {
                         stream <<< Format.asJSON(string)

--- a/Tests/Basic/TemporaryFileTests.swift
+++ b/Tests/Basic/TemporaryFileTests.swift
@@ -26,7 +26,7 @@ class TemporaryFileTests: XCTestCase {
             XCTAssertTrue(file.path.asString.isFile)
 
             // Try writing some data to the file.
-            let stream = OutputByteStream()
+            let stream = BufferedOutputByteStream()
             stream <<< "foo"
             stream <<< "bar"
             stream <<< "baz"

--- a/Tests/Xcodeproj/FunctionalTests.swift
+++ b/Tests/Xcodeproj/FunctionalTests.swift
@@ -125,7 +125,7 @@ class FunctionalTests: XCTestCase {
 }
 
 func write(path: AbsolutePath, write: (OutputByteStream) -> Void) throws {
-    let stream = OutputByteStream()
+    let stream = BufferedOutputByteStream()
     write(stream)
     try localFileSystem.writeFileContents(path, bytes: stream.bytes)
 }


### PR DESCRIPTION
This makes the OutputByteStream class subclassable and implements an
InMemory version.