### PR TITLE
[Xcodeproj] conditionally add default linker path

### DIFF
--- a/Sources/Xcodeproj/Module+PBXProj.swift
+++ b/Sources/Xcodeproj/Module+PBXProj.swift
@@ -219,11 +219,13 @@ extension Module  {
         var buildSettings = [String: Any]()
         let plistPath = xcodeProjectPath.appending(component: infoPlistFileName)
 
-        // Add default library search path to the directory where symlinks to framework
+        // Add default library search path to the directory where symlinks to C target framework
         // binaries will be put with name `lib<library-name>.dylib` so that autolinking
         // can proceed without providing another modulemap for Xcode projects.
         // See: https://bugs.swift.org/browse/SR-2465
-        buildSettings["LIBRARY_SEARCH_PATHS"] = ["$(PROJECT_TEMP_DIR)/SymlinkLibs/"]
+        if recursiveDependencies.first(where: { $0 is ClangModule }) != nil {
+            buildSettings["LIBRARY_SEARCH_PATHS"] = ["$(PROJECT_TEMP_DIR)/SymlinkLibs/"]
+        }
 
         if isTest {
             buildSettings["EMBEDDED_CONTENT_CONTAINS_SWIFT"] = "YES"


### PR DESCRIPTION
<rdar://problem/28253740> Don't add add the default linker search path
in Xcode generation if there are no C Targets dependees on Swift target