### PR TITLE
[Basic] Add await() to convert async methods to sync

### DIFF
--- a/Sources/Basic/Await.swift
+++ b/Sources/Basic/Await.swift
@@ -1,0 +1,32 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// Converts an asynchronous method having callback using Result enum to asynchronous.
+///
+/// - Parameter body: The async method must be called inside this body and closure provided in the parameter
+///                   should be passed to the async method's completion handler.
+/// - Returns: The value wrapped by the async method's result.
+/// - Throws: The error wrapped by the async method's result
+public func await<T, ErrorType: Swift.Error>(_ body: (@escaping (Result<T, ErrorType>) -> Void) -> Void) throws -> T {
+    let condition = Condition()
+    var result: Result<T, ErrorType>? = nil
+    body { theResult in
+        condition.whileLocked {
+            result = theResult
+            condition.signal()
+        }
+    }
+    condition.whileLocked {
+        while result == nil {
+            condition.wait()
+        }
+    }
+    return try result!.dematerialize()
+}

--- a/Tests/BasicTests/AwaitTests.swift
+++ b/Tests/BasicTests/AwaitTests.swift
@@ -1,0 +1,49 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2015 - 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import Dispatch
+
+import Basic
+
+class AwaitTests: XCTestCase {
+
+    enum DummyError: Error {
+        case error
+    }
+
+    func async(_ param: String, _ completion: @escaping (Result<String, AnyError>) -> Void) {
+        DispatchQueue.global().async {
+            completion(Result(param))
+        }
+    }
+
+    func throwingAsync(_ param: String, _ completion: @escaping (Result<String, AnyError>) -> Void) {
+        DispatchQueue.global().async {
+            completion(Result(AnyError(DummyError.error)))
+        }
+    }
+
+    func testBasics() throws {
+        let value = try await { async("Hi", $0) }
+        XCTAssertEqual("Hi", value)
+
+        do {
+            let value = try await { throwingAsync("Hi", $0) }
+            XCTFail("Unexpected success \(value)")
+        } catch let error as AnyError {
+            XCTAssertEqual(error.underlyingError as? DummyError, DummyError.error)
+        }
+    }
+
+    static var allTests = [
+        ("testBasics", testBasics),
+    ]
+}

--- a/Tests/BasicTests/XCTestManifests.swift
+++ b/Tests/BasicTests/XCTestManifests.swift
@@ -13,6 +13,7 @@ import XCTest
 #if !os(macOS)
 public func allTests() -> [XCTestCaseEntry] {
     return [
+        testCase(AwaitTests.allTests),
         testCase(ByteStringTests.allTests),
         testCase(CollectionAlgorithmsTests.allTests),
         testCase(ConditionTests.allTests),


### PR DESCRIPTION
This is a common pattern used in some of the places, this utility will
avoid the repititive code.