### PR TITLE
Fix build if TIOCGWINSZ is missing

### DIFF
--- a/Sources/Basic/TerminalController.swift
+++ b/Sources/Basic/TerminalController.swift
@@ -78,11 +78,13 @@ public final class TerminalController {
             return width
         }
 
+#if TIOCGWINSZ
         // Try determining using ioctl.
         var ws = winsize()
         if ioctl(1, UInt(TIOCGWINSZ), &ws) == 0 {
             return Int(ws.ws_col)
         }
+#endif
         return nil
     }
 


### PR DESCRIPTION
swiftpm fails to build if the TIOCGWINSZ ioctl isn't defined.  Fix that.