### PR TITLE
[SE-0127] Add "to:" argument label to withUnsafe[Mutable]Pointer.

### DIFF
--- a/Sources/POSIX/readdir.swift
+++ b/Sources/POSIX/readdir.swift
@@ -30,7 +30,7 @@ extension dirent {
     /// This returns nil if the name is not valid UTF8.
     public var name: String? {
         var name = self.d_name
-        return withUnsafePointer(&name) { (ptr) -> String? in
+        return withUnsafePointer(to: &name) { (ptr) -> String? in
             // FIXME: This is wasteful, but String doesn't have a public API
             // that let's us avoid the copy.
             var nameBytes = [CChar](UnsafeBufferPointer(start: unsafeBitCast(ptr, to: UnsafePointer<CChar>.self), count: Int(self.d_namlen)))

--- a/Tests/POSIX/ReaddirTests.swift
+++ b/Tests/POSIX/ReaddirTests.swift
@@ -16,7 +16,7 @@ class ReaddirTests: XCTestCase {
     func testName() {
         do {
             var s = dirent()
-            withUnsafeMutablePointer(&s.d_name) { ptr in
+            withUnsafeMutablePointer(to: &s.d_name) { ptr in
                 let ptr = unsafeBitCast(ptr, to: UnsafeMutablePointer<UInt8>.self)
                 ptr[0] = UInt8(ascii: "A")
                 ptr[1] = UInt8(ascii: "B")
@@ -27,7 +27,7 @@ class ReaddirTests: XCTestCase {
         
         do {
             var s = dirent()
-            withUnsafeMutablePointer(&s.d_name) { ptr in
+            withUnsafeMutablePointer(to: &s.d_name) { ptr in
                 let ptr = unsafeBitCast(ptr, to: UnsafeMutablePointer<UInt8>.self)
                 ptr[0] = 0xFF
                 ptr[1] = 0xFF
@@ -39,7 +39,7 @@ class ReaddirTests: XCTestCase {
         do {
             var s = dirent()
             let n = sizeof(s.d_name.dynamicType)
-            withUnsafeMutablePointer(&s.d_name) { ptr in
+            withUnsafeMutablePointer(to: &s.d_name) { ptr in
                 let ptr = unsafeBitCast(ptr, to: UnsafeMutablePointer<UInt8>.self)
                 for i in 0 ..< n {
                     ptr[i] = UInt8(ascii: "A")


### PR DESCRIPTION
SR-1937
rdar://problem/26529498