### PR TITLE
Only replace first invalid prefix character

### DIFF
--- a/Sources/Utility/StringMangling.swift
+++ b/Sources/Utility/StringMangling.swift
@@ -211,6 +211,7 @@ extension String {
                 0x0CE6...0x0CEF, 0x0D66...0x0D6F, 0x0E50...0x0E59,
                 0x0ED0...0x0ED9, 0x0F20...0x0F33:
                 mangledUnichars[idx] = replacementUnichar
+                break loop
               default:
                 break loop
             }

--- a/Tests/UtilityTests/StringConversionTests.swift
+++ b/Tests/UtilityTests/StringConversionTests.swift
@@ -30,6 +30,8 @@ class StringConversionTests: XCTestCase {
         // Invalid leading characters.
         XCTAssertEqual("1".mangledToC99ExtendedIdentifier(), "_")
         XCTAssertEqual("1foo".mangledToC99ExtendedIdentifier(), "_foo")
+        XCTAssertEqual("٠٠٠".mangledToC99ExtendedIdentifier(), "_٠٠")
+        XCTAssertEqual("12 3".mangledToC99ExtendedIdentifier(), "_2_3")
         
         // FIXME: There are lots more interesting test cases to add here.
         var str1 = ""


### PR DESCRIPTION
I believe we are currently too greedy in replacing invalid prefix characters, only the first one needs to be replaced in order to form a valid C99 identifier.