### PR TITLE
[Xcodeproj] Add "CLANG_ENABLE_OBJC_ARC = YES" as default

### DIFF
--- a/Sources/Xcodeproj/XcodeProjectModel.swift
+++ b/Sources/Xcodeproj/XcodeProjectModel.swift
@@ -321,6 +321,7 @@ public struct Xcode {
             // Note: although some of these build settings sound like booleans,
             // they are all either strings or arrays of strings, because even
             // a boolean may be a macro reference expression.
+            var CLANG_ENABLE_OBJC_ARC: String?
             var COMBINE_HIDPI_IMAGES: String?
             var COPY_PHASE_STRIP: String?
             var DEBUG_INFORMATION_FORMAT: String?

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -127,6 +127,9 @@ func xcodeProject(
     // magic behavior that isn't present in `swift build`.
     projectSettings.common.USE_HEADERMAP = "NO"
     
+    // Enable `Automatic Reference Counting` for Objective-C sources
+    projectSettings.common.CLANG_ENABLE_OBJC_ARC = "YES"
+    
     // Add some debug-specific settings.
     projectSettings.debug.COPY_PHASE_STRIP = "NO"
     projectSettings.debug.DEBUG_INFORMATION_FORMAT = "dwarf"

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -66,6 +66,7 @@ class PackageGraphTests: XCTestCase {
 
             XCTAssertEqual(project.buildSettings.common.SDKROOT, "macosx")
             XCTAssertEqual(project.buildSettings.common.SUPPORTED_PLATFORMS!, ["macosx", "iphoneos", "iphonesimulator", "appletvos", "appletvsimulator", "watchos", "watchsimulator"])
+            XCTAssertEqual(project.buildSettings.common.CLANG_ENABLE_OBJC_ARC, "YES")
             XCTAssertEqual(project.buildSettings.release.SWIFT_OPTIMIZATION_LEVEL, "-Owholemodule")
             XCTAssertEqual(project.buildSettings.debug.SWIFT_OPTIMIZATION_LEVEL, "-Onone")
 


### PR DESCRIPTION
Some frameworks are contains ObjC target. And these are almost requires ARC.