### PR TITLE
SR-3086: Xcode project generation puts modules from external packages together with local ones

### DIFF
--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -19,7 +19,7 @@ import TestSupport
 class PackageGraphTests: XCTestCase {
     func testBasics() throws {
       let fs = InMemoryFileSystem(emptyFiles:
-          "/Foo/foo.swift",
+          "/Foo/Sources/foo.swift",
           "/Foo/Tests/FooTests/fooTests.swift",
           "/Bar/Sources/Bar/bar.swift",
           "/Bar/Sources/Sea/include/Sea.h",
@@ -46,7 +46,6 @@ class PackageGraphTests: XCTestCase {
             result.check(references:
                 "Package.swift",
                 "Configs/Overrides.xcconfig",
-                "Sources/Foo/foo.swift",
                 "Sources/Sea2/Sea2.c",
                 "Sources/Sea2/include/Sea2.h",
                 "Sources/Sea2/include/module.modulemap",
@@ -55,6 +54,7 @@ class PackageGraphTests: XCTestCase {
                 "Sources/Sea/include/Sea.h",
                 "Sources/Sea/include/module.modulemap",
                 "Tests/BarTests/barTests.swift",
+                "Dependencies/Foo 1.0.0/foo.swift",
                 "Products/Foo.framework",
                 "Products/Sea2.framework",
                 "Products/Bar.framework",


### PR DESCRIPTION
When external packages are present, add a `Dependencies` group, and add modules from the external packages to appropriate directories underneath.  This is just a structure navigator change; there is no change to linkage semantics.  The structure of the groups tries to respect whether the package uses shallow or deep package format, but does not depend on all of the package dependencies ending up inside a `Packages` subdirectory in the source.

This addresses https://bugs.swift.org/browse/SR-3086

The diffs are staged into three separate commits to make them easier to read.