### PR TITLE
[ManifestLoader] Throw any manifest loading errors

### DIFF
--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -84,12 +84,14 @@ public func handle(error: Any) -> Never {
         if let fix = error.fix {
             print(fix: fix)
         }
+
     case ManifestParseError.invalidManifestFormat(let errors):
-        var errorString = "invalid manifest format"
-        if let errors = errors {
-            errorString += "; " + errors.joined(separator: ", ")
-        }
+        print(error: errors)
+
+    case ManifestParseError.runtimeManifestErrors(let errors):
+        let errorString = "invalid manifest format; " + errors.joined(separator: ", ")
         print(error: errorString)
+
     case PackageToolOperationError.insufficientOptions(let usage):
         print(usage, to: &stderr)
     default:

--- a/Tests/PackageLoadingTests/ManifestTests.swift
+++ b/Tests/PackageLoadingTests/ManifestTests.swift
@@ -34,12 +34,16 @@ class ManifestTests: XCTestCase {
         }
     }
 
+    private func loadManifest(_ contents: ByteString, baseURL: String? = nil) throws -> Manifest {
+        let fs = InMemoryFileSystem()
+        let manifestPath = AbsolutePath.root.appending(component: Manifest.filename)
+        try fs.writeFileContents(manifestPath, bytes: contents)
+        return try manifestLoader.loadFile(path: manifestPath, baseURL: baseURL ?? AbsolutePath.root.asString, version: nil, fileSystem: fs)
+    }
+
     private func loadManifest(_ contents: ByteString, baseURL: String? = nil, line: UInt = #line, body: (Manifest) -> Void) {
         do {
-            let fs = InMemoryFileSystem()
-            let manifestPath = AbsolutePath.root.appending(component: Manifest.filename)
-            try fs.writeFileContents(manifestPath, bytes: contents)
-            body(try manifestLoader.loadFile(path: manifestPath, baseURL: baseURL ?? AbsolutePath.root.asString, version: nil, fileSystem: fs))
+            body(try loadManifest(contents, baseURL: baseURL))
         } catch {
             XCTFail("Unexpected error: \(error)", file: #file, line: line)
         }
@@ -154,6 +158,58 @@ class ManifestTests: XCTestCase {
             XCTAssertEqual(manifest.name, "Trivial")
         }
     }
+
+    func testRuntimeManifestErrors() throws {
+        let stream = BufferedOutputByteStream()
+        stream <<< "import PackageDescription" <<< "\n"
+        stream <<< "let package = Package(" <<< "\n"
+        stream <<< "   name: \"Foo\"," <<< "\n"
+        stream <<< "           dependencies: [" <<< "\n"
+        stream <<< "              .Package(url: \"/url\", \"1.0,0\")" <<< "\n"
+        stream <<< "           ])" <<< "\n" <<< "\n"
+
+        do {
+            let manifest = try loadManifest(stream.bytes)
+            XCTFail("Unexpected success \(manifest)")
+        } catch ManifestParseError.runtimeManifestErrors(let errors) {
+            XCTAssertEqual(errors, ["Invalid version string: 1.0,0"])
+        }
+    }
+
+    func testSwiftInterpreterErrors() throws {
+        // Forgot importing package description.
+        var stream = BufferedOutputByteStream()
+        stream <<< "let package = Package(" <<< "\n"
+        stream <<< "   name: \"Foo\")"
+
+        assertManifestContainsError(error: "use of unresolved identifier 'Package'", stream: stream)
+
+        // Missing name in package object.
+        stream = BufferedOutputByteStream()
+        stream <<< "import PackageDescription" <<< "\n"
+        stream <<< "let package = Package()" <<< "\n"
+
+        assertManifestContainsError(error: "missing argument for parameter 'name' in call", stream: stream)
+
+        // Random syntax error.
+        stream = BufferedOutputByteStream()
+        stream <<< "import PackageDescription" <<< "\n"
+        stream <<< "let package = Package(name: \"foo\")'" <<< "\n"
+
+        assertManifestContainsError(error: "error: unterminated string literal", stream: stream)
+    }
+
+    /// Helper to check for swift interpreter errors while loading manifest.
+    private func assertManifestContainsError(error: String, stream: BufferedOutputByteStream, file: StaticString = #file, line: UInt = #line) {
+        do {
+            let manifest = try loadManifest(stream.bytes)
+            XCTFail("Unexpected success \(manifest)", file: file, line: line)
+        } catch ManifestParseError.invalidManifestFormat(let errors) {
+            XCTAssertTrue(errors.contains(error), "\nActual:\n\(errors) \n\nExpected: \(error)", file: file, line: line)
+        } catch {
+            XCTFail("Unexpected error \(error)", file: file, line: line)
+        }
+    }
     
     static var allTests = [
         ("testManifestLoading", testManifestLoading),
@@ -161,5 +217,7 @@ class ManifestTests: XCTestCase {
         ("testNonexistentBaseURL", testNonexistentBaseURL),
         ("testInvalidTargetName", testInvalidTargetName),
         ("testVersionSpecificLoading", testVersionSpecificLoading),
+        ("testRuntimeManifestErrors", testRuntimeManifestErrors),
+        ("testSwiftInterpreterErrors", testSwiftInterpreterErrors),
     ]
 }


### PR DESCRIPTION
Instead of directly printing on stdout/stderr throw any errors
from swift interpreter