### PR TITLE
Fix generated `PRODUCT_BUNDLE_IDENTIFIER`

### DIFF
--- a/Sources/Utility/StringMangling.swift
+++ b/Sources/Utility/StringMangling.swift
@@ -12,6 +12,30 @@
 /// of them are programming-related.
 extension String {
 
+    /// Returns a form of the string that is a valid bundle identifier
+    public func mangledToBundleIdentifier() -> String {
+        let mangledUnichars: [UInt16] = self.utf16.map {
+            switch $0 {
+            case
+            // A-Z
+            0x0041...0x005A,
+            // a-z
+            0x0061...0x007A,
+            // 0-9
+            0x0030...0x0039,
+            // -
+            0x2D,
+            // .
+            0x2E:
+                return $0
+            default:
+                return 0x2D
+            }
+        }
+
+        return String(utf16CodeUnits: mangledUnichars, count: mangledUnichars.count)
+    }
+
     /// Returns a form of the string that is valid C99 Extended Identifier (by
     /// replacing any invalid characters in an unspecified but consistent way).
     /// The output string is guaranteed to be non-empty as long as the input

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -350,7 +350,7 @@ func xcodeProject(
                 targetSettings.common.ENABLE_TESTABILITY = "YES"
                 targetSettings.common.PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)"
                 targetSettings.common.PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)"
-                targetSettings.common.PRODUCT_BUNDLE_IDENTIFIER = module.c99name
+                targetSettings.common.PRODUCT_BUNDLE_IDENTIFIER = module.c99name.mangledToBundleIdentifier()
             }
             else {
                 targetSettings.common.SWIFT_FORCE_STATIC_LINK_STDLIB = "NO"

--- a/Tests/UtilityTests/StringConversionTests.swift
+++ b/Tests/UtilityTests/StringConversionTests.swift
@@ -13,6 +13,13 @@ import Utility
 
 class StringConversionTests: XCTestCase {
 
+    func testManglingToBundleIdentifier() {
+        XCTAssertEqual("foo".mangledToBundleIdentifier(), "foo")
+        XCTAssertEqual("1foo__ò".mangledToBundleIdentifier(), "1foo---")
+        XCTAssertEqual("com.example.🐴🔄".mangledToBundleIdentifier(), "com.example.----")
+        XCTAssertEqual("٠٠٠".mangledToBundleIdentifier(), "---")
+    }
+
     func testManglingToC99ExtendedIdentifier() {
         
         // Simple cases.


### PR DESCRIPTION
Underscores are illegal in bundle identifiers, so we should post process the C99 identifiers and replace them. Xcode uses dashes, so let's use those, too.