### PR TITLE
[PackageGraph] Replace `products` with computed property.

### DIFF
--- a/Sources/PackageGraph/PackageGraph.swift
+++ b/Sources/PackageGraph/PackageGraph.swift
@@ -25,17 +25,22 @@ public struct PackageGraph {
     // FIXME: These are temporary.
     public let modules: [Module]
     public let externalModules: Set<Module>
-    public let products: [Product]
     
     /// Construct a package graph directly.
-    public init(rootPackage: Package, modules: [Module], externalModules: Set<Module>, products: [Product]) {
+    public init(rootPackage: Package, modules: [Module], externalModules: Set<Module>) {
         self.rootPackage = rootPackage
         self.modules = modules
         self.externalModules = externalModules
-        self.products = products
         
         // This will leave the root package at the beginning, considering the relation we are providing.
         self.packages = try! topologicalSort([rootPackage], successors: { $0.dependencies })
         assert(self.rootPackage == self.packages[0])
+    }
+
+    /// A sequence of all of the products in the graph.
+    ///
+    /// This yields all products in topological order starting with the root package.
+    public var products: AnySequence<Product> {
+        return AnySequence(packages.lazy.flatMap{ $0.products })
     }
 }

--- a/Sources/PackageGraph/PackageGraphLoader.swift
+++ b/Sources/PackageGraph/PackageGraphLoader.swift
@@ -68,7 +68,6 @@ public struct PackageGraphLoader {
 
         // Create the packages and convert to modules.
         var packages: [Package] = []
-        var products: [Product] = []
         var map: [Package: [Module]] = [:]
         for (i, manifest) in allManifests.enumerated() {
             let isRootPackage = (i + 1) == allManifests.count
@@ -81,7 +80,6 @@ public struct PackageGraphLoader {
             let package = try Package.createUsingConventions(manifest: manifest, includingTestModules: isRootPackage)
             packages.append(package)
             
-            products += package.products
             map[package] = package.modules + package.testModules
 
             // Diagnose empty non-root packages, which are something we allow as a special case.
@@ -117,7 +115,7 @@ public struct PackageGraphLoader {
         let modules = try recursiveDependencies(packages.flatMap{ map[$0] ?? [] })
         let externalModules = try recursiveDependencies(externalPackages.flatMap{ map[$0] ?? [] })
 
-        return PackageGraph(rootPackage: rootPackage, modules: modules, externalModules: Set(externalModules), products: products)
+        return PackageGraph(rootPackage: rootPackage, modules: modules, externalModules: Set(externalModules))
     }
 }
 

--- a/Tests/Build/DescribeTests.swift
+++ b/Tests/Build/DescribeTests.swift
@@ -31,7 +31,7 @@ final class DescribeTests: XCTestCase {
     func testDescribingNoModulesThrows() {
         do {
             let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
-            let graph = PackageGraph(rootPackage: dummyPackage, modules: [], externalModules: [], products: [])
+            let graph = PackageGraph(rootPackage: dummyPackage, modules: [], externalModules: [])
             _ = try describe(tempDir.path.appending("foo"), .debug, graph, flags: BuildFlags(), toolchain: InvalidToolchain())
             XCTFail("This call should throw")
         } catch Build.Error.noModules {
@@ -44,7 +44,7 @@ final class DescribeTests: XCTestCase {
     func testDescribingCModuleThrows() {
         do {
             let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
-            let graph = PackageGraph(rootPackage: dummyPackage, modules: [try CModule(name: "MyCModule", sources: Sources(paths: [], root: "/"), path: "/")], externalModules: [], products: [])
+            let graph = PackageGraph(rootPackage: dummyPackage, modules: [try CModule(name: "MyCModule", sources: Sources(paths: [], root: "/"), path: "/")], externalModules: [])
             _ = try describe(tempDir.path.appending("foo"), .debug, graph, flags: BuildFlags(), toolchain: InvalidToolchain())
             XCTFail("This call should throw")
         } catch Build.Error.onlyCModule (let name) {

--- a/Tests/Xcodeproj/GenerateXcodeprojTests.swift
+++ b/Tests/Xcodeproj/GenerateXcodeprojTests.swift
@@ -27,7 +27,7 @@ class GenerateXcodeprojTests: XCTestCase {
 
             let projectName = "DummyProjectName"
             let dummyPackage = Package(manifest: Manifest(path: dstdir, url: dstdir.asString, package: PackageDescription.Package(name: "Foo"), products: [], version: nil))
-            let graph = PackageGraph(rootPackage: dummyPackage, modules: try dummy(), externalModules: [], products: [])
+            let graph = PackageGraph(rootPackage: dummyPackage, modules: try dummy(), externalModules: [])
             let outpath = try Xcodeproj.generate(dstdir: dstdir, projectName: projectName, graph: graph, options: XcodeprojOptions())
 
             XCTAssertDirectoryExists(outpath)


### PR DESCRIPTION
[PackageGraph] Replace `products` with computed property.

 - This is a trivially derived property, using `makeNestedIterator`.
