### PR TITLE
[PackageDescription] Restore the old product API

### DIFF
--- a/Fixtures/Products/DynamicLibrary/Package.swift
+++ b/Fixtures/Products/DynamicLibrary/Package.swift
@@ -1,8 +1,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "packageName",
-    products: [
-        .Library(name: "ProductName", type: .dynamic, targets: ["packageName"]),
-    ]
+    name: "packageName"
 )
+
+products.append(Product(name: "ProductName", type: .Library(.Dynamic), modules: ["packageName"]))

--- a/Fixtures/Products/StaticLibrary/Package.swift
+++ b/Fixtures/Products/StaticLibrary/Package.swift
@@ -1,8 +1,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "PackageName",
-    products: [
-        .Library(name: "ProductName", type: .static, targets: ["PackageName"]),
-    ]
+    name: "PackageName"
 )
+
+products.append(Product(name: "ProductName", type: .Library(.Static), modules: ["PackageName"]))

--- a/Package.swift
+++ b/Package.swift
@@ -170,20 +170,32 @@ let package = Package(
             name: "XcodeprojTests",
             dependencies: ["Xcodeproj", "TestSupport"]),
     ],
-    products: [
-        // Runtime Library: contains the package description API itself.
-        .Library(
-            name: "PackageDescription",
-            type: .dynamic,
-            targets: ["PackageDescription"]),
-
-        // SwiftPM Library: provides package management functionality to clients.
-        .Library(
-            name: "SwiftPM",
-            type: .dynamic,
-            targets: ["libc", "POSIX", "Basic", "Utility", "SourceControl", "PackageDescription", "PackageModel", "PackageLoading", "Get", "PackageGraph", "Build", "Xcodeproj", "Workspace"]),
-    ],
     exclude: [
         "Tests/PackageLoadingTests/Inputs",
     ]
+)
+
+
+// The executable products are automatically determined by SwiftPM; any module
+// that contains a `main.swift` source file results in an implicit executable
+// product.
+
+
+// Runtime Library -- contains the package description API itself
+products.append(
+    Product(
+        name: "PackageDescription",
+        type: .Library(.Dynamic),
+        modules: ["PackageDescription"]
+    )
+)
+
+
+// SwiftPM Library -- provides package management functionality to clients
+products.append(
+    Product(
+        name: "SwiftPM",
+        type: .Library(.Dynamic),
+        modules: ["libc", "POSIX", "Basic", "Utility", "SourceControl", "PackageDescription", "PackageModel", "PackageLoading", "Get", "PackageGraph", "Build", "Xcodeproj", "Workspace"]
+    )
 )

