### PR TITLE
Revert "[GitRepository] Add methods to get and set remotes"

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -211,40 +211,6 @@ public class GitRepository: Repository, WorkingCheckout {
         self.path = path
     }
 
-    /// Adds a remote to the git repository.
-    ///
-    /// - parameters:
-    ///   - remote: The name of the remote. It shouldn't already be present.
-    ///   - url: The url of the remote.
-    func add(remote: String, url: String) throws {
-        try runCommandQuietly([Git.tool, "-C", path.asString, "remote", "add", remote, url])
-    }
-
-    /// Removes a remote from the git repository.
-    ///
-    /// - parameters:
-    ///   - remote: The name of the remote to be removed. It should already be present.
-    ///   - url: the url of the remote.
-    func remove(remote: String) throws {
-        try runCommandQuietly([Git.tool, "-C", path.asString, "remote", "remove", remote])
-    }
-
-    /// Gets the current list of remotes of the repository.
-    ///
-    /// - Returns: An array of tuple containing name and url of the remote.
-    func remotes() throws -> [(name: String, url: String)] {
-        return try queue.sync {
-            // Get the remote names.
-            let remoteNamesOutput = try Git.runPopen([Git.tool, "-C", path.asString, "remote"]).chomp()
-            let remoteNames = remoteNamesOutput.characters.split(separator: "\n").map(String.init)
-            return try remoteNames.map { name in
-                // For each remote get the url.
-                let url = try Git.runPopen([Git.tool, "-C", path.asString, "remote", "get-url", name]).chomp()
-                return (name, url)
-            }
-        }
-    }
-
     // MARK: Repository Interface
 
     /// Returns the tags present in repository.

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -303,55 +303,12 @@ class GitRepositoryTests: XCTestCase {
         }
     }
 
-    func testRemotes() {
-        mktmpdir { path in
-            // Create a repo.
-            let testRepoPath = path.appending(component: "test-repo")
-            try makeDirectories(testRepoPath)
-            initGitRepo(testRepoPath)
-            let repo = GitRepository(path: testRepoPath)
-
-            // There should be no remotes currently.
-            XCTAssert(try repo.remotes().isEmpty)
-
-            // Add a remote via git cli.
-            try systemQuietly([Git.tool, "-C", testRepoPath.asString, "remote", "add", "origin", "../foo"])
-            // Test if it was added.
-            XCTAssertEqual(Dictionary(items: try repo.remotes().map { ($0, $1) }), ["origin": "../foo"])
-
-            // Remove the remote via cli.
-            try systemQuietly([Git.tool, "-C", testRepoPath.asString, "remote", "remove", "origin"])
-            // Test if it was removed.
-            XCTAssert(try repo.remotes().isEmpty)
-
-            // Add a remote.
-            try repo.add(remote: "origin", url: "../foo")
-            // Check it was added.
-            let remote = Dictionary(items: try repo.remotes().map { ($0, $1) })
-            XCTAssertEqual(remote, ["origin": "../foo"])
-
-            // Add another remote.
-            try repo.add(remote: "origin2", url: "../bar")
-            // Check that there are two remotes now.
-            let remotes = Dictionary(items: try repo.remotes().map { ($0, $1)})
-            XCTAssertEqual(remotes, ["origin": "../foo", "origin2": "../bar"])
-
-            // Remove the remotes.
-            try repo.remove(remote: "origin")
-            try repo.remove(remote: "origin2")
-
-            // All remotes should be removed now.
-            XCTAssert(try repo.remotes().isEmpty)
-        }
-    }
-
     static var allTests = [
         ("testFetch", testFetch),
         ("testRepositorySpecifier", testRepositorySpecifier),
         ("testProvider", testProvider),
         ("testGitRepositoryHash", testGitRepositoryHash),
         ("testRawRepository", testRawRepository),
-        ("testRemotes", testRemotes),
         ("testGitFileView", testGitFileView),
         ("testCheckouts", testCheckouts),
         ("testHasUnpushedCommits", testHasUnpushedCommits),


### PR DESCRIPTION
Reverts apple/swift-package-manager#681

`get-url` doesn't work with Ubuntu 14.04's stock git, will find some other method to implement getting remotes.