### PR TITLE
Fix warnings emitted when using the new resolver

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -21,18 +21,21 @@ private class ToolWorkspaceDelegate: WorkspaceDelegate {
     }
     
     func fetching(repository: String) {
+        print("Fetching \(repository)")
     }
 
     func cloning(repository: String) {
+        print("Cloning \(repository)")
     }
 
     func checkingOut(repository: String, at reference: String) {
         // FIXME: This is temporary output similar to old one, we will need to figure
         // out better reporting text.
-        print("Resolved version: \(reference)")
+        print("Resolving \(repository) at \(reference)")
     }
 
     func removing(repository: String) {
+        print("Removing \(repository)")
     }
 }
 

--- a/Sources/Utility/Verbosity.swift
+++ b/Sources/Utility/Verbosity.swift
@@ -8,6 +8,8 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+// FIXME: This file needs cleanup.
+
 public enum Verbosity: Int {
     case concise
     case verbose
@@ -100,6 +102,10 @@ import var libc.stdout
 import enum POSIX.Error
 
 public func system(_ arguments: String..., environment: [String:String] = [:], message: String?) throws {
+    try system(args: arguments, environment: environment, message: message)
+}
+
+public func system(args arguments: [String], environment: [String:String] = [:], message: String? = nil) throws {
     var out = ""
     do {
         if Utility.verbosity == .concise {

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -26,8 +26,13 @@ class MiscellaneousTestCase: XCTestCase {
 
         fixture(name: "DependencyResolution/External/Simple", tags: ["1.3.5"]) { prefix in
             let output = try executeSwiftBuild(prefix.appending(component: "Bar"))
-            let lines = output.characters.split(separator: "\n").map(String.init)
-            XCTAssertTrue(lines.contains("Resolved version: 1.3.5"))
+            if SwiftPMProduct.enableNewResolver {
+                XCTAssertTrue(output.contains("Resolving"))
+                XCTAssertTrue(output.contains("at 1.3.5"))
+            } else {
+                let lines = output.characters.split(separator: "\n").map(String.init)
+                XCTAssertTrue(lines.contains("Resolved version: 1.3.5"))
+            }
         }
     }
 


### PR DESCRIPTION
Switch to using correct system() and popen() methods.
- <rdar://problem/28699965> Warnings when using new resolver