--- a/Sources/PackageDescription/Package.swift
+++ b/Sources/PackageDescription/Package.swift
@@ -60,9 +60,6 @@ public final class Package {
     /// The list of targets.
     public var targets: [Target]
 
-    /// The list of products vended by this package.
-    public var products: [Product]
-
     /// The list of dependencies.
     public var dependencies: [Dependency]
 
@@ -75,7 +72,6 @@ public final class Package {
         pkgConfig: String? = nil,
         providers: [SystemPackageProvider]? = nil,
         targets: [Target] = [],
-        products: [Product] = [],
         dependencies: [Dependency] = [],
         exclude: [String] = []
     ) {
@@ -83,7 +79,6 @@ public final class Package {
         self.pkgConfig = pkgConfig
         self.providers = providers
         self.targets = targets
-        self.products = products
         self.dependencies = dependencies
         self.exclude = exclude
 
@@ -167,7 +162,6 @@ extension Package {
         dict["dependencies"] = .array(dependencies.map { $0.toJSON() })
         dict["exclude"] = .array(exclude.map { .string($0) })
         dict["targets"] = .array(targets.map { $0.toJSON() })
-        dict["products"] = .array(products.map { $0.toJSON() })
         if let providers = self.providers {
             dict["providers"] = .array(providers.map { $0.toJSON() })
         }
@@ -215,6 +209,7 @@ struct Errors {
 func manifestToJSON(_ package: Package) -> String {
     var dict: [String: JSON] = [:]
     dict["package"] = package.toJSON()
+    dict["products"] = .array(products.map { $0.toJSON() })
     dict["errors"] = errors.toJSON()
     return JSON.dictionary(dict).toString()
 }

--- a/Sources/PackageDescription/Product.swift
+++ b/Sources/PackageDescription/Product.swift
@@ -8,125 +8,56 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-/// Defines a product in the package.
-public enum Product {
+public struct Product {
+    public let name: String
+    public let type: ProductType
+    public let modules: [String]
 
-    /// An exectuable product.
-    public struct ExecutableProduct {
-
-        /// The name of the executable product.
-        public let name: String
-
-        /// The names of targets in the product.
-        public let targets: [String]
+    public init(name: String, type: ProductType, modules: String...) {
+        self.init(name: name, type: type, modules: modules)
     }
 
-    /// A library product.
-    public struct LibraryProduct {
-
-        /// The type of library products.
-        public enum LibraryType: String {
-            case `static`
-            case `dynamic`
-        }
-
-        /// The name of the library product.
-        public let name: String
-
-        /// The type of the library.
-        ///
-        /// If the type is unspecified, package manager will automatically choose a type.
-        public let type: LibraryType?
-
-        /// The names of targets in the product.
-        public let targets: [String]
+    public init(name: String, type: ProductType, modules: [String]) {
+        self.name = name
+        self.type = type
+        self.modules = modules
     }
+}
 
-    /// Executable product.
-    case exe(ExecutableProduct)
+public enum LibraryType {
+    case Static
+    case Dynamic
+}
 
-    /// Library product.
-    case lib(LibraryProduct)
+public enum ProductType {
+    case Test
+    case Executable
+    case Library(LibraryType)
+}
 
-    /// Create an executable product.
-    public static func Executable(name: String, targets: [String]) -> Product {
-        return .exe(ExecutableProduct(name: name, targets: targets))
-    }
-
-    /// Create a library product.
-    public static func Library(name: String, type: LibraryProduct.LibraryType? = nil, targets: [String]) -> Product {
-        return .lib(LibraryProduct(name: name, type: type, targets: targets))
-    }
-
-    /// Name of the product.
-    public var name: String {
+extension ProductType: CustomStringConvertible {
+    public var description: String {
         switch self {
-        case .exe(let p): return p.name
-        case .lib(let p): return p.name
+        case .Test:
+            return "test"
+        case .Executable:
+            return "exe"
+        case .Library(.Static):
+            return "a"
+        case .Library(.Dynamic):
+            return "dylib"
         }
-    }
-}
-
-extension Product.ExecutableProduct {
-    func toJSON() -> [String: JSON] {
-        return [
-            "name": .string(name),
-            "targets": .array(targets.map(JSON.string)),
-        ]
-    }
-}
-
-extension Product.LibraryProduct {
-    func toJSON() -> [String: JSON] {
-        return [
-            "name": .string(name),
-            "type": type.map{ JSON.string($0.rawValue) } ?? .null,
-            "targets": .array(targets.map(JSON.string)),
-        ]
     }
 }
 
 extension Product {
     func toJSON() -> JSON {
-        switch self {
-        case .exe(let product):
-            var dict = product.toJSON()
-            dict["product_type"] = .string("exe")
-            return .dictionary(dict)
-        case .lib(let product):
-            var dict = product.toJSON()
-            dict["product_type"] = .string("lib")
-            return .dictionary(dict)
-        }
+        var dict: [String: JSON] = [:]
+        dict["name"] = .string(name)
+        dict["type"] = .string(type.description)
+        dict["modules"] = .array(modules.map(JSON.string))
+        return .dictionary(dict)
     }
 }
 
-extension Product.ExecutableProduct: Equatable {
-    public static func ==(lhs: Product.ExecutableProduct, rhs: Product.ExecutableProduct) -> Bool {
-        return lhs.name == rhs.name &&
-               lhs.targets == rhs.targets
-    }
-}
-
-extension Product.LibraryProduct: Equatable {
-    public static func ==(lhs: Product.LibraryProduct, rhs: Product.LibraryProduct) -> Bool {
-        return lhs.name == rhs.name &&
-               lhs.type == rhs.type &&
-               lhs.targets == rhs.targets
-    }
-}
-
-extension Product: Equatable {
-    public static func ==(lhs: Product, rhs: Product) -> Bool {
-        switch (lhs, rhs) {
-        case (.exe(let a), .exe(let b)):
-            return a == b
-        case (.exe, _):
-            return false
-        case (.lib(let a), .lib(let b)):
-            return a == b
-        case (.lib, _):
-            return false
-        }
-    }
-}
+public var products = [Product]()

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -640,23 +640,10 @@ public struct PackageBuilder {
             return productModules
         }
 
-        // Create products declared in the manifest.
-        for product in manifest.package.products {
-            switch product {
-            case .exe(let p):
-                // FIXME: We should handle/diagnose name collisions between local and vended executables (SR-3562).
-                products += [Product(name: p.name, type: .Executable, modules: try modulesFrom(targetNames: p.targets, product: p.name))]
-            case .lib(let p):
-                // Get the library type.
-                let type: ProductType
-                switch p.type {
-                case .static?: type = .Library(.Static)
-                case .dynamic?: type = .Library(.Dynamic)
-                // FIXME: For now infer nil as dylibs, we need to expand PackageModel.Product to store this information.
-                case nil: type = .Library(.Dynamic)
-                }
-                products += [Product(name: p.name, type: type, modules: try modulesFrom(targetNames: p.targets, product: p.name))]
-            }
+        for p in manifest.products {
+            let modules = try modulesFrom(targetNames: p.modules, product: p.name)
+            let product = Product(name: p.name, type: p.type, modules: modules)
+            products.append(product)
         }
 
         return products

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -37,6 +37,9 @@ public struct Manifest {
     /// The raw package description.
     public let package: PackageDescription.Package
 
+    /// The raw product descriptions.
+    public let products: [PackageDescription.Product]
+
     /// The version this package was loaded from, if known.
     public let version: Version?
 
@@ -45,10 +48,17 @@ public struct Manifest {
         return package.name
     }
 
-    public init(path: AbsolutePath, url: String, package: PackageDescription.Package, version: Version?) {
+    public init(
+        path: AbsolutePath,
+        url: String,
+        package: PackageDescription.Package,
+        products: [PackageDescription.Product] = [],
+        version: Version?
+    ) {
         self.path = path
         self.url = url
         self.package = package
+        self.products = products 
         self.version = version
     }
 }

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -10,31 +10,7 @@
 
 import Basic
 
-public enum LibraryType {
-    case Static
-    case Dynamic
-}
-
-public enum ProductType {
-    case Test
-    case Executable
-    case Library(LibraryType)
-}
-
-extension ProductType: CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case .Test:
-            return "test"
-        case .Executable:
-            return "exe"
-        case .Library(.Static):
-            return "a"
-        case .Library(.Dynamic):
-            return "dylib"
-        }
-    }
-}
+@_exported import enum PackageDescription.ProductType
 
 public class Product {
     /// The name of the product.

--- a/Tests/PackageLoadingTests/JSONSerializationTests.swift
+++ b/Tests/PackageLoadingTests/JSONSerializationTests.swift
@@ -23,7 +23,7 @@ class JSONSerializationTests: XCTestCase {
 
     func testSimple() {
         let package = Package(name: "Simple")
-        assertEqual(package: package, expected: "{\"dependencies\": [], \"exclude\": [], \"name\": \"Simple\", \"products\": [], \"targets\": []}")
+        assertEqual(package: package, expected: "{\"dependencies\": [], \"exclude\": [], \"name\": \"Simple\", \"targets\": []}")
     }
     
     func testDependencies() {
@@ -33,7 +33,7 @@ class JSONSerializationTests: XCTestCase {
                 .Package(url: "https://github.com/apple/llvm.git", majorVersion: 2)
         ]
         let package = Package(name: "WithDeps", pkgConfig: nil, providers: nil, targets: [], dependencies: deps, exclude: [])
-        assertEqual(package: package, expected: "{\"dependencies\": [{\"url\": \"https://github.com/apple/swift.git\", \"version\": {\"lowerBound\": \"3.0.0\", \"upperBound\": \"3.9223372036854775807.9223372036854775807\"}}, {\"url\": \"https://github.com/apple/llvm.git\", \"version\": {\"lowerBound\": \"2.0.0\", \"upperBound\": \"2.9223372036854775807.9223372036854775807\"}}], \"exclude\": [], \"name\": \"WithDeps\", \"products\": [], \"targets\": []}")
+        assertEqual(package: package, expected: "{\"dependencies\": [{\"url\": \"https://github.com/apple/swift.git\", \"version\": {\"lowerBound\": \"3.0.0\", \"upperBound\": \"3.9223372036854775807.9223372036854775807\"}}, {\"url\": \"https://github.com/apple/llvm.git\", \"version\": {\"lowerBound\": \"2.0.0\", \"upperBound\": \"2.9223372036854775807.9223372036854775807\"}}], \"exclude\": [], \"name\": \"WithDeps\", \"targets\": []}")
     }
 
     func testPkgConfig() {
@@ -42,43 +42,26 @@ class JSONSerializationTests: XCTestCase {
                             .Apt("AptPackage")
                             ]
         let package = Package(name: "PkgPackage", pkgConfig: "PkgPackage-1.0", providers: providers)
-        assertEqual(package: package, expected: "{\"dependencies\": [], \"exclude\": [], \"name\": \"PkgPackage\", \"pkgConfig\": \"PkgPackage-1.0\", \"products\": [], \"providers\": [{\"name\": \"Brew\", \"value\": \"BrewPackage\"}, {\"name\": \"Apt\", \"value\": \"AptPackage\"}], \"targets\": []}")
+        assertEqual(package: package, expected: "{\"dependencies\": [], \"exclude\": [], \"name\": \"PkgPackage\", \"pkgConfig\": \"PkgPackage-1.0\", \"providers\": [{\"name\": \"Brew\", \"value\": \"BrewPackage\"}, {\"name\": \"Apt\", \"value\": \"AptPackage\"}], \"targets\": []}")
     }
 
     func testExclude() {
         let package = Package(name: "Exclude", exclude: ["pikachu", "bulbasaur"])
-        assertEqual(package: package, expected: "{\"dependencies\": [], \"exclude\": [\"pikachu\", \"bulbasaur\"], \"name\": \"Exclude\", \"products\": [], \"targets\": []}")
+        assertEqual(package: package, expected: "{\"dependencies\": [], \"exclude\": [\"pikachu\", \"bulbasaur\"], \"name\": \"Exclude\", \"targets\": []}")
     }
     
     func testTargets() {
         let t1 = Target(name: "One")
         let t2 = Target(name: "Two", dependencies: [.Target(name: "One")])
         let package = Package(name: "Targets", targets: [t1, t2])
-        assertEqual(package: package, expected: "{\"dependencies\": [], \"exclude\": [], \"name\": \"Targets\", \"products\": [], \"targets\": [{\"dependencies\": [], \"name\": \"One\"}, {\"dependencies\": [\"One\"], \"name\": \"Two\"}]}")
+        assertEqual(package: package, expected: "{\"dependencies\": [], \"exclude\": [], \"name\": \"Targets\", \"targets\": [{\"dependencies\": [], \"name\": \"One\"}, {\"dependencies\": [\"One\"], \"name\": \"Two\"}]}")
     }
     
-    func testProducts() {
-        var product: PackageDescription.Product
-
-        product = .Executable(name: "exe", targets: ["foo", "bar"])
-        XCTAssertEqual(product.toJSON().toString(), "{\"name\": \"exe\", \"product_type\": \"exe\", \"targets\": [\"foo\", \"bar\"]}")
-
-        product = .Library(name: "lib", targets: ["foo", "bar"])
-        XCTAssertEqual(product.toJSON().toString(), "{\"name\": \"lib\", \"product_type\": \"lib\", \"targets\": [\"foo\", \"bar\"], \"type\": null}")
-
-        product = .Library(name: "lib", type: .static, targets: ["foo", "bar"])
-        XCTAssertEqual(product.toJSON().toString(), "{\"name\": \"lib\", \"product_type\": \"lib\", \"targets\": [\"foo\", \"bar\"], \"type\": \"static\"}")
-
-        product = .Library(name: "lib", type: .dynamic, targets: ["foo", "bar"])
-        XCTAssertEqual(product.toJSON().toString(), "{\"name\": \"lib\", \"product_type\": \"lib\", \"targets\": [\"foo\", \"bar\"], \"type\": \"dynamic\"}")
-    }
-
     static var allTests = [
         ("testSimple", testSimple),
         ("testDependencies", testDependencies),
         ("testPkgConfig", testPkgConfig),
         ("testExclude", testExclude),
         ("testTargets", testTargets),
-        ("testProducts", testProducts),
     ]
 }

--- a/Tests/PackageLoadingTests/ManifestTests.swift
+++ b/Tests/PackageLoadingTests/ManifestTests.swift
@@ -190,27 +190,6 @@ class ManifestTests: XCTestCase {
         }
     }
 
-    func testProducts() throws {
-        let stream = BufferedOutputByteStream()
-        stream <<< "import PackageDescription" <<< "\n"
-        stream <<< "let package = Package(" <<< "\n"
-        stream <<< "    name: \"Foo\"," <<< "\n"
-        stream <<< "    products: [" <<< "\n"
-        stream <<< "    .Library(name: \"libfooA\", targets: [\"Foo\"])," <<< "\n"
-        stream <<< "    .Library(name: \"libfooS\", type: .static, targets: [\"Foo\"])," <<< "\n"
-        stream <<< "    .Library(name: \"libfooD\", type: .dynamic, targets: [\"Foo\"])," <<< "\n"
-        stream <<< "    .Executable(name: \"exe\", targets: [\"Bar\"])," <<< "\n"
-        stream <<< "    ])" <<< "\n" <<< "\n"
-
-        let manifest = try loadManifest(stream.bytes)
-        let products = Dictionary(items: manifest.package.products.map{ ($0.name, $0) })
-
-        XCTAssertEqual(products["libfooA"], .Library(name: "libfooA", targets: ["Foo"]))
-        XCTAssertEqual(products["libfooS"], .Library(name: "libfooS", type: .static, targets: ["Foo"]))
-        XCTAssertEqual(products["libfooD"], .Library(name: "libfooD", type: .dynamic, targets: ["Foo"]))
-        XCTAssertEqual(products["exe"], .Executable(name: "exe", targets: ["Bar"]))
-    }
-
     func testSwiftInterpreterErrors() throws {
         // Forgot importing package description.
         var stream = BufferedOutputByteStream()

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -324,7 +324,7 @@ def parse_manifest():
         r'Target\(.*?name: "(.*?)",\n *dependencies: (\[.*?\])\)',
         re.DOTALL | re.MULTILINE)
     product_pattern = re.compile(
-        r'Library\([\n ]*name: \"(.*?)\",[\n ]*type: (.*?),[\n ]*targets: (\[.*?\])[\n ]*\)',
+        r'Product\([\n ]*name: \"(.*?)\",[\n ]*type: (.*?),[\n ]*modules: (\[.*?\])[\n ]*\)',
         re.DOTALL | re.MULTILINE)
 
     # Load the manifest as a string (we always assume UTF-8 encoding).
@@ -340,13 +340,13 @@ def parse_manifest():
     targets = list(map(make_target, target_pattern.finditer(manifest_data)))
 
     # Extract the product definitions.
-    # Note: This only deals with library products (as that is all we need for now).
     def make_product(match):
         name = match.group(1)
         try:
             type = {
-                '.dynamic': ProductType.DYNAMIC_LIBRARY,
-                '.static': ProductType.STATIC_LIBRARY
+                '.Executable': ProductType.EXECUTABLE,
+                '.Library(.Dynamic)': ProductType.DYNAMIC_LIBRARY,
+                '.Library(.Static)': ProductType.STATIC_LIBRARY
             }[match.group(2)]
         except:
             error("unknown type '%s for product '%s' in manifest" % (match.group(2), name))


### PR DESCRIPTION
This API was removed when implementing the product proposal but is being
restored to keep compatibility with current Swift 3 packages. The new
API will be introduced in the PackageDescription4 module.