### PR TITLE
[SR-2083] Don't error if a directory contains only ignored files

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -407,7 +407,7 @@ public struct PackageBuilder {
                 do {
                     return try createModule(path, name: path.basename, isTest: false)
                 } catch Module.Error.noSources {
-                    warningStream <<< "warning: module `\(path.basename)` does not contain any sources.\n"
+                    warningStream <<< "warning: module '\(path.basename)' does not contain any sources.\n"
                     warningStream.flush()
                     return nil
                 }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -387,7 +387,10 @@ public struct PackageBuilder {
         let modules: [Module]
         if potentialModulePaths.isEmpty {
             // There are no directories that look like modules, so try to create a module for the source directory itself (with the name coming from the name in the manifest).
-            modules = [try createModule(srcDir, name: manifest.name, isTest: false)].flatMap { $0 }
+            guard let module = try createModule(srcDir, name: manifest.name, isTest: false) else {
+                return []
+            }
+            modules = [module]
         } else {
             // We have at least one directory that looks like a module, so we try to create a module for each one.
             modules = try potentialModulePaths.flatMap { path in

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -604,7 +604,12 @@ public struct PackageBuilder {
         
         // Create the test modules
         return try testsDirContents.filter(shouldConsiderDirectory).flatMap { dir in
-            return [try createModule(dir, name: dir.basename, isTest: true)].flatMap { $0 }
+            guard let module = try createModule(dir, name: dir.basename, isTest: true) else {
+                warningStream <<< "warning: test module '\(dir.basename)' does not contain any sources.\n"
+                warningStream.flush()
+                return nil
+            }
+            return module
         }
     }
 }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -109,9 +109,6 @@ extension Module {
             case hasTestSuffix
         }
         
-        /// The module contains no source code at all.
-        case noSources(String)
-        
         /// The module contains an invalid mix of languages (e.g. both Swift and C).
         case mixedSources(String)
     }
@@ -122,8 +119,6 @@ extension Module.Error: FixableError {
         switch self {
           case .invalidName(let path, let name, let problem):
             return "the module at \(path) has an invalid name ('\(name)'): \(problem.error)"
-          case .noSources(let path):
-            return "the module at \(path) does not contain any source files"
           case .mixedSources(let path):
             return "the module at \(path) contains mixed language source files"
         }
@@ -133,8 +128,6 @@ extension Module.Error: FixableError {
         switch self {
         case .invalidName(let path, _, let problem):
             return "rename the module at ‘\(path)’\(problem.fix ?? "")"
-        case .noSources(_):
-            return "either remove the module folder, or add a source file to the module"
         case .mixedSources(_):
             return "use only a single language within a module"
         }
@@ -394,23 +387,16 @@ public struct PackageBuilder {
         let modules: [Module]
         if potentialModulePaths.isEmpty {
             // There are no directories that look like modules, so try to create a module for the source directory itself (with the name coming from the name in the manifest).
-            do {
-                modules = [try createModule(srcDir, name: manifest.name, isTest: false)]
-            }
-            catch Module.Error.noSources {
-                // Completely empty packages are allowed as a special case.
-                modules = []
-            }
+            modules = [try createModule(srcDir, name: manifest.name, isTest: false)].flatMap { $0 }
         } else {
             // We have at least one directory that looks like a module, so we try to create a module for each one.
             modules = try potentialModulePaths.flatMap { path in
-                do {
-                    return try createModule(path, name: path.basename, isTest: false)
-                } catch Module.Error.noSources {
+                guard let module = try createModule(path, name: path.basename, isTest: false) else {
                     warningStream <<< "warning: module '\(path.basename)' does not contain any sources.\n"
                     warningStream.flush()
                     return nil
                 }
+                return module
             }
         }
 
@@ -489,7 +475,7 @@ public struct PackageBuilder {
     }
     
     /// Private function that constructs a single Module object for the module at `path`, having the name `name`.  If `isTest` is true, the module is constructed as a test module; if false, it is a regular module.
-    private func createModule(_ path: AbsolutePath, name: String, isTest: Bool) throws -> Module {
+    private func createModule(_ path: AbsolutePath, name: String, isTest: Bool) throws -> Module? {
         
         // Validate the module name.  This function will throw an error if it detects a problem.
         try validateModuleName(path, name, isTest: isTest)
@@ -502,15 +488,23 @@ public struct PackageBuilder {
         let cSources = sources.filter{ SupportedLanguageExtension.cFamilyExtensions.contains($0.extension!) }
         let swiftSources = sources.filter{ SupportedLanguageExtension.swiftExtensions.contains($0.extension!) }
         assert(sources.count == cSources.count + swiftSources.count)
+        
+        // Expect either C or Swift sources. Not both.
+        guard cSources.isEmpty != swiftSources.isEmpty else {
+            if swiftSources.isEmpty {
+                // No sources at all. This is not a module.
+                return nil
+            } else {
+                throw Module.Error.mixedSources(path.asString)
+            }
+        }
 
         // Create and return the right kind of module depending on what kind of sources we found.
         if cSources.isEmpty {
             // No C sources, so we expect to have Swift sources, and we create a Swift module.
-            guard !swiftSources.isEmpty else { throw Module.Error.noSources(path.asString) }
             return try SwiftModule(name: name, isTest: isTest, sources: Sources(paths: swiftSources, root: path))
         } else {
             // No Swift sources, so we expect to have C sources, and we create a C module.
-            guard swiftSources.isEmpty else { throw Module.Error.mixedSources(path.asString) }
             return try ClangModule(name: name, isTest: isTest, sources: Sources(paths: cSources, root: path))
         }
     }
@@ -607,7 +601,7 @@ public struct PackageBuilder {
         
         // Create the test modules
         return try testsDirContents.filter(shouldConsiderDirectory).flatMap { dir in
-            return [try createModule(dir, name: dir.basename, isTest: true)]
+            return [try createModule(dir, name: dir.basename, isTest: true)].flatMap { $0 }
         }
     }
 }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -403,8 +403,14 @@ public struct PackageBuilder {
             }
         } else {
             // We have at least one directory that looks like a module, so we try to create a module for each one.
-            modules = try potentialModulePaths.map { path in
-                try createModule(path, name: path.basename, isTest: false)
+            modules = try potentialModulePaths.flatMap { path in
+                do {
+                    return try createModule(path, name: path.basename, isTest: false)
+                } catch Module.Error.noSources {
+                    warningStream <<< "warning: module `\(path.basename)` does not contain any sources.\n"
+                    warningStream.flush()
+                    return nil
+                }
             }
         }
 

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -490,20 +490,20 @@ public struct PackageBuilder {
         assert(sources.count == cSources.count + swiftSources.count)
         
         // Expect either C or Swift sources. Not both.
-        guard cSources.isEmpty != swiftSources.isEmpty else {
-            if swiftSources.isEmpty {
-                // No sources at all. This is not a module.
-                return nil
-            } else {
-                throw Module.Error.mixedSources(path.asString)
-            }
-        }
+        switch (cSources.isEmpty, swiftSources.isEmpty) {
+        case (true, true):
+            // No sources at all. This is not a module.
+            return nil
+
+        case (false, false):
+            throw Module.Error.mixedSources(path.asString)
 
         // Create and return the right kind of module depending on what kind of sources we found.
-        if cSources.isEmpty {
+        case (true, false):
             // No C sources, so we expect to have Swift sources, and we create a Swift module.
             return try SwiftModule(name: name, isTest: isTest, sources: Sources(paths: swiftSources, root: path))
-        } else {
+
+        case (false, true):
             // No Swift sources, so we expect to have C sources, and we create a C module.
             return try ClangModule(name: name, isTest: isTest, sources: Sources(paths: cSources, root: path))
         }

--- a/Tests/PackageLoadingTests/ConventionTests.swift
+++ b/Tests/PackageLoadingTests/ConventionTests.swift
@@ -851,11 +851,16 @@ class ConventionTests: XCTestCase {
     }
 
     func testNoSourcesInModule() throws {
-        let fs = InMemoryFileSystem()
+        var fs = InMemoryFileSystem()
         try fs.createDirectory(AbsolutePath("/Sources/Module"), recursive: true)
-
         PackageBuilderTester("MyPackage", in: fs) { result in
             result.checkDiagnostic("warning: module 'Module' does not contain any sources.")
+        }
+
+        fs = InMemoryFileSystem()
+        try fs.createDirectory(AbsolutePath("/Tests/ModuleTests"), recursive: true)
+        PackageBuilderTester("MyPackage", in: fs) { result in
+            result.checkDiagnostic("warning: test module 'ModuleTests' does not contain any sources.")
         }
     }
 

--- a/Tests/PackageLoadingTests/ConventionTests.swift
+++ b/Tests/PackageLoadingTests/ConventionTests.swift
@@ -618,6 +618,15 @@ class ConventionTests: XCTestCase {
         PackageBuilderTester(package, in: fs) { result in
             result.checkDiagnostic("the target lib cannot have the executable exec as a dependency fix: move the shared logic inside a library, which can be referenced from both the target and the executable")
         }
+
+        // Reference a target which doesn't have sources.
+        fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/pkg1/Foo.swift",
+            "/Sources/pkg2/readme.txt")
+        package = PackageDescription.Package(name: "pkg", targets: [Target(name: "pkg1", dependencies: ["pkg2"])])
+        PackageBuilderTester(package, in: fs) { result in
+            result.checkDiagnostic("these referenced modules could not be found: pkg2 fix: reference only valid modules")
+        }
     }
 
     func testProducts() throws {

--- a/Tests/PackageLoadingTests/ConventionTests.swift
+++ b/Tests/PackageLoadingTests/ConventionTests.swift
@@ -625,6 +625,7 @@ class ConventionTests: XCTestCase {
             "/Sources/pkg2/readme.txt")
         package = PackageDescription.Package(name: "pkg", targets: [Target(name: "pkg1", dependencies: ["pkg2"])])
         PackageBuilderTester(package, in: fs) { result in
+            result.checkDiagnostic("warning: module 'pkg2' does not contain any sources.")
             result.checkDiagnostic("these referenced modules could not be found: pkg2 fix: reference only valid modules")
         }
     }
@@ -854,7 +855,7 @@ class ConventionTests: XCTestCase {
         try fs.createDirectory(AbsolutePath("/Sources/Module"), recursive: true)
 
         PackageBuilderTester("MyPackage", in: fs) { result in
-            result.checkDiagnostic("warning: module `Module` does not contain any sources.")
+            result.checkDiagnostic("warning: module 'Module' does not contain any sources.")
         }
     }
 

--- a/Tests/PackageLoadingTests/ConventionTests.swift
+++ b/Tests/PackageLoadingTests/ConventionTests.swift
@@ -845,7 +845,7 @@ class ConventionTests: XCTestCase {
         try fs.createDirectory(AbsolutePath("/Sources/Module"), recursive: true)
 
         PackageBuilderTester("MyPackage", in: fs) { result in
-            result.checkDiagnostic("the module at /Sources/Module does not contain any source files fix: either remove the module folder, or add a source file to the module")
+            result.checkDiagnostic("warning: module `Module` does not contain any sources.")
         }
     }
 


### PR DESCRIPTION
This PR will make it easier to work on different branches, as git doesn't remove empty directories when switching. Empty directories will now be warned about, but won't result in an error.

It will catch Module.Error.noSources when iterating over possible modules. It will then issue a warning on the warningStream that the module has been skipped due to missing sources.