### PR TITLE
[Tests] Create a dylib by hand instead of depending on SwiftPM

### DIFF
--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -413,15 +413,18 @@ class MiscellaneousTestCase: XCTestCase {
 
     func testPkgConfigClangModules() throws {
         fixture(name: "Miscellaneous/PkgConfig") { prefix in
-            _ = try executeSwiftBuild(prefix.appending(component: "SystemModule"))
-            XCTAssertFileExists(prefix.appending(components: "SystemModule", ".build", "debug", "libSystemModule.\(Product.dynamicLibraryExtension)"))
+            let systemModule = prefix.appending(component: "SystemModule")
+            // Create a shared library.
+            let input = systemModule.appending(components: "Sources", "SystemModule.c")
+            let output =  systemModule.appending(component: "libSystemModule.\(Product.dynamicLibraryExtension)")
+            try systemQuietly(["clang", "-shared", input.asString, "-o", output.asString])
 
             let pcFile = prefix.appending(component: "libSystemModule.pc")
 
             let stream = BufferedOutputByteStream()
-            stream <<< "prefix=\(prefix.appending(component: "SystemModule").asString)\n"
+            stream <<< "prefix=\(systemModule.asString)\n"
             stream <<< "exec_prefix=${prefix}\n"
-            stream <<< "libdir=${exec_prefix}/.build/debug\n"
+            stream <<< "libdir=${exec_prefix}\n"
             stream <<< "includedir=${prefix}/Sources/include\n"
             stream <<< "Name: SystemModule\n"
             stream <<< "URL: http://127.0.0.1/\n"

--- a/Tests/XcodeprojTests/FunctionalTests.swift
+++ b/Tests/XcodeprojTests/FunctionalTests.swift
@@ -49,13 +49,17 @@ class FunctionalTests: XCTestCase {
     func testXcodeProjWithPkgConfig() {
 #if os(macOS)
         fixture(name: "Miscellaneous/PkgConfig") { prefix in
-            XCTAssertBuilds(prefix.appending(component: "SystemModule"))
-            XCTAssertFileExists(prefix.appending(components: "SystemModule", ".build", "debug", "libSystemModule.\(Product.dynamicLibraryExtension)"))
+            let systemModule = prefix.appending(component: "SystemModule")
+            // Create a shared library.
+            let input = systemModule.appending(components: "Sources", "SystemModule.c")
+            let output =  systemModule.appending(component: "libSystemModule.\(Product.dynamicLibraryExtension)")
+            try systemQuietly(["clang", "-shared", input.asString, "-o", output.asString])
+
             let pcFile = prefix.appending(component: "libSystemModule.pc")
             try! write(path: pcFile) { stream in
                 stream <<< "prefix=\(prefix.appending(component: "SystemModule").asString)\n"
                 stream <<< "exec_prefix=${prefix}\n"
-                stream <<< "libdir=${exec_prefix}/.build/debug\n"
+                stream <<< "libdir=${exec_prefix}\n"
                 stream <<< "includedir=${prefix}/Sources/include\n"
 
                 stream <<< "Name: SystemModule\n"


### PR DESCRIPTION
This removes the dependency on dylib being created by swift build
invocation.