### PR TITLE
[Build] Add language link arguments for clang modules

### DIFF
--- a/Sources/Build/Command.link(ClangModule).swift
+++ b/Sources/Build/Command.link(ClangModule).swift
@@ -28,7 +28,7 @@ extension Command {
             let buildMeta = ClangModuleBuildMetadata(module: module, prefix: prefix, otherArgs: [])
             objects += buildMeta.objects
             inputs += buildMeta.inputs
-            linkFlags += buildMeta.linkDependenciesFlags
+            linkFlags += buildMeta.linkDependenciesFlags + module.languageLinkArgs
         }
 
         args += try ClangModuleBuildMetadata.basicArgs() + otherArgs


### PR DESCRIPTION
The language link flags was lost at some point and c++ was never being
linked.

- https://bugs.swift.org/browse/SR-3152