### PR TITLE
[Resolver] Stop computing after encountering error

### DIFF
--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -675,6 +675,8 @@ public class DependencyResolver<
         //
         // FIXME: We must detect recursion here.
         return AnySequence(validVersions(container).lazy.flatMap{ version -> AnySequence<AssignmentSet> in
+                // If we had encountered any error, return early.
+                guard self.error == nil else { return AnySequence([]) }
                 // Create an assignment for this container and version.
                 var assignment = AssignmentSet()
                 assignment[container] = .version(version)
@@ -734,6 +736,9 @@ public class DependencyResolver<
         // merged. Thus, the reduce itself can be eager since the result is
         // lazy.
         return AnySequence(constraints.map{ $0.identifier }.reduce(AnySequence([(assignment, allConstraints)])) { (possibleAssignments, identifier) -> AnySequence<(AssignmentSet, ConstraintSet)> in
+                    // If we had encountered any error, return early.
+                    guard self.error == nil else { return AnySequence([]) }
+
                     // Get the container.
                     //
                     // Failures here will immediately abort the solution, although in

--- a/Tests/FunctionalTests/VersionSpecificTests.swift
+++ b/Tests/FunctionalTests/VersionSpecificTests.swift
@@ -35,7 +35,7 @@ class VersionSpecificTests: XCTestCase {
             }
             try repo.stage(file: "Package.swift")
             try repo.commit(message: "Initial")
-            try repo.tag(name: "initialtag")
+            try repo.tag(name: "1.0.0")
 
             // Create the version to test against.
             try fs.writeFileContents(depPath.appending(component: "Package.swift")) {


### PR DESCRIPTION
The resolver keeps on looking for a valid solution even when it
encounters an error. I introduced this bug when fixing the lazy
behaviour of resolver.
At the time, I thought this was valid behaviour, see: 79c1de3