### PR TITLE
Unify test git repo creation

### DIFF
--- a/Sources/TestSupport/GitRepositoryExtensions.swift
+++ b/Sources/TestSupport/GitRepositoryExtensions.swift
@@ -44,6 +44,11 @@ public extension GitRepository {
         try systemQuietly([Git.tool, "-C", path.asString, "commit", "-m", message ?? "Add some files."])
     }
 
+    /// Tag the git repo.
+    func tag(name: String) throws {
+        try systemQuietly([Git.tool, "-C", path.asString, "tag", name])
+    }
+
     /// Push the changes to specified remote and branch.
     func push(remote: String, branch: String) throws {
         try systemQuietly([Git.tool, "-C", path.asString, "push", remote, branch])

--- a/Sources/TestSupport/misc.swift
+++ b/Sources/TestSupport/misc.swift
@@ -11,10 +11,11 @@
 import func XCTest.XCTFail
 
 import Basic
-import PackageGraph
 import PackageDescription
+import PackageGraph
 import PackageModel
 import POSIX
+import SourceControl
 import Utility
 
 #if os(macOS)
@@ -97,31 +98,16 @@ public func initGitRepo(_ dir: AbsolutePath, tags: [String], addFile: Bool = tru
         try systemQuietly([Git.tool, "-C", dir.asString, "config", "user.email", "example@example.com"])
         try systemQuietly([Git.tool, "-C", dir.asString, "config", "user.name", "Example Example"])
         try systemQuietly([Git.tool, "-C", dir.asString, "config", "commit.gpgsign", "false"])
-        try addGitRepo(dir, file: RelativePath("."))
-        try commitGitRepo(dir, message: "msg")
+        let repo = GitRepository(path: dir)
+        try repo.stageEverything()
+        try repo.commit(message: "msg")
         for tag in tags {
-            try tagGitRepo(dir, tag: tag)
+            try repo.tag(name: tag)
         }
     }
     catch {
         XCTFail("\(error)", file: file, line: line)
     }
-}
-
-public func tagGitRepo(_ dir: AbsolutePath, tag: String) throws {
-    try systemQuietly([Git.tool, "-C", dir.asString, "tag", tag])
-}
-
-public func removeTagGitRepo(_ dir: AbsolutePath, tag: String) throws {
-    try systemQuietly([Git.tool, "-C", dir.asString, "tag", "-d", tag])
-}
-
-public func addGitRepo(_ dir: AbsolutePath, file path: RelativePath) throws {
-    try systemQuietly([Git.tool, "-C", dir.asString, "add", path.asString])
-}
-
-public func commitGitRepo(_ dir: AbsolutePath, message: String = "Test commit") throws {
-    try systemQuietly([Git.tool, "-C", dir.asString, "commit", "-m", message])
 }
 
 public enum Configuration {

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -21,11 +21,11 @@ final class PackageToolTests: XCTestCase {
     private func execute(_ args: [String], chdir: AbsolutePath? = nil) throws -> String {
         return try SwiftPMProduct.SwiftPackage.execute(args, chdir: chdir, printIfError: true)
     }
-    
+
     func testUsage() throws {
         XCTAssert(try execute(["--help"]).contains("USAGE: swift package"))
     }
-    
+
     func testVersion() throws {
         XCTAssert(try execute(["--version"]).contains("Swift Package Manager"))
     }
@@ -51,7 +51,8 @@ final class PackageToolTests: XCTestCase {
             XCTAssertEqual(GitRepository(path: path).tags, ["1.2.3"])
 
             // Retag the dependency, and update.
-            try tagGitRepo(prefix.appending(component: "Foo"), tag: "1.2.4")
+            let repo = GitRepository(path: prefix.appending(component: "Foo"))
+            try repo.tag(name: "1.2.4")
             _ = try execute(["update"], chdir: packageRoot)
 
             // We shouldn't assume package path will be same after an update so ask again for it.

--- a/Tests/CommandsTests/WorkspaceTests.swift
+++ b/Tests/CommandsTests/WorkspaceTests.swift
@@ -76,9 +76,9 @@ final class WorkspaceTests: XCTestCase {
             let testRepo = GitRepository(path: testRepoPath)
             try testRepo.stage(file: "test.txt")
             try testRepo.commit()
-            try tagGitRepo(testRepoPath, tag: "test-tag")
+            try testRepo.tag(name: "test-tag")
             let currentRevision = try GitRepository(path: testRepoPath).getCurrentRevision()
-            
+
             // Create the initial workspace.
             do {
                 let workspace = try Workspace(rootPackage: path)
@@ -316,7 +316,7 @@ final class WorkspaceTests: XCTestCase {
             let testRepo = GitRepository(path: repoPath)
             try testRepo.stageEverything()
             try testRepo.commit(message: "update")
-            try tagGitRepo(repoPath, tag: "1.0.1")
+            try testRepo.tag(name: "1.0.1")
 
             try workspace.updateDependencies()
             // Test the delegates after update.

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -47,8 +47,9 @@ class DependencyResolutionTests: XCTestCase {
         // This will tag 'Foo' with 1.0.0, to start.
         fixture(name: "DependencyResolution/External/Simple", tags: ["1.0.0"]) { prefix in
             // Add several other tags to check version selection.
+            let repo = GitRepository(path: prefix.appending(components: "Foo"))
             for tag in ["1.1.0", "1.2.0", "1.2.3"] {
-                try tagGitRepo(prefix.appending(components: "Foo"), tag: tag)
+                try repo.tag(name: tag)
             }
 
             let packageRoot = prefix.appending(component: "Bar")

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -29,7 +29,7 @@ class GitRepositoryTests: XCTestCase {
         XCTAssertEqual(a, a2)
         XCTAssertEqual(Set([a]), Set([a2]))
     }
-        
+
     /// Test the basic provider functions.
     func testProvider() throws {
         mktmpdir { path in
@@ -64,14 +64,14 @@ class GitRepositoryTests: XCTestCase {
     func testGitRepositoryHash() throws {
         let validHash = "0123456789012345678901234567890123456789"
         XCTAssertNotEqual(GitRepository.Hash(validHash), nil)
-        
+
         let invalidHexHash = validHash + "1"
         XCTAssertEqual(GitRepository.Hash(invalidHexHash), nil)
-        
+
         let invalidNonHexHash = "012345678901234567890123456789012345678!"
         XCTAssertEqual(GitRepository.Hash(invalidNonHexHash), nil)
     }
-    
+
     /// Check raw repository facilities.
     ///
     /// In order to be stable, this test uses a static test git repository in
@@ -141,7 +141,7 @@ class GitRepositoryTests: XCTestCase {
             let testRepo = GitRepository(path: testRepoPath)
             try testRepo.stage(files: "test-file-1.txt", "subdir/test-file-2.txt")
             try testRepo.commit()
-            try tagGitRepo(testRepoPath, tag: "test-tag")
+            try testRepo.tag(name: "test-tag")
 
             // Get the the repository via the provider. the provider.
             let testClonePath = path.appending(component: "clone")
@@ -181,7 +181,7 @@ class GitRepositoryTests: XCTestCase {
             XCTAssertThrows(FileSystemError.notDirectory) {
                 _ = try view.readFileContents(AbsolutePath("/test-file-1.txt/thing"))
             }
-            
+
             // Check read/write into a missing directory.
             XCTAssertThrows(FileSystemError.noEntry) {
                 _ = try view.getDirectoryContents(AbsolutePath("/does-not-exist"))
@@ -210,7 +210,7 @@ class GitRepositoryTests: XCTestCase {
             let testRepo = GitRepository(path: testRepoPath)
             try testRepo.stage(file: "test.txt")
             try testRepo.commit()
-            try tagGitRepo(testRepoPath, tag: "test-tag")
+            try testRepo.tag(name: "test-tag")
             let currentRevision = Git.Repo(path: testRepoPath)!.sha
 
             // Fetch the repository using the provider.
@@ -271,7 +271,7 @@ class GitRepositoryTests: XCTestCase {
             let testRepo = GitRepository(path: testRepoPath)
             try testRepo.stage(file: "test.txt")
             try testRepo.commit()
-            try tagGitRepo(testRepoPath, tag: "2.0.0")
+            try testRepo.tag(name: "2.0.0")
 
             // Update the cloned repo.
             try clonedRepo.fetch()

--- a/Tests/UtilityTests/GitTests.swift
+++ b/Tests/UtilityTests/GitTests.swift
@@ -14,6 +14,7 @@ import Basic
 
 @testable import Utility
 
+import SourceControl
 import TestSupport
 
 class GitMoc: Git {
@@ -37,7 +38,7 @@ class GitUtilityTests: XCTestCase {
         GitMoc.mocVersion = "1.25.4"
         XCTAssertEqual(GitMoc.majorVersionNumber, 1)
     }
-    
+
     func testHeadSha() {
         mktmpdir { dir in
             initGitRepo(dir)
@@ -45,7 +46,7 @@ class GitUtilityTests: XCTestCase {
             checkSha(sha!)
         }
     }
-    
+
     func testVersionSha() {
         mktmpdir { dir in
             initGitRepo(dir, tag: "0.1.0")
@@ -58,7 +59,7 @@ class GitUtilityTests: XCTestCase {
         mktmpdir { dir in
             initGitRepo(dir, tag: "0.1.0")
             try commit(dir, file: RelativePath("file2.swift"))
-            
+
             let headSha = Git.Repo(path: dir)?.sha
             let versionSha = try Git.Repo(path: dir)?.versionSha(tag: "0.1.0")
             checkSha(headSha!)
@@ -84,20 +85,21 @@ class GitUtilityTests: XCTestCase {
         mktmpdir { dir in
             let versionTags = (0..<10).map{ "\($0).0.0" }
             initGitRepo(dir)
-            try versionTags.forEach{ try tagGitRepo(dir, tag: $0) }
+            let testRepo = GitRepository(path: dir)
+            try versionTags.forEach { try testRepo.tag(name: $0) }
             let repo = Git.Repo(path: dir)!
             XCTAssertEqual(repo.versions, versionTags.map{ Version($0)! })
         }
     }
 
 //MARK: - Helpers
-    
+
     func checkSha(_ sha: String) {
         XCTAssertNotNil(sha)
         XCTAssertFalse(sha.isEmpty)
         XCTAssertEqual(sha.characters.count, 40)
     }
-    
+
     func commit(_ dstdir: AbsolutePath, file: RelativePath) throws {
         let filePath = dstdir.appending(file)
         try systemQuietly(["touch", filePath.asString])


### PR DESCRIPTION
This eliminates one of the methods for creating a git repo for fixtures
by reusing the other method.