### PR TITLE
Generate Xcode projects using a layered data model instead of print statements

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -230,7 +230,7 @@ public struct SwiftPackageTool: SwiftTool {
                     dstdir = opts.path.root
                     projectName = graph.rootPackage.name
                 }
-                let outpath = try Xcodeproj.generate(dstdir: dstdir, projectName: projectName, graph: graph, options: opts.xcodeprojOptions)
+                let outpath = try Xcodeproj.generate(outputDir: dstdir, projectName: projectName, graph: graph, options: opts.xcodeprojOptions)
         
                 print("generated:", outpath.prettyPath)
                 

--- a/Sources/Xcodeproj/XcodeProjectModel.swift
+++ b/Sources/Xcodeproj/XcodeProjectModel.swift
@@ -1,0 +1,374 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+ -----------------------------------------------------------------------------
+
+ A very simple rendition of the Xcode project model.  There is only sufficient
+ functionality to allow creation of Xcode projects in a somewhat readable way,
+ and serialization to .xcodeproj plists.  There is no consistency checking to
+ ensure, for example, that build settings have valid values, dependency cycles
+ are not created, etc.
+ 
+ Everything here is geared toward supporting project generation.  The intended
+ usage model is for custom logic to build up a project using Xcode terminology
+ (e.g. "group", "reference", "target", "build phase"), but there is almost no
+ provision for modifying the model after it has been built up.  The intent is
+ to create it as desired from the start.
+ 
+ Rather than try to represent everything that Xcode's project model supports,
+ the approach is to start small and to add functionality as needed.
+ 
+ Note that this API represents only the project model — there is no notion of
+ workspaces, schemes, etc (although schemes are represented individually in a
+ separate API).  The notion of build settings is also somewhat different from
+ what it is in Xcode:  instead of an open-ended mapping of build configuration
+ names to dictionaries of build settings, here there is a single set of common
+ build settings plus two overlay sets for debug and release.  The generated
+ project has just the two Debug and Release configurations, created by merging
+ the common set into the release and debug sets.  This allows a more natural
+ configuration of the settings, since most values are the same between Debug
+ and Release.  Also, the build settings themselves are represented as structs
+ of named fields, instead of dictionaries with arbitrary name strings as keys.
+ 
+ It is expected that some of these simplifications will need to be lifted over
+ time, based on need.  That should be done carefully, however, to avoid ending
+ up with an overly complicated model.
+ 
+ Some things that are incomplete in even this first model:
+ - copy files build phases are incomplete
+ - shell script build phases are incomplete
+ - file types in file references are specified using strings; should be enums
+   so that the client doesn't have to hardcode the mapping to Xcode file type
+   identifiers
+ - debug and release settings override common settings; they should be merged
+   in a way that respects `$(inhertied)` when the same setting is defined in
+   common and in debug or release
+ - there is no good way to control the ordering of the `Products` group in the
+   main group; it needs to be added last in order to appear after the other
+   references
+*/
+
+public struct Xcode {
+    
+    /// An Xcode project, consisting of a tree of groups and file references,
+    /// a list of targets, and some additional information.  Note that schemes
+    /// are outside of the project data model.
+    public class Project {
+        let mainGroup: Group
+        var buildSettings: BuildSettingsTable
+        var productGroup: Group?
+        var projectDir: String
+        var targets: [Target]
+        init() {
+            self.mainGroup = Group(path: "")
+            self.buildSettings = BuildSettingsTable()
+            self.productGroup = nil
+            self.projectDir = ""
+            self.targets = []
+        }
+        
+        /// Creates and adds a new target (which does not initially have any
+        /// build phases).
+        public func addTarget(productType: Target.ProductType, name: String) -> Target {
+            let target = Target(productType: productType, name: name)
+            targets.append(target)
+            return target
+        }
+    }
+    
+    /// Abstract base class for all items in the group hierarhcy.
+    public class Reference {
+        /// Relative path of the reference.  It is usually a literal, but may
+        /// in fact contain build settings.
+        var path: String
+        /// Determines the base path for the reference's relative path.
+        var pathBase: RefPathBase
+        /// Name of the reference, if different from the last path component
+        /// (if not set, Xcode will use the last path component as the name).
+        var name: String? = nil
+        
+        /// Determines the base path for a reference's relative path (this is
+        /// what for some reason is called a "source tree" in Xcode).
+        public enum RefPathBase: String {
+            /// Indicates that the path is relative to the source root (i.e.
+            /// the "project directory").
+            case projectDir = "SOURCE_ROOT"
+            /// Indicates that the path is relative to the path of the parent
+            /// group.
+            case groupDir = "<group>"
+            /// Indicates that the path is relative to the effective build
+            /// directory (which varies depending on active scheme, active run
+            /// destination, or even an overridden build setting.
+            case buildDir = "BUILT_PRODUCTS_DIR"
+            /// The string form, suitable for use in an Xcode project file.
+            var asString: String { return rawValue }
+        }
+        
+        init(path: String, pathBase: RefPathBase = .groupDir, name: String? = nil) {
+            self.path = path
+            self.pathBase = pathBase
+            self.name = name
+        }
+    }
+    
+    /// A reference to a file system entity (a file, folder, etc).
+    public class FileReference: Reference {
+        var fileType: String?
+        
+        init(path: String, pathBase: RefPathBase = .groupDir, name: String? = nil, fileType: String? = nil) {
+            super.init(path: path, pathBase: pathBase, name: name)
+            self.fileType = fileType
+        }
+    }
+    
+    /// A group that can contain References (FileReferences and other Groups).
+    /// The resolved path of a group is used as the base path for any child
+    /// references whose source tree type is GroupRelative.
+    public class Group: Reference {
+        var subitems = [Reference]()
+        
+        /// Creates and appends a new Group to the list of subitems.
+        /// The new group is returned so that it can be configured.
+        @discardableResult public func addGroup(path: String, pathBase: RefPathBase = .groupDir, name: String? = nil) -> Group {
+            let group = Group(path: path, pathBase: pathBase, name: name)
+            subitems.append(group)
+            return group
+        }
+        
+        /// Creates and appends a new FileReference to the list of subitems.
+        @discardableResult public func addFileReference(path: String, pathBase: RefPathBase = .groupDir, name: String? = nil, fileType: String? = nil) -> FileReference {
+            let fref = FileReference(path: path, pathBase: pathBase, name: name, fileType: fileType)
+            subitems.append(fref)
+            return fref
+        }
+    }
+    
+    /// An Xcode target, representing a single entity to build.
+    public class Target {
+        var name: String
+        var productName: String
+        var productType: ProductType
+        var buildSettings: BuildSettingsTable
+        var buildPhases: [BuildPhase]
+        var productReference: FileReference?
+        var dependencies: [TargetDependency]
+        public enum ProductType: String {
+            case application = "com.apple.product-type.application"
+            case staticArchive = "com.apple.product-type.library.static"
+            case dynamicLibrary = "com.apple.product-type.library.dynamic"
+            case framework = "com.apple.product-type.framework"
+            case executable = "com.apple.product-type.tool"
+            case unitTest = "com.apple.product-type.bundle.unit-test"
+            var asString: String { return rawValue }
+        }
+        init(productType: ProductType, name: String) {
+            self.name = name
+            self.productType = productType
+            self.productName = name
+            self.buildSettings = BuildSettingsTable()
+            self.buildPhases = []
+            self.dependencies = []
+        }
+        
+        // FIXME: There's a lot repetition in these methods; using generics to
+        // try to avoid that raised other issues in terms of requirements on
+        // the Reference class, though.
+        
+        /// Adds a "headers" build phase, i.e. one that copies headers into a
+        /// directory of the product, after suitable processing.
+        @discardableResult public func addHeadersBuildPhase() -> HeadersBuildPhase {
+            let phase = HeadersBuildPhase()
+            buildPhases.append(phase)
+            return phase
+        }
+        
+        /// Adds a "sources" build phase, i.e. one that compiles sources and
+        /// provides them to be linked into the executable code of the product.
+        @discardableResult public func addSourcesBuildPhase() -> SourcesBuildPhase {
+            let phase = SourcesBuildPhase()
+            buildPhases.append(phase)
+            return phase
+        }
+        
+        /// Adds a "frameworks" build phase, i.e. one that links compiled code
+        /// and libraries into the executable of the product.
+        @discardableResult public func addFrameworksBuildPhase() -> FrameworksBuildPhase {
+            let phase = FrameworksBuildPhase()
+            buildPhases.append(phase)
+            return phase
+        }
+        
+        /// Adds a "copy files" build phase, i.e. one that copies files to an
+        /// arbitrary location relative to the product.
+        @discardableResult public func addCopyFilesBuildPhase(dstDir: String) -> CopyFilesBuildPhase {
+            let phase = CopyFilesBuildPhase(dstDir: dstDir)
+            buildPhases.append(phase)
+            return phase
+        }
+        
+        /// Adds a "shell script" build phase, i.e. one that runs a custom
+        /// shell script as part of the build.
+        @discardableResult public func addShellScriptBuildPhase(script: String) -> ShellScriptBuildPhase {
+            let phase = ShellScriptBuildPhase(script: script)
+            buildPhases.append(phase)
+            return phase
+        }
+        
+        /// Adds a dependency on another target.
+        /// FIXME: We do not check for cycles.  Should we?  This is an extremely
+        /// minimal API so it's not clear that we should.
+        public func addDependency(on target: Target) {
+            dependencies.append(TargetDependency(target: target))
+        }
+        
+        /// A simple wrapper to prevent ownership cycles in the `dependencies`
+        /// property.
+        struct TargetDependency {
+            unowned var target: Target
+        }
+    }
+    
+    /// Abstract base class for all build phases in a target.
+    public class BuildPhase {
+        var files: [BuildFile] = []
+        
+        /// Adds a new build file that refers to `fileRef`.
+        @discardableResult public func addBuildFile(fileRef: FileReference) -> BuildFile {
+            let buildFile = BuildFile(fileRef: fileRef)
+            files.append(buildFile)
+            return buildFile
+        }
+    }
+    
+    /// A "headers" build phase, i.e. one that copies headers into a directory
+    /// of the product, after suitable processing.
+    public class HeadersBuildPhase: BuildPhase {
+        // Nothing extra yet.
+    }
+    
+    /// A "sources" build phase, i.e. one that compiles sources and provides
+    /// them to be linked into the executable code of the product.
+    public class SourcesBuildPhase: BuildPhase {
+        // Nothing extra yet.
+    }
+    
+    /// A "frameworks" build phase, i.e. one that links compiled code and
+    /// libraries into the executable of the product.
+    public class FrameworksBuildPhase: BuildPhase {
+        // Nothing extra yet.
+    }
+    
+    /// A "copy files" build phase, i.e. one that copies files to an arbitrary
+    /// location relative to the product.
+    public class CopyFilesBuildPhase: BuildPhase {
+        var dstDir: String
+        init(dstDir: String) {
+            self.dstDir = dstDir
+        }
+    }
+    
+    /// A "shell script" build phase, i.e. one that runs a custom shell script.
+    public class ShellScriptBuildPhase: BuildPhase {
+        var script: String
+        init(script: String) {
+            self.script = script
+        }
+    }
+    
+    /// A build file, representing the membership of a file reference in a
+    /// build phase of a target.
+    public class BuildFile {
+        weak var fileRef: FileReference?
+        init(fileRef: FileReference) {
+            self.fileRef = fileRef
+        }
+    }
+    
+    /// A table of build settings, which for the sake of simplicity consists
+    /// (in this simplified model) of a set of common settings, and a set of
+    /// overlay settings for Debug and Release builds.  There can also be a
+    /// file reference to an .xcconfig file on which to base the settings.
+    public class BuildSettingsTable {
+        /// Common build settings are in both generated configurations (Debug
+        /// and Release).
+        var common = BuildSettings()
+        
+        /// Debug build settings are overlaid over the common settings in the
+        /// generated Debug configuration.
+        /// FIXME: They are not currently, but should be, overlaid in a manner
+        /// that preserves the semantics of `$(inherited)`.
+        var debug = BuildSettings()
+        
+        /// Release build settings are overlaid over the common settings in the
+        /// generated Release configuration.
+        /// FIXME: They are not currently, but should be, overlaid in a manner
+        /// that preserves the semantics of `$(inherited)`.
+        var release = BuildSettings()
+        
+        /// An optional file reference to an .xcconfig file.
+        var xcconfigFileRef: FileReference? = nil
+
+        /// A set of build settings, which is represented as a struct of optional
+        /// build settings.  This is not optimally efficient, but it is great for
+        /// code completion and type-checking.
+        public struct BuildSettings {
+            // Note: although some of these build settings sound like booleans,
+            // they are all either strings or arrays of strings, because even
+            // a boolean may be a macro reference expression.
+            var COMBINE_HIDPI_IMAGES: String?
+            var COPY_PHASE_STRIP: String?
+            var DEBUG_INFORMATION_FORMAT: String?
+            var DEFINES_MODULE: String?
+            var DYLIB_INSTALL_NAME_BASE: String?
+            var EMBEDDED_CONTENT_CONTAINS_SWIFT: String?
+            var ENABLE_NS_ASSERTIONS: String?
+            var ENABLE_TESTABILITY: String?
+            var FRAMEWORK_SEARCH_PATHS: [String]?
+            var GCC_OPTIMIZATION_LEVEL: String?
+            var HEADER_SEARCH_PATHS: [String]?
+            var INFOPLIST_FILE: String?
+            var LD_RUNPATH_SEARCH_PATHS: [String]?
+            var LIBRARY_SEARCH_PATHS: [String]?
+            var MACOSX_DEPLOYMENT_TARGET: String?
+            var MODULEMAP_FILE: String?
+            var ONLY_ACTIVE_ARCH: String?
+            var OTHER_CFLAGS: [String]?
+            var OTHER_LDFLAGS: [String]?
+            var OTHER_SWIFT_FLAGS: [String]?
+            var PRODUCT_BUNDLE_IDENTIFIER: String?
+            var PRODUCT_MODULE_NAME: String?
+            var PRODUCT_NAME: String?
+            var PROJECT_NAME: String?
+            var SUPPORTED_PLATFORMS: [String]?
+            var SWIFT_ACTIVE_COMPILATION_CONDITIONS: String?
+            var SWIFT_FORCE_STATIC_LINK_STDLIB: String?
+            var SWIFT_FORCE_DYNAMIC_LINK_STDLIB: String?
+            var SWIFT_OPTIMIZATION_LEVEL: String?
+            var SWIFT_VERSION: String?
+            var TARGET_NAME: String?
+            var USE_HEADERMAP: String?
+        }
+    }
+}
+
+/// Adds the abililty to append to an option array of strings that hasn't yet
+/// been created.
+/// FIXME: While we want the end result of being able to say `FLAGS += ["-O"]`
+/// it is probably not how we want to implement it, since it changes behavior
+/// for all arrays of string.  Instead, we should probably have a build setting
+/// struct that wraps a string, and then we can write this in terms of just
+/// build settings.
+public func += (lhs: inout [String]?, rhs: [String]) {
+    if lhs == nil {
+        lhs = rhs
+    }
+    else {
+        lhs = lhs! + rhs
+    }
+}

