### PR TITLE
Fixes ‘Illegal instruction’ crash caused by SR-2339

### DIFF
--- a/Sources/PackageDescription/Version.swift
+++ b/Sources/PackageDescription/Version.swift
@@ -56,7 +56,7 @@ extension Version: Hashable {
         if let build = buildMetadataIdentifier {
             result = (result &* mul) ^ UInt64(build.hashValue)
         }
-        return Int(bitPattern: UInt(result))
+        return Int(truncatingBitPattern: result)
     }
 }
 


### PR DESCRIPTION
Recently _swift build_ has been failing on ARMv7 (Raspberry Pi, etc) with an _Illegal instruction_ error. 

I traced it to an issue on the conversion from UInt64 to UInt (which is 32bit on armv7) introduced when Version adopted Hashable on https://github.com/apple/swift-package-manager/commit/5c21e9853b6c46df193ac4b6ccdd03fc51c43c1b

I have reported the general crash as issue [SR-2339](https://bugs.swift.org/browse/SR-2339) but for Package manager specifically I think Int(truncatingBitPattern:) suggested here would be the correct form to call, especially on 32-bit platforms - may be suitable for all? 

This change also enables _swift build_ to work again on armv7 at least in my testing