### PR TITLE
Reorder swiftc args to allow user override

### DIFF
--- a/Fixtures/Miscellaneous/OverrideSwiftcArgs/Package.swift
+++ b/Fixtures/Miscellaneous/OverrideSwiftcArgs/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "OverrideSwiftcArgs"
+)

--- a/Fixtures/Miscellaneous/OverrideSwiftcArgs/Sources/main.swift
+++ b/Fixtures/Miscellaneous/OverrideSwiftcArgs/Sources/main.swift
@@ -1,0 +1,7 @@
+/// This file exists to test the ability to override deployment targets via args passed to swiftc
+/// For this test to work, this file must have an API call which was introduced in a version
+/// higher than the default macOS deployment target that is checked in.
+@available(macOS 10.20, *)
+func foo() {}
+
+foo()

--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -38,7 +38,7 @@ public func describe(_ prefix: AbsolutePath, _ conf: Configuration, _ graph: Pac
     for module in graph.modules {
         switch module {
         case let module as SwiftModule:
-            let compile = try Command.compile(swiftModule: module, configuration: conf, prefix: prefix, otherArgs: swiftcArgs + toolchain.swiftPlatformArgs, compilerExec: toolchain.swiftCompiler)
+            let compile = try Command.compile(swiftModule: module, configuration: conf, prefix: prefix, otherArgs: toolchain.swiftPlatformArgs + swiftcArgs, compilerExec: toolchain.swiftCompiler)
             commands.append(compile)
             targets.append([compile], for: module)
 
@@ -48,7 +48,7 @@ public func describe(_ prefix: AbsolutePath, _ conf: Configuration, _ graph: Pac
             if module.isTest { continue }
           #endif
             // FIXME: Find a way to eliminate `externalModules` from here.
-            let compile = try Command.compile(clangModule: module, externalModules: graph.externalModules, configuration: conf, prefix: prefix, otherArgs: flags.cCompilerFlags + toolchain.clangPlatformArgs, compilerExec: toolchain.clangCompiler)
+            let compile = try Command.compile(clangModule: module, externalModules: graph.externalModules, configuration: conf, prefix: prefix, otherArgs: toolchain.clangPlatformArgs + flags.cCompilerFlags, compilerExec: toolchain.clangCompiler)
             commands += compile
             targets.append(compile, for: module)
 
@@ -62,7 +62,7 @@ public func describe(_ prefix: AbsolutePath, _ conf: Configuration, _ graph: Pac
 
     for product in graph.products {
         var rpathArgs = [String]()
-        
+
         // On Linux, always embed an RPATH adjacent to the linked binary. Note
         // that the '$ORIGIN' here is literal, it is a reference which is
         // understood by the dynamic linker.
@@ -73,7 +73,7 @@ public func describe(_ prefix: AbsolutePath, _ conf: Configuration, _ graph: Pac
         if product.containsOnlyClangModules {
             command = try Command.linkClangModule(product, configuration: conf, prefix: prefix, otherArgs: Xld, linkerExec: toolchain.clangCompiler)
         } else {
-            command = try Command.linkSwiftModule(product, configuration: conf, prefix: prefix, otherArgs: Xld + swiftcArgs + toolchain.swiftPlatformArgs + rpathArgs, linkerExec: toolchain.swiftCompiler)
+            command = try Command.linkSwiftModule(product, configuration: conf, prefix: prefix, otherArgs: Xld + toolchain.swiftPlatformArgs + swiftcArgs + rpathArgs, linkerExec: toolchain.swiftCompiler)
         }
 
         commands.append(command)

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -21,7 +21,7 @@ import func POSIX.popen
 class MiscellaneousTestCase: XCTestCase {
     func testPrintsSelectedDependencyVersion() {
 
-        // verifies the stdout contains information about 
+        // verifies the stdout contains information about
         // the selected version of the package
 
         fixture(name: "DependencyResolution/External/Simple", tags: ["1.3.5"]) { prefix in
@@ -91,21 +91,21 @@ class MiscellaneousTestCase: XCTestCase {
             XCTAssertNoSuchPath(buildDir.appending(component: "some"))
         }
     }
-    
+
     func testManifestExcludes4() {
-        
+
         // exclude directory is inside Tests folder (Won't build without exclude)
-        
+
         fixture(name: "Miscellaneous/ExcludeDiagnostic4") { prefix in
             XCTAssertBuilds(prefix)
             XCTAssertFileExists(prefix.appending(components: ".build", "debug", "FooPackage.swiftmodule"))
         }
     }
-    
+
     func testManifestExcludes5() {
-        
+
         // exclude directory is Tests folder (Won't build without exclude)
-        
+
         fixture(name: "Miscellaneous/ExcludeDiagnostic5") { prefix in
             XCTAssertBuilds(prefix)
             XCTAssertFileExists(prefix.appending(components: ".build", "debug", "FooPackage.swiftmodule"))
@@ -318,13 +318,13 @@ class MiscellaneousTestCase: XCTestCase {
             XCTAssertFileExists(prefix.appending(components: ".build", "debug", "libProductName.\(Product.dynamicLibraryExtension)"))
         }
     }
-    
+
     func testProductWithNoModules() {
         fixture(name: "Miscellaneous/ProductWithNoModules") { prefix in
             XCTAssertBuildFails(prefix)
         }
     }
-    
+
     func testProductWithMissingModules() {
         fixture(name: "Miscellaneous/ProductWithMissingModules") { prefix in
             XCTAssertBuildFails(prefix)
@@ -387,6 +387,14 @@ class MiscellaneousTestCase: XCTestCase {
         }
     }
 
+    func testOverridingSwiftcArguments() throws {
+#if os(macOS)
+        fixture(name: "Miscellaneous/OverrideSwiftcArgs") { prefix in
+            try executeSwiftBuild(prefix, configuration: .Debug, printIfError: true, Xcc: [], Xld: [], Xswiftc: ["-target", "x86_64-apple-macosx10.20"], env: [:])
+        }
+#endif
+    }
+
     static var allTests = [
         ("testExecutableAsBuildOrderDependency", testExecutableAsBuildOrderDependency),
         ("testPrintsSelectedDependencyVersion", testPrintsSelectedDependencyVersion),
@@ -418,5 +426,6 @@ class MiscellaneousTestCase: XCTestCase {
         ("testSecondBuildIsNullInModulemapGen", testSecondBuildIsNullInModulemapGen),
         ("testSwiftTestParallel", testSwiftTestParallel),
         ("testInitPackageNonc99Directory", testInitPackageNonc99Directory),
+        ("testOverridingSwiftcArguments", testOverridingSwiftcArguments),
     ]
 }


### PR DESCRIPTION
Currently the build target arguments are hard coded in the swiftpm
source. Until they are broken out into some configuration method, it
would be useful for users to be able to override these arguments for
their use case. This change reorders the passed arguments to pass along
the users arguments after the default arguments.

See this thread for more info: https://lists.swift.org/pipermail/swift-build-dev//Week-of-Mon-20160919/000637.html