### PR TITLE
Disable git GPG signing

### DIFF
--- a/Sources/TestSupport/GitRepositoryExtensions.swift
+++ b/Sources/TestSupport/GitRepositoryExtensions.swift
@@ -40,6 +40,7 @@ public extension GitRepository {
         // FIXME: We don't need to set these everytime but we usually only commit once or twice for a test repo.
         try systemQuietly([Git.tool, "-C", path.asString, "config", "user.email", "example@example.com"])
         try systemQuietly([Git.tool, "-C", path.asString, "config", "user.name", "Example Example"])
+        try systemQuietly([Git.tool, "-C", path.asString, "config", "commit.gpgsign", "false"])
         try systemQuietly([Git.tool, "-C", path.asString, "commit", "-m", message ?? "Add some files."])
     }
 


### PR DESCRIPTION
Previously, if you had this option set in your global gitconfig, it
would be inherited for these repos, which would make running `git
commit` fail, and subsequently the tests would crash. Now we explicitly
disable this for the example repos.

This is pretty much a duplicate PR to https://github.com/apple/swift-package-manager/pull/139
I'm not sure if this setting was intentionally removed somewhere in between that PR and now, if so we should come up with a way to handle these failures more gracefully. I briefly looked through a few man pages to see if there was a simple way to ignore the user's config, which would probably be most ideal, but I didn't see anything offhand.