### PR TITLE
add supported platforms to the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The Swift Package Manager is a tool for managing distribution of source code, ai
 
 We’ve designed the system to make it easy to share packages on services like GitHub, but packages are also great for private personal development, sharing code within a team, or at any other granularity.
 
+Note that at this time the Package Manager has no support for iOS, watchOS, or tvOS platforms.
+
 ---
 
 ## Table of Contents


### PR DESCRIPTION
As a potential user, I wanted to see quickly whether I could use SPM for the platform I was developing for. It wasn't immediately clear if I could use it for iOS, so I had to go searching for this information in the documentation folder, which took some time before I could find the answer.

I think this information is important enough for it to be on the main README, as it is probably one of the first things users want to know about SPM.

Note: The text comes from https://github.com/apple/swift-package-manager/blob/master/Documentation/Reference.md#depending-on-apple-modules