### PR TITLE
[Build] Pass -fblocks to C targets

### DIFF
--- a/Fixtures/ClangModules/CBlocks/.gitignore
+++ b/Fixtures/ClangModules/CBlocks/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/Fixtures/ClangModules/CBlocks/Package.swift
+++ b/Fixtures/ClangModules/CBlocks/Package.swift
@@ -1,0 +1,8 @@
+import PackageDescription
+
+let package = Package(
+    name: "blocks",
+    targets: [
+        Target(name: "swiftexec", dependencies: ["clib"])
+    ]
+)

--- a/Fixtures/ClangModules/CBlocks/Sources/clib/foo.c
+++ b/Fixtures/ClangModules/CBlocks/Sources/clib/foo.c
@@ -1,0 +1,11 @@
+#include "foo.h"
+
+int operate(int a, int b, Operation operation) {
+    return operation(a,b);
+}
+
+int addOperation(int a, int b) {
+    return operate(a, b, ^int(int a, int b) {
+        return a+b;
+    });
+}

--- a/Fixtures/ClangModules/CBlocks/Sources/clib/include/foo.h
+++ b/Fixtures/ClangModules/CBlocks/Sources/clib/include/foo.h
@@ -1,0 +1,4 @@
+typedef int (^Operation)(int, int);
+
+int operate(int a, int b, Operation operation);
+int addOperation(int a, int b);

--- a/Fixtures/ClangModules/CBlocks/Sources/swiftexec/main.swift
+++ b/Fixtures/ClangModules/CBlocks/Sources/swiftexec/main.swift
@@ -1,0 +1,7 @@
+import clib
+
+let result = operate(5, 6) { a, b in 
+    return a + b
+}
+print(result)
+print(addOperation(1, 1))

--- a/Sources/Build/Command.compile(ClangModule).swift
+++ b/Sources/Build/Command.compile(ClangModule).swift
@@ -89,7 +89,7 @@ struct ClangModuleBuildMetadata {
 
     /// Basic flags needed to compile this module.
     func basicCompileArgs() throws -> [String] {
-        return try ClangModuleBuildMetadata.basicArgs() + ["-fobjc-arc", "-fmodules", "-fmodule-name=\(module.c99name)"] + otherArgs + module.moduleCacheArgs(prefix: prefix)
+        return try ClangModuleBuildMetadata.basicArgs() + ["-fobjc-arc", "-fblocks", "-fmodules", "-fmodule-name=\(module.c99name)"] + otherArgs + module.moduleCacheArgs(prefix: prefix)
     }
 
     /// Flags to link the C language dependencies of this module.

--- a/Tests/FunctionalTests/ClangModuleTests.swift
+++ b/Tests/FunctionalTests/ClangModuleTests.swift
@@ -122,6 +122,16 @@ class ClangModulesTestCase: XCTestCase {
         }
     }
 
+    func testCanUseBlocksInClangTargets() {
+        fixture(name: "ClangModules/CBlocks") { prefix in
+            XCTAssertBuilds(prefix)
+            let debugPath = prefix.appending(components: ".build", "debug")
+            XCTAssertFileExists(debugPath.appending(component: "swiftexec"))
+            let output = try popen([debugPath.appending(component: "swiftexec").asString])
+            XCTAssertEqual(output, "11\n2\n")
+        }
+    }
+
     static var allTests = [
         ("testSingleModuleFlatCLibrary", testSingleModuleFlatCLibrary),
         ("testSingleModuleCLibraryInSources", testSingleModuleCLibraryInSources),
@@ -133,5 +143,6 @@ class ClangModulesTestCase: XCTestCase {
         ("testCExecutable", testCExecutable),
         ("testModuleMapGenerationCases", testModuleMapGenerationCases),
         ("testCanForwardExtraFlagsToClang", testCanForwardExtraFlagsToClang),
+        ("testCanUseBlocksInClangTargets", testCanUseBlocksInClangTargets),
     ]
 }


### PR DESCRIPTION
Since blocks runtime is a swift dependency now and is automatically
added by swift compiler for swift sources, its safe to always pass this
for C targets.