### PR TITLE
[SE-0101] Migration

### DIFF
--- a/Tests/POSIXTests/ReaddirTests.swift
+++ b/Tests/POSIXTests/ReaddirTests.swift
@@ -38,7 +38,7 @@ class ReaddirTests: XCTestCase {
         
         do {
             var s = dirent()
-            let n = sizeof(s.d_name.dynamicType)
+            let n = MemoryLayout.of(s.d_name).size
             withUnsafeMutablePointer(to: &s.d_name) { ptr in
                 let ptr = unsafeBitCast(ptr, to: UnsafeMutablePointer<UInt8>.self)
                 for i in 0 ..< n {


### PR DESCRIPTION
Depends on https://github.com/apple/swift/pull/3854

[SE-0101](https://github.com/apple/swift-evolution/blob/master/proposals/0101-standardizing-sizeof-naming.md) removes `sizeof`, `sizeofValue` and related functions from the stdlib.
This PR is migrating them to newly introduced `MemoryLayout<T>` values.