### PR TITLE
Remove uses of private API (String._contiguousUTF8)

### DIFF
--- a/Sources/Basic/ByteString.swift
+++ b/Sources/Basic/ByteString.swift
@@ -47,13 +47,7 @@ public struct ByteString: ExpressibleByArrayLiteral {
     
     /// Create a byte string from the UTF8 encoding of a string.
     public init(encodingAsUTF8 string: String) {
-        let stringPtrStart = string._contiguousUTF8
-        defer { _fixLifetime(string) }
-        if stringPtrStart != nil {
-            _bytes = [UInt8](UnsafeBufferPointer(start: stringPtrStart, count: string.utf8.count))
-        } else {
-            _bytes = [UInt8](string.utf8)
-        }
+        _bytes = [UInt8](string.utf8)
     }
 
     /// Access the byte string contents as an array.

--- a/Sources/Basic/OutputByteStream.swift
+++ b/Sources/Basic/OutputByteStream.swift
@@ -171,14 +171,7 @@ public class OutputByteStream: TextOutputStream {
 
     /// Write a string to the buffer (as UTF8).
     public final func write(_ string: String) {
-        // Fast path for contiguous strings. For some reason Swift itself
-        // doesn't implement this optimization: <rdar://problem/24100375> Missing fast path for [UInt8] += String.UTF8View
-        let stringPtrStart = string._contiguousUTF8
-        if stringPtrStart != nil {
-            write(UnsafeBufferPointer(start: stringPtrStart, count: string.utf8.count))
-        } else {
-            write(sequence: string.utf8)
-        }
+        write(sequence: string.utf8)
     }
 
     /// Write a character to the buffer (as UTF8).


### PR DESCRIPTION
I'm about to remove this API in https://github.com/apple/swift/pull/4631

I could avoid removing this API for now, but a rewrite of String is coming, so this use will have to be removed then.