### PR TITLE
[POSIX] Propagate complete env when lauching subprocess

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -244,6 +244,8 @@ private func findPackageRoot() -> AbsolutePath? {
 }
 
 private func getEnvBuildPath() -> AbsolutePath? {
+    // Don't rely on build path from env for SwiftPM's own tests.
+    guard getenv("IS_SWIFTPM_TEST") == nil else { return nil }
     guard let env = getenv("SWIFT_BUILD_PATH") else { return nil }
     return AbsolutePath(env, relativeTo: currentWorkingDirectory)
 }

--- a/Sources/Commands/UserToolchain.swift
+++ b/Sources/Commands/UserToolchain.swift
@@ -8,8 +8,6 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
-import class Foundation.ProcessInfo
-
 import POSIX
 
 import Basic
@@ -126,7 +124,7 @@ struct UserToolchain: Toolchain {
         }
         else {
             // No value in env, so search for `clang`.
-            guard let foundPath = try? POSIX.popen(whichClangArgs, environment: ProcessInfo.processInfo.environment).chomp(), !foundPath.isEmpty else {
+            guard let foundPath = try? POSIX.popen(whichClangArgs).chomp(), !foundPath.isEmpty else {
                 throw Error.invalidToolchain(problem: "could not find `clang`")
             }
             clangCompiler = AbsolutePath(foundPath, relativeTo: currentWorkingDirectory)
@@ -146,7 +144,7 @@ struct UserToolchain: Toolchain {
         }
         else {
             // No value in env, so search for it.
-            guard let foundPath = try? POSIX.popen(whichDefaultSDKArgs, environment: ProcessInfo.processInfo.environment).chomp(), !foundPath.isEmpty else {
+            guard let foundPath = try? POSIX.popen(whichDefaultSDKArgs).chomp(), !foundPath.isEmpty else {
                 throw Error.invalidToolchain(problem: "could not find default SDK")
             }
             defaultSDK = AbsolutePath(foundPath, relativeTo: currentWorkingDirectory)

--- a/Sources/Get/Git.swift
+++ b/Sources/Get/Git.swift
@@ -8,8 +8,6 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import class Foundation.ProcessInfo
-
 import Basic
 import Utility
 
@@ -27,11 +25,10 @@ extension Git {
         }
 
         do {
-            let env = ProcessInfo.processInfo.environment
             try system(Git.tool, "clone",
                        "--recursive",   // get submodules too so that developers can use these if they so choose
                 "--depth", "10",
-                url, dstdir.asString, environment: env, message: "Cloning \(url)")
+                url, dstdir.asString, message: "Cloning \(url)")
         } catch POSIX.Error.exitStatus {
             // Git 2.0 or higher is required
             if let majorVersion = Git.majorVersionNumber, majorVersion < 2 {

--- a/Sources/POSIX/popen.swift
+++ b/Sources/POSIX/popen.swift
@@ -10,7 +10,7 @@
 
 import libc
 
-public func popen(_ arguments: [String], redirectStandardError: Bool = false, environment: [String: String] = [:]) throws -> String
+public func popen(_ arguments: [String], redirectStandardError: Bool = false, environment: [String: String]? = nil) throws -> String
 {
     var out = ""
     try popen(arguments, redirectStandardError: redirectStandardError, environment: environment) { line in
@@ -19,7 +19,7 @@ public func popen(_ arguments: [String], redirectStandardError: Bool = false, en
     return out
 }
 
-public func popen(_ arguments: [String], redirectStandardError: Bool = false, environment: [String: String] = [:], body: (String) -> Void) throws
+public func popen(_ arguments: [String], redirectStandardError: Bool = false, environment: [String: String]? = nil, body: (String) -> Void) throws
 {
     do {
         // Create a pipe to use for reading the result.

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -14,7 +14,6 @@ import Utility
 
 import func POSIX.getenv
 import enum POSIX.Error
-import class Foundation.ProcessInfo
 
 enum GitRepositoryProviderError: Swift.Error {
     case gitCloneFailure(url: String, path: AbsolutePath)
@@ -45,10 +44,9 @@ public class GitRepositoryProvider: RepositoryProvider {
         do {
             // FIXME: We need infrastructure in this subsystem for reporting
             // status information.
-            let env = ProcessInfo.processInfo.environment
             try system(
                 Git.tool, "clone", "--bare", repository.url, path.asString,
-                environment: env, message: nil)
+                message: nil)
         } catch POSIX.Error.exitStatus {
             throw GitRepositoryProviderError.gitCloneFailure(url: repository.url, path: path)
         }

--- a/Sources/TestSupport/XCTAssertHelpers.swift
+++ b/Sources/TestSupport/XCTAssertHelpers.swift
@@ -18,7 +18,7 @@ import Utility
 import class Foundation.Bundle
 #endif
 
-public func XCTAssertBuilds(_ path: AbsolutePath, configurations: Set<Configuration> = [.Debug, .Release], file: StaticString = #file, line: UInt = #line, Xcc: [String] = [], Xld: [String] = [], Xswiftc: [String] = [], env: [String: String] = [:]) {
+public func XCTAssertBuilds(_ path: AbsolutePath, configurations: Set<Configuration> = [.Debug, .Release], file: StaticString = #file, line: UInt = #line, Xcc: [String] = [], Xld: [String] = [], Xswiftc: [String] = [], env: [String: String]? = nil) {
     for conf in configurations {
         do {
             print("    Building \(conf)")
@@ -29,7 +29,7 @@ public func XCTAssertBuilds(_ path: AbsolutePath, configurations: Set<Configurat
     }
 }
 
-public func XCTAssertSwiftTest(_ path: AbsolutePath, file: StaticString = #file, line: UInt = #line, env: [String: String] = [:]) {
+public func XCTAssertSwiftTest(_ path: AbsolutePath, file: StaticString = #file, line: UInt = #line, env: [String: String]? = nil) {
     do {
         _ = try SwiftPMProduct.SwiftTest.execute([], chdir: path, env: env, printIfError: true)
     } catch {
@@ -37,7 +37,7 @@ public func XCTAssertSwiftTest(_ path: AbsolutePath, file: StaticString = #file,
     }
 }
 
-public func XCTAssertBuildFails(_ path: AbsolutePath, file: StaticString = #file, line: UInt = #line, Xcc: [String] = [], Xld: [String] = [], Xswiftc: [String] = [], env: [String: String] = [:]) {
+public func XCTAssertBuildFails(_ path: AbsolutePath, file: StaticString = #file, line: UInt = #line, Xcc: [String] = [], Xld: [String] = [], Xswiftc: [String] = [], env: [String: String]? = nil) {
     do {
         _ = try executeSwiftBuild(path, Xcc: Xcc, Xld: Xld, Xswiftc: Xswiftc)
 

--- a/Sources/TestSupport/misc.swift
+++ b/Sources/TestSupport/misc.swift
@@ -118,7 +118,7 @@ public enum Configuration {
 private var globalSymbolInMainBinary = 0
 
 @discardableResult
-public func executeSwiftBuild(_ chdir: AbsolutePath, configuration: Configuration = .Debug, printIfError: Bool = false, Xcc: [String] = [], Xld: [String] = [], Xswiftc: [String] = [], env: [String: String] = [:]) throws -> String {
+public func executeSwiftBuild(_ chdir: AbsolutePath, configuration: Configuration = .Debug, printIfError: Bool = false, Xcc: [String] = [], Xld: [String] = [], Xswiftc: [String] = [], env: [String: String]? = nil) throws -> String {
     var args = ["--configuration"]
     switch configuration {
     case .Debug:
@@ -130,13 +130,7 @@ public func executeSwiftBuild(_ chdir: AbsolutePath, configuration: Configuratio
     args += Xld.flatMap{ ["-Xlinker", $0] }
     args += Xswiftc.flatMap{ ["-Xswiftc", $0] }
 
-    let swiftBuild = SwiftPMProduct.SwiftBuild
-    var env = env
-
-    // FIXME: We use this private environment variable hack to be able to
-    // create special conditions in swift-build for swiftpm tests.
-    env["IS_SWIFTPM_TEST"] = "1"
-    return try swiftBuild.execute(args, chdir: chdir, env: env, printIfError: printIfError)
+    return try SwiftPMProduct.SwiftBuild.execute(args, chdir: chdir, env: env, printIfError: printIfError)
 }
 
 /// Test helper utility for executing a block with a temporary directory.

--- a/Sources/Utility/Git.swift
+++ b/Sources/Utility/Git.swift
@@ -12,7 +12,6 @@ import Basic
 import func POSIX.realpath
 import func POSIX.getenv
 import libc
-import class Foundation.ProcessInfo
 
 extension Version {
     static func vprefix(_ string: String) -> Version? {
@@ -124,7 +123,7 @@ public class Git {
         }
 
         public func fetch() throws {
-            try system(Git.tool, "-C", path.asString, "fetch", "--tags", "origin", environment: ProcessInfo.processInfo.environment, message: nil)
+            try system(Git.tool, "-C", path.asString, "fetch", "--tags", "origin", message: nil)
         }
     }
 

--- a/Sources/Utility/Platform.swift
+++ b/Sources/Utility/Platform.swift
@@ -10,7 +10,6 @@
 
 import Basic
 import func POSIX.popen
-import class Foundation.ProcessInfo
 
 public enum Platform {
     case darwin
@@ -41,7 +40,7 @@ public enum Platform {
 public func platformFrameworksPath() throws -> AbsolutePath {
     // Lazily compute the platform the first time it is needed.
     struct Static {
-        static let value = { try? POSIX.popen(["xcrun", "--sdk", "macosx", "--show-sdk-platform-path"], environment: ProcessInfo.processInfo.environment) }()
+        static let value = { try? POSIX.popen(["xcrun", "--sdk", "macosx", "--show-sdk-platform-path"]) }()
     }
     guard let popened = Static.value, let chuzzled = popened.chuzzle() else {
         throw Error.invalidPlatformPath

--- a/Sources/Utility/Verbosity.swift
+++ b/Sources/Utility/Verbosity.swift
@@ -81,17 +81,17 @@ private func printArgumentsIfVerbose(_ arguments: [String]) {
     }
 }
 
-public func system(_ arguments: [String], environment: [String:String] = [:]) throws {
+public func system(_ arguments: [String], environment: [String:String]? = nil) throws {
     printArgumentsIfVerbose(arguments)
     try POSIX.system(arguments, environment: environment)
 }
 
-public func popen(_ arguments: [String], redirectStandardError: Bool = false, environment: [String: String] = [:]) throws -> String {
+public func popen(_ arguments: [String], redirectStandardError: Bool = false, environment: [String: String]? = nil) throws -> String {
     printArgumentsIfVerbose(arguments)
     return try POSIX.popen(arguments, redirectStandardError: redirectStandardError, environment: environment)
 }
 
-public func popen(_ arguments: [String], redirectStandardError: Bool = false, environment: [String: String] = [:], body: (String) -> Void) throws {
+public func popen(_ arguments: [String], redirectStandardError: Bool = false, environment: [String: String]? = nil, body: (String) -> Void) throws {
     printArgumentsIfVerbose(arguments)
     return try POSIX.popen(arguments, redirectStandardError: redirectStandardError, environment: environment, body: body)
 }
@@ -101,11 +101,11 @@ import func libc.fflush
 import var libc.stdout
 import enum POSIX.Error
 
-public func system(_ arguments: String..., environment: [String:String] = [:], message: String?) throws {
+public func system(_ arguments: String..., environment: [String:String]? = nil, message: String?) throws {
     try system(args: arguments, environment: environment, message: message)
 }
 
-public func system(args arguments: [String], environment: [String:String] = [:], message: String? = nil, quietly: Bool = false) throws {
+public func system(args arguments: [String], environment: [String:String]? = nil, message: String? = nil, quietly: Bool = false) throws {
     var out = ""
     do {
         if Utility.verbosity == .concise {

--- a/Tests/BuildTests/IncrementalBuildTests.swift
+++ b/Tests/BuildTests/IncrementalBuildTests.swift
@@ -40,7 +40,7 @@ final class IncrementalBuildTests: XCTestCase {
     func testIncrementalSingleModuleCLibraryInSources() {
         fixture(name: "ClangModules/CLibrarySources") { prefix in
             // Build it once and capture the log (this will be a full build).
-            let fullLog = try executeSwiftBuild(prefix, configuration: .Debug, printIfError: true, Xcc: [], Xld: [], Xswiftc: [], env: [:])
+            let fullLog = try executeSwiftBuild(prefix, printIfError: true)
             
             // Check various things that we expect to see in the full build log.
             // FIXME:  This is specific to the format of the log output, which
@@ -68,13 +68,13 @@ final class IncrementalBuildTests: XCTestCase {
             try localFileSystem.writeFileContents(sourceFile, bytes: contents)
             
             // Now build again.  This should be an incremental build.
-            let log2 = try executeSwiftBuild(prefix, configuration: .Debug, printIfError: true, Xcc: [], Xld: [], Xswiftc: [], env: [:])
+            let log2 = try executeSwiftBuild(prefix, printIfError: true)
             XCTAssertTrue(log2.contains("Compile CLibrarySources Foo.c"))
             XCTAssertTrue(log2.contains("Linking CLibrarySources"))
             
             // Now build again without changing anything.  This should be a null
             // build.
-            let log3 = try executeSwiftBuild(prefix, configuration: .Debug, printIfError: true, Xcc: [], Xld: [], Xswiftc: [], env: [:])
+            let log3 = try executeSwiftBuild(prefix, printIfError: true)
             XCTAssertFalse(log3.contains("Compile CLibrarySources Foo.c"))
             XCTAssertFalse(log3.contains("Linking CLibrarySources"))
         }

--- a/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
+++ b/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
@@ -20,7 +20,7 @@ class BuildPerfTests: XCTestCase {
 
     @discardableResult
     func execute(args: [String] = [], chdir: AbsolutePath) throws -> String {
-        // FIXME: We shouldn't pass the SWIFT_EXEC at lower level.
+        // FIXME: We should pass the SWIFT_EXEC at lower level.
         return try SwiftPMProduct.SwiftBuild.execute(args + ["--enable-new-resolver"], chdir: chdir, env: ["SWIFT_EXEC": resources.swiftCompilerPath.asString], printIfError: true)
     }
 

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -360,7 +360,7 @@ class MiscellaneousTestCase: XCTestCase {
         XCTAssertTrue(localFileSystem.isDirectory(packageRoot))
 
         // Run package init.
-        _ = try SwiftPMProduct.SwiftPackage.execute(["init"], chdir: packageRoot, env: [:], printIfError: true)
+        _ = try SwiftPMProduct.SwiftPackage.execute(["init"], chdir: packageRoot, printIfError: true)
         // Try building it.
         XCTAssertBuilds(packageRoot)
         XCTAssertFileExists(packageRoot.appending(components: ".build", "debug", "some_package.swiftmodule"))
@@ -369,9 +369,9 @@ class MiscellaneousTestCase: XCTestCase {
     func testSecondBuildIsNullInModulemapGen() throws {
         // Make sure that swiftpm doesn't rebuild second time if the modulemap is being generated.
         fixture(name: "ClangModules/SwiftCMixed") { prefix in
-            var output = try executeSwiftBuild(prefix, configuration: .Debug, printIfError: true, Xcc: [], Xld: [], Xswiftc: [], env: [:])
+            var output = try executeSwiftBuild(prefix, printIfError: true)
             XCTAssertFalse(output.isEmpty)
-            output = try executeSwiftBuild(prefix, configuration: .Debug, printIfError: true, Xcc: [], Xld: [], Xswiftc: [], env: [:])
+            output = try executeSwiftBuild(prefix, printIfError: true)
             XCTAssertTrue(output.isEmpty)
         }
     }
@@ -402,7 +402,7 @@ class MiscellaneousTestCase: XCTestCase {
     func testOverridingSwiftcArguments() throws {
 #if os(macOS)
         fixture(name: "Miscellaneous/OverrideSwiftcArgs") { prefix in
-            try executeSwiftBuild(prefix, configuration: .Debug, printIfError: true, Xcc: [], Xld: [], Xswiftc: ["-target", "x86_64-apple-macosx10.20"], env: [:])
+            try executeSwiftBuild(prefix, printIfError: true, Xswiftc: ["-target", "x86_64-apple-macosx10.20"])
         }
 #endif
     }

--- a/Tests/XcodeprojTests/FunctionalTests.swift
+++ b/Tests/XcodeprojTests/FunctionalTests.swift
@@ -152,7 +152,7 @@ func XCTAssertXcodeBuild(project: AbsolutePath, file: StaticString = #file, line
     }
 }
 
-func XCTAssertXcodeprojGen(_ prefix: AbsolutePath, flags: [String] = [], env: [String: String] = [:], file: StaticString = #file, line: UInt = #line) {
+func XCTAssertXcodeprojGen(_ prefix: AbsolutePath, flags: [String] = [], env: [String: String]? = nil, file: StaticString = #file, line: UInt = #line) {
     do {
         print("    Generating XcodeProject")
         _ = try SwiftPMProduct.SwiftPackage.execute(flags + ["generate-xcodeproj"], chdir: prefix, env: env, printIfError: true)


### PR DESCRIPTION
- <rdar://problem/29462783>

Unless an env is specified, propagate complete env by default.
This is also the default behavior in NSTask API and python's
subprocess