### PR TITLE
Eliminate unnecessary Foundation lock typealiases

### DIFF
--- a/Sources/Basic/Condition.swift
+++ b/Sources/Basic/Condition.swift
@@ -10,11 +10,6 @@
 
 import Foundation
 
-// FIXME: Temporary compatibility shims.
-#if !os(macOS)
-private typealias NSCondition = Foundation.Condition
-#endif
-
 /// A simple condition wrapper.
 public struct Condition {
     private let _condition = NSCondition()

--- a/Sources/Basic/Lock.swift
+++ b/Sources/Basic/Lock.swift
@@ -10,11 +10,6 @@
 
 import Foundation
 
-// FIXME: Temporary compatibility shims.
-#if !os(macOS)
-private typealias NSLock = Foundation.Lock
-#endif
-
 /// A simple lock wrapper.
 public struct Lock {
     private var _lock = NSLock()


### PR DESCRIPTION
Integrate changes introduced by https://github.com/apple/swift-corelibs-foundation/pull/545