### PR TITLE
Work around type checker ambiguity when generalized collection casts are enabled.

### DIFF
--- a/Tests/POSIX/ReaddirTests.swift
+++ b/Tests/POSIX/ReaddirTests.swift
@@ -50,7 +50,7 @@ class ReaddirTests: XCTestCase {
         }
     }
     
-    static var allTests = [
+    static var allTests: [(String, (ReaddirTests) -> () throws -> Void)] = [
         ("testName", testName),
     ]
 }


### PR DESCRIPTION
The type checker erroneously calls it ambiguous when both throws and nonthrowing functions can be used by collection conversion. To let id-as-Any land, temporarily work around this.