### PR TITLE
Validate xcconfig override file existence

### DIFF
--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -15,6 +15,11 @@ import PackageModel
 import PackageLoading
 import Utility
 
+/// Errors encounter during Xcode project generation
+public enum ProjectGenerationError: Swift.Error {
+    /// The given xcconfig override file does not exist
+    case xcconfigOverrideNotFound(path: AbsolutePath)
+}
 
 /// Generates the contents of the `project.pbxproj` for the package graph.  The
 /// project file is generated with the assumption that it will be written to an
@@ -132,6 +137,11 @@ func xcodeProject(
     // Add a group for the overriding .xcconfig file, if we have one.
     let xcconfigOverridesFileRef: Xcode.FileReference?
     if let xcconfigPath = options.xcconfigOverrides {
+        // Verify that the xcconfig override file exists
+        if !fileSystem.exists(xcconfigPath) {
+            throw ProjectGenerationError.xcconfigOverrideNotFound(path: xcconfigPath)
+        }
+
         // Create a "Configs" group whose path is the same as the project path.
         let xcconfigsGroup = project.mainGroup.addGroup(path: "", name: "Configs")
         

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -27,7 +27,8 @@ class PackageGraphTests: XCTestCase {
           "/Bar/Sources/Sea2/include/Sea2.h",
           "/Bar/Sources/Sea2/include/module.modulemap",
           "/Bar/Sources/Sea2/Sea2.c",
-          "/Bar/Tests/BarTests/barTests.swift"
+          "/Bar/Tests/BarTests/barTests.swift",
+          "/Overrides.xcconfig"
       )
 
         let g = try loadMockPackageGraph([


### PR DESCRIPTION
Previously if you passed a `--xcconfig-override` from the command line
that was a non-existent file, the project would still be generated. This
change validates that the file exists, and if it doesn't, an error is
thrown.