### PR TITLE
SR-1708: Fix incorrect use of virtual nodes in the generated build manifest

### DIFF
--- a/Sources/Build/Command.compile(ClangModule).swift
+++ b/Sources/Build/Command.compile(ClangModule).swift
@@ -61,12 +61,12 @@ struct ClangModuleBuildMetadata {
         return module.recursiveDependencies.flatMap { module in
             switch module {
             case let module as ClangModule:
-                 let product = Product(name: module.name, type: .Library(.Dynamic), modules: [module])
-                return product.targetName
-            case let module as CModule:
-                return module.targetName
+                let product = Product(name: module.name, type: .Library(.Dynamic), modules: [module])
+                return prefix.appending(product.outname).asString
+            case is CModule:
+                return nil
             case let module as SwiftModule:
-                return module.targetName
+                return prefix.appending(component: module.c99name + ".swiftmodule").asString
             default:
                 fatalError("ClangModule \(self.module) can't have \(module) as a dependency.")
             }

--- a/Sources/Build/Command.compile(ClangModule).swift
+++ b/Sources/Build/Command.compile(ClangModule).swift
@@ -141,7 +141,7 @@ extension Command {
                                   args: [compilerExec.asString] + args,
                                   deps: path.deps.asString)
 
-            let command = Command(node: path.object.asString, tool: clang)
+            let command = Command(name: path.object.asString, tool: clang)
 
             compileCommands.append(command)
         }

--- a/Sources/Build/Command.compile(SwiftModule).swift
+++ b/Sources/Build/Command.compile(SwiftModule).swift
@@ -30,6 +30,6 @@ extension Command {
       #endif
 
         let tool = SwiftcTool(module: module, prefix: prefix, otherArgs: args + otherArgs, executable: compilerExec.asString, conf: conf)
-        return Command(node: module.targetName, tool: tool)
+        return Command(name: module.targetName, tool: tool)
     }
 }

--- a/Sources/Build/Command.link(ClangModule).swift
+++ b/Sources/Build/Command.link(ClangModule).swift
@@ -56,6 +56,6 @@ extension Command {
                               outputs: [productPath.asString, product.targetName],
                               args: [linkerExec.asString] + args)
         
-        return Command(node: product.targetName, tool: shell)
+        return Command(name: product.targetName, tool: shell)
     }
 }

--- a/Sources/Build/Command.link(ClangModule).swift
+++ b/Sources/Build/Command.link(ClangModule).swift
@@ -53,7 +53,7 @@ extension Command {
         
         let shell = ShellTool(description: "Linking \(product.name)",
                               inputs: objects.map{ $0.asString } + inputs,
-                              outputs: [productPath.asString, product.targetName],
+                              outputs: [productPath.asString],
                               args: [linkerExec.asString] + args)
         
         return Command(name: product.targetName, tool: shell)

--- a/Sources/Build/Command.link(SwiftModule).swift
+++ b/Sources/Build/Command.link(SwiftModule).swift
@@ -47,7 +47,7 @@ extension Command {
 
         case .Library(.Static):
             let inputs = buildables.map{ $0.targetName } + objects.map{ $0.asString }
-            let outputs = [product.targetName, outpath.asString]
+            let outputs = [outpath.asString]
             return Command(name: product.targetName, tool: ArchiveTool(inputs: inputs, outputs: outputs))
         }
 
@@ -103,7 +103,7 @@ extension Command {
         let shell = ShellTool(
             description: "Linking \(outpath.prettyPath)",
             inputs: objects.map{ $0.asString },
-            outputs: [product.targetName, outpath.asString],
+            outputs: [outpath.asString],
             args: args)
 
         return Command(name: product.targetName, tool: shell)

--- a/Sources/Build/Command.link(SwiftModule).swift
+++ b/Sources/Build/Command.link(SwiftModule).swift
@@ -48,7 +48,7 @@ extension Command {
         case .Library(.Static):
             let inputs = buildables.map{ $0.targetName } + objects.map{ $0.asString }
             let outputs = [product.targetName, outpath.asString]
-            return Command(node: product.targetName, tool: ArchiveTool(inputs: inputs, outputs: outputs))
+            return Command(name: product.targetName, tool: ArchiveTool(inputs: inputs, outputs: outputs))
         }
 
         switch product.type {
@@ -106,6 +106,6 @@ extension Command {
             outputs: [product.targetName, outpath.asString],
             args: args)
 
-        return Command(node: product.targetName, tool: shell)
+        return Command(name: product.targetName, tool: shell)
     }
 }

--- a/Sources/Build/Command.swift
+++ b/Sources/Build/Command.swift
@@ -8,7 +8,14 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+/// A command represents an atomic unit of build system work.
 struct Command {
-    let node: String
+    /// A unique name for the command.  This need not match any of the outputs
+    /// of the tool, but it does define the stable identifier that is used to
+    /// match up incremental build records.
+    let name: String
+    
+    /// A configured tool instance for the command.
+    /// FIXME: Clean up the names here; tool, command, task, etc.
     let tool: ToolProtocol
 }

--- a/Sources/Build/ToolProtocol.swift
+++ b/Sources/Build/ToolProtocol.swift
@@ -104,8 +104,15 @@ struct SwiftcTool: ToolProtocol {
     }
 }
 
