### PR TITLE
Change to using AbsolutePath-based `isDirectory`, `isFile`, `isSymlink` et.al.

### DIFF
--- a/Sources/Build/Buildable.swift
+++ b/Sources/Build/Buildable.swift
@@ -31,7 +31,7 @@ extension Module: Buildable {
                 ///in ClangModule's `generateModuleMap(inDir wd: String)`
                 ///there shouldn't be need to redo this but is difficult in 
                 ///current architecture
-                if module.moduleMapPath.asString.isFile {
+                if isFile(module.moduleMapPath) {
                     return ["-Xcc", "-fmodule-map-file=\(module.moduleMapPath.asString)"]
                 }
 

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -45,7 +45,7 @@ public struct Flag {
 
 private func getroot() -> AbsolutePath {
     var root = currentWorkingDirectory
-    while !root.appending(component: Manifest.filename).asString.isFile {
+    while !isFile(root.appending(component: Manifest.filename)) {
         root = root.parentDirectory
 
         guard root != "/" else {

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -149,14 +149,14 @@ public struct SwiftBuildTool: SwiftTool {
                 try build(yamlPath: yaml, target: opts.buildTests ? "test" : nil)
         
             case .clean(.dist):
-                if opts.path.packages.asString.exists {
+                if exists(opts.path.packages) {
                     try removeFileTree(opts.path.packages)
                 }
                 fallthrough
         
             case .clean(.build):
                 // FIXME: This test is lame, `removeFileTree` shouldn't error on this.
-                if opts.path.build.asString.exists {
+                if exists(opts.path.build) {
                     try removeFileTree(opts.path.build)
                 }
             }

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -182,7 +182,7 @@ public struct SwiftPackageTool: SwiftTool {
                         let item = opts.path.packages.appending(RelativePath(name))
 
                         // Only look at repositories.
-                        guard item.appending(".git").asString.exists else { continue }
+                        guard exists(item.appending(".git")) else { continue }
 
                         // If there is a staged or unstaged diff, don't remove the
                         // tree. This won't detect new untracked files, but it is

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -184,7 +184,7 @@ public struct SwiftTestTool: SwiftTool {
 
         let possibleTestPath: AbsolutePath
 
-        if maybePath.asString.exists {
+        if exists(maybePath) {
             possibleTestPath = maybePath
         } else {
             let possiblePaths = try walk(opts.path.build).filter {
@@ -283,13 +283,13 @@ public struct SwiftTestTool: SwiftTool {
         let binDirectory = AbsolutePath(CommandLine.arguments.first!, relativeTo: currentWorkingDirectory).parentDirectory
         // XCTestHelper tool is installed in libexec.
         let maybePath = binDirectory.appending("../libexec/swift/pm/").appending(RelativePath(xctestHelperBin))
-        if maybePath.asString.isFile {
+        if isFile(maybePath) {
             return maybePath
         }
         // This will be true during swiftpm developement.
         // FIXME: Factor all of the development-time resource location stuff into a common place.
         let path = binDirectory.appending(RelativePath(xctestHelperBin))
-        if path.asString.isFile {
+        if isFile(path) {
             return path 
         }
         fatalError("XCTestHelper binary not found.") 
@@ -327,9 +327,9 @@ public struct SwiftTestTool: SwiftTool {
 
 private func isValidTestPath(_ path: AbsolutePath) -> Bool {
   #if os(macOS)
-    return path.asString.isDirectory  // ${foo}.xctest is dir on OSX
+    return isDirectory(path)  // ${foo}.xctest is dir on OSX
   #else
-    return path.asString.isFile       // otherwise ${foo}.xctest is executable file
+    return isFile(path)       // otherwise ${foo}.xctest is executable file
   #endif
 }
 

--- a/Sources/Commands/build().swift
+++ b/Sources/Commands/build().swift
@@ -28,7 +28,7 @@ public func build(yamlPath: AbsolutePath, target: String? = nil) throws {
         // out its own error conditions and then try
         // to infer what happened afterwards.
 
-        if yamlPath.asString.isFile {
+        if isFile(yamlPath) {
             throw error
         } else {
             throw Error.buildYAMLNotFound(yamlPath.asString)

--- a/Sources/Commands/init.swift
+++ b/Sources/Commands/init.swift
@@ -79,7 +79,7 @@ final class InitPackage {
     
     private func writeManifestFile() throws {
         let manifest = rootd.appending(component: Manifest.filename)
-        guard manifest.asString.exists == false else {
+        guard exists(manifest) == false else {
             throw InitError.manifestAlreadyExists
         }
 
@@ -94,7 +94,7 @@ final class InitPackage {
     
     private func writeGitIgnore() throws {
         let gitignore = rootd.appending(".gitignore")
-        guard gitignore.asString.exists == false else {
+        guard exists(gitignore) == false else {
             return
         } 
     
@@ -111,7 +111,7 @@ final class InitPackage {
             return
         }
         let sources = rootd.appending("Sources")
-        guard sources.asString.exists == false else {
+        guard exists(sources) == false else {
             return
         }
         print("Creating Sources/")
@@ -139,7 +139,7 @@ final class InitPackage {
             return
         }
         let modulemap = rootd.appending("module.modulemap")
-        guard modulemap.asString.exists == false else {
+        guard exists(modulemap) == false else {
             return
         }
         
@@ -157,7 +157,7 @@ final class InitPackage {
             return
         }
         let tests = rootd.appending("Tests")
-        guard tests.asString.exists == false else {
+        guard exists(tests) == false else {
             return
         }
         print("Creating Tests/")

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -66,10 +66,10 @@ public final class ManifestLoader {
         }
 
         // Compute the actual input file path.
-        let path: AbsolutePath = inputPath.asString.isDirectory ? inputPath.appending(component: Manifest.filename) : inputPath
+        let path: AbsolutePath = isDirectory(inputPath) ? inputPath.appending(component: Manifest.filename) : inputPath
 
         // Validate that the file exists.
-        guard path.asString.isFile else { throw PackageModel.Package.Error.noManifest(path.asString) }
+        guard isFile(path) else { throw PackageModel.Package.Error.noManifest(path.asString) }
 
         // Load the manifest description.
         guard let tomlString = try parse(path: path) else {

--- a/Sources/Utility/Git.swift
+++ b/Sources/Utility/Git.swift
@@ -20,7 +20,7 @@ public class Git {
 
         public init?(path: AbsolutePath) {
             self.path = resolveSymlinks(path)
-            guard path.appending(".git").asString.isDirectory else { return nil }
+            guard isDirectory(path.appending(component: ".git")) else { return nil }
         }
 
         public lazy var origin: String? = { repo in

--- a/Sources/Utility/Path.swift
+++ b/Sources/Utility/Path.swift
@@ -205,7 +205,7 @@ extension String {
     }
 
     /// - Returns: true if the string looks like an absolute path
-    public var isAbsolute: Bool {
+    fileprivate var isAbsolute: Bool {
         return hasPrefix("/")
     }
 
@@ -215,7 +215,7 @@ extension String {
        directory, then this function returns true. Use `isSymlink`
        if the distinction is important.
     */
-    public var isDirectory: Bool {
+    fileprivate var isDirectory: Bool {
         var mystat = stat()
         let rv = stat(self, &mystat)
         return rv == 0 && (mystat.st_mode & S_IFMT) == S_IFDIR
@@ -227,7 +227,7 @@ extension String {
        file, then this function returns true. Use `isSymlink` if the
        distinction is important.
      */
-    public var isFile: Bool {
+    fileprivate var isFile: Bool {
         var mystat = stat()
         let rv = stat(self, &mystat)
         return rv == 0 && (mystat.st_mode & S_IFMT) == S_IFREG
@@ -247,7 +247,7 @@ extension String {
     /**
      - Returns: true if the string is a symlink on the filesystem
      */
-    public var isSymlink: Bool {
+    fileprivate var isSymlink: Bool {
         var mystat = stat()
         let rv = lstat(self, &mystat)
         return rv == 0 && (mystat.st_mode & S_IFMT) == S_IFLNK
@@ -257,7 +257,7 @@ extension String {
      - Returns: true if the string is an entry on the filesystem
      - Note: symlinks are resolved
      */
-    public var exists: Bool {
+    fileprivate var exists: Bool {
         return access(self, F_OK) == 0
     }
 

--- a/Sources/Utility/PkgConfig.swift
+++ b/Sources/Utility/PkgConfig.swift
@@ -93,7 +93,7 @@ public struct PkgConfig {
         // we end up searching for a reasonably sized number of packages.
         for path in OrderedSet(pkgConfigSearchPaths + searchPaths + envSearchPaths) {
             let pcFile = path.appending(component: name + ".pc")
-            if pcFile.asString.isFile {
+            if isFile(pcFile) {
                 return pcFile
             }
         }

--- a/Sources/Utility/Platform.swift
+++ b/Sources/Utility/Platform.swift
@@ -27,7 +27,7 @@ public enum Platform {
         case "darwin":
             return .darwin
         case "linux":
-            if "/etc/debian_version".isFile {
+            if isFile("/etc/debian_version") {
                 return .linux(.debian)
             }
         default:

--- a/Sources/Utility/Verbosity.swift
+++ b/Sources/Utility/Verbosity.swift
@@ -123,7 +123,7 @@ public func system(_ arguments: String..., environment: [String:String] = [:], m
 }
 
 private func which(_ arg0: String) -> String {
-    if arg0.isAbsolute {
+    if arg0.hasPrefix("/") {
         return arg0
     } else if let fullpath = try? POSIX.popen(["which", arg0]) {
         return fullpath.chomp()

--- a/Sources/Xcodeproj/Module+PBXProj.swift
+++ b/Sources/Xcodeproj/Module+PBXProj.swift
@@ -265,7 +265,7 @@ extension Module  {
             buildSettings["DEFINES_MODULE"] = "YES"
             let moduleMapPath: AbsolutePath
             // If user provided the modulemap no need to generate.
-            if clangModule.moduleMapPath.asString.isFile {
+            if isFile(clangModule.moduleMapPath) {
                 moduleMapPath = clangModule.moduleMapPath
             } else {
                 // Generate and drop the modulemap inside Xcodeproj folder.

--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -143,7 +143,7 @@ func findDirectoryReferences(path: AbsolutePath) throws -> [AbsolutePath] {
         if $0.suffix == ".xcodeproj" { return false }
         if $0.suffix == ".playground" { return false }
         if $0.basename.hasPrefix(".") { return false }
-        return $0.asString.isDirectory
+        return isDirectory($0)
     }
     
     let filteredDirectories = try rootDirectoriesToConsider.filter {

--- a/Tests/Basic/PathShimTests.swift
+++ b/Tests/Basic/PathShimTests.swift
@@ -55,7 +55,7 @@ class PathShimTests : XCTestCase {
         try! makeDirectories(dirPath)
         
         // Check that we were able to actually create the directory.
-        XCTAssertTrue(dirPath.asString.isDirectory)
+        XCTAssertTrue(isDirectory(dirPath))
         
         // Check that there's no error if we try to create the directory again.
         try! makeDirectories(dirPath)
@@ -78,18 +78,18 @@ class PathShimTests : XCTestCase {
         try! createSymlink(slnkPath, pointingAt: keepDirPath, relative: true)
         
         // Make sure the symbolic link got set up correctly.
-        XCTAssertTrue(slnkPath.asString.isSymlink)
+        XCTAssertTrue(isSymlink(slnkPath))
         XCTAssertEqual(resolveSymlinks(slnkPath), keepDirPath)
-        XCTAssertTrue(resolveSymlinks(slnkPath).asString.isDirectory)
+        XCTAssertTrue(isDirectory(resolveSymlinks(slnkPath)))
         
         // Now remove the directory hierarchy that contains the symlink.
         try! removeFileTree(tossDirPath)
         
         // Make sure it got removed, along with the symlink, but that the target of the symlink remains.
-        XCTAssertFalse(tossDirPath.asString.exists)
-        XCTAssertFalse(tossDirPath.asString.isDirectory)
-        XCTAssertTrue(keepDirPath.asString.exists)
-        XCTAssertTrue(keepDirPath.asString.isDirectory)
+        XCTAssertFalse(exists(tossDirPath))
+        XCTAssertFalse(isDirectory(tossDirPath))
+        XCTAssertTrue(exists(keepDirPath))
+        XCTAssertTrue(isDirectory(keepDirPath))
     }
     
     func testCurrentWorkingDirectory() {
@@ -146,9 +146,9 @@ class WalkTests : XCTestCase {
         try! makeDirectories(tmpDirPath.appending("bar/baz/goo"))
         try! createSymlink(tmpDirPath.appending("foo/symlink"), pointingAt: tmpDirPath.appending("bar"), relative: true)
 
-        XCTAssertTrue(tmpDirPath.appending("foo/symlink").asString.isSymlink)
+        XCTAssertTrue(isSymlink(tmpDirPath.appending("foo/symlink")))
         XCTAssertEqual(resolveSymlinks(tmpDirPath.appending("foo/symlink")), tmpDirPath.appending("bar"))
-        XCTAssertTrue(resolveSymlinks(tmpDirPath.appending("foo/symlink/baz")).asString.isDirectory)
+        XCTAssertTrue(isDirectory(resolveSymlinks(tmpDirPath.appending("foo/symlink/baz"))))
 
         let results = try! walk(tmpDirPath.appending("foo")).map{ $0 }
 
@@ -164,7 +164,7 @@ class WalkTests : XCTestCase {
         try! createSymlink(tmpDirPath.appending("symlink"), pointingAt: tmpDirPath.appending("foo"), relative: true)
         try! createSymlink(tmpDirPath.appending("foo/baz"), pointingAt: tmpDirPath.appending("abc"), relative: true)
 
-        XCTAssertTrue(tmpDirPath.appending("symlink").asString.isSymlink)
+        XCTAssertTrue(isSymlink(tmpDirPath.appending("symlink")))
 
         let results = try! walk(tmpDirPath.appending("symlink")).map{ $0 }.sorted()
 

--- a/Tests/Basic/TemporaryFileTests.swift
+++ b/Tests/Basic/TemporaryFileTests.swift
@@ -23,7 +23,7 @@ class TemporaryFileTests: XCTestCase {
             XCTAssertTrue(file.path.basename.hasSuffix("mysuffix"))
 
             // Check if file is created.
-            XCTAssertTrue(file.path.asString.isFile)
+            XCTAssertTrue(isFile(file.path))
 
             // Try writing some data to the file.
             let stream = BufferedOutputByteStream()
@@ -41,7 +41,7 @@ class TemporaryFileTests: XCTestCase {
             filePath = file.path
         }
         // File should be deleted now.
-        XCTAssertFalse(filePath.asString.isFile)
+        XCTAssertFalse(isFile(filePath))
     }
 
     func testCanCreateUniqueTempFiles() throws {
@@ -51,16 +51,16 @@ class TemporaryFileTests: XCTestCase {
             let fileOne = try TemporaryFile()
             let fileTwo = try TemporaryFile()
             // Check files exists.
-            XCTAssertTrue(fileOne.path.asString.isFile)
-            XCTAssertTrue(fileTwo.path.asString.isFile)
+            XCTAssertTrue(isFile(fileOne.path))
+            XCTAssertTrue(isFile(fileTwo.path))
             // Their paths should be different.
             XCTAssertTrue(fileOne.path != fileTwo.path)
 
             filePathOne = fileOne.path
             filePathTwo = fileTwo.path
         }
-        XCTAssertFalse(filePathOne.asString.isFile)
-        XCTAssertFalse(filePathTwo.asString.isFile)
+        XCTAssertFalse(isFile(filePathOne))
+        XCTAssertFalse(isFile(filePathTwo))
     }
 
     func testBasicTemporaryDirectory() throws {

--- a/Tests/Commands/BuildToolTests.swift
+++ b/Tests/Commands/BuildToolTests.swift
@@ -38,12 +38,12 @@ final class BuildToolTests: XCTestCase {
             // Build it.
             XCTAssertBuilds(packageRoot)
             XCTAssertFileExists(packageRoot.appending(".build/debug/Foo"))
-            XCTAssert(packageRoot.appending(".build").asString.isDirectory)
+            XCTAssert(isDirectory(packageRoot.appending(".build")))
 
             // Clean, and check for removal.
             _ = try execute(["--clean"], chdir: packageRoot)
-            XCTAssert(!packageRoot.appending(".build/debug/Foo").asString.isFile)
-            XCTAssert(!packageRoot.appending(".build").asString.isDirectory)
+            XCTAssert(!isFile(packageRoot.appending(".build/debug/Foo")))
+            XCTAssert(!isDirectory(packageRoot.appending(".build")))
 
             // Clean again to ensure we get no error.
             _ = try execute(["--clean"], chdir: packageRoot)
@@ -57,18 +57,18 @@ final class BuildToolTests: XCTestCase {
             // Build it.
             XCTAssertBuilds(packageRoot)
             XCTAssertFileExists(packageRoot.appending(".build/debug/Bar"))
-            XCTAssert(packageRoot.appending(".build").asString.isDirectory)
-            XCTAssert(packageRoot.appending("Packages").asString.isDirectory)
+            XCTAssert(isDirectory(packageRoot.appending(".build")))
+            XCTAssert(isDirectory(packageRoot.appending("Packages")))
 
             // Clean, and check for removal of the build directory but not Packages.
             _ = try execute(["--clean"], chdir: packageRoot)
-            XCTAssert(!packageRoot.appending(".build").asString.isDirectory)
-            XCTAssert(packageRoot.appending("Packages").asString.isDirectory)
+            XCTAssert(!isDirectory(packageRoot.appending(".build")))
+            XCTAssert(isDirectory(packageRoot.appending("Packages")))
 
             // Fully clean, and check for removal of both.
             _ = try execute(["--clean=dist"], chdir: packageRoot)
-            XCTAssert(!packageRoot.appending(".build").asString.isDirectory)
-            XCTAssert(!packageRoot.appending("Packages").asString.isDirectory)
+            XCTAssert(!isDirectory(packageRoot.appending(".build")))
+            XCTAssert(!isDirectory(packageRoot.appending("Packages")))
         }
     }
 

--- a/Tests/Functional/Utilities.swift
+++ b/Tests/Functional/Utilities.swift
@@ -33,13 +33,13 @@ func fixture(name fixtureSubpath: RelativePath, tags: [String] = [], file: Stati
         let fixtureDir = AbsolutePath(#file).appending("../../../Fixtures").appending(fixtureSubpath)
         
         // Check that the fixture is really there.
-        guard fixtureDir.asString.isDirectory else {
+        guard isDirectory(fixtureDir) else {
             XCTFail("No such fixture: \(fixtureDir.asString)", file: file, line: line)
             return
         }
         
         // The fixture contains either a checkout or just a Git directory.
-        if fixtureDir.appending("Package.swift").asString.isFile {
+        if isFile(fixtureDir.appending(component: "Package.swift")) {
             // It's a single package, so copy the whole directory as-is.
             let dstDir = tmpDir.path.appending(component: copyName)
             try systemQuietly("cp", "-R", "-H", fixtureDir.asString, dstDir.asString)
@@ -62,7 +62,7 @@ func fixture(name fixtureSubpath: RelativePath, tags: [String] = [], file: Stati
             // Copy each of the package directories and construct a git repo in it.
             for fileName in try! localFileSystem.getDirectoryContents(fixtureDir).sorted() {
                 let srcDir = fixtureDir.appending(component: fileName)
-                guard srcDir.asString.isDirectory else { continue }
+                guard isDirectory(srcDir) else { continue }
                 let dstDir = tmpDir.path.appending(component: fileName)
                 try systemQuietly("cp", "-R", "-H", srcDir.asString, dstDir.asString)
                 try systemQuietly([Git.tool, "-C", dstDir.asString, "init"])
@@ -246,19 +246,19 @@ func XCTAssertBuildFails(_ path: AbsolutePath, file: StaticString = #file, line:
 }
 
 func XCTAssertFileExists(_ path: AbsolutePath, file: StaticString = #file, line: UInt = #line) {
-    if !path.asString.isFile {
+    if !isFile(path) {
         XCTFail("Expected file doesn’t exist: \(path.asString)", file: file, line: line)
     }
 }
 
 func XCTAssertDirectoryExists(_ path: AbsolutePath, file: StaticString = #file, line: UInt = #line) {
-    if !path.asString.isDirectory {
+    if !isDirectory(path) {
         XCTFail("Expected directory doesn’t exist: \(path.asString)", file: file, line: line)
     }
 }
 
 func XCTAssertNoSuchPath(_ path: AbsolutePath, file: StaticString = #file, line: UInt = #line) {
-    if path.asString.exists {
+    if exists(path) {
         XCTFail("path exists but should not: \(path.asString)", file: file, line: line)
     }
 }

--- a/Tests/SourceControl/GitRepositoryTests.swift
+++ b/Tests/SourceControl/GitRepositoryTests.swift
@@ -43,7 +43,7 @@ class GitRepositoryTests: XCTestCase {
             try! provider.fetch(repository: repoSpec, to: testCheckoutPath)
 
             // Verify the checkout was made.
-            XCTAssert(testCheckoutPath.asString.exists)
+            XCTAssert(exists(testCheckoutPath))
 
             // Test the repository interface.
             let repository = provider.open(repository: repoSpec, at: testCheckoutPath)

--- a/Tests/Utility/PathTests.swift
+++ b/Tests/Utility/PathTests.swift
@@ -94,30 +94,30 @@ class PathTests: XCTestCase {
 class StatTests: XCTestCase {
 
     func test_isdir() {
-        XCTAssertTrue("/usr".isDirectory)
-        XCTAssertTrue("/etc/passwd".isFile)
+        XCTAssertTrue(isDirectory("/usr"))
+        XCTAssertTrue(isFile("/etc/passwd"))
 
         mktmpdir { root in
             try makeDirectories(root.appending("foo/bar"))
             try createSymlink(root.appending("symlink"), pointingAt: root.appending("foo"), relative: true)
 
-            XCTAssertTrue(root.appending("foo/bar").asString.isDirectory)
-            XCTAssertTrue(root.appending("symlink/bar").asString.isDirectory)
-            XCTAssertTrue(root.appending("symlink").asString.isDirectory)
-            XCTAssertTrue(root.appending("symlink").asString.isSymlink)
+            XCTAssertTrue(isDirectory(root.appending("foo/bar")))
+            XCTAssertTrue(isDirectory(root.appending("symlink/bar")))
+            XCTAssertTrue(isDirectory(root.appending("symlink")))
+            XCTAssertTrue(isSymlink(root.appending("symlink")))
 
             try removeFileTree(root.appending("foo/bar"))
             try removeFileTree(root.appending("foo"))
 
-            XCTAssertTrue(root.appending("symlink").asString.isSymlink)
-            XCTAssertFalse(root.appending("symlink").asString.isDirectory)
-            XCTAssertFalse(root.appending("symlink").asString.isFile)
+            XCTAssertTrue(isSymlink(root.appending("symlink")))
+            XCTAssertFalse(isDirectory(root.appending("symlink")))
+            XCTAssertFalse(isFile(root.appending("symlink")))
         }
     }
 
     func test_isfile() {
-        XCTAssertTrue(!"/usr".isFile)
-        XCTAssertTrue("/etc/passwd".isFile)
+        XCTAssertTrue(!isFile("/usr"))
+        XCTAssertTrue(isFile("/etc/passwd"))
     }
 
     func test_realpath() {


### PR DESCRIPTION
Change to using AbsolutePath-based `isDirectory`, `isFile`, `isSymlink`, and `exists` checks.