### PR TITLE
[PackageGraphLoader] Remove stray exit()

### DIFF
--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -39,6 +39,8 @@ public class SwiftBuildTool: SwiftTool<BuildToolOptions> {
             checkClangVersion()
             #endif
             let graph = try loadPackage()
+            // If we don't have any modules in root package, we're done.
+            guard !graph.rootPackages[0].modules.isEmpty else { break }
             let yaml = try describe(buildPath, conf, graph, flags: options.buildFlags, toolchain: toolchain)
             try build(yamlPath: yaml, target: options.buildTests ? "test" : nil)
 

--- a/Sources/PackageGraph/PackageGraphLoader.swift
+++ b/Sources/PackageGraph/PackageGraphLoader.swift
@@ -94,19 +94,9 @@ public struct PackageGraphLoader {
             map[package] = package.modules + package.testModules
             packageURLMap[package.manifest.url] = package
 
-            // Diagnose empty non-root packages, which are something we allow as a special case.
-            if package.modules.isEmpty {
-                if isRootPackage {
-                    // Ignore and print warning if root package doesn't contain any sources.
-                    print("warning: root package '\(package)' does not contain any sources")
-                    
-                    // Exit now if there are no more packages.
-                    //
-                    // FIXME: This does not belong here.
-                    if allManifests.count == 1 { exit(0) }
-                } else {
-                    throw PackageGraphError.noModules(package)
-                }
+            // Throw if any of the non-root package is empty.
+            if package.modules.isEmpty && !isRootPackage {
+                throw PackageGraphError.noModules(package)
             }
         }
 

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -40,16 +40,18 @@ class MiscellaneousTestCase: XCTestCase {
         // Tests that a package with no source files doesn't error.
         fixture(name: "Miscellaneous/Empty") { prefix in
             let output = try executeSwiftBuild(prefix, configuration: .Debug)
-            XCTAssert(output.contains("warning: root package 'Empty' does not contain any sources"), "unexpected output: \(output)")
+            XCTAssert(output.contains("warning: module 'Empty' does not contain any sources"), "unexpected output: \(output)")
         }
     }
 
     func testPackageWithNoSourcesButDependency() throws {
-        // Tests a package with no source files but a dependency builds.
+        // Tests a package with no source files but a dependency.
         fixture(name: "Miscellaneous/ExactDependencies") { prefix in
             let output = try executeSwiftBuild(prefix.appending(component: "EmptyWithDependency"))
-            XCTAssert(output.contains("warning: root package 'EmptyWithDependency' does not contain any sources"), "unexpected output: \(output)")
-            XCTAssertFileExists(prefix.appending(components: "EmptyWithDependency", ".build", "debug", "FooLib2.swiftmodule"))
+            XCTAssert(output.contains("warning: module 'EmptyWithDependency' does not contain any sources"), "unexpected output: \(output)")
+            // We should only build the modules that are needed to be built. If we have a dependency package but no way to reach
+            // some module in that package, we shouldn't waste time building that.
+            XCTAssertFalse(isFile(prefix.appending(components: "EmptyWithDependency", ".build", "debug", "FooLib2.swiftmodule")))
         }
     }
 


### PR DESCRIPTION
We're already printing empty sources warning from package builder so
this warning isn't needed in package graph loader. The exit() is removed
and we check at tool level if there are no root modules which can be
built.