### PR TITLE
More updates for SE-0025 ('private' and 'fileprivate')

### DIFF
--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -223,7 +223,7 @@ public struct AbsolutePath {
 /// never accessed in any way when initializing a RelativePath.
 public struct RelativePath {
     /// Private implementation details, shared with the AbsolutePath struct.
-    private let _impl: PathImpl
+    fileprivate let _impl: PathImpl
     
     /// Initializes the RelativePath from `str`, which must be a relative path
     /// (which means that it must not begin with a path separator or a tilde).

--- a/Sources/Basic/PathShims.swift
+++ b/Sources/Basic/PathShims.swift
@@ -174,7 +174,7 @@ public class RecursibleDirectoryContentsGenerator: IteratorProtocol, Sequence {
     private let shouldRecurse: (AbsolutePath) -> Bool
     private let fileSystem: FileSystem
     
-    private init(path: AbsolutePath, fileSystem: FileSystem, recursionFilter: (AbsolutePath) -> Bool) throws {
+    fileprivate init(path: AbsolutePath, fileSystem: FileSystem, recursionFilter: (AbsolutePath) -> Bool) throws {
         self.fileSystem = fileSystem
         // FIXME: getDirectoryContents should have an iterator version.
         current = (path, try fileSystem.getDirectoryContents(path).makeIterator())

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -220,7 +220,7 @@ public struct SwiftBuildTool: SwiftTool {
 }
 
 extension Build.Configuration {
-    private init(_ rawValue: String?) throws {
+    fileprivate init(_ rawValue: String?) throws {
         switch rawValue?.lowercased() {
         case "debug"?:
             self = .debug
@@ -237,7 +237,7 @@ extension Build.Configuration {
 enum CleanMode: CustomStringConvertible {
     case build, dist
 
-    private init(_ rawValue: String?) throws {
+    fileprivate init(_ rawValue: String?) throws {
         switch rawValue?.lowercased() {
         case nil, "build"?:
             self = .build

--- a/Sources/POSIX/stat.swift
+++ b/Sources/POSIX/stat.swift
@@ -17,7 +17,7 @@ extension libc.stat {
      public enum Kind {
          case file, directory, symlink, fifo, blockdev, chardev, socket, unknown
 
-         private init(mode: mode_t) {
+         fileprivate init(mode: mode_t) {
              switch mode {
                  case S_IFREG:  self = .file
                  case S_IFDIR:  self = .directory

--- a/Sources/PackageLoading/Module+PkgConfig.swift
+++ b/Sources/PackageLoading/Module+PkgConfig.swift
@@ -54,7 +54,7 @@ extension ModuleProtocol {
 }
 
 private extension SystemPackageProvider {
-    fileprivate var installText: String {
+    var installText: String {
         switch self {
         case .Brew(let name):
             return "    brew install \(name)\n"

--- a/Tests/PackageLoading/ConventionTests.swift
+++ b/Tests/PackageLoading/ConventionTests.swift
@@ -280,7 +280,7 @@ final class PackageBuilderTester {
         private let module: Module
         private lazy var sources: Set<RelativePath> = { Set(self.module.sources.relativePaths) }()
 
-        private init(_ module: Module) {
+        fileprivate init(_ module: Module) {
             self.module = module
         }
 

--- a/Tests/PackageLoading/ModuleDependencyTests.swift
+++ b/Tests/PackageLoading/ModuleDependencyTests.swift
@@ -174,11 +174,11 @@ class ModuleDependencyTests: XCTestCase {
 }
 
 private extension Module {
-    fileprivate func depends(on target: Module) {
+    func depends(on target: Module) {
         dependencies.append(target)
     }
     
-    fileprivate var recursiveDeps: [Module] {
+    var recursiveDeps: [Module] {
         // FIXME: Eliminate this, it is a bad historical artifact.
         return recursiveDependencies.reversed()
     }


### PR DESCRIPTION
Since I didn't finish the implementation of SE-0025 quite fast enough to avoid these creeping in. This time I have a real implementation in hand, so no further changes should be necessary.

(Some of the diffs actually change what I did in #476. I don't think these changes should strictly be necessary in the model—i.e. there's still bugs in my implementation—but I don't want to block landing the main feature and flipping the switch.)