### PR TITLE
improving failure output per SR-3275

### DIFF
--- a/Fixtures/Miscellaneous/MissingDependency/Bar/Package.swift
+++ b/Fixtures/Miscellaneous/MissingDependency/Bar/Package.swift
@@ -1,0 +1,6 @@
+import PackageDescription
+
+let package = Package(
+    name: "Bar",
+    dependencies: [
+        .Package(url: "../NonExistantPackage", majorVersion: 1)])

--- a/Fixtures/Miscellaneous/MissingDependency/Bar/main.swift
+++ b/Fixtures/Miscellaneous/MissingDependency/Bar/main.swift
@@ -1,0 +1,3 @@
+import Foo
+
+foo()

--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -10,10 +10,12 @@
 
 import Basic
 import PackageModel
+import SourceControl
 
 import Utility
 import func POSIX.exit
 import enum PackageLoading.ManifestParseError
+
 import Workspace
 
 public enum Error: Swift.Error {
@@ -105,6 +107,10 @@ public func handle(error: Any) -> Never {
 
     case PackageToolOperationError.insufficientOptions(let usage):
         print(usage, to: &stderr)
+        
+    case GitRepositoryProviderError.gitCloneFailure(let url, let path, let errorOutput):
+        print(error: "Failed to clone \(url) to \(path.asString):\n\(errorOutput)")
+        
     default:
         print(error: error)
     }

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -15,16 +15,8 @@ import Utility
 import func POSIX.getenv
 import enum POSIX.Error
 
-enum GitRepositoryProviderError: Swift.Error {
-    case gitCloneFailure(url: String, path: AbsolutePath)
-}
-extension GitRepositoryProviderError: CustomStringConvertible {
-    var description: String {
-        switch self {
-        case .gitCloneFailure(let url, let path):
-            return "Failed to clone \(url) to \(path)"
-        }
-    }
+public enum GitRepositoryProviderError: Swift.Error {
+    case gitCloneFailure(url: String, path: AbsolutePath, errorOutput: String)
 }
 
 /// A `git` repository provider.
@@ -60,7 +52,8 @@ public class GitRepositoryProvider: RepositoryProvider {
         processSet?.remove(process)
         // Throw if cloning failed.
         guard result.exitStatus == .terminated(code: 0) else {
-            throw GitRepositoryProviderError.gitCloneFailure(url: repository.url, path: path)
+            let errorOutput = try result.utf8Output()
+            throw GitRepositoryProviderError.gitCloneFailure(url: repository.url, path: path, errorOutput: errorOutput)
         }
     }
 

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -491,6 +491,24 @@ class MiscellaneousTestCase: XCTestCase {
         }
     }
 
+    func testReportingErrorFromGitCommand() throws {
+        fixture(name: "Miscellaneous/MissingDependency") { prefix in
+            // This fixture has a setup that is intentionally missing a local dependency to induce a failure
+
+            // Launch swift-build.
+            let app = prefix.appending(component: "Bar")
+            let process = Process(args: SwiftPMProduct.SwiftBuild.path.asString, "--chdir", app.asString)
+            try process.launch()
+
+            let result = try process.waitUntilExit()
+            let resultOutputString = try result.utf8Output()
+
+            // We should exited with a failure from the attempt to "git clone" something that doesn't exist
+            XCTAssert(result.exitStatus != .terminated(code: 0))
+            XCTAssert(resultOutputString.contains("does not exist"), "Error from git was not propogated to process output: \(resultOutputString)")
+        }
+    }
+
     static var allTests = [
         ("testExecutableAsBuildOrderDependency", testExecutableAsBuildOrderDependency),
         ("testPrintsSelectedDependencyVersion", testPrintsSelectedDependencyVersion),
@@ -525,5 +543,6 @@ class MiscellaneousTestCase: XCTestCase {
         ("testOverridingSwiftcArguments", testOverridingSwiftcArguments),
         ("testPkgConfigClangModules", testPkgConfigClangModules),
         ("testCanKillSubprocessOnSigInt", testCanKillSubprocessOnSigInt),
+        ("testReportingErrorFromGitCommand", testReportingErrorFromGitCommand),
     ]
 }


### PR DESCRIPTION
 - resolves https://bugs.swift.org/browse/SR-3275
 - handing through process result utf8output to error for more informative string result
 - adds functional test fixture that will intentionally fail
 - adds test to validate error from underlying git is propogated on failure
 - adds Error capture for tool commands to handle pretty-print of output