### PR TITLE
[Build] Use -lstdc++ instead of -lc++

### DIFF
--- a/Sources/Build/misc.swift
+++ b/Sources/Build/misc.swift
@@ -61,7 +61,7 @@ extension ClangModule {
         }
         // Link C++ if found any cpp source. 
         if linkCpp {
-            args += ["-lc++"]
+            args += ["-lstdc++"]
         }
         return args
     }

--- a/Tests/BuildTests/DescribeTests.swift
+++ b/Tests/BuildTests/DescribeTests.swift
@@ -81,7 +81,7 @@ final class DescribeTests: XCTestCase {
             let graph = try loadMockPackageGraph(["/Pkg": Package(name: "Pkg")], root: "/Pkg", in: fs)
             let yaml = try describe(path.appending(component: "foo"), .debug, graph, flags: BuildFlags(), toolchain: DummyToolchain())
             // FIXME: This is not a good test but should be good enough until we have the Buld re-write.
-            XCTAssertTrue(try localFileSystem.readFileContents(yaml).asString!.contains("-lc++"))
+            XCTAssertTrue(try localFileSystem.readFileContents(yaml).asString!.contains("-lstdc++"))
         }
     }
 


### PR DESCRIPTION
-lc++ doesn't work on linux where as -lstdc++ works on both platforms.