### PR TITLE
[TestSupport] Throw error with execution output

### DIFF
--- a/Sources/TestSupport/SwiftPMProduct.swift
+++ b/Sources/TestSupport/SwiftPMProduct.swift
@@ -18,8 +18,9 @@ import Utility
 import class Foundation.Bundle
 #endif
 
-enum SwiftPMProductError: Swift.Error {
+public enum SwiftPMProductError: Swift.Error {
     case packagePathNotFound
+    case executionFailure(error: Swift.Error, output: String)
 }
 
 /// Defines the executables used by SwiftPM.
@@ -103,7 +104,7 @@ public enum SwiftPMProduct {
                 print("SWIFT_EXEC:", env["SWIFT_EXEC"] ?? "nil")
                 print("output:", out)
             }
-            throw error
+            throw SwiftPMProductError.executionFailure(error: error, output: out)
         }
     }
 

--- a/Sources/TestSupport/XCTAssertHelpers.swift
+++ b/Sources/TestSupport/XCTAssertHelpers.swift
@@ -43,8 +43,13 @@ public func XCTAssertBuildFails(_ path: AbsolutePath, file: StaticString = #file
 
         XCTFail("`swift build' succeeded but should have failed", file: file, line: line)
 
-    } catch POSIX.Error.exitStatus(let status, _) where status == 1{
-        // noop
+    } catch SwiftPMProductError.executionFailure(let error, _) {
+        switch error {
+        case POSIX.Error.exitStatus(let status, _) where status == 1: break
+            // noop
+        default:
+        XCTFail("`swift build' failed in an unexpected manner")
+        }
     } catch {
         XCTFail("`swift build' failed in an unexpected manner")
     }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -149,12 +149,16 @@ class MiscellaneousTestCase: XCTestCase {
         var foo = false
         do {
             try executeSwiftBuild(AbsolutePath("/"))
-        } catch POSIX.Error.exitStatus(let code, _) {
+        } catch SwiftPMProductError.executionFailure(let error, _) {
+            switch error {
+            case POSIX.Error.exitStatus(let code, _):
 
             // if our code crashes we'll get an exit code of 256
             XCTAssertEqual(code, Int32(1))
-
             foo = true
+            default:
+                XCTFail()
+            }
         } catch {
             XCTFail("\(error)")
         }
@@ -166,12 +170,15 @@ class MiscellaneousTestCase: XCTestCase {
             var foo = false
             do {
                 try executeSwiftBuild(prefix)
-            } catch POSIX.Error.exitStatus(let code, _) {
-
-                // if our code crashes we'll get an exit code of 256
-                XCTAssertEqual(code, Int32(1))
-
-                foo = true
+            } catch SwiftPMProductError.executionFailure(let error, _) {
+                switch error {
+                case POSIX.Error.exitStatus(let code, _):
+                    // if our code crashes we'll get an exit code of 256
+                    XCTAssertEqual(code, Int32(1))
+                    foo = true
+                default:
+                    XCTFail()
+                }
             } catch {
                 XCTFail()
             }


### PR DESCRIPTION
This will allow inspecting output if SwiftPM product execution fails.