### PR TITLE
[DependencyResolver] Implement backtracking support.

### DIFF
--- a/Tests/CommandsTests/WorkspaceTests.swift
+++ b/Tests/CommandsTests/WorkspaceTests.swift
@@ -840,11 +840,11 @@ final class WorkspaceTests: XCTestCase {
             let graph = try workspace.loadPackageGraph()
             XCTAssert(graph.lookup("A").version == v1)
             // Pinning non existant version should fail.
-            XCTAssertThrows(DependencyResolverError.unimplemented) {
+            XCTAssertThrows(DependencyResolverError.unsatisfiable) {
                 try pin(at: "1.0.2")
             }
             // Pinning an unstatisfiable version should fail.
-            XCTAssertThrows(DependencyResolverError.unimplemented) {
+            XCTAssertThrows(DependencyResolverError.unsatisfiable) {
                 try pin(at: "1.0.1")
             }
             // But we should still be able to repin at v1.
@@ -885,12 +885,12 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // We should not be able to load package graph.
-        XCTAssertThrows(DependencyResolverError.unimplemented) {
+        XCTAssertThrows(DependencyResolverError.unsatisfiable) {
             _ = try newWorkspace().loadPackageGraph()
         }
 
         // We should not be able to pin all.
-        XCTAssertThrows(DependencyResolverError.unimplemented) {
+        XCTAssertThrows(DependencyResolverError.unsatisfiable) {
             _ = try newWorkspace().pinAll()
         }
     }


### PR DESCRIPTION
 - Previously we would fail to resolve any situations that would have required
   the resolver to backtrack.

 - This commit just switches us to use the naive implementation which enumerates
   all possible solutions in a preferred order, and returns the first complete
   one. This is simple, but can perform very poorly in situations which
   backtrack frequently, as it makes very little attempt to early-exit when
   pursuing an infeasible solution, or to cache partial solutions to the
   constraint solving problem. OTOH, it is easy! :)

 - The one thing the algorithm *does* do is eagerly merge all constraints at the
   level of any individual package, before initiating the native recursive
   search. The upshot of this is that in the cases of real performance problems
   in the backtracking, it should always be possible for packages to work around
   this issue by manually adding additional constraints for indirect
   dependencies which clarify what version is ultimately required.

 - This doesn't yet have all the necessary test coverage, although the fix
   itself is covered simply by virtue of resolving existing tests which expected
   to trigger the unimplemented error.