### PR TITLE
Eliminate arithmetic overflows in Version.hashValue

### DIFF
--- a/Sources/PackageDescription/Version.swift
+++ b/Sources/PackageDescription/Version.swift
@@ -49,12 +49,12 @@ extension Version: Hashable {
         // inspired code inside the Swift stdlib.
         let mul: UInt64 = 0x9ddfea08eb382d69
         var result: UInt64 = 0
-        result = (result &* mul) ^ UInt64(major.hashValue)
-        result = (result &* mul) ^ UInt64(minor.hashValue)
-        result = (result &* mul) ^ UInt64(patch.hashValue)
-        result = prereleaseIdentifiers.reduce(result, { ($0 &* mul) ^ UInt64($1.hashValue) })
+        result = (result &* mul) ^ UInt64(bitPattern: Int64(major.hashValue))
+        result = (result &* mul) ^ UInt64(bitPattern: Int64(minor.hashValue))
+        result = (result &* mul) ^ UInt64(bitPattern: Int64(patch.hashValue))
+        result = prereleaseIdentifiers.reduce(result, { ($0 &* mul) ^ UInt64(bitPattern: Int64($1.hashValue)) })
         if let build = buildMetadataIdentifier {
-            result = (result &* mul) ^ UInt64(build.hashValue)
+            result = (result &* mul) ^ UInt64(bitPattern: Int64(build.hashValue))
         }
         return Int(truncatingBitPattern: result)
     }


### PR DESCRIPTION
`UInt64(hashValue)` traps when the hash value is negative.