### PR TITLE
[Xcodeproj] Default SDKROOT build setting to macosx

### DIFF
--- a/Sources/Xcodeproj/XcodeProjectModel.swift
+++ b/Sources/Xcodeproj/XcodeProjectModel.swift
@@ -345,6 +345,7 @@ public struct Xcode {
             var PRODUCT_MODULE_NAME: String?
             var PRODUCT_NAME: String?
             var PROJECT_NAME: String?
+            var SDKROOT: String?
             var SUPPORTED_PLATFORMS: [String]?
             var SWIFT_ACTIVE_COMPILATION_CONDITIONS: String?
             var SWIFT_FORCE_STATIC_LINK_STDLIB: String?

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -230,6 +230,7 @@ func xcodeProject(
         targetSettings.xcconfigFileRef = xcconfigOverridesFileRef
         
         targetSettings.common.SUPPORTED_PLATFORMS = ["macosx"]
+        targetSettings.common.SDKROOT = "macosx"
         targetSettings.common.TARGET_NAME = module.name
         
         let infoPlistFilePath = xcodeprojPath.appending(component: module.infoPlistFileName)

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -68,6 +68,7 @@ class PackageGraphTests: XCTestCase {
                 targetResult.check(productType: .framework)
                 targetResult.check(dependencies: [])
                 XCTAssertEqual(targetResult.target.buildSettings.xcconfigFileRef?.path, "../Overrides.xcconfig")
+                XCTAssertEqual(targetResult.target.buildSettings.common.SDKROOT, "macosx")
             }
 
             result.check(target: "Bar") { targetResult in


### PR DESCRIPTION
<rdar://problem/28670975> SwiftPM project generation should set SDKROOT
instead of leaving it blank