### PR TITLE
[PerfTests] Move old disabled perf tests to perf test module

### DIFF
--- a/Tests/BasicPerformanceTests/ByteStringPerfTests.swift
+++ b/Tests/BasicPerformanceTests/ByteStringPerfTests.swift
@@ -12,10 +12,6 @@ import XCTest
 
 import Basic
 
-// FIXME: Performance tests are disabled by default for the time being because they have
-// too high an impact on overall testing time.
-//
-// See: https://bugs.swift.org/browse/SR-1354
 #if ENABLE_PERF_TESTS
 
 class ByteStringPerfTests: XCTestCase {

--- a/Tests/BasicPerformanceTests/OutputByteStreamPerfTests.swift
+++ b/Tests/BasicPerformanceTests/OutputByteStreamPerfTests.swift
@@ -12,11 +12,7 @@ import XCTest
 
 import Basic
 
-// FIXME: Performance tests are disabled for the time being because they have
-// too high an impact on overall testing time.
-//
-// See: https://bugs.swift.org/browse/SR-1354
-#if false
+#if ENABLE_PERF_TESTS
 
 struct ByteSequence: Sequence {
     let bytes16 = [UInt8](repeating: 0, count: 1 << 4)

--- a/Tests/BasicPerformanceTests/PathPerfTests.swift
+++ b/Tests/BasicPerformanceTests/PathPerfTests.swift
@@ -12,11 +12,7 @@ import XCTest
 
 import Basic
 
-// FIXME: Performance tests are disabled for the time being because they have
-// too high an impact on overall testing time.
-//
-// See: https://bugs.swift.org/browse/SR-1354
-#if false
+#if ENABLE_PERF_TESTS
 
 class PathPerfTests: XCTestCase {
     
@@ -28,7 +24,7 @@ class PathPerfTests: XCTestCase {
         self.measure {
             var lengths = 0
             for _ in 0 ..< N {
-                let result = absPath.join(relPath)
+                let result = absPath.appending(relPath)
                 lengths = lengths &+ result.asString.utf8.count
             }
             XCTAssertEqual(lengths, (absPath.asString.utf8.count + 1 + relPath.asString.utf8.count) &* N)
@@ -36,10 +32,6 @@ class PathPerfTests: XCTestCase {
     }
     
     // FIXME: We will obviously want a lot more tests here.
-
-    static var allTests = [
-        ("testJoinPerf_X100000",         testJoinPerf_X100000),
-    ]
 }
     
 #endif

--- a/Tests/BasicPerformanceTests/StringConversionsPerfTests.swift
+++ b/Tests/BasicPerformanceTests/StringConversionsPerfTests.swift
@@ -12,11 +12,7 @@ import XCTest
 
 import Basic
 
-// FIXME: Performance tests are disabled for the time being because they have
-// too high an impact on overall testing time.
-//
-// See: https://bugs.swift.org/browse/SR-1354
-#if false 
+#if ENABLE_PERF_TESTS
 
 class StringConversionsPerfTests: XCTestCase {
     func testLongString() {


### PR DESCRIPTION
These tests are completely disabled, move them under ENABLE_PERF_TESTS
define and to perf test module.