### PR TITLE
[Workspace] Remove version payload from unchanged case

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -607,7 +607,7 @@ public class Workspace {
         case removed
 
         /// The package is unchanged.
-        case unchanged(Version)
+        case unchanged
 
         /// The package is updated to a new version.
         case updated(old: Version, new: Version)
@@ -665,7 +665,7 @@ public class Workspace {
             case .updated(_, let version):
                 _ = try clone(specifier: specifier, version: version)
             case .removed: try remove(specifier: specifier)
-            case .unchanged(_): break
+            case .unchanged: break
             }
         }
     }
@@ -685,7 +685,7 @@ public class Workspace {
                     continue
                 }
                 if currentVersion == version {
-                    packageStateChanges[specifier] = .unchanged(version)
+                    packageStateChanges[specifier] = .unchanged
                 } else {
                     packageStateChanges[specifier] = .updated(old: currentVersion, new: version)
                 }
@@ -859,7 +859,7 @@ public class Workspace {
                 // update is needed, or cases where the range is invalid.
                 fatalError("unexpected dependency resolution result")
             case .removed: try remove(specifier: specifier)
-            case .unchanged(_): break
+            case .unchanged: break
             }
         }
 


### PR DESCRIPTION
We don't actually use the payload. We might want to have a payload which
can represent version as well as git hashes in future but no payload
should work for now.