### PR TITLE
[Commands] don't create Source folder if exist in swift package init

### DIFF
--- a/Sources/Commands/init.swift
+++ b/Sources/Commands/init.swift
@@ -111,10 +111,10 @@ final class InitPackage {
         if mode == .systemModule {
             return
         }
-        let sources = rootd.appending(component: "Sources")
-        guard exists(sources) == false else {
+        guard try sourceDirectoryExists() == false else {
             return
         }
+        let sources = rootd.appending(component: "Sources")
         print("Creating \(sources.relative(to: rootd).asString)/")
         try makeDirectories(sources)
 
@@ -137,6 +137,18 @@ final class InitPackage {
                 fatalError("invalid")
             }
         }
+    }
+
+    private func sourceDirectoryExists() throws -> Bool {
+        let sourceDir = try localFileSystem.getDirectoryContents(rootd).first { dir in
+            switch dir.lowercased() {
+            case "sources", "source", "src", "srcs":
+                return true
+            default:
+                return false
+            }
+        }
+        return sourceDir != nil
     }
     
     private func writeModuleMap() throws {

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -125,6 +125,26 @@ final class PackageToolTests: XCTestCase {
         }
     }
 
+    func testInitWithSources() throws {
+        mktmpdir { tmpPath in
+            var fs = localFileSystem
+            let path = tmpPath.appending(component: "Foo")
+            try fs.createDirectory(path)
+
+            let src = path.appending(component: "src")
+            try fs.createDirectory(src)
+            let mainFile = src.appending(component: "main.swift")
+            try fs.writeFileContents(mainFile) { stream in
+                stream <<< "let a: Int"
+            }
+
+            _ = try execute(["-C", path.asString, "init", "--type", "empty"])
+            XCTAssert(fs.exists(path.appending(component: "Package.swift")))
+            XCTAssertEqual(try fs.getDirectoryContents(path), [".gitignore", "Package.swift", "src", "Tests"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "src")), ["main.swift"])
+        }
+    }
+
     static var allTests = [
         ("testUsage", testUsage),
         ("testVersion", testVersion),
@@ -135,5 +155,6 @@ final class PackageToolTests: XCTestCase {
         ("testInitEmpty", testInitEmpty),
         ("testInitExecutable", testInitExecutable),
         ("testInitLibrary", testInitLibrary),
+        ("testInitWithSources", testInitWithSources),
     ]
 }


### PR DESCRIPTION
`swift package init` Don't create a Source folder if it exists 

**Motivation**: When I want to add support for swiftpm for an existing project I run `swift package init`. If there a source folder with other name than Sources, Sources (which makes an error when building) 
