### PR TITLE
Add Dispatch to the library list and library search path when

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -501,6 +501,9 @@ def create_bootstrap_files(sandbox_path, args):
             if args.foundation_path:
                 link_command.extend(["-L", args.foundation_path])
 
+            if args.libdispatch_build_dir:
+                link_command.extend(["-L", os.path.join(args.libdispatch_build_dir, "src", ".libs"), "-ldispatch"])
+
         # Write out the link command.
         print("  %s:" % json.dumps(target.linked_virtual_node), file=output)
         print("    tool: shell", file=output)
@@ -844,6 +847,8 @@ def main():
         build_flags.extend(["-Xswiftc", "-I{}".format(args.xctest_path)])
 
     if args.libdispatch_build_dir:
+        build_flags.extend(["-Xlinker", "-L", "-Xlinker", os.path.join(args.libdispatch_build_dir, "src", ".libs")])
+        build_flags.extend(["-Xlinker", "-ldispatch"])
         build_flags.extend(["-Xswiftc", "-I{}".format(
             os.path.join(args.libdispatch_build_dir, "src"))])
         build_flags.extend(["-Xswiftc", "-I{}".format(


### PR DESCRIPTION
linking

While building on s390x, the linker cannot find the symbols from libdispatch so I'd like to add libdispatch to the library list and search path for linking.