### PR TITLE
Revert "Removing the TextOutputStreamable typealias..."

### DIFF
--- a/Sources/Basic/SwiftShims.swift
+++ b/Sources/Basic/SwiftShims.swift
@@ -1,0 +1,11 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+public typealias TextOutputStreamable = Streamable


### PR DESCRIPTION
Reverts apple/swift-package-manager#609. This breaks CI without apple/swift#4361, but #4361 failed its own tests.