### PR TITLE
[PackageBuilder] Fix a broken logic

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -370,8 +370,8 @@ public struct PackageBuilder {
         // Locate any directories that might be the roots of modules inside the source directory.
         let potentialModulePaths = try directoryContents(srcDir).filter(shouldConsiderDirectory)
         
-        // If there's a single module inside the source directory, make sure there are no loose source files in the sources directory.
-        if potentialModulePaths.count == 1 && potentialModulePaths[0] != srcDir {
+        // If atleast one module in the source directory, make sure there are no loose source files in the sources directory.
+        if let firstPath = potentialModulePaths.first, firstPath != srcDir {
             let invalidModuleFiles = try directoryContents(srcDir).filter(isValidSource)
             guard invalidModuleFiles.isEmpty else {
                 throw ModuleError.invalidLayout(.unexpectedSourceFiles(invalidModuleFiles.map{ $0.asString }))

--- a/Tests/PackageLoadingTests/ConventionTests.swift
+++ b/Tests/PackageLoadingTests/ConventionTests.swift
@@ -857,6 +857,17 @@ class ConventionTests: XCTestCase {
         }
     }
 
+    func testInvalidLayout6() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/file.swift",
+            "/Sources/foo/foo.swift",
+            "/Sources/bar/bar.swift")
+
+        PackageBuilderTester("MyPackage", in: fs) { result in
+            result.checkDiagnostic("the package has an unsupported layout, unexpected source file(s) found: /Sources/file.swift fix: move the file(s) inside a module")
+        }
+    }
+
     func testNoSourcesInModule() throws {
         var fs = InMemoryFileSystem()
         try fs.createDirectory(AbsolutePath("/Sources/Module"), recursive: true)
@@ -933,6 +944,7 @@ class ConventionTests: XCTestCase {
         ("testInvalidLayout3", testInvalidLayout3),
         ("testInvalidLayout4", testInvalidLayout4),
         ("testInvalidLayout5", testInvalidLayout5),
+        ("testInvalidLayout6", testInvalidLayout5),
         ("testNoSourcesInModule", testNoSourcesInModule),
         ("testValidSources", testValidSources),
         ("testExcludes", testExcludes),


### PR DESCRIPTION
We need to check for loose source files if there is atleast one module
inside Sources/ and not when there is exactly one.

Related radar: <rdar://problem/29228963>