### PR TITLE
[PkgConfig] Consider quotes when parsing pc file key-value pairs

### DIFF
--- a/Tests/UtilityTests/PkgConfigParserTests.swift
+++ b/Tests/UtilityTests/PkgConfigParserTests.swift
@@ -16,8 +16,7 @@ import Basic
 final class PkgConfigParserTests: XCTestCase {
     
     func testGTK3PCFile() {
-        loadPCFile("gtk+-3.0.pc") { parser in
-            guard let parser = parser else { XCTFail("Unexpected parsing error"); return}
+        try! loadPCFile("gtk+-3.0.pc") { parser in
             XCTAssertEqual(parser.variables, ["libdir": "/usr/local/Cellar/gtk+3/3.18.9/lib", "gtk_host": "x86_64-apple-darwin15.3.0", "includedir": "/usr/local/Cellar/gtk+3/3.18.9/include", "prefix": "/usr/local/Cellar/gtk+3/3.18.9", "gtk_binary_version": "3.0.0", "exec_prefix": "/usr/local/Cellar/gtk+3/3.18.9", "targets": "quartz"])
             XCTAssertEqual(parser.dependencies, ["gdk-3.0", "atk", "cairo", "cairo-gobject", "gdk-pixbuf-2.0", "gio-2.0"])
             XCTAssertEqual(parser.cFlags, ["-I/usr/local/Cellar/gtk+3/3.18.9/include/gtk-3.0"])
@@ -26,8 +25,7 @@ final class PkgConfigParserTests: XCTestCase {
     }
     
     func testEmptyCFlags() {
-        loadPCFile("empty_cflags.pc") { parser in
-            guard let parser = parser else { XCTFail("Unexpected parsing error"); return}
+        try! loadPCFile("empty_cflags.pc") { parser in
             XCTAssertEqual(parser.variables, ["prefix": "/usr/local/bin", "exec_prefix": "/usr/local/bin"])
             XCTAssertEqual(parser.dependencies, ["gdk-3.0", "atk"])
             XCTAssertEqual(parser.cFlags, [])
@@ -36,8 +34,7 @@ final class PkgConfigParserTests: XCTestCase {
     }
     
     func testVariableinDependency() {
-        loadPCFile("deps_variable.pc") { parser in
-            guard let parser = parser else { XCTFail("Unexpected parsing error"); return}
+        try! loadPCFile("deps_variable.pc") { parser in
             XCTAssertEqual(parser.variables, ["prefix": "/usr/local/bin", "exec_prefix": "/usr/local/bin", "my_dep": "atk"])
             XCTAssertEqual(parser.dependencies, ["gdk-3.0", "atk"])
             XCTAssertEqual(parser.cFlags, ["-I"])
@@ -45,17 +42,17 @@ final class PkgConfigParserTests: XCTestCase {
         }
     }
     
-    func testUnresolvablePCFile() {
-        loadPCFile("failure_case.pc") { parser in
-            if parser != nil {
-                XCTFail("parsing should have failed: \(parser.debugDescription)")
-            }
+    func testUnresolvablePCFile() throws {
+        do {
+            try loadPCFile("failure_case.pc")
+            XCTFail("Unexpected success")
+        } catch PkgConfigError.parsingError(let desc) {
+            XCTAssert(desc.hasPrefix("Expected variable in"))
         }
     }
     
     func testEscapedSpaces() {
-        loadPCFile("escaped_spaces.pc") { parser in
-            guard let parser = parser else { XCTFail("Unexpected parsing error"); return}
+        try! loadPCFile("escaped_spaces.pc") { parser in
             XCTAssertEqual(parser.variables, ["prefix": "/usr/local/bin", "exec_prefix": "/usr/local/bin", "my_dep": "atk"])
             XCTAssertEqual(parser.dependencies, ["gdk-3.0", "atk"])
             XCTAssertEqual(parser.cFlags, ["-I/usr/local/Wine Cellar/gtk+3/3.18.9/include/gtk-3.0", "-I/after/extra/spaces"])
@@ -72,15 +69,11 @@ final class PkgConfigParserTests: XCTestCase {
         XCTAssertEqual("/usr/lib/pkgconfig/foo.pc", try PkgConfig.locatePCFile(name: "foo", customSearchPaths: [], fileSystem: fs).asString)
     }
 
-    private func loadPCFile(_ inputName: String, body: (PkgConfigParser?) -> Void) {
+    private func loadPCFile(_ inputName: String, body: ((PkgConfigParser) -> Void)? = nil) throws {
         let input = AbsolutePath(#file).parentDirectory.appending(components: "pkgconfigInputs", inputName)
-        var parser: PkgConfigParser? = PkgConfigParser(pcFile: input, fileSystem: localFileSystem)
-        do {
-            try parser?.parse()
-        } catch {
-            parser = nil
-        }
-        body(parser)
+        var parser = PkgConfigParser(pcFile: input, fileSystem: localFileSystem)
+        try parser.parse()
+        body?(parser)
     }
 
     static var allTests = [

--- a/Tests/UtilityTests/PkgConfigParserTests.swift
+++ b/Tests/UtilityTests/PkgConfigParserTests.swift
@@ -56,7 +56,7 @@ final class PkgConfigParserTests: XCTestCase {
             XCTAssertEqual(parser.variables, ["prefix": "/usr/local/bin", "exec_prefix": "/usr/local/bin", "my_dep": "atk"])
             XCTAssertEqual(parser.dependencies, ["gdk-3.0", "atk"])
             XCTAssertEqual(parser.cFlags, ["-I/usr/local/Wine Cellar/gtk+3/3.18.9/include/gtk-3.0", "-I/after/extra/spaces"])
-            XCTAssertEqual(parser.libs, ["-L/usr/local/bin", "-lgtk-3", "-wantareal\\here", "-one\\", "-two"])
+            XCTAssertEqual(parser.libs, ["-L/usr/local/bin", "-lgtk 3", "-wantareal\\here", "-one\\", "-two"])
         }
     }
     
@@ -69,6 +69,15 @@ final class PkgConfigParserTests: XCTestCase {
         XCTAssertEqual("/usr/lib/pkgconfig/foo.pc", try PkgConfig.locatePCFile(name: "foo", customSearchPaths: [], fileSystem: fs).asString)
     }
 
+    func testUnevenQuotes() throws {
+        do {
+            try loadPCFile("quotes_failure.pc")
+            XCTFail("Unexpected success")
+        } catch PkgConfigError.parsingError(let desc) {
+            XCTAssert(desc.hasPrefix("Text ended before matching quote"))
+        }
+    }
+    
     private func loadPCFile(_ inputName: String, body: ((PkgConfigParser) -> Void)? = nil) throws {
         let input = AbsolutePath(#file).parentDirectory.appending(components: "pkgconfigInputs", inputName)
         var parser = PkgConfigParser(pcFile: input, fileSystem: localFileSystem)

--- a/Tests/UtilityTests/pkgconfigInputs/quotes_failure.pc
+++ b/Tests/UtilityTests/pkgconfigInputs/quotes_failure.pc
@@ -4,5 +4,5 @@ my_dep=atk
 #some comment
 
 Requires: gdk-3.0 >= 1.0.0 ${my_dep}
-Libs: -L"${prefix}" -l"gtk 3" -wantareal\\here -one\\ -two
+Libs: -L"${prefix}" -l"gt"k3" -wantareal\\here -one\\ -two
 Cflags: -I/usr/local/Wine\ Cellar/gtk+3/3.18.9/include/gtk-3.0    -I/after/extra/spaces


### PR DESCRIPTION
- https://bugs.swift.org/browse/SR-2898