### PR TITLE
Remove `ExpressibleByStringLiteral` conformance for AbsolutePath and RelativePath

### DIFF
--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -201,23 +201,6 @@ public struct AbsolutePath {
     }
 }
 
-/// Adoption of the ExpressibleByStringLiteral protocol allows literal strings
-/// to be implicitly converted to AbsolutePaths.
-extension AbsolutePath : ExpressibleByStringLiteral {
-    public typealias UnicodeScalarLiteralType = StringLiteralType
-    public typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
-    public init(stringLiteral value: String) {
-        self.init(value)
-    }
-    public init(extendedGraphemeClusterLiteral value: String) {
-        self.init(stringLiteral: value)
-    }
-    public init(unicodeScalarLiteral value: String) {
-        self.init(stringLiteral: value)
-    }
-}
-
-
 /// Represents a relative file system path.  A relative path never starts with
 /// a `/` character, and holds a normalized string representation.  As with
 /// AbsolutePath, the normalization is strictly syntactic, and does not access

--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -294,22 +294,6 @@ public struct RelativePath {
     }
 }
 
-/// Adoption of the ExpressibleByStringLiteral protocol allows literal strings
-/// to be implicitly converted to RelativePaths.
-extension RelativePath : ExpressibleByStringLiteral {
-    public typealias UnicodeScalarLiteralType = StringLiteralType
-    public typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
-    public init(stringLiteral value: String) {
-        self.init(value)
-    }
-    public init(extendedGraphemeClusterLiteral value: String) {
-        self.init(stringLiteral: value)
-    }
-    public init(unicodeScalarLiteral value: String) {
-        self.init(stringLiteral: value)
-    }
-}
-
 // Make absolute paths Hashable.
 extension AbsolutePath : Hashable {
     public var hashValue: Int {

--- a/Sources/Build/misc.swift
+++ b/Sources/Build/misc.swift
@@ -145,7 +145,7 @@ protocol ClangModuleCachable {
 
 extension ClangModuleCachable {
     func moduleCacheDir(prefix: AbsolutePath) -> AbsolutePath {
-        return prefix.appending("ModuleCache")
+        return prefix.appending(component: "ModuleCache")
     }
 }
 

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -20,10 +20,10 @@ public class Options {
 
     public class Path {
         public lazy var root = getroot()
-        public var packages: AbsolutePath { return root.appending("Packages") }
+        public var packages: AbsolutePath { return root.appending(component: "Packages") }
 
         public var build: AbsolutePath {
-            get { return _build != nil ? AbsolutePath(_build!) : getroot().appending(".build") }
+            get { return _build != nil ? AbsolutePath(_build!) : getroot().appending(component: ".build") }
             set { _build = newValue.asString }
         }
         private var _build = getEnvBuildPath()?.asString

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -48,7 +48,7 @@ private func getroot() -> AbsolutePath {
     while !isFile(root.appending(component: Manifest.filename)) {
         root = root.parentDirectory
 
-        guard root != "/" else {
+        guard !root.isRoot else {
             // abort because lazy properties cannot throw and we
             // want erroring on no manifest found to be “lazy” so
             // any path that requires this property errors, but we

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -182,7 +182,7 @@ public struct SwiftPackageTool: SwiftTool {
                         let item = opts.path.packages.appending(RelativePath(name))
 
                         // Only look at repositories.
-                        guard exists(item.appending(".git")) else { continue }
+                        guard exists(item.appending(component: ".git")) else { continue }
 
                         // If there is a staged or unstaged diff, don't remove the
                         // tree. This won't detect new untracked files, but it is

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -282,13 +282,13 @@ public struct SwiftTestTool: SwiftTool {
         let xctestHelperBin = "swiftpm-xctest-helper"
         let binDirectory = AbsolutePath(CommandLine.arguments.first!, relativeTo: currentWorkingDirectory).parentDirectory
         // XCTestHelper tool is installed in libexec.
-        let maybePath = binDirectory.appending("../libexec/swift/pm/").appending(RelativePath(xctestHelperBin))
+        let maybePath = binDirectory.parentDirectory.appending(components: "libexec", "swift", "pm", xctestHelperBin)
         if isFile(maybePath) {
             return maybePath
         }
         // This will be true during swiftpm developement.
         // FIXME: Factor all of the development-time resource location stuff into a common place.
-        let path = binDirectory.appending(RelativePath(xctestHelperBin))
+        let path = binDirectory.appending(component: xctestHelperBin)
         if isFile(path) {
             return path 
         }

--- a/Sources/Commands/init.swift
+++ b/Sources/Commands/init.swift
@@ -93,7 +93,7 @@ final class InitPackage {
     }
     
     private func writeGitIgnore() throws {
-        let gitignore = rootd.appending(".gitignore")
+        let gitignore = rootd.appending(component: ".gitignore")
         guard exists(gitignore) == false else {
             return
         } 
@@ -110,7 +110,7 @@ final class InitPackage {
         if mode == .systemModule {
             return
         }
-        let sources = rootd.appending("Sources")
+        let sources = rootd.appending(component: "Sources")
         guard exists(sources) == false else {
             return
         }
@@ -138,7 +138,7 @@ final class InitPackage {
         if mode != .systemModule {
             return
         }
-        let modulemap = rootd.appending("module.modulemap")
+        let modulemap = rootd.appending(component: "module.modulemap")
         guard exists(modulemap) == false else {
             return
         }
@@ -156,7 +156,7 @@ final class InitPackage {
         if mode == .systemModule {
             return
         }
-        let tests = rootd.appending("Tests")
+        let tests = rootd.appending(component: "Tests")
         guard exists(tests) == false else {
             return
         }
@@ -171,7 +171,7 @@ final class InitPackage {
     }
     
     private func writeLinuxMain(testsPath: AbsolutePath) throws {
-        try writePackageFile(testsPath.appending("LinuxMain.swift")) { stream in
+        try writePackageFile(testsPath.appending(component: "LinuxMain.swift")) { stream in
             stream <<< "import XCTest\n"
             stream <<< "@testable import \(moduleName)TestSuite\n\n"
             stream <<< "XCTMain([\n"

--- a/Sources/Get/PackagesDirectory.swift
+++ b/Sources/Get/PackagesDirectory.swift
@@ -43,7 +43,7 @@ public final class PackagesDirectory {
 
     /// The path to the packages.
     var packagesPath: AbsolutePath {
-        return rootPath.appending("Packages")
+        return rootPath.appending(component: "Packages")
     }
     
     /// The set of all repositories available within the `Packages` directory, by origin.

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -110,7 +110,7 @@ public final class ManifestLoader {
         cmd += [manifestPath.asString]
     
         //Create and open a temporary file to write toml to
-        let filePath = manifestPath.parentDirectory.appending(".Package.toml")
+        let filePath = manifestPath.parentDirectory.appending(component: ".Package.toml")
         let fp = try fopen(filePath, mode: .write)
         defer { fp.closeFile() }
     

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -191,7 +191,7 @@ public struct PackageBuilder {
     }
 
     private var packagesDirectory: AbsolutePath {
-        return packagePath.appending("Packages")
+        return packagePath.appending(component: "Packages")
     }
 
     private var excludedPaths: [AbsolutePath] {
@@ -232,7 +232,7 @@ public struct PackageBuilder {
 
     /// Collects the modules which are defined by a package.
     private func constructModules() throws -> [Module] {
-        let moduleMapPath = packagePath.appending("module.modulemap")
+        let moduleMapPath = packagePath.appending(component: "module.modulemap")
         if fileSystem.isFile(moduleMapPath) {
             let sources = Sources(paths: [moduleMapPath], root: packagePath)
             return [try CModule(name: manifest.name, sources: sources, path: packagePath, pkgConfig: pkgConfigPath, providers: manifest.package.providers)]
@@ -408,7 +408,7 @@ public struct PackageBuilder {
     }
 
     private func constructTestModules(modules: [Module]) throws -> [Module] {
-        let testsPath = packagePath.appending("Tests")
+        let testsPath = packagePath.appending(component: "Tests")
         
         // Don't try to walk Tests if it is in excludes or doesn't exists.
         guard fileSystem.isDirectory(testsPath) && !excludedPaths.contains(testsPath) else {

--- a/Sources/PackageModel/Module.swift
+++ b/Sources/PackageModel/Module.swift
@@ -131,7 +131,7 @@ public class ClangModule: CModule {
         }
         let type: ModuleType = isLibrary ? .library : .executable
         
-        try super.init(name: name, type: type, sources: sources, path: sources.root.appending("include"), isTest: isTest)
+        try super.init(name: name, type: type, sources: sources, path: sources.root.appending(component: "include"), isTest: isTest)
     }
 }
 

--- a/Sources/SourceControl/CheckoutManager.swift
+++ b/Sources/SourceControl/CheckoutManager.swift
@@ -182,7 +182,7 @@ public class CheckoutManager {
 
     /// The path at which we persist the manager state.
     private var statePath: AbsolutePath {
-        return path.appending("manager-state.json")
+        return path.appending(component: "manager-state.json")
     }
     
     /// Restore the manager state from disk.

--- a/Sources/Utility/Platform.swift
+++ b/Sources/Utility/Platform.swift
@@ -27,7 +27,7 @@ public enum Platform {
         case "darwin":
             return .darwin
         case "linux":
-            if isFile("/etc/debian_version") {
+            if isFile(AbsolutePath("/etc/debian_version")) {
                 return .linux(.debian)
             }
         default:

--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -40,14 +40,14 @@ public func generate(dstdir: AbsolutePath, projectName: String, graph: PackageGr
 
     let xcodeprojName = "\(projectName).xcodeproj"
     let xcodeprojPath = dstdir.appending(RelativePath(xcodeprojName))
-    let schemesDirectory = xcodeprojPath.appending("xcshareddata/xcschemes")
+    let schemesDirectory = xcodeprojPath.appending(components: "xcshareddata", "xcschemes")
     try makeDirectories(xcodeprojPath)
     try makeDirectories(schemesDirectory)
     let schemeName = "\(projectName).xcscheme"
     let directoryReferences = try findDirectoryReferences(path: srcroot)
 
 ////// the pbxproj file describes the project and its targets
-    try open(xcodeprojPath.appending("project.pbxproj")) { stream in
+    try open(xcodeprojPath.appending(component: "project.pbxproj")) { stream in
         try pbxproj(srcroot: srcroot, projectRoot: dstdir, xcodeprojPath: xcodeprojPath, graph: graph, directoryReferences: directoryReferences, options: options, printer: stream)
     }
 
@@ -59,7 +59,7 @@ public func generate(dstdir: AbsolutePath, projectName: String, graph: PackageGr
 
 ////// we generate this file to ensure our main scheme is listed
    /// before any inferred schemes Xcode may autocreate
-    try open(schemesDirectory.appending("xcschememanagement.plist")) { print in
+    try open(schemesDirectory.appending(component: "xcschememanagement.plist")) { print in
         print("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
         print("<plist version=\"1.0\">")
         print("<dict>")

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -53,7 +53,7 @@ public func pbxproj(srcroot: AbsolutePath, projectRoot: AbsolutePath, xcodeprojP
     print("        };")
 
 ////// Package.swift file
-    let packageSwift = fileRef(inProjectRoot: "Package.swift", srcroot: srcroot)
+    let packageSwift = fileRef(inProjectRoot: RelativePath("Package.swift"), srcroot: srcroot)
     print("        \(packageSwift.refId) = {")
     print("            isa = PBXFileReference;")
     print("            lastKnownFileType = sourcecode.swift;")

--- a/Tests/Basic/FileSystemTests.swift
+++ b/Tests/Basic/FileSystemTests.swift
@@ -46,7 +46,7 @@ class FileSystemTests: XCTestCase {
 
         // isSymlink()
         let tempDir = try! TemporaryDirectory(removeTreeOnDeinit: true)
-        let sym = tempDir.path.appending("hello")
+        let sym = tempDir.path.appending(component: "hello")
         try! createSymlink(sym, pointingAt: file.path)
         XCTAssertTrue(fs.isSymlink(sym))
         XCTAssertTrue(fs.isFile(sym))
@@ -71,7 +71,7 @@ class FileSystemTests: XCTestCase {
         
         let tmpDir = try TemporaryDirectory(prefix: #function, removeTreeOnDeinit: true)
         do {
-            let testPath = tmpDir.path.appending("new-dir")
+            let testPath = tmpDir.path.appending(component: "new-dir")
             XCTAssert(!fs.exists(testPath))
             try! fs.createDirectory(testPath)
             XCTAssert(fs.exists(testPath))
@@ -79,7 +79,7 @@ class FileSystemTests: XCTestCase {
         }
 
         do {
-            let testPath = tmpDir.path.appending("another-new-dir/with-a-subdir")
+            let testPath = tmpDir.path.appending(components: "another-new-dir", "with-a-subdir")
             XCTAssert(!fs.exists(testPath))
             try! fs.createDirectory(testPath, recursive: true)
             XCTAssert(fs.exists(testPath))
@@ -93,7 +93,7 @@ class FileSystemTests: XCTestCase {
         let tmpDir = try TemporaryDirectory(prefix: #function, removeTreeOnDeinit: true)
         // Check read/write of a simple file.
         let testData = (0..<1000).map { $0.description }.joined(separator: ", ")
-        let filePath = tmpDir.path.appending("test-data.txt")
+        let filePath = tmpDir.path.appending(component: "test-data.txt")
         try! fs.writeFileContents(filePath, bytes: ByteString(testData))
         XCTAssertTrue(fs.isFile(filePath))
         let data = try! fs.readFileContents(filePath)
@@ -123,15 +123,15 @@ class FileSystemTests: XCTestCase {
     
         // Check read/write into a non-directory.
         XCTAssertThrows(FileSystemError.notDirectory) {
-            _ = try fs.readFileContents(filePath.appending("not-possible"))
+            _ = try fs.readFileContents(filePath.appending(component: "not-possible"))
         }
         XCTAssertThrows(FileSystemError.notDirectory) {
-            try fs.writeFileContents(filePath.appending("not-possible"), bytes: [])
+            try fs.writeFileContents(filePath.appending(component: "not-possible"), bytes: [])
         }
         XCTAssert(fs.exists(filePath))
     
         // Check read/write into a missing directory.
-        let missingDir = tmpDir.path.appending("does/not/exist")
+        let missingDir = tmpDir.path.appending(components: "does", "not", "exist")
         XCTAssertThrows(FileSystemError.noEntry) {
             _ = try fs.readFileContents(missingDir)
         }
@@ -181,7 +181,7 @@ class FileSystemTests: XCTestCase {
         XCTAssert(fs.isDirectory(subdir))
         
         // Check non-recursive subdir creation.
-        let subsubdir = subdir.appending("new-subdir")
+        let subsubdir = subdir.appending(component: "new-subdir")
         XCTAssert(!fs.isDirectory(subsubdir))
         try! fs.createDirectory(subsubdir, recursive: false)
         XCTAssert(fs.isDirectory(subsubdir))
@@ -202,7 +202,7 @@ class FileSystemTests: XCTestCase {
             try fs.createDirectory(filePath, recursive: true)
         }
         XCTAssertThrows(FileSystemError.notDirectory) {
-            try fs.createDirectory(filePath.appending("not-possible"), recursive: true)
+            try fs.createDirectory(filePath.appending(component: "not-possible"), recursive: true)
         }
         XCTAssert(fs.exists(filePath) && !fs.isDirectory(filePath))
     }
@@ -212,7 +212,7 @@ class FileSystemTests: XCTestCase {
         try! fs.createDirectory("/new-dir/subdir", recursive: true)
 
         // Check read/write of a simple file.
-        let filePath = AbsolutePath("/new-dir/subdir").appending("new-file.txt")
+        let filePath = AbsolutePath("/new-dir/subdir").appending(component: "new-file.txt")
         XCTAssert(!fs.exists(filePath))
         XCTAssertFalse(fs.isFile(filePath))
         try! fs.writeFileContents(filePath, bytes: "Hello, world!")
@@ -247,10 +247,10 @@ class FileSystemTests: XCTestCase {
         
         // Check read/write into a non-directory.
         XCTAssertThrows(FileSystemError.notDirectory) {
-            _ = try fs.readFileContents(filePath.appending("not-possible"))
+            _ = try fs.readFileContents(filePath.appending(component: "not-possible"))
         }
         XCTAssertThrows(FileSystemError.notDirectory) {
-            try fs.writeFileContents(filePath.appending("not-possible"), bytes: [])
+            try fs.writeFileContents(filePath.appending(component: "not-possible"), bytes: [])
         }
         XCTAssert(fs.exists(filePath))
         

--- a/Tests/Basic/POSIXTests.swift
+++ b/Tests/Basic/POSIXTests.swift
@@ -25,7 +25,7 @@ class POSIXTests : XCTestCase {
         XCTAssertFalse(isFile(dir.path))
         XCTAssertTrue(isDirectory(dir.path))
 
-        let sym = dir.path.appending("hello")
+        let sym = dir.path.appending(component: "hello")
         try createSymlink(sym, pointingAt: file.path)
         XCTAssertTrue(exists(sym))
         XCTAssertFalse(isFile(sym, followSymlink: false))
@@ -34,7 +34,7 @@ class POSIXTests : XCTestCase {
         XCTAssertFalse(isDirectory(sym, followSymlink: true))
 
         let dir2 = try TemporaryDirectory()
-        let dirSym = dir.path.appending("dir2")
+        let dirSym = dir.path.appending(component: "dir2")
         try createSymlink(dirSym, pointingAt: dir2.path)
         XCTAssertTrue(exists(dirSym))
         XCTAssertFalse(isFile(dirSym, followSymlink: false))

--- a/Tests/Basic/PathShimTests.swift
+++ b/Tests/Basic/PathShimTests.swift
@@ -27,8 +27,8 @@ class PathShimTests : XCTestCase {
         let tmpDirPath = resolveSymlinks(tmpDir.path)
 
         // Create a symbolic link and directory.
-        let slnkPath = tmpDirPath.appending("slnk")
-        let fldrPath = tmpDirPath.appending("fldr")
+        let slnkPath = tmpDirPath.appending(component: "slnk")
+        let fldrPath = tmpDirPath.appending(component: "fldr")
         
         // Create a symbolic link pointing at the (so far non-existent) directory.
         try! createSymlink(slnkPath, pointingAt: fldrPath, relative: true)
@@ -142,37 +142,37 @@ class WalkTests : XCTestCase {
         // FIXME: it would be better to not need to resolve symbolic links, but we end up relying on /tmp -> /private/tmp.
         let tmpDirPath = resolveSymlinks(tmpDir.path)
             
-        try! makeDirectories(tmpDirPath.appending("foo"))
-        try! makeDirectories(tmpDirPath.appending("bar/baz/goo"))
-        try! createSymlink(tmpDirPath.appending("foo/symlink"), pointingAt: tmpDirPath.appending("bar"), relative: true)
+        try! makeDirectories(tmpDirPath.appending(component: "foo"))
+        try! makeDirectories(tmpDirPath.appending(components: "bar", "baz", "goo"))
+        try! createSymlink(tmpDirPath.appending(components: "foo", "symlink"), pointingAt: tmpDirPath.appending(component: "bar"), relative: true)
 
-        XCTAssertTrue(isSymlink(tmpDirPath.appending("foo/symlink")))
-        XCTAssertEqual(resolveSymlinks(tmpDirPath.appending("foo/symlink")), tmpDirPath.appending("bar"))
-        XCTAssertTrue(isDirectory(resolveSymlinks(tmpDirPath.appending("foo/symlink/baz"))))
+        XCTAssertTrue(isSymlink(tmpDirPath.appending(components: "foo", "symlink")))
+        XCTAssertEqual(resolveSymlinks(tmpDirPath.appending(components: "foo", "symlink")), tmpDirPath.appending(component: "bar"))
+        XCTAssertTrue(isDirectory(resolveSymlinks(tmpDirPath.appending(components: "foo", "symlink", "baz"))))
 
-        let results = try! walk(tmpDirPath.appending("foo")).map{ $0 }
+        let results = try! walk(tmpDirPath.appending(component: "foo")).map{ $0 }
 
-        XCTAssertEqual(results, [tmpDirPath.appending("foo/symlink")])
+        XCTAssertEqual(results, [tmpDirPath.appending(components: "foo", "symlink")])
     }
 
     func testWalkingADirectorySymlinkResolvesOnce() {
         let tmpDir = try! TemporaryDirectory(removeTreeOnDeinit: true)
         let tmpDirPath = tmpDir.path
         
-        try! makeDirectories(tmpDirPath.appending("foo/bar"))
-        try! makeDirectories(tmpDirPath.appending("abc/bar"))
-        try! createSymlink(tmpDirPath.appending("symlink"), pointingAt: tmpDirPath.appending("foo"), relative: true)
-        try! createSymlink(tmpDirPath.appending("foo/baz"), pointingAt: tmpDirPath.appending("abc"), relative: true)
+        try! makeDirectories(tmpDirPath.appending(components: "foo", "bar"))
+        try! makeDirectories(tmpDirPath.appending(components: "abc", "bar"))
+        try! createSymlink(tmpDirPath.appending(component: "symlink"), pointingAt: tmpDirPath.appending(component: "foo"), relative: true)
+        try! createSymlink(tmpDirPath.appending(components: "foo", "baz"), pointingAt: tmpDirPath.appending(component: "abc"), relative: true)
 
-        XCTAssertTrue(isSymlink(tmpDirPath.appending("symlink")))
+        XCTAssertTrue(isSymlink(tmpDirPath.appending(component: "symlink")))
 
-        let results = try! walk(tmpDirPath.appending("symlink")).map{ $0 }.sorted()
+        let results = try! walk(tmpDirPath.appending(component: "symlink")).map{ $0 }.sorted()
 
         // we recurse a symlink to a directory, so this should work,
         // but `abc` should not show because `baz` is a symlink too
         // and that should *not* be followed
 
-        XCTAssertEqual(results, [tmpDirPath.appending("symlink/bar"), tmpDirPath.appending("symlink/baz")])
+        XCTAssertEqual(results, [tmpDirPath.appending(components: "symlink", "bar"), tmpDirPath.appending(components: "symlink", "baz")])
     }
 
     static var allTests = [

--- a/Tests/Basic/PathShimTests.swift
+++ b/Tests/Basic/PathShimTests.swift
@@ -114,7 +114,7 @@ class WalkTests : XCTestCase {
             AbsolutePath("/bin"),
             AbsolutePath("/sbin")
         ]
-        for x in try! walk("/", recursively: false) {
+        for x in try! walk(AbsolutePath("/"), recursively: false) {
             if let i = expected.index(of: x) {
                 expected.remove(at: i)
             }

--- a/Tests/Basic/PathTests.swift
+++ b/Tests/Basic/PathTests.swift
@@ -27,7 +27,7 @@ class PathTests: XCTestCase {
     }
     
     func testStringInitialization() {
-        let abs1: AbsolutePath = "/"
+        let abs1 = AbsolutePath("/")
         let abs2 = AbsolutePath(abs1, ".")
         XCTAssertEqual(abs1, abs2)
         let rel3 = "."
@@ -43,7 +43,7 @@ class PathTests: XCTestCase {
     }
     
     func testStringLiteralInitialization() {
-        let abs: AbsolutePath = "/"
+        let abs = AbsolutePath("/")
         XCTAssertEqual(abs.asString, "/")
         let rel1 = RelativePath(".")
         XCTAssertEqual(rel1.asString, ".")

--- a/Tests/Basic/PathTests.swift
+++ b/Tests/Basic/PathTests.swift
@@ -45,9 +45,9 @@ class PathTests: XCTestCase {
     func testStringLiteralInitialization() {
         let abs: AbsolutePath = "/"
         XCTAssertEqual(abs.asString, "/")
-        let rel: RelativePath = "."
-        XCTAssertEqual(rel.asString, ".")
-        let rel2: RelativePath = "~"
+        let rel1 = RelativePath(".")
+        XCTAssertEqual(rel1.asString, ".")
+        let rel2 = RelativePath("~")
         XCTAssertEqual(rel2.asString, "~")  // `~` is not special
     }
     

--- a/Tests/Basic/TemporaryFileTests.swift
+++ b/Tests/Basic/TemporaryFileTests.swift
@@ -78,7 +78,7 @@ class TemporaryFileTests: XCTestCase {
             let tempDir = try TemporaryDirectory()
             XCTAssertTrue(localFileSystem.isDirectory(tempDir.path))
             // Create a file inside the temp directory.
-            let filePath = tempDir.path.appending("somefile")
+            let filePath = tempDir.path.appending(component: "somefile")
             try localFileSystem.writeFileContents(filePath, bytes: ByteString())
             path = tempDir.path
         }
@@ -95,7 +95,7 @@ class TemporaryFileTests: XCTestCase {
         do {
             let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
             XCTAssertTrue(localFileSystem.isDirectory(tempDir.path))
-            let filePath = tempDir.path.appending("somefile")
+            let filePath = tempDir.path.appending(component: "somefile")
             try localFileSystem.writeFileContents(filePath, bytes: ByteString())
             path = tempDir.path
         }

--- a/Tests/Build/DescribeTests.swift
+++ b/Tests/Build/DescribeTests.swift
@@ -32,7 +32,7 @@ final class DescribeTests: XCTestCase {
         do {
             let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
             let graph = PackageGraph(rootPackage: dummyPackage, modules: [], externalModules: [])
-            _ = try describe(tempDir.path.appending("foo"), .debug, graph, flags: BuildFlags(), toolchain: InvalidToolchain())
+            _ = try describe(tempDir.path.appending(component: "foo"), .debug, graph, flags: BuildFlags(), toolchain: InvalidToolchain())
             XCTFail("This call should throw")
         } catch Build.Error.noModules {
             XCTAssert(true, "This error should be thrown")
@@ -45,7 +45,7 @@ final class DescribeTests: XCTestCase {
         do {
             let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
             let graph = PackageGraph(rootPackage: dummyPackage, modules: [try CModule(name: "MyCModule", sources: Sources(paths: [], root: "/"), path: "/")], externalModules: [])
-            _ = try describe(tempDir.path.appending("foo"), .debug, graph, flags: BuildFlags(), toolchain: InvalidToolchain())
+            _ = try describe(tempDir.path.appending(component: "foo"), .debug, graph, flags: BuildFlags(), toolchain: InvalidToolchain())
             XCTFail("This call should throw")
         } catch Build.Error.onlyCModule (let name) {
             XCTAssert(true, "This error should be thrown")

--- a/Tests/Build/DescribeTests.swift
+++ b/Tests/Build/DescribeTests.swift
@@ -44,7 +44,7 @@ final class DescribeTests: XCTestCase {
     func testDescribingCModuleThrows() {
         do {
             let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
-            let graph = PackageGraph(rootPackage: dummyPackage, modules: [try CModule(name: "MyCModule", sources: Sources(paths: [], root: "/"), path: "/")], externalModules: [])
+            let graph = PackageGraph(rootPackage: dummyPackage, modules: [try CModule(name: "MyCModule", sources: Sources(paths: [], root: AbsolutePath("/")), path: AbsolutePath("/"))], externalModules: [])
             _ = try describe(tempDir.path.appending(component: "foo"), .debug, graph, flags: BuildFlags(), toolchain: InvalidToolchain())
             XCTFail("This call should throw")
         } catch Build.Error.onlyCModule (let name) {

--- a/Tests/Build/PackageVersionDataTests.swift
+++ b/Tests/Build/PackageVersionDataTests.swift
@@ -19,8 +19,8 @@ import PackageDescription
 final class PackageVersionDataTests: XCTestCase {
 
     func makePackage(version: Version?) -> PackageModel.Package {
-        let m = Manifest(path: "/path", url: "https://github.com/testPkg", package: PackageDescription.Package(name: "a"), products: [], version: version)
-        return Package(manifest: m, path: "/path", modules: [], testModules: [], products: [])
+        let m = Manifest(path: AbsolutePath("/path"), url: "https://github.com/testPkg", package: PackageDescription.Package(name: "a"), products: [], version: version)
+        return Package(manifest: m, path: AbsolutePath("/path"), modules: [], testModules: [], products: [])
     }
 
     func testPackageData(_ package: PackageModel.Package, url: String, version: Version?) {
@@ -52,8 +52,8 @@ final class PackageVersionDataTests: XCTestCase {
         mktmpdir { dir in
             let package = makePackage(version: nil)
 
-            let m = Manifest(path: "/path", url: "https://github.com/rootPkg", package: PackageDescription.Package(name: "a"), products: [], version: nil)
-            let rootPkg = Package(manifest: m, path: "/path", modules: [], testModules: [], products: [])
+            let m = Manifest(path: AbsolutePath("/path"), url: "https://github.com/rootPkg", package: PackageDescription.Package(name: "a"), products: [], version: nil)
+            let rootPkg = Package(manifest: m, path: AbsolutePath("/path"), modules: [], testModules: [], products: [])
 
             try generateVersionData(dir, rootPackage:rootPkg, externalPackages: [package])
             XCTAssertFileExists(dir.appending(components: ".build", "versionData", package.name + ".swift"))

--- a/Tests/Commands/BuildToolTests.swift
+++ b/Tests/Commands/BuildToolTests.swift
@@ -29,7 +29,7 @@ final class BuildToolTests: XCTestCase {
     func testBuildAndClean() throws {
         mktmpdir { path in
             // Create a known directory.
-            let packageRoot = path.appending("Foo")
+            let packageRoot = path.appending(component: "Foo")
             try localFileSystem.createDirectory(packageRoot)
 
             // Run package init.
@@ -37,13 +37,13 @@ final class BuildToolTests: XCTestCase {
 
             // Build it.
             XCTAssertBuilds(packageRoot)
-            XCTAssertFileExists(packageRoot.appending(".build/debug/Foo"))
-            XCTAssert(isDirectory(packageRoot.appending(".build")))
+            XCTAssertFileExists(packageRoot.appending(components: ".build", "debug", "Foo"))
+            XCTAssert(isDirectory(packageRoot.appending(component: ".build")))
 
             // Clean, and check for removal.
             _ = try execute(["--clean"], chdir: packageRoot)
-            XCTAssert(!isFile(packageRoot.appending(".build/debug/Foo")))
-            XCTAssert(!isDirectory(packageRoot.appending(".build")))
+            XCTAssert(!isFile(packageRoot.appending(components: ".build", "debug", "Foo")))
+            XCTAssert(!isDirectory(packageRoot.appending(component: ".build")))
 
             // Clean again to ensure we get no error.
             _ = try execute(["--clean"], chdir: packageRoot)
@@ -52,23 +52,23 @@ final class BuildToolTests: XCTestCase {
 
     func testCleanDist() throws {
         fixture(name: "DependencyResolution/External/Simple") { prefix in
-            let packageRoot = prefix.appending("Bar")
+            let packageRoot = prefix.appending(component: "Bar")
             
             // Build it.
             XCTAssertBuilds(packageRoot)
-            XCTAssertFileExists(packageRoot.appending(".build/debug/Bar"))
-            XCTAssert(isDirectory(packageRoot.appending(".build")))
-            XCTAssert(isDirectory(packageRoot.appending("Packages")))
+            XCTAssertFileExists(packageRoot.appending(components: ".build", "debug", "Bar"))
+            XCTAssert(isDirectory(packageRoot.appending(component: ".build")))
+            XCTAssert(isDirectory(packageRoot.appending(component: "Packages")))
 
             // Clean, and check for removal of the build directory but not Packages.
             _ = try execute(["--clean"], chdir: packageRoot)
-            XCTAssert(!isDirectory(packageRoot.appending(".build")))
-            XCTAssert(isDirectory(packageRoot.appending("Packages")))
+            XCTAssert(!isDirectory(packageRoot.appending(component: ".build")))
+            XCTAssert(isDirectory(packageRoot.appending(component: "Packages")))
 
             // Fully clean, and check for removal of both.
             _ = try execute(["--clean=dist"], chdir: packageRoot)
-            XCTAssert(!isDirectory(packageRoot.appending(".build")))
-            XCTAssert(!isDirectory(packageRoot.appending("Packages")))
+            XCTAssert(!isDirectory(packageRoot.appending(component: ".build")))
+            XCTAssert(!isDirectory(packageRoot.appending(component: "Packages")))
         }
     }
 

--- a/Tests/Commands/PackageToolTests.swift
+++ b/Tests/Commands/PackageToolTests.swift
@@ -28,7 +28,7 @@ final class PackageToolTests: XCTestCase {
 
     func testFetch() throws {
         fixture(name: "DependencyResolution/External/Simple") { prefix in
-            let packageRoot = prefix.appending("Bar")
+            let packageRoot = prefix.appending(component: "Bar")
             let packagesPath = packageRoot.appending(component: "Packages")
 
             // Check that `fetch` works.
@@ -39,7 +39,7 @@ final class PackageToolTests: XCTestCase {
 
     func testUpdate() throws {
         fixture(name: "DependencyResolution/External/Simple") { prefix in
-            let packageRoot = prefix.appending("Bar")
+            let packageRoot = prefix.appending(component: "Bar")
             let packagesPath = packageRoot.appending(component: "Packages")
 
             // Perform an initial fetch.
@@ -47,7 +47,7 @@ final class PackageToolTests: XCTestCase {
             XCTAssertEqual(try localFileSystem.getDirectoryContents(packagesPath), ["Foo-1.2.3"])
 
             // Retag the dependency, and update.
-            try tagGitRepo(prefix.appending("Foo"), tag: "1.2.4")
+            try tagGitRepo(prefix.appending(component: "Foo"), tag: "1.2.4")
             _ = try execute(["update"], chdir: packageRoot)
             XCTAssertEqual(try localFileSystem.getDirectoryContents(packagesPath), ["Foo-1.2.4"])
         }
@@ -55,7 +55,7 @@ final class PackageToolTests: XCTestCase {
 
     func testDumpPackage() throws {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
-            let packageRoot = prefix.appending("app")
+            let packageRoot = prefix.appending(component: "app")
             let dumpOutput = try execute(["dump-package"], chdir: packageRoot)
             let json = try JSON(bytes: ByteString(encodingAsUTF8: dumpOutput))
             guard case let .dictionary(contents) = json else { XCTFail("unexpected result"); return }
@@ -66,7 +66,7 @@ final class PackageToolTests: XCTestCase {
 
     func testShowDependencies() throws {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
-            let packageRoot = prefix.appending("app")
+            let packageRoot = prefix.appending(component: "app")
             let textOutput = try execute(["show-dependencies", "--format=text"], chdir: packageRoot)
             XCTAssert(textOutput.contains("FisherYates@1.2.3"))
 

--- a/Tests/Functional/ClangModuleTests.swift
+++ b/Tests/Functional/ClangModuleTests.swift
@@ -53,11 +53,11 @@ class ClangModulesTestCase: XCTestCase {
     
     func testExternalSimpleCDep() {
         fixture(name: "DependencyResolution/External/SimpleCDep") { prefix in
-            XCTAssertBuilds(prefix.appending("Bar"))
+            XCTAssertBuilds(prefix.appending(component: "Bar"))
             let debugPath = prefix.appending(components: "Bar", ".build", "debug")
             XCTAssertFileExists(debugPath.appending(component: "Bar"))
             XCTAssertFileExists(debugPath.appending(component: "Foo".soname))
-            XCTAssertDirectoryExists(prefix.appending(RelativePath("Bar/Packages/Foo-1.2.3")))
+            XCTAssertDirectoryExists(prefix.appending(components: "Bar", "Packages", "Foo-1.2.3"))
         }
     }
     
@@ -73,10 +73,10 @@ class ClangModulesTestCase: XCTestCase {
     
     func testCUsingCDep() {
         fixture(name: "DependencyResolution/External/CUsingCDep") { prefix in
-            XCTAssertBuilds(prefix.appending("Bar"))
+            XCTAssertBuilds(prefix.appending(component: "Bar"))
             let debugPath = prefix.appending(components: "Bar", ".build", "debug")
             XCTAssertFileExists(debugPath.appending(component: "Foo".soname))
-            XCTAssertDirectoryExists(prefix.appending(RelativePath("Bar/Packages/Foo-1.2.3")))
+            XCTAssertDirectoryExists(prefix.appending(components: "Bar", "Packages", "Foo-1.2.3"))
         }
     }
     
@@ -93,10 +93,10 @@ class ClangModulesTestCase: XCTestCase {
     func testCUsingCDep2() {
         //The C dependency "Foo" has different layout
         fixture(name: "DependencyResolution/External/CUsingCDep2") { prefix in
-            XCTAssertBuilds(prefix.appending("Bar"))
+            XCTAssertBuilds(prefix.appending(component: "Bar"))
             let debugPath = prefix.appending(components: "Bar", ".build", "debug")
             XCTAssertFileExists(debugPath.appending(component: "Foo".soname))
-            XCTAssertDirectoryExists(prefix.appending(RelativePath("Bar/Packages/Foo-1.2.3")))
+            XCTAssertDirectoryExists(prefix.appending(components: "Bar", "Packages", "Foo-1.2.3"))
         }
     }
     

--- a/Tests/Functional/DependencyResolutionTests.swift
+++ b/Tests/Functional/DependencyResolutionTests.swift
@@ -17,7 +17,7 @@ class DependencyResolutionTestCase: XCTestCase {
         fixture(name: "DependencyResolution/Internal/Simple") { prefix in
             XCTAssertBuilds(prefix)
 
-            let output = try popen([prefix.appending(".build/debug/Foo").asString])
+            let output = try popen([prefix.appending(components: ".build", "debug", "Foo").asString])
             XCTAssertEqual(output, "Foo\nBar\n")
         }
     }
@@ -32,16 +32,16 @@ class DependencyResolutionTestCase: XCTestCase {
         fixture(name: "DependencyResolution/Internal/Complex") { prefix in
             XCTAssertBuilds(prefix)
 
-            let output = try popen([prefix.appending(".build/debug/Foo").asString])
+            let output = try popen([prefix.appending(components: ".build", "debug", "Foo").asString])
             XCTAssertEqual(output, "meiow Baz\n")
         }
     }
 
     func testExternalSimple() {
         fixture(name: "DependencyResolution/External/Simple") { prefix in
-            XCTAssertBuilds(prefix.appending("Bar"))
-            XCTAssertFileExists(prefix.appending("Bar/.build/debug/Bar"))
-            XCTAssertDirectoryExists(prefix.appending("Bar/Packages/Foo-1.2.3"))
+            XCTAssertBuilds(prefix.appending(component: "Bar"))
+            XCTAssertFileExists(prefix.appending(components: "Bar", ".build", "debug", "Bar"))
+            XCTAssertDirectoryExists(prefix.appending(components: "Bar", "Packages", "Foo-1.2.3"))
         }
     }
 
@@ -53,15 +53,15 @@ class DependencyResolutionTestCase: XCTestCase {
 
     func testExternalComplex() {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
-            XCTAssertBuilds(prefix.appending("app"))
-            let output = try POSIX.popen([prefix.appending("app/.build/debug/Dealer").asString])
+            XCTAssertBuilds(prefix.appending(component: "app"))
+            let output = try POSIX.popen([prefix.appending(components: "app", ".build", "debug", "Dealer").asString])
             XCTAssertEqual(output, "♣︎K\n♣︎Q\n♣︎J\n♣︎10\n♣︎9\n♣︎8\n♣︎7\n♣︎6\n♣︎5\n♣︎4\n")
         }
     }
 
     func testIndirectTestsDontBuild() {
         fixture(name: "DependencyResolution/External/IgnoreIndirectTests") { prefix in
-            XCTAssertBuilds(prefix.appending("app"))
+            XCTAssertBuilds(prefix.appending(component: "app"))
         }
     }
 

--- a/Tests/Functional/InvalidLayoutTests.swift
+++ b/Tests/Functional/InvalidLayoutTests.swift
@@ -33,7 +33,7 @@ class InvalidLayoutsTestCase: XCTestCase {
         */
         fixture(name: "InvalidLayouts/Generic1") { prefix in
             XCTAssertBuildFails(prefix)
-            try removeFileTree(prefix.appending("main.swift"))
+            try removeFileTree(prefix.appending(component: "main.swift"))
             XCTAssertBuilds(prefix)
         }
     }
@@ -48,7 +48,7 @@ class InvalidLayoutsTestCase: XCTestCase {
         */
         fixture(name: "InvalidLayouts/Generic2") { prefix in
             XCTAssertBuildFails(prefix)
-            try removeFileTree(prefix.appending("main.swift"))
+            try removeFileTree(prefix.appending(component: "main.swift"))
             XCTAssertBuilds(prefix)
         }
     }
@@ -63,7 +63,7 @@ class InvalidLayoutsTestCase: XCTestCase {
         */
         fixture(name: "InvalidLayouts/Generic3") { prefix in
             XCTAssertBuildFails(prefix)
-            try removeFileTree(prefix.appending("Sources").appending("main.swift"))
+            try removeFileTree(prefix.appending(components: "Sources", "main.swift"))
             XCTAssertBuilds(prefix)
         }
     }
@@ -78,7 +78,7 @@ class InvalidLayoutsTestCase: XCTestCase {
         */
         fixture(name: "InvalidLayouts/Generic4") { prefix in
             XCTAssertBuildFails(prefix)
-            try removeFileTree(prefix.appending("main.swift"))
+            try removeFileTree(prefix.appending(component: "main.swift"))
             XCTAssertBuilds(prefix)
         }
     }
@@ -100,8 +100,8 @@ class InvalidLayoutsTestCase: XCTestCase {
             // determineTargets() but also we are saying: this
             // layout is only for *very* simple projects.
 
-            try removeFileTree(prefix.appending("Foo").appending("Foo.swift"))
-            try removeFileTree(prefix.appending("Foo"))
+            try removeFileTree(prefix.appending(components: "Foo", "Foo.swift"))
+            try removeFileTree(prefix.appending(component: "Foo"))
             XCTAssertBuilds(prefix)
         }
     }

--- a/Tests/Functional/MiscellaneousTests.swift
+++ b/Tests/Functional/MiscellaneousTests.swift
@@ -187,7 +187,7 @@ class MiscellaneousTestCase: XCTestCase {
     func testNoArgumentsExitsWithOne() {
         var foo = false
         do {
-            try executeSwiftBuild("/")
+            try executeSwiftBuild(AbsolutePath("/"))
         } catch POSIX.Error.exitStatus(let code, _) {
 
             // if our code crashes we'll get an exit code of 256

--- a/Tests/Functional/ModuleMapTests.swift
+++ b/Tests/Functional/ModuleMapTests.swift
@@ -23,7 +23,7 @@ private let dylib = "so"
 
 class ModuleMapsTestCase: XCTestCase {
 
-    private func fixture(name: RelativePath, cModuleName: String, rootpkg: String, body: (AbsolutePath, [String]) throws -> Void) {
+    private func fixture(name: String, cModuleName: String, rootpkg: String, body: (AbsolutePath, [String]) throws -> Void) {
         FunctionalTestSuite.fixture(name: name) { prefix in
             let input = prefix.appending(components: cModuleName, "C", "foo.c")
             let outdir = prefix.appending(components: rootpkg, ".build", "debug")

--- a/Tests/Functional/SwiftPMXCTestHelperTests.swift
+++ b/Tests/Functional/SwiftPMXCTestHelperTests.swift
@@ -19,7 +19,7 @@ class SwiftPMXCTestHelperTests: XCTestCase {
         fixture(name: "Miscellaneous/SwiftPMXCTestHelper") { prefix in
             // Build the package.
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix.appending(".build").appending("debug").appending("SwiftPMXCTestHelper.swiftmodule"))
+            XCTAssertFileExists(prefix.appending(components: ".build", "debug", "SwiftPMXCTestHelper.swiftmodule"))
             // Run swift-test on package.
             XCTAssertSwiftTest(prefix)
             // Expected output dictionary.
@@ -36,7 +36,7 @@ class SwiftPMXCTestHelperTests: XCTestCase {
               ]]]
             ] as NSDictionary
             // Run the XCTest helper tool and check result.
-            XCTAssertXCTestHelper(prefix.appending(".build").appending("debug").appending("SwiftPMXCTestHelperTests.xctest"), testCases: testCases)
+            XCTAssertXCTestHelper(prefix.appending(components: ".build", "debug", "SwiftPMXCTestHelperTests.xctest"), testCases: testCases)
         }
 #endif
     }
@@ -51,7 +51,7 @@ class SwiftPMXCTestHelperTests: XCTestCase {
 func XCTAssertXCTestHelper(_ bundlePath: AbsolutePath, testCases: NSDictionary) {
     do {
         let env = ["DYLD_FRAMEWORK_PATH": try platformFrameworksPath().asString]
-        let outputFile = bundlePath.parentDirectory.appending("tests.txt")
+        let outputFile = bundlePath.parentDirectory.appending(component: "tests.txt")
         let _ = try SwiftPMProduct.XCTestHelper.execute([bundlePath.asString, outputFile.asString], env: env, printIfError: true)
         guard let data = NSData(contentsOfFile: outputFile.asString) else {
             XCTFail("No output found in : \(outputFile.asString)"); return;

--- a/Tests/Functional/Utilities.swift
+++ b/Tests/Functional/Utilities.swift
@@ -19,10 +19,11 @@ import class Foundation.Bundle
 #endif
 
 
-/// Test-helper function that runs a block of code on a copy of a test fixture package.  The copy is made into a temporary directory, and the block is given a path to that directory.  The block is permitted to modify the copy.  The temporary copy is deleted after the block returns.
-func fixture(name fixtureSubpath: RelativePath, tags: [String] = [], file: StaticString = #file, line: UInt = #line, body: @noescape(AbsolutePath) throws -> Void) {
+/// Test-helper function that runs a block of code on a copy of a test fixture package.  The copy is made into a temporary directory, and the block is given a path to that directory.  The block is permitted to modify the copy.  The temporary copy is deleted after the block returns.  The fixture name may contain `/` characters, which are treated as path separators, exactly as if the name were a relative path.
+func fixture(name: String, tags: [String] = [], file: StaticString = #file, line: UInt = #line, body: @noescape(AbsolutePath) throws -> Void) {
     do {
         // Make a suitable test directory name from the fixture subpath.
+        let fixtureSubpath = RelativePath(name)
         let copyName = fixtureSubpath.components.joined(separator: "_")
         
         // Create a temporary directory for the duration of the block.
@@ -30,7 +31,7 @@ func fixture(name fixtureSubpath: RelativePath, tags: [String] = [], file: Stati
             
         // Construct the expected path of the fixture.
         // FIXME: This seems quite hacky; we should provide some control over where fixtures are found.
-        let fixtureDir = AbsolutePath(#file).appending("../../../Fixtures").appending(fixtureSubpath)
+        let fixtureDir = AbsolutePath(#file).appending(RelativePath("../../../Fixtures")).appending(fixtureSubpath)
         
         // Check that the fixture is really there.
         guard isDirectory(fixtureDir) else {
@@ -136,13 +137,13 @@ enum SwiftPMProduct {
     var exec: RelativePath {
         switch self {
         case .SwiftBuild:
-            return "swift-build"
+            return RelativePath("swift-build")
         case .SwiftPackage:
-            return "swift-package"
+            return RelativePath("swift-package")
         case .SwiftTest:
-            return "swift-test"
+            return RelativePath("swift-test")
         case .XCTestHelper:
-            return "swiftpm-xctest-helper"
+            return RelativePath("swiftpm-xctest-helper")
         }
     }
 }

--- a/Tests/Functional/ValidLayoutTests.swift
+++ b/Tests/Functional/ValidLayoutTests.swift
@@ -22,7 +22,7 @@ class ValidLayoutsTestCase: XCTestCase {
         runLayoutFixture(name: "SingleModule/Library") { prefix in
             XCTAssertBuilds(prefix)
             let debugPath = prefix.appending(components: ".build", "debug")
-            XCTAssertFileExists(debugPath.appending("Library.swiftmodule"))
+            XCTAssertFileExists(debugPath.appending(component: "Library.swiftmodule"))
         }
     }
 
@@ -30,7 +30,7 @@ class ValidLayoutsTestCase: XCTestCase {
         runLayoutFixture(name: "SingleModule/Executable") { prefix in
             XCTAssertBuilds(prefix)
             let debugPath = prefix.appending(components: ".build", "debug")
-            XCTAssertFileExists(debugPath.appending("Executable"))
+            XCTAssertFileExists(debugPath.appending(component: "Executable"))
         }
     }
 
@@ -42,7 +42,7 @@ class ValidLayoutsTestCase: XCTestCase {
         runLayoutFixture(name: "SingleModule/CustomizedName") { prefix in
             XCTAssertBuilds(prefix)
             let debugPath = prefix.appending(components: ".build", "debug")
-            XCTAssertFileExists(debugPath.appending("Bar.swiftmodule"))
+            XCTAssertFileExists(debugPath.appending(component: "Bar.swiftmodule"))
         }
     }
 
@@ -50,7 +50,7 @@ class ValidLayoutsTestCase: XCTestCase {
         fixture(name: "ValidLayouts/SingleModule/SubfolderWithSwiftSuffix", file: #file, line: #line) { prefix in
             XCTAssertBuilds(prefix)
             let debugPath = prefix.appending(components: ".build", "debug")
-            XCTAssertFileExists(debugPath.appending("Bar.swiftmodule"))
+            XCTAssertFileExists(debugPath.appending(component: "Bar.swiftmodule"))
         }
     }
 
@@ -126,8 +126,8 @@ class ValidLayoutsTestCase: XCTestCase {
 // MARK: Utility
 
 extension ValidLayoutsTestCase {
-    func runLayoutFixture(name: RelativePath, line: UInt = #line, body: @noescape(AbsolutePath) throws -> Void) {
-        let name = RelativePath("ValidLayouts/\(name.asString)")
+    func runLayoutFixture(name: String, line: UInt = #line, body: @noescape(AbsolutePath) throws -> Void) {
+        let name = "ValidLayouts/\(name)"
 
         // 1. Rooted layout
         fixture(name: name, file: #file, line: line, body: body)
@@ -146,7 +146,7 @@ extension ValidLayoutsTestCase {
         // 3. Symlink some other directory to a directory called "Sources"
         fixture(name: name, file: #file, line: line) { prefix in
             let files = try! localFileSystem.getDirectoryContents(prefix).filter{ $0 != "Package.swift" }
-            let dir = prefix.appending("Floobles")
+            let dir = prefix.appending(component: "Floobles")
             try makeDirectories(dir)
             for file in files {
                 try rename(old: prefix.appending(component: file).asString, new: dir.appending(component: file).asString)

--- a/Tests/Get/GetTests.swift
+++ b/Tests/Get/GetTests.swift
@@ -68,7 +68,7 @@ class GetTests: XCTestCase {
 
     func testGitRepoInitialization() {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
-            XCTAssertNotNil(Git.Repo(path: prefix.appending("app")))
+            XCTAssertNotNil(Git.Repo(path: prefix.appending(component: "app")))
         }
 
         XCTAssertNil(Git.Repo(path: #file))

--- a/Tests/Get/GetTests.swift
+++ b/Tests/Get/GetTests.swift
@@ -71,7 +71,7 @@ class GetTests: XCTestCase {
             XCTAssertNotNil(Git.Repo(path: prefix.appending(component: "app")))
         }
 
-        XCTAssertNil(Git.Repo(path: #file))
+        XCTAssertNil(Git.Repo(path: AbsolutePath(#file)))
         XCTAssertNil(Git.Repo(path: AbsolutePath(#file).parentDirectory))
     }
 

--- a/Tests/PackageLoading/ConventionTests.swift
+++ b/Tests/PackageLoading/ConventionTests.swift
@@ -39,7 +39,7 @@ class ConventionTests: XCTestCase {
     
     func testDotFilesAreIgnored() throws {
         do {
-            try fixture(files: [".Bar.swift", "Foo.swift"]) { (package, modules) in
+            try fixture(files: [ RelativePath(".Bar.swift"), RelativePath("Foo.swift") ]) { (package, modules) in
                 XCTAssertEqual(modules.count, 1)
                 guard let swiftModule = modules.first as? SwiftModule else { return XCTFail() }
                 XCTAssertEqual(swiftModule.sources.paths.count, 1)
@@ -52,7 +52,7 @@ class ConventionTests: XCTestCase {
     }
 
     func testResolvesSingleSwiftModule() throws {
-        let files: [RelativePath] = ["Foo.swift"]
+        let files = [ RelativePath("Foo.swift") ]
         test(files: files) { (module: SwiftModule) in 
             XCTAssertEqual(module.sources.paths.count, files.count)
             XCTAssertEqual(Set(module.sources.relativePaths), Set(files))
@@ -60,11 +60,11 @@ class ConventionTests: XCTestCase {
     }
 
     func testResolvesSystemModulePackage() throws {
-        test(files: ["module.modulemap"]) { module in }
+        test(files: [ RelativePath("module.modulemap") ]) { module in }
     }
 
     func testResolvesSingleClangModule() throws {
-        test(files: ["Foo.c", "Foo.h"]) { module in }
+        test(files: [ RelativePath("Foo.c"), RelativePath("Foo.h") ]) { module in }
     }
 
     static var allTests = [
@@ -89,7 +89,7 @@ private func fixture(files: [RelativePath], body: @noescape (AbsolutePath) throw
 /// Check the behavior of a test project with the given file paths.
 private func fixture(files: [RelativePath], file: StaticString = #file, line: UInt = #line, body: @noescape (PackageModel.Package, [Module]) throws -> ()) throws {
     fixture(files: files) { (prefix: AbsolutePath) in
-        let manifest = Manifest(path: prefix.appending("Package.swift"), url: prefix.asString, package: Package(name: "name"), products: [], version: nil)
+        let manifest = Manifest(path: prefix.appending(component: "Package.swift"), url: prefix.asString, package: Package(name: "name"), products: [], version: nil)
         let package = try PackageBuilder(manifest: manifest, path: prefix).construct(includingTestModules: false)
         try body(package, package.modules)
     }

--- a/Tests/PackageLoading/ManifestTests.swift
+++ b/Tests/PackageLoading/ManifestTests.swift
@@ -35,7 +35,7 @@ private struct Resources: ManifestResourceProvider {
     let swiftCompilerPath: AbsolutePath = {
         let swiftc: AbsolutePath
         if let base = getenv("XCODE_DEFAULT_TOOLCHAIN_OVERRIDE")?.chuzzle() {
-            swiftc = AbsolutePath(base).appending("usr/bin/swiftc")
+            swiftc = AbsolutePath(base).appending(components: "usr", "bin", "swiftc")
         } else if let override = getenv("SWIFT_EXEC")?.chuzzle() {
             swiftc = AbsolutePath(override)
         } else {
@@ -56,9 +56,9 @@ private struct Resources: ManifestResourceProvider {
 
 class ManifestTests: XCTestCase {
 
-    private func loadManifest(_ inputName: RelativePath, line: UInt = #line, body: (Manifest) -> Void) {
+    private func loadManifest(_ inputName: String, line: UInt = #line, body: (Manifest) -> Void) {
         do {
-            let input = AbsolutePath(#file).appending("../Inputs").appending(inputName)
+            let input = AbsolutePath(#file).parentDirectory.appending(component: "Inputs").appending(component: inputName)
             body(try ManifestLoader(resources: Resources()).load(path: input, baseURL: input.parentDirectory.asString, version: nil))
         } catch {
             XCTFail("Unexpected error: \(error)", file: #file, line: line)
@@ -101,7 +101,7 @@ class ManifestTests: XCTestCase {
     func testInvalidTargetName() {
         fixture(name: "Miscellaneous/PackageWithInvalidTargets") { (prefix: AbsolutePath) in
             do {
-                let manifest = try ManifestLoader(resources: Resources()).load(path: prefix.appending("Package.swift"), baseURL: prefix.asString, version: nil)
+                let manifest = try ManifestLoader(resources: Resources()).load(path: prefix.appending(component: "Package.swift"), baseURL: prefix.asString, version: nil)
                 _ = try PackageBuilder(manifest: manifest, path: prefix).construct(includingTestModules: false)
             } catch ModuleError.modulesNotFound(let moduleNames) {
                 XCTAssertEqual(Set(moduleNames), Set(["Bake", "Fake"]))

--- a/Tests/PackageLoading/ManifestTests.swift
+++ b/Tests/PackageLoading/ManifestTests.swift
@@ -41,7 +41,7 @@ private struct Resources: ManifestResourceProvider {
         } else {
             swiftc = try! AbsolutePath(popen(["xcrun", "--find", "swiftc"]).chuzzle() ?? "BADPATH")
         }
-        precondition(swiftc != "/usr/bin/swiftc")
+        precondition(swiftc != AbsolutePath("/usr/bin/swiftc"))
         return swiftc
     }()
   #else
@@ -94,7 +94,7 @@ class ManifestTests: XCTestCase {
     }
 
     func testNoManifest() {
-        let foo = try? ManifestLoader(resources: Resources()).load(path: "/non-existent-file", baseURL: "/", version: nil)
+        let foo = try? ManifestLoader(resources: Resources()).load(path: AbsolutePath("/non-existent-file"), baseURL: "/", version: nil)
         XCTAssertNil(foo)
     }
 

--- a/Tests/PackageLoading/ManifestTests.swift
+++ b/Tests/PackageLoading/ManifestTests.swift
@@ -45,7 +45,7 @@ private struct Resources: ManifestResourceProvider {
         return swiftc
     }()
   #else
-    let swiftCompilerPath = bundleRoot().appending("swiftc")
+    let swiftCompilerPath = bundleRoot().appending(component: "swiftc")
   #endif
     let libraryPath = bundleRoot()
 #else

--- a/Tests/PackageLoading/ModuleDependencyTests.swift
+++ b/Tests/PackageLoading/ModuleDependencyTests.swift
@@ -10,12 +10,13 @@
 
 import XCTest
 
+import Basic
 import PackageModel
 import PackageLoading
 
 private extension Module {
     convenience init(name: String) throws {
-        try self.init(name: name, type: .library, sources: Sources(paths: [], root: "/"))
+        try self.init(name: name, type: .library, sources: Sources(paths: [], root: AbsolutePath("/")))
     }
 }
 

--- a/Tests/PackageModel/ModuleTests.swift
+++ b/Tests/PackageModel/ModuleTests.swift
@@ -9,12 +9,13 @@
 */
 
 import XCTest
+import Basic
 
 @testable import PackageModel
 
 private extension Module {
     convenience init(name: String) throws {
-        try self.init(name: name, type: .library, sources: Sources(paths: [], root: "/"))
+        try self.init(name: name, type: .library, sources: Sources(paths: [], root: AbsolutePath("/")))
     }
 }
 

--- a/Tests/SourceControl/GitRepositoryTests.swift
+++ b/Tests/SourceControl/GitRepositoryTests.swift
@@ -152,45 +152,45 @@ class GitRepositoryTests: XCTestCase {
             let view = try repository.openFileView(revision: repository.resolveRevision(tag: "test-tag"))
 
             // Check basic predicates.
-            XCTAssert(view.isDirectory("/"))
-            XCTAssert(view.isDirectory("/subdir"))
-            XCTAssert(!view.isDirectory("/does-not-exist"))
-            XCTAssert(view.exists("/test-file-1.txt"))
-            XCTAssert(!view.exists("/does-not-exist"))
-            XCTAssert(view.isFile("/test-file-1.txt"))
-            XCTAssert(!view.isSymlink("/test-file-1.txt"))
+            XCTAssert(view.isDirectory(AbsolutePath("/")))
+            XCTAssert(view.isDirectory(AbsolutePath("/subdir")))
+            XCTAssert(!view.isDirectory(AbsolutePath("/does-not-exist")))
+            XCTAssert(view.exists(AbsolutePath("/test-file-1.txt")))
+            XCTAssert(!view.exists(AbsolutePath("/does-not-exist")))
+            XCTAssert(view.isFile(AbsolutePath("/test-file-1.txt")))
+            XCTAssert(!view.isSymlink(AbsolutePath("/test-file-1.txt")))
 
             // Check read of a directory.
-            XCTAssertEqual(try view.getDirectoryContents("/").sorted(), ["file.swift", "subdir", "test-file-1.txt"])
-            XCTAssertEqual(try view.getDirectoryContents("/subdir").sorted(), ["test-file-2.txt"])
+            XCTAssertEqual(try view.getDirectoryContents(AbsolutePath("/")).sorted(), ["file.swift", "subdir", "test-file-1.txt"])
+            XCTAssertEqual(try view.getDirectoryContents(AbsolutePath("/subdir")).sorted(), ["test-file-2.txt"])
             XCTAssertThrows(FileSystemError.isDirectory) {
-                _ = try view.readFileContents("/subdir")
+                _ = try view.readFileContents(AbsolutePath("/subdir"))
             }
 
             // Check read versus root.
             XCTAssertThrows(FileSystemError.isDirectory) {
-                _ = try view.readFileContents("/")
+                _ = try view.readFileContents(AbsolutePath("/"))
             }
 
             // Check read through a non-directory.
             XCTAssertThrows(FileSystemError.notDirectory) {
-                _ = try view.getDirectoryContents("/test-file-1.txt")
+                _ = try view.getDirectoryContents(AbsolutePath("/test-file-1.txt"))
             }
             XCTAssertThrows(FileSystemError.notDirectory) {
-                _ = try view.readFileContents("/test-file-1.txt/thing")
+                _ = try view.readFileContents(AbsolutePath("/test-file-1.txt/thing"))
             }
             
             // Check read/write into a missing directory.
             XCTAssertThrows(FileSystemError.noEntry) {
-                _ = try view.getDirectoryContents("/does-not-exist")
+                _ = try view.getDirectoryContents(AbsolutePath("/does-not-exist"))
             }
             XCTAssertThrows(FileSystemError.noEntry) {
-                _ = try view.readFileContents("/does/not/exist")
+                _ = try view.readFileContents(AbsolutePath("/does/not/exist"))
             }
 
             // Check read of a file.
-            XCTAssertEqual(try view.readFileContents("/test-file-1.txt"), test1FileContents)
-            XCTAssertEqual(try view.readFileContents("/subdir/test-file-2.txt"), test2FileContents)
+            XCTAssertEqual(try view.readFileContents(AbsolutePath("/test-file-1.txt")), test1FileContents)
+            XCTAssertEqual(try view.readFileContents(AbsolutePath("/subdir/test-file-2.txt")), test2FileContents)
         }
     }
 

--- a/Tests/SourceControl/GitRepositoryTests.swift
+++ b/Tests/SourceControl/GitRepositoryTests.swift
@@ -32,12 +32,12 @@ class GitRepositoryTests: XCTestCase {
     /// Test the basic provider functions.
     func testProvider() throws {
         mktmpdir { path in
-            let testRepoPath = path.appending("test-repo")
+            let testRepoPath = path.appending(component: "test-repo")
             try! makeDirectories(testRepoPath)
             initGitRepo(testRepoPath, tag: "1.2.3")
 
             // Test the provider.
-            let testCheckoutPath = path.appending("checkout")
+            let testCheckoutPath = path.appending(component: "checkout")
             let provider = GitRepositoryProvider()
             let repoSpec = RepositorySpecifier(url: testRepoPath.asString)
             try! provider.fetch(repository: repoSpec, to: testCheckoutPath)
@@ -81,7 +81,7 @@ class GitRepositoryTests: XCTestCase {
             // Unarchive the static test repository.
             let inputArchivePath = AbsolutePath(#file).parentDirectory.appending(components: "Inputs", "TestRepo.tgz")
             try systemQuietly(["tar", "-x", "-v", "-C", path.asString, "-f", inputArchivePath.asString])
-            let testRepoPath = path.appending("TestRepo")
+            let testRepoPath = path.appending(component: "TestRepo")
 
             // Check hash resolution.
             let repo = GitRepository(path: testRepoPath)
@@ -142,7 +142,7 @@ class GitRepositoryTests: XCTestCase {
             try tagGitRepo(testRepoPath, tag: "test-tag")
 
             // Get the the repository via the provider. the provider.
-            let testCheckoutPath = path.appending("checkout")
+            let testCheckoutPath = path.appending(component: "checkout")
             let provider = GitRepositoryProvider()
             let repoSpec = RepositorySpecifier(url: testRepoPath.asString)
             try provider.fetch(repository: repoSpec, to: testCheckoutPath)

--- a/Tests/Utility/GitTests.swift
+++ b/Tests/Utility/GitTests.swift
@@ -54,7 +54,7 @@ class GitUtilityTests: XCTestCase {
     func testHeadAndVersionSha() {
         mktmpdir { dir in
             initGitRepo(dir, tag: "0.1.0")
-            try commit(dir, file: "file2.swift") 
+            try commit(dir, file: RelativePath("file2.swift"))
             
             let headSha = Git.Repo(path: dir)?.sha
             let versionSha = try Git.Repo(path: dir)?.versionSha(tag: "0.1.0")
@@ -70,7 +70,7 @@ class GitUtilityTests: XCTestCase {
             let repo = Git.Repo(path: dir)!
             XCTAssertFalse(repo.hasLocalChanges)
 
-            let filePath = dir.appending("file2.swift")
+            let filePath = dir.appending(component: "file2.swift")
             try systemQuietly(["touch", filePath.asString])
 
             XCTAssertTrue(repo.hasLocalChanges)

--- a/Tests/Xcodeproj/FunctionalTests.swift
+++ b/Tests/Xcodeproj/FunctionalTests.swift
@@ -94,10 +94,10 @@ class FunctionalTests: XCTestCase {
     func testSystemModule() {
 #if os(macOS)
         // Because there isn't any one system module that we can depend on for testing purposes, we build our own.
-        try! write(path: "/tmp/fake.h") { stream in
+        try! write(path: AbsolutePath("/tmp/fake.h")) { stream in
             stream <<< "extern const char GetFakeString(void);\n"
         }
-        try! write(path: "/tmp/fake.c") { stream in
+        try! write(path: AbsolutePath("/tmp/fake.c")) { stream in
             stream <<< "const char * GetFakeString(void) { return \"abc\"; }\n"
         }
         var out = ""

--- a/Tests/Xcodeproj/FunctionalTests.swift
+++ b/Tests/Xcodeproj/FunctionalTests.swift
@@ -24,7 +24,7 @@ class FunctionalTests: XCTestCase {
             XCTAssertDirectoryExists(pbx)
             XCTAssertXcodeBuild(project: pbx)
             let build = prefix.appending(components: "build", "Debug")
-            XCTAssertDirectoryExists(build.appending("Library.framework"))
+            XCTAssertDirectoryExists(build.appending(component: "Library.framework"))
         }
 #endif
     }


### PR DESCRIPTION
This was used to make transition simpler, but can cause confusing runtime errors (since there are implicit requirements about whether or not the string starts with a `/` depending on the context).  It also makes it far less clear in the code whether a string or a path will result.

This change also standardizes the clients to that they use the `appending(component:)` or `appending(components:)` methods, as appropriate.

Almost all of the resulting cases that require `Absolute("/a/literal/path")` are in unit tests and not in the business logic, which makes sense, since it's in unit tests that we find arbitrary strings.  We can add convenience code for unit tests later, but after having experienced a couple of runtime crashes that were due to subtle string-to-AbsolutePath vs string-to-RelativePath conversions, I think this is important.  Hopefully it won't be all that controversial.