### PR TITLE
[SR-2142] Shell completion scripts

### DIFF
--- a/Utilities/bash/completions
+++ b/Utilities/bash/completions
@@ -1,0 +1,148 @@
+#!/bin/bash
+
+_swift() 
+{
+    declare -a cur prev shared_options
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    COMPREPLY=()
+
+    # completions for tools, and compiler flags (non-tool)
+    if [[ $COMP_CWORD == 1 ]]; then
+        COMPREPLY=( $(compgen -W "build package test" -- $cur) )
+        _swift_compiler
+        return
+    fi
+
+    # shared options are available in all tools
+    shared_options="-C --chdir --color -v --verbose --version -Xcc -Xlinker -Xswiftc"
+    case $prev in
+        (-C|--chdir)
+            _filedir
+            return
+            ;;
+        (--color)
+            COMPREPLY=( $(compgen -W "auto always never" -- $cur) )
+            return
+            ;;
+        (-Xcc|-Xlinker|-Xswiftc)
+            return
+            ;;
+    esac
+
+    # specify for each tool
+    case ${COMP_WORDS[1]} in
+        (build)
+            _swift_build
+            ;;
+        (package)
+            _swift_package
+            ;;
+        (test)
+            _swift_test
+            ;;
+        (*)
+            _swift_compiler
+            ;;
+    esac
+}
+
+_swift_build()
+{
+    case $prev in
+        (-c|--configuration)
+            COMPREPLY=( $(compgen -W "debug release" -- $cur) )
+            return
+            ;;
+        (--clean)
+            COMPREPLY=( $(compgen -W "build dist" -- $cur) )
+            ;;
+        (--build-path)
+            _filedir
+            return
+            ;;
+    esac
+    COMPREPLY+=( $(compgen -W "-c --configuration --clean --build-path $shared_options" -- $cur) )
+}
+
+_swift_package()
+{
+    if [[ $COMP_CWORD == 2 ]]; then
+        COMPREPLY=( $(compgen -W "init fetch update generate-xcodeproj show-dependencies dump-package" -- $cur) )
+        return
+    fi
+    local package_options
+    package_options="--enable-code-coverage $shared_options"
+    case $prev in
+        (--type)
+            COMPREPLY=( $(compgen -W "empty library executable system-module" -- $cur) )
+            return
+            ;;
+        (--output)
+            _filedir
+            return
+            ;;
+        (--format)
+            COMPREPLY=( $(compgen -W "text json dot" -- $cur) )
+            return
+            ;;
+        (--input)
+            _filedir
+            return
+            ;;
+    esac
+    case ${COMP_WORDS[2]} in
+        (init)
+            COMPREPLY=( $(compgen -W "--type $package_options" -- $cur) )
+            ;;
+        (generate-xcodeproj)
+            COMPREPLY=( $(compgen -W "--output $package_options" -- $cur) )
+            ;;
+        (show-dependencies)
+            COMPREPLY=( $(compgen -W "--format $package_options" -- $cur) )
+            ;;
+        (dump-package)
+            COMPREPLY=( $(compgen -W "--input $package_options" -- $cur) )
+            ;;
+        (*)
+            COMPREPLY=( $(compgen -W "$package_options" -- $cur) )
+            ;;
+    esac
+}
+
+_swift_test()
+{
+    case $prev in
+        (-s|--specifier)
+            return
+            ;;
+    esac
+    COMPREPLY=( $(compgen -W "-s --specifier -l --list-tests --skip-build $shared_options" -- $cur) )
+}
+
+_swift_compiler()
+{
+    case $prev in
+        (-assert-config)
+            COMPREPLY=( $(compgen -W "Debug Release Unchecked DisableReplacement" -- $cur) )
+            return
+            ;;
+        (-D|-framework|-j|-l|-module-link-name|-module-name|-num-threads|-sdk|-target-cpu|-target|-use-ld)
+            return
+            ;;
+        (-F|-index-store-path|-I|-L|-module-cache-path)
+            _filedir
+            ;;
+    esac
+    local args
+    args="-assert-config -D -framework -F -gdwarf-types -gline-tables-only \
+         -gnone -g -help -index-store-path -I -j -L -l -module-cache-path \
+         -module-link-name -module-name -nostdimport -num-threads -Onone \
+         -Ounchecked -O -sdk -static-stdlib -suppress-warnings -target-cpu \
+         -target -use-ld -version -v -warnings-as-errors -Xcc -Xlinker"
+    COMPREPLY+=( $(compgen -W "$args" -- $cur))
+    _filedir
+}
+
+complete -F _swift swift

--- a/Utilities/bash/completions
+++ b/Utilities/bash/completions
@@ -16,7 +16,7 @@ _swift()
     fi
 
     # shared options are available in all tools
-    shared_options="-C --chdir --color -v --verbose --version -Xcc -Xlinker -Xswiftc"
+    shared_options="-C --chdir --color -v --verbose -Xcc -Xlinker -Xswiftc"
     case $prev in
         (-C|--chdir)
             _filedir
