### PR TITLE
[GitRepository] Do actual checkout in checkout methods

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -346,7 +346,7 @@ public class GitRepository: Repository, WorkingCheckout {
     public func checkout(revision: Revision) throws {
         // FIXME: Audit behavior with off-branch tags in remote repositories, we
         // may need to take a little more care here.
-        try runCommandQuietly([Git.tool, "-C", path.asString, "reset", "--hard", revision.identifier])
+        try runCommandQuietly([Git.tool, "-C", path.asString, "checkout", "-f", revision.identifier])
     }
 
     /// Returns true if a revision exists.

--- a/Tests/CommandsTests/WorkspaceTests.swift
+++ b/Tests/CommandsTests/WorkspaceTests.swift
@@ -522,7 +522,7 @@ final class WorkspaceTests: XCTestCase {
             }
             let dependency = getDependency(aManifest)
             // Put the dependency in edit mode.
-            try workspace.edit(dependency: dependency, at: dependency.currentRevision!, packageName: aManifest.name)
+            try workspace.edit(dependency: dependency, at: dependency.currentRevision!, packageName: aManifest.name, checkoutBranch: "bugfix")
 
             let editedDependency = getDependency(aManifest)
             let editRepoPath = workspace.editablesPath.appending(editedDependency.subpath)


### PR DESCRIPTION
Currently it just hard resets which keeps the HEAD on master branch