### PR TITLE
Warn if clang < 3.6 on Ubuntu

### DIFF
--- a/Sources/Utility/misc.swift
+++ b/Sources/Utility/misc.swift
@@ -1,0 +1,29 @@
+/*
+ This source file is part of the Swift.org open source project
+ 
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+ 
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// Get clang's version from the given version output string on Ubuntu.
+public func getClangVersion(versionOutput: String) -> (major: Int, minor: Int)? {
+    // Clang outputs version in this format on Ubuntu:
+    // Ubuntu clang version 3.6.0-2ubuntu1~trusty1 (tags/RELEASE_360/final) (based on LLVM 3.6.0)
+    let versionStringPrefix = "Ubuntu clang version "
+    let versionStrings = versionOutput.utf8.split(separator: UInt8(ascii: "-")).flatMap(String.init)
+    guard let clangVersionString = versionStrings.first,
+          clangVersionString.hasPrefix(versionStringPrefix) else {
+        return nil
+    }
+    let versionStartIndex = clangVersionString.index(clangVersionString.startIndex, offsetBy: versionStringPrefix.utf8.count)
+    let versionString = clangVersionString[versionStartIndex..<clangVersionString.endIndex]
+    // Split major minor patch etc.
+    let versions = versionString.utf8.split(separator: UInt8(ascii: ".")).flatMap(String.init)
+    guard versions.count > 1, let major = Int(versions[0]), let minor = Int(versions[1]) else {
+        return nil
+    }
+    return (major, minor)
+}

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 import TestSupport
 import Basic
-import Commands
+@testable import Commands
 
 final class BuildToolTests: XCTestCase {
     private func execute(_ args: [String], chdir: AbsolutePath? = nil) throws -> String {

--- a/Tests/UtilityTests/XCTestManifests.swift
+++ b/Tests/UtilityTests/XCTestManifests.swift
@@ -15,6 +15,7 @@ public func allTests() -> [XCTestCaseEntry] {
     return [
         testCase(CollectionTests.allTests),
         testCase(GitUtilityTests.allTests),
+        testCase(miscTests.allTests),
         testCase(PkgConfigParserTests.allTests),
         testCase(ProgressBarTests.allTests),
         testCase(ShellTests.allTests),

--- a/Tests/UtilityTests/miscTests.swift
+++ b/Tests/UtilityTests/miscTests.swift
@@ -1,0 +1,32 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import XCTest
+@testable import Utility
+
+class miscTests: XCTestCase {
+    func testClangVersionOutput() {
+        var versionOutput = ""
+        XCTAssert(getClangVersion(versionOutput: versionOutput) == nil)
+
+        versionOutput = "some - random - string"
+        XCTAssert(getClangVersion(versionOutput: versionOutput) == nil)
+
+        versionOutput = "Ubuntu clang version 3.6.0-2ubuntu1~trusty1 (tags/RELEASE_360/final) (based on LLVM 3.6.0)"
+        XCTAssert(getClangVersion(versionOutput: versionOutput) ?? (0, 0) == (3, 6))
+
+        versionOutput = "Ubuntu clang version 2.4-1ubuntu3 (tags/RELEASE_34/final) (based on LLVM 3.4)"
+        XCTAssert(getClangVersion(versionOutput: versionOutput) ?? (0, 0) == (2, 4))
+    }
+
+    static var allTests = [
+        ("testClangVersionOutput", testClangVersionOutput),
+    ]
+}


### PR DESCRIPTION
Since gold linker option is available from clang 3.6 the builds fail on
14.04 because it ships with clang 3.4 and only ways to fix are either
replace ld with gold system wide or update clang.

- https://bugs.swift.org/browse/SR-2299
- <rdar://problem/28108951> SR-2299 Swift isn't using Gold by default on
  stock 14.04