### PR TITLE
[SR-2473] Support non-linked Homebrew packages pkgconfig

### DIFF
--- a/Sources/PackageLoading/Module+PkgConfig.swift
+++ b/Sources/PackageLoading/Module+PkgConfig.swift
@@ -94,12 +94,10 @@ private extension SystemPackageProvider {
             // ``brew switch NAME VERSION``, so we shouldn't assume to link
             // to the latest version. Instead use the version as symlinked
             // in /usr/local/opt/(NAME)/lib/pkgconfig.
-            guard
-                let brewPath = try? popen(["brew", "--prefix"]),
-                let brewPathChuzzled = brewPath.chuzzle() else {
-                    return nil
+            guard let brewPrefix = try? popen(["brew", "--prefix"]).chomp() else {
+                return nil
             }
-            return AbsolutePath("\(brewPathChuzzled)/opt/\(name)/lib/pkgconfig")
+            return AbsolutePath("\(brewPrefix)/opt/\(name)/lib/pkgconfig")
         default: return nil
         }
     }

--- a/Sources/PackageLoading/Module+PkgConfig.swift
+++ b/Sources/PackageLoading/Module+PkgConfig.swift
@@ -105,8 +105,7 @@ private extension SystemPackageProvider {
             } else {
                 return nil
             }
-//            return AbsolutePath("\(brewPrefix)/opt/\(name)/lib/pkgconfig")
-            return nil
+            return AbsolutePath("\(brewPrefix)/opt/\(name)/lib/pkgconfig")
         default: return nil
         }
     }

