### PR TITLE
[Tools] Pass command line arguments through init

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -66,8 +66,10 @@ public class SwiftTool<Mode: Argument, OptionType: Options> {
     /// Path to the build directory.
     let buildPath: AbsolutePath
 
-    public init() {
-        let args = Array(CommandLine.arguments.dropFirst())
+    /// Create an instance of this tool.
+    ///
+    /// - parameter args: The command line arguments to be passed to this tool.
+    public init(args: [String]) {
         self.args = args
         let dynamicType = type(of: self)
         do {

--- a/Sources/swift-build/main.swift
+++ b/Sources/swift-build/main.swift
@@ -10,5 +10,5 @@
 
 import Commands
 
-let tool = SwiftBuildTool()
+let tool = SwiftBuildTool(args: Array(CommandLine.arguments.dropFirst()))
 tool.run()

--- a/Sources/swift-package/main.swift
+++ b/Sources/swift-package/main.swift
@@ -10,5 +10,5 @@
 
 import Commands
 
-let tool = SwiftPackageTool()
+let tool = SwiftPackageTool(args: Array(CommandLine.arguments.dropFirst()))
 tool.run()

--- a/Sources/swift-test/main.swift
+++ b/Sources/swift-test/main.swift
@@ -10,5 +10,5 @@
 
 import Commands
 
-let tool = SwiftTestTool()
+let tool = SwiftTestTool(args: Array(CommandLine.arguments.dropFirst()))
 tool.run()


### PR DESCRIPTION
This will allow running the tool from for eg tests without reusing the
existing commandline arguments which may not be valid in context of that
tool.