### PR TITLE
[Resolver] Return return as container and binding

### DIFF
--- a/Sources/Commands/SwiftPackageResolveTool.swift
+++ b/Sources/Commands/SwiftPackageResolveTool.swift
@@ -50,14 +50,14 @@ extension SwiftPackageTool {
         switch opts.resolveToolMode {
         case .text:
             print("Resolved dependencies for: \(manifest.name)")
-            for (container, version) in result {
+            for (container, binding) in result {
                 // FIXME: It would be nice to show the reference path, should we get
                 // that back or do we need to re-derive it?
 
                 // FIXME: It would be nice to show information on the resulting
                 // constraints, e.g., how much latitude do we have on particular
                 // dependencies.
-                print("  \(container.url): \(version)")
+                print("  \(container.url): \(binding.description)")
             }
         case .json:
             let json = JSON.dictionary([

--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -196,7 +196,7 @@ public protocol DependencyResolverDelegate {
 /// A bound version for a package within an assignment.
 //
 // FIXME: This should be nested, but cannot be currently.
-enum BoundVersion: Equatable {
+public enum BoundVersion: Equatable, CustomStringConvertible {
     /// The assignment should not include the package.
     ///
     /// This is different from the absence of an assignment for a particular
@@ -206,8 +206,17 @@ enum BoundVersion: Equatable {
 
     /// The version of the package to include.
     case version(Version)
+
+    public var description: String {
+        switch self {
+        case .excluded:
+            return "excluded"
+        case .version(let version):
+            return version.description
+        }
+    }
 }
-func ==(_ lhs: BoundVersion, _ rhs: BoundVersion) -> Bool {
+public func ==(_ lhs: BoundVersion, _ rhs: BoundVersion) -> Bool {
     switch (lhs, rhs) {
     case (.excluded, .excluded):
         return true
@@ -613,15 +622,10 @@ public class DependencyResolver<
     /// - Parameters:
     ///   - constraints: The contraints to solve. It is legal to supply multiple
     ///                  constraints for the same container identifier.
-    /// - Returns: A satisfying assignment of containers and versions.
+    /// - Returns: A satisfying assignment of containers and their version binding.
     /// - Throws: DependencyResolverError, or errors from the underlying package provider.
-    public func resolve(constraints: [Constraint]) throws -> [(container: Identifier, version: Version)] {
-        return try resolveAssignment(constraints: constraints).map { (container, binding) in
-            guard case .version(let version) = binding else {
-                fatalError("unexpected exclude binding")
-            }
-            return (container: container.identifier, version: version)
-        }
+    public func resolve(constraints: [Constraint]) throws -> [(container: Identifier, binding: BoundVersion)] {
+        return try resolveAssignment(constraints: constraints).map{ ($0.identifier, $1) }
     }
 
     /// Execute the resolution algorithm to find a valid assignment of versions.

--- a/Sources/TestSupport/MockDependencyResolver.swift
+++ b/Sources/TestSupport/MockDependencyResolver.swift
@@ -138,6 +138,19 @@ public class MockResolverDelegate: DependencyResolverDelegate {
     public init(){}
 }
 
+extension DependencyResolver where P == MockPackagesProvider, D == MockResolverDelegate {
+    /// Helper method which returns all the version binding out of resolver and assert failure for non version bindings.
+    public func resolveToVersion(constraints: [MockPackageConstraint], file: StaticString = #file, line: UInt = #line) throws -> [(container: String, version: Version)] {
+        return try resolve(constraints: constraints).flatMap {
+            guard case .version(let version) = $0.binding else {
+                XCTFail("Unexpected non version binding \($0.binding)", file: file, line: line)
+                return nil
+            }
+            return ($0.container, version)
+        }
+    }
+}
+
 public struct MockGraph {
 
     public let name: String

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -48,7 +48,7 @@ class DependencyResolverPerfTests: XCTestCase {
         let resolver = MockDependencyResolver(provider, MockResolverDelegate())
         measure {
             for _ in 0..<N {
-                let result = try! resolver.resolve(constraints: [MockPackageConstraint(container: "A", versionRequirement: v1Range)])
+                let result = try! resolver.resolveToVersion(constraints: [MockPackageConstraint(container: "A", versionRequirement: v1Range)])
                 XCTAssertEqual(result, ["A": v1, "B": v1, "C": v1, "D": v1])
             }
         }
@@ -168,7 +168,7 @@ class DependencyResolverRealWorldPerfTests: XCTestCase {
         measure {
             for _ in 0 ..< N {
                 let resolver = MockDependencyResolver(provider, MockResolverDelegate())
-                let result = try! resolver.resolve(constraints: graph.constraints)
+                let result = try! resolver.resolveToVersion(constraints: graph.constraints)
                 graph.checkResult(result)
             }
         }
@@ -261,7 +261,7 @@ struct GitRepositoryResolutionHelper {
         }
     }
 
-    func resolve(enablePrefetching: Bool = false) -> [(container: RepositorySpecifier, version: Version)] {
+    func resolve(enablePrefetching: Bool = false) -> [(container: RepositorySpecifier, binding: BoundVersion)] {
         let repositoriesPath = path.appending(component: "repositories")
         _ = try? systemQuietly(["rm", "-r", repositoriesPath.asString])
         let repositoryManager = RepositoryManager(path: repositoriesPath, provider: GitRepositoryProvider(), delegate: DummyRepositoryManagerDelegate())

--- a/Tests/PackageGraphTests/DependencyResolverTests.swift
+++ b/Tests/PackageGraphTests/DependencyResolverTests.swift
@@ -313,14 +313,14 @@ class DependencyResolverTests: XCTestCase {
 
             // Check the constraints are respected.
             XCTAssertEqual(
-                try resolver.resolve(constraints: [
+                try resolver.resolveToVersion(constraints: [
                         MockPackageConstraint(container: "A", versionRequirement: v1to3Range),
                         MockPackageConstraint(container: "A", versionRequirement: v1Range)]),
                 ["A": v1])
 
             // Check the constraints are respected if unsatisfiable.
             XCTAssertThrows(DependencyResolverError.unsatisfiable) {
-                _ = try resolver.resolve(constraints: [
+                _ = try resolver.resolveToVersion(constraints: [
                         MockPackageConstraint(container: "A", versionRequirement: v1Range),
                         MockPackageConstraint(container: "A", versionRequirement: v2Range)])
             }
@@ -355,7 +355,7 @@ class DependencyResolverTests: XCTestCase {
         let a = MockPackageContainer(name: "A", dependenciesByVersion: [v1: [], v1_1: []])
         let provider = MockPackagesProvider(containers: [a])
         let resolver = MockDependencyResolver(provider, MockResolverDelegate())
-        let result = try resolver.resolve(constraints: [
+        let result = try resolver.resolveToVersion(constraints: [
             MockPackageConstraint(container: "A", versionRequirement: v1Range),
         ])
         XCTAssertEqual(result[0].version, v1_1)
@@ -368,14 +368,14 @@ class DependencyResolverTests: XCTestCase {
         ])
         let resolver = MockDependencyResolver(provider, MockResolverDelegate())
 
-        let result = try resolver.resolve(constraints: [
+        let result = try resolver.resolveToVersion(constraints: [
             MockPackageConstraint(container: "A", versionRequirement: .exact(v1)),
             MockPackageConstraint(container: "A", versionRequirement: v1Range)
         ])
         XCTAssertEqual(result[0].version, v1)
 
         XCTAssertThrows(DependencyResolverError.unsatisfiable) {
-            _ = try resolver.resolve(constraints: [
+            _ = try resolver.resolveToVersion(constraints: [
                 MockPackageConstraint(container: "A", versionRequirement: .exact(v1)),
                 MockPackageConstraint(container: "A", versionRequirement: v1_1Range)
             ])

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -134,7 +134,7 @@ private struct MockDependencyResolver {
         self.resolver = DependencyResolver(provider, delegate)
     }
 
-    func resolve(constraints: [RepositoryPackageConstraint]) throws -> [(container: RepositorySpecifier, version: Version)] {
+    func resolve(constraints: [RepositoryPackageConstraint]) throws -> [(container: RepositorySpecifier, binding: BoundVersion)] {
         return try resolver.resolve(constraints: constraints)
     }
 }
@@ -184,7 +184,13 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
                     container: repoA.specifier,
                     versionRequirement: v1Range)
             ]
-            let result = try resolver.resolve(constraints: constraints)
+            let result: [(RepositorySpecifier, Version)] = try resolver.resolve(constraints: constraints).flatMap {
+                guard case .version(let version) = $0.binding else {
+                    XCTFail("Unexpecting non version binding \($0.binding)")
+                    return nil
+                }
+                return ($0.container, version)
+            }
             XCTAssertEqual(result, [
                     repoA.specifier: v1,
                     repoB.specifier: v2,


### PR DESCRIPTION
Since we need resolver to give us more information about the binding,
make BoundVersion enum public and return that in resolver result instead
of just version.

- [x] Cleanup a bit

- [x] Check if Perf tests compile