### PR TITLE
[Build] Manually link ClangModules in Swift products

### DIFF
--- a/Sources/Build/Command.link(SwiftModule).swift
+++ b/Sources/Build/Command.link(SwiftModule).swift
@@ -15,6 +15,21 @@ import Utility
 
 //FIXME messy :/
 
+extension Product {
+
+    /// Returns link arguments for the clang module dependencies of a product.
+    func clangModuleLinkArguments() -> [String] {
+        var linkArguments = [String]()
+        for module in modules {
+            // Add link argument for each clang module dependency of modules in the product.
+            for case let clangModule as ClangModule in module.dependencies where clangModule.type == .library {
+                linkArguments.append("-l" + clangModule.c99name)
+            }
+        }
+        return linkArguments
+    }
+}
+
 extension Command {
     static func linkSwiftModule(_ product: Product, configuration conf: Configuration, prefix: AbsolutePath, otherArgs: [String], linkerExec: AbsolutePath) throws -> Command {
 
@@ -77,8 +92,10 @@ extension Command {
             args += ["-I", prefix.asString]
           #endif
         case .Library(.Dynamic):
+            args += product.clangModuleLinkArguments()
             args.append("-emit-library")
         case .Executable:
+            args += product.clangModuleLinkArguments()
             args.append("-emit-executable")
         }
         

--- a/Sources/PackageLoading/ModuleMapGenerator.swift
+++ b/Sources/PackageLoading/ModuleMapGenerator.swift
@@ -159,7 +159,6 @@ public struct ModuleMapGenerator {
         case .directory(let path):
             stream <<< "    umbrella \"\(path.asString)\"\n"
         }
-        stream <<< "    link \"\(module.c99name)\"\n"
         stream <<< "    export *\n"
         stream <<< "}\n"
 

--- a/Tests/BuildTests/DescribeTests.swift
+++ b/Tests/BuildTests/DescribeTests.swift
@@ -85,6 +85,25 @@ final class DescribeTests: XCTestCase {
         }
     }
 
+    func testClangModuleLinkArguments() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Pkg/Sources/swift/main.swift",
+            "/Pkg/Sources/cLib1/see.c",
+            "/Pkg/Sources/cLib2/see.c",
+            "/Pkg/Sources/cLib3/see.c"
+        )
+        let pkg = PackageDescription.Package(
+            name: "Pkg",
+            targets: [
+                Target(name: "swift", dependencies: ["cLib1", "cLib2"]),
+                Target(name: "cLib2", dependencies: ["cLib3"]),
+            ]
+        )
+        let graph = try loadMockPackageGraph(["/Pkg": pkg], root: "/Pkg", in: fs)
+        let product = graph.products.first{ _ in return true }!
+        XCTAssertEqual(product.clangModuleLinkArguments(), ["-lcLib1", "-lcLib2"])
+    }
+
     static var allTests = [
         ("testDescribingNoModulesThrows", testDescribingNoModulesThrows),
         ("testDescribingCModuleThrows", testDescribingCModuleThrows),

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -24,7 +24,6 @@ class ModuleMapGeneration: XCTestCase {
         let expected = BufferedOutputByteStream()
         expected <<< "module Foo {\n"
         expected <<< "    umbrella header \"/include/Foo.h\"\n"
-        expected <<< "    link \"Foo\"\n"
         expected <<< "    export *\n"
         expected <<< "}\n"
 
@@ -41,7 +40,6 @@ class ModuleMapGeneration: XCTestCase {
         let expected = BufferedOutputByteStream()
         expected <<< "module Foo {\n"
         expected <<< "    umbrella header \"/include/Foo/Foo.h\"\n"
-        expected <<< "    link \"Foo\"\n"
         expected <<< "    export *\n"
         expected <<< "}\n"
 
@@ -55,7 +53,6 @@ class ModuleMapGeneration: XCTestCase {
         let expected = BufferedOutputByteStream()
         expected <<< "module Foo {\n"
         expected <<< "    umbrella \"/include\"\n"
-        expected <<< "    link \"Foo\"\n"
         expected <<< "    export *\n"
         expected <<< "}\n"
 
@@ -99,7 +96,6 @@ class ModuleMapGeneration: XCTestCase {
         let expected = BufferedOutputByteStream()
         expected <<< "module F_o_o {\n"
         expected <<< "    umbrella \"/include\"\n"
-        expected <<< "    link \"F_o_o\"\n"
         expected <<< "    export *\n"
         expected <<< "}\n"
         ModuleMapTester("F-o-o", in: fs) { result in


### PR DESCRIPTION
This will get rid of current autolinking for linking Clang modules in
Swift modules. This will help when the product proposal is implemented, i.e.
when we statically link ClangModules we won't need to create .a files.

This also means that all users using a custom modulemap will need to
remove the link statement from their modulemap.

- <rdar://problem/30016942> Link C language libraries via Build instead
  of using autolinking via modulemaps