### PR TITLE
[PackageLoading] Fix linux XCTest module name

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -482,10 +482,10 @@ public struct PackageBuilder {
         }
       #endif
         if !testModules.isEmpty {
-            //TODO and then we should prefix all modules with their package probably
-            //Suffix 'Tests' to test product so the module name of linux executable don't collide with
-            //main package, if present.
-            let product = Product(name: manifest.name + "Tests", type: .Test, modules: testModules)
+            // TODO and then we should prefix all modules with their package probably.
+            // Add suffix 'PackageTests' to test product so the module name of linux executable don't collide with
+            // main package, if present.
+            let product = Product(name: manifest.name + "PackageTests", type: .Test, modules: testModules)
             products.append(product)
         }
 

--- a/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
+++ b/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
@@ -24,7 +24,7 @@ class SwiftPMXCTestHelperTests: XCTestCase {
             // Run swift-test on package.
             XCTAssertSwiftTest(prefix)
             // Expected output dictionary.
-            let testCases = ["name": "All Tests", "tests": [["name" : "SwiftPMXCTestHelperTests.xctest",
+            let testCases = ["name": "All Tests", "tests": [["name" : "SwiftPMXCTestHelperPackageTests.xctest",
                 "tests": [
                 [
                 "name": "ObjCTests",
@@ -37,7 +37,7 @@ class SwiftPMXCTestHelperTests: XCTestCase {
               ] as Array<Dictionary<String, Any>>]] as Array<Dictionary<String, Any>>
             ] as Dictionary<String, Any> as NSDictionary
             // Run the XCTest helper tool and check result.
-            XCTAssertXCTestHelper(prefix.appending(components: ".build", "debug", "SwiftPMXCTestHelperTests.xctest"), testCases: testCases)
+            XCTAssertXCTestHelper(prefix.appending(components: ".build", "debug", "SwiftPMXCTestHelperPackageTests.xctest"), testCases: testCases)
         }
 #endif
     }

--- a/Tests/PackageLoadingTests/ConventionTests.swift
+++ b/Tests/PackageLoadingTests/ConventionTests.swift
@@ -598,7 +598,7 @@ class ConventionTests: XCTestCase {
             }
 
             result.checkProduct("libpm") { productResult in
-                productResult.check(type: .Library(.Dynamic), modules: ["Foo", "Bar"])
+                productResult.check(type: .Library(.Dynamic), modules: ["Bar", "Foo"])
             }
         }
     }
@@ -939,7 +939,7 @@ final class PackageBuilderTester {
 
         func check(type: PackageDescription.ProductType, modules: [String], file: StaticString = #file, line: UInt = #line) {
             XCTAssertEqual(product.type, type, file: file, line: line)
-            XCTAssertEqual(product.modules.map{$0.name}, modules, file: file, line: line)
+            XCTAssertEqual(product.modules.map{$0.name}.sorted(), modules, file: file, line: line)
         }
     }
 


### PR DESCRIPTION
This was colliding with main package module name if there is only one
module. It got broken during the transition from `TestSuite` to `Tests`
suffix.

Fixes SR-2244