### PR TITLE
[SE-0121] remove usage of optional < operator

### DIFF
--- a/Sources/Utility/Git.swift
+++ b/Sources/Utility/Git.swift
@@ -101,7 +101,7 @@ public class Git {
 
     @noreturn public class func checkGitVersion(_ error: Swift.Error) throws {
         // Git 2.0 or higher is required
-        if Git.majorVersionNumber < 2 {
+        if let majorVersion = Git.majorVersionNumber, majorVersion < 2 {
             // FIXME: This does not belong here.
             print("error: ", Error.obsoleteGitVersion)
             exit(1)


### PR DESCRIPTION
This operator will be removed as part of SE-0121 and apple/swift#3637.

This use site was discovered by CI: https://ci.swift.org/job/swift-PR-osx/2624/console