### PR TITLE
Add a flag to enable performance tests in generated Xcode project

### DIFF
--- a/Tests/BasicTests/ByteStringPerfTests.swift
+++ b/Tests/BasicTests/ByteStringPerfTests.swift
@@ -12,16 +12,16 @@ import XCTest
 
 import Basic
 
-// FIXME: Performance tests are disabled for the time being because they have
+// FIXME: Performance tests are disabled by default for the time being because they have
 // too high an impact on overall testing time.
 //
 // See: https://bugs.swift.org/browse/SR-1354
-#if false
+#if ENABLE_PERF_TESTS
 
 class ByteStringPerfTests: XCTestCase {
     func testInitialization() {
         let listOfStrings: [String] = (0..<10).map { "This is the number: \($0)!\n" }
-        let expectedTotalCount = listOfStrings.map({ $0.utf8.count }).reduce(0, combine: (+))
+        let expectedTotalCount = listOfStrings.map({ $0.utf8.count }).reduce(0, +)
         measure {
             var count = 0
             let N = 10000

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -773,6 +773,8 @@ def main():
                         help="Build stage 2 for release")
     parser.add_argument("--generate-xcodeproj", action="store_true",
                         help="Also generate an Xcode project for SwiftPM")
+    parser.add_argument("--enable-perf-tests", action="store_true",
+                        help="Enables performance tests in the generated Xcode project")
     parser.add_argument("--vendor-name", dest="vendor_name",
                         help="vendor name for use in --version")
     parser.add_argument("--build-identifier", dest="build_identifier",
@@ -1131,7 +1133,10 @@ def main():
     if args.generate_xcodeproj:
         # We will use the `swift-package` binary we just built to generate the
         # Xcode project.
-        cmd = [swift_package_path, "generate-xcodeproj"]
+        cmd = [swift_package_path]
+        if args.enable_perf_tests:
+            cmd.extend(["-Xswiftc", "-DENABLE_PERF_TESTS"])
+        cmd.extend(["generate-xcodeproj"])
         
         # If there is a `llvm-profdata` binary next to `swiftc`, we enable code
         # coverage in the generated project.


### PR DESCRIPTION
This flag will enable performance tests in the generated SwiftPM
Xcodeproject using conditional compilation flag 'ENABLE_PERF_TESTS'.