### PR TITLE
Make sure PathShims tests are also being run on Linux, and fix ensuing failures

### DIFF
--- a/Sources/Basic/PathShims.swift
+++ b/Sources/Basic/PathShims.swift
@@ -50,14 +50,7 @@ public func exists(_ path: AbsolutePath) -> Bool {
 /// Returns the "real path" corresponding to `path` by resolving any symbolic links.
 public func resolveSymlinks(_ path: AbsolutePath) -> AbsolutePath {
     let pathStr = path.asString
-  #if os(Linux)
-    // FIXME: This is really unfortunate but seems to be the only way to invoke this functionality on Linux.
-    let url = URL(fileURLWithPath: pathStr)
-    guard let resolvedPathStr = (try? url.resolvingSymlinksInPath())?.path else { return path }
-  #else
-    // FIXME: It's unfortunate to have to cast to NSString here but apparently the String method is deprecated.
-    let resolvedPathStr = (pathStr as NSString).resolvingSymlinksInPath
-  #endif
+    guard let resolvedPathStr = try? POSIX.realpath(pathStr) else { return path }
     // FIXME: We should measure if it's really more efficient to compare the strings first.
     return (resolvedPathStr == pathStr) ? path : AbsolutePath(resolvedPathStr)
 }

--- a/Tests/Basic/PathShimTests.swift
+++ b/Tests/Basic/PathShimTests.swift
@@ -22,13 +22,15 @@ class PathShimTests : XCTestCase {
         
         // For the rest of the tests we'll need a temporary directory.
         let tmpDir = try! TemporaryDirectory(removeTreeOnDeinit: true)
-        
+        // FIXME: it would be better to not need to resolve symbolic links, but we end up relying on /tmp -> /private/tmp.
+        let tmpDirPath = resolveSymlinks(tmpDir.path)
+
         // Create a symbolic link and directory.
-        let slnkPath = tmpDir.path.appending("slnk")
-        let fldrPath = tmpDir.path.appending("fldr")
+        let slnkPath = tmpDirPath.appending("slnk")
+        let fldrPath = tmpDirPath.appending("fldr")
         
         // Create a symbolic link pointing at the (so far non-existent) directory.
-        try! symlink(create: slnkPath.asString, pointingAt: fldrPath.asString, relativeTo: tmpDir.path.asString)
+        try! symlink(create: slnkPath.asString, pointingAt: fldrPath.asString, relativeTo: tmpDirPath.asString)
         
         // Resolving the symlink should not yet change anything.
         XCTAssertEqual(resolveSymlinks(slnkPath), slnkPath)
@@ -61,11 +63,13 @@ class PathShimTests : XCTestCase {
     func testRecursiveDirectoryRemoval() {
         // For the tests we'll need a temporary directory.
         let tmpDir = try! TemporaryDirectory(removeTreeOnDeinit: true)
-        
+        // FIXME: it would be better to not need to resolve symbolic links, but we end up relying on /tmp -> /private/tmp.
+        let tmpDirPath = resolveSymlinks(tmpDir.path)
+
         // Create a couple of directories.  The first one shouldn't end up getting removed, the second one will.
-        let keepDirPath = tmpDir.path.appending(components: "abc1")
+        let keepDirPath = tmpDirPath.appending(components: "abc1")
         try! makeDirectories(keepDirPath)
-        let tossDirPath = tmpDir.path.appending(components: "abc2", "def", "ghi", "mno", "pqr")
+        let tossDirPath = tmpDirPath.appending(components: "abc2", "def", "ghi", "mno", "pqr")
         try! makeDirectories(tossDirPath)
         
         // Create a symbolic link in a directory to be removed; it points to a directory to not remove.

--- a/Tests/Basic/XCTestManifests.swift
+++ b/Tests/Basic/XCTestManifests.swift
@@ -24,6 +24,7 @@ public func allTests() -> [XCTestCaseEntry] {
         testCase(OrderedSetTests.allTests),
         testCase(OutputByteStreamTests.allTests),
         testCase(PathTests.allTests),
+        testCase(PathShimTests.allTests),
         testCase(StringConversionTests.allTests),
         testCase(SyncronizedQueueTests.allTests),
         testCase(TOMLTests.allTests),


### PR DESCRIPTION
Change `resolveSymlinks()` to again call `realpath`, since Foundation
does a bit of magic that doesn't translate between macOS and Linux.
Part of the reason this went unnoticed was that the path shim tests
were not being run on Linux (since Linux requires specific listing of
the test suites).  Now they are.