### PR TITLE
Convert pkgconfig code to AbsolutePath

### DIFF
--- a/Sources/Build/Command.compile(ClangModule).swift
+++ b/Sources/Build/Command.compile(ClangModule).swift
@@ -102,7 +102,7 @@ struct ClangModuleBuildMetadata {
     static func basicArgs() throws -> [String] {
         var args: [String] = []
       #if os(macOS)
-        args += ["-F", try platformFrameworksPath()]
+        args += ["-F", try platformFrameworksPath().asString]
       #else
         args += ["-fPIC"]
       #endif

--- a/Sources/Build/Command.compile(SwiftModule).swift
+++ b/Sources/Build/Command.compile(SwiftModule).swift
@@ -25,9 +25,9 @@ extension Command {
             args += ["-O"]
         }
 
-        #if os(macOS)
-        args += ["-F", try platformFrameworksPath()]
-        #endif
+      #if os(macOS)
+        args += ["-F", try platformFrameworksPath().asString]
+      #endif
 
         let tool = SwiftcTool(module: module, prefix: prefix, otherArgs: args + otherArgs, executable: SWIFT_EXEC, conf: conf)
         return Command(node: module.targetName, tool: tool)

--- a/Sources/Build/Command.link(SwiftModule).swift
+++ b/Sources/Build/Command.link(SwiftModule).swift
@@ -39,7 +39,7 @@ extension Command {
             args += ["-o", outpath.asString]
 
           #if os(macOS)
-            args += ["-F", try platformFrameworksPath()]
+            args += ["-F", try platformFrameworksPath().asString]
           #endif
 
         case .Library(.Static):
@@ -57,7 +57,7 @@ extension Command {
             objects += product.modules.flatMap{ $0 as? ClangModule }.flatMap{ ClangModuleBuildMetadata(module: $0, prefix: prefix, otherArgs: []).objects }
           #if os(macOS)
             args += ["-Xlinker", "-bundle"]
-            args += ["-F", try platformFrameworksPath()]
+            args += ["-F", try platformFrameworksPath().asString]
 
             // TODO should be llbuild rules∫
             if conf == .debug {

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -313,7 +313,7 @@ public struct SwiftTestTool: SwiftTool {
       #if os(macOS)
         let tempFile = try TemporaryFile()
         let args = [xctestHelperPath().asString, path.asString, tempFile.path.asString]
-        try system(args, environment: ["DYLD_FRAMEWORK_PATH": try platformFrameworksPath()])
+        try system(args, environment: ["DYLD_FRAMEWORK_PATH": try platformFrameworksPath().asString])
         // Read the temporary file's content.
         let data = try fopen(tempFile.path.asString).readFileContents()
       #else

--- a/Sources/Utility/Platform.swift
+++ b/Sources/Utility/Platform.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basic
 import func POSIX.popen
 
 public enum Platform {
@@ -36,7 +37,7 @@ public enum Platform {
     }
 }
 
-public func platformFrameworksPath() throws -> String {
+public func platformFrameworksPath() throws -> AbsolutePath {
     // Lazily compute the platform the first time it is needed.
     struct Static {
         static let value = { try? POSIX.popen(["xcrun", "--sdk", "macosx", "--show-sdk-platform-path"]) }()
@@ -44,5 +45,5 @@ public func platformFrameworksPath() throws -> String {
     guard let popened = Static.value, let chuzzled = popened.chuzzle() else {
         throw Error.invalidPlatformPath
     }
-    return Path.join(chuzzled, "Developer/Library/Frameworks")
+    return AbsolutePath(chuzzled).appending(components: "Developer", "Library", "Frameworks")
 }

--- a/Tests/Functional/SwiftPMXCTestHelperTests.swift
+++ b/Tests/Functional/SwiftPMXCTestHelperTests.swift
@@ -50,7 +50,7 @@ class SwiftPMXCTestHelperTests: XCTestCase {
 #if os(macOS)
 func XCTAssertXCTestHelper(_ bundlePath: AbsolutePath, testCases: NSDictionary) {
     do {
-        let env = ["DYLD_FRAMEWORK_PATH": try platformFrameworksPath()]
+        let env = ["DYLD_FRAMEWORK_PATH": try platformFrameworksPath().asString]
         let outputFile = bundlePath.parentDirectory.appending("tests.txt")
         let _ = try SwiftPMProduct.XCTestHelper.execute([bundlePath.asString, outputFile.asString], env: env, printIfError: true)
         guard let data = NSData(contentsOfFile: outputFile.asString) else {

--- a/Tests/Utility/PkgConfigParserTests.swift
+++ b/Tests/Utility/PkgConfigParserTests.swift
@@ -9,6 +9,7 @@
 */
 
 import XCTest
+import Basic
 
 @testable import Utility
 
@@ -63,7 +64,7 @@ final class PkgConfigParserTests: XCTestCase {
     }
     
     private func loadPCFile(_ inputName: String, body: (PkgConfigParser?) -> Void) {
-        let input = Path.join(#file, "../pkgconfigInputs", inputName).normpath
+        let input = AbsolutePath(#file).parentDirectory.appending(components: "pkgconfigInputs", inputName)
         var parser: PkgConfigParser? = PkgConfigParser(pcFile: input)
         do {
             try parser?.parse()


### PR DESCRIPTION
I discovered that some of the pkgconfig code was still using String,
so this converts it to AbsolutePath.
