### PR TITLE
Generate shell completion scripts

### DIFF
--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -94,4 +94,9 @@ public enum BuildToolMode {
     case version
 }
 
-extension Build.Configuration: StringEnumArgument {}
+extension Build.Configuration: StringEnumArgument {
+    public static var completion: ShellCompletion = .values([
+        (debug.rawValue, "build with DEBUG configuration"),
+        (release.rawValue, "build with RELEASE configuration")
+    ])
+}

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -417,7 +417,7 @@ public class PackageToolOptions: ToolOptions {
     /// Repin the dependencies when running package update.
     var repin = false
 
-    enum ResolveToolMode: String, StringEnumArgument {
+    enum ResolveToolMode: String {
         case text
         case json
     }
@@ -449,8 +449,41 @@ public enum PackageMode: String, StringEnumArgument {
     case update
     case version
     case help
+
+    // PackageMode is not used as an argument; completions will be
+    // provided by the subparsers.
+    public static var completion: ShellCompletion = .none
 }
 
-extension InitPackage.PackageType: StringEnumArgument {}
-extension ShowDependenciesMode: StringEnumArgument {}
-extension DescribeMode: StringEnumArgument {}
+extension InitPackage.PackageType: StringEnumArgument {
+    public static var completion: ShellCompletion = .values([
+        (empty.description, "generates an empty project"),
+        (library.description, "generates project for a dynamic library"),
+        (executable.description, "generates a project for a cli executable"),
+        (systemModule.description, "generates a project for a system module")
+    ])
+}
+
+extension ShowDependenciesMode: StringEnumArgument {
+    public static var completion: ShellCompletion = .values([
+        (text.description, "list dependencies using text format"),
+        (dot.description, "list dependencies using dot format"),
+        (json.description, "list dependencies using JSON format")
+    ])
+}
+
+extension DescribeMode: StringEnumArgument {
+    public static var completion: ShellCompletion = .values([
+        (text.rawValue, "describe using text format"),
+        (json.rawValue, "describe using JSON format")
+    ])
+}
+
+extension PackageToolOptions.ResolveToolMode: StringEnumArgument {
+    static var completion: ShellCompletion {
+        return .values([
+            (text.rawValue, "resolve using text format"),
+            (json.rawValue, "resolve using JSON format")
+        ])
+    }
+}

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -456,27 +456,33 @@ public enum PackageMode: String, StringEnumArgument {
 }
 
 extension InitPackage.PackageType: StringEnumArgument {
-    public static var completion: ShellCompletion = .values([
-        (empty.description, "generates an empty project"),
-        (library.description, "generates project for a dynamic library"),
-        (executable.description, "generates a project for a cli executable"),
-        (systemModule.description, "generates a project for a system module")
-    ])
+    public static var completion: ShellCompletion {
+        return .values([
+            (empty.description, "generates an empty project"),
+            (library.description, "generates project for a dynamic library"),
+            (executable.description, "generates a project for a cli executable"),
+            (systemModule.description, "generates a project for a system module")
+        ])
+    }
 }
 
 extension ShowDependenciesMode: StringEnumArgument {
-    public static var completion: ShellCompletion = .values([
-        (text.description, "list dependencies using text format"),
-        (dot.description, "list dependencies using dot format"),
-        (json.description, "list dependencies using JSON format")
-    ])
+    public static var completion: ShellCompletion {
+        return .values([
+            (text.description, "list dependencies using text format"),
+            (dot.description, "list dependencies using dot format"),
+            (json.description, "list dependencies using JSON format")
+        ])
+    }
 }
 
 extension DescribeMode: StringEnumArgument {
-    public static var completion: ShellCompletion = .values([
-        (text.rawValue, "describe using text format"),
-        (json.rawValue, "describe using JSON format")
-    ])
+    public static var completion: ShellCompletion {
+        return .values([
+            (text.rawValue, "describe using text format"),
+            (json.rawValue, "describe using JSON format")
+        ])
+    }
 }
 
 extension PackageToolOptions.ResolveToolMode: StringEnumArgument {

--- a/Sources/Utility/ArgumentParser.swift
+++ b/Sources/Utility/ArgumentParser.swift
@@ -238,7 +238,7 @@ public final class PositionalArgument<Kind>: ArgumentProtocol {
 /// A type-erased argument.
 ///
 /// Note: Only used for argument parsing purpose.
-internal final class AnyArgument: ArgumentProtocol, CustomStringConvertible {
+final class AnyArgument: ArgumentProtocol, CustomStringConvertible {
     typealias ArgumentKindTy = Any
 
     let name: String
@@ -365,11 +365,11 @@ public final class ArgumentParser {
     }
 
     /// The mapping of subparsers to their subcommand.
-    internal var subparsers: [String: ArgumentParser] = [:]
+    private(set) var subparsers: [String: ArgumentParser] = [:]
 
     /// List of arguments added to this parser.
-    internal var options = [AnyArgument]()
-    internal var positionalArgs = [AnyArgument]()
+    private(set) var options = [AnyArgument]()
+    private(set) var positionalArgs = [AnyArgument]()
 
     // If provided, will be substituted instead of arg0 in usage text.
     let commandName: String?

--- a/Sources/Utility/ArgumentParserShellCompletion.swift
+++ b/Sources/Utility/ArgumentParserShellCompletion.swift
@@ -1,0 +1,230 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import Basic
+
+fileprivate let removeDefaultRegex = try! NSRegularExpression(pattern: "\\[default: .+?\\]", options: [])
+
+extension ArgumentParser {
+
+    /// Generates part of a completion script for the given shell.
+    ///
+    /// These aren't complete scripts, as some setup code is required. See
+    /// `Utilities/bash/completions` and `Utilities/zsh/_swift` for example
+    /// usage.
+    public func generateCompletionScript(for shell: Shell, on stream: OutputByteStream) {
+        guard let commandName = commandName else { abort() }
+        let name = "_\(commandName.replacingOccurrences(of: " ", with: "_"))"
+
+        switch shell {
+        case .bash:
+            // Information about how to include this function in a completion script.
+            stream <<< "# Generates completions for \(commandName)\n"
+            stream <<< "#\n"
+            stream <<< "# Parameters\n"
+            stream <<< "# - the start position of this parser; set to 1 if unknown\n"
+            stream <<< "function \(name)\n"
+            stream <<< "{\n"
+
+            generateBashSwiftTool(name: name, on: stream)
+
+        case .zsh:
+            // Information about how to include this function in a completion script.
+            stream <<< "# Generates completions for \(commandName)\n"
+            stream <<< "#\n"
+            stream <<< "# In the final compdef file, set the following file header:\n"
+            stream <<< "#\n"
+            stream <<< "#     #compdef \(name)\n"
+            stream <<< "#     local context state state_descr line\n"
+            stream <<< "#     typeset -A opt_args\n"
+
+            generateZshSwiftTool(name: name, on: stream)
+        }
+        stream.flush()
+    }
+
+
+    // MARK:- BASH
+
+    fileprivate func generateBashSwiftTool(name: String, on stream: OutputByteStream) -> () {
+
+        // Suggest positional arguments. Beware that this forces positional arguments
+        // before options. For example [swift package pin <TAB>] expects a name as the
+        // first argument. So no options (like --all) will be suggested. However after
+        // the positional argument; [swift package pin MyPackage <TAB>] will list them
+        // just fine.
+        for (position, option) in positionalArgs.enumerated() {
+            stream <<< "    if [[ $COMP_CWORD == $(($1+\(position))) ]]; then\n"
+            generateBashCompletion(option, on: stream)
+            stream <<< "    fi\n"
+        }
+
+        // Suggest subparsers in addition to other arguments.
+        stream <<< "    if [[ $COMP_CWORD == $1 ]]; then\n"
+        var completions = [String]()
+        for (subName, _) in subparsers {
+            completions.append(subName)
+        }
+        for option in options {
+            completions.append(option.name)
+            if let shortName = option.shortName {
+                completions.append(shortName)
+            }
+        }
+        stream <<< "        COMPREPLY=( $(compgen -W \"\(completions.joined(separator: " "))\" -- $cur) )\n"
+        stream <<< "        return\n"
+        stream <<< "    fi\n"
+
+        // Suggest completions based on previous word.
+        generateBashCasePrev(on: stream)
+
+        // Forward completions to subparsers.
+        stream <<< "    case ${COMP_WORDS[$1]} in\n"
+        for (subName, _) in subparsers {
+            stream <<< "        (\(subName))\n"
+            stream <<< "            \(name)_\(subName) $(($1+1))\n"
+            stream <<< "            return\n"
+            stream <<< "        ;;\n"
+        }
+        stream <<< "    esac\n"
+
+        // In all other cases (no positional / previous / subparser), suggest
+        // this parsers completions.
+        stream <<< "    COMPREPLY=( $(compgen -W \"\(completions.joined(separator: " "))\" -- $cur) )\n"
+        stream <<< "}\n"
+        stream <<< "\n"
+
+        for (subName, subParser) in subparsers {
+            subParser.generateBashSwiftTool(name: "\(name)_\(subName)", on: stream)
+        }
+    }
+
+    fileprivate func generateBashCasePrev(on stream: OutputByteStream) {
+        stream <<< "    case $prev in\n"
+        for option in options {
+            let flags = [option.name] + (option.shortName.map({[$0]}) ?? [])
+            stream <<< "        (\(flags.joined(separator: "|")))\n"
+            generateBashCompletion(option, on: stream)
+            stream <<< "        ;;\n"
+        }
+        stream <<< "    esac\n"
+    }
+
+    fileprivate func generateBashCompletion(_ argument: AnyArgument, on stream: OutputByteStream) {
+        switch argument.kind.completion {
+        case .none:
+            // return; no value to complete
+            stream <<< "            return\n"
+        case .unspecified:
+            break
+        case .values(let values):
+            stream <<< "            COMPREPLY=( $(compgen -W \"\(values.map({$0.value}).joined(separator: " "))\" -- $cur) )\n"
+            stream <<< "            return\n"
+        case .filename:
+            stream <<< "            _filedir\n"
+            stream <<< "            return\n"
+        }
+    }
+
+
+    // MARK:- ZSH
+
+    private func generateZshSwiftTool(name: String, on stream: OutputByteStream) {
+        // Completions are provided by zsh's _arguments builtin.
+        stream <<< "\(name)() {\n"
+        stream <<< "    arguments=(\n"
+        for option in positionalArgs {
+            stream <<< "        \""
+            generateZshCompletion(option, on: stream)
+            stream <<< "\"\n"
+        }
+        for option in options {
+            generateZshArgument(option, on: stream)
+        }
+
+        // Use a simple state-machine when dealing with sub parsers.
+        if subparsers.count > 0 {
+            stream <<< "        '(-): :->command'\n"
+            stream <<< "        '(-)*:: :->arg'\n"
+        }
+
+        stream <<< "    )\n"
+        stream <<< "    _arguments $arguments && return\n"
+
+        // Handle the state set by the state machine.
+        if subparsers.count > 0 {
+            stream <<< "    case $state in\n"
+            stream <<< "        (command)\n"
+            stream <<< "            local modes\n"
+            stream <<< "            modes=(\n"
+            for (subName, subParser) in subparsers {
+                stream <<< "                '\(subName):\(subParser.overview)'\n"
+            }
+            stream <<< "            )\n"
+            stream <<< "            _describe \"mode\" modes\n"
+            stream <<< "            ;;\n"
+            stream <<< "        (arg)\n"
+            stream <<< "            case ${words[1]} in\n"
+            for (subName, _) in subparsers {
+                stream <<< "                (\(subName))\n"
+                stream <<< "                    \(name)_\(subName)\n"
+                stream <<< "                    ;;\n"
+            }
+            stream <<< "            esac\n"
+            stream <<< "            ;;\n"
+            stream <<< "    esac\n"
+        }
+        stream <<< "}\n"
+        stream <<< "\n"
+
+        for (subName, subParser) in subparsers {
+            subParser.generateZshSwiftTool(name: "\(name)_\(subName)", on: stream)
+        }
+    }
+
+    /// Generates an option argument for `_arguments`, complete with description and completion values.
+    fileprivate func generateZshArgument(_ argument: AnyArgument, on stream: OutputByteStream) {
+        stream <<< "        \""
+        switch argument.shortName {
+        case .none: stream <<< "\(argument.name)"
+        case let shortName?: stream <<< "(\(argument.name) \(shortName))\"{\(argument.name),\(shortName)}\""
+        }
+
+        let description = removeDefaultRegex.replace(in: argument.usage ?? "", with: "").replacingOccurrences(of: "\"", with: "\\\"")
+        stream <<< "[\(description)]"
+
+        generateZshCompletion(argument, on: stream)
+        stream <<< "\"\n"
+    }
+
+    /// Generates completion values, as part of an item for `_arguments`.
+    fileprivate func generateZshCompletion(_ argument: AnyArgument, on stream: OutputByteStream) {
+        let message = removeDefaultRegex.replace(in: argument.usage ?? " ", with: "").replacingOccurrences(of: "\"", with: "\\\"")
+
+        switch argument.kind.completion {
+        case .none: stream <<< ":\(message): "
+        case .unspecified: break
+        case .filename: stream <<< ":\(message):_files"
+        case let .values(values):
+            stream <<< ": :{_values ''"
+            for (value, description) in values {
+                stream <<< " '\(value)[\(description)]'"
+            }
+            stream <<< "}"
+        }
+    }
+}
+
+fileprivate extension NSRegularExpression {
+    func replace(`in` original: String, with replacement: String) -> String {
+        return stringByReplacingMatches(in: original, options: [], range: NSRange(location: 0, length: original.characters.count), withTemplate: replacement)
+    }
+}


### PR DESCRIPTION
This is in addition to the work done in [PR#703][1]. The status of this PR is WIP and pushed to get feedback from the maintainers.

I've made a few changes to the public API of ArgumentParser to get all the meta data required to generate the scripts, as well as the descriptions that zsh shows. For the SwiftPM tools, this means no duplication of the arguments anymore inside SwiftPM.

Things left to tackle:
* [x] Support positional arguments
* [x] Cleanup the code along with some documentation

Not handled in this PR, requires further discussion:
* Compiler flags are still duplicated; should we add some sort of "discovery" based on the output of `swift -h`? -- What to do with flags we cannot handle (nicely), like `-l<name>`?
* How to include this in the toolchain?
* How to generate the full completion script, including setup code? (see `_swift` functions in the current scripts under `Utilities/{bash,zsh}`.

[1]: https://github.com/apple/swift-package-manager/pull/703