### PR TITLE
SR-2718: Xcode generated projects in custom locations have incorrect path to project in scheme file

### DIFF
--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -73,7 +73,7 @@ public func generate(outputDir: AbsolutePath, projectName: String, graph: Packag
    /// it has all tests associated so CMD+U works
     let schemeName = "\(projectName).xcscheme"
     try open(schemesDir.appending(RelativePath(schemeName))) { stream in
-        xcscheme(container: xcodeprojName, graph: graph, enableCodeCoverage: options.enableCodeCoverage, printer: stream)
+        xcscheme(container: xcodeprojPath.relative(to: srcroot).asString, graph: graph, enableCodeCoverage: options.enableCodeCoverage, printer: stream)
     }
 
 ////// we generate this file to ensure our main scheme is listed


### PR DESCRIPTION
Fix https://bugs.swift.org/browse/SR-2718 Xcode generated projects in custom locations have incorrect path to project in scheme file; causes broken refs to buildables

When using the `--output` option of the `generate-xcodeproj` command line action, the resulting scheme had an incorrect path reference to the location of the project, causing Xcode to not be able to find the referenced targets.
