### PR TITLE
[PackageModel] Remove throws from Module init

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -373,7 +373,7 @@ public struct PackageBuilder {
         if fileSystem.isFile(moduleMapPath) {
             // Package contains a modulemap at the top level, so we assuming it's a system module.
             let sources = Sources(paths: [moduleMapPath], root: packagePath)
-            return [try CModule(name: manifest.name, sources: sources, path: packagePath, pkgConfig: pkgConfigPath, providers: manifest.package.providers, dependencies: moduleDependencies())]
+            return [CModule(name: manifest.name, sources: sources, path: packagePath, pkgConfig: pkgConfigPath, providers: manifest.package.providers, dependencies: moduleDependencies())]
         }
 
         // At this point the module can't be a system module, make sure manifest doesn't contain
@@ -537,7 +537,7 @@ public struct PackageBuilder {
         if cSources.isEmpty {
             guard !swiftSources.isEmpty else { return nil }
             // No C sources, so we expect to have Swift sources, and we create a Swift module.
-            return try SwiftModule(
+            return SwiftModule(
                 name: potentialModule.name,
                 isTest: potentialModule.isTest,
                 sources: Sources(paths: swiftSources, root: potentialModule.path),
@@ -545,7 +545,7 @@ public struct PackageBuilder {
         } else {
             // No Swift sources, so we expect to have C sources, and we create a C module.
             guard swiftSources.isEmpty else { throw Module.Error.mixedSources(potentialModule.path.asString) }
-            return try ClangModule(
+            return ClangModule(
                 name: potentialModule.name,
                 isTest: potentialModule.isTest,
                 sources: Sources(paths: cSources, root: potentialModule.path),

--- a/Sources/PackageModel/Module.swift
+++ b/Sources/PackageModel/Module.swift
@@ -52,7 +52,7 @@ public class Module {
     /// The sources for the module.
     public let sources: Sources
 
-    public init(name: String, type: ModuleType, sources: Sources, isTest: Bool = false, dependencies: [Module]) throws {
+    public init(name: String, type: ModuleType, sources: Sources, isTest: Bool = false, dependencies: [Module]) {
         self.name = name
         self.type = type
         self.sources = sources
@@ -79,7 +79,7 @@ public func ==(lhs: Module, rhs: Module) -> Bool {
 }
 
 public class SwiftModule: Module {
-    public init(name: String, isTest: Bool = false, sources: Sources, dependencies: [Module] = []) throws {
+    public init(name: String, isTest: Bool = false, sources: Sources, dependencies: [Module] = []) {
         // Compute the module type.
         let isLibrary = !sources.relativePaths.contains { path in
             let file = path.basename.lowercased()
@@ -88,7 +88,7 @@ public class SwiftModule: Module {
         }
         let type: ModuleType = isLibrary ? .library : .executable
         
-        try super.init(name: name, type: type, sources: sources, isTest: isTest, dependencies: dependencies)
+        super.init(name: name, type: type, sources: sources, isTest: isTest, dependencies: dependencies)
     }
 }
 
@@ -96,11 +96,11 @@ public class CModule: Module {
     public let path: AbsolutePath
     public let pkgConfig: RelativePath?
     public let providers: [SystemPackageProvider]?
-    public init(name: String, type: ModuleType = .systemModule, sources: Sources, path: AbsolutePath, isTest: Bool = false, pkgConfig: RelativePath? = nil, providers: [SystemPackageProvider]? = nil, dependencies: [Module] = []) throws {
+    public init(name: String, type: ModuleType = .systemModule, sources: Sources, path: AbsolutePath, isTest: Bool = false, pkgConfig: RelativePath? = nil, providers: [SystemPackageProvider]? = nil, dependencies: [Module] = []) {
         self.path = path
         self.pkgConfig = pkgConfig
         self.providers = providers
-        try super.init(name: name, type: type, sources: sources, isTest: false, dependencies: dependencies)
+        super.init(name: name, type: type, sources: sources, isTest: false, dependencies: dependencies)
     }
 }
 
@@ -110,7 +110,7 @@ public class ClangModule: Module {
         return sources.root.appending(component: "include")
     }
 
-    public init(name: String, isTest: Bool = false, sources: Sources, dependencies: [Module] = []) throws {
+    public init(name: String, isTest: Bool = false, sources: Sources, dependencies: [Module] = []) {
         // Compute the module type.
         let isLibrary = !sources.relativePaths.contains { path in
             let file = path.basename.lowercased()
@@ -119,7 +119,7 @@ public class ClangModule: Module {
         }
         let type: ModuleType = isLibrary ? .library : .executable
         
-        try super.init(name: name, type: type, sources: sources, isTest: isTest, dependencies: dependencies)
+        super.init(name: name, type: type, sources: sources, isTest: isTest, dependencies: dependencies)
     }
 }
 

--- a/Tests/BuildTests/DescribeTests.swift
+++ b/Tests/BuildTests/DescribeTests.swift
@@ -53,7 +53,7 @@ final class DescribeTests: XCTestCase {
     func testDescribingCModuleThrows() {
         do {
             let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
-            let graph = PackageGraph(rootPackages: [dummyPackage], modules: [try CModule(name: "MyCModule", sources: Sources(paths: [], root: AbsolutePath("/")), path: AbsolutePath("/"))], externalModules: [])
+            let graph = PackageGraph(rootPackages: [dummyPackage], modules: [CModule(name: "MyCModule", sources: Sources(paths: [], root: AbsolutePath("/")), path: AbsolutePath("/"))], externalModules: [])
             _ = try describe(tempDir.path.appending(component: "foo"), .debug, graph, flags: BuildFlags(), toolchain: InvalidToolchain())
             XCTFail("This call should throw")
         } catch Build.Error.onlyCModule (let name) {
@@ -65,8 +65,8 @@ final class DescribeTests: XCTestCase {
     }
 
     func testClangModuleCanHaveSwiftDep() throws {
-        let swiftModule = try SwiftModule(name: "SwiftModule", sources: Sources(paths: [], root: .root))
-        let clangModule = try ClangModule(name: "ClangModule", sources: Sources(paths: [], root: .root), dependencies: [swiftModule])
+        let swiftModule = SwiftModule(name: "SwiftModule", sources: Sources(paths: [], root: .root))
+        let clangModule = ClangModule(name: "ClangModule", sources: Sources(paths: [], root: .root), dependencies: [swiftModule])
         let buildMeta = ClangModuleBuildMetadata(module: clangModule, prefix: .root, otherArgs: [])
         XCTAssertEqual(buildMeta.inputs, ["/SwiftModule.swiftmodule"])
     }

--- a/Tests/PackageLoadingTests/ModuleDependencyTests.swift
+++ b/Tests/PackageLoadingTests/ModuleDependencyTests.swift
@@ -15,8 +15,8 @@ import PackageModel
 import PackageLoading
 
 private extension Module {
-    convenience init(name: String, deps: Module...) throws {
-        try self.init(name: name, type: .library, sources: Sources(paths: [], root: AbsolutePath("/")), dependencies: deps)
+    convenience init(name: String, deps: Module...) {
+        self.init(name: name, type: .library, sources: Sources(paths: [], root: AbsolutePath("/")), dependencies: deps)
     }
 }
 
@@ -32,9 +32,9 @@ class ModuleDependencyTests: XCTestCase {
 
     func test1() {
         testModules {
-            let t1 = try Module(name: "t1")
-            let t2 = try Module(name: "t2", deps: t1)
-            let t3 = try Module(name: "t3", deps: t2)
+            let t1 = Module(name: "t1")
+            let t2 = Module(name: "t2", deps: t1)
+            let t3 = Module(name: "t3", deps: t2)
 
             XCTAssertEqual(t3.recursiveDeps, [t2, t1])
             XCTAssertEqual(t2.recursiveDeps, [t1])
@@ -43,10 +43,10 @@ class ModuleDependencyTests: XCTestCase {
 
     func test2() {
         testModules {
-            let t1 = try Module(name: "t1")
-            let t2 = try Module(name: "t2", deps: t1)
-            let t3 = try Module(name: "t3", deps: t2, t1)
-            let t4 = try Module(name: "t4", deps: t2, t3, t1)
+            let t1 = Module(name: "t1")
+            let t2 = Module(name: "t2", deps: t1)
+            let t3 = Module(name: "t3", deps: t2, t1)
+            let t4 = Module(name: "t4", deps: t2, t3, t1)
 
             XCTAssertEqual(t4.recursiveDeps, [t3, t2, t1])
             XCTAssertEqual(t3.recursiveDeps, [t2, t1])
@@ -56,10 +56,10 @@ class ModuleDependencyTests: XCTestCase {
 
     func test3() {
         testModules {
-            let t1 = try Module(name: "t1")
-            let t2 = try Module(name: "t2", deps: t1)
-            let t3 = try Module(name: "t3", deps: t2, t1)
-            let t4 = try Module(name: "t4", deps: t1, t2, t3)
+            let t1 = Module(name: "t1")
+            let t2 = Module(name: "t2", deps: t1)
+            let t3 = Module(name: "t3", deps: t2, t1)
+            let t4 = Module(name: "t4", deps: t1, t2, t3)
 
             XCTAssertEqual(t4.recursiveDeps, [t3, t2, t1])
             XCTAssertEqual(t3.recursiveDeps, [t2, t1])
@@ -69,10 +69,10 @@ class ModuleDependencyTests: XCTestCase {
 
     func test4() {
         testModules {
-            let t1 = try Module(name: "t1")
-            let t2 = try Module(name: "t2", deps: t1)
-            let t3 = try Module(name: "t3", deps: t2)
-            let t4 = try Module(name: "t4", deps: t3)
+            let t1 = Module(name: "t1")
+            let t2 = Module(name: "t2", deps: t1)
+            let t3 = Module(name: "t3", deps: t2)
+            let t4 = Module(name: "t4", deps: t3)
 
             XCTAssertEqual(t4.recursiveDeps, [t3, t2, t1])
             XCTAssertEqual(t3.recursiveDeps, [t2, t1])
@@ -82,12 +82,12 @@ class ModuleDependencyTests: XCTestCase {
 
     func test5() {
         testModules {
-            let t1 = try Module(name: "t1")
-            let t2 = try Module(name: "t2", deps: t1)
-            let t3 = try Module(name: "t3", deps: t2)
-            let t4 = try Module(name: "t4", deps: t3)
-            let t5 = try Module(name: "t5", deps: t2)
-            let t6 = try Module(name: "t6", deps: t5, t4)
+            let t1 = Module(name: "t1")
+            let t2 = Module(name: "t2", deps: t1)
+            let t3 = Module(name: "t3", deps: t2)
+            let t4 = Module(name: "t4", deps: t3)
+            let t5 = Module(name: "t5", deps: t2)
+            let t6 = Module(name: "t6", deps: t5, t4)
 
             // precise order is not important, but it is important that the following are true
             let t6rd = t6.recursiveDeps
@@ -106,12 +106,12 @@ class ModuleDependencyTests: XCTestCase {
 
     func test6() {
         testModules {
-            let t1 = try Module(name: "t1")
-            let t2 = try Module(name: "t2", deps: t1)
-            let t3 = try Module(name: "t3", deps: t2)
-            let t4 = try Module(name: "t4", deps: t3)
-            let t5 = try Module(name: "t5", deps: t2)
-            let t6 = try Module(name: "t6", deps: t4, t5) // same as above, but these two swapped
+            let t1 = Module(name: "t1")
+            let t2 = Module(name: "t2", deps: t1)
+            let t3 = Module(name: "t3", deps: t2)
+            let t4 = Module(name: "t4", deps: t3)
+            let t5 = Module(name: "t5", deps: t2)
+            let t6 = Module(name: "t6", deps: t4, t5) // same as above, but these two swapped
 
             // precise order is not important, but it is important that the following are true
             let t6rd = t6.recursiveDeps

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -138,7 +138,7 @@ class ModuleMapGeneration: XCTestCase {
 }
 
 func ModuleMapTester(_ name: String, in fileSystem: FileSystem, _ body: (ModuleMapResult) -> Void) {
-    let module = try! ClangModule(name: name, isTest: false, sources: Sources(paths: [], root: .root))
+    let module = ClangModule(name: name, isTest: false, sources: Sources(paths: [], root: .root))
     let warningStream = BufferedOutputByteStream()
     var generator = ModuleMapGenerator(for: module, fileSystem: fileSystem, warningStream: warningStream)
     var diagnostics = Set<String>()

--- a/Tests/PackageModelTests/ModuleTests.swift
+++ b/Tests/PackageModelTests/ModuleTests.swift
@@ -14,17 +14,17 @@ import Basic
 @testable import PackageModel
 
 private extension Module {
-    convenience init(name: String, dependencies: [Module] = []) throws {
-        try self.init(name: name, type: .library, sources: Sources(paths: [], root: AbsolutePath("/")), dependencies: dependencies)
+    convenience init(name: String, dependencies: [Module] = []) {
+        self.init(name: name, type: .library, sources: Sources(paths: [], root: AbsolutePath("/")), dependencies: dependencies)
     }
 }
 
 class ModuleTests: XCTestCase {
     /// Check that module dependencies appear in build order.
     func testDependencyOrder() throws {
-        let c = try Module(name: "c")
-        let b = try Module(name: "b", dependencies: [c])
-        let a = try Module(name: "a", dependencies: [b])
+        let c = Module(name: "c")
+        let b = Module(name: "b", dependencies: [c])
+        let a = Module(name: "a", dependencies: [b])
         XCTAssertEqual(a.recursiveDependencies, [c, b])
     }
 


### PR DESCRIPTION
initializer isn't needed to be throwable anymore.