### PR TITLE
[Commands] Fix PATH env parsing

### DIFF
--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -492,7 +492,7 @@ extension AbsolutePath {
 ///
 /// The normalization rules are as described for the AbsolutePath struct.
 private func normalize(absolute string: String) -> String {
-    precondition(string.characters.first == "/")
+    precondition(string.characters.first == "/", "Failure normalizing \(string), absolute paths should start with '/'")
     
     // Get a hold of the character view.
     // FIXME: Switch to use the UTF-8 view, which is more efficient.

--- a/Tests/CommandsTests/UserToolchainTests.swift
+++ b/Tests/CommandsTests/UserToolchainTests.swift
@@ -46,7 +46,14 @@ final class UserToolchainTests: XCTestCase {
         }
     }
 
+    func testEnvSearchPaths() throws {
+        let cwd = AbsolutePath("/dummy")
+        let paths = UserToolchain.getEnvSearchPaths(pathString: "something:.:abc/../.build/debug:/usr/bin:/bin/", currentWorkingDirectory: cwd)
+        XCTAssertEqual(paths, ["/dummy/something", "/dummy", "/dummy/.build/debug", "/usr/bin", "/bin"].map(AbsolutePath.init))
+    }
+
     static var allTests = [
         ("testExecutableLookup", testExecutableLookup),
+        ("testEnvSearchPaths", testEnvSearchPaths),
     ]
 }


### PR DESCRIPTION
There was wrong assumption that all paths inside PATH are
absolute paths.

- https://bugs.swift.org/browse/SR-3283