### PR TITLE
[PkgConfig] Add simplified pkgConfig support

### DIFF
--- a/Sources/PackageLoading/Module+PkgConfig.swift
+++ b/Sources/PackageLoading/Module+PkgConfig.swift
@@ -13,6 +13,72 @@ import POSIX
 import PackageModel
 import Utility
 
+/// Wrapper struct containing result of a pkgConfig query.
+public struct PkgConfigResult {
+
+    /// The name of the pkgConfig file.
+    public let pkgConfigName: String
+
+    /// The cFlags from pkgConfig.
+    public let cFlags: [String]
+
+    /// The library flags from pkgConfig.
+    public let libs: [String]
+
+    /// Available provider, if any.
+    public let provider: SystemPackageProvider?
+
+    /// Any error encountered during operation.
+    public let error: Swift.Error?
+
+    /// If the pc file was not found.
+    public var noPcFile: Bool {
+        switch error {
+            case PkgConfigError.couldNotFindConfigFile?: return true
+            default: return false
+        }
+    }
+
+    /// Create a successful result with given cflags and libs.
+    fileprivate init(pkgConfigName: String, cFlags: [String], libs: [String]) {
+        self.pkgConfigName = pkgConfigName
+        self.cFlags = cFlags
+        self.libs = libs
+        self.error = nil
+        self.provider = nil
+    }
+
+    /// Create an error result.
+    fileprivate init(pkgConfigName: String, error: Swift.Error, provider: SystemPackageProvider?) {
+        self.cFlags = []
+        self.libs = []
+        self.error = error
+        self.provider = provider
+        self.pkgConfigName = pkgConfigName
+    }
+}
+
+/// Get pkgConfig result for a CModule.
+public func pkgConfigArgs(for module: CModule) -> PkgConfigResult? {
+    // If there is no pkg config name defined, we're done.
+    guard let pkgConfigName = module.pkgConfig?.asString else { return nil }
+    // Compute additional search paths for the provider, if any.
+    let provider = module.providers?.first{ $0.isAvailable }
+    let additionalSearchPaths = provider?.pkgConfigSearchPath().map{[$0]} ?? []
+    // Get the pkg config flags.
+    do {
+        let pkgConfig = try PkgConfig(name: pkgConfigName, additionalSearchPaths: additionalSearchPaths)
+        // Run the whitelist checker.
+        try whitelist(pcFile: pkgConfigName, flags: (pkgConfig.cFlags, pkgConfig.libs))
+        // Remove any default flags which compiler adds automatically.
+        let (cFlags, libs) = removeDefaultFlags(cFlags: pkgConfig.cFlags, libs: pkgConfig.libs)
+        return PkgConfigResult(pkgConfigName: pkgConfigName, cFlags: cFlags, libs: libs)
+    } catch {
+        return PkgConfigResult(pkgConfigName: pkgConfigName, error: error, provider: provider)
+    }
+}
+
+// FIXME: Get rid of this extension once we move on to new Build code.
 extension Module {
     /// Returns the pkgConfig flags (cFlags + libs) escaping the cflags with -Xcc.
     //
@@ -61,8 +127,8 @@ extension Module {
     }
 }
 
