### PR TITLE
Fixes SR-2904 by moving SDKROOT and SUPPORTED_PLATFORMS to the project level

### DIFF
--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -65,11 +65,11 @@ func xcodeProject(
     // First of all, set a standard definition of `PROJECT_NAME`.
     projectSettings.common.PRODUCT_NAME = "$(TARGET_NAME)"
     
-    // Set the SUPPORTED_PLATFORMS to all platforms.
-    // FIXME: This doesn't seem correct, but was what the old project generation
-    // code did, so for now we do so too.
-    projectSettings.common.SUPPORTED_PLATFORMS = ["macosx", "iphoneos", "iphonesimulator", "appletvos", "appletvsimulator", "watchos", "watchsimulator"]
-    
+    // Set the platform to macOS.  We do this at the project level so that it
+    // can be overridden by the .xcconfig if needed.
+    projectSettings.common.SDKROOT = "macosx"
+    projectSettings.common.SUPPORTED_PLATFORMS = ["macosx"]
+
     // Set a conservative default deployment target.
     // FIXME: There needs to be some kind of control over this.  But currently
     // it is required to set this in order for SwiftPM to be able to self-host
@@ -229,8 +229,6 @@ func xcodeProject(
         // .xcconfig, if we have one.  This lets it override project settings.
         targetSettings.xcconfigFileRef = xcconfigOverridesFileRef
         
-        targetSettings.common.SUPPORTED_PLATFORMS = ["macosx"]
-        targetSettings.common.SDKROOT = "macosx"
         targetSettings.common.TARGET_NAME = module.name
         
         let infoPlistFilePath = xcodeprojPath.appending(component: module.infoPlistFileName)

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -63,12 +63,14 @@ class PackageGraphTests: XCTestCase {
             )
 
             XCTAssertNil(project.buildSettings.xcconfigFileRef)
+            
+            XCTAssertEqual(project.buildSettings.common.SDKROOT, "macosx")
+            XCTAssertEqual(project.buildSettings.common.SUPPORTED_PLATFORMS!, ["macosx"])
 
             result.check(target: "Foo") { targetResult in
                 targetResult.check(productType: .framework)
                 targetResult.check(dependencies: [])
                 XCTAssertEqual(targetResult.target.buildSettings.xcconfigFileRef?.path, "../Overrides.xcconfig")
-                XCTAssertEqual(targetResult.target.buildSettings.common.SDKROOT, "macosx")
             }
 
             result.check(target: "Bar") { targetResult in


### PR DESCRIPTION
Because SDKROOT and SUPPORTED_PLATFORMS are defined at the target level, they cannot be overridden by .xcconfig files.  This addresses that.