### PR TITLE
[SE-0101] Migrate sizeof() to MemoryLayout

### DIFF
--- a/Tests/POSIXTests/ReaddirTests.swift
+++ b/Tests/POSIXTests/ReaddirTests.swift
@@ -12,6 +12,12 @@ import XCTest
 
 import POSIX
 
+extension MemoryLayout {
+  fileprivate static func ofInstance(_: @autoclosure () -> T) -> MemoryLayout<T>.Type {
+    return MemoryLayout<T>.self
+  }
+}
+
 class ReaddirTests: XCTestCase {
     func testName() {
         do {
@@ -38,7 +44,7 @@ class ReaddirTests: XCTestCase {
         
         do {
             var s = dirent()
-            let n = sizeof(s.d_name.dynamicType)
+            let n = MemoryLayout.ofInstance(s.d_name).size
             withUnsafeMutablePointer(to: &s.d_name) { ptr in
                 let ptr = unsafeBitCast(ptr, to: UnsafeMutablePointer<UInt8>.self)
                 for i in 0 ..< n {


### PR DESCRIPTION
Originally by @rintaro.

Depends on https://github.com/apple/swift/pull/3854

[SE-0101](https://github.com/apple/swift-evolution/blob/master/proposals/0101-standardizing-sizeof-naming.md) removes `sizeof`, `sizeofValue` and related functions from the stdlib.
This PR is migrating them to newly introduced `MemoryLayout<T>` values.