### PR TITLE
Test pkg config environment search paths

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -140,7 +140,7 @@ let package = Package(
             dependencies: ["PackageGraph", "TestSupport"]),
         Target(
             name: "POSIXTests",
-            dependencies: ["TestSupport"]),
+            dependencies: ["POSIX", "TestSupport"]),
         Target(
             name: "SourceControlTests",
             dependencies: ["SourceControl", "TestSupport"]),

--- a/Package.swift
+++ b/Package.swift
@@ -140,7 +140,7 @@ let package = Package(
             dependencies: ["PackageGraph", "TestSupport"]),
         Target(
             name: "POSIXTests",
-            dependencies: ["POSIX"]),
+            dependencies: ["TestSupport"]),
         Target(
             name: "SourceControlTests",
             dependencies: ["SourceControl", "TestSupport"]),

--- a/Sources/TestSupport/misc.swift
+++ b/Sources/TestSupport/misc.swift
@@ -194,6 +194,14 @@ public func loadMockPackageGraph(_ packageMap: [String: PackageDescription.Packa
 }
 
 /// Temporary override environment variables
+///
+/// WARNING! This method is not thread-safe. POSIX environments are shared 
+/// between threads. This means that when this method is called simultaneously 
+/// from different threads, the environment will neither be setup nor restored
+/// correctly.
+///
+/// - throws: errors thrown in `body`, POSIX.SystemError.setenv and 
+///           POSIX.SystemError.unsetenv
 public func withCustomEnv(_ env: [String: String], body: () throws -> ()) throws {
     let state = Array(env.keys).map { ($0, getenv($0)) }
     let restore = {

--- a/Tests/POSIXTests/EnvTests.swift
+++ b/Tests/POSIXTests/EnvTests.swift
@@ -37,7 +37,6 @@ class EnvTests: XCTestCase {
         let value = "TEST"
         XCTAssertNil(POSIX.getenv(key))
         try withCustomEnv([key: value]) {
-            print(POSIX.getenv(key))
             XCTAssertEqual(value, POSIX.getenv(key))
         }
         XCTAssertNil(POSIX.getenv(key))

--- a/Tests/POSIXTests/EnvTests.swift
+++ b/Tests/POSIXTests/EnvTests.swift
@@ -11,8 +11,13 @@
 import XCTest
 
 import POSIX
+import TestSupport
 
 class EnvTests: XCTestCase {
+    enum CustomEnvError: Swift.Error {
+        case someError
+    }
+
     func testGet() throws {
         XCTAssertNotNil(POSIX.getenv("PATH"))
     }
@@ -24,6 +29,27 @@ class EnvTests: XCTestCase {
         try POSIX.setenv(key, value: value)
         XCTAssertEqual(value, POSIX.getenv(key))
         try POSIX.unsetenv(key)
+        XCTAssertNil(POSIX.getenv(key))
+    }
+
+    func testWithCustomEnv() throws {
+        let key = "XCTEST_TEST"
+        let value = "TEST"
+        XCTAssertNil(POSIX.getenv(key))
+        try withCustomEnv([key: value]) {
+            print(POSIX.getenv(key))
+            XCTAssertEqual(value, POSIX.getenv(key))
+        }
+        XCTAssertNil(POSIX.getenv(key))
+        do {
+            try withCustomEnv([key: value]) {
+                XCTAssertEqual(value, POSIX.getenv(key))
+                throw CustomEnvError.someError
+            }
+        } catch CustomEnvError.someError {
+        } catch {
+            XCTFail("Incorrect error thrown")
+        }
         XCTAssertNil(POSIX.getenv(key))
     }
 }


### PR DESCRIPTION
To test the correct pkg config file search paths, the environment variables should be changed during the tests. This PR adds functionality to temporary override the environment and should restore the environment afterwards. This will be used by #731 (or its successor) to verify the correct search order. This PR is based upon #743 (setenv / unsetenv).