### PR TITLE
Add an `AbsolutePath` initializer that takes a string that can be either absolute or relative

### DIFF
--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -63,6 +63,18 @@ public struct AbsolutePath {
         self.init(PathImpl(string: normalize(absolute: absStr)))
     }
     
+    /// Initializes an AbsolutePath from a string that may be either absolute
+    /// or relative; if relative, `basePath` is used as the anchor; if absolute,
+    /// it is used as is, and in this case `basePath` is ignored.
+    public init(_ str: String, relativeTo basePath: AbsolutePath) {
+        if str.hasPrefix("/") {
+            self.init(str)
+        }
+        else {
+            self.init(basePath, RelativePath(str))
+        }
+    }
+    
     /// Initializes the AbsolutePath by concatenating a relative path to an
     /// existing absolute path, and renormalizing if necessary.
     public init(_ absPath: AbsolutePath, _ relPath: RelativePath) {

--- a/Tests/Basic/PathTests.swift
+++ b/Tests/Basic/PathTests.swift
@@ -32,6 +32,11 @@ class PathTests: XCTestCase {
         let rel3 = "."
         let abs3 = AbsolutePath(abs2, rel3)
         XCTAssertEqual(abs2, abs3)
+        let base = AbsolutePath("/base/path")
+        let abs4 = AbsolutePath("/a/b/c", relativeTo: base)
+        XCTAssertEqual(abs4, AbsolutePath("/a/b/c"))
+        let abs5 = AbsolutePath("./a/b/c", relativeTo: base)
+        XCTAssertEqual(abs5, AbsolutePath("/base/path/a/b/c"))
     }
     
     func testStringLiteralInitialization() {


### PR DESCRIPTION
Add an `AbsolutePath` initializer that takes a string that can be either
absolute or relative, and a base path to use if it is relative.  This is
a replacement for the `Utility` module's `Path.join()` function.

Comments about the form of the initializer are of course welcome
(specifically the "relativeTo:" part vs "basePath" etc).