@@ -69,7 +69,7 @@ _swift_build()
 _swift_package()
 {
     if [[ $COMP_CWORD == 2 ]]; then
-        COMPREPLY=( $(compgen -W "init fetch update generate-xcodeproj show-dependencies dump-package" -- $cur) )
+        COMPREPLY=( $(compgen -W "init fetch update generate-xcodeproj show-dependencies dump-package --version" -- $cur) )
         return
     fi
     local package_options
@@ -118,7 +118,7 @@ _swift_test()
             return
             ;;
     esac
-    COMPREPLY=( $(compgen -W "-s --specifier -l --list-tests --skip-build $shared_options" -- $cur) )
+    COMPREPLY=( $(compgen -W "-s --specifier -l --list-tests --skip-build --version $shared_options" -- $cur) )
 }
 
 _swift_compiler()

--- a/Utilities/zsh/_swift
+++ b/Utilities/zsh/_swift
@@ -8,7 +8,6 @@ _swift() {
         '(-C --chdir)'{-C,--chdir}"[Change working directory before any other operation]: :_files"
         "--color[Specify color mode (auto|always|never)]: :{_values "mode" auto always never}"
         '(-v --verbose)'{-v,--verbose}"[Increase verbosity of informational output]"
-        "--version[Print the Swift Package Manager version]"
         "-Xcc[Pass flag through to all C compiler invocations]: : "
         "-Xlinker[Pass flag through to all linker invocations]: : "
         "-Xswiftc[Pass flag through to all Swift compiler invocations]: : "
@@ -67,6 +66,7 @@ _swift_package() {
         'generate-xcodeproj:Generates an Xcode project'
         'show-dependencies:Print the resolved dependency graph'
         'dump-package:Print parsed Package.swift as JSON'
+        '--version:Print the Swift Package Manager version'
     )
     _arguments \
         '(-): :{_describe "commands" commands}' \
@@ -115,6 +115,7 @@ _swift_test() {
         '(-s --specifier)'{-s,--specifier}'[Run a specific test method <test-module>.<test-case>/<test>]: : ' \
         '(-l --list-tests)'{-l,--list-tests}'[Lists test methods in specifier format]' \
         '--skip-build[Skip building the test target]' \
+        "--version[Print the Swift Package Manager version]" \
         $shared_options
 }
 

--- a/Utilities/zsh/_swift
+++ b/Utilities/zsh/_swift
@@ -1,0 +1,162 @@
+#compdef swift
+local context state state_descr line
+typeset -A opt_args
+
+_swift() {
+    declare -a shared_options
+    shared_options=(
+        '(-C --chdir)'{-C,--chdir}"[Change working directory before any other operation]: :_files"
+        "--color[Specify color mode (auto|always|never)]: :{_values "mode" auto always never}"
+        '(-v --verbose)'{-v,--verbose}"[Increase verbosity of informational output]"
+        "--version[Print the Swift Package Manager version]"
+        "-Xcc[Pass flag through to all C compiler invocations]: : "
+        "-Xlinker[Pass flag through to all linker invocations]: : "
+        "-Xswiftc[Pass flag through to all Swift compiler invocations]: : "
+    )
+
+    _arguments -C \
+        '(- :)--help[prints the synopsis and a list of the most commonly used commands]: :->arg' \
+        '(-): :->command' \
+        '(-)*:: :->arg' && return
+
+    case $state in
+        (command)
+            local tools
+            tools=(
+                'build:build the package'
+                'package:package management'
+                'test:run tests'
+            )
+            _alternative \
+                'tools:common:{_describe "tool" tools }' \
+                'compiler: :_swift_compiler' && _ret=0
+            ;;
+        (arg)
+            case ${words[1]} in
+                (build)
+                    _swift_build
+                    ;;
+                (package)
+                    _swift_package
+                    ;;
+                (test)
+                    _swift_test
+                    ;;
+                (*)
+                    _swift_compiler
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+_swift_build() {
+    _arguments \
+        '(-c --configuration)'{-c,--configuration}'[Build with configuration]:MODES:(debug release)' \
+        '--clean[Delete artifacts (build|dist) (default: build)]:MODES:(build dist)' \
+        $shared_options \
+        '--build-path[Specify build directory]: :_files'
+}
+
+_swift_package() {
+    local -a commands
+    commands=(
+        'init:Initialize a new package'
+        'fetch:Fetch package dependencies'
+        'update:Update package dependencies'
+        'generate-xcodeproj:Generates an Xcode project'
+        'show-dependencies:Print the resolved dependency graph'
+        'dump-package:Print parsed Package.swift as JSON'
+    )
+    _arguments \
+        '(-): :{_describe "commands" commands}' \
+        '(-)*:: :->arg'
+
+    case $state in
+        (arg)
+            declare -a package_options
+            package_options=(
+                $shared_options
+                "--enable-code-coverage[Enable code coverage in generated Xcode projects]"
+            )
+
+            case ${words[1]} in
+                (init)
+                    _arguments \
+                        '--type[Type of package to initialize]: :{_values "package types" empty library executable system-module}' \
+                        $package_options
+                    ;;
+                (generate-xcodeproj)
+                    _arguments \
+                        '--output:[Xcode project filename]:_files' \
+                        $package_options
+                    ;;
+                (show-dependencies)
+                    _arguments \
+                        '--format[Dependency graph output format]:FORMATS:{_values "formats" text dot json}' \
+                        $package_options
+                    ;;
+                (dump-package)
+                    _arguments \
+                        '--input:[Package filename to parse]:_files' \
+                        $package_options
+                    ;;
+                (*)
+                    _arguments $package_options
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+_swift_test() {
+    _arguments \
+        '(-s --specifier)'{-s,--specifier}'[Run a test case subclass <test-module>.<test-case>]: : ' \
+        '(-s --specifier)'{-s,--specifier}'[Run a specific test method <test-module>.<test-case>/<test>]: : ' \
+        '(-l --list-tests)'{-l,--list-tests}'[Lists test methods in specifier format]' \
+        '--skip-build[Skip building the test target]' \
+        $shared_options
+}
+
+_swift_compiler() {
+    declare -a build_options
+    build_options=(
+        '-assert-config[Specify the assert_configuration replacement.]: :{_values "" Debug Release Unchecked DisableReplacement}'
+        '-D[Marks a conditional compilation flag as true]: : '
+        '-framework[Specifies a framework which should be linked against]: : '
+        '-F[Add directory to framework search path]: :_files'
+        '-gdwarf-types[Emit full DWARF type info.]'
+        '-gline-tables-only[Emit minimal debug info for backtraces only]'
+        "-gnone[Don't emit debug info]"
+        '-g[Emit debug info. This is the preferred setting for debugging with LLDB.]'
+        '-help[Display available options]'
+        '-index-store-path[Store indexing data to <path>]: :_files'
+        '-I[Add directory to the import search path]: :_files'
+        '-j[Number of commands to execute in parallel]: : '
+        '-L[Add directory to library link search path]: :_files'
+        '-l-[Specifies a library which should be linked against]: : '
+        '-module-cache-path[Specifies the Clang module cache path]: :_files'
+        '-module-link-name[Library to link against when using this module]: : '
+        '-module-name[Name of the module to build]: : '
+        "-nostdimport[Don't search the standard library import path for modules]"
+        '-num-threads[Enable multi-threading and specify number of threads]: : '
+        '-Onone[Compile without any optimization]'
+        '-Ounchecked[Compile with optimizations and remove runtime safety checks]'
+        '-O[Compile with optimizations]'
+        '-sdk[Compile against <sdk>]: : '
+        '-static-stdlib[Statically link the Swift standard library]'
+        '-suppress-warnings[Suppress all warnings]'
+        '-target-cpu[Generate code for a particular CPU variant]: : '
+        '-target[Generate code for the given target]: : '
+        '-use-ld=-[Specifies the linker to be used]'
+        '-version[Print version information and exit]'
+        '-v[Show commands to run and use verbose output]'
+        '-warnings-as-errors[Treat warnings as errors]'
+        '-Xcc[Pass <arg> to the C/C++/Objective-C compiler]: : '
+        '-Xlinker[Specifies an option which should be passed to the linker]: : '
+        '*:inputs:_files'
+    )
+    _arguments $build_options
+}
+
+_swift


### PR DESCRIPTION
# How / why

My initial attempt was rather focused on how bash performs auto completions. I added a package command "completions" which received some context about the cursor. However this doesn't work for zsh, which has a richer completion system.

In order to accomodate for the different shells, I have written two separate terminal completion scripts. Each tailored to the specific needs of bash and zsh. The ticket also mentions the fish shell, but I don't have experience with that shell.

# Demo

ZSH:
![zsh demo](https://cloud.githubusercontent.com/assets/235882/18910036/805fb40a-8576-11e6-98ff-2114c9997bf6.gif)

BASH:
![bash demo](https://cloud.githubusercontent.com/assets/235882/18910038/8468299c-8576-11e6-954e-7b6c5749bba9.gif)

# Instructions

For bash, add the following to your ``~/.bash_profile``:

    source /path/to/Utilities/bash/completion

For zsh, add the following line to your ``~/.zshrc``:

    fpath=(/path/to/Utilities/zsh $fpath)
    autoload -U compinit && compinit

# Room for improvement

* I don't have much experience writing shell scripts, it took me quite a while to get this somewhat working. The code might be brittle. However I think it is good to have initial support for shell completion, and the scripts would be improved over time.
* Currently there is no completion for ``swift test -s`` which would be very nice. 
* How would these scripts be published with the toolchains?