### PR TITLE
[PackageDescription] Fix crash if version string is invalid

### DIFF
--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -16,6 +16,7 @@ import enum Utility.Stream
 import func POSIX.exit
 import func Utility.isTTY
 import var Utility.stderr
+import enum PackageLoading.ManifestParseError
 
 public enum Error: Swift.Error {
     case noManifestFound
@@ -78,6 +79,12 @@ public func handle(error: Any, usage: ((String) -> Void) -> Void) -> Never {
         if let fix = error.fix {
             print(fix: fix)
         }
+    case ManifestParseError.invalidManifestFormat(let errors):
+        var errorString = "invalid manifest format"
+        if let errors = errors {
+            errorString += "; " + errors.joined(separator: ", ")
+        }
+        print(error: errorString)
     default:
         print(error: error)
     }

--- a/Sources/PackageDescription/Version+StringLiteralConvertible.swift
+++ b/Sources/PackageDescription/Version+StringLiteralConvertible.swift
@@ -11,7 +11,14 @@
 extension Version: ExpressibleByStringLiteral {
 
     public init(stringLiteral value: String) {
-        self.init(value.characters)!
+        if let version = Version(value.characters) {
+            self.init(version)
+        } else {
+            // If version can't be initialized using the string literal, report the error and initialize with a dummy value.
+            // This is done to fail the invoking tool (like swift build) gracefully rather than just crashing.
+            errors.add("Invalid version string: \(value)")
+            self.init(0, 0, 0)
+        }
     }
 
     public init(extendedGraphemeClusterLiteral value: String) {
@@ -24,6 +31,14 @@ extension Version: ExpressibleByStringLiteral {
 }
 
 extension Version {
+
+    init(_ version: Version) {
+        major = version.major
+        minor = version.minor
+        patch = version.patch
+        prereleaseIdentifiers = version.prereleaseIdentifiers
+        buildMetadataIdentifier = version.buildMetadataIdentifier
+    }
 
     public init?(_ versionString: String) {
         self.init(versionString.characters)

--- a/Tests/PackageLoadingTests/SerializationTests.swift
+++ b/Tests/PackageLoadingTests/SerializationTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 
 import Basic
-import PackageDescription
+@testable import PackageDescription
 import Utility
 
 @testable import PackageLoading
@@ -42,9 +42,15 @@ class SerializationTests: XCTestCase {
       XCTAssertEqual(Target.Dependency.Target(name: "foo"), "foo")
     }
 
+    func testInvalidVersionString() {
+        let _ = Package(name: "a", dependencies: [.Package(url: "https://example.com/example", "1.0,0")])
+        XCTAssertEqual(parseErrors(parseTOML(errors.toTOML())), ["Invalid version string: 1.0,0"])
+    }
+
     static var allTests = [
         ("testBasics", testBasics),
         ("testExclude", testExclude),
-        ("testTargetDependencyIsStringConvertible", testTargetDependencyIsStringConvertible)
+        ("testTargetDependencyIsStringConvertible", testTargetDependencyIsStringConvertible),
+        ("testInvalidVersionString", testInvalidVersionString),
     ]
 }


### PR DESCRIPTION
Adds a global error array to add errors encounted during evaluation of
manifest files. Errors are serialzied and checked by the invoking tool.

Fixes SR-1934