### PR TITLE
[Tests] Remove duplicate module functional test

### DIFF
--- a/Fixtures/DependencyResolution/External/DuplicateModules/Bar/Package.swift
+++ b/Fixtures/DependencyResolution/External/DuplicateModules/Bar/Package.swift
@@ -1,6 +1,0 @@
-import PackageDescription
-
-let package = Package(
-    name: "Bar",
-    dependencies: [
-        .Package(url: "../Foo", majorVersion: 1)])

--- a/Fixtures/DependencyResolution/External/DuplicateModules/Bar/Sources/Bar/Bar.swift
+++ b/Fixtures/DependencyResolution/External/DuplicateModules/Bar/Sources/Bar/Bar.swift
@@ -1,2 +1,0 @@
-public func bar() {
-}

--- a/Fixtures/DependencyResolution/External/DuplicateModules/Bar/Sources/app/main.swift
+++ b/Fixtures/DependencyResolution/External/DuplicateModules/Bar/Sources/app/main.swift
@@ -1,5 +1,0 @@
-import Foo
-import Biz
-
-foo()
-biz()

--- a/Fixtures/DependencyResolution/External/DuplicateModules/Foo/Sources/Bar/Bar.swift
+++ b/Fixtures/DependencyResolution/External/DuplicateModules/Foo/Sources/Bar/Bar.swift
@@ -1,2 +1,0 @@
-public func bar() {
-}

--- a/Fixtures/DependencyResolution/External/DuplicateModules/Foo/Sources/Biz/Biz.swift
+++ b/Fixtures/DependencyResolution/External/DuplicateModules/Foo/Sources/Biz/Biz.swift
@@ -1,2 +1,0 @@
-public func biz() {
-}

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -60,12 +60,6 @@ class DependencyResolutionTests: XCTestCase {
         }
     }
 
-    func testExternalDuplicateModule() {
-        fixture(name: "DependencyResolution/External/DuplicateModules") { prefix in
-            XCTAssertBuildFails(prefix)
-        }
-    }
-
     func testExternalComplex() {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
             XCTAssertBuilds(prefix.appending(component: "app"))
@@ -85,7 +79,6 @@ class DependencyResolutionTests: XCTestCase {
         ("testInternalExecAsDep", testInternalExecAsDep),
         ("testInternalComplex", testInternalComplex),
         ("testExternalSimple", testExternalSimple),
-        ("testExternalDuplicateModule", testExternalDuplicateModule),
         ("testExternalComplex", testExternalComplex),
         ("testIndirectTestsDontBuild", testIndirectTestsDontBuild),
     ]

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -78,8 +78,27 @@ class PackageGraphTests: XCTestCase {
         }
     }
 
+    func testDuplicateModules() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Foo/Sources/Bar/source.swift",
+            "/Bar/source.swift"
+        )
+
+        do {
+            let g = try loadMockPackageGraph([
+                "/Foo": Package(name: "Foo"),
+                "/Bar": Package(name: "Bar", dependencies: [.Package(url: "/Foo", majorVersion: 1)]),
+            ], root: "/Bar", in: fs)
+            XCTFail("Unexpected graph \(g)")
+        } catch PackageGraphError.duplicateModule(let module) {
+            XCTAssertEqual(module, "Bar")
+        }
+
+    }
+
     static var allTests = [
         ("testBasic", testBasic),
+        ("testDuplicateModules", testDuplicateModules),
         ("testCycle", testCycle),
         ("testTestTargetDeclInExternalPackage", testTestTargetDeclInExternalPackage),
     ]


### PR DESCRIPTION
And add unit test instead. This test doesn't need to be functional as we
now have infrastructure to test unit test it.
PS: This test was broken anyway as the Package.swift was empty :(