### PR TITLE
[PackageBuilder] Emit clearer error message

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -111,7 +111,7 @@ extension Module.Error: FixableError {
     var error: String {
         switch self {
           case .invalidName(let path, let name, let problem):
-            return "the module at \(path) has an invalid name ('\(name)'): \(problem.error)"
+            return "the directory \(path) has an invalid name ('\(name)'): \(problem.error)"
           case .mixedSources(let path):
             return "the module at \(path) contains mixed language source files"
         }
@@ -120,7 +120,7 @@ extension Module.Error: FixableError {
     var fix: String? {
         switch self {
         case .invalidName(let path, _, let problem):
-            return "rename the module at ‘\(path)’\(problem.fix ?? "")"
+            return "rename the directory ‘\(path)’\(problem.fix ?? "")"
         case .mixedSources(_):
             return "use only a single language within a module"
         }

--- a/Tests/PackageLoadingTests/ConventionTests.swift
+++ b/Tests/PackageLoadingTests/ConventionTests.swift
@@ -542,7 +542,7 @@ class ConventionTests: XCTestCase {
         var fs = InMemoryFileSystem(emptyFiles:
             "/Sources/FooTests/source.swift")
         PackageBuilderTester("TestsInSources", in: fs) { result in
-            result.checkDiagnostic("the module at Sources/FooTests has an invalid name (\'FooTests\'): the name of a non-test module has a ‘Tests’ suffix fix: rename the module at ‘Sources/FooTests’ to not have a ‘Tests’ suffix")
+            result.checkDiagnostic("the directory Sources/FooTests has an invalid name (\'FooTests\'): the name of a non-test module has a ‘Tests’ suffix fix: rename the directory ‘Sources/FooTests’ to not have a ‘Tests’ suffix")
         }
 
         // Normal module in Tests/
@@ -550,7 +550,7 @@ class ConventionTests: XCTestCase {
             "/Sources/main.swift",
             "/Tests/Foo/source.swift")
         PackageBuilderTester("TestsInSources", in: fs) { result in
-            result.checkDiagnostic("the module at Tests/Foo has an invalid name (\'Foo\'): the name of a test module has no ‘Tests’ suffix fix: rename the module at ‘Tests/Foo’ to have a ‘Tests’ suffix")
+            result.checkDiagnostic("the directory Tests/Foo has an invalid name (\'Foo\'): the name of a test module has no ‘Tests’ suffix fix: rename the directory ‘Tests/Foo’ to have a ‘Tests’ suffix")
         }
     }
 


### PR DESCRIPTION
Diagnostic about renaming a directory is better than renaming a module.

- <rdar://problem/27890022> Make error message more prescriptive