-private extension SystemPackageProvider {
-    var installText: String {
+extension SystemPackageProvider {
+    public var installText: String {
         switch self {
         case .Brew(let name):
             return "    brew install \(name)\n"
@@ -107,6 +173,7 @@ private extension SystemPackageProvider {
         }
     }
 
+    // FIXME: Get rid of this method once we move on to new Build code.
     static func providerForCurrentPlatform(providers: [SystemPackageProvider]) -> SystemPackageProvider? {
         return providers.filter{ $0.isAvailable }.first
     }

--- a/Sources/PackageLoading/Module+PkgConfig.swift
+++ b/Sources/PackageLoading/Module+PkgConfig.swift
@@ -95,7 +95,10 @@ private extension SystemPackageProvider {
             // ``brew switch NAME VERSION``, so we shouldn't assume to link
             // to the latest version. Instead use the version as symlinked
             // in /usr/local/opt/(NAME)/lib/pkgconfig.
-            guard let brewPrefix = try? Utility.popen(["brew", "--prefix"]).chomp() else {
+            struct Static {
+                static let value = { try? Utility.popen(["brew", "--prefix"]).chomp() }()
+            }
+            guard let brewPrefix = Static.value else {
                 return nil
             }
             return AbsolutePath(brewPrefix).appending(components: "opt", name, "lib", "pkgconfig")

--- a/Tests/PackageLoadingTests/Inputs/Bar.pc
+++ b/Tests/PackageLoadingTests/Inputs/Bar.pc
@@ -1,0 +1,11 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: Foo
+URL: http://127.0.0.1/
+Description: The one and only SystemModule
+Version: 1.10.0
+Cflags: -I${includedir} -I/path/to/inc -DBlackListed
+Libs: -L${libdir} -L/usr/da/lib -lSystemModule -lok

--- a/Tests/PackageLoadingTests/Inputs/Foo.pc
+++ b/Tests/PackageLoadingTests/Inputs/Foo.pc
@@ -1,0 +1,11 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: Foo
+URL: http://127.0.0.1/
+Description: The one and only SystemModule
+Version: 1.10.0
+Cflags: -I${includedir} -I/path/to/inc
+Libs: -L${libdir} -L/usr/da/lib -lSystemModule -lok

--- a/Tests/PackageLoadingTests/PkgConfigTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigTests.swift
@@ -1,0 +1,103 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2014 - 2017 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+import Basic
+import PackageModel
+import PackageLoading
+import Utility
+import TestSupport
+
+extension CModule {
+    convenience init(pkgConfig: String, providers: [SystemPackageProvider] = []) {
+        let root = AbsolutePath("/fake")
+        let sources = Sources(paths: [root.appending(component: "module.modulemap")], root: root)
+        try! self.init(
+            name: "Foo",
+            sources: sources,
+            path: root,
+            pkgConfig: pkgConfig.isEmpty ? nil : RelativePath(pkgConfig),
+            providers: providers.isEmpty ? nil : providers,
+            dependencies: [])
+    }
+}
+
+class PkgConfigTests: XCTestCase {
+
+    func testBasics() throws {
+        // No pkgConfig name.
+        do {
+            let result = pkgConfigArgs(for: CModule(pkgConfig: ""))
+            XCTAssertNil(result)
+        }
+
+        // No pc file.
+        do {
+            let module = CModule(
+                pkgConfig: "Foo",
+                providers: [
+                    .Brew("libFoo"),
+                    .Apt("libFoo-dev"),
+                ]
+            )
+            let result = pkgConfigArgs(for: module)!
+            XCTAssertEqual(result.pkgConfigName, "Foo")
+            XCTAssertEqual(result.cFlags, [])
+            XCTAssertEqual(result.libs, [])
+            switch result.provider {
+            case .Brew(let name)?:
+                XCTAssertEqual(name, "libFoo")
+            case .Apt(let name)?:
+                XCTAssertEqual(name, "libFoo-dev")
+            case nil:
+                XCTFail("Expected a provider here")
+            }
+            XCTAssertTrue(result.noPcFile)
+            switch result.error {
+                case PkgConfigError.couldNotFindConfigFile?: break
+                default: 
+                XCTFail("Unexpected error \(String(describing: result.error))")
+            }
+        }
+
+    let inputsDir = AbsolutePath(#file).parentDirectory.appending(components: "Inputs")
+        // Pc file.
+        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.asString]) {
+            let result = pkgConfigArgs(for: CModule(pkgConfig: "Foo"))!
+            XCTAssertEqual(result.pkgConfigName, "Foo")
+            XCTAssertEqual(result.cFlags, ["-I/path/to/inc"])
+            XCTAssertEqual(result.libs, ["-L/usr/da/lib", "-lSystemModule", "-lok"])
+            XCTAssertNil(result.provider)
+            XCTAssertNil(result.error)
+            XCTAssertFalse(result.noPcFile)
+        }
+
+        // Pc file with non whitelisted flags.
+        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.asString]) {
+            let result = pkgConfigArgs(for: CModule(pkgConfig: "Bar"))!
+            XCTAssertEqual(result.pkgConfigName, "Bar")
+            XCTAssertEqual(result.cFlags, [])
+            XCTAssertEqual(result.libs, [])
+            XCTAssertNil(result.provider)
+            XCTAssertFalse(result.noPcFile)
+            switch result.error {
+            case PkgConfigError.nonWhitelistedFlags(let desc)?:
+                XCTAssertEqual(desc, "Non whitelisted flags found: [\"-DBlackListed\"] in pc file Bar")
+            default:
+                XCTFail("unexpected error \(result.error.debugDescription)")
+            }
+        }
+    }
+
+    static var allTests = [
+        ("testBasics", testBasics),
+    ]
+}

--- a/Tests/PackageLoadingTests/XCTestManifests.swift
+++ b/Tests/PackageLoadingTests/XCTestManifests.swift
@@ -18,6 +18,7 @@ public func allTests() -> [XCTestCaseEntry] {
         testCase(ManifestTests.allTests),
         testCase(ModuleDependencyTests.allTests),
         testCase(ModuleMapGeneration.allTests),
+        testCase(PkgConfigTests.allTests),
         testCase(SerializationTests.allTests),
         testCase(PkgConfigWhitelistTests.allTests),
     ]


### PR DESCRIPTION
The current helper always iterates over the recursive dependencies, this
introduces a method to get pkgconfig flags for one module at a time.

tests coming soon