### PR TITLE
Add TestSupport module for test specific deps

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -48,6 +48,10 @@ let package = Package(
             /** Source control operations */
             name: "SourceControl",
             dependencies: ["Basic", "Utility"]),
+        Target(
+            /** Test support library */
+            name: "TestSupport",
+            dependencies: ["Basic", "Utility", "POSIX"]),
 
         // MARK: Project Model
         
@@ -108,8 +112,26 @@ let package = Package(
         // MARK: Additional Test Dependencies
         
         Target(
+            name: "BuildTests",
+            dependencies: ["Build", "TestSupport"]),
+        Target(
+            name: "CommandsTests",
+            dependencies: ["Commands", "TestSupport"]),
+        Target(
             name: "FunctionalTests",
-            dependencies: ["Basic", "Utility", "PackageModel"]),
+            dependencies: ["Basic", "Utility", "PackageModel", "TestSupport"]),
+        Target(
+            name: "GetTests",
+            dependencies: ["Get", "TestSupport"]),
+        Target(
+            name: "PackageLoadingTests",
+            dependencies: ["PackageLoading", "TestSupport"]),
+        Target(
+            name: "SourceControlTests",
+            dependencies: ["SourceControl", "TestSupport"]),
+        Target(
+            name: "UtilityTests",
+            dependencies: ["Utility", "TestSupport"]),
     ])
 
 

--- a/Sources/TestSupport/SwiftPMProduct.swift
+++ b/Sources/TestSupport/SwiftPMProduct.swift
@@ -1,0 +1,87 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import func XCTest.XCTFail
+
+import Basic
+import POSIX
+import Utility
+
+#if os(macOS)
+import class Foundation.Bundle
+#endif
+
+/// Defines the executables used by SwiftPM.
+/// Contains path to the currently built executable and
+/// helper method to execute them.
+public enum SwiftPMProduct {
+    case SwiftBuild
+    case SwiftPackage
+    case SwiftTest
+    case XCTestHelper
+
+    /// Path to currently built binary.
+    var path: AbsolutePath {
+      #if os(macOS)
+        for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+            return AbsolutePath(bundle.bundlePath).parentDirectory.appending(self.exec)
+        }
+        fatalError()
+      #else
+        return AbsolutePath(CommandLine.arguments.first!, relativeTo: currentWorkingDirectory).parentDirectory.appending(self.exec)
+      #endif
+    }
+
+    /// Executable name.
+    var exec: RelativePath {
+        switch self {
+        case .SwiftBuild:
+            return RelativePath("swift-build")
+        case .SwiftPackage:
+            return RelativePath("swift-package")
+        case .SwiftTest:
+            return RelativePath("swift-test")
+        case .XCTestHelper:
+            return RelativePath("swiftpm-xctest-helper")
+        }
+    }
+
+    /// Executes the product with specified arguments.
+    ///
+    /// - Parameters:
+    ///         - args: The arguments to pass.
+    ///         - env: Enviroment variables to pass. Enviroment will never be inherited.
+    ///         - chdir: Adds argument `--chdir <path>` if not nil.
+    ///         - printIfError: Print the output on non-zero exit.
+    ///
+    /// - Returns: The output of the process.
+    public func execute(_ args: [String], chdir: AbsolutePath? = nil, env: [String: String] = [:], printIfError: Bool = false) throws -> String {
+        var out = ""
+        var completeArgs = [path.asString]
+        if let chdir = chdir {
+            completeArgs += ["--chdir", chdir.asString]
+        }
+        completeArgs += args
+        do {
+            try POSIX.popen(completeArgs, redirectStandardError: true, environment: env) {
+                out += $0
+            }
+            return out
+        } catch {
+            if printIfError {
+                print("**** FAILURE EXECUTING SUBPROCESS ****")
+                print("command: " + completeArgs.map{ $0.shellEscaped() }.joined(separator: " "))
+                print("SWIFT_EXEC:", env["SWIFT_EXEC"] ?? "nil")
+                print("output:", out)
+            }
+            throw error
+        }
+    }
+}

--- a/Sources/TestSupport/XCTAssertHelpers.swift
+++ b/Sources/TestSupport/XCTAssertHelpers.swift
@@ -1,0 +1,69 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import func XCTest.XCTFail
+
+import Basic
+import POSIX
+import Utility
+
+#if os(macOS)
+import class Foundation.Bundle
+#endif
+
+public func XCTAssertBuilds(_ path: AbsolutePath, configurations: Set<Configuration> = [.Debug, .Release], file: StaticString = #file, line: UInt = #line, Xcc: [String] = [], Xld: [String] = [], Xswiftc: [String] = [], env: [String: String] = [:]) {
+    for conf in configurations {
+        do {
+            print("    Building \(conf)")
+            _ = try executeSwiftBuild(path, configuration: conf, printIfError: true, Xcc: Xcc, Xld: Xld, Xswiftc: Xswiftc, env: env)
+        } catch {
+            XCTFail("`swift build -c \(conf)' failed:\n\n\(error)\n", file: file, line: line)
+        }
+    }
+}
+
+public func XCTAssertSwiftTest(_ path: AbsolutePath, file: StaticString = #file, line: UInt = #line, env: [String: String] = [:]) {
+    do {
+        _ = try SwiftPMProduct.SwiftTest.execute([], chdir: path, env: env, printIfError: true)
+    } catch {
+        XCTFail("`swift test' failed:\n\n\(error)\n", file: file, line: line)
+    }
+}
+
+public func XCTAssertBuildFails(_ path: AbsolutePath, file: StaticString = #file, line: UInt = #line, Xcc: [String] = [], Xld: [String] = [], Xswiftc: [String] = [], env: [String: String] = [:]) {
+    do {
+        _ = try executeSwiftBuild(path, Xcc: Xcc, Xld: Xld, Xswiftc: Xswiftc)
+
+        XCTFail("`swift build' succeeded but should have failed", file: file, line: line)
+
+    } catch POSIX.Error.exitStatus(let status, _) where status == 1{
+        // noop
+    } catch {
+        XCTFail("`swift build' failed in an unexpected manner")
+    }
+}
+
+public func XCTAssertFileExists(_ path: AbsolutePath, file: StaticString = #file, line: UInt = #line) {
+    if !isFile(path) {
+        XCTFail("Expected file doesn’t exist: \(path.asString)", file: file, line: line)
+    }
+}
+
+public func XCTAssertDirectoryExists(_ path: AbsolutePath, file: StaticString = #file, line: UInt = #line) {
+    if !isDirectory(path) {
+        XCTFail("Expected directory doesn’t exist: \(path.asString)", file: file, line: line)
+    }
+}
+
+public func XCTAssertNoSuchPath(_ path: AbsolutePath, file: StaticString = #file, line: UInt = #line) {
+    if exists(path) {
+        XCTFail("path exists but should not: \(path.asString)", file: file, line: line)
+    }
+}

--- a/Tests/BuildTests/PackageVersionDataTests.swift
+++ b/Tests/BuildTests/PackageVersionDataTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import TestSupport
 import Basic
 import PackageModel
 import PackageDescription

--- a/Tests/BuildTests/Utilities.swift
+++ b/Tests/BuildTests/Utilities.swift
@@ -1,1 +1,0 @@
-../FunctionalTests/Utilities.swift

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import TestSupport
 import Basic
 import Commands
 

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import TestSupport
 import Basic
 import Commands
 

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import TestSupport
 import Commands
 
 final class TestToolTests: XCTestCase {

--- a/Tests/CommandsTests/Utilities.swift
+++ b/Tests/CommandsTests/Utilities.swift
@@ -1,1 +1,0 @@
-../FunctionalTests/Utilities.swift

--- a/Tests/FunctionalTests/ClangModuleTests.swift
+++ b/Tests/FunctionalTests/ClangModuleTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import TestSupport
 import Basic
 import PackageModel
 import Utility

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -9,6 +9,7 @@
 */
 
 import XCTest
+import TestSupport
 import Basic
 import func POSIX.popen
 

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -9,7 +9,7 @@
 */
 
 import XCTest
-
+import TestSupport
 import Basic
 import PackageModel
 

--- a/Tests/FunctionalTests/ModuleMapTests.swift
+++ b/Tests/FunctionalTests/ModuleMapTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import TestSupport
 import Basic
 import Utility
 
@@ -23,8 +24,8 @@ private let dylib = "so"
 
 class ModuleMapsTestCase: XCTestCase {
 
-    private func fixture(name: String, cModuleName: String, rootpkg: String, body: (AbsolutePath, [String]) throws -> Void) {
-        FunctionalTests.fixture(name: name) { prefix in
+    private func fixture(name: String, cModuleName: String, rootpkg: String, body: @escaping (AbsolutePath, [String]) throws -> Void) {
+        TestSupport.fixture(name: name) { prefix in
             let input = prefix.appending(components: cModuleName, "C", "foo.c")
             let outdir = prefix.appending(components: rootpkg, ".build", "debug")
             try makeDirectories(outdir)

--- a/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
+++ b/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
@@ -9,6 +9,7 @@
 */
 
 import Basic
+import TestSupport
 import XCTest
 import Utility
 

--- a/Tests/FunctionalTests/ValidLayoutTests.swift
+++ b/Tests/FunctionalTests/ValidLayoutTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import TestSupport
 import Basic
 import Utility
 

--- a/Tests/GetTests/GetTests.swift
+++ b/Tests/GetTests/GetTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import TestSupport
 import Basic
 import Utility
 

--- a/Tests/GetTests/GitTests.swift
+++ b/Tests/GetTests/GitTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import TestSupport
 import Basic
 @testable import Get
 import struct PackageModel.Manifest

--- a/Tests/GetTests/Utilities.swift
+++ b/Tests/GetTests/Utilities.swift
@@ -1,1 +1,0 @@
-../FunctionalTests/Utilities.swift

--- a/Tests/PackageLoadingTests/ManifestTests.swift
+++ b/Tests/PackageLoadingTests/ManifestTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import TestSupport
 import Basic
 import PackageDescription
 import PackageModel

--- a/Tests/PackageLoadingTests/Utilities.swift
+++ b/Tests/PackageLoadingTests/Utilities.swift
@@ -1,1 +1,0 @@
-../FunctionalTests/Utilities.swift

--- a/Tests/SourceControlTests/CheckoutManagerTests.swift
+++ b/Tests/SourceControlTests/CheckoutManagerTests.swift
@@ -9,6 +9,7 @@
 */
 
 import XCTest
+import TestSupport
 import Basic
 import SourceControl
 

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import TestSupport
 import Basic
 import SourceControl
 import Utility

--- a/Tests/SourceControlTests/Utilities.swift
+++ b/Tests/SourceControlTests/Utilities.swift
@@ -1,1 +1,0 @@
-../FunctionalTests/Utilities.swift

--- a/Tests/UtilityTests/GitTests.swift
+++ b/Tests/UtilityTests/GitTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import TestSupport
 import Basic
 @testable import Utility
 

--- a/Tests/UtilityTests/Utilities.swift
+++ b/Tests/UtilityTests/Utilities.swift
@@ -1,1 +1,0 @@
-../FunctionalTests/Utilities.swift

--- a/Tests/XcodeprojTests/FunctionalTests.swift
+++ b/Tests/XcodeprojTests/FunctionalTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 
+import TestSupport
 import Basic
 import PackageModel
 import Utility

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -9,6 +9,7 @@
 */
 
 import Basic
+import TestSupport
 import PackageDescription
 import PackageGraph
 import PackageModel

--- a/Tests/XcodeprojTests/Utilities.swift
+++ b/Tests/XcodeprojTests/Utilities.swift
@@ -1,1 +1,0 @@
-../FunctionalTests/Utilities.swift

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -340,7 +340,7 @@ def parse_manifest():
 # Hard-coded target definition.
 g_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 g_source_root = os.path.join(g_project_root, "Sources")
-g_ignored_targets = ["swiftpm-xctest-helper", "BasicTests", "FunctionalTests", "PackageLoadingTests"]
+g_ignored_targets = ["swiftpm-xctest-helper", "TestSupport", "BuildTests", "CommandsTests", "FunctionalTests", "GetTests", "PackageLoadingTests", "SourceControlTests", "UtilityTests"]
 targets = parse_manifest()
 target_map = dict((t.name, t) for t in targets)
 


### PR DESCRIPTION
This removes the use of Utilities.swift symlinks and adds a tests
specific library which all tests can depend on