### PR TITLE
strerror is not thread-safe

### DIFF
--- a/Sources/POSIX/Error.swift
+++ b/Sources/POSIX/Error.swift
@@ -52,7 +52,7 @@ extension SystemError: CustomStringConvertible {
                 if err != 0 {
                     fatalError("strerror_r error: \(err)")
                 }
-                return String(cString: buf)
+                return "\(String(cString: buf)) (\(errno))"
             }
         }
      

--- a/Sources/POSIX/Error.swift
+++ b/Sources/POSIX/Error.swift
@@ -33,6 +33,8 @@ public enum SystemError: Swift.Error {
 }
 
 import func libc.strerror_r
+import var libc.EINVAL
+import var libc.ERANGE
 
 
 extension SystemError: CustomStringConvertible {

--- a/Sources/POSIX/Error.swift
+++ b/Sources/POSIX/Error.swift
@@ -32,7 +32,7 @@ public enum SystemError: Swift.Error {
     case waitpid(Int32)
 }
 
-import func libc.strerror
+import func libc.strerror_r
 
 
 extension SystemError: CustomStringConvertible {
@@ -40,7 +40,7 @@ extension SystemError: CustomStringConvertible {
         func strerror(_ errno: Int32) -> String {
             for cap in [64, 128, 512, 1024, 2048, 4096, 8192, 16_384] {
                 var buf = [Int8](repeating: 0, count: cap)
-                let err = strerror_r(errno, &buf, buf.count)
+                let err = libc.strerror_r(errno, &buf, buf.count)
                 if err == EINVAL {
                     return "Unknown error \(errno)"
                 }

--- a/Sources/POSIX/Error.swift
+++ b/Sources/POSIX/Error.swift
@@ -38,15 +38,13 @@ import func libc.strerror
 extension SystemError: CustomStringConvertible {
     public var description: String {
         func strerror(_ errno: Int32) -> String {
-            var cap = 64
-            while true {
+            for cap in [64, 128, 512, 1024, 2048, 4096, 8192, 16_384] {
                 var buf = [Int8](repeating: 0, count: cap)
                 let err = strerror_r(errno, &buf, buf.count)
                 if err == EINVAL {
                     return "Unknown error \(errno)"
                 }
                 if err == ERANGE {
-                    cap *= 2
                     continue
                 }
                 if err != 0 {
@@ -54,6 +52,7 @@ extension SystemError: CustomStringConvertible {
                 }
                 return "\(String(cString: buf)) (\(errno))"
             }
+            fatalError("strerror_r error: \(ERANGE)")
         }
         
         switch self {

--- a/Sources/POSIX/Error.swift
+++ b/Sources/POSIX/Error.swift
@@ -38,7 +38,7 @@ import func libc.strerror_r
 extension SystemError: CustomStringConvertible {
     public var description: String {
         func strerror(_ errno: Int32) -> String {
-            for cap in [64, 128, 512, 1024, 2048, 4096, 8192, 16_384] {
+            for cap in sequence(first: 64, next: { $0 < 16 * 1024 ? $0 * 2 : nil }) {
                 var buf = [Int8](repeating: 0, count: cap)
                 let err = libc.strerror_r(errno, &buf, buf.count)
                 if err == EINVAL {

--- a/Sources/POSIX/Error.swift
+++ b/Sources/POSIX/Error.swift
@@ -38,13 +38,15 @@ import func libc.strerror_r
 extension SystemError: CustomStringConvertible {
     public var description: String {
         func strerror(_ errno: Int32) -> String {
-            for cap in sequence(first: 64, next: { $0 < 16 * 1024 ? $0 * 2 : nil }) {
+            var cap = 64
+            while cap <= 16 * 1024 {
                 var buf = [Int8](repeating: 0, count: cap)
                 let err = libc.strerror_r(errno, &buf, buf.count)
                 if err == EINVAL {
                     return "Unknown error \(errno)"
                 }
                 if err == ERANGE {
+                    cap *= 2
                     continue
                 }
                 if err != 0 {

--- a/Sources/POSIX/Error.swift
+++ b/Sources/POSIX/Error.swift
@@ -36,7 +36,7 @@ import func libc.strerror
 
 
 extension SystemError: CustomStringConvertible {
-    public var description: {
+    public var description: String {
         func strerror(_ errno: Int32) -> String {
             var cap = 64
             while true {
@@ -55,7 +55,7 @@ extension SystemError: CustomStringConvertible {
                 return "\(String(cString: buf)) (\(errno))"
             }
         }
-     
+        
         switch self {
         case .chdir(let errno, let path):
             return "chdir error: \(strerror(errno)): \(path)"


### PR DESCRIPTION
See http://manpages.ubuntu.com/manpages/xenial/en/man3/strerror_r.3.html

Assuming that the POSIX target allows using the different functions from different threads, the error reporting facility should be thread-safe. Since strerror_r is available with different signatures depending on the system, it may be necessary to implement this multiple times.