### PR TITLE
Improve the error message that's shown when trying to access a package by a broken local path

### DIFF
--- a/Sources/Get/Error.swift
+++ b/Sources/Get/Error.swift
@@ -10,6 +10,7 @@
 
 import Utility
 
+/// Errors that can result from trying to fetch a package from a repository.
 enum Error: Swift.Error {
 
     typealias ClonePath = String
@@ -21,6 +22,10 @@ enum Error: Swift.Error {
     case updateRequired(ClonePath)
     case unversioned(ClonePath)
     case invalidDependencyGraphMissingTag(package: String, requestedTag: String, existingTags: String)
+    /// A package is referenced using a `file` URL (i.e. a local file system reference), but there is no package at that path.
+    case missingLocalFileURL(URL)
+    /// A package is referenced using a `file` URL (i.e. a local file system reference), but the file system entity at that path isn't a cloned repository (a situation that is not currently supported).
+    case nonRepoLocalFileURL(URL)
 }
 
 extension Error: CustomStringConvertible {
@@ -38,6 +43,10 @@ extension Error: CustomStringConvertible {
             return "No version tag found in (\(package)) package. Add a version tag with \"git tag\" command. Example: \"git tag 0.1.0\""
         case .noManifest(let clonePath, let version):
             return "The package at `\(clonePath)' has no Package.swift for the specific version: \(version)"
+        case .missingLocalFileURL(let url):
+            return "No package at path \(url)"
+        case .nonRepoLocalFileURL(let url):
+            return "Directory at path \(url) is not a Git repository"
         }
     }
 }

--- a/Sources/Get/PackagesDirectory.swift
+++ b/Sources/Get/PackagesDirectory.swift
@@ -123,6 +123,19 @@ extension PackagesDirectory: Fetcher {
         let manifestParser = { try self.manifestLoader.load(packagePath: $0, baseURL: $1, version: $2) }
         let basename = url.components(separatedBy: "/").last!
         let dstdir = packagesPath.appending(component: basename)
+        // If it's a local URL, do some preliminary checking.  The reason we don't just give it a try and then do forensics if it fails is to avoid spurious successes (not sure if that can happen.
+        // FIXME: We should also support `file` URLs in addition to "no scheme" URLs to mean a file path.
+        if URL.scheme(url) == nil {
+            // It's a local path -- by the time we get here we currently always have an absolute path (this is spelled out it ManifestLoader's `loadFile(path:,baseURL:,version:,fileSystem:)` method, albeit with a note that it should doesn't belong in that method).
+            let path = AbsolutePath(url)
+            guard localFileSystem.exists(path) else {
+                throw Error.missingLocalFileURL(url)
+            }
+            // FIXME: We should not be baking in the assumption about ".git" at this point.
+            guard localFileSystem.isDirectory(path.appending(component: ".git")) else {
+                throw Error.nonRepoLocalFileURL(url)
+            }
+        }
         if let repo = Git.Repo(path: dstdir), repo.origin == url {
             //TODO need to canonicalize the URL need URL struct
             return try RawClone(path: dstdir, manifestParser: manifestParser)


### PR DESCRIPTION
SwiftPM supports file URLs for referring to other packages, but the resolved path is still expected to be a repository.  Until we lift this requirement (and there's some debate as to whether and how to do that) we should show specific error messages about this case.

This implementation is a fairly low-risk preflighting check.  I had other diffs at the level of Git.Repo, causing the initializer to throw an informative error instead of just returning nil, but some of the usage sites would need to be refactored to work with that.  So that's a later fix.

I'm opening this PR but I still want to add tests for this — not all of the error enums seem to be tested, but I'm sure there's a good place in the tests to add that.

rdar://problem/28039345
https://bugs.swift.org/browse/SR-2261