### PR TITLE
[DO NOT MERGE YET] Cherry-pick commits required for swift-3.0-branch Foundation integration

### DIFF
--- a/Sources/Basic/Condition.swift
+++ b/Sources/Basic/Condition.swift
@@ -10,11 +10,6 @@
 
 import Foundation
 
-// FIXME: Temporary compatibility shims.
-#if !os(macOS)
-private typealias NSCondition = Foundation.Condition
-#endif
-
 /// A simple condition wrapper.
 public struct Condition {
     private let _condition = NSCondition()

--- a/Sources/Basic/Lock.swift
+++ b/Sources/Basic/Lock.swift
@@ -10,11 +10,6 @@
 
 import Foundation
 
-// FIXME: Temporary compatibility shims.
-#if !os(macOS)
-private typealias NSLock = Foundation.Lock
-#endif
-
 /// A simple lock wrapper.
 public struct Lock {
     private var _lock = NSLock()

--- a/Sources/Basic/Thread.swift
+++ b/Sources/Basic/Thread.swift
@@ -76,7 +76,7 @@ final private class ThreadImpl: Foundation.Thread {
         task()
     }
 
-    init(_ task: @escaping () -> Void) {
+    init(block task: @escaping () -> Void) {
         self.task = task
     }
 }

--- a/Sources/Basic/Thread.swift
+++ b/Sources/Basic/Thread.swift
@@ -47,7 +47,7 @@ final public class Thread {
             }
         }
 
-        self.thread = ThreadImpl(theTask)
+        self.thread = ThreadImpl(block: theTask)
     }
 
     /// Starts the thread execution.

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -291,11 +291,7 @@ public struct SwiftTestTool: SwiftTool {
 
         // Execute the XCTest with inherited environment as it is convenient to pass senstive
         // information like username, password etc to test cases via enviornment variables.
-      #if os(Linux)
-        let result: Void? = try? system(args, environment: ProcessInfo.processInfo().environment)
-      #else
         let result: Void? = try? system(args, environment: ProcessInfo.processInfo.environment)
-      #endif
         return result != nil
     }
 

--- a/Sources/Get/Git.swift
+++ b/Sources/Get/Git.swift
@@ -25,11 +25,7 @@ extension Git {
         }
 
         do {
-          #if os(Linux)
-            let env = ProcessInfo.processInfo().environment
-          #else
             let env = ProcessInfo.processInfo.environment
-          #endif
             try system(Git.tool, "clone",
                        "--recursive",   // get submodules too so that developers can use these if they so choose
                 "--depth", "10",

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -47,11 +47,7 @@ public class GitRepositoryProvider: RepositoryProvider {
         do {
             // FIXME: We need infrastructure in this subsystem for reporting
             // status information.
-          #if os(Linux)
-            let env = ProcessInfo.processInfo().environment
-          #else
             let env = ProcessInfo.processInfo.environment
-          #endif
             try system(
                 Git.tool, "clone", "--bare", repository.url, path.asString,
                 environment: env, message: "Cloning \(repository.url)")

--- a/Sources/Utility/Git.swift
+++ b/Sources/Utility/Git.swift
@@ -121,11 +121,7 @@ public class Git {
         }
 
         public func fetch() throws {
-#if os(Linux)
-            try system(Git.tool, "-C", path.asString, "fetch", "--tags", "origin", environment: ProcessInfo.processInfo().environment, message: nil)
-#else
             try system(Git.tool, "-C", path.asString, "fetch", "--tags", "origin", environment: ProcessInfo.processInfo.environment, message: nil)
-#endif
         }
     }
 


### PR DESCRIPTION
Integrates changes made on master into the Swift 3 branch. These are required for branching swift-corelibs-foundation for Swift 3.

Not to be merged until similar changes are ready to land for [swift #4528](https://github.com/apple/swift/pull/4528), [swift-corelibs-xctest #170](https://github.com/apple/swift-corelibs-xctest/pull/170), and [libdispatch #165](https://github.com/apple/swift-corelibs-libdispatch/pull/165).