### PR TITLE
[Xcodeproj] Add `--enable-code-coverage` and disable code coverage by…

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -77,6 +77,7 @@ private enum Mode: Argument, Equatable, CustomStringConvertible {
 private enum PackageToolFlag: Argument {
     case initMode(String)
     case showDepsMode(String)
+    case enableCodeCoverage
     case inputPath(AbsolutePath)
     case outputPath(AbsolutePath)
     case chdir(AbsolutePath)
@@ -100,6 +101,8 @@ private enum PackageToolFlag: Argument {
             self = try .chdir(AbsolutePath(forcePop(), relativeTo: currentWorkingDirectory))
         case "--type":
             self = try .initMode(forcePop())
+        case "--enable-code-coverage":
+            self = .enableCodeCoverage
         case "--format":
             self = try .showDepsMode(forcePop())
         case "--output":
@@ -259,6 +262,7 @@ public struct SwiftPackageTool: SwiftTool {
         print("OPTIONS:")
         print("  -C, --chdir <path>        Change working directory before any other operation")
         print("  --color <mode>            Specify color mode (auto|always|never)")
+        print("  --enable-code-coverage    Enable code coverage in generated Xcode projects")
         print("  -v, --verbose             Increase verbosity of informational output")
         print("  --version                 Print the Swift Package Manager version")
         print("  -Xcc <flag>               Pass flag through to all C compiler invocations")
@@ -284,6 +288,8 @@ public struct SwiftPackageTool: SwiftTool {
                 opts.outputPath = path
             case .chdir(let path):
                 opts.chdir = path
+            case .enableCodeCoverage:
+                opts.xcodeprojOptions.enableCodeCoverage = true
             case .xcc(let value):
                 opts.xcodeprojOptions.flags.cCompilerFlags.append(value)
             case .xld(let value):

--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -23,9 +23,13 @@ public struct XcodeprojOptions {
     /// This allows the client to override settings defined in the project itself.
     public var xcconfigOverrides: AbsolutePath?
 
-    public init(flags: BuildFlags = BuildFlags(), xcconfigOverrides: AbsolutePath? = nil) {
+    /// Whether code coverage should be enabled in the generated scheme.
+    public var enableCodeCoverage: Bool
+    
+    public init(flags: BuildFlags = BuildFlags(), xcconfigOverrides: AbsolutePath? = nil, enableCodeCoverage: Bool = false) {
         self.flags = flags
         self.xcconfigOverrides = xcconfigOverrides
+        self.enableCodeCoverage = enableCodeCoverage
     }
 }
 
@@ -54,7 +58,7 @@ public func generate(dstdir: AbsolutePath, projectName: String, graph: PackageGr
 ////// the scheme acts like an aggregate target for all our targets
    /// it has all tests associated so CMD+U works
     try open(schemesDirectory.appending(RelativePath(schemeName))) { stream in
-        xcscheme(container: xcodeprojName, graph: graph, printer: stream)
+        xcscheme(container: xcodeprojName, graph: graph, enableCodeCoverage: options.enableCodeCoverage, printer: stream)
     }
 
 ////// we generate this file to ensure our main scheme is listed

--- a/Sources/Xcodeproj/xcscheme().swift
+++ b/Sources/Xcodeproj/xcscheme().swift
@@ -11,7 +11,7 @@
 import PackageGraph
 import PackageModel
 
-func xcscheme(container: String, graph: PackageGraph, printer print: (String) -> Void) {
+func xcscheme(container: String, graph: PackageGraph, enableCodeCoverage: Bool, printer print: (String) -> Void) {
     print("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
     print("<Scheme LastUpgradeVersion = \"9999\" version = \"1.3\">")
     print("  <BuildAction parallelizeBuildables = \"YES\" buildImplicitDependencies = \"YES\">")
@@ -45,7 +45,7 @@ func xcscheme(container: String, graph: PackageGraph, printer print: (String) ->
     print("    selectedDebuggerIdentifier = \"Xcode.DebuggerFoundation.Debugger.LLDB\"")
     print("    selectedLauncherIdentifier = \"Xcode.DebuggerFoundation.Launcher.LLDB\"")
     print("    shouldUseLaunchSchemeArgsEnv = \"YES\"")
-    print("    codeCoverageEnabled = \"YES\">")
+    print("    codeCoverageEnabled = \"\(enableCodeCoverage ? "YES" : "NO")\">")
     print("    <Testables>")
 
     // Create testable references.


### PR DESCRIPTION
… default.

 - The downloadable toolchains don't work with coverage without workarounds yet
   due to the missing `llvm-profdata`. See: https://bugs.swift.org/browse/SR-1281