### PR TITLE
Clang Module XCTest support on macOS

### DIFF
--- a/Fixtures/ClangModules/ObjCmacOSPackage/Package.swift
+++ b/Fixtures/ClangModules/ObjCmacOSPackage/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "ObjCmacOSPackage"
+    )

--- a/Fixtures/ClangModules/ObjCmacOSPackage/Sources/HelloWorldExample.m
+++ b/Fixtures/ClangModules/ObjCmacOSPackage/Sources/HelloWorldExample.m
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+#import "HelloWorldExample.h"
+
+@implementation HelloWorld
+- (NSString *)hello:(NSString *)name {
+  if(!name) {
+    name = @"World";
+  }
+  return [NSString stringWithFormat:@"Hello, %@!", name];
+}
+@end

--- a/Fixtures/ClangModules/ObjCmacOSPackage/Sources/Include/HelloWorldExample.h
+++ b/Fixtures/ClangModules/ObjCmacOSPackage/Sources/Include/HelloWorldExample.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface HelloWorld : NSObject
+
+- (NSString *)hello:(NSString *)name;
+
+@end

--- a/Fixtures/ClangModules/ObjCmacOSPackage/Tests/ObjCmacOSPackageTests/HelloWorldTest.m
+++ b/Fixtures/ClangModules/ObjCmacOSPackage/Tests/ObjCmacOSPackageTests/HelloWorldTest.m
@@ -1,0 +1,36 @@
+#import <XCTest/XCTest.h>
+
+# import "HelloWorldExample.h"
+
+@interface HelloWorldTest : XCTestCase
+
+@end
+
+@implementation HelloWorldTest
+
+- (HelloWorld *)helloWorld {
+  return [[HelloWorld alloc] init];
+}
+
+- (void)testNoName {
+  NSString *input = nil;
+  NSString *expected = @"Hello, World!";
+  NSString *result = [[self helloWorld] hello:input];
+  XCTAssertEqualObjects(expected, result);
+}
+
+- (void)testSampleName {
+  NSString *input = @"Alice";
+  NSString *expected = @"Hello, Alice!";
+  NSString *result = [[self helloWorld] hello:input];
+  XCTAssertEqualObjects(expected, result);
+}
+  
+- (void)testOtherSampleName {
+  NSString *input = @"Bob";
+  NSString *expected = @"Hello, Bob!";
+  NSString *result = [[self helloWorld] hello:input];
+  XCTAssertEqualObjects(expected, result);
+}
+
+@end

--- a/Sources/Build/Command.link(ClangModule).swift
+++ b/Sources/Build/Command.link(ClangModule).swift
@@ -44,7 +44,15 @@ extension Command {
         case .Executable: break
         case .Library(.Dynamic):
             args += ["-shared"]
-        case .Test, .Library(.Static):
+        case .Test:
+            #if os(macOS)
+                args += ["-Xlinker", "-bundle"]
+                args += ["-F", try platformFrameworksPath().asString]
+            #else
+                fatalError("Can't build \(product.name), \(product.type) is not yet supported.")
+            #endif
+
+        case .Library(.Static):
             fatalError("Can't build \(product.name), \(product.type) is not yet supported.")
         }
 

--- a/Tests/FunctionalTests/ClangModuleTests.swift
+++ b/Tests/FunctionalTests/ClangModuleTests.swift
@@ -137,6 +137,34 @@ class ClangModulesTestCase: XCTestCase {
             XCTAssertFileExists(debugPath.appending(component: "CDynamicLookup".soname))
         }
     }
