### PR TITLE
[Repository] Add exists(revision:) method

### DIFF
--- a/Sources/SourceControl/Repository.swift
+++ b/Sources/SourceControl/Repository.swift
@@ -113,6 +113,9 @@ public protocol Repository {
     /// - Throws: If an error occurs while performing the fetch operation.
     func fetch() throws
 
+    /// Returns true if the given revision exists.
+    func exists(revision: Revision) -> Bool
+
     /// Open an immutable file system view for a particular revision.
     ///
     /// This view exposes the contents of the repository at the given revision

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -48,6 +48,10 @@ private class MockRepository: Repository {
         fatalError("Unexpected API call")
     }
 
+    func exists(revision: Revision) -> Bool {
+        fatalError("Unexpected API call")
+    }
+
     func remove() throws {
         fatalError("Unexpected API call")
     }

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -33,6 +33,10 @@ private class DummyRepository: Repository {
         fatalError("unexpected API call")
     }
 
+    func exists(revision: Revision) -> Bool {
+        fatalError("unexpected API call")
+    }
+
     func fetch() throws {
         provider.numFetches += 1
     }


### PR DESCRIPTION
This is already implemented, forgot to add this to Repository protocol before