### PR TITLE
[Xcodeproj] Fix Build Settings Plist

### DIFF
--- a/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
+++ b/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
@@ -339,7 +339,8 @@ extension Xcode.BuildSettingsTable.BuildSettings {
     /// applies to classes.  Creating a property list representation is totally
     /// independent of that serialization infrastructure (though it might well
     /// be invoked during of serialization of actual model objects).
-    fileprivate func asPropertyList() -> PropertyList {
+    // FIXME: Internal only for unit testing.
+    func asPropertyList() -> PropertyList {
         // Borderline hacky, but the main thing is that adding or changing a
         // build setting does not require any changes to the property list
         // representation code.  Using a handcoded serializer might be more

--- a/Tests/XcodeprojTests/XcodeProjectModelSerializationTests.swift
+++ b/Tests/XcodeprojTests/XcodeProjectModelSerializationTests.swift
@@ -75,7 +75,57 @@ class XcodeProjectModelSerializationTests: XCTestCase {
         XCTAssertEqual(projectClassName, "PBXProject")
     }
     
+    func testBuildSettingsSerialization() {
+        
+        // Create build settings.
+        var buildSettings = Xcode.BuildSettingsTable.BuildSettings()
+        
+        let productNameValue = "$(TARGET_NAME:c99extidentifier)"
+        buildSettings.PRODUCT_NAME = productNameValue
+        
+        let otherSwiftFlagValues = ["$(inherited)", "-DXcode"]
+        buildSettings.OTHER_SWIFT_FLAGS = otherSwiftFlagValues
+
+        // Serialize it to a property list.
+        let plist = buildSettings.asPropertyList()
+        
+        // Assert things about plist
+        guard case let .dictionary(buildSettingsDict) = plist else {
+            XCTFail("build settings plist must be a dictionary")
+            return
+        }
+        
+        guard
+            let productNamePlist = buildSettingsDict["PRODUCT_NAME"],
+            let otherSwiftFlagsPlist = buildSettingsDict["OTHER_SWIFT_FLAGS"]
+        else {
+            XCTFail("build settings plist must contain PRODUCT_NAME and OTHER_SWIFT_FLAGS")
+            return
+        }
+        
+        guard case let .string(productName) = productNamePlist else {
+            XCTFail("productName plist must be a string")
+            return
+        }
+        XCTAssertEqual(productName, productNameValue)
+
+        guard case let .array(otherSwiftFlagsPlists) = otherSwiftFlagsPlist else {
+            XCTFail("otherSwiftFlags plist must be an array")
+            return
+        }
+        
+        let otherSwiftFlags = otherSwiftFlagsPlists.flatMap { flagPlist -> String? in
+            guard case let .string(flag) = flagPlist else {
+                XCTFail("otherSwiftFlag plist must be string")
+                return nil
+            }
+            return flag
+        }
+        XCTAssertEqual(otherSwiftFlags, otherSwiftFlagValues)
+    }
+    
     static var allTests = [
-        ("testBasicProjectCreation", testBasicProjectSerialization),
+        ("testBasicProjectSerialization", testBasicProjectSerialization),
+        ("testBuildSettingsSerialization", testBuildSettingsSerialization),
     ]
 }


### PR DESCRIPTION
This fixes an issue in ```toPlist()``` where arrays of strings were being escaped and having extra quotes added incorrectly when Plist enum ```serialize()``` already performs that work.

The downstream effect was that the build settings for modules were incorrect in Xcode in cases where an array of arguments was passed in. This effects ``OTHER_SWIFT_FLAGS```, ```OTHER_LDFLAGS```, etc.

For example, see this screen shot where the module build setting ```OTHER_SWIFT_FLAGS``` is set to ```"$(inherited)"``` instead of ```$(inherited)```. In this example, ```-DXcode``` is not passed to the compiler. 

<img width="891" alt="screen shot 2016-09-10 at 12 45 02 pm" src="https://cloud.githubusercontent.com/assets/7111607/18413141/7a4916ae-7754-11e6-9395-67783a6a1158.png">


Here is the generated build settings in ```project.pbxproj```:

<img width="785" alt="screen shot 2016-09-10 at 1 03 00 pm" src="https://cloud.githubusercontent.com/assets/7111607/18413246/0c3bfa48-7757-11e6-9c5d-fa269511e80d.png">

