### PR TITLE
[Basic] Add isSymlink to FileSystem

### DIFF
--- a/Sources/Basic/FileSystem.swift
+++ b/Sources/Basic/FileSystem.swift
@@ -96,6 +96,9 @@ public protocol FileSystem {
     /// Check whether the given path is accessible and a file.
     func isFile(_ path: AbsolutePath) -> Bool
 
+    /// Check whether the given path is accessible and is a symbolic link.
+    func isSymlink(_ path: AbsolutePath) -> Bool
+
     /// Get the contents of the given directory, in an undefined order.
     //
     // FIXME: Actual file system interfaces will allow more efficient access to
@@ -144,6 +147,10 @@ private class LocalFileSystem: FileSystem {
 
     func isFile(_ path: AbsolutePath) -> Bool {
         return Basic.isFile(path)
+    }
+
+    func isSymlink(_ path: AbsolutePath) -> Bool {
+        return Basic.isSymlink(path)
     }
     
     func getDirectoryContents(_ path: AbsolutePath) throws -> [String] {
@@ -353,6 +360,12 @@ public class InMemoryFileSystem: FileSystem {
             return false
         }
     }
+
+    public func isSymlink(_ path: AbsolutePath) -> Bool {
+        // FIXME: Always return false until in memory implementation
+        // gets symbolic link semantics.
+        return false
+    }
     
     public func getDirectoryContents(_ path: AbsolutePath) throws -> [String] {
         guard let node = try getNode(path) else {
@@ -500,6 +513,10 @@ public struct RerootedFileSystemView: FileSystem {
     
     public func isFile(_ path: AbsolutePath) -> Bool {
         return underlyingFileSystem.isFile(formUnderlyingPath(path))
+    }
+
+    public func isSymlink(_ path: AbsolutePath) -> Bool {
+        return underlyingFileSystem.isSymlink(formUnderlyingPath(path))
     }
 
     public func getDirectoryContents(_ path: AbsolutePath) throws -> [String] {

--- a/Tests/Basic/FileSystemTests.swift
+++ b/Tests/Basic/FileSystemTests.swift
@@ -42,6 +42,15 @@ class FileSystemTests: XCTestCase {
         XCTAssertTrue(fs.isFile(file.path))
         XCTAssertFalse(fs.isDirectory(file.path))
         XCTAssertFalse(fs.isFile("/does-not-exist"))
+        XCTAssertFalse(fs.isSymlink("/does-not-exist"))
+
+        // isSymlink()
+        let tempDir = try! TemporaryDirectory(removeTreeOnDeinit: true)
+        let sym = tempDir.path.appending("hello")
+        try! symlink(sym, pointingAt: file.path)
+        XCTAssertTrue(fs.isSymlink(sym))
+        XCTAssertTrue(fs.isFile(sym))
+        XCTAssertFalse(fs.isDirectory(sym))
 
         // isDirectory()
         XCTAssert(fs.isDirectory("/"))
@@ -146,6 +155,9 @@ class FileSystemTests: XCTestCase {
         // isFile()
         XCTAssert(!fs.isFile("/does-not-exist"))
 
+        // isSymlink()
+        XCTAssert(!fs.isSymlink("/does-not-exist"))
+
         // getDirectoryContents()
         XCTAssertThrows(FileSystemError.noEntry) {
             _ = try fs.getDirectoryContents("/does-not-exist")
@@ -206,6 +218,7 @@ class FileSystemTests: XCTestCase {
         try! fs.writeFileContents(filePath, bytes: "Hello, world!")
         XCTAssert(fs.exists(filePath))
         XCTAssertTrue(fs.isFile(filePath))
+        XCTAssertFalse(fs.isSymlink(filePath))
         XCTAssert(!fs.isDirectory(filePath))
         XCTAssertEqual(try! fs.readFileContents(filePath), "Hello, world!")
 


### PR DESCRIPTION
isSymlink will always return false for InMemoryFileSystem until it gains
symbolic link semantics.