### PR TITLE
[Utility] Priortize pkgconfig env variable

### DIFF
--- a/Sources/Utility/PkgConfig.swift
+++ b/Sources/Utility/PkgConfig.swift
@@ -61,7 +61,7 @@ public struct PkgConfig {
     /// - throws: PkgConfigError
     public init(name: String, fileSystem: FileSystem = localFileSystem) throws {
         self.name = name
-        self.pcFile = try PkgConfig.locatePCFile(name: name, fileSystem: fileSystem)
+        self.pcFile = try PkgConfig.locatePCFile(name: name, customSearchPaths: PkgConfig.envSearchPaths, fileSystem: fileSystem)
 
         var parser = PkgConfigParser(pcFile: pcFile, fileSystem: fileSystem)
         try parser.parse()
@@ -90,11 +90,11 @@ public struct PkgConfig {
         return []
     }
     
-    static func locatePCFile(name: String, fileSystem: FileSystem) throws -> AbsolutePath {
+    static func locatePCFile(name: String, customSearchPaths: [AbsolutePath], fileSystem: FileSystem) throws -> AbsolutePath {
         // FIXME: We should consider building a registry for all items in the
         // search paths, which is likely to be substantially more efficient if
         // we end up searching for a reasonably sized number of packages.
-        for path in OrderedSet(pkgConfigSearchPaths + searchPaths + envSearchPaths) {
+        for path in OrderedSet(customSearchPaths + pkgConfigSearchPaths + searchPaths) {
             let pcFile = path.appending(component: name + ".pc")
             if fileSystem.isFile(pcFile) {
                 return pcFile

--- a/Sources/Utility/PkgConfig.swift
+++ b/Sources/Utility/PkgConfig.swift
@@ -55,12 +55,15 @@ public struct PkgConfig {
 
     /// Load the information for the named package.
     ///
+    /// - name: Name of the pkg config file (without file extension).
+    /// - fileSystem: The file system to use, defaults to local file system.
+    ///
     /// - throws: PkgConfigError
-    public init(name: String) throws {
+    public init(name: String, fileSystem: FileSystem = localFileSystem) throws {
         self.name = name
-        self.pcFile = try PkgConfig.locatePCFile(name: name)
+        self.pcFile = try PkgConfig.locatePCFile(name: name, fileSystem: fileSystem)
 
-        var parser = PkgConfigParser(pcFile: pcFile)
+        var parser = PkgConfigParser(pcFile: pcFile, fileSystem: fileSystem)
         try parser.parse()
         
         var cFlags = parser.cFlags
@@ -87,13 +90,13 @@ public struct PkgConfig {
         return []
     }
     
-    private static func locatePCFile(name: String) throws -> AbsolutePath {
+    static func locatePCFile(name: String, fileSystem: FileSystem) throws -> AbsolutePath {
         // FIXME: We should consider building a registry for all items in the
         // search paths, which is likely to be substantially more efficient if
         // we end up searching for a reasonably sized number of packages.
         for path in OrderedSet(pkgConfigSearchPaths + searchPaths + envSearchPaths) {
             let pcFile = path.appending(component: name + ".pc")
-            if isFile(pcFile) {
+            if fileSystem.isFile(pcFile) {
                 return pcFile
             }
         }
@@ -108,14 +111,16 @@ public struct PkgConfig {
 // FIXME: This is only internal so it can be unit tested.
 struct PkgConfigParser {
     private let pcFile: AbsolutePath
+    private let fileSystem: FileSystem
     private(set) var variables = [String: String]()
     var dependencies = [String]()
     var cFlags = [String]()
     var libs = [String]()
     
-    init(pcFile: AbsolutePath) {
-        precondition(isFile(pcFile))
+    init(pcFile: AbsolutePath, fileSystem: FileSystem) {
+        precondition(fileSystem.isFile(pcFile))
         self.pcFile = pcFile
+        self.fileSystem = fileSystem
     }
     
     mutating func parse() throws {
@@ -126,8 +131,9 @@ struct PkgConfigParser {
             return line
         }
         
-        let file = try fopen(self.pcFile, mode: .read)
-        for line in try file.readFileContents().components(separatedBy: "\n") {
+        let fileContents = try fileSystem.readFileContents(pcFile)
+        // FIXME: Should we error out instead if content is not UTF8 representable?
+        for line in fileContents.asString?.components(separatedBy: "\n") ?? [] {
             // Remove commented or any trailing comment from the line.
             let uncommentedLine = removeComment(line: line)
             // Ignore any empty or whitespace line.

--- a/Tests/UtilityTests/PkgConfigParserTests.swift
+++ b/Tests/UtilityTests/PkgConfigParserTests.swift
@@ -63,6 +63,15 @@ final class PkgConfigParserTests: XCTestCase {
         }
     }
     
+    /// Test custom search path get higher priority for locating pc files.
+    func testCustomPcFileSearchPath() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/usr/lib/pkgconfig/foo.pc",
+            "/custom/foo.pc")
+        XCTAssertEqual("/custom/foo.pc", try PkgConfig.locatePCFile(name: "foo", customSearchPaths: [AbsolutePath("/custom")], fileSystem: fs).asString)
+        XCTAssertEqual("/usr/lib/pkgconfig/foo.pc", try PkgConfig.locatePCFile(name: "foo", customSearchPaths: [], fileSystem: fs).asString)
+    }
+
     private func loadPCFile(_ inputName: String, body: (PkgConfigParser?) -> Void) {
         let input = AbsolutePath(#file).parentDirectory.appending(components: "pkgconfigInputs", inputName)
         var parser: PkgConfigParser? = PkgConfigParser(pcFile: input, fileSystem: localFileSystem)
@@ -80,5 +89,6 @@ final class PkgConfigParserTests: XCTestCase {
         ("testVariableinDependency", testVariableinDependency),
         ("testUnresolvablePCFile", testUnresolvablePCFile),
         ("testEscapedSpaces", testEscapedSpaces),
+        ("testCustomPcFileSearchPath", testCustomPcFileSearchPath),
     ]
 }

--- a/Tests/UtilityTests/PkgConfigParserTests.swift
+++ b/Tests/UtilityTests/PkgConfigParserTests.swift
@@ -65,7 +65,7 @@ final class PkgConfigParserTests: XCTestCase {
     
     private func loadPCFile(_ inputName: String, body: (PkgConfigParser?) -> Void) {
         let input = AbsolutePath(#file).parentDirectory.appending(components: "pkgconfigInputs", inputName)
-        var parser: PkgConfigParser? = PkgConfigParser(pcFile: input)
+        var parser: PkgConfigParser? = PkgConfigParser(pcFile: input, fileSystem: localFileSystem)
         do {
             try parser?.parse()
         } catch {


### PR DESCRIPTION
The env variable should be searched first because of possible overrides.

Related: <rdar://problem/28039143> SR-2473: Unable to use system module
package with `brew` provided OpenSSL