### PR TITLE
[Workspace] update() should error out in edit mode

### DIFF
--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -79,6 +79,9 @@ public func handle(error: Any) -> Never {
     case PackageToolOperationError.packageNotFound:
         print(error: "The provided package was not found")
 
+    case WorkspaceOperationError.dependenciesInEditMode(let packages):
+        print(error: "Can't update because these dependencies are in edit mode: " + packages.joined(separator: ", "))
+
     case let error as FixableError:
         print(error: error.error)
         if let fix = error.fix {

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -460,6 +460,14 @@ final class WorkspaceTests: XCTestCase {
             // Put the dependency in edit mode at its current revision.
             try workspace.edit(dependency: dependency, at: dependency.currentRevision!, packageName: aManifest.name)
 
+            // We should fail to update dependencies.
+            do {
+                try workspace.updateDependencies()
+                XCTFail("Unexpected success")
+            } catch WorkspaceOperationError.dependenciesInEditMode(let packages) {
+                XCTAssertEqual(packages, ["A"])
+            }
+
             let editedDependency = getDependency(aManifest)
             // It should be in edit mode.
             XCTAssert(editedDependency.isInEditableState)


### PR DESCRIPTION
Do this because there are number of gotchas if we try to update when something is in edit mode, error out for now.