### PR TITLE
[SE-0133] flatten() has been renamed to joined()

### DIFF
--- a/Sources/PackageLoading/Module+PkgConfig.swift
+++ b/Sources/PackageLoading/Module+PkgConfig.swift
@@ -19,7 +19,7 @@ extension ModuleProtocol {
     // swift compiler.
     public func pkgConfigSwiftcArgs() throws -> [String] {
         let pkgArgs = try pkgConfigArgs()
-        return pkgArgs.cFlags.map{["-Xcc", $0]}.flatten() + pkgArgs.libs
+        return pkgArgs.cFlags.map{["-Xcc", $0]}.joined() + pkgArgs.libs
     }
 
     /// Finds cFlags and link flags for all the CModule i.e. System Module


### PR DESCRIPTION
Depends on apple/swift#3809