### PR TITLE
SR-2703: Fix a sporadic unit test failure caused by bad pseudoterminal interaction

### DIFF
--- a/Tests/UtilityTests/ProgressBarTests.swift
+++ b/Tests/UtilityTests/ProgressBarTests.swift
@@ -43,11 +43,11 @@ final class PseudoTerminal {
         return String(cString: buf)
     }
 
-    func close() {
+    func closeSlave() {
         _ = libc.close(slave)
     }
 
-    deinit {
+    func closeMaster() {
         _ = libc.close(master)
     }
 }
@@ -79,9 +79,10 @@ final class ProgressBarTests: XCTestCase {
         }
         thread.start()
         runProgressBar(bar)
-        pty.close()
+        pty.closeSlave()
         // Make sure to read the complete output before checking it.
         thread.join()
+        pty.closeMaster()
         XCTAssertTrue(output.chuzzle()?.hasPrefix("\u{1B}[36m\u{1B}[1mTestHeader\u{1B}[0m") ?? false)
     }
 

--- a/Tests/UtilityTests/ShellTests.swift
+++ b/Tests/UtilityTests/ShellTests.swift
@@ -16,27 +16,18 @@ import Utility
 class ShellTests: XCTestCase {
 
     func testPopen() {
-        // FIXME: Disabled due to https://bugs.swift.org/browse/SR-2703
-      #if false
         XCTAssertEqual(try! popen(["echo", "foo"]), "foo\n")
-      #endif
     }
 
     func testPopenWithBufferLargerThanThatAllocated() {
-        // FIXME: Disabled due to https://bugs.swift.org/browse/SR-2703
-      #if false
         let path = AbsolutePath(#file).parentDirectory.parentDirectory.appending(components: "GetTests", "VersionGraphTests.swift")
         XCTAssertGreaterThan(try! popen(["cat", path.asString]).characters.count, 4096)
-      #endif
     }
 
     func testPopenWithBinaryOutput() {
-        // FIXME: Disabled due to https://bugs.swift.org/browse/SR-2703
-      #if false
         if (try? popen(["cat", "/bin/cat"])) != nil {
             XCTFail("popen succeeded but should have faileds")
         }
-      #endif
     }
 
     static var allTests = [


### PR DESCRIPTION
Cherry-picking a fix for <rdar://problem/28411803> SR-2703: POSIX.popen() sometimes breaks the build
