### PR TITLE
Get rid of uses of `Path.join` in favor of AbsolutePath API

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -215,7 +215,8 @@ extension PackageDescription.Package.Dependency {
 
         func fixURL() -> String {
             if let baseURL = baseURL, URL.scheme(url) == nil {
-                return Path.join(baseURL, url).normpath
+                // If the URL has no scheme, we treat it as a path (either absolute or relative to the base URL).
+                return AbsolutePath(url, relativeTo: AbsolutePath(baseURL)).asString
             } else {
                 return url
             }

--- a/Sources/Utility/Path.swift
+++ b/Sources/Utility/Path.swift
@@ -24,12 +24,12 @@ public struct Path {
        future we support platforms that have a different separator we will
        convert any "/" characters in your strings to the platform separator.
     */
-    public static func join(_ components: String...) -> String {
+    private static func join(_ components: String...) -> String {
         return Path.join(components)
     }
 
     /// - See: Path.join(components: String...)
-    public static func join(_ components: [String]) -> String {
+    private static func join(_ components: [String]) -> String {
         return components.reduce("") { memo, component in
             let component = component.onesep
             if component.isEmpty {

--- a/Sources/Xcodeproj/Module+PBXProj.swift
+++ b/Sources/Xcodeproj/Module+PBXProj.swift
@@ -258,7 +258,7 @@ extension Module  {
         }
 
         // Add framework search path to build settings.
-        buildSettings["FRAMEWORK_SEARCH_PATHS"] = Path.join("$(PLATFORM_DIR)", "Developer/Library/Frameworks")
+        buildSettings["FRAMEWORK_SEARCH_PATHS"] = "$(PLATFORM_DIR)/Developer/Library/Frameworks"
 
         // Generate modulemap for a ClangModule if not provided by user and add to build settings.
         if case let clangModule as ClangModule = self, clangModule.type == .library {

--- a/Tests/Utility/PathTests.swift
+++ b/Tests/Utility/PathTests.swift
@@ -12,38 +12,9 @@ import XCTest
 
 import Basic
 import POSIX
-import Utility
+@testable import Utility
 
 class PathTests: XCTestCase {
-
-    func test() {
-        XCTAssertEqual(Path.join("a","b","c","d"), "a/b/c/d")
-        XCTAssertEqual(Path.join("/a","b","c","d"), "/a/b/c/d")
-
-        XCTAssertEqual(Path.join("/", "a"), "/a")
-        XCTAssertEqual(Path.join("//", "a"), "/a")
-        XCTAssertEqual(Path.join("//", "//", "/", "///", "", "/", "//", "a"), "/a")
-        XCTAssertEqual(Path.join("//", "//a//"), "/a")
-        XCTAssertEqual(Path.join("/////"), "/")
-    }
-
-    func testPrecombined() {
-        XCTAssertEqual(Path.join("a","b/c","d/"), "a/b/c/d")
-        XCTAssertEqual(Path.join("a","b///c","d/"), "a/b/c/d")
-
-        XCTAssertEqual(Path.join("/a","b/c","d/"), "/a/b/c/d")
-        XCTAssertEqual(Path.join("/a","b///c","d/"), "/a/b/c/d")
-    }
-
-    func testExtraSeparators() {
-        XCTAssertEqual(Path.join("a","b/","c/","d/"), "a/b/c/d")
-        XCTAssertEqual(Path.join("/a","b/","c/","d/"), "/a/b/c/d")
-    }
-
-    func testEmpties() {
-        XCTAssertEqual(Path.join("a","b/","","","c//","d/", ""), "a/b/c/d")
-        XCTAssertEqual(Path.join("/a","b/","","","c//","d/", ""), "/a/b/c/d")
-    }
 
     func testNormalizePath() {
         XCTAssertEqual("".normpath, ".")
@@ -63,12 +34,7 @@ class PathTests: XCTestCase {
         // Only run tests using HOME if it is defined.
         if POSIX.getenv("HOME") != nil {
             XCTAssertEqual("~".normpath, Path.home)
-            XCTAssertEqual("~abc".normpath, Path.join(Path.home, "..", "abc").normpath)
         }
-    }
-
-    func testJoinWithAbsoluteReturnsLastAbsoluteComponent() {
-        XCTAssertEqual(Path.join("foo", "/abc/def"), "/abc/def")
     }
 
     func testParentDirectory() {
@@ -81,12 +47,7 @@ class PathTests: XCTestCase {
     }
 
     static var allTests = [
-        ("test", test),
-        ("testPrecombined", testPrecombined),
-        ("testExtraSeparators", testExtraSeparators),
-        ("testEmpties", testEmpties),
         ("testNormalizePath", testNormalizePath),
-        ("testJoinWithAbsoluteReturnsLastAbsoluteComponent", testJoinWithAbsoluteReturnsLastAbsoluteComponent),
         ("testParentDirectory", testParentDirectory),
     ]
 }
@@ -160,17 +121,10 @@ class RelativePathTests: XCTestCase {
         XCTAssertEqual("../../../4/5", Path("/1/2/4/5").relative(to: "/1/2/3/6/7"))
     }
     
-    func testCombiningRelativePaths() {
-        XCTAssertEqual("/1/2/3", Path.join("/1/2/4", "../3").normpath)
-        XCTAssertEqual("/1/2", Path.join("/1/2/3", "..").normpath)
-        XCTAssertEqual("2", Path.join("2/3", "..").normpath)
-    }
-
     static var allTests = [
         ("testAbsolute", testAbsolute),
         ("testRelative", testRelative),
         ("testMixed", testMixed),
         ("testRelativeCommonSubprefix", testRelativeCommonSubprefix),
-        ("testCombiningRelativePaths", testCombiningRelativePaths)
     ]
 }

--- a/Tests/Utility/ShellTests.swift
+++ b/Tests/Utility/ShellTests.swift
@@ -8,8 +8,10 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Utility
 import XCTest
+
+import Basic
+import Utility
 
 class ShellTests: XCTestCase {
 
@@ -18,8 +20,8 @@ class ShellTests: XCTestCase {
     }
 
     func testPopenWithBufferLargerThanThatAllocated() {
-        let path = Path.join(#file, "../../Get/VersionGraphTests.swift").normpath
-        XCTAssertGreaterThan(try! popen(["cat", path]).characters.count, 4096)
+        let path = AbsolutePath(#file).parentDirectory.parentDirectory.appending(components: "Get", "VersionGraphTests.swift")
+        XCTAssertGreaterThan(try! popen(["cat", path.asString]).characters.count, 4096)
     }
 
     func testPopenWithBinaryOutput() {


### PR DESCRIPTION
Another step toward getting rid of `Utility.Path` completely.