--- a/Sources/PackageLoading/Module+PkgConfig.swift
+++ b/Sources/PackageLoading/Module+PkgConfig.swift
@@ -95,14 +95,7 @@ private extension SystemPackageProvider {
             // ``brew switch NAME VERSION``, so we shouldn't assume to link
             // to the latest version. Instead use the version as symlinked
             // in /usr/local/opt/(NAME)/lib/pkgconfig.
-            let brewPrefix: String
-            if let prefix = getenv("BREW_PREFIX") {
-                brewPrefix = prefix
-            } else if let prefix = try? Utility.popen(["/usr/local/bin/brew", "--prefix"]).chomp() {
-                brewPrefix = prefix
-            } else if let prefix = try? Utility.popen(["brew", "--prefix"]).chomp() {
-                brewPrefix = prefix
-            } else {
+            guard let brewPrefix = try? Utility.popen(["brew", "--prefix"]).chomp() else {
                 return nil
             }
             return AbsolutePath("\(brewPrefix)/opt/\(name)/lib/pkgconfig")

--- a/Sources/PackageLoading/Module+PkgConfig.swift
+++ b/Sources/PackageLoading/Module+PkgConfig.swift
@@ -9,6 +9,7 @@
 */
 
 import Basic
+import POSIX
 import PackageModel
 import Utility
 
@@ -94,10 +95,18 @@ private extension SystemPackageProvider {
             // ``brew switch NAME VERSION``, so we shouldn't assume to link
             // to the latest version. Instead use the version as symlinked
             // in /usr/local/opt/(NAME)/lib/pkgconfig.
-            guard let brewPrefix = try? popen(["brew", "--prefix"]).chomp() else {
+            let brewPrefix: String
+            if let prefix = getenv("BREW_PREFIX") {
+                brewPrefix = prefix
+            } else if let prefix = try? Utility.popen(["/usr/local/bin/brew", "--prefix"]).chomp() {
+                brewPrefix = prefix
+            } else if let prefix = try? Utility.popen(["brew", "--prefix"]).chomp() {
+                brewPrefix = prefix
+            } else {
                 return nil
             }
-            return AbsolutePath("\(brewPrefix)/opt/\(name)/lib/pkgconfig")
+//            return AbsolutePath("\(brewPrefix)/opt/\(name)/lib/pkgconfig")
+            return nil
         default: return nil
         }
     }

--- a/Sources/PackageLoading/Module+PkgConfig.swift
+++ b/Sources/PackageLoading/Module+PkgConfig.swift
@@ -98,8 +98,9 @@ private extension SystemPackageProvider {
             guard let brewPrefix = try? Utility.popen(["brew", "--prefix"]).chomp() else {
                 return nil
             }
-            return AbsolutePath("\(brewPrefix)/opt/\(name)/lib/pkgconfig")
-        default: return nil
+            return AbsolutePath(brewPrefix).appending(components: "opt", name, "lib", "pkgconfig")
+        case .Apt:
+            return nil
         }
     }
 

--- a/Sources/Utility/PkgConfig.swift
+++ b/Sources/Utility/PkgConfig.swift
@@ -59,9 +59,9 @@ public struct PkgConfig {
     /// - fileSystem: The file system to use, defaults to local file system.
     ///
     /// - throws: PkgConfigError
-    public init(name: String, fileSystem: FileSystem = localFileSystem) throws {
+    public init(name: String, additionalSearchPaths: [AbsolutePath] = [], fileSystem: FileSystem = localFileSystem) throws {
         self.name = name
-        self.pcFile = try PkgConfig.locatePCFile(name: name, customSearchPaths: PkgConfig.envSearchPaths, fileSystem: fileSystem)
+        self.pcFile = try PkgConfig.locatePCFile(name: name, customSearchPaths: PkgConfig.envSearchPaths + additionalSearchPaths, fileSystem: fileSystem)
 
         var parser = PkgConfigParser(pcFile: pcFile, fileSystem: fileSystem)
         try parser.parse()

--- a/Sources/Utility/PkgConfig.swift
+++ b/Sources/Utility/PkgConfig.swift
@@ -55,8 +55,14 @@ public struct PkgConfig {
 
     /// Load the information for the named package.
     ///
-    /// - name: Name of the pkg config file (without file extension).
-    /// - fileSystem: The file system to use, defaults to local file system.
+    /// It will search `fileSystem` for the pkg config file in the following order:
+    /// * Paths defined in `PKG_CONFIG_PATH` environment variable
+    /// * Paths defined in `additionalSearchPaths` argument
+    /// * Built-in search paths (see `PkgConfig.searchPaths`)
+    ///
+    /// - parameter name: Name of the pkg config file (without file extension).
+    /// - parameter additionalSearchPaths: Additional paths to search for pkg config file.
+    /// - parameter fileSystem: The file system to use, defaults to local file system.
     ///
     /// - throws: PkgConfigError
     public init(name: String, additionalSearchPaths: [AbsolutePath] = [], fileSystem: FileSystem = localFileSystem) throws {

--- a/Tests/UtilityTests/PkgConfigParserTests.swift
+++ b/Tests/UtilityTests/PkgConfigParserTests.swift
@@ -65,10 +65,13 @@ final class PkgConfigParserTests: XCTestCase {
     
     /// Test custom search path get higher priority for locating pc files.
     func testCustomPcFileSearchPath() throws {
+
+
         let fs = InMemoryFileSystem(emptyFiles:
             "/usr/lib/pkgconfig/foo.pc",
             "/custom/foo.pc")
         XCTAssertEqual("/custom/foo.pc", try PkgConfig.locatePCFile(name: "foo", customSearchPaths: [AbsolutePath("/custom")], fileSystem: fs).asString)
+        XCTAssertEqual("/custom/foo.pc", try PkgConfig(name: "foo", additionalSearchPaths: [AbsolutePath("/custom")], fileSystem: fs).pcFile.asString)
         XCTAssertEqual("/usr/lib/pkgconfig/foo.pc", try PkgConfig.locatePCFile(name: "foo", customSearchPaths: [], fileSystem: fs).asString)
     }
 


### PR DESCRIPTION
Some Homebrew packages cannot be linked, like OpenSSL. This patch adds support for packages that are not linked. It will query Homebrew about the installed version of that package, and add an additional pkg-config search path.

There was a discussion about this being a fallback. However Apple ships ``/usr/lib/pkgconfig/openssl.pc``, so the fallback wouldn't be triggered.

Review questions:
* `brew` is assumed to live on PATH -- is that ok? Otherwise, we might try the default location and use an environment variable (eg ``BREW_PREFIX``) as fallback?
* If the ``brew`` command could not be found (or produces an error), should that issue a warning on the console?
* How can we create tests for this? We shouldn't assume ``brew`` being available or certain packages to be installed.
* <s>If the JSON could not be parsed, should that issue a warning on the console?</s>