### PR TITLE
Move off of `abspath` and onto the new `AbsolutePath()` initializer

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -13,6 +13,7 @@ import POSIX
 import PackageModel
 import Utility
 
+// FIXME: The functionality to find the package root path etc should move to `SwiftTool`, and `Options` should be a struct that gets initialized in a clean way other than just on demand.  Right now, for example, if you happen to ask for `path.root` (which doesn't mean the path of the root directory but rather the top-level package directory path) before you change directory to the path specified by `chdir`, you get the wrong value.  This doesn't need to be so complicated, and in particular, behavior shouldn't depend on the order in which properties are asked for.
 public class Options {
     public var chdir: AbsolutePath?
     public var path = Path()
@@ -25,12 +26,16 @@ public class Options {
             get { return _build != nil ? AbsolutePath(_build!) : getroot().appending(".build") }
             set { _build = newValue.asString }
         }
-
-        private var _build = getenv("SWIFT_BUILD_PATH")?.abspath
+        private var _build = getEnvBuildPath()?.asString
     }
 
     public init()
     {}
+}
+
+fileprivate func getEnvBuildPath() -> AbsolutePath? {
+    guard let env = getenv("SWIFT_BUILD_PATH") else { return nil }
+    return AbsolutePath(env, relativeTo: currentWorkingDirectory)
 }
 
 public struct Flag {

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -78,7 +78,7 @@ private enum BuildToolFlag: Argument {
         
         switch argument {
         case Flag.chdir, Flag.C:
-            self = try .chdir(AbsolutePath(forcePop().abspath))
+            self = try .chdir(AbsolutePath(forcePop(), relativeTo: currentWorkingDirectory))
         case "--verbose", "-v":
             self = .verbose(1)
         case "-Xcc":
@@ -88,7 +88,7 @@ private enum BuildToolFlag: Argument {
         case "-Xswiftc":
             self = try .xswiftc(forcePop())
         case "--build-path":
-            self = try .buildPath(AbsolutePath(forcePop().abspath))
+            self = try .buildPath(AbsolutePath(forcePop(), relativeTo: currentWorkingDirectory))
         case "--build-tests":
             self = .buildTests
         case "--color":

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -97,15 +97,15 @@ private enum PackageToolFlag: Argument {
 
         switch argument {
         case Flag.chdir, Flag.C:
-            self = try .chdir(AbsolutePath(forcePop().abspath))
+            self = try .chdir(AbsolutePath(forcePop(), relativeTo: currentWorkingDirectory))
         case "--type":
             self = try .initMode(forcePop())
         case "--format":
             self = try .showDepsMode(forcePop())
         case "--output":
-            self = try .outputPath(AbsolutePath(forcePop().abspath))
+            self = try .outputPath(AbsolutePath(forcePop(), relativeTo: currentWorkingDirectory))
         case "--input":
-            self = try .inputPath(AbsolutePath(forcePop().abspath))
+            self = try .inputPath(AbsolutePath(forcePop(), relativeTo: currentWorkingDirectory))
         case "--verbose", "-v":
             self = .verbose(1)
         case "--color":
@@ -123,7 +123,7 @@ private enum PackageToolFlag: Argument {
         case "-Xswiftc":
             self = try .xswiftc(forcePop())
         case "--xcconfig-overrides":
-            self = try .xcconfigOverrides(AbsolutePath(forcePop().abspath))
+            self = try .xcconfigOverrides(AbsolutePath(forcePop(), relativeTo: currentWorkingDirectory))
         default:
             return nil
         }

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -84,12 +84,12 @@ private enum TestToolFlag: Argument {
         switch argument {
         case "--chdir", "-C":
             guard let path = pop() else { throw OptionParserError.expectedAssociatedValue(argument) }
-            self = .chdir(AbsolutePath(path.abspath))
+            self = .chdir(AbsolutePath(path, relativeTo: currentWorkingDirectory))
         case "--skip-build":
             self = .skipBuild
         case "--build-path":
             guard let path = pop() else { throw OptionParserError.expectedAssociatedValue(argument) }
-            self = .buildPath(AbsolutePath(path.abspath))
+            self = .buildPath(AbsolutePath(path, relativeTo: currentWorkingDirectory))
         default:
             return nil
         }
@@ -280,7 +280,7 @@ public struct SwiftTestTool: SwiftTool {
     /// - Returns: Path to XCTestHelper tool.
     private func xctestHelperPath() -> AbsolutePath {
         let xctestHelperBin = "swiftpm-xctest-helper"
-        let binDirectory = AbsolutePath(CommandLine.arguments.first!.abspath).parentDirectory
+        let binDirectory = AbsolutePath(CommandLine.arguments.first!, relativeTo: currentWorkingDirectory).parentDirectory
         // XCTestHelper tool is installed in libexec.
         let maybePath = binDirectory.appending("../libexec/swift/pm/").appending(RelativePath(xctestHelperBin))
         if maybePath.asString.isFile {

--- a/Sources/Commands/ToolDefaults.swift
+++ b/Sources/Commands/ToolDefaults.swift
@@ -14,18 +14,24 @@ import PackageModel
 import POSIX
 
 struct ToolDefaults: ManifestResourceProvider {
+    // We have to do things differently depending on whether we're running in
+    // Xcode or in other cases, unfortunately.
+    
+    // First we form the absolute path of the directory that contains the main
+    // executable.
+    static let execBinDir = AbsolutePath(argv0, relativeTo: currentWorkingDirectory).parentDirectory
   #if Xcode
     // when in Xcode we are built with same toolchain as we will run
     // this is not a production ready mode
 
     // FIXME: This isn't correct; we need to handle a missing SWIFT_EXEC.
-    static let SWIFT_EXEC = AbsolutePath(getenv("SWIFT_EXEC")!.abspath)
-    static let llbuild = AbsolutePath(getenv("SWIFT_EXEC")!.abspath).appending("../swift-build-tool")
-    static let libdir = AbsolutePath(argv0.abspath).parentDirectory
+    static let SWIFT_EXEC = AbsolutePath(getenv("SWIFT_EXEC")!, relativeTo: currentWorkingDirectory)
+    static let llbuild = AbsolutePath(getenv("SWIFT_EXEC")!, relativeTo: currentWorkingDirectory).parentDirectory.appending(component: "swift-build-tool")
+    static let libdir = execBinDir
   #else
-    static let SWIFT_EXEC = AbsolutePath(argv0.abspath).appending("../swiftc")
-    static let llbuild = AbsolutePath(argv0.abspath).appending("../swift-build-tool")
-    static let libdir = AbsolutePath(argv0.abspath).appending("../../lib/swift/pm")
+    static let SWIFT_EXEC = execBinDir.appending(component: "swiftc")
+    static let llbuild = execBinDir.appending(component: "swift-build-tool")
+    static let libdir = execBinDir.parentDirectory.appending(components: "lib", "swift", "pm")
   #endif
 
     var swiftCompilerPath: AbsolutePath {

--- a/Sources/Commands/UserToolchain.swift
+++ b/Sources/Commands/UserToolchain.swift
@@ -41,7 +41,7 @@ struct UserToolchain: Toolchain {
         do {
             SWIFT_EXEC = getenv("SWIFT_EXEC")
                 // use the swiftc installed alongside ourselves
-                ?? AbsolutePath(CommandLine.arguments[0].abspath).appending("../swiftc").asString
+                ?? AbsolutePath(CommandLine.arguments[0], relativeTo: currentWorkingDirectory).parentDirectory.appending(component: "swiftc").asString
 
             clang = try getenv("CC") ?? POSIX.popen(whichClangArgs).chomp()
 

--- a/Sources/Utility/Path.swift
+++ b/Sources/Utility/Path.swift
@@ -199,7 +199,8 @@ extension String {
 
          Path.join(getcwd(), self).normpath
      */
-    public var abspath: String {
+    // Note: This is being made `fileprivate` right now, but is kept for a while since other methods in this file rely on it.
+    fileprivate var abspath: String {
         return Path.join(getcwd(), self).normpath
     }
 

--- a/Tests/Functional/Utilities.swift
+++ b/Tests/Functional/Utilities.swift
@@ -128,7 +128,7 @@ enum SwiftPMProduct {
         }
         fatalError()
       #else
-        return AbsolutePath(CommandLine.arguments.first!.abspath).parentDirectory.appending(self.exec)
+        return AbsolutePath(CommandLine.arguments.first!, relativeTo: currentWorkingDirectory).parentDirectory.appending(self.exec)
       #endif
     }
 

--- a/Tests/PackageLoading/ManifestTests.swift
+++ b/Tests/PackageLoading/ManifestTests.swift
@@ -49,8 +49,9 @@ private struct Resources: ManifestResourceProvider {
   #endif
     let libraryPath = bundleRoot()
 #else
-    let libraryPath = AbsolutePath(CommandLine.arguments.first!.parentDirectory.abspath)
-    let swiftCompilerPath = AbsolutePath(CommandLine.arguments.first!.abspath).appending("../swiftc")
+    let execBinDir = AbsolutePath(CommandLine.arguments.first!, relativeTo: currentWorkingDirectory).parentDirectory
+    let libraryPath = execBinDir
+    let swiftCompilerPath = execBinDir.appending(component: "swiftc")
 #endif
 }
 


### PR DESCRIPTION
Move client code off of `Utility/Path`'s `abspath` method, and onto `AbsolutePath`'s new initializer.