### PR TITLE
[PackageTool] Add describe subcommand to swift package

### DIFF
--- a/Sources/Commands/Describe.swift
+++ b/Sources/Commands/Describe.swift
@@ -1,0 +1,90 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Basic
+import PackageModel
+import Utility
+
+enum DescribeMode: String {
+    /// JSON format.
+    case json
+
+    /// Human readable format.
+    case text
+}
+
+func describe(_ package: Package, in mode: DescribeMode, on stream: OutputByteStream) {
+    switch mode {
+    case .json:
+        // FIXME: Pretty print support would be nice.
+        stream <<< package.toJSON().toString() <<< "\n"
+    case .text:
+        package.describe(on: stream)
+    }
+    stream.flush()
+}
+
+extension Package: JSONSerializable {
+
+    func describe(on stream: OutputByteStream) {
+        stream <<< "Name: " <<< name <<< "\n"
+        stream <<< "Path: " <<< path.asString <<< "\n"
+        stream <<< "Modules: " <<< "\n"
+        for module in modules + testModules {
+            module.describe(on: stream, indent: 4)
+            stream <<< "\n"
+        }
+    }
+
+    public func toJSON() -> JSON {
+        return .dictionary([
+            "name": .string(name),
+            "path": .string(path.asString),
+            "modules": .array((modules + testModules).map{ $0.toJSON() }),
+        ])
+    }
+}
+
+extension Module: JSONSerializable {
+
+    func describe(on stream: OutputByteStream, indent: Int = 0) {
+        stream <<< String.spaces(n: indent) <<< "Name: " <<< name <<< "\n"
+        stream <<< String.spaces(n: indent) <<< "C99name: " <<< c99name <<< "\n"
+        stream <<< String.spaces(n: indent) <<< "Test module: " <<< isTest.description <<< "\n"
+        stream <<< String.spaces(n: indent) <<< "Type: " <<< type.rawValue <<< "\n"
+        stream <<< String.spaces(n: indent) <<< "Module type: " <<< String(describing: type(of: self)) <<< "\n"
+        stream <<< String.spaces(n: indent) <<< "Path: " <<< sources.root.asString <<< "\n"
+        stream <<< String.spaces(n: indent) <<< "Sources: " <<< sources.relativePaths.map{$0.asString}.joined(separator: ", ") <<< "\n"
+    }
+
+    public func toJSON() -> JSON {
+        return .dictionary([
+            "name": .string(name),
+            "c99name": .string(c99name),
+            "is_test": .bool(isTest),
+            "type": type.toJSON(),
+            "module_type": .string(String(describing: type(of: self))),
+            "path": .string(sources.root.asString),
+            "sources": sources.toJSON(),
+        ])
+    }
+}
+
+extension Sources: JSONSerializable {
+    public func toJSON() -> JSON {
+        return .array(relativePaths.map{.string($0.asString)})
+    }
+}
+
+extension ModuleType: JSONSerializable {
+    public func toJSON() -> JSON {
+        return .string(rawValue)
+    }
+}

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -165,6 +165,10 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
 
             print("generated:", outpath.prettyPath)
 
+        case .describe:
+            let graph = try loadPackage()
+            describe(graph.rootPackage, in: options.describeMode, on: stdoutStream)
+
         case .dumpPackage:
             let manifest = try loadRootManifest(options)
             // FIXME: It would be nice if this has a pretty print option.
@@ -200,6 +204,11 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
         binder.bind(
             option: parser.add(option: "--version", kind: Bool.self),
             to: { options, _ in options.mode = .version })
+
+        let describeParser = parser.add(subparser: PackageMode.describe.rawValue, overview: "Describe the current package")
+        binder.bind(
+            option: describeParser.add(option: "--type", kind: DescribeMode.self, usage: "json|text"),
+            to: { $0.describeMode = $1 })
 
         _ = parser.add(subparser: PackageMode.dumpPackage.rawValue, overview: "Print parsed Package.swift as JSON")
 
