### PR TITLE
Rename CheckoutManager to RepositoryManager

### DIFF
--- a/Sources/Commands/SwiftPackageResolveTool.swift
+++ b/Sources/Commands/SwiftPackageResolveTool.swift
@@ -12,14 +12,14 @@ import Basic
 import PackageGraph
 import SourceControl
 
-private class ResolverToolDelegate: DependencyResolverDelegate, CheckoutManagerDelegate {
+private class ResolverToolDelegate: DependencyResolverDelegate, RepositoryManagerDelegate {
     typealias Identifier = RepositoryPackageContainer.Identifier
 
     func added(container identifier: Identifier) {
         print("note: considering repository: \(identifier.url)")
     }
 
-    func fetching(handle: CheckoutManager.RepositoryHandle, to path: AbsolutePath) {
+    func fetching(handle: RepositoryManager.RepositoryHandle, to path: AbsolutePath) {
         print("note: fetching \(handle.repository.url) to \(path.asString)")
     }
 }
@@ -30,13 +30,13 @@ extension SwiftPackageTool {
         let manifest = try loadRootManifest(opts)
         let delegate = ResolverToolDelegate()
 
-        // Create the checkout manager.
+        // Create the repository manager.
         let repositoriesPath = buildPath.appending(component: "repositories")
-        let checkoutManager = CheckoutManager(path: repositoriesPath, provider: GitRepositoryProvider(), delegate: delegate)
+        let repositoryManager = RepositoryManager(path: repositoriesPath, provider: GitRepositoryProvider(), delegate: delegate)
 
         // Create the container provider interface.
         let provider = RepositoryPackageContainerProvider(
-            checkoutManager: checkoutManager, manifestLoader: manifestLoader)
+            repositoryManager: repositoryManager, manifestLoader: manifestLoader)
 
         // Create the resolver.
         let resolver = DependencyResolver(provider, delegate)

--- a/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
@@ -22,24 +22,24 @@ import struct PackageDescription.Version
 public class RepositoryPackageContainerProvider: PackageContainerProvider {
     public typealias Container = RepositoryPackageContainer
 
-    let checkoutManager: CheckoutManager
+    let repositoryManager: RepositoryManager
     let manifestLoader: ManifestLoaderProtocol
     
     /// Create a repository-based package provider.
     ///
     /// - Parameters:
-    ///   - checkoutManager: The checkout manager responsible for providing repositories.
+    ///   - repositoryManager: The repository manager responsible for providing repositories.
     ///   - manifestLoader: The manifest loader instance.
-    public init(checkoutManager: CheckoutManager, manifestLoader: ManifestLoaderProtocol) {
-        self.checkoutManager = checkoutManager
+    public init(repositoryManager: RepositoryManager, manifestLoader: ManifestLoaderProtocol) {
+        self.repositoryManager = repositoryManager
         self.manifestLoader = manifestLoader
     }
 
     public func getContainer(for identifier: RepositorySpecifier) throws -> Container {
-        // Resolve the container using the checkout manager.
+        // Resolve the container using the repository manager.
         //
         // FIXME: We need to move this to an async interface, or document the interface as thread safe.
-        let handle = checkoutManager.lookup(repository: identifier)
+        let handle = repositoryManager.lookup(repository: identifier)
 
         // Wait for the repository to be fetched.
         let wasAvailableCondition = Condition()

--- a/Sources/SourceControl/Repository.swift
+++ b/Sources/SourceControl/Repository.swift
@@ -26,7 +26,7 @@ public struct RepositorySpecifier: Hashable {
     /// unique for each repository.
     public var fileSystemIdentifier: String {
         // FIXME: Need to do something better here. In particular, we should use
-        // a stable hash function since this interacts with the CheckoutManager
+        // a stable hash function since this interacts with the RepositoryManager
         // persistence.
         let basename = url.components(separatedBy: "/").last!
         return basename + "-" + String(url.hashValue)
@@ -44,7 +44,7 @@ public func ==(lhs: RepositorySpecifier, rhs: RepositorySpecifier) -> Bool {
 ///
 /// This protocol defines the lower level interface used to to access
 /// repositories. High-level clients should access repositories via a
-/// `CheckoutManager`.
+/// `RepositoryManager`.
 public protocol RepositoryProvider {
     /// Fetch the complete repository at the given location to `path`.
     ///
@@ -82,13 +82,13 @@ public protocol RepositoryProvider {
 /// Abstract repository operations.
 ///
 /// This interface provides access to an abstracted representation of a
-/// repository which is ultimately owned by a `CheckoutManager`. This interface
+/// repository which is ultimately owned by a `RepositoryManager`. This interface
 /// is designed in such a way as to provide the minimal facilities required by
 /// the package manager to gather basic information about a repository, but it
 /// does not aim to provide all of the interfaces one might want for working
 /// with an editable checkout of a repository on disk.
 ///
-/// The goal of this design is to allow the `CheckoutManager` a large degree of
+/// The goal of this design is to allow the `RepositoryManager` a large degree of
 /// flexibility in the storage and maintenance of its underlying repositories.
 ///
 /// This protocol is designed under the assumption that the repository can only

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -95,7 +95,7 @@ private class MockRepositories: RepositoryProvider {
     }
 }
 
-private class MockResolverDelegate: DependencyResolverDelegate, CheckoutManagerDelegate {
+private class MockResolverDelegate: DependencyResolverDelegate, RepositoryManagerDelegate {
     typealias Identifier = RepositoryPackageContainer.Identifier
 
     var addedContainers: [Identifier] = []
@@ -105,7 +105,7 @@ private class MockResolverDelegate: DependencyResolverDelegate, CheckoutManagerD
         addedContainers.append(identifier)
     }
 
-    func fetching(handle: CheckoutManager.RepositoryHandle, to path: AbsolutePath) {
+    func fetching(handle: RepositoryManager.RepositoryHandle, to path: AbsolutePath) {
         fetched += [handle.repository]
     }
 }
@@ -120,9 +120,9 @@ private struct MockDependencyResolver {
         self.tmpDir = try! TemporaryDirectory()
         self.repositories = MockRepositories(repositories: repositories)
         self.delegate = MockResolverDelegate()
-        let checkoutManager = CheckoutManager(path: self.tmpDir.path, provider: self.repositories, delegate: self.delegate)
+        let repositoryManager = RepositoryManager(path: self.tmpDir.path, provider: self.repositories, delegate: self.delegate)
         let provider = RepositoryPackageContainerProvider(
-            checkoutManager: checkoutManager, manifestLoader: self.repositories.manifestLoader)
+            repositoryManager: repositoryManager, manifestLoader: self.repositories.manifestLoader)
         self.resolver = DependencyResolver(provider, delegate)
     }
 

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -15,7 +15,7 @@ import SourceControl
 
 import TestSupport
 
-@testable import class SourceControl.CheckoutManager
+@testable import class SourceControl.RepositoryManager
 
 private enum DummyError: Swift.Error {
     case invalidRepository
@@ -73,20 +73,20 @@ private class DummyRepositoryProvider: RepositoryProvider {
     }
 }
 
-private class DummyCheckoutManagerDelegate: CheckoutManagerDelegate {
+private class DummyRepositoryManagerDelegate: RepositoryManagerDelegate {
     var fetched = [RepositorySpecifier]()
 
-    func fetching(handle: CheckoutManager.RepositoryHandle, to path: AbsolutePath) {
+    func fetching(handle: RepositoryManager.RepositoryHandle, to path: AbsolutePath) {
         fetched += [handle.repository]
     }
 }
 
-class CheckoutManagerTests: XCTestCase {
+class RepositoryManagerTests: XCTestCase {
     func testBasics() throws {
         mktmpdir { path in
             let provider = DummyRepositoryProvider()
-            let delegate = DummyCheckoutManagerDelegate()
-            let manager = CheckoutManager(path: path, provider: provider, delegate: delegate)
+            let delegate = DummyRepositoryManagerDelegate()
+            let manager = RepositoryManager(path: path, provider: provider, delegate: delegate)
 
             // Check that we can "fetch" a repository.
             let dummyRepo = RepositorySpecifier(url: "dummy")
@@ -128,8 +128,8 @@ class CheckoutManagerTests: XCTestCase {
     /// Check the behavior of the observer of repository status.
     func testObserver() {
         mktmpdir { path in
-            let delegate = DummyCheckoutManagerDelegate()
-            let manager = CheckoutManager(path: path, provider: DummyRepositoryProvider(), delegate: delegate)
+            let delegate = DummyRepositoryManagerDelegate()
+            let manager = RepositoryManager(path: path, provider: DummyRepositoryProvider(), delegate: delegate)
             let dummyRepo = RepositorySpecifier(url: "dummy")
             let handle = manager.lookup(repository: dummyRepo)
 
@@ -151,8 +151,8 @@ class CheckoutManagerTests: XCTestCase {
 
             // Do the initial fetch.
             do {
-                let delegate = DummyCheckoutManagerDelegate()
-                let manager = CheckoutManager(path: path, provider: provider, delegate: delegate)
+                let delegate = DummyRepositoryManagerDelegate()
+                let manager = RepositoryManager(path: path, provider: provider, delegate: delegate)
                 let dummyRepo = RepositorySpecifier(url: "dummy")
                 let handle = manager.lookup(repository: dummyRepo)
                 XCTAssertEqual(delegate.fetched, [dummyRepo])
@@ -165,8 +165,8 @@ class CheckoutManagerTests: XCTestCase {
 
             // Create a new manager, and fetch.
             do {
-                let delegate = DummyCheckoutManagerDelegate()
-                let manager = CheckoutManager(path: path, provider: provider, delegate: delegate)
+                let delegate = DummyRepositoryManagerDelegate()
+                let manager = RepositoryManager(path: path, provider: provider, delegate: delegate)
                 let dummyRepo = RepositorySpecifier(url: "dummy")
                 let handle = manager.lookup(repository: dummyRepo)
                 // This time fetch shouldn't be called.
@@ -180,10 +180,10 @@ class CheckoutManagerTests: XCTestCase {
 
             // Manually destroy the manager state, and check it still works.
             do {
-                let delegate = DummyCheckoutManagerDelegate()
-                var manager = CheckoutManager(path: path, provider: provider, delegate: delegate)
+                let delegate = DummyRepositoryManagerDelegate()
+                var manager = RepositoryManager(path: path, provider: provider, delegate: delegate)
                 try! removeFileTree(manager.statePath)
-                manager = CheckoutManager(path: path, provider: provider, delegate: delegate)
+                manager = RepositoryManager(path: path, provider: provider, delegate: delegate)
                 let dummyRepo = RepositorySpecifier(url: "dummy")
                 let handle = manager.lookup(repository: dummyRepo)
                 XCTAssertEqual(delegate.fetched, [dummyRepo])

--- a/Tests/SourceControlTests/XCTestManifests.swift
+++ b/Tests/SourceControlTests/XCTestManifests.swift
@@ -13,7 +13,7 @@ import XCTest
 #if !os(macOS)
 public func allTests() -> [XCTestCaseEntry] {
     return [
-        testCase(CheckoutManagerTests.allTests),
+        testCase(RepositoryManagerTests.allTests),
         testCase(GitRepositoryTests.allTests),
     ]
 }


### PR DESCRIPTION
This better conveys the intent of the class.