### PR TITLE
Use concrete constrained extensions to get rid of protocol conformance trick

### DIFF
--- a/Sources/Get/Range.swift
+++ b/Sources/Get/Range.swift
@@ -10,11 +10,7 @@
 
 import struct Utility.Version
 
-// FIXME: workaround for inability to constrain the extension to `Bound == Version`.
-protocol _VersionProtocol : Comparable {}
-extension Version : _VersionProtocol {}
-
-extension Range where Bound : _VersionProtocol {
+extension Range where Bound == Version {
 
     /**
      - Returns: A new Range with startIndex and endIndex constrained such that


### PR DESCRIPTION
Now that [SR-1009](https://bugs.swift.org/browse/SR-1009) is resolved, we can remove the FIXME and the extension can constrain to  the concrete `Version` type without using any protocols.
