### PR TITLE
[Basic] Add Result enum

### DIFF
--- a/Sources/Basic/Result.swift
+++ b/Sources/Basic/Result.swift
@@ -1,0 +1,81 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// An simple enum which is either a value or an error.
+/// It can be used for error handling in situations where try catch is
+/// problematic to use, for eg: asynchronous APIs.
+public enum Result<Value, ErrorType: Swift.Error> {
+    /// Indicates success with value in the associated object.
+    case success(Value)
+
+    /// Indicates failure with error inside the associated object.
+    case failure(ErrorType)
+
+    /// Initialiser for value.
+    public init(_ value: Value) {
+        self = .success(value)
+    }
+
+    /// Initialiser for error.
+    public init(_ error: ErrorType) {
+        self = .failure(error)
+    }
+
+    /// Initialise with something that can throw ErrorType.
+    public init(_ body: () throws -> Value) throws {
+        do {
+            self = .success(try body())
+        } catch let error as ErrorType {
+            self = .failure(error)
+        }
+    }
+
+    /// Get the value if success else throw the saved error.
+    public func dematerialize() throws -> Value {
+        switch self {
+        case .success(let value):
+            return value
+        case .failure(let error):
+            throw error
+        }
+    }
+}
+
+extension Result: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .success(let value):
+            return "Result(\(value))"
+        case .failure(let error):
+            return "Result(\(error))"
+        }
+    }
+}
+
+/// A type erased error enum.
+public struct AnyError: Swift.Error, CustomStringConvertible  {
+    /// The underlying error.
+    public let underlyingError: Swift.Error
+
+    public init(_ error: Swift.Error) {
+        self.underlyingError = error
+    }
+
+    public var description: String {
+        return String(describing: underlyingError)
+    }
+}
+
+extension Result where ErrorType == AnyError {
+    /// Convenience Initialiser for any error types.
+    public init(_ error: Swift.Error) {
+        self = .failure(AnyError(error))
+    }
+}

--- a/Tests/BasicTests/ResultTests.swift
+++ b/Tests/BasicTests/ResultTests.swift
@@ -1,0 +1,95 @@
+/*
+This source file is part of the Swift.org open source project
+
+Copyright 2016 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See http://swift.org/LICENSE.txt for license information
+See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+import Basic
+
+private enum DummyError: Swift.Error {
+    case somethingWentWrong
+}
+
+class ResultTests: XCTestCase {
+
+    func testBasics() throws {
+
+        func doSomething(right: Bool) -> Result<String, DummyError> {
+            if right {
+                return Result("All OK.")
+            }
+            return Result(DummyError.somethingWentWrong)
+        }
+        // Success.
+        switch doSomething(right: true) {
+        case .success(let string):
+            XCTAssertEqual(string, "All OK.")
+        case .failure(let error):
+            XCTFail("Unexpected failure: \(error)")
+        }
+
+        // Error.
+        switch doSomething(right: false) {
+        case .success(let string):
+            XCTFail("Unexpected success: \(string)")
+        case .failure(let error):
+            XCTAssertEqual(error, DummyError.somethingWentWrong)
+        }
+
+        // Test dematerialize.
+        XCTAssertEqual(try doSomething(right: true).dematerialize(), "All OK.")
+        do {
+            _ = try doSomething(right: false).dematerialize()
+            XCTFail("Unexpected success")
+        } catch DummyError.somethingWentWrong {}
+
+        func should(`throw`: Bool) throws -> Int {
+            if `throw` {
+                throw DummyError.somethingWentWrong
+            }
+            return 1
+        }
+
+        // Test closure.
+        let result: Result<Int, DummyError> = try Result {
+            return try should(throw: false)
+        }
+        XCTAssertEqual(try result.dematerialize(), 1)
+    }
+
+    func testAnyError() {
+        func doSomething(right: Bool) -> Result<String, AnyError> {
+            if right {
+                return Result("All OK.")
+            }
+            return Result(DummyError.somethingWentWrong)
+        }
+
+        // Success.
+        switch doSomething(right: true) {
+        case .success(let string):
+            XCTAssertEqual(string, "All OK.")
+        case .failure(let error):
+            XCTFail("Unexpected failure: \(error)")
+        }
+
+        // Error.
+        switch doSomething(right: false) {
+        case .success(let string):
+            XCTFail("Unexpected success: \(string)")
+        case .failure(let error):
+            XCTAssertEqual(error.underlyingError as? DummyError, DummyError.somethingWentWrong)
+        }
+    }
+
+    static var allTests = [
+        ("testBasics", testBasics),
+        ("testAnyError", testAnyError),
+    ]
+}

--- a/Tests/BasicTests/XCTestManifests.swift
+++ b/Tests/BasicTests/XCTestManifests.swift
@@ -30,6 +30,7 @@ public func allTests() -> [XCTestCaseEntry] {
         testCase(POSIXTests.allTests),
         testCase(PathShimTests.allTests),
         testCase(PathTests.allTests),
+        testCase(ResultTests.allTests),
         testCase(StringConversionTests.allTests),
         testCase(SyncronizedQueueTests.allTests),
         testCase(TemporaryFileTests.allTests),


### PR DESCRIPTION
Result is a simple enum to wrap up errors instead of throwing in
places where try-catch is difficult like in async APIs