@@ -276,6 +285,7 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
 public class PackageToolOptions: ToolOptions {
     var mode: PackageMode = .help
 
+    var describeMode: DescribeMode = .text
     var initMode: InitMode = .library
 
     var inputPath: AbsolutePath?
@@ -295,6 +305,7 @@ public class PackageToolOptions: ToolOptions {
 }
 
 public enum PackageMode: String, StringEnumArgument {
+    case describe
     case dumpPackage = "dump-package"
     case edit
     case fetch
@@ -311,3 +322,4 @@ public enum PackageMode: String, StringEnumArgument {
 
 extension InitMode: StringEnumArgument {}
 extension ShowDependenciesMode: StringEnumArgument {}
+extension DescribeMode: StringEnumArgument {}

--- a/Sources/PackageModel/Module.swift
+++ b/Sources/PackageModel/Module.swift
@@ -19,8 +19,10 @@ import Basic
 
 @_exported import enum PackageDescription.SystemPackageProvider
 
-public enum ModuleType {
-    case executable, library, systemModule
+public enum ModuleType: String {
+    case executable
+    case library
+    case systemModule = "system-module"
 }
 
 public class Module {

--- a/Sources/TestSupport/JSONExtensions.swift
+++ b/Sources/TestSupport/JSONExtensions.swift
@@ -1,0 +1,54 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Basic
+
+/// Useful extensions to JSON to use in assert methods where 
+/// the type diagnostics is not that important.
+public extension JSON {
+    var dictionary: [String: JSON]? {
+        if case let .dictionary(contents) = self {
+            return contents
+        }
+        return nil
+    }
+
+    var array: [JSON]? {
+        if case let .array(contents) = self {
+            return contents
+        }
+        return nil
+    }
+
+    var string: String? {
+        if case let .string(contents) = self {
+            return contents
+        }
+        return nil
+    }
+
+    var stringValue: String {
+        return string ?? ""
+    }
+
+    subscript(_ string: String) -> JSON? {
+        return dictionary?[string]
+    }
+
+    subscript(_ idx: Int) -> JSON? {
+        if let array = array {
+            guard idx >= 0 && array.count > idx else {
+                return nil
+            }
+            return array[idx]
+        }
+        return nil
+    }
+}

--- a/Sources/Utility/StringExtensions.swift
+++ b/Sources/Utility/StringExtensions.swift
@@ -82,4 +82,14 @@ extension String {
             return (head, nil)
         }
     }
+
+    /// Returns a string of n spaces for n >= 0 otherwise empty string.
+    public static func spaces(n: Int) -> String {
+        guard n >= 0 else { return "" }
+        var str = ""
+        for _ in 0..<n {
+            str += " "
+        }
+        return str
+    }
 }


### PR DESCRIPTION
This subcommand outputs information about the current package's modules,
including things like source files etc.

```json
{
  "modules":[
    {
      "c99name":"Basic",
      "is_test":false,
      "module_type":"SwiftModule",
      "name":"Basic",
      "path":"/Users/ankit/workspace/swift.org/swiftpm/Sources/Basic",
      "sources":[
        "ByteString.swift",
        "CollectionAlgorithms.swift",
        "Condition.swift",
        "DictionaryExtensions.swift",
        "FileSystem.swift",
        "FixableError.swift",
        "GraphAlgorithms.swift",
        "JSON.swift",
        "KeyedPair.swift",
        "LazyCache.swift",
        "Lock.swift",
        "OptionParser.swift",
        "OrderedSet.swift",
        "OutputByteStream.swift",
        "Path.swift",
        "PathShims.swift",
        "Result.swift",
        "StringConversions.swift",
        "SynchronizedQueue.swift",
        "TemporaryFile.swift",
        "TerminalController.swift",
        "Thread.swift"
      ],
      "type":"library"
    },
    {
      "c99name":"Build",
      "is_test":false,
      "module_type":"SwiftModule",
      "name":"Build",
      "path":"/Users/ankit/workspace/swift.org/swiftpm/Sources/Build",
      "sources":[
        "Buildable.swift",
        "Command.compile(ClangModule).swift",
        "Command.compile(SwiftModule).swift",
        "Command.link(ClangModule).swift",
        "Command.link(SwiftModule).swift",
        "Command.swift",
        "Configuration.swift",
        "describe().swift",
        "Error.swift",
        "misc.swift",
        "ToolProtocol.swift"
      ],
      "type":"library"
    }
  ],
  "name":"SwiftPM",
  "path":"/Users/ankit/workspace/swift.org/swiftpm"
}
```