+/// A target is a grouping of commands that should be built together for a
+/// particular purpose.
 struct Target {
-    let node: String
+    /// A unique name for the target.  These should be names that have meaning
+    /// to a client wanting to control the build.
+    let name: String
+    
+    /// A list of commands to run when building the target.  A command may be
+    /// in multiple targets, or might not be in any target at all.
     var cmds: [Command]
 }
 

--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -86,7 +86,7 @@ public func describe(_ prefix: AbsolutePath, _ conf: Configuration, _ graph: Pac
         stream <<< "tools: {}\n"
         stream <<< "targets:\n"
         for target in [targets.test, targets.main] {
-            stream <<< "  " <<< Format.asJSON(target.name) <<< ": " <<< Format.asJSON(target.cmds.map{$0.name}) <<< "\n"
+            stream <<< "  " <<< Format.asJSON(target.name) <<< ": " <<< Format.asJSON(target.cmds.flatMap{$0.tool.outputs}) <<< "\n"
         }
         stream <<< "default: " <<< Format.asJSON(targets.main.name) <<< "\n"
         stream <<< "commands: \n"

--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -86,12 +86,12 @@ public func describe(_ prefix: AbsolutePath, _ conf: Configuration, _ graph: Pac
         stream <<< "tools: {}\n"
         stream <<< "targets:\n"
         for target in [targets.test, targets.main] {
-            stream <<< "  " <<< Format.asJSON(target.node) <<< ": " <<< Format.asJSON(target.cmds.map{$0.node}) <<< "\n"
+            stream <<< "  " <<< Format.asJSON(target.node) <<< ": " <<< Format.asJSON(target.cmds.map{$0.name}) <<< "\n"
         }
         stream <<< "default: " <<< Format.asJSON(targets.main.node) <<< "\n"
         stream <<< "commands: \n"
         for command in commands {
-            stream <<< "  " <<< Format.asJSON(command.node) <<< ":\n"
+            stream <<< "  " <<< Format.asJSON(command.name) <<< ":\n"
             command.tool.append(to: stream)
             stream <<< "\n"
         }

--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -86,9 +86,9 @@ public func describe(_ prefix: AbsolutePath, _ conf: Configuration, _ graph: Pac
         stream <<< "tools: {}\n"
         stream <<< "targets:\n"
         for target in [targets.test, targets.main] {
-            stream <<< "  " <<< Format.asJSON(target.node) <<< ": " <<< Format.asJSON(target.cmds.map{$0.name}) <<< "\n"
+            stream <<< "  " <<< Format.asJSON(target.name) <<< ": " <<< Format.asJSON(target.cmds.map{$0.name}) <<< "\n"
         }
-        stream <<< "default: " <<< Format.asJSON(targets.main.node) <<< "\n"
+        stream <<< "default: " <<< Format.asJSON(targets.main.name) <<< "\n"
         stream <<< "commands: \n"
         for command in commands {
             stream <<< "  " <<< Format.asJSON(command.name) <<< ":\n"
@@ -106,8 +106,8 @@ private func write(path: AbsolutePath, write: (OutputByteStream) -> Void) throws
 }
 
 private struct Targets {
-    var test = Target(node: "test", cmds: [])
-    var main = Target(node: "main", cmds: [])
+    var test = Target(name: "test", cmds: [])
+    var main = Target(name: "main", cmds: [])
 
     mutating func append(_ commands: [Command], for buildable: Buildable) {
         if !buildable.isTest {

--- a/Tests/BuildTests/DescribeTests.swift
+++ b/Tests/BuildTests/DescribeTests.swift
@@ -60,7 +60,7 @@ final class DescribeTests: XCTestCase {
         let swiftModule = try SwiftModule(name: "SwiftModule", sources: Sources(paths: [], root: .root))
         clangModule.dependencies = [swiftModule]
         let buildMeta = ClangModuleBuildMetadata(module: clangModule, prefix: .root, otherArgs: [])
-        XCTAssertEqual(buildMeta.inputs, ["<SwiftModule.module>"])
+        XCTAssertEqual(buildMeta.inputs, ["/SwiftModule.swiftmodule"])
     }
 
     static var allTests = [

--- a/Tests/BuildTests/IncrementalBuildTests.swift
+++ b/Tests/BuildTests/IncrementalBuildTests.swift
@@ -1,0 +1,89 @@
+/*
+ This source file is part of the Swift.org open source project
+ 
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+ 
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+import TestSupport
+import Basic
+import Utility
+import func libc.sleep
+
+
+/// Functional tests of incremental builds.  These are fairly ad hoc at this
+/// point, and because of the time they take, they need to be kept minimal.
+/// There are at least a couple of ways in which this could be improved to a
+/// greater or lesser degree:
+///
+/// a) we could look at the llbuild manifest to determine that the right fine-
+///    grained dependencies exist (however, this feels a bit too much like a
+///    "test that we wrote what we wrote" kind of test, i.e. it doesn't really
+///    test that the net effect of triggering rebuilds is achieved; it is also
+///    hard to write such tests in a black-box manner, i.e. in terms of the
+///    desired effect
+///
+/// b) a much better way would be if llbuild could quickly report on what files
+///    it would update if a build were to be triggered;  this would be a lot
+///    faster than actually doing the build, but would of course also bake in
+///    an assumption that the needs-to-be-rebuilt state of a file system entity
+///    could be determined without running any of the commands (i.e. it would
+///    assume that there's no feedback during the build)
+///
+final class IncrementalBuildTests: XCTestCase {
+
+    func testIncrementalSingleModuleCLibraryInSources() {
+        fixture(name: "ClangModules/CLibrarySources") { prefix in
+            // Build it once and capture the log (this will be a full build).
+            let fullLog = try executeSwiftBuild(prefix, configuration: .Debug, printIfError: true, Xcc: [], Xld: [], Xswiftc: [], env: [:])
+            
+            // Check various things that we expect to see in the full build log.
+            // FIXME:  This is specific to the format of the log output, which
+            // is quite unfortunate but not easily avoidable at the moment.
+            XCTAssertTrue(fullLog.contains("Compile CLibrarySources Foo.c"))
+            XCTAssertTrue(fullLog.contains("Linking CLibrarySources"))
+            
+            // Now sleep for one second.  This is super-unfortunate, but with
+            // the one-second granularity that many file systems have, and with
+            // the lower-level build engine still using timestamps to determine
+            // when files change, we need to make sure that touching the file
+            // results in a new timestamp.
+            sleep(1)
+            
+            // Touch a source file.  Right now the way to do that is to write
+            // out the file contents again.
+            // FIXME: We can make this better when/if we get a way to set the
+            // timestamp of a file in the `FileSystem` class.  However, when
+            // the low-level build system starts looking at file contents (as
+            // I hope that it will at some point), we may again want to do this
+            // by reading the contents, appending a newline, and then writing
+            // it out.
+            let sourceFile = prefix.appending(components: "Sources", "Foo.c")
+            let contents = try localFileSystem.readFileContents(sourceFile)
+            try localFileSystem.writeFileContents(sourceFile, bytes: contents)
+            
+            // Now build again.  This should be an incremental build.
+            let log2 = try executeSwiftBuild(prefix, configuration: .Debug, printIfError: true, Xcc: [], Xld: [], Xswiftc: [], env: [:])
+            XCTAssertTrue(log2.contains("Compile CLibrarySources Foo.c"))
+            XCTAssertTrue(log2.contains("Linking CLibrarySources"))
+            
+            // Now build again without changing anything.  This should be a null
+            // build.
+            let log3 = try executeSwiftBuild(prefix, configuration: .Debug, printIfError: true, Xcc: [], Xld: [], Xswiftc: [], env: [:])
+            XCTAssertFalse(log3.contains("Compile CLibrarySources Foo.c"))
+            XCTAssertFalse(log3.contains("Linking CLibrarySources"))
+        }
+    }
+    
+    // FIXME:  We should add a lot more test cases here; the one above is just
+    // a starter test.
+    
+    static var allTests = [
+        ("testIncrementalSingleModuleCLibraryInSources", testIncrementalSingleModuleCLibraryInSources),
+    ]
+}

--- a/Tests/BuildTests/XCTestManifests.swift
+++ b/Tests/BuildTests/XCTestManifests.swift
@@ -14,6 +14,7 @@ import XCTest
 public func allTests() -> [XCTestCaseEntry] {
     return [
         testCase(DescribeTests.allTests),
+        testCase(IncrementalBuildTests.allTests),
     ]
 }
 #endif


### PR DESCRIPTION
This is a fix for https://bugs.swift.org/browse/SR-1708.

The actual problem is a bit deeper, and comes from incorrect assumptions about how llbuild works.  The solution is to eliminate the virtual nodes and instead model the actual file system dependencies.

I have split the changes into three commits; the first two perform some name changes that result in a lot of diffs but that are straightforward.  The third commit contains the semantic changes.

There is one more thing to add to this PR, which is some better testing than the minimal amount that was already in place.  But I don't know of any more bugs in the logic (missing dependencies, in particular).