### PR TITLE
Remove TestSupportExecutable from BasicTest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -119,7 +119,7 @@ let package = Package(
         
         Target(
             name: "BasicTests",
-            dependencies: ["TestSupport", "TestSupportExecutable"]),
+            dependencies: ["TestSupport"]),
         Target(
             name: "BuildTests",
             dependencies: ["Build", "TestSupport"]),


### PR DESCRIPTION
Error message on macosx

```
swift-test: error: the target BasicTests cannot have the executable TestSupportExecutable as a dependency
fix: move the shared logic inside a library, which can be referenced from both the target and the executable
```

Please review for possible side effects.