--- a/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
+++ b/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
@@ -1,0 +1,620 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+ -----------------------------------------------------------------
+
+ An extemely simple rendition of the Xcode project model into a plist.  There
+ is only enough functionality to allow serialization of Xcode projects.
+*/
+
+extension Xcode.Project: PropertyListSerializable {
+    
+    /// Generates and returns the contents of a `project.pbxproj` plist.  Does
+    /// not generate any ancillary files, such as a set of schemes.
+    ///
+    /// Many complexities of the Xcode project model are not represented; we
+    /// should not add functionality to this model unless it's needed, since
+    /// implementation of the full Xcode project model would be unnecessarily
+    /// complex.
+    public func generatePlist() -> PropertyList {
+        // The project plist is a bit special in that it's the archive for the
+        // whole file.  We create a plist serializer and serialize the entire
+        // object graph to it, and then return an archive dictionary containing
+        // the serialized object dictionaries.
+        let serializer = PropertyListSerializer()
+        serializer.serialize(object: self)
+        return .dictionary([
+            "archiveVersion": .string("1"),
+            "objectVersion":  .string("46"),  // Xcode 8.0
+            "rootObject":     .identifier(serializer.id(of: self)),
+            "objects":        .dictionary(serializer.idsToDicts),
+        ])
+    }
+    
+    /// Called by the Serializer to serialize the Project.
+    fileprivate func serialize(to serializer: PropertyListSerializer) -> [String: PropertyList] {
+        // Create a `PBXProject` plist dictionary.
+        // Note: we skip things like the `Products` group; they get autocreated
+        // by Xcode when it opens the project and notices that they are missing.
+        // Note: we also skip schemes, since they are not in the project plist.
+        var dict = [String: PropertyList]()
+        dict["isa"] = .string("PBXProject")
+        // Since the project file is generated, we opt out of upgrade-checking.
+        // FIXME: Shoule we really?  Why would we not want to get upgraded?
+        dict["attributes"] = .dictionary(["LastUpgradeCheck": .string("9999")])
+        dict["compatibilityVersion"] = .string("Xcode 3.2")
+        dict["developmentRegion"] = .string("English")
+        // Build settings are a bit tricky; in Xcode, each is stored in a named
+        // XCBuildConfiguration object, and the list of build configurations is
+        // in turn stored in an XCConfigurationList.  In our simplified model,
+        // we have a BuildSettingsTable, with three sets of settings:  one for
+        // the common settings, and one each for the Debug and Release overlays.
+        // So we consider the BuildSettingsTable to be the configuration list.
+        dict["buildConfigurationList"] = .identifier(serializer.serialize(object: buildSettings))
+        dict["mainGroup"] = .identifier(serializer.serialize(object: mainGroup))
+        dict["hasScannedForEncodings"] = .string("0")
+        dict["knownRegions"] = .array([.string("en")])
+        if let productGroup = productGroup {
+            dict["productRefGroup"] = .identifier(serializer.id(of: productGroup))
+        }
+        dict["projectDirPath"] = .string(projectDir)
+        dict["targets"] = .array(targets.map{ target in
+            .identifier(serializer.serialize(object: target))
+        })
+        return dict
+    }
+}
+
+/// Private helper function that constructs and returns a partial property list
+/// dictionary for references.  The caller can add to the returned dictionary.
+/// FIXME:  It would be nicer to be able to use inheritance to serialize the
+/// attributes inherited from Reference, but but in Swift 3.0 we get an error
+/// that "declarations in extensions cannot override yet".
+fileprivate func makeReferenceDict(reference: Xcode.Reference, serializer: PropertyListSerializer, xcodeClassName: String) -> [String: PropertyList] {
+    var dict = [String: PropertyList]()
+    dict["isa"] = .string(xcodeClassName)
+    dict["path"] = .string(reference.path)
+    if let name = reference.name {
+        dict["name"] = .string(name)
+    }
+    dict["sourceTree"] = .string(reference.pathBase.asString)
+    return dict
+}
+
+extension Xcode.Group: PropertyListSerializable {
+    
+    /// Called by the Serializer to serialize the Group.
+    fileprivate func serialize(to serializer: PropertyListSerializer) -> [String: PropertyList] {
+        // Create a `PBXGroup` plist dictionary.
+        // FIXME:  It would be nicer to be able to use inheritance for the code
+        // inherited from Reference, but but in Swift 3.0 we get an error that
+        // "declarations in extensions cannot override yet".
+        var dict = makeReferenceDict(reference: self, serializer: serializer, xcodeClassName: "PBXGroup")
+        dict["children"] = .array(subitems.map{ reference in
+            // For the same reason, we have to cast as `PropertyListSerializable`
+            // here; as soon as we try to make Reference conform to the protocol,
+            // we get the problem of not being able to override `serialize(to:)`.
+            .identifier(serializer.serialize(object: reference as! PropertyListSerializable))
+        })
+        return dict
+    }
+}
+
+extension Xcode.FileReference: PropertyListSerializable {
+    
+    /// Called by the Serializer to serialize the FileReference.
+    fileprivate func serialize(to serializer: PropertyListSerializer) -> [String: PropertyList] {
+        // Create a `PBXFileReference` plist dictionary.
+        // FIXME:  It would be nicer to be able to use inheritance for the code
+        // inherited from Reference, but but in Swift 3.0 we get an error that
+        // "declarations in extensions cannot override yet".
+        var dict = makeReferenceDict(reference: self, serializer: serializer, xcodeClassName: "PBXFileReference")
+        if let fileType = fileType {
+            dict["explicitFileType"] = .string(fileType)
+        }
+        // FileReferences don't need to store a name if it's the same as the path.
+        if name == path {
+            dict["name"] = nil
+        }
+        return dict
+    }
+}
+
+extension Xcode.Target: PropertyListSerializable {
+
+    /// Called by the Serializer to serialize the Target.
+    fileprivate func serialize(to serializer: PropertyListSerializer) -> [String: PropertyList] {
+        // Create a `PBXNativeTarget` plist dictionary.
+        var dict = [String: PropertyList]()
+        dict["isa"] = .string("PBXNativeTarget")
+        dict["name"] = .string(name)
+        // Build settings are a bit tricky; in Xcode, each is stored in a named
+        // XCBuildConfiguration object, and the list of build configurations is
+        // in turn stored in an XCConfigurationList.  In our simplified model,
+        // we have a BuildSettingsTable, with three sets of settings:  one for
+        // the common settings, and one each for the Debug and Release overlays.
+        // So we consider the BuildSettingsTable to be the configuration list.
+        // This is the same situation as for Project.
+        dict["buildConfigurationList"] = .identifier(serializer.serialize(object: buildSettings))
+        dict["buildPhases"] = .array(buildPhases.map{ phase in
+            // Here we have the same problem as for Reference; we cannot inherit
+            // functionality since we're in an extension.
+            .identifier(serializer.serialize(object: phase as! PropertyListSerializable))
+        })
+        /// Private wrapper class for a target dependency relation.  This is
+        /// glue between our value-based settings structures and the Xcode
+        /// project model's identity-based TargetDependency objects.
+        class TargetDependency: PropertyListSerializable {
+            var target: Xcode.Target
+            init(target: Xcode.Target) {
+                self.target = target
+            }
+            func serialize(to serializer: PropertyListSerializer) -> [String: PropertyList] {
+                // Create a `PBXTargetDependency` plist dictionary.
+                var dict = [String: PropertyList]()
+                dict["isa"] = .string("PBXTargetDependency")
+                dict["target"] = .identifier(serializer.id(of: target))
+                return dict
+            }
+        }
+        dict["dependencies"] = .array(dependencies.map { dep in
+            // In the Xcode project model, target dependencies are objects,
+            // so we need a helper class here.
+            .identifier(serializer.serialize(object: TargetDependency(target: dep.target)))
+        })
+        dict["productName"] = .string(productName)
+        dict["productType"] = .string(productType.asString)
+        if let productReference = productReference {
+            dict["productReference"] = .identifier(serializer.id(of: productReference))
+        }
+        return dict
+    }
+}
+
+/// Private helper function that constructs and returns a partial property list
+/// dictionary for build phases.  The caller can add to the returned dictionary.
+/// FIXME:  It would be nicer to be able to use inheritance to serialize the
+/// attributes inherited from BuildPhase, but but in Swift 3.0 we get an error
+/// that "declarations in extensions cannot override yet".
+fileprivate func makeBuildPhaseDict(buildPhase: Xcode.BuildPhase, serializer: PropertyListSerializer, xcodeClassName: String) -> [String: PropertyList] {
+    var dict = [String: PropertyList]()
+    dict["isa"] = .string(xcodeClassName)
+    dict["files"] = .array(buildPhase.files.map{ file in
+        .identifier(serializer.serialize(object: file))
+    })
+    return dict
+}
+
+
+extension Xcode.HeadersBuildPhase: PropertyListSerializable {
+    
+    /// Called by the Serializer to serialize the HeadersBuildPhase.
+    fileprivate func serialize(to serializer: PropertyListSerializer) -> [String: PropertyList] {
+        // Create a `PBXHeadersBuildPhase` plist dictionary.
+        // FIXME:  It would be nicer to be able to use inheritance for the code
+        // inherited from BuildPhase, but but in Swift 3.0 we get an error that
+        // "declarations in extensions cannot override yet".
+        return makeBuildPhaseDict(buildPhase: self, serializer: serializer, xcodeClassName: "PBXHeadersBuildPhase")
+    }
+}
+
+extension Xcode.SourcesBuildPhase: PropertyListSerializable {
+    
+    /// Called by the Serializer to serialize the SourcesBuildPhase.
+    fileprivate func serialize(to serializer: PropertyListSerializer) -> [String: PropertyList] {
+        // Create a `PBXSourcesBuildPhase` plist dictionary.
+        // FIXME:  It would be nicer to be able to use inheritance for the code
+        // inherited from BuildPhase, but but in Swift 3.0 we get an error that
+        // "declarations in extensions cannot override yet".
+        return makeBuildPhaseDict(buildPhase: self, serializer: serializer, xcodeClassName: "PBXSourcesBuildPhase")
+    }
+}
+
+extension Xcode.FrameworksBuildPhase: PropertyListSerializable {
+    
+    /// Called by the Serializer to serialize the FrameworksBuildPhase.
+    fileprivate func serialize(to serializer: PropertyListSerializer) -> [String: PropertyList] {
+        // Create a `PBXFrameworksBuildPhase` plist dictionary.
+        // FIXME:  It would be nicer to be able to use inheritance for the code
+        // inherited from BuildPhase, but but in Swift 3.0 we get an error that
+        // "declarations in extensions cannot override yet".
+        return makeBuildPhaseDict(buildPhase: self, serializer: serializer, xcodeClassName: "PBXFrameworksBuildPhase")
+    }
+}
+
+extension Xcode.CopyFilesBuildPhase: PropertyListSerializable {
+    
+    /// Called by the Serializer to serialize the FrameworksBuildPhase.
+    fileprivate func serialize(to serializer: PropertyListSerializer) -> [String: PropertyList] {
+        // Create a `PBXCopyFilesBuildPhase` plist dictionary.
+        // FIXME:  It would be nicer to be able to use inheritance for the code
+        // inherited from BuildPhase, but but in Swift 3.0 we get an error that
+        // "declarations in extensions cannot override yet".
+        var dict = makeBuildPhaseDict(buildPhase: self, serializer: serializer, xcodeClassName: "PBXCopyFilesBuildPhase")
+        dict["dstPath"] = .string("")   // FIXME: needs to be real
+        dict["dstSubfolderSpec"] = .string("")   // FIXME: needs to be real
+        return dict
+    }
+}
+
+extension Xcode.ShellScriptBuildPhase: PropertyListSerializable {
+    
+    /// Called by the Serializer to serialize the ShellScriptBuildPhase.
+    fileprivate func serialize(to serializer: PropertyListSerializer) -> [String: PropertyList] {
+        // Create a `PBXShellScriptBuildPhase` plist dictionary.
+        // FIXME:  It would be nicer to be able to use inheritance for the code
+        // inherited from BuildPhase, but but in Swift 3.0 we get an error that
+        // "declarations in extensions cannot override yet".
+        var dict = makeBuildPhaseDict(buildPhase: self, serializer: serializer, xcodeClassName: "PBXShellScriptBuildPhase")
+        dict["shellPath"] = .string("/bin/sh")   // FIXME: should be settable
+        dict["shellScript"] = .string(script)
+        return dict
+    }
+}
+
+extension Xcode.BuildFile: PropertyListSerializable {
+    
+    /// Called by the Serializer to serialize the BuildFile.
+    fileprivate func serialize(to serializer: PropertyListSerializer) -> [String: PropertyList] {
+        // Create a `PBXBuildFile` plist dictionary.
+        var dict = [String: PropertyList]()
+        dict["isa"] = .string("PBXBuildFile")
+        if let fileRef = fileRef {
+            dict["fileRef"] = .identifier(serializer.id(of: fileRef))
+        }
+        return dict
+    }
+}
+
+
+extension Xcode.BuildSettingsTable: PropertyListSerializable {
+    
+    /// Called by the Serializer to serialize the BuildFile.  It is serialized
+    /// as an XCBuildConfigurationList and two additional XCBuildConfiguration
+    /// objects (one for debug and one for release).
+    fileprivate func serialize(to serializer: PropertyListSerializer) -> [String: PropertyList] {
+        /// Private wrapper class for BuildSettings structures.  This is glue
+        /// between our value-based settings structures and the Xcode project
+        /// model's identity-based XCBuildConfiguration objects.
+        class BuildSettingsDictWrapper: PropertyListSerializable {
+            let name: String
+            var baseSettings: BuildSettings
+            var overlaySettings: BuildSettings
+            let xcconfigFileRef: Xcode.FileReference?
+            init(name: String, baseSettings: BuildSettings, overlaySettings: BuildSettings, xcconfigFileRef: Xcode.FileReference?) {
+                self.name = name
+                self.baseSettings = baseSettings
+                self.overlaySettings = overlaySettings
+                self.xcconfigFileRef = xcconfigFileRef
+            }
+            func serialize(to serializer: PropertyListSerializer) -> [String: PropertyList] {
+                // Create a `XCBuildConfiguration` plist dictionary.
+                var dict = [String: PropertyList]()
+                dict["isa"] = .string("XCBuildConfiguration")
+                dict["name"] = .string(name)
+                // Combine the base settings and the overlay settings.
+                dict["buildSettings"] = combineBuildSettingsPropertyLists(baseSettings: baseSettings.asPropertyList(), overlaySettings: overlaySettings.asPropertyList())
+                // Add a reference to the base configuration, if there is one.
+                if let xcconfigFileRef = xcconfigFileRef {
+                    dict["baseConfigurationReference"] = .identifier(serializer.id(of: xcconfigFileRef))
+                }
+                return dict
+            }
+        }
+        
+        // Create a `XCConfigurationList` plist dictionary.
+        var dict = [String: PropertyList]()
+        dict["isa"] = .string("XCConfigurationList")
+        dict["buildConfigurations"] = .array([
+            // We use a private wrapper to "objectify" our two build settings
+            // structures (which, being structs, are value types).
+            .identifier(serializer.serialize(object: BuildSettingsDictWrapper(name: "Debug", baseSettings: common, overlaySettings: debug, xcconfigFileRef: xcconfigFileRef))),
+            .identifier(serializer.serialize(object: BuildSettingsDictWrapper(name: "Release", baseSettings: common, overlaySettings: release, xcconfigFileRef: xcconfigFileRef))),
+        ])
+        // FIXME: What is this, and why are we setting it?
+        dict["defaultConfigurationIsVisible"] = .string("0")
+        // FIXME: Should we allow this to be set in the model?
+        dict["defaultConfigurationName"] = .string("Debug")
+        return dict
+    }
+}
+
+
+extension Xcode.BuildSettingsTable.BuildSettings {
+    
+    /// Returns a property list representation of the build settings, in which
+    /// every struct field is represented as a dictionary entry.  Fields of
+    /// type `String` are represented as `PropertyList.string` values; fields
+    /// of type `[String]` are represented as `PropertyList.array` values with
+    /// `PropertyList.string` values as the array elements.  The property list
+    /// dictionary only contains entries for struct fields that aren't nil.
+    ///
+    /// Note: BuildSettings is a value type and PropertyListSerializable only
+    /// applies to classes.  Creating a property list representation is totally
+    /// independent of that serialization infrastructure (though it might well
+    /// be invoked during of serialization of actual model objects).
+    fileprivate func asPropertyList() -> PropertyList {
+        // Borderline hacky, but the main thing is that adding or changing a
+        // build setting does not require any changes to the property list
+        // representation code.  Using a handcoded serializer might be more
+        // efficient but not even remotely as robust, and robustness is the
+        // key factor for this use case, as there aren't going to be millions
+        // of BuildSettings structs.
+        var dict = [String: PropertyList]()
+        let mirror = Mirror(reflecting: self)
+        for child in mirror.children {
+            guard let name = child.label else {
+                preconditionFailure("unnamed build settings are not supported")
+            }
+            switch child.value {
+              case nil:
+                continue
+              case let value as String:
+                dict[name] = .string(value)
+              case let value as [String]:
+                dict[name] = .array(value.map{ .string($0) })
+              default:
+                // FIXME: I haven't found a way of distinguishing a value of an
+                // unexpected type from a value that is nil; they all seem to go
+                // throught the `default` case instead of the `nil` case above.
+                // Hopefully someone reading this will clue me in about what I
+                // did wrong.  But currently we will silently fail to serialize
+                // any struct field that isn't a `String` or a `[String]` (or
+                // an optional of either of those two).
+                // This would only come up if a field were to be added of a type
+                // other than `String` or `[String]`.
+                continue
+            }
+        }
+        return .dictionary(dict)
+    }
+}
+
+
+/// Private helper function that combines a base property list and an overlay
+/// property list, respecting the semantics of `$(inherited)` as we go.
+/// FIXME:  This should possibly be done while constructing the property list.
+fileprivate func combineBuildSettingsPropertyLists(baseSettings: PropertyList, overlaySettings: PropertyList) -> PropertyList {
+    // Extract the base and overlay dictionaries.
+    guard case let .dictionary(baseDict) = baseSettings else {
+        preconditionFailure("base settings plist must be a dictionary")
+    }
+    guard case let .dictionary(overlayDict) = overlaySettings else {
+        preconditionFailure("overlay settings plist must be a dictionary")
+    }
+    
+    // Iterate over the overlay values and apply them to the base.
+    var resultDict = baseDict
+    for (name, value) in overlayDict {
+        // FIXME: We should resolve `$(inherited)` here.  The way this works is
+        // that occurrences of `$(inherited)` in the overlay are replaced with
+        // the overlaid value in the base.
+        resultDict[name] = value
+    }
+    return .dictionary(resultDict)
+}
+
+
+/// A simple property list serializer with the same semantics as the Xcode
+/// property list serializer.  Not generally reusable at this point, but only
+/// because of implementation details (architecturally it isn't tied to Xcode).
+fileprivate class PropertyListSerializer {
+    
+    /// Private struct that represents a strong reference to a serializable
+    /// object.  This prevents any temporary objects from being deallocated
+    /// during the serialization and replaced with other objects having the
+    /// same object identifier (a violation of our assumptions)
+    struct SerializedObjectRef: Hashable, Equatable {
+        let object: PropertyListSerializable
+        init(_ object: PropertyListSerializable) {
+            self.object = object
+        }
+        var hashValue: Int {
+            return ObjectIdentifier(object).hashValue
+        }
+        static func ==(lhs: SerializedObjectRef, rhs: SerializedObjectRef) -> Bool {
+            return lhs.object === rhs.object
+        }
+    }
+    
+    /// Maps objects to the identifiers that have been assigned to them.  The
+    /// next identifier to be assigned is always one greater than the number
+    /// of entries in the mapping.
+    var objsToIds = [SerializedObjectRef: String]()
+    
+    /// Maps serialized objects ids to dictionaries.  This may contain fewer
+    /// entries than `objsToIds`, since ids are assigned upon reference, but
+    /// plist dictionaries are created only upon actual serialization.  This
+    /// dictionary is what gets written to the property list.
+    var idsToDicts = [String: PropertyList]()
+    
+    /// Returns the identifier for the object, assigning one if needed.
+    func id(of object: PropertyListSerializable) -> String {
+        // We need a "serialized object ref" wrapper for the `objsToIds` map.
+        let serObjRef = SerializedObjectRef(object)
+        if let id = objsToIds[serObjRef] {
+            return id
+        }
+        // We currently always assign identifiers starting at 1 and going up.
+        // FIXME: This is a suboptimal format for object identifier strings;
+        // for debugging purposes they should at least sort in numeric order.
+        let id = "OBJ_\(objsToIds.count + 1)"
+        objsToIds[serObjRef] = id
+        return id
+    }
+    
+    /// Serializes `object` by asking it to construct a plist dictionary and
+    /// then adding that dictionary to the serializer.  This may in turn cause
+    /// recursive invocations of `serialize(object:)`; the closure of these
+    /// invocations end up serializing the whole object graph.
+    @discardableResult func serialize(object: PropertyListSerializable) -> String {
+        // Assign an id for the object, if it doesn't already have one.
+        let id = self.id(of: object)
+        
+        // If that id is already in `idsToDicts`, we've detected recursion or
+        // repeated serialization.
+        precondition(idsToDicts[id] == nil, "tried to serialize \(object) twice")
+        
+        // Set a sentinel value in the `idsToDicts` mapping to detect recursion.
+        idsToDicts[id] = .dictionary([:])
+        
+        // Now recursively serialize the object, and store the result (replacing
+        // the sentinel).
+        idsToDicts[id] = .dictionary(object.serialize(to: self))
+        
+        // Finally, return the identifier so the caller can store it (usually in
+        // an attribute in its own serialization dictionary).
+        return id
+    }
+}
+
+
+fileprivate protocol PropertyListSerializable: class {
+    /// Called by the Serializer to construct and return a dictionary for a
+    /// serializable object.  The entries in the dictionary should represent
+    /// the receiver's attributes and relationships, as PropertyList values.
+    ///
+    /// Every object that is written to the Serializer is assigned an id (an
+    /// arbitrary but unique string).  Forward references can use `id(of:)`
+    /// of the Serializer to assign and access the id before the object is
+    /// actually written.
+    ///
+    /// Implementations can use the Serializer's `serialize(object:)` method
+    /// to serialize owned objects (getting an id to the serialized object,
+    /// which can be stored in one of the attributes) or can use the `id(of:)`
+    /// method to store a reference to an unowned object.
+    ///
+    /// The implementation of this method for each serializable objects looks
+    /// something like this:
+    ///
+    ///   // Create a `PBXSomeClassOrOther` plist dictionary.
+    ///   var dict = [String: PropertyList]()
+    ///   dict["isa"] = .string("PBXSomeClassOrOther")
+    ///   dict["name"] = .string(name)
+    ///   if let path = path { dict["path"] = .string(path) }
+    ///   dict["mainGroup"] = .identifier(serializer.serialize(object: mainGroup))
+    ///   dict["subitems"] = .array(subitems.map{ .string($0.id) })
+    ///   dict["cross-ref"] = .identifier(serializer.id(of: unownedObject))
+    ///   return dict
+    ///
+    /// FIXME: I'm not totally happy with how this looks.  It's far too clunky
+    /// and could be made more elegant.  However, since the Xcode project model
+    /// is static, this is not something that will need to evolve over time.
+    /// What does need to evolve, which is how the project model is constructed
+    /// from the package contents, is where the elegance and simplicity really
+    /// matters.  So this is acceptable for now in the interest of getting it
+    /// done.
+    
+    /// Should create and return a property list dictionary of the object's
+    /// attributes.  This function may also use the serializer's `serialize()`
+    /// function to serialize other objects, and may use `id(of:)` to access
+    /// ids of objects that either have or will be serialized.
+    func serialize(to serializer: PropertyListSerializer) -> [String: PropertyList]
+}
+
+
+/// A very simple representation of a property list.  Note that the `identifier`
+/// enum is not strictly necessary, but useful to semantically distinguish the
+/// strings that represents object identifiers from those that are just data.
+public enum PropertyList {
+    case identifier(String)
+    case string(String)
+    case array([PropertyList])
+    case dictionary([String: PropertyList])
+}
+
+
+/// Private struct to generate indentation strings.
+fileprivate struct Indentation: CustomStringConvertible {
+    var level: Int = 0
+    mutating func increase() {
+        level += 1
+        precondition(level > 0, "indentation level overflow")
+    }
+    mutating func decrease() {
+        precondition(level > 0, "indentation level underflow")
+        level -= 1
+    }
+    var description: String {
+        return String(repeating: "   ", count: level)
+    }
+}
+
+/// Escapes the string for plist.
+/// Finds the instances of quote (") and backward slash (\) and prepends
+/// the escape character backward slash (\).
+/// FIXME: Reconcile this with the one that Ankit has meanwhile checked in.
+fileprivate func escape(string: String) -> String {
+    func needsEscape(_ char: UInt8) -> Bool {
+        return char == UInt8(ascii: "\\") || char == UInt8(ascii: "\"")
+    }
+
+    guard let pos = string.utf8.index(where: needsEscape) else {
+        return string
+    }
+    var newString = String(string.utf8[string.utf8.startIndex..<pos])!
+    for char in string.utf8[pos..<string.utf8.endIndex] {
+        if needsEscape(char) {
+            newString += "\\"
+        }
+        newString += String(UnicodeScalar(char))
+    }
+    return newString
+}
+
+/// Private function to generate OPENSTEP-style plist representation.
+fileprivate func generatePlistRepresentation(plist: PropertyList, indentation: Indentation) -> String {
+    // Do the appropriate thing for each type of plist node.
+    switch plist {
+        
+      case .identifier(let ident):
+        // FIXME: we should assert that the identifier doesn't need quoting
+        return ident
+        
+      case .string(let string):
+        return "\"" + escape(string: string) + "\""
+        
+      case .array(let array):
+        var indent = indentation
+        var str = "(\n"
+        indent.increase()
+        for item in array {
+            str += "\(indent)\(generatePlistRepresentation(plist: item, indentation: indent)),\n"
+        }
+        indent.decrease()
+        str += "\(indent))"
+        return str
+        
+      case .dictionary(let dict):
+        var indent = indentation
+        let dict = dict.sorted{
+            // Make `isa` sort first (just for readability purposes).
+            switch ($0.key, $1.key) {
+              case ("isa", "isa"): return false
+              case ("isa", _): return true
+              case (_, "isa"): return false
+              default: return $0.key < $1.key
+            }
+        }
+        var str = "{\n"
+        indent.increase()
+        for item in dict {
+            str += "\(indent)\(item.key) = \(generatePlistRepresentation(plist: item.value, indentation: indent));\n"
+        }
+        indent.decrease()
+        str += "\(indent)}"
+        return str
+    }
+}
+
+extension PropertyList: CustomStringConvertible {
+    public var description: String {
+        return generatePlistRepresentation(plist: self, indentation: Indentation())
+    }
+}

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -12,451 +12,355 @@ import Basic
 import POSIX
 import PackageGraph
 import PackageModel