+    
+    func testObjectiveCPackageWithTestTarget(){
+#if os(macOS)
+        fixture(name: "ClangModules/ObjCmacOSPackage") { prefix in
+            // Build the package.
+            XCTAssertBuilds(prefix)
+            XCTAssertFileExists(prefix.appending(components: ".build", "debug", "ObjCmacOSPackage".soname))
+            // Run swift-test on package.
+            XCTAssertSwiftTest(prefix)
+            // Expected output dictionary.
+            let testCases = ["name": "All Tests", "tests": [["name" : "ObjCmacOSPackagePackageTests.xctest",
+                "tests": [
+                [
+                "name": "HelloWorldTest",
+                "tests": [
+                        ["name": "testNoName"],
+                        ["name": "testOtherSampleName"],
+                        ["name": "testSampleName"],
+                        ] as Array<Dictionary<String, String>>
+                ],
+              ] as Array<Dictionary<String, Any>>]] as Array<Dictionary<String, Any>>
+            ] as Dictionary<String, Any> as NSDictionary
+            // Run the XCTest helper tool and check result.
+            XCTAssertXCTestHelper(prefix.appending(components: ".build", "debug", "ObjCmacOSPackagePackageTests.xctest"), testCases: testCases)
+        }
+#endif
+
+    }
 
     static var allTests = [
         ("testSingleModuleFlatCLibrary", testSingleModuleFlatCLibrary),
@@ -149,5 +177,6 @@ class ClangModulesTestCase: XCTestCase {
         ("testCExecutable", testCExecutable),
         ("testModuleMapGenerationCases", testModuleMapGenerationCases),
         ("testCanForwardExtraFlagsToClang", testCanForwardExtraFlagsToClang),
+        ("testObjectiveCPackageWithTestTarget", testObjectiveCPackageWithTestTarget),
     ]
 }

--- a/Tests/FunctionalTests/ClangModuleTests.swift
+++ b/Tests/FunctionalTests/ClangModuleTests.swift
@@ -146,21 +146,6 @@ class ClangModulesTestCase: XCTestCase {
             XCTAssertFileExists(prefix.appending(components: ".build", "debug", "ObjCmacOSPackage".soname))
             // Run swift-test on package.
             XCTAssertSwiftTest(prefix)
-            // Expected output dictionary.
-            let testCases = ["name": "All Tests", "tests": [["name" : "ObjCmacOSPackagePackageTests.xctest",
-                "tests": [
-                [
-                "name": "HelloWorldTest",
-                "tests": [
-                        ["name": "testNoName"],
-                        ["name": "testOtherSampleName"],
-                        ["name": "testSampleName"],
-                        ] as Array<Dictionary<String, String>>
-                ],
-              ] as Array<Dictionary<String, Any>>]] as Array<Dictionary<String, Any>>
-            ] as Dictionary<String, Any> as NSDictionary
-            // Run the XCTest helper tool and check result.
-            XCTAssertXCTestHelper(prefix.appending(components: ".build", "debug", "ObjCmacOSPackagePackageTests.xctest"), testCases: testCases)
         }
 #endif
 


### PR DESCRIPTION
This addresses 
https://bugs.swift.org/browse/SR-3413
https://bugs.swift.org/browse/SR-3408

This only works on macOS with the Objective-C XCTest. 

Tested with this. 
https://github.com/masters3d/SwiftPackageManagerSamples/tree/master/ObjC-PackageAcronym

```
Compile AcronymTests AcronymTest.m
Linking AcronymPackageTests
Test Suite 'All tests' started at 2016-12-14 09:57:15.866
Test Suite 'AcronymPackageTests.xctest' started at 2016-12-14 09:57:15.867
Test Suite 'AcronymTest' started at 2016-12-14 09:57:15.867
Test Case '-[AcronymTest testAcronymAbbreviateTest1]' started.
Test Case '-[AcronymTest testAcronymAbbreviateTest1]' passed (0.000 seconds).
Test Case '-[AcronymTest testAcronymAbbreviateTest2]' started.
Test Case '-[AcronymTest testAcronymAbbreviateTest2]' passed (0.000 seconds).
Test Case '-[AcronymTest testAcronymAbbreviateTest3]' started.
Test Case '-[AcronymTest testAcronymAbbreviateTest3]' passed (0.000 seconds).
Test Case '-[AcronymTest testAcronymAbbreviateTest4]' started.
Test Case '-[AcronymTest testAcronymAbbreviateTest4]' passed (0.000 seconds).
Test Case '-[AcronymTest testAcronymAbbreviateTest5]' started.
Test Case '-[AcronymTest testAcronymAbbreviateTest5]' passed (0.000 seconds).
Test Case '-[AcronymTest testAcronymAbbreviateTest6]' started.
Test Case '-[AcronymTest testAcronymAbbreviateTest6]' passed (0.000 seconds).
Test Suite 'AcronymTest' passed at 2016-12-14 09:57:15.868.
	 Executed 6 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'AcronymPackageTests.xctest' passed at 2016-12-14 09:57:15.868.
	 Executed 6 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'All tests' passed at 2016-12-14 09:57:15.868.
	 Executed 6 tests, with 0 failures (0 unexpected) in 0.001 (0.002) seconds
Program ended with exit code: 0
```