### PR TITLE
Fixed SR-2174, wrong stringification of a path in generated xcodeproj

### DIFF
--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -144,7 +144,7 @@ public func pbxproj(srcroot: AbsolutePath, projectRoot: AbsolutePath, xcodeprojP
         print("        \(module.productReference) = {")
         print("            isa = PBXFileReference;")
         print("            explicitFileType = '\(module.explicitFileType)';")
-        print("            path = '\(module.productPath)';")
+        print("            path = '\(module.productPath.asString)';")
         print("            sourceTree = BUILT_PRODUCTS_DIR;")
         print("        };")
 


### PR DESCRIPTION
Fixes https://bugs.swift.org/browse/SR-2174