+import PackageLoading
 import Utility
 
 
-// FIXME: escaping
-
-
-public func pbxproj(srcroot: AbsolutePath, projectRoot: AbsolutePath, xcodeprojPath: AbsolutePath, graph: PackageGraph, directoryReferences: [AbsolutePath], options: XcodeprojOptions, printer print: (String) -> Void) throws {
-    // FIXME: Push this lower.
-    let modules = graph.modules.filter{ $0.type != .systemModule }
-    let externalModules = graph.externalModules.filter{ $0.type != .systemModule }
-
-    // let rootModulesSet = Set(modules).subtract(Set(externalModules))
-    let rootModulesSet = modules
-    let nonTestRootModules = rootModulesSet.filter{ !$0.isTest }
-
-    print("// !$*UTF8*$!")
-    print("{")
-    print("    archiveVersion = 1;")
-    print("    classes = {};")
-    print("    objectVersion = 46;")
-    print("    rootObject = \(rootObjectReference);")
-
-    print("    objects = {")
-
-////// root object, ie. the Project itself
-    print("        \(rootObjectReference) = {")
-    print("            isa = PBXProject;")
-    print("            attributes = {LastUpgradeCheck = 9999;};")   // we're generated: don’t upgrade check
-    print("            buildConfigurationList = \(rootBuildConfigurationListReference);")
-    print("            compatibilityVersion = 'Xcode 3.2';")
-    print("            developmentRegion = English;")
-    print("            hasScannedForEncodings = 0;")
-    print("            knownRegions = (en);")
-    print("            mainGroup = \(rootGroupReference);")
-    print("            productRefGroup = \(productsGroupReference);")
-    print("            projectDirPath = '';")
-    print("            projectRoot = '';")
-    print("            targets = (" + modules.map{ $0.targetReference }.joined(separator: ", ") + ");")
-    print("        };")
-
-////// Package.swift file
-    let packageSwift = fileRef(inProjectRoot: RelativePath("Package.swift"), srcroot: srcroot)
-    print("        \(packageSwift.refId) = {")
-    print("            isa = PBXFileReference;")
-    print("            lastKnownFileType = sourcecode.swift;")
-    print("            path = '\(packageSwift.path.relative(to: projectRoot).asString)';")
-    print("            sourceTree = '<group>';")
-    print("        };")
-
-////// Reference directories
-
-    var folderRefs = ""
-    for directoryReference in directoryReferences {
-        let folderRef = fileRef(inProjectRoot: directoryReference.relative(to: srcroot), srcroot: srcroot)
-        folderRefs.append("\(folderRef.refId),")
-        print("        \(folderRef.refId) = {")
-        print("            isa = PBXFileReference;")
-        print("            lastKnownFileType = folder;")
-        print("            name = '\(directoryReference.basename)';")
-        print("            path = '\(folderRef.path.relative(to: projectRoot).asString)';")
-        print("            sourceTree = '<group>';")
-        print("        };")
+/// Generates the contents of the `project.pbxproj` for the package graph.  The
+/// project file is generated with the assumption that it will be written to an
+/// .xcodeproj wrapper at `xcodeprojPath` (this affects relative references to
+/// ancillary files inside the wrapper).  Note that the root directory of the
+/// sources is not necessarily related to this path; the source root directory
+/// is the path of the root package in the package graph, independent of the
+/// directory to which the .xcodeproj is being generated.
+public func pbxproj(xcodeprojPath: AbsolutePath, graph: PackageGraph, extraDirs: [AbsolutePath], options: XcodeprojOptions) throws -> String {
+    
+    // Create the project.
+    let project = Xcode.Project()
+    
+    // Determine the source root directory (which is NOT necessarily related in
+    // any way to `xcodeprojPath`, i.e. we cannot assume that the Xcode project
+    // will be generated into to the source root directory).
+    let sourceRootDir = graph.rootPackage.path
+    
+    // Set the project's notion of the source root directory to be a relative
+    // path from the directory that contains the .xcodeproj to the source root
+    // directory (note that those two directories might or might be the same).
+    // The effect is to make any `projectDir`-relative path be relative to the
+    // source root directory, i.e. the path of the root package.
+    project.projectDir = sourceRootDir.relative(to: xcodeprojPath.parentDirectory).asString
+    
+    // Configure the project settings.
+    let projectSettings = project.buildSettings
+    
+    // First of all, set a standard definition of `PROJECT_NAME`.
+    projectSettings.common.PRODUCT_NAME = "$(TARGET_NAME)"
+    
+    // Set the SUPPORTED_PLATFORMS to all platforms.
+    // FIXME: This doesn't seem correct, but was what the old project generation
+    // code did, so for now we do so too.
+    projectSettings.common.SUPPORTED_PLATFORMS = ["macosx", "iphoneos", "iphonesimulator", "appletvos", "appletvsimulator", "watchos", "watchsimulator"]
+    
+    // Set a conservative default deployment target.
+    // FIXME: There needs to be some kind of control over this.  But currently
+    // it is required to set this in order for SwiftPM to be able to self-host
+    // in Xcode; otherwise, the PackageDescription library will be incompatible
+    // with the default deployment target we pass when building.
+    projectSettings.common.MACOSX_DEPLOYMENT_TARGET = "10.10"
+    
+    // Default to @rpath-based install names.  Any target that links against
+    // these products will need to establish the appropriate runpath search
+    // paths so that all the products can be found.
+    projectSettings.common.DYLIB_INSTALL_NAME_BASE = "@rpath"
+    
+    // Add any additional compiler and linker flags the user has specified.
+    if !options.flags.cCompilerFlags.isEmpty {
+        projectSettings.common.OTHER_CFLAGS = options.flags.cCompilerFlags
     }
+    if !options.flags.linkerFlags.isEmpty {
+        projectSettings.common.OTHER_LDFLAGS = options.flags.linkerFlags
+    }
+    if !options.flags.swiftCompilerFlags.isEmpty {
+        projectSettings.common.OTHER_SWIFT_FLAGS = options.flags.swiftCompilerFlags
+    }
+    
+    // Also set the `Xcode` build preset in Swift to let code conditionalize on
+    // being built in Xcode.
+    projectSettings.common.OTHER_SWIFT_FLAGS += ["-DXcode"]
+    
+    // Prevent Xcode project upgrade warnings.
+    projectSettings.common.COMBINE_HIDPI_IMAGES = "YES"
+    
+    // Opt out of headermaps.  The semantics of the build should be explicitly
+    // defined by the project structure, so that we don't get any additional
+    // magic behavior that isn't present in `swift build`.
+    projectSettings.common.USE_HEADERMAP = "NO"
+    
+    // Add some debug-specific settings.
+    projectSettings.debug.COPY_PHASE_STRIP = "NO"
+    projectSettings.debug.DEBUG_INFORMATION_FORMAT = "dwarf"
+    projectSettings.debug.ENABLE_NS_ASSERTIONS = "YES"
+    projectSettings.debug.GCC_OPTIMIZATION_LEVEL = "0"
+    projectSettings.debug.ONLY_ACTIVE_ARCH = "YES"
+    projectSettings.debug.SWIFT_OPTIMIZATION_LEVEL = "-Onone"
+    
+    // Add some release-specific settings.
+    projectSettings.release.COPY_PHASE_STRIP = "YES"
+    projectSettings.release.DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym"
+    projectSettings.release.GCC_OPTIMIZATION_LEVEL = "s"
+    projectSettings.release.SWIFT_OPTIMIZATION_LEVEL = "-O"
 
-////// root group
-    print("        \(rootGroupReference) = {")
-    print("            isa = PBXGroup;")
-    print("            children = (\(packageSwift.refId), \(configsGroupReference), \(sourcesGroupReference), \(folderRefs) \(dependenciesGroupReference), \(testsGroupReference), \(productsGroupReference));")
-    print("            sourceTree = '<group>';")
-    print("        };")
-
-////// modules group
+    // Add a file reference for the package manifest itself.
+    project.mainGroup.addFileReference(path: "Package.swift", fileType: "sourcecode.swift")
+    
+    // Add a group for the .xcconfig files.
+    if let xcconfigPath = options.xcconfigOverrides {
+        let xcconfigsGroup = project.mainGroup.addGroup(path: "Configs")
+        let xcconfigFileRef = xcconfigsGroup.addFileReference(path: xcconfigPath.relative(to: sourceRootDir).asString)
+        project.buildSettings.xcconfigFileRef = xcconfigFileRef
+    }
+    
+    // Add a `Sources` group, to which we'll add a subgroup for every regular
+    // module.
+    let sourcesGroup = project.mainGroup.addGroup(path: "Sources")
+    
+    // Add a `Tests` group, to which we'll add a subgroup for every test module.
+    let testsGroup = project.mainGroup.addGroup(path: "Tests")
+    
+    // Add "blue folders" for all the other directories at the top level.
+    for extraDir in extraDirs {
+        project.mainGroup.addFileReference(path: extraDir.relative(to: sourceRootDir).asString, pathBase: .projectDir)
+    }
+    
+    // Add a `Products` group, and set it as the project's product group.  This
+    // is the group to which we'll add references to the outputs of the various
+    // targets; these references will be added to the link phases.
+    let productsGroup = project.mainGroup.addGroup(path: "", pathBase: .buildDir, name: "Products")
+    project.productGroup = productsGroup
+    
+    // Determine the set of modules to generate in the project by excluding
+    // any system modules.
+    let modules = graph.modules.filter{ $0.type != .systemModule }
+    
+    // We'll need a mapping of modules to the corresponding targets.
+    var modulesToTargets: [Module: Xcode.Target] = [:]
+    
+    // To avoid creating multiple groups for the same path, we keep a mapping
+    // of the paths we've seen and the corresponding groups we've created.
+    var srcPathsToGroups: [AbsolutePath: Xcode.Group] = [:]
+    
+    // Private helper function to make a group (or return an existing one) for
+    // a particular path, including any intermediate groups that may be needed.
+    func makeGroup(for path: AbsolutePath) -> Xcode.Group {
+        // Check if we already have a group.
+        if let group = srcPathsToGroups[path] {
+            return group
+        }
+        // We don't, so create one, starting with the parent.
+        let parentGroup = makeGroup(for: path.parentDirectory)
+        let group = parentGroup.addGroup(path: path.basename)
+        srcPathsToGroups[path] = group
+        return group
+    }
+    
+    // Add a mapping from the project dir to the main group, as a backstop for
+    // any paths that get so far (doesn't happen in a standard package layout).
+    srcPathsToGroups[sourceRootDir] = project.mainGroup
+    
+    // Go through all the modules, creating targets and adding file references
+    // to the group tree (the specific top-level group under which they are
+    // added depends on whether or not the module is a test module).
     for module in modules {
-        // Base directory for source files belonging to the module.
-        let moduleRoot = module.sources.root
-
-        // Contruct an array of (refId, path, bflId) tuples for all the source files in the model.  The reference id is for the PBXFileReference in the group hierarchy, and the build file id is for the PBXBuildFile in the CompileSources build phase.
-        let sourceFileRefs = fileRefs(forModuleSources: module, srcroot: srcroot)
-
-        // Hash of AbsolutePath of a group and reference id's of its children.
-        // Children can be either a source file or a nested group
-        var groupsChildren = [AbsolutePath: OrderedSet<String>]()
-
-        // reference id's of immediate children of this module group.
-        var topLevelRefs  = OrderedSet<String>()
-
-        // the contents of the “Project Navigator” group for this module
-        for fileRef in sourceFileRefs {
-            let path = fileRef.path.relative(to: moduleRoot)
-            print("        \(fileRef.refId) = {")
-            print("            name = '\(fileRef.path.basename)';")
-            print("            isa = PBXFileReference;")
-            print("            lastKnownFileType = \(module.fileType(forSource: path));")
-            print("            path = '\(fileRef.path.relative(to: srcroot).asString)';")
-            print("            sourceTree = '<group>';")
-            print("        };")
-
-            // This source file is immediate children of module directory, ie., no nested folders
-            if path.dirname == "." {
-                topLevelRefs.append(fileRef.refId)
+        // Add a target for the module.  The product type depends on the kind
+        // of module it is.
+        // FIXME: We should factor this out.
+        let productType: Xcode.Target.ProductType
+        if module.isTest {
+            productType = .unitTest
+        } else if module.isLibrary {
+            productType = .framework
+        } else {
+            productType = .executable
+        }
+        let productName = module.c99name
+        let target = project.addTarget(productType: productType, name: module.name)
+        target.productName = productName
+        
+        // Configure the target settings based on the module.
+        let targetSettings = target.buildSettings
+        
+        targetSettings.common.SUPPORTED_PLATFORMS = ["macosx"]
+        targetSettings.common.TARGET_NAME = module.name
+        
+        let infoPlistFilePath = xcodeprojPath.appending(component: module.infoPlistFileName)
+        targetSettings.common.INFOPLIST_FILE = infoPlistFilePath.relative(to: sourceRootDir).asString
+        
+        // Add default library search path to the directory where symlinks to
+        // framework binaries will be put with name `lib<library-name>.dylib`
+        // so that autolinking can proceed without providing another modulemap
+        // for Xcode projects.
+        // See: https://bugs.swift.org/browse/SR-2465
+        if module.recursiveDependencies.first(where: { $0 is ClangModule }) != nil {
+            targetSettings.common.LIBRARY_SEARCH_PATHS = ["$(PROJECT_TEMP_DIR)/SymlinkLibs/"]
+        }
+        
+        if module.isTest {
+            targetSettings.common.EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES"
+            targetSettings.common.LD_RUNPATH_SEARCH_PATHS = ["@loader_path/../Frameworks"]
+        }
+        else {
+            // We currently force a search path to the toolchain, since we can't
+            // establish an expected location for the Swift standard libraries.
+            //
+            // Note that this means that the built binaries are not suitable for
+            // distribution, among other things.
+            targetSettings.common.LD_RUNPATH_SEARCH_PATHS = ["$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"]
+            if module.isLibrary {
+                targetSettings.common.ENABLE_TESTABILITY = "YES"
+                targetSettings.common.PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)"
+                targetSettings.common.PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)"
+                targetSettings.common.PRODUCT_BUNDLE_IDENTIFIER = module.c99name
+            }
+            else {
+                targetSettings.common.SWIFT_FORCE_STATIC_LINK_STDLIB = "NO"
+                targetSettings.common.SWIFT_FORCE_DYNAMIC_LINK_STDLIB = "YES"
+                
+                targetSettings.common.LD_RUNPATH_SEARCH_PATHS += ["@executable_path"]
+            }
+        }
+        
+        if let pkgArgs = try? module.pkgConfigArgs() {
+            targetSettings.common.OTHER_LDFLAGS = ["$(inherited)"] + pkgArgs.libs
+            targetSettings.common.OTHER_SWIFT_FLAGS = ["$(inherited)"] + pkgArgs.cFlags
+        }
+        
+        // Add header search paths for any C module on which we depend.
+        var hdrInclPaths = [String]()
+        for depModule in [module] + module.recursiveDependencies {
+            // FIXME: Possibly factor this out into a separate protocol; the
+            // idea would be that we would ask the module how it contributes
+            // to the overall build environment for client modules, which can
+            // affect search paths and other flags.  This should be done in a
+            // way that allows SwiftPM to detect incompatibilities.
+            switch depModule {
+              case let cModule as CModule:  // System module
+                hdrInclPaths.append(cModule.path.relative(to: sourceRootDir).asString)
+              case let clangModule as ClangModule:
+                hdrInclPaths.append(clangModule.includeDir.relative(to: sourceRootDir).asString)
+              default:
                 continue
             }
+        }
+        targetSettings.common.HEADER_SEARCH_PATHS = hdrInclPaths
 
-
-            // Generate paths as follows:
-            // Example:
-            //    input: "MyModule/Foo/foo.swift"
-            //   output: ["MyModule/Foo",
-            //            "MyModule"]
-            //
-            let paths = [AbsolutePath](sequence(first: fileRef.path.parentDirectory, next: { path in
-                let parent = path.parentDirectory
-                return parent == moduleRoot ? nil : parent
-            }))
-
-            guard let parentGroupPath = paths.last else {
-                fatalError("The source file: \(path.basename) is expected to be in a nested group")
+        // Add framework search path to build settings.
+        targetSettings.common.FRAMEWORK_SEARCH_PATHS = ["$(PLATFORM_DIR)/Developer/Library/Frameworks"]
+        
+        // Generate a module map for ClangModule (if not provided by user) and
+        // add to the build settings.
+        if case let clangModule as ClangModule = module, clangModule.type == .library {
+            targetSettings.common.DEFINES_MODULE = "YES"
+            let moduleMapPath: AbsolutePath
+            // If user provided the modulemap no need to generate.
+            if isFile(clangModule.moduleMapPath) {
+                moduleMapPath = clangModule.moduleMapPath
+            } else {
+                // Generate and drop the modulemap inside Xcodeproj folder.
+                let path = xcodeprojPath.appending(components: "GeneratedModuleMap", clangModule.c99name)
+                var moduleMapGenerator = ModuleMapGenerator(for: clangModule)
+                try moduleMapGenerator.generateModuleMap(inDir: path)
+                moduleMapPath = path.appending(component: moduleMapFilename)
             }
-
-
-            topLevelRefs.append(parentGroupPath.groupReference(srcroot: srcroot))
-
-            // Calculate children for each group.
-            //
-            // `paths` contains breadcrumbs paths as seen from the file.
-            //
-            // Ex:
-            //   for source file: "MyModule/Foo/Bar/baz.swift"
-            //   `paths` will contain: ["MyModule/Foo/Bar", "MyModule/Foo", "MyModule"]
-            //                               paths[0]           path[1]       path[2]
-            //
-            //   So, the file, baz.swift, will be the child of paths[0],
-            //                  paths[0], will be the child of paths[1],
-            //                  paths[1], will be the child of paths[2], etc.,
-            var currentChildren = fileRef.refId
-            for path in paths {
-                var children = groupsChildren[path] ?? OrderedSet<String>()
-                children.append(currentChildren)
-                groupsChildren[path] = children
-
-                currentChildren = path.groupReference(srcroot: srcroot)
-            }
+            
+            targetSettings.common.MODULEMAP_FILE = moduleMapPath.relative(to: xcodeprojPath.parentDirectory).asString
         }
-
-        // Create nested groups under this module.
-        for (path, children) in groupsChildren {
-            print("        \(path.groupReference(srcroot: srcroot)) = {")
-            print("            isa = PBXGroup;")
-            print("            name = '\(path.basename)';")
-            print("            sourceTree = '<group>';")
-            print("            children = (" + children.joined(separator: ", ") + ");")
-            print("        };")
-        }
-
-        // the “Project Navigator” group for this module
-        print("        \(module.groupReference) = {")
-        print("            isa = PBXGroup;")
-        print("            name = '\(module.name)';")
-        print("            sourceTree = '<group>';")
-        print("            children = (" + topLevelRefs.joined(separator: ", ") + ");")
-        print("        };")
-
-
-        // the target reference for this module’s product
-        print("        \(module.targetReference) = {")
-        print("            isa = PBXNativeTarget;")
-        print("            buildConfigurationList = \(module.configurationListReference);")
-
-        print("            buildPhases = (")
-        // Add a shell script phase for clang module libraries for SR-2465.
-        if module.isClangModuleLibrary {
-            print("\(module.shellScriptPhaseReference), ")
-        }
-        print("\(module.compilePhaseReference), \(module.linkPhaseReference));")
-
-        print("            buildRules = ();")
-        print("            dependencies = (\(module.nativeTargetDependencies));")
-        print("            name = '\(module.name)';")
-        print("            productName = \(module.c99name);")
-        print("            productReference = \(module.productReference);")
-        print("            productType = '\(module.productType)';")
-        print("        };")
-
-        // the product file reference
-        print("        \(module.productReference) = {")
-        print("            isa = PBXFileReference;")
-        print("            explicitFileType = '\(module.explicitFileType)';")
-        print("            path = '\(module.productPath.asString)';")
-        print("            sourceTree = BUILT_PRODUCTS_DIR;")
-        print("        };")
-
-        // shell script build phase.
-        if module.isClangModuleLibrary {
-            print("        \(module.shellScriptPhaseReference) = {")
-            print("            isa = PBXShellScriptBuildPhase;")
-            print("            shellPath = /bin/sh;")
-            print("            shellScript = \"mkdir -p \\\"$PROJECT_TEMP_DIR/SymlinkLibs\\\"\nln -sf \\\"$BUILT_PRODUCTS_DIR/$EXECUTABLE_PATH\\\" \\\"$PROJECT_TEMP_DIR/SymlinkLibs/lib$EXECUTABLE_NAME.dylib\\\"\";")
-            print("            runOnlyForDeploymentPostprocessing = 0;")
-            print("        };")
-        }
-
-        // sources build phase
-        print("        \(module.compilePhaseReference) = {")
-        print("            isa = PBXSourcesBuildPhase;")
-        print("            files = (\(sourceFileRefs.map{ $0.bflId }.joined(separator: ", ")));")
-        print("            runOnlyForDeploymentPostprocessing = 0;")
-        print("        };")
-
-        // the fileRefs for the children in the build phases
-        for fileRef in sourceFileRefs {
-            print("        \(fileRef.bflId) = {")
-            print("            isa = PBXBuildFile;")
-            print("            fileRef = \(fileRef.refId);")
-            print("        };")
-        }
-
-        // link build phase
-        let linkPhaseFileRefs = module.linkPhaseFileRefs
-        print("        \(module.linkPhaseReference) = {")
-        print("            isa = PBXFrameworksBuildPhase;")
-        print("            files = (\(linkPhaseFileRefs.map{ $0.fileRef }.joined(separator: ", ")));")
-        print("            runOnlyForDeploymentPostprocessing = 0;")
-        print("        };")
-        for item in linkPhaseFileRefs {
-            print("        \(item.fileRef) = {")
-            print("            isa = PBXBuildFile;")
-            print("            fileRef = \(item.dependency.productReference);")
-            print("        };")
-        }
-
-        // the target build configuration
-        print("        \(module.configurationListReference) = {")
-        print("            isa = XCConfigurationList;")
-        print("            buildConfigurations = (\(module.debugConfigurationReference), \(module.releaseConfigurationReference));")
-        print("            defaultConfigurationIsVisible = 0;")
-        print("            defaultConfigurationName = Debug;")
-        print("        };")
-        print("        \(module.debugConfigurationReference) = {")
-        print("            isa = XCBuildConfiguration;")
-        print("            buildSettings = \(try module.getDebugBuildSettings(options, xcodeProjectPath: xcodeprojPath))")
-        print("            name = Debug;")
-        print("        };")
-        print("        \(module.releaseConfigurationReference) = {")
-        print("            isa = XCBuildConfiguration;")
-        print("            buildSettings = \(try module.getReleaseBuildSettings(options, xcodeProjectPath: xcodeprojPath))")
-        print("            name = Release;")
-        print("        };")
-
-        //TODO ^^ probably can consolidate this into the three kinds
-        //TODO we use rather than have one per module
-
-        // targets that depend on this target use these
-        print("        \(module.dependencyReference) = {")
-        print("            isa = PBXTargetDependency;")
-        print("            target = \(module.targetReference);")
-        print("        };")
-    }
-
-////// “Configs” group
-    
-    // The project-level xcconfig files.
-    //
-    // FIXME: Generate these into a sane path.
-    let projectXCConfig = fileRef(inProjectRoot: RelativePath("\(xcodeprojPath.basename)/Configs/Project.xcconfig"), srcroot: srcroot)
-    try makeDirectories(projectXCConfig.path.parentDirectory)
-    try open(projectXCConfig.path) { print in
-        // Set the standard PRODUCT_NAME.
-        print("PRODUCT_NAME = $(TARGET_NAME)")
         
-        // Set SUPPORTED_PLATFORMS to all platforms.
-        //
-        // The goal here is to define targets which *can be* built for any
-        // platform (although some might not work correctly). It is then up to
-        // the integrating project to only set these targets up as dependencies
-        // where appropriate.
-        let supportedPlatforms = [
-            "macosx",
-            "iphoneos", "iphonesimulator",
-            "appletvos", "appletvsimulator",
-            "watchos", "watchsimulator"]
-        print("SUPPORTED_PLATFORMS = \(supportedPlatforms.joined(separator: " "))")
-
-        // Set a conservative default deployment target.
-        //
-        // We currently *must* do this for SwiftPM to be able to self-host in
-        // Xcode (otherwise, the PackageDescription library will be incompatible
-        // with the default deployment target we pass when building).
-        //
-        // FIXME: Eventually there should be a way for the project using Xcode
-        // generation to have control over this.
-        print("MACOSX_DEPLOYMENT_TARGET = 10.10")
+        // At the moment, set the Swift version to 3 (we will need to make this dynamic), but for now this is necessary.
+        targetSettings.common.SWIFT_VERSION = "3.0"
         
-        // Default to @rpath-based install names.
-        //
-        // The expectation is that the application or executable consuming these
-        // products will need to establish the appropriate runpath search paths
-        // so that all the products can be found in a relative manner.
-        print("DYLIB_INSTALL_NAME_BASE = @rpath")
+        // Defined for regular `swift build` instantiations, so also should be defined here.
+        targetSettings.common.SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE"
 
-        // Propagate any user provided build flag overrides.
-        //
-        // FIXME: Need to get quoting correct here.
-        if !options.flags.cCompilerFlags.isEmpty {
-            print("OTHER_CFLAGS = \(options.flags.cCompilerFlags.joined(separator: " "))")
-        }
-        if !options.flags.linkerFlags.isEmpty {
-            print("OTHER_LDFLAGS = \(options.flags.linkerFlags.joined(separator: " "))")
-        }
-        print("OTHER_SWIFT_FLAGS = \((options.flags.swiftCompilerFlags+["-DXcode"]).joined(separator: " "))")
+        // Add a file reference for the target's product.
+        let productRef = productsGroup.addFileReference(path: module.productPath.asString, pathBase: .buildDir)
         
-        // Prevents Xcode project upgrade warnings.
-        print("COMBINE_HIDPI_IMAGES = YES")
-
-        // Always disable use of headermaps.
-        //
-        // The semantics of the build should be explicitly defined by the
-        // project structure, we don't want any additional behaviors not shared
-        // with `swift build`.
-        print("USE_HEADERMAP = NO")
-
-        // If the user provided an overriding xcconfig path, include it here.
-        if let path = options.xcconfigOverrides {
-            print("\n#include \"\(path.asString)\"")
+        // Set that file reference as the target's product reference.
+        target.productReference = productRef
+        
+        // Add a shell script build phase to create a symlink to the produced
+        // library in a shared location so other modules can find it.
+        if case let clangModule as ClangModule = module, clangModule.type == .library {
+            let script = "mkdir -p \"${PROJECT_TEMP_DIR}/SymlinkLibs\"\n"
+                       + "ln -sf \"${BUILT_PRODUCTS_DIR}/${EXECUTABLE_PATH}\" \"${PROJECT_TEMP_DIR}/SymlinkLibs/lib${EXECUTABLE_NAME}.dylib\"\n"
+            target.addShellScriptBuildPhase(script: script)
         }
-    }
-    let debugXCConfig = fileRef(inProjectRoot: RelativePath("\(xcodeprojPath.basename)/Configs/Debug.xcconfig"), srcroot: srcroot)
-    try open(debugXCConfig.path) { print in
-        print("#include \"Project.xcconfig\"")
-        print("COPY_PHASE_STRIP = NO")
-        print("DEBUG_INFORMATION_FORMAT = dwarf")
-        print("ENABLE_NS_ASSERTIONS = YES")
-        print("GCC_OPTIMIZATION_LEVEL = 0")
-        print("ONLY_ACTIVE_ARCH = YES")
-        print("SWIFT_OPTIMIZATION_LEVEL = -Onone")
-    }
-    let releaseXCConfig = fileRef(inProjectRoot: RelativePath("\(xcodeprojPath.basename)/Configs/Release.xcconfig"), srcroot: srcroot)
-    try open(releaseXCConfig.path) { print in
-        print("#include \"Project.xcconfig\"")
-        print("DEBUG_INFORMATION_FORMAT = dwarf-with-dsym")
-        print("GCC_OPTIMIZATION_LEVEL = s")
-        print("SWIFT_OPTIMIZATION_LEVEL = -O")
-        print("COPY_PHASE_STRIP = YES")
-    }
-
-    var configs = [projectXCConfig, debugXCConfig, releaseXCConfig]
-    if let path = options.xcconfigOverrides {
-        configs.append(fileRef(inProjectRoot: path.relative(to: srcroot), srcroot: srcroot))
-    }    
-    for configInfo in configs {
-        print("        \(configInfo.refId) = {")
-        print("            isa = PBXFileReference;")
-        print("            lastKnownFileType = text.xcconfig;")
-        print("            path = '\(configInfo.path.relative(to: projectRoot).asString)';")
-        print("            sourceTree = '<group>';")
-        print("        };")
+        
+        // Add a compile build phase (which Xcode calls "Sources").
+        let compilePhase = target.addSourcesBuildPhase()
+        
+        // We don't add dependencies yet — we do so in a separate pass, since
+        // some dependencies might be on targets that we have not yet created.
+        
+        // We also don't add the link phase yet, since we'll do so at the same
+        // time as we set up dependencies.
+        
+        // Record the target that we created for this module, for later passes.
+        modulesToTargets[module] = target
+        
+        // Determine the top-level directory for source files of the module.
+        let moduleRootDir = module.sources.root
+        
+        // Choose either `Sources` or `Tests` as the parent group.
+        let moduleParentGroup = module.isTest ? testsGroup : sourcesGroup
+        
+        // Create a group for the module, and set its path to the module source
+        // root.  We make it a top-level group even if it isn't in the package's
+        // `Sources` directory (doesn't happen in a standard package layout).
+        let moduleGroup = moduleParentGroup.addGroup(path: moduleRootDir.relative(to: sourceRootDir).asString, pathBase: .projectDir, name: module.name)
+        
+        // We add the group to the mapping, so that sources will find it.
+        srcPathsToGroups[moduleRootDir] = moduleGroup
+        
+        // Go through the module source files.  As we do, we create groups for
+        // any path components other than the last one.  We also add build files
+        // to the compile phase of the target we created.
+        for sourceFile in module.sources.paths {
+            // Make (or find) a group for the directory.
+            let group = makeGroup(for: sourceFile.parentDirectory)
+            
+            // Create a reference for the source file.  We don't set its file
+            // type; rather, we let Xcode determine it based on the suffix.
+            let srcFileRef = group.addFileReference(path: sourceFile.basename)
+            
+            // Also add the source file to the compile phase.
+            compilePhase.addBuildFile(fileRef: srcFileRef)
+        }
     }
     
-    print("        \(configsGroupReference) = {")
-    print("            isa = PBXGroup;")
-    print("            children = (" + configs.map{ $0.refId }.joined(separator: ", ") + ");")
-    print("            name = Configs;")
-    print("            sourceTree = '<group>';")
-    print("        };")
-
-////// “Sources” group
-    print("        \(sourcesGroupReference) = {")
-    print("            isa = PBXGroup;")
-    print("            children = (" + nonTestRootModules.map{ $0.groupReference }.joined(separator: ", ") + ");")
-    print("            name = Sources;")
-    print("            sourceTree = '<group>';")
-    print("        };")
-
-    if !externalModules.isEmpty {
-        ////// “Dependencies” group
-        print("        \(dependenciesGroupReference) = {")
-        print("            isa = PBXGroup;")
-        print("            children = (" + externalModules.map{ $0.groupReference }.joined(separator: ", ") + ");")
-        print("            name = Dependencies;")
-        print("            sourceTree = '<group>';")
-        print("        };")
+    // Go through all the module/target pairs again, and add target dependencies
+    // for any module dependencies.  As we go, we also add link phases and set
+    // up the targets to link against the products of the dependencies.
+    for (module, target) in modulesToTargets {
+        // Add link build phase (which Xcode calls "Frameworks & Libraries").
+        // We need to do this whether or not there are dependencies on other
+        // modules.
+        let linkPhase = target.addFrameworksBuildPhase()
+        
+        // For each module on which this one depends, add a target dependency
+        // and also link against the target's product.
+        for dependency in module.recursiveDependencies {
+            // We should never find ourself in the list of dependencies.
+            assert(dependency != module)
+            
+            // Find the target that corresponds to the other module.
+            guard let otherTarget = modulesToTargets[dependency] else {
+                // FIXME: We're depending on a module for which we didn't create
+                // a target.  This is unexpected, and we should report this as
+                // an error.
+                // FIXME: Or is it?  What about system modules, can we depend
+                // on those?  If so, we would just link and not depend, right?
+                continue
+            }
+            
+            // Add a dependency on the other target.
+            target.addDependency(on: otherTarget)
+            let _ = linkPhase.addBuildFile(fileRef: otherTarget.productReference!)
+        }
     }
-
-////// “Tests” group
-    let tests = modules.filter{ $0.isTest }
-    if !tests.isEmpty {
-        print("        \(testsGroupReference) = {")
-        print("            isa = PBXGroup;")
-        print("            children = (" + tests.map{ $0.groupReference }.joined(separator: ", ") + ");")
-        print("            name = Tests;")
-        print("            sourceTree = '<group>';")
-        print("        };")
-    }
-
-    var productReferences: [String] = []
-    if !tests.isEmpty {
-        ////// “Product/Tests” group
-        print("       \(testProductsGroupReference) = {")
-        print("            isa = PBXGroup;")
-        print("            children = (" + tests.map{ $0.productReference }.joined(separator: ", ") + ");")
-        print("            name = Tests;")
-        print("            sourceTree = '<group>';")
-        print("        };")
-
-        productReferences = [testProductsGroupReference]
-    }
-
-////// “Products” group
-    productReferences += modules.flatMap { !$0.isTest ? $0.productReference : nil }
-
-    print("        \(productsGroupReference) = {")
-    print("            isa = PBXGroup;")
-    print("            children = (" + productReferences.joined(separator: ", ") + ");")
-    print("            name = Products;")
-    print("            sourceTree = '<group>';")
-    print("        };")
-
-////// primary build configurations
-    print("        \(rootDebugBuildConfigurationReference) = {")
-    print("            isa = XCBuildConfiguration;")
-    print("            baseConfigurationReference = \(debugXCConfig.0);")
-    print("            buildSettings = {};")
-    print("            name = Debug;")
-    print("        };")
-    print("        \(rootReleaseBuildConfigurationReference) = {")
-    print("            isa = XCBuildConfiguration;")
-    print("            baseConfigurationReference = \(releaseXCConfig.0);")
-    print("            buildSettings = {};")
-    print("            name = Release;")
-    print("        };")
-    print("        \(rootBuildConfigurationListReference) = {")
-    print("            isa = XCConfigurationList;")
-    print("            buildConfigurations = (\(rootDebugBuildConfigurationReference), \(rootReleaseBuildConfigurationReference));")
-    print("            defaultConfigurationIsVisible = 0;")
-    print("            defaultConfigurationName = Debug;")
-    print("        };")
-    print("    };")
-
-////// done!
-    print("}")
-}
-
-extension AbsolutePath {
-    func groupReference(srcroot base: AbsolutePath) -> String {
-        return "__Group_" + relative(to: base).asString
-    }
+    
+    // Finally, serialize the project model we created to a plist, and return
+    // its string description.
+    return "// !$*UTF8*$!\n" + project.generatePlist().description
 }
 
 extension Module {
@@ -491,14 +395,6 @@ private extension SupportedLanguageExtension {
 }
 
 private extension Module {
-
-    var isClangModuleLibrary: Bool {
-        if case let clangModule as ClangModule = self, clangModule.type == .library {
-            return true
-        }
-        return false
-    }
-
     func fileType(forSource source: RelativePath) -> String {
         switch self {
         case is SwiftModule:

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -28,7 +28,7 @@ class GenerateXcodeprojTests: XCTestCase {
             let projectName = "DummyProjectName"
             let dummyPackage = Package(manifest: Manifest(path: dstdir, url: dstdir.asString, package: PackageDescription.Package(name: "Foo"), products: [], version: nil), path: dstdir, modules: [], testModules: [], products: [])
             let graph = PackageGraph(rootPackage: dummyPackage, modules: try dummy(), externalModules: [])
-            let outpath = try Xcodeproj.generate(dstdir: dstdir, projectName: projectName, graph: graph, options: XcodeprojOptions())
+            let outpath = try Xcodeproj.generate(outputDir: dstdir, projectName: projectName, graph: graph, options: XcodeprojOptions())
 
             XCTAssertDirectoryExists(outpath)
             XCTAssertEqual(outpath, dstdir.appending(component: projectName + ".xcodeproj"))

--- a/Tests/XcodeprojTests/XCTestManifests.swift
+++ b/Tests/XcodeprojTests/XCTestManifests.swift
@@ -16,6 +16,8 @@ public func allTests() -> [XCTestCaseEntry] {
         testCase(GenerateXcodeprojTests.allTests),
         testCase(FunctionalTests.allTests),
         testCase(PlistTests.allTests),
+        testCase(XcodeProjectModelTests.allTests),
+        testCase(XcodeProjectModelSerializationTests.allTests),
     ]
 }
 #endif

--- a/Tests/XcodeprojTests/XcodeProjectModelSerializationTests.swift
+++ b/Tests/XcodeprojTests/XcodeProjectModelSerializationTests.swift
@@ -1,0 +1,81 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Basic
+import TestSupport
+@testable import Xcodeproj
+import XCTest
+
+class XcodeProjectModelSerializationTests: XCTestCase {
+    
+    func testBasicProjectSerialization() {
+        // Create a project.
+        let proj = Xcode.Project()
+        
+        // Serialize it to a property list.
+        let plist = proj.generatePlist()
+        
+        // Assert various things about the property list.
+        guard case let .dictionary(topLevelDict) = plist else {
+            XCTFail("top-level of plist must be a dictionary")
+            return
+        }
+        XCTAssertFalse(topLevelDict.isEmpty)
+        
+        // FIXME: We should factor out all of the following using helper assert
+        // functions that deal with the enum casing.
+        
+        // Archive version should be 1.
+        guard case let .string(archiveVersionStr) = topLevelDict["archiveVersion"]! else {
+            XCTFail("top-level plist dictionary must have an `archiveVersion` string")
+            return
+        }
+        XCTAssertEqual(archiveVersionStr, "1")
+        
+        // Object version should be 46 (Xcode 8.0).
+        guard case let .string(objectVersionStr) = topLevelDict["objectVersion"]! else {
+            XCTFail("top-level plist dictionary must have an `objectVersion` string")
+            return
+        }
+        XCTAssertEqual(objectVersionStr, "46")
+        
+        // There should be a root object.
+        guard case let .identifier(rootObjectID) = topLevelDict["rootObject"]! else {
+            XCTFail("top-level plist dictionary must have a `rootObject` string")
+            return
+        }
+        XCTAssertFalse(rootObjectID.isEmpty)
+        
+        // There should be a dictionary mapping identifiers to object dictionaries.
+        guard case let .dictionary(objectDict) = topLevelDict["objects"]! else {
+            XCTFail("top-level plist dictionary must have a `objects` dictionary")
+            return
+        }
+        XCTAssertFalse(objectDict.isEmpty)
+        
+        // The root object should reference a PBXProject dictionary.
+        guard case let .dictionary(projectDict) = objectDict[rootObjectID]! else {
+            XCTFail("object dictionary must have an entry for the project")
+            return
+        }
+        XCTAssertFalse(projectDict.isEmpty)
+        
+        // Project dictionary's `isa` must be "PBXProject".
+        guard case let .string(projectClassName) = projectDict["isa"]! else {
+            XCTFail("project object dictionary must have an `isa` string")
+            return
+        }
+        XCTAssertEqual(projectClassName, "PBXProject")
+    }
+    
+    static var allTests = [
+        ("testBasicProjectCreation", testBasicProjectSerialization),
+    ]
+}

--- a/Tests/XcodeprojTests/XcodeProjectModelTests.swift
+++ b/Tests/XcodeprojTests/XcodeProjectModelTests.swift
@@ -1,0 +1,209 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Basic
+import TestSupport
+@testable import Xcodeproj
+import XCTest
+
+class XcodeProjectModelTests: XCTestCase {
+    
+    func testBasicProjectCreation() {
+        // Create a project.
+        let proj = Xcode.Project()
+        XCTAssert(proj.mainGroup.subitems.isEmpty)
+        XCTAssert(proj.mainGroup.pathBase == .groupDir)
+        XCTAssert(proj.targets.isEmpty)
+        
+        // Add a group to the main group.
+        let group = proj.mainGroup.addGroup(path: "a group")
+        XCTAssert(group.path == "a group")
+        XCTAssert(group.pathBase == .groupDir)
+        XCTAssert(group.name == nil)
+        XCTAssert(group.subitems.isEmpty)
+        
+        // Check that we can assign a group name.
+        group.name = "a group!"
+        XCTAssert(group.name == "a group!")
+        
+        // Check that setting the name didn't change the path.
+        XCTAssert(group.path == "a group")
+        XCTAssert(group.pathBase == .groupDir)
+
+        // Check that we can change the path.
+        group.path = "a group!!"
+        XCTAssert(group.path == "a group!!")
+        XCTAssert(group.pathBase == .groupDir)
+
+        // Check that setting the path didn't change the name we assigned.
+        XCTAssert(group.name == "a group!")
+
+        // Add another group and set a property.
+        let subgroup = group.addGroup(path: "a subpath")
+        subgroup.name = "subgroup name"
+        XCTAssert(subgroup.name == "subgroup name")
+        XCTAssert(subgroup.path == "a subpath")
+        XCTAssert(subgroup.pathBase == .groupDir)
+        
+        // Check that we can change the name and path.
+        subgroup.name = "new name"
+        subgroup.path.append("/subpath")
+        XCTAssert(subgroup.name == "new name")
+        XCTAssert(subgroup.path == "a subpath/subpath")
+        
+        // Add a file reference under the subgroup.
+        let fileRef = subgroup.addFileReference(path: "MyFile.swift")
+        XCTAssert(fileRef.path == "MyFile.swift")
+        XCTAssert(fileRef.pathBase == .groupDir)
+        XCTAssert(fileRef.name == nil)
+        XCTAssert(fileRef.fileType == nil)
+        
+        // Configure the reference.
+        fileRef.path = "Foo/MyFile.swift"
+        XCTAssert(fileRef.path == "Foo/MyFile.swift")
+        
+        // Change the source tree.
+        fileRef.pathBase = .projectDir
+        
+        let _ = proj.generatePlist()
+    }
+    
+    func testTargetCreation() {
+        // Create a project.
+        let proj = Xcode.Project()
+        
+        // Add a `Sources` group and some file refs.
+        let srcGroup = proj.mainGroup.addGroup(path: "Sources")
+        let srcFileRef1 = srcGroup.addFileReference(path: "Source File 1.swift")
+        let srcFileRef2 = srcGroup.addFileReference(path: "Source File 2.swift")
+        
+        // Add a target.
+        let target = proj.addTarget(productType: .executable, name: "My App")
+        XCTAssert(target.name == "My App")
+        XCTAssert(target.productType == .executable)
+        XCTAssert(target.buildPhases.isEmpty)
+        
+        // Add a Sources build phase, and add the file refs to it.
+        let srcPhase = target.addSourcesBuildPhase()
+        XCTAssert(srcPhase.files.isEmpty)
+        let srcBldFile1 = srcPhase.addBuildFile(fileRef: srcFileRef1)
+        let srcBldFile2 = srcPhase.addBuildFile(fileRef: srcFileRef2)
+        XCTAssert(srcBldFile1.fileRef === srcFileRef1)
+        XCTAssert(srcBldFile2.fileRef === srcFileRef2)
+        
+        let _ = proj.generatePlist()
+    }
+    
+    func testBuildPhases() {
+        // Create a project.
+        let proj = Xcode.Project()
+        
+        // Add a `Sources` group and some file refs.
+        let srcGroup = proj.mainGroup.addGroup(path: "Sources")
+        let srcFileRef1 = srcGroup.addFileReference(path: "SourceFile1.swift")
+        let srcFileRef2 = srcGroup.addFileReference(path: "SourceFile2.swift")
+        
+        // Add a `Resources` group and some file refs.
+        let resGroup = proj.mainGroup.addGroup(path: "Resources")
+        let resFileRef1 = resGroup.addFileReference(path: "ResFile1.png")
+        let resFileRef2 = resGroup.addFileReference(path: "ResFile2.xml")
+        
+        // Add a target.
+        let target = proj.addTarget(productType: .dynamicLibrary, name: "My Lib")
+        XCTAssert(target.name == "My Lib")
+        XCTAssert(target.productType == .dynamicLibrary)
+        XCTAssert(target.buildPhases.isEmpty)
+        
+        // Add a Sources build phase, and add the file refs to it.
+        let srcPhase = target.addSourcesBuildPhase()
+        XCTAssert(srcPhase.files.isEmpty)
+        let srcBldFile1 = srcPhase.addBuildFile(fileRef: srcFileRef1)
+        let srcBldFile2 = srcPhase.addBuildFile(fileRef: srcFileRef2)
+        XCTAssert(srcBldFile1.fileRef === srcFileRef1)
+        XCTAssert(srcBldFile2.fileRef === srcFileRef2)
+        
+        // Add a ShellScript build phase, and add the file refs to it.
+        let shPhase = target.addShellScriptBuildPhase(script: "echo 'hello'")
+        XCTAssert(shPhase.files.isEmpty)
+        XCTAssert(shPhase.script == "echo 'hello'")
+        
+        // Add a CopyFiles build phase.
+        let copyPhase = target.addCopyFilesBuildPhase(dstDir: "/tmp")
+        XCTAssert(copyPhase.files.isEmpty)
+        XCTAssert(copyPhase.dstDir == "/tmp")
+        let copyBldFile1 = copyPhase.addBuildFile(fileRef: resFileRef1)
+        let copyBldFile2 = copyPhase.addBuildFile(fileRef: resFileRef2)
+        XCTAssert(copyBldFile1.fileRef === resFileRef1)
+        XCTAssert(copyBldFile2.fileRef === resFileRef2)
+        
+        let _ = proj.generatePlist()
+    }
+    
+    func testProductReferences() {
+        // Create a project.
+        let proj = Xcode.Project()
+        
+        // Add a target.
+        let exeTarget = proj.addTarget(productType: .executable, name: "My Exe")
+        XCTAssert(exeTarget.name == "My Exe")
+        XCTAssert(exeTarget.productType == .executable)
+        
+        // Associate a product reference.
+        
+        let _ = proj.generatePlist()
+    }
+    
+    func testTargetDependencies() {
+        // Create a project.
+        let proj = Xcode.Project()
+        
+        // Add a target.
+        let appTarget = proj.addTarget(productType: .executable, name: "My App")
+        XCTAssert(appTarget.name == "My App")
+        XCTAssert(appTarget.productType == .executable)
+        
+        // Add another target.
+        let libTarget = proj.addTarget(productType: .framework, name: "My Lib")
+        XCTAssert(libTarget.name == "My Lib")
+        XCTAssert(libTarget.productType == .framework)
+        
+        // Make the app target depend on the library target.
+        appTarget.addDependency(on: libTarget)
+        
+        let _ = proj.generatePlist()
+    }
+    
+    func testBuildSettings() {
+        // Create a build settings table.
+        let settings = Xcode.BuildSettingsTable()
+        
+        // Make sure we start out empty.
+        XCTAssertNil(settings.common.HEADER_SEARCH_PATHS)
+        XCTAssertNil(settings.common.PROJECT_NAME)
+        
+        // Do a couple of basic checks.  These properties are standard Strings
+        // [String]s, though, so we don't need too intensive testing.
+        settings.common.PROJECT_NAME = "Bla"
+        XCTAssertNotNil(settings.common.PROJECT_NAME)
+        settings.common.PROJECT_NAME = nil
+        XCTAssertNil(settings.common.PROJECT_NAME)
+        settings.common.HEADER_SEARCH_PATHS = ["$(inherited)"]
+        settings.common.HEADER_SEARCH_PATHS += ["/tmp/path"]
+        XCTAssertEqual(settings.common.HEADER_SEARCH_PATHS!, ["$(inherited)", "/tmp/path"])
+    }
+    
+    static var allTests = [
+        ("testBasicProjectCreation", testBasicProjectCreation),
+        ("testTargetCreation",       testTargetCreation),
+        ("testBuildPhases",          testBuildPhases),
+        ("testTargetDependencies",   testTargetDependencies),
+        ("testBuildSettings",        testBuildSettings),
+    ]
+}


### PR DESCRIPTION
This is a first version of a more layered, robust, and readable Xcode project generation.  The idea is to provide a simple representation of the Xcode project model, so that the logic that creates a project is readable, understandable, and maintainable.  The actual generation of the project file is then a separate, testable layer, as is the transformation of the plist to text.

There are plenty more tests that should be added, and there are plenty of FIXMEs in the code for future improvements.  There generation of schemes should also be redone in the same manner, but that is a much simpler model and completely separate from the project model.  It will be done as a separate PR.

At this point the PR has be updated to the top-of-master, passes all unit tests (including the fixtures), is able to generate SwiftPM itself, and has resolved all known issues to handle all cases that the old implementation could.  This should be a much better platform on which to do future enhancements and fixes.

Note:  This code does not try to assign human-authored object identifiers.  I went down that path at first, but it is a lot of effort on the part of the logic that creates the model for no apparent gain.  We may all have our opinions about Xcode's use of opaque object identifiers in the project file, but those relate mostly to diffing project file changes in the case in which the project file is primary data.  In this case the project is entirely generated and is not intended to be checked into an SCM, so there is less need to diff it.  That said, the identifiers are of course entirely predictable, so that the exact same output is always created when generating the project file.