### PR TITLE
Refactor command

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -13,57 +13,18 @@ import POSIX
 import PackageModel
 import Utility
 
-// FIXME: The functionality to find the package root path etc should move to `SwiftTool`, and `Options` should be a struct that gets initialized in a clean way other than just on demand.  Right now, for example, if you happen to ask for `path.root` (which doesn't mean the path of the root directory but rather the top-level package directory path) before you change directory to the path specified by `chdir`, you get the wrong value.  This doesn't need to be so complicated, and in particular, behavior shouldn't depend on the order in which properties are asked for.
 public class Options {
     public var chdir: AbsolutePath?
-    public var path = Path()
     public var enableNewResolver = false
     public var colorMode: ColorWrap.Mode = .Auto
     public var verbosity: Int = 0
     public var buildPath: AbsolutePath?
 
-    public class Path {
-        public lazy var root = getroot()
-        public var packages: AbsolutePath { return root.appending(component: "Packages") }
-
-        public var build: AbsolutePath {
-            get { return _build != nil ? AbsolutePath(_build!) : getroot().appending(component: ".build") }
-            set { _build = newValue.asString }
-        }
-        private var _build = getEnvBuildPath()?.asString
-    }
-
     public init()
     {}
-}
-
-fileprivate func getEnvBuildPath() -> AbsolutePath? {
-    guard let env = getenv("SWIFT_BUILD_PATH") else { return nil }
-    return AbsolutePath(env, relativeTo: currentWorkingDirectory)
 }
 
 public struct Flag {
     public static let chdir = "--chdir"
     public static let C = "-C"
-}
-
-private func getroot() -> AbsolutePath {
-    var root = currentWorkingDirectory
-    while !isFile(root.appending(component: Manifest.filename)) {
-        root = root.parentDirectory
-
-        guard !root.isRoot else {
-            // abort because lazy properties cannot throw and we
-            // want erroring on no manifest found to be “lazy” so
-            // any path that requires this property errors, but we
-            // don't have to correctly figure out all those paths
-            // ahead of time, since that is flakier
-            
-            let header = ColorWrap.wrap("error:", with: .Red, for: .stdErr) 
-
-            print("\(header): no Package.swift found", to: &stderr)
-            exit(1)
-        }
-    }
-    return root
 }

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -18,6 +18,8 @@ public class Options {
     public var chdir: AbsolutePath?
     public var path = Path()
     public var enableNewResolver = false
+    public var colorMode: ColorWrap.Mode = .Auto
+    public var verbosity: Int = 0
 
     public class Path {
         public lazy var root = getroot()

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -20,6 +20,7 @@ public class Options {
     public var enableNewResolver = false
     public var colorMode: ColorWrap.Mode = .Auto
     public var verbosity: Int = 0
+    public var buildPath: AbsolutePath?
 
     public class Path {
         public lazy var root = getroot()

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -98,10 +98,8 @@ private enum BuildToolFlag: Argument {
 }
 
 public class BuildToolOptions: Options {
-    var verbosity: Int = 0
     var flags = BuildFlags()
     var buildTests: Bool = false
-    var colorMode: ColorWrap.Mode = .Auto
 }
 
 /// swift-build tool namespace

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -20,13 +20,13 @@ import protocol Build.Toolchain
 
 import func POSIX.chdir
 
-private enum Mode: Argument, Equatable, CustomStringConvertible {
+public enum BuildToolMode: Argument, Equatable, CustomStringConvertible {
     case build(Configuration, Toolchain)
     case clean(CleanMode)
     case usage
     case version
 
-    init?(argument: String, pop: @escaping () -> String?) throws {
+    public init?(argument: String, pop: @escaping () -> String?) throws {
         switch argument {
         case "--configuration", "--config", "-c":
             self = try .build(Configuration(pop()), UserToolchain())
@@ -41,7 +41,7 @@ private enum Mode: Argument, Equatable, CustomStringConvertible {
         }
     }
 
-    var description: String {
+    public var description: String {
         switch self {
             case .build(let conf, _): return "--configuration \(conf)"
             case .clean(let mode): return "--clean \(mode)"
@@ -97,7 +97,7 @@ private enum BuildToolFlag: Argument {
     }
 }
 
-private class BuildToolOptions: Options {
+public class BuildToolOptions: Options {
     var verbosity: Int = 0
     var flags = BuildFlags()
     var buildTests: Bool = false
@@ -105,22 +105,21 @@ private class BuildToolOptions: Options {
 }
 
 /// swift-build tool namespace
-public class SwiftBuildTool: SwiftTool {
+public class SwiftBuildTool: SwiftTool<BuildToolMode, BuildToolOptions> {
 
     override func runImpl() {
         do {
-            let (mode, opts) = try parse(commandLineArguments: args)
+
+            verbosity = Verbosity(rawValue: options.verbosity)
+            colorMode = options.colorMode
         
-            verbosity = Verbosity(rawValue: opts.verbosity)
-            colorMode = opts.colorMode
-        
-            if let dir = opts.chdir {
+            if let dir = options.chdir {
                 try chdir(dir.asString)
             }
             
             switch mode {
             case .usage:
-                usage()
+                SwiftBuildTool.usage()
         
             case .version:
                 print(Versioning.currentVersion.completeDisplayString)
@@ -131,29 +130,29 @@ public class SwiftBuildTool: SwiftTool {
                 // See: <rdar://problem/28108951> SR-2299 Swift isn't using Gold by default on stock 14.04.
                 checkClangVersion()
               #endif
-                let graph = try loadPackage(at: opts.path.root, opts)
-                let yaml = try describe(opts.path.build, conf, graph, flags: opts.flags, toolchain: toolchain)
-                try build(yamlPath: yaml, target: opts.buildTests ? "test" : nil)
+                let graph = try loadPackage(at: options.path.root, options)
+                let yaml = try describe(options.path.build, conf, graph, flags: options.flags, toolchain: toolchain)
+                try build(yamlPath: yaml, target: options.buildTests ? "test" : nil)
         
             case .clean(.dist):
-                if exists(opts.path.packages) {
-                    try removeFileTree(opts.path.packages)
+                if exists(options.path.packages) {
+                    try removeFileTree(options.path.packages)
                 }
                 fallthrough
         
             case .clean(.build):
                 // FIXME: This test is lame, `removeFileTree` shouldn't error on this.
-                if exists(opts.path.build) {
-                    try removeFileTree(opts.path.build)
+                if exists(options.path.build) {
+                    try removeFileTree(options.path.build)
                 }
             }
         
         } catch {
-            handle(error: error, usage: usage)
+            handle(error: error, usage: SwiftBuildTool.usage)
         }
     }
 
-    private func usage(_ print: (String) -> Void = { print($0) }) {
+    override class func usage(_ print: (String) -> Void = { print($0) }) {
         //     .........10.........20.........30.........40.........50.........60.........70..
         print("OVERVIEW: Build sources into binary products")
         print("")
@@ -175,34 +174,34 @@ public class SwiftBuildTool: SwiftTool {
         print("NOTE: Use `swift package` to perform other functions on packages")
     }
     
-    private func parse(commandLineArguments args: [String]) throws -> (Mode, BuildToolOptions) {
-        let (mode, flags): (Mode?, [BuildToolFlag]) = try Basic.parseOptions(arguments: args)
+    override class func parse(commandLineArguments args: [String]) throws -> (BuildToolMode, BuildToolOptions) {
+        let (mode, flags): (BuildToolMode?, [BuildToolFlag]) = try Basic.parseOptions(arguments: args)
     
-        let opts = BuildToolOptions()
+        let options = BuildToolOptions()
         for flag in flags {
             switch flag {
             case .chdir(let path):
-                opts.chdir = path
+                options.chdir = path
             case .verbose(let amount):
-                opts.verbosity += amount
+                options.verbosity += amount
             case .xcc(let value):
-                opts.flags.cCompilerFlags.append(value)
+                options.flags.cCompilerFlags.append(value)
             case .xld(let value):
-                opts.flags.linkerFlags.append(value)
+                options.flags.linkerFlags.append(value)
             case .xswiftc(let value):
-                opts.flags.swiftCompilerFlags.append(value)
+                options.flags.swiftCompilerFlags.append(value)
             case .buildPath(let path):
-                opts.path.build = path
+                options.path.build = path
             case .enableNewResolver:
-                opts.enableNewResolver = true
+                options.enableNewResolver = true
             case .buildTests:
-                opts.buildTests = true
+                options.buildTests = true
             case .colorMode(let mode):
-                opts.colorMode = mode
+                options.colorMode = mode
             }
         }
     
-        return try (mode ?? .build(.debug, UserToolchain()), opts)
+        return try (mode ?? .build(.debug, UserToolchain()), options)
     }
 
     private func checkClangVersion() {
@@ -235,10 +234,10 @@ extension Build.Configuration {
     }
 }
 
-enum CleanMode: CustomStringConvertible {
+public enum CleanMode: CustomStringConvertible {
     case build, dist
 
-    fileprivate init(_ rawValue: String?) throws {
+    public init(_ rawValue: String?) throws {
         switch rawValue?.lowercased() {
         case nil, "build"?:
             self = .build
@@ -249,7 +248,7 @@ enum CleanMode: CustomStringConvertible {
         }
     }
 
-    var description: String {
+    public var description: String {
         switch self {
             case .dist: return "distribution"
             case .build: return "build"
@@ -257,6 +256,6 @@ enum CleanMode: CustomStringConvertible {
     }
 }
 
-private func ==(lhs: Mode, rhs: Mode) -> Bool {
+public func ==(lhs: BuildToolMode, rhs: BuildToolMode) -> Bool {
     return lhs.description == rhs.description
 }

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -176,7 +176,9 @@ public class SwiftBuildTool: SwiftTool<BuildToolMode, BuildToolOptions> {
             case .xswiftc(let value):
                 options.flags.swiftCompilerFlags.append(value)
             case .buildPath(let path):
+                // FIXME: Eliminate this.
                 options.path.build = path
+                options.buildPath = path
             case .enableNewResolver:
                 options.enableNewResolver = true
             case .buildTests:

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -106,13 +106,6 @@ public class BuildToolOptions: Options {
 public class SwiftBuildTool: SwiftTool<BuildToolMode, BuildToolOptions> {
 
     override func runImpl() throws {
-        verbosity = Verbosity(rawValue: options.verbosity)
-        colorMode = options.colorMode
-
-        if let dir = options.chdir {
-            try chdir(dir.asString)
-        }
-
         switch mode {
         case .usage:
             SwiftBuildTool.usage()

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -119,20 +119,20 @@ public class SwiftBuildTool: SwiftTool<BuildToolMode, BuildToolOptions> {
             // See: <rdar://problem/28108951> SR-2299 Swift isn't using Gold by default on stock 14.04.
             checkClangVersion()
             #endif
-            let graph = try loadPackage(at: options.path.root, options)
-            let yaml = try describe(options.path.build, conf, graph, flags: options.flags, toolchain: toolchain)
+            let graph = try loadPackage()
+            let yaml = try describe(buildPath, conf, graph, flags: options.flags, toolchain: toolchain)
             try build(yamlPath: yaml, target: options.buildTests ? "test" : nil)
 
         case .clean(.dist):
-            if exists(options.path.packages) {
-                try removeFileTree(options.path.packages)
+            if try exists(getCheckoutsDirectory()) {
+                try removeFileTree(getCheckoutsDirectory())
             }
             fallthrough
 
         case .clean(.build):
             // FIXME: This test is lame, `removeFileTree` shouldn't error on this.
-            if exists(options.path.build) {
-                try removeFileTree(options.path.build)
+            if exists(buildPath) {
+                try removeFileTree(buildPath)
             }
         }
     }
@@ -176,8 +176,6 @@ public class SwiftBuildTool: SwiftTool<BuildToolMode, BuildToolOptions> {
             case .xswiftc(let value):
                 options.flags.swiftCompilerFlags.append(value)
             case .buildPath(let path):
-                // FIXME: Eliminate this.
-                options.path.build = path
                 options.buildPath = path
             case .enableNewResolver:
                 options.enableNewResolver = true

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -105,14 +105,9 @@ private class BuildToolOptions: Options {
 }
 
 /// swift-build tool namespace
-public struct SwiftBuildTool: SwiftTool {
-    let args: [String]
+public class SwiftBuildTool: SwiftTool {
 
-    public init(args: [String]) {
-        self.args = args
-    }
-
-    public func run() {
+    override func runImpl() {
         do {
             let (mode, opts) = try parse(commandLineArguments: args)
         

--- a/Sources/Commands/SwiftPackageResolveTool.swift
+++ b/Sources/Commands/SwiftPackageResolveTool.swift
@@ -31,7 +31,7 @@ extension SwiftPackageTool {
         let delegate = ResolverToolDelegate()
 
         // Create the checkout manager.
-        let repositoriesPath = opts.path.build.appending(component: "repositories")
+        let repositoriesPath = buildPath.appending(component: "repositories")
         let checkoutManager = CheckoutManager(path: repositoriesPath, provider: GitRepositoryProvider(), delegate: delegate)
 
         // Create the container provider interface.

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -146,13 +146,6 @@ public class PackageToolOptions: Options {
 public class SwiftPackageTool: SwiftTool<PackageMode, PackageToolOptions> {
 
     override func runImpl() throws {
-        verbosity = Verbosity(rawValue: options.verbosity)
-        colorMode = options.colorMode
-
-        if let dir = options.chdir {
-            try chdir(dir.asString)
-        }
-
         switch mode {
         case .usage:
             SwiftPackageTool.usage()

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -139,8 +139,6 @@ public class PackageToolOptions: Options {
     var showDepsMode: ShowDependenciesMode = ShowDependenciesMode.text
     var inputPath: AbsolutePath? = nil
     var outputPath: AbsolutePath? = nil
-    var verbosity: Int = 0
-    var colorMode: ColorWrap.Mode = .Auto
     var xcodeprojOptions = XcodeprojOptions()
 }
 

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -285,7 +285,9 @@ public class SwiftPackageTool: SwiftTool<PackageMode, PackageToolOptions> {
             case .xswiftc(let value):
                 options.xcodeprojOptions.flags.swiftCompilerFlags.append(value)
             case .buildPath(let path):
+                // FIXME: Eliminate this.
                 options.path.build = path
+                options.buildPath = path
             case .enableNewResolver:
                 options.enableNewResolver = true
             case .verbose(let amount):

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -145,14 +145,9 @@ class PackageToolOptions: Options {
 }
 
 /// swift-build tool namespace
-public struct SwiftPackageTool: SwiftTool {
-    let args: [String]
+public class SwiftPackageTool: SwiftTool {
 
-    public init(args: [String]) {
-        self.args = args
-    }
-
-    public func run() {
+    override func runImpl() {
         do {
             let (mode, opts) = try parse(commandLineArguments: args)
         

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -132,45 +132,37 @@ public class TestToolOptions: Options {
 /// swift-test tool namespace
 public class SwiftTestTool: SwiftTool<TestMode, TestToolOptions> {
 
-    override func runImpl() {
-        do {
-        
-            verbosity = Verbosity(rawValue: options.verbosity)
-            colorMode = options.colorMode
+    override func runImpl() throws {
+        verbosity = Verbosity(rawValue: options.verbosity)
+        colorMode = options.colorMode
 
-            if let dir = options.chdir {
-                try chdir(dir.asString)
-            }
+        if let dir = options.chdir {
+            try chdir(dir.asString)
+        }
 
-            switch mode {
-            case .usage:
-                SwiftTestTool.usage()
-        
-            case .version:
-                print(Versioning.currentVersion.completeDisplayString)
-        
-            case .listTests:
-                let testPath = try buildTestsIfNeeded(options)
-                let testSuites = try getTestSuites(path: testPath)
-                // Print the tests.
-                for testSuite in testSuites {
-                    for testCase in testSuite.tests {
-                        for test in testCase.tests {
-                            print(testCase.name + "/" + test)
-                        }
+        switch mode {
+        case .usage:
+            SwiftTestTool.usage()
+
+        case .version:
+            print(Versioning.currentVersion.completeDisplayString)
+
+        case .listTests:
+            let testPath = try buildTestsIfNeeded(options)
+            let testSuites = try getTestSuites(path: testPath)
+            // Print the tests.
+            for testSuite in testSuites {
+                for testCase in testSuite.tests {
+                    for test in testCase.tests {
+                        print(testCase.name + "/" + test)
                     }
                 }
-
-            case .run(let specifier):
-                let testPath = try buildTestsIfNeeded(options)
-                let success = test(path: testPath, xctestArg: specifier)
-                exit(success ? 0 : 1)
             }
-        } catch Error.buildYAMLNotFound {
-            print("error: you must run `swift build` first", to: &stderr)
-            exit(1)
-        } catch {
-            handle(error: error, usage: SwiftTestTool.usage)
+
+        case .run(let specifier):
+            let testPath = try buildTestsIfNeeded(options)
+            let success = test(path: testPath, xctestArg: specifier)
+            exit(success ? 0 : 1)
         }
     }
 

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -131,12 +131,6 @@ public class TestToolOptions: Options {
 public class SwiftTestTool: SwiftTool<TestMode, TestToolOptions> {
 
     override func runImpl() throws {
-        verbosity = Verbosity(rawValue: options.verbosity)
-        colorMode = options.colorMode
-
-        if let dir = options.chdir {
-            try chdir(dir.asString)
-        }
 
         switch mode {
         case .usage:

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -162,9 +162,9 @@ public class SwiftTestTool: SwiftTool<TestMode, TestToolOptions> {
     ///
     /// - Returns: The path to the test binary.
     private func buildTestsIfNeeded(_ options: TestToolOptions) throws -> AbsolutePath {
-        let graph = try loadPackage(at: options.path.root, options)
+        let graph = try loadPackage()
         if options.buildTests {
-            let yaml = try describe(options.path.build, configuration, graph, flags: options.flags, toolchain: UserToolchain())
+            let yaml = try describe(buildPath, configuration, graph, flags: options.flags, toolchain: UserToolchain())
             try build(yamlPath: yaml, target: "test")
         }
                 
@@ -184,7 +184,7 @@ public class SwiftTestTool: SwiftTool<TestMode, TestToolOptions> {
         } else if testProducts.count > 1 {
             throw TestError.multipleTestProducts
         } else {
-            return options.path.build.appending(RelativePath(configuration.dirname)).appending(component: testProducts[0].name + ".xctest")
+            return buildPath.appending(RelativePath(configuration.dirname)).appending(component: testProducts[0].name + ".xctest")
         }
     }
 
@@ -231,8 +231,6 @@ public class SwiftTestTool: SwiftTool<TestMode, TestToolOptions> {
             case .xswiftc(let value):
                 options.flags.swiftCompilerFlags.append(value)
             case .buildPath(let path):
-                // FIXME: Eliminate this.
-                options.path.build = path
                 options.buildPath = path
             case .enableNewResolver:
                 options.enableNewResolver = true

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -230,8 +230,10 @@ public class SwiftTestTool: SwiftTool<TestMode, TestToolOptions> {
                 options.flags.linkerFlags.append(value)
             case .xswiftc(let value):
                 options.flags.swiftCompilerFlags.append(value)
-            case .buildPath(let buildPath):
-                options.path.build = buildPath
+            case .buildPath(let path):
+                // FIXME: Eliminate this.
+                options.path.build = path
+                options.buildPath = path
             case .enableNewResolver:
                 options.enableNewResolver = true
             case .colorMode(let mode):

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -130,14 +130,9 @@ private class TestToolOptions: Options {
 }
 
 /// swift-test tool namespace
-public struct SwiftTestTool: SwiftTool {
-    let args: [String]
+public class SwiftTestTool: SwiftTool {
 
-    public init(args: [String]) {
-        self.args = args
-    }
-    
-    public func run() {
+    override func runImpl() {
         do {
             let (mode, opts) = try parseOptions(commandLineArguments: args)
         

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -123,9 +123,7 @@ private enum TestToolFlag: Argument {
 }
 
 public class TestToolOptions: Options {
-    var verbosity: Int = 0
     var buildTests: Bool = true
-    var colorMode: ColorWrap.Mode = .Auto
     var flags = BuildFlags()
 }
 

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -12,6 +12,8 @@ import Basic
 import Get
 import PackageLoading
 import PackageGraph
+import func POSIX.chdir
+import Utility
 
 private class ToolWorkspaceDelegate: WorkspaceDelegate {
     func fetchingMissingRepositories(_ urls: Set<String>) {
@@ -46,6 +48,10 @@ public class SwiftTool<Mode: Argument, OptionType: Options> {
         let dynamicSelf = type(of: self)
         do {
             (self.mode, self.options) = try dynamicSelf.parse(commandLineArguments: args)
+            // Honor chdir option is provided.
+            if let dir = options.chdir {
+                try chdir(dir.asString)
+            }
         } catch {
             handle(error: error, usage: dynamicSelf.usage)
         }
@@ -58,6 +64,10 @@ public class SwiftTool<Mode: Argument, OptionType: Options> {
     /// Execute the tool.
     public func run() {
         do {
+            // Setup the globals.
+            verbosity = Verbosity(rawValue: options.verbosity)
+            colorMode = options.colorMode
+            // Call the implementation.
             try runImpl()
         } catch {
             handle(error: error, usage: type(of: self).usage)

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -92,6 +92,13 @@ public class SwiftTool<Mode: Argument, OptionType: Options> {
         fatalError("Must be implmented by subclasses")
     }
 
+    /// Returns the currently active workspace.
+    func getActiveWorkspace() throws -> Workspace {
+        // Get the active workspace.
+        let delegate = ToolWorkspaceDelegate()
+        return try Workspace(rootPackage: try getPackageRoot(), dataPath: buildPath, manifestLoader: manifestLoader, delegate: delegate)
+    }
+
     /// Execute the tool.
     public func run() {
         do {
@@ -118,9 +125,7 @@ public class SwiftTool<Mode: Argument, OptionType: Options> {
     /// Fetch and load the complete package at the given path.
     func loadPackage() throws -> PackageGraph {
         if options.enableNewResolver {
-            // Get the active workspace.
-            let delegate = ToolWorkspaceDelegate()
-            let workspace = try Workspace(rootPackage: try getPackageRoot(), dataPath: buildPath, manifestLoader: manifestLoader, delegate: delegate)
+            let workspace = try getActiveWorkspace()
 
             // Fetch and load the package graph.
             let graph = try workspace.loadPackageGraph()

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -27,15 +27,32 @@ private class ToolWorkspaceDelegate: WorkspaceDelegate {
     }
 }
 
-public class SwiftTool {
+public class SwiftTool<Mode: Argument, OptionType: Options> {
     /// The command line arguments this tool should honor.
     let args: [String]
+
+    /// The mode in which this tool is currently executing.
+    let mode: Mode
+
+    /// The options of this tool.
+    let options: OptionType
 
     /// The package graph loader.
     let manifestLoader = ManifestLoader(resources: ToolDefaults())
 
     public init() {
+        let args = Array(CommandLine.arguments.dropFirst())
         self.args = Array(CommandLine.arguments.dropFirst())
+        let dynamicSelf = type(of: self)
+        do {
+            (self.mode, self.options) = try dynamicSelf.parse(commandLineArguments: args)
+        } catch {
+            handle(error: error, usage: dynamicSelf.usage)
+        }
+    }
+
+    class func parse(commandLineArguments args: [String]) throws -> (Mode, OptionType) {
+        fatalError("Must be implmented by subclasses")
     }
 
     /// Execute the tool.
@@ -45,6 +62,11 @@ public class SwiftTool {
 
     /// Run method implmentation to be overridden by subclasses.
     func runImpl() {
+        fatalError("Must be implmented by subclasses")
+    }
+
+    /// Method to be called to print the usage text of this tool.
+    class func usage(_ print: (String) -> Void = { print($0) }) {
         fatalError("Must be implmented by subclasses")
     }
 

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -68,7 +68,7 @@ public class SwiftTool<Mode: Argument, OptionType: Options> {
 
     public init() {
         let args = Array(CommandLine.arguments.dropFirst())
-        self.args = Array(CommandLine.arguments.dropFirst())
+        self.args = args
         let dynamicSelf = type(of: self)
         do {
             (self.mode, self.options) = try dynamicSelf.parse(commandLineArguments: args)

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -13,10 +13,6 @@ import Get
 import PackageLoading
 import PackageGraph
 
-// FIXME: Find a home for this. Ultimately it might need access to some of the
-// options, and we might just want the SwiftTool type to become a class.
-private let sharedManifestLoader = ManifestLoader(resources: ToolDefaults())
-
 private class ToolWorkspaceDelegate: WorkspaceDelegate {
     func fetchingMissingRepositories(_ urls: Set<String>) {
     }
@@ -35,6 +31,9 @@ public class SwiftTool {
     /// The command line arguments this tool should honor.
     let args: [String]
 
+    /// The package graph loader.
+    let manifestLoader = ManifestLoader(resources: ToolDefaults())
+
     public init() {
         self.args = Array(CommandLine.arguments.dropFirst())
     }
@@ -47,11 +46,6 @@ public class SwiftTool {
     /// Run method implmentation to be overridden by subclasses.
     func runImpl() {
         fatalError("Must be implmented by subclasses")
-    }
-
-    /// The shared package graph loader.
-    var manifestLoader: ManifestLoader {
-        return sharedManifestLoader
     }
 
     /// Fetch and load the complete package at the given path.

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -57,11 +57,15 @@ public class SwiftTool<Mode: Argument, OptionType: Options> {
 
     /// Execute the tool.
     public func run() {
-        runImpl()
+        do {
+            try runImpl()
+        } catch {
+            handle(error: error, usage: type(of: self).usage)
+        }
     }
 
     /// Run method implmentation to be overridden by subclasses.
-    func runImpl() {
+    func runImpl() throws {
         fatalError("Must be implmented by subclasses")
     }
 

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -13,13 +13,6 @@ import Get
 import PackageLoading
 import PackageGraph
 
-/// A common interface for swift tools
-public protocol SwiftTool {
-    init()
-    init(args: [String])
-    func run()
-}
-
 // FIXME: Find a home for this. Ultimately it might need access to some of the
 // options, and we might just want the SwiftTool type to become a class.
 private let sharedManifestLoader = ManifestLoader(resources: ToolDefaults())
@@ -38,9 +31,22 @@ private class ToolWorkspaceDelegate: WorkspaceDelegate {
     }
 }
 
-public extension SwiftTool {
-    init() {
-        self.init(args: Array(CommandLine.arguments.dropFirst()))
+public class SwiftTool {
+    /// The command line arguments this tool should honor.
+    let args: [String]
+
+    public init() {
+        self.args = Array(CommandLine.arguments.dropFirst())
+    }
+
+    /// Execute the tool.
+    public func run() {
+        runImpl()
+    }
+
+    /// Run method implmentation to be overridden by subclasses.
+    func runImpl() {
+        fatalError("Must be implmented by subclasses")
     }
 
     /// The shared package graph loader.


### PR DESCRIPTION
<rdar://problem/28335332> Refactor Commands module
There is repetition of code in the swift tools: build, package and test. This can be factored into a common class SwiftTool which has become more necessary with upcoming implementation of package edit.

This is a big refactor so might get annoying to review but I have tried to do it in small chunks so that it can be reviewed commit by commit without a lot of noise.

The major highlights are:
Add a SwiftTool class
Initialise globals once during init of SwiftTool
Eliminate Options.Path struct
Remove some of the code repetition 