### PR TITLE
Move walk to filesystem

### DIFF
--- a/Sources/Basic/FileSystem.swift
+++ b/Sources/Basic/FileSystem.swift
@@ -96,6 +96,9 @@ public protocol FileSystem {
     /// Check whether the given path is accessible and a file.
     func isFile(_ path: AbsolutePath) -> Bool
 
+    /// Check whether the given path is accessible and is a symbolic link.
+    func isSymlink(_ path: AbsolutePath) -> Bool
+
     /// Get the contents of the given directory, in an undefined order.
     //
     // FIXME: Actual file system interfaces will allow more efficient access to
@@ -144,6 +147,10 @@ private class LocalFileSystem: FileSystem {
 
     func isFile(_ path: AbsolutePath) -> Bool {
         return Basic.isFile(path)
+    }
+
+    func isSymlink(_ path: AbsolutePath) -> Bool {
+        return Basic.isSymlink(path)
     }
     
     func getDirectoryContents(_ path: AbsolutePath) throws -> [String] {
@@ -353,6 +360,12 @@ public class InMemoryFileSystem: FileSystem {
             return false
         }
     }
+
+    public func isSymlink(_ path: AbsolutePath) -> Bool {
+        // FIXME: Always return false until in memory implementation
+        // gets symbolic link semantics.
+        return false
+    }
     
     public func getDirectoryContents(_ path: AbsolutePath) throws -> [String] {
         guard let node = try getNode(path) else {
@@ -500,6 +513,10 @@ public struct RerootedFileSystemView: FileSystem {
     
     public func isFile(_ path: AbsolutePath) -> Bool {
         return underlyingFileSystem.isFile(formUnderlyingPath(path))
+    }
+
+    public func isSymlink(_ path: AbsolutePath) -> Bool {
+        return underlyingFileSystem.isSymlink(formUnderlyingPath(path))
     }
 
     public func getDirectoryContents(_ path: AbsolutePath) throws -> [String] {

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -187,7 +187,7 @@ public struct SwiftTestTool: SwiftTool {
         if maybePath.asString.exists {
             possibleTestPath = maybePath
         } else {
-            let possiblePaths = walk(opts.path.build).filter {
+            let possiblePaths = try walk(opts.path.build).filter {
                 $0.basename != "Package.xctest" &&   // this was our hardcoded name, may still exist if no clean
                 $0.suffix == ".xctest"
             }

--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -138,7 +138,7 @@ func open(_ path: AbsolutePath, body: ((String) -> Void) throws -> Void) throws 
 /// Finds directories that will be added as blue folder
 /// Excludes hidden directories and Xcode projects and directories that contains source code
 func findDirectoryReferences(path: AbsolutePath) throws -> [AbsolutePath] {
-    let rootDirectories = walk(path, recursively: false)
+    let rootDirectories = try walk(path, recursively: false)
     let rootDirectoriesToConsider = rootDirectories.filter {
         if $0.suffix == ".xcodeproj" { return false }
         if $0.suffix == ".playground" { return false }
@@ -146,8 +146,8 @@ func findDirectoryReferences(path: AbsolutePath) throws -> [AbsolutePath] {
         return $0.asString.isDirectory
     }
     
-    let filteredDirectories = rootDirectoriesToConsider.filter {
-        let directoriesWithSources = walk($0).filter {
+    let filteredDirectories = try rootDirectoriesToConsider.filter {
+        let directoriesWithSources = try walk($0).filter {
             guard let fileExt = $0.asString.fileExt else { return false }
             return SupportedLanguageExtension.validExtensions.contains(fileExt)
         }

--- a/Tests/Basic/FileSystemTests.swift
+++ b/Tests/Basic/FileSystemTests.swift
@@ -42,6 +42,15 @@ class FileSystemTests: XCTestCase {
         XCTAssertTrue(fs.isFile(file.path))
         XCTAssertFalse(fs.isDirectory(file.path))
         XCTAssertFalse(fs.isFile("/does-not-exist"))
+        XCTAssertFalse(fs.isSymlink("/does-not-exist"))
+
+        // isSymlink()
+        let tempDir = try! TemporaryDirectory(removeTreeOnDeinit: true)
+        let sym = tempDir.path.appending("hello")
+        try! symlink(sym, pointingAt: file.path)
+        XCTAssertTrue(fs.isSymlink(sym))
+        XCTAssertTrue(fs.isFile(sym))
+        XCTAssertFalse(fs.isDirectory(sym))
 
         // isDirectory()
         XCTAssert(fs.isDirectory("/"))
@@ -146,6 +155,9 @@ class FileSystemTests: XCTestCase {
         // isFile()
         XCTAssert(!fs.isFile("/does-not-exist"))
 
+        // isSymlink()
+        XCTAssert(!fs.isSymlink("/does-not-exist"))
+
         // getDirectoryContents()
         XCTAssertThrows(FileSystemError.noEntry) {
             _ = try fs.getDirectoryContents("/does-not-exist")
@@ -206,6 +218,7 @@ class FileSystemTests: XCTestCase {
         try! fs.writeFileContents(filePath, bytes: "Hello, world!")
         XCTAssert(fs.exists(filePath))
         XCTAssertTrue(fs.isFile(filePath))
+        XCTAssertFalse(fs.isSymlink(filePath))
         XCTAssert(!fs.isDirectory(filePath))
         XCTAssertEqual(try! fs.readFileContents(filePath), "Hello, world!")
 

--- a/Tests/Basic/PathShimTests.swift
+++ b/Tests/Basic/PathShimTests.swift
@@ -102,7 +102,7 @@ class WalkTests : XCTestCase {
             AbsolutePath("/bin"),
             AbsolutePath("/sbin")
         ]
-        for x in walk("/", recursively: false) {
+        for x in try! walk("/", recursively: false) {
             if let i = expected.index(of: x) {
                 expected.remove(at: i)
             }
@@ -117,7 +117,7 @@ class WalkTests : XCTestCase {
             root.appending(component: "Build"),
             root.appending(component: "Utility")
         ]
-        for x in walk(root) {
+        for x in try! walk(root) {
             if let i = expected.index(of: x) {
                 expected.remove(at: i)
             }
@@ -138,7 +138,7 @@ class WalkTests : XCTestCase {
         XCTAssertEqual(resolveSymlinks(tmpDirPath.appending("foo/symlink")), tmpDirPath.appending("bar"))
         XCTAssertTrue(resolveSymlinks(tmpDirPath.appending("foo/symlink/baz")).asString.isDirectory)
 
-        let results = walk(tmpDirPath.appending("foo")).map{ $0 }
+        let results = try! walk(tmpDirPath.appending("foo")).map{ $0 }
 
         XCTAssertEqual(results, [tmpDirPath.appending("foo/symlink")])
     }
@@ -154,7 +154,7 @@ class WalkTests : XCTestCase {
 
         XCTAssertTrue(tmpDirPath.appending("symlink").asString.isSymlink)
 
-        let results = walk(tmpDirPath.appending("symlink")).map{ $0 }.sorted()
+        let results = try! walk(tmpDirPath.appending("symlink")).map{ $0 }.sorted()
 
         // we recurse a symlink to a directory, so this should work,
         // but `abc` should not show because `baz` is a symlink too


### PR DESCRIPTION
we eventually need to rethink:
* name of walk()
* Should be it inside a protocol extension instead or live somewhere else