### PR TITLE
[Build] Fix for linking C targets recursive dependencies

### DIFF
--- a/Fixtures/ClangModules/SwiftCMixed2/Package.swift
+++ b/Fixtures/ClangModules/SwiftCMixed2/Package.swift
@@ -3,6 +3,7 @@ import PackageDescription
 let package = Package(
     name: "SwiftCMixed",
     targets: [
-        Target(name: "SeaExec", dependencies: ["SeaLib"]),
+        Target(name: "SeaExec", dependencies: ["SwiftLib"]),
+        Target(name: "SwiftLib", dependencies: ["SeaLib"]),
     ]
 )

--- a/Fixtures/ClangModules/SwiftCMixed2/Sources/SeaExec/main.swift
+++ b/Fixtures/ClangModules/SwiftCMixed2/Sources/SeaExec/main.swift
@@ -1,5 +1,4 @@
-import SeaLib
+import SwiftLib
 
-let a = foo(5)
-print("a = \(a)")
+print("a = \(bar())")
 

--- a/Fixtures/ClangModules/SwiftCMixed2/Sources/SwiftLib/lib.swift
+++ b/Fixtures/ClangModules/SwiftCMixed2/Sources/SwiftLib/lib.swift
@@ -1,0 +1,5 @@
+import SeaLib
+
+public func bar() -> Int32 {
+    return foo(5)
+}

--- a/Sources/Build/Command.link(SwiftModule).swift
+++ b/Sources/Build/Command.link(SwiftModule).swift
@@ -22,7 +22,7 @@ extension Product {
         var linkArguments = [String]()
         for module in modules {
             // Add link argument for each clang module dependency of modules in the product.
-            for case let clangModule as ClangModule in module.dependencies where clangModule.type == .library {
+            for case let clangModule as ClangModule in module.recursiveDependencies where clangModule.type == .library {
                 linkArguments.append("-l" + clangModule.c99name)
             }
         }

--- a/Tests/BuildTests/DescribeTests.swift
+++ b/Tests/BuildTests/DescribeTests.swift
@@ -101,7 +101,7 @@ final class DescribeTests: XCTestCase {
         )
         let graph = try loadMockPackageGraph(["/Pkg": pkg], root: "/Pkg", in: fs)
         let product = graph.products.first{ _ in return true }!
-        XCTAssertEqual(product.clangModuleLinkArguments(), ["-lcLib1", "-lcLib2"])
+        XCTAssertEqual(product.clangModuleLinkArguments().sorted(), ["-lcLib1", "-lcLib2", "-lcLib3"])
     }
 
     static var allTests = [


### PR DESCRIPTION
CLibrary
   ↑
SwiftLibrary
   ↑
SwiftExe

The above graph resulted in undefined symbols because SwiftExe never
linked with the CLibrary.