### PR TITLE
[SR-2087] Better error message for module map generator

### DIFF
--- a/Sources/PackageLoading/ModuleMapGenerator.swift
+++ b/Sources/PackageLoading/ModuleMapGenerator.swift
@@ -181,30 +181,38 @@ extension ModuleMapGenerator.ModuleMapError: FixableError {
     public var error: String {
         switch self {
         case .unsupportedIncludeLayoutForModule(let (name, problem)):
-            let additional: String
-            switch problem {
-            case .umbrellaHeaderWithAdditionalNonEmptyDirectories(let (umbrella, dirs)):
-                additional = "an umbrella header is defined at \(umbrella.asString), but the following directories exist: \(dirs.map { $0.asString }.joined(separator: ", "))"
-            case .umbrellaHeaderWithAdditionalDirectoriesInIncludeDirectory(let (umbrella, dirs)):
-                additional = "an umbrella header is defined at \(umbrella.asString), but more than 1 directories exist: \(dirs.map { $0.asString }.joined(separator: ", "))"
-            case .umbrellaHeaderWithAdditionalFilesInIncludeDirectory(let (umbrella, files)):
-                additional = "an umbrella header is defined at \(umbrella.asString), but the following files exist: \(files.map { $0.asString }.joined(separator: ", "))"
-            }
-            return "could not generate module map for module \(name), the file layout is not supported: \(additional)"
+            return "could not generate module map for module '\(name)', the file layout is not supported: \(problem.error)"
         }
     }
 
     public var fix: String? {
         switch self {
         case .unsupportedIncludeLayoutForModule(let (_, problem)):
-            switch problem {
-            case .umbrellaHeaderWithAdditionalNonEmptyDirectories(let (_, dirs)):
-                return "remove these directories: \(dirs.map { $0.asString }.joined(separator: ", "))"
-            case .umbrellaHeaderWithAdditionalDirectoriesInIncludeDirectory(let (_, dirs)):
-                return "reduce these directories to a single directory: \(dirs.map { $0.asString }.joined(separator: ", "))"
-            case.umbrellaHeaderWithAdditionalFilesInIncludeDirectory(let (_, files)):
-                return "remove these files: \(files.map { $0.asString }.joined(separator: ", "))"
-            }
+            return problem.fix
+        }
+    }
+}
+
+extension ModuleMapGenerator.ModuleMapError.UnsupportedIncludeLayoutType: FixableError {
+    public var error: String {
+        switch self {
+        case .umbrellaHeaderWithAdditionalNonEmptyDirectories(let (umbrella, dirs)):
+            return "an umbrella header is defined at \(umbrella.asString), but the following directories exist: \(dirs.map { $0.asString }.sorted().joined(separator: ", "))"
+        case .umbrellaHeaderWithAdditionalDirectoriesInIncludeDirectory(let (umbrella, dirs)):
+            return "an umbrella header is defined at \(umbrella.asString), but more than 1 directories exist: \(dirs.map { $0.asString }.sorted().joined(separator: ", "))"
+        case .umbrellaHeaderWithAdditionalFilesInIncludeDirectory(let (umbrella, files)):
+            return "an umbrella header is defined at \(umbrella.asString), but the following files exist: \(files.map { $0.asString }.sorted().joined(separator: ", "))"
+        }
+    }
+
+    public var fix: String? {
+        switch self {
+        case .umbrellaHeaderWithAdditionalNonEmptyDirectories(let (_, dirs)):
+            return "remove these directories: \(dirs.map { $0.asString }.sorted().joined(separator: ", "))"
+        case .umbrellaHeaderWithAdditionalDirectoriesInIncludeDirectory(let (_, dirs)):
+            return "reduce these directories to a single directory: \(dirs.map { $0.asString }.sorted().joined(separator: ", "))"
+        case.umbrellaHeaderWithAdditionalFilesInIncludeDirectory(let (_, files)):
+            return "remove these files: \(files.map { $0.asString }.sorted().joined(separator: ", "))"
         }
     }
 }

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -120,12 +120,12 @@ class ModuleMapGeneration: XCTestCase {
         fs = InMemoryFileSystem(emptyFiles:
             "/include/Foo/Foo.h",
             "/include/Bar/Foo.h")
-        checkExpected("could not generate module map for module Foo, the file layout is not supported: an umbrella header is defined at /include/Foo/Foo.h, but more than 1 directories exist: /include/Foo, /include/Bar fix: reduce these directories to a single directory: /include/Foo, /include/Bar")
+        checkExpected("could not generate module map for module 'Foo', the file layout is not supported: an umbrella header is defined at /include/Foo/Foo.h, but more than 1 directories exist: /include/Bar, /include/Foo fix: reduce these directories to a single directory: /include/Bar, /include/Foo")
 
         fs = InMemoryFileSystem(emptyFiles:
             "/include/Foo.h",
             "/include/Bar/Foo.h")
-        checkExpected("could not generate module map for module Foo, the file layout is not supported: an umbrella header is defined at /include/Foo.h, but the following directories exist: /include/Bar fix: remove these directories: /include/Bar")
+        checkExpected("could not generate module map for module 'Foo', the file layout is not supported: an umbrella header is defined at /include/Foo.h, but the following directories exist: /include/Bar fix: remove these directories: /include/Bar")
     }
 
     static var allTests = [

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -110,22 +110,22 @@ class ModuleMapGeneration: XCTestCase {
 
     func testUnsupportedLayouts() throws {
         var fs: InMemoryFileSystem
-        func checkExpected() {
+        func checkExpected(_ str: String, file: StaticString = #file, line: UInt = #line) {
             ModuleMapTester("Foo", in: fs) { result in
                 result.checkNotCreated()
-                result.checkDiagnostics("unsupportedIncludeLayoutForModule(\"Foo\")")
+                result.checkDiagnostics(str, file: file, line: line)
             }
         }
 
         fs = InMemoryFileSystem(emptyFiles:
             "/include/Foo/Foo.h",
             "/include/Bar/Foo.h")
-        checkExpected()
+        checkExpected("could not generate module map for module Foo, the file layout is not supported: an umbrella header is defined at /include/Foo/Foo.h, but more than 1 directories exist: /include/Foo, /include/Bar fix: reduce these directories to a single directory: /include/Foo, /include/Bar")
 
         fs = InMemoryFileSystem(emptyFiles:
             "/include/Foo.h",
             "/include/Bar/Foo.h")
-        checkExpected()
+        checkExpected("could not generate module map for module Foo, the file layout is not supported: an umbrella header is defined at /include/Foo.h, but the following directories exist: /include/Bar fix: remove these directories: /include/Bar")
     }
 
     static var allTests = [


### PR DESCRIPTION
Currently the error message for an invalid C module is this:

```
swift build
error: unsupportedIncludeLayoutForModule("sodium")
```

With this PR, it becomes:

```
swift build
error: could not generate module map for module sodium, the file layout is not supported: an 
umbrella header is defined at /[...]/Sources/sodium/include/sodium/sodium.h, but the following
files exist: /[...]/Sources/sodium/include/other.h
fix: remove these files: /[...]/Sources/sodium/include/other.h
```