### PR TITLE
[WIP][Xcodeproj] Allow blue folders with source code files on generated Xcode project

### DIFF
--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -148,21 +148,23 @@ func findDirectoryReferences(path: AbsolutePath) throws -> [AbsolutePath] {
         if $0.suffix == ".xcodeproj" { return false }
         if $0.suffix == ".playground" { return false }
         if $0.basename.hasPrefix(".") { return false }
-        if isReservedDirectory($0.basename) { return false }
+        if isReservedDirectory($0) { return false }
         return isDirectory($0)
     }
 }
 
-func isReservedDirectory(_ directory: String) -> Bool {
-    return isPackageDirectory(directory) || isSourceDirectory(directory) || isTestDirectory(directory)
+func isReservedDirectory(_ path: AbsolutePath) -> Bool {
+    return isPackageDirectory(path) ||
+        isSourceDirectory(path) ||
+        isTestDirectory(path)
 }
 
-func isPackageDirectory(_ directory: String) -> Bool {
-    return directory.lowercased() == "packages"
+func isPackageDirectory(_ path: AbsolutePath) -> Bool {
+    return path.basename.lowercased() == "packages"
 }
 
-func isSourceDirectory(_ directory: String) -> Bool {
-    switch directory.lowercased() {
+func isSourceDirectory(_ path: AbsolutePath) -> Bool {
+    switch path.basename.lowercased() {
     case "sources", "source", "src", "srcs":
         return true
     default:
@@ -170,6 +172,6 @@ func isSourceDirectory(_ directory: String) -> Bool {
     }
 }
 
-func isTestDirectory(_ directory: String) -> Bool {
-    return directory.lowercased() == "tests"
+func isTestDirectory(_ path: AbsolutePath) -> Bool {
+    return path.basename.lowercased() == "tests"
 }

--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -12,6 +12,7 @@ import Basic
 import POSIX
 import PackageGraph
 import PackageModel
+import PackageLoading
 import Utility
 
 public struct XcodeprojOptions {
@@ -148,30 +149,7 @@ func findDirectoryReferences(path: AbsolutePath) throws -> [AbsolutePath] {
         if $0.suffix == ".xcodeproj" { return false }
         if $0.suffix == ".playground" { return false }
         if $0.basename.hasPrefix(".") { return false }
-        if isReservedDirectory($0) { return false }
+        if PackageBuilder.isReservedDirectory(pathComponent: $0.basename) { return false }
         return isDirectory($0)
     }
-}
-
-func isReservedDirectory(_ path: AbsolutePath) -> Bool {
-    return isPackageDirectory(path) ||
-        isSourceDirectory(path) ||
-        isTestDirectory(path)
-}
-
-func isPackageDirectory(_ path: AbsolutePath) -> Bool {
-    return path.basename.lowercased() == "packages" && isDirectory(path)
-}
-
-func isSourceDirectory(_ path: AbsolutePath) -> Bool {
-    switch path.basename.lowercased() {
-    case "sources", "source", "src", "srcs":
-        return isDirectory(path)
-    default:
-        return false
-    }
-}
-
-func isTestDirectory(_ path: AbsolutePath) -> Bool {
-    return path.basename.lowercased() == "tests" && isDirectory(path)
 }

--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -160,18 +160,18 @@ func isReservedDirectory(_ path: AbsolutePath) -> Bool {
 }
 
 func isPackageDirectory(_ path: AbsolutePath) -> Bool {
-    return path.basename.lowercased() == "packages"
+    return path.basename.lowercased() == "packages" && isDirectory(path)
 }
 
 func isSourceDirectory(_ path: AbsolutePath) -> Bool {
     switch path.basename.lowercased() {
     case "sources", "source", "src", "srcs":
-        return true
+        return isDirectory(path)
     default:
         return false
     }
 }
 
 func isTestDirectory(_ path: AbsolutePath) -> Bool {
-    return path.basename.lowercased() == "tests"
+    return path.basename.lowercased() == "tests" && isDirectory(path)
 }


### PR DESCRIPTION
Current logic doesn't add directories which contain source files as blue folders. This PR changes the logic to add any directory that is **not** a reserved directory (sources, source, src, srcs, tests, packages) as a blue folder.

I created some helper functions to determine if a directory is a reserved directory. This is my first PR so I'm not familiar with the codebase. I think these functions should be moved to a better place, maybe become static functions on a correspondent struct or class. Maybe receive an `AbsolutePath` instead of `String`. I think `PackageModel` would be the best module?