### PR TITLE
[ArgParser] Add a protocol to auto conform enums to ArgumentKind

### DIFF
--- a/Sources/Utility/ArgumentParser.swift
+++ b/Sources/Utility/ArgumentParser.swift
@@ -78,6 +78,35 @@ extension Bool: ArgumentKind {
     }
 }
 
+/// A protocol which implements ArgumentKind for string initializable enums.
+///
+/// Conforming to this protocol will automatically make an enum with is
+/// String initializable conform to ArgumentKind.
+public protocol StringEnumArgument: ArgumentKind {
+    init?(rawValue: String)
+}
+
+extension StringEnumArgument {
+
+    // FIXME: Hack because can not use init(arg:) in init(parser:)
+    static func createObject(_ arg: String) -> Self? {
+        return self.init(arg: arg)
+    }
+
+    public init(parser: ArgumentParserProtocol) throws {
+        let arg = try parser.next()
+        guard let obj = Self.createObject(arg) else {
+            throw ArgumentParserError.unknown(option: arg)
+        }
+        self = obj
+    }
+
+    public init?(arg: String) {
+        self.init(rawValue: arg)
+    }
+}
+
+
 /// A protocol representing positional or options argument.
 protocol ArgumentProtocol: Hashable {
     /// The argument kind of this argument for eg String, Bool etc.

--- a/Tests/UtilityTests/ArgumentParserTests.swift
+++ b/Tests/UtilityTests/ArgumentParserTests.swift
@@ -17,19 +17,7 @@ enum SampleEnum: String {
     case Bar
 }
 
-extension SampleEnum: ArgumentKind {
-    public init(parser: ArgumentParserProtocol) throws {
-        let arg = try parser.next()
-        guard let obj = SampleEnum(arg: arg) else {
-            throw ArgumentParserError.unknown(option: arg)
-        }
-        self = obj
-    }
-
-    init?(arg: String) {
-        self.init(rawValue: arg)
-    }
-}
+extension SampleEnum: StringEnumArgument {}
 
 class ArgumentParserTests: XCTestCase {
 


### PR DESCRIPTION
This protocol will help avoiding the boilerpate code needed to conform
enums to ArgumentKind