### PR TITLE
Revert "update for SE-0110 Part I"

### DIFF
--- a/Sources/Build/Command.compile(ClangModule).swift
+++ b/Sources/Build/Command.compile(ClangModule).swift
@@ -85,7 +85,7 @@ struct ClangModuleBuildMetadata {
     }
 
     /// Returns all the objects files for this module.
-    var objects: [AbsolutePath] { return compilePaths().map{ _, _, object, _ in object} }
+    var objects: [AbsolutePath] { return compilePaths().map{$0.object} }
 
     /// Basic flags needed to compile this module.
     func basicCompileArgs() throws -> [String] {

--- a/Sources/POSIX/system.swift
+++ b/Sources/POSIX/system.swift
@@ -65,7 +65,7 @@ func posix_spawnp(_ path: String, args: [String], environment: [String: String] 
         }
     }
 
-    let env: [UnsafeMutablePointer<CChar>?] = environment.map{ "\($0)=\($1)".withCString(strdup) }
+    let env: [UnsafeMutablePointer<CChar>?] = environment.map{ "\($0.0)=\($0.1)".withCString(strdup) }
     defer { for case let arg? in env { free(arg) } }
     
     var pid = pid_t()

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -92,7 +92,7 @@ public func pbxproj(srcroot: AbsolutePath, projectRoot: AbsolutePath, xcodeprojP
         let sourceFileRefs = fileRefs(forModuleSources: module, srcroot: srcroot)
         
         // Make an array of all the source file reference ids to add to the main group.
-        var sourceRefIds = sourceFileRefs.map{ refId, _, _ in refId }
+        var sourceRefIds = sourceFileRefs.map{ $0.refId }
 
         ////// Info.plist file reference if this a framework target
         if module.isLibrary {
@@ -151,7 +151,7 @@ public func pbxproj(srcroot: AbsolutePath, projectRoot: AbsolutePath, xcodeprojP
         // sources build phase
         print("        \(module.compilePhaseReference) = {")
         print("            isa = PBXSourcesBuildPhase;")
-        print("            files = (\(sourceFileRefs.map{ _, _, bflId in bflId }.joined(separator: ", ")));")
+        print("            files = (\(sourceFileRefs.map{ $0.bflId }.joined(separator: ", ")));")
         print("            runOnlyForDeploymentPostprocessing = 0;")
         print("        };")
 
@@ -167,7 +167,7 @@ public func pbxproj(srcroot: AbsolutePath, projectRoot: AbsolutePath, xcodeprojP
         let linkPhaseFileRefs = module.linkPhaseFileRefs
         print("        \(module.linkPhaseReference) = {")
         print("            isa = PBXFrameworksBuildPhase;")
-        print("            files = (\(linkPhaseFileRefs.map{ _, fileRef in fileRef }.joined(separator: ", ")));")
+        print("            files = (\(linkPhaseFileRefs.map{ $0.fileRef }.joined(separator: ", ")));")
         print("            runOnlyForDeploymentPostprocessing = 0;")
         print("        };")
         for item in linkPhaseFileRefs {
@@ -284,7 +284,7 @@ public func pbxproj(srcroot: AbsolutePath, projectRoot: AbsolutePath, xcodeprojP
     
     print("        \(configsGroupReference) = {")
     print("            isa = PBXGroup;")
-    print("            children = (" + configs.map{ refId, _ in refId }.joined(separator: ", ") + ");")
+    print("            children = (" + configs.map{ $0.refId }.joined(separator: ", ") + ");")
     print("            name = Configs;")
     print("            sourceTree = '<group>';")
     print("        };")

--- a/Tests/GetTests/GitTests.swift
+++ b/Tests/GetTests/GitTests.swift
@@ -60,7 +60,7 @@ private func tryCloningRepoWithTag(_ tag: String?, shouldCrash: Bool) {
     mktmpdir { path in
         _ = makeGitRepo(path, tag: tag)!
         do {
-            _ = try RawClone(path: path, manifestParser: { _, _, _ throws in
+            _ = try RawClone(path: path, manifestParser: { _ throws in
                 return Manifest(path: path, url: path.asString, package: PackageDescription.Package(name: path.basename), products: [], version: nil)
             })
         } catch Get.Error.unversioned {

--- a/Tests/PackageGraphTests/DependencyResolverTests.swift
+++ b/Tests/PackageGraphTests/DependencyResolverTests.swift
@@ -93,7 +93,7 @@ class DependencyResolverTests: XCTestCase {
             provider: provider,
             delegate: delegate)
         let packages = try resolver.resolve()
-        XCTAssertEqual(packages.map{ container, _ in container }.sorted(), ["A", "B", "C"])
+        XCTAssertEqual(packages.map{ $0.container }.sorted(), ["A", "B", "C"])
         XCTAssertEqual(delegate.messages, [
                 "added container: A",
                 "added container: B",


### PR DESCRIPTION
Reverts apple/swift-package-manager#581. The changes to higher-order functions are not correct. See apple/swift#3922.