### PR TITLE
[PackageBuilder] Error on invalid manifest config

### DIFF
--- a/Tests/PackageLoadingTests/ConventionTests.swift
+++ b/Tests/PackageLoadingTests/ConventionTests.swift
@@ -840,6 +840,26 @@ class ConventionTests: XCTestCase {
         }
     }
 
+    func testInvalidManifestConfigForNonSystemModules() {
+        var fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/main.swift"
+        )
+        var package = PackageDescription.Package(name: "pkg", pkgConfig: "foo")
+
+        PackageBuilderTester(package, in: fs) { result in
+            result.checkDiagnostic("invalid configuration in 'pkg': pkgConfig should only be used with a System Module Package")
+        }
+
+        fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/Foo/main.c"
+        )
+        package = PackageDescription.Package(name: "pkg", providers: [.Brew("foo")])
+
+        PackageBuilderTester(package, in: fs) { result in
+            result.checkDiagnostic("invalid configuration in 'pkg': providers should only be used with a System Module Package")
+        }
+    }
+
     static var allTests = [
         ("testCInTests", testCInTests),
         ("testDotFilesAreIgnored", testDotFilesAreIgnored),
@@ -873,6 +893,7 @@ class ConventionTests: XCTestCase {
         ("testBadProducts", testBadProducts),
         ("testVersionSpecificManifests", testVersionSpecificManifests),
         ("testTestsProduct", testTestsProduct),
+        ("testInvalidManifestConfigForNonSystemModules", testInvalidManifestConfigForNonSystemModules),
     ]
 }
 


### PR DESCRIPTION
Error out when pkgconfig and providers are used by non
system module packages.

- SR-2533
- <rdar://problem/28118479> SR-2533 Error out when pkgconfig and
  providers are used by non system module packages