### PR TITLE
Move SDKROOT to project level settings

### DIFF
--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -69,7 +69,10 @@ func xcodeProject(
     // FIXME: This doesn't seem correct, but was what the old project generation
     // code did, so for now we do so too.
     projectSettings.common.SUPPORTED_PLATFORMS = ["macosx", "iphoneos", "iphonesimulator", "appletvos", "appletvsimulator", "watchos", "watchsimulator"]
-    
+
+    // Set the default `SDKROOT` to the latest macOS SDK.
+    projectSettings.common.SDKROOT = "macosx"
+
     // Set a conservative default deployment target.
     // FIXME: There needs to be some kind of control over this.  But currently
     // it is required to set this in order for SwiftPM to be able to self-host
@@ -228,9 +231,7 @@ func xcodeProject(
         // Set the target's base .xcconfig file to the user-supplied override
         // .xcconfig, if we have one.  This lets it override project settings.
         targetSettings.xcconfigFileRef = xcconfigOverridesFileRef
-        
-        targetSettings.common.SUPPORTED_PLATFORMS = ["macosx"]
-        targetSettings.common.SDKROOT = "macosx"
+
         targetSettings.common.TARGET_NAME = module.name
         
         let infoPlistFilePath = xcodeprojPath.appending(component: module.infoPlistFileName)

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -64,11 +64,14 @@ class PackageGraphTests: XCTestCase {
 
             XCTAssertNil(project.buildSettings.xcconfigFileRef)
 
+            XCTAssertEqual(project.buildSettings.common.SDKROOT, "macosx")
+            XCTAssertEqual(project.buildSettings.common.SUPPORTED_PLATFORMS!, ["macosx", "iphoneos", "iphonesimulator", "appletvos", "appletvsimulator", "watchos", "watchsimulator"])
+
             result.check(target: "Foo") { targetResult in
                 targetResult.check(productType: .framework)
                 targetResult.check(dependencies: [])
                 XCTAssertEqual(targetResult.target.buildSettings.xcconfigFileRef?.path, "../Overrides.xcconfig")
-                XCTAssertEqual(targetResult.target.buildSettings.common.SDKROOT, "macosx")
+                XCTAssertNil(targetResult.target.buildSettings.common.SDKROOT)
             }
 
             result.check(target: "Bar") { targetResult in


### PR DESCRIPTION
This allows users to override SDKROOT with the xcconfig-overrides option.

This is a possible fix for https://bugs.swift.org/browse/SR-2904