### PR TITLE
[GitRepo] Add methods to check and create branches

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -349,6 +349,21 @@ public class GitRepository: Repository, WorkingCheckout {
         try runCommandQuietly([Git.tool, "-C", path.asString, "reset", "--hard", revision.identifier])
     }
 
+    /// Returns true if a revision exists.
+    public func exists(revision: Revision) -> Bool {
+        do {
+           _ = try runCommandQuietly([Git.tool, "-C", path.asString, "rev-parse", "--verify", revision.identifier])
+        } catch {
+            return false
+        }
+        return true
+    }
+
+    public func checkout(newBranch: String) throws {
+        precondition(isWorkingRepo, "This operation should run in a working repo.")
+        try runCommandQuietly([Git.tool, "-C", path.asString, "checkout", "-b", newBranch])
+    }
+
     // MARK: Git Operations
 
     /// Resolve a "treeish" to a concrete hash.

--- a/Sources/SourceControl/Repository.swift
+++ b/Sources/SourceControl/Repository.swift
@@ -156,6 +156,14 @@ public protocol WorkingCheckout {
 
     /// Check out the given revision.
     func checkout(revision: Revision) throws
+
+    /// Returns true if the given revision exists.
+    func exists(revision: Revision) -> Bool
+
+    /// Create a new branch and checkout HEAD to it.
+    ///
+    /// Note: It is an error to provide a branch name which already exists.
+    func checkout(newBranch: String) throws
 }
 
 /// A single repository revision.


### PR DESCRIPTION
- The exists() is needed to check if already have a branch when we are
going to checkout to the branch provided by user. We need to check
before creating the checkouts otherwise we would have created a stray
checkout.

- The checkout(newBranch:) will create and checkout to a new branch.