### PR TITLE
[PackageDescription] Restore the old product API

### DIFF
--- a/Fixtures/Products/DynamicLibrary/Package.swift
+++ b/Fixtures/Products/DynamicLibrary/Package.swift
@@ -1,8 +1,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "packageName",
-    products: [
-        .Library(name: "ProductName", type: .dynamic, targets: ["packageName"]),
-    ]
+    name: "packageName"
 )
+
+products.append(Product(name: "ProductName", type: .Library(.Dynamic), modules: ["packageName"]))

--- a/Fixtures/Products/StaticLibrary/Package.swift
+++ b/Fixtures/Products/StaticLibrary/Package.swift
@@ -1,8 +1,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "PackageName",
-    products: [
-        .Library(name: "ProductName", type: .static, targets: ["PackageName"]),
-    ]
+    name: "PackageName"
 )
+
+products.append(Product(name: "ProductName", type: .Library(.Static), modules: ["PackageName"]))

--- a/Package.swift
+++ b/Package.swift
@@ -170,20 +170,32 @@ let package = Package(
             name: "XcodeprojTests",
             dependencies: ["Xcodeproj", "TestSupport"]),
     ],
-    products: [
-        // Runtime Library: contains the package description API itself.
-        .Library(
-            name: "PackageDescription",
-            type: .dynamic,
-            targets: ["PackageDescription"]),
-
-        // SwiftPM Library: provides package management functionality to clients.
-        .Library(
-            name: "SwiftPM",
-            type: .dynamic,
-            targets: ["libc", "POSIX", "Basic", "Utility", "SourceControl", "PackageDescription", "PackageModel", "PackageLoading", "Get", "PackageGraph", "Build", "Xcodeproj", "Workspace"]),
-    ],
     exclude: [
         "Tests/PackageLoadingTests/Inputs",
     ]
+)
+
+
+// The executable products are automatically determined by SwiftPM; any module
+// that contains a `main.swift` source file results in an implicit executable
+// product.
+
+
+// Runtime Library -- contains the package description API itself
+products.append(
+    Product(
+        name: "PackageDescription",
+        type: .Library(.Dynamic),
+        modules: ["PackageDescription"]
+    )
+)
+
+
+// SwiftPM Library -- provides package management functionality to clients
+products.append(
+    Product(
+        name: "SwiftPM",
+        type: .Library(.Dynamic),
+        modules: ["libc", "POSIX", "Basic", "Utility", "SourceControl", "PackageDescription", "PackageModel", "PackageLoading", "Get", "PackageGraph", "Build", "Xcodeproj", "Workspace"]
+    )
 )

--- a/Sources/PackageDescription/Package.swift
+++ b/Sources/PackageDescription/Package.swift
@@ -60,9 +60,6 @@ public final class Package {
     /// The list of targets.
     public var targets: [Target]
 
-    /// The list of products vended by this package.
-    public var products: [Product]
-
     /// The list of dependencies.
     public var dependencies: [Dependency]
 
@@ -75,7 +72,6 @@ public final class Package {
         pkgConfig: String? = nil,
         providers: [SystemPackageProvider]? = nil,
         targets: [Target] = [],
-        products: [Product] = [],
         dependencies: [Dependency] = [],
         exclude: [String] = []
     ) {
@@ -83,7 +79,6 @@ public final class Package {
         self.pkgConfig = pkgConfig
         self.providers = providers
         self.targets = targets
-        self.products = products
         self.dependencies = dependencies
         self.exclude = exclude
 
@@ -167,7 +162,6 @@ extension Package {
         dict["dependencies"] = .array(dependencies.map { $0.toJSON() })
         dict["exclude"] = .array(exclude.map { .string($0) })
         dict["targets"] = .array(targets.map { $0.toJSON() })
-        dict["products"] = .array(products.map { $0.toJSON() })
         if let providers = self.providers {
             dict["providers"] = .array(providers.map { $0.toJSON() })
         }
@@ -215,6 +209,7 @@ struct Errors {
 func manifestToJSON(_ package: Package) -> String {
     var dict: [String: JSON] = [:]
     dict["package"] = package.toJSON()
+    dict["products"] = .array(products.map { $0.toJSON() })
     dict["errors"] = errors.toJSON()
     return JSON.dictionary(dict).toString()
 }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -142,13 +142,14 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         }
         let json = try JSON(string: jsonString)
         let package = PackageDescription.Package.fromJSON(json, baseURL: baseURL)
+        let products = PackageDescription.Product.fromJSON(json)
         let errors = parseErrors(json)
 
         guard errors.isEmpty else {
             throw ManifestParseError.runtimeManifestErrors(errors)
         }
 
-        return Manifest(path: path, url: baseURL, package: package, version: version)
+        return Manifest(path: path, url: baseURL, package: package, legacyProducts: products, version: version)
     }
 
     /// Parse the manifest at the given path to JSON.
@@ -236,12 +237,6 @@ extension PackageDescription.Package {
             targets = array.map(PackageDescription.Target.fromJSON)
         }
 
-        // Parse the products.
-        var products: [PackageDescription.Product] = []
-        if case .array(let array)? = package["products"] {
-            products = array.map(PackageDescription.Product.fromJSON)
-        }
-
         var providers: [PackageDescription.SystemPackageProvider]? = nil
         if case .array(let array)? = package["providers"] {
             providers = array.map(PackageDescription.SystemPackageProvider.fromJSON)
@@ -262,7 +257,7 @@ extension PackageDescription.Package {
             }
         }
 
-        return PackageDescription.Package(name: name, pkgConfig: pkgConfig, providers: providers, targets: targets, products: products, dependencies: dependencies, exclude: exclude)
+        return PackageDescription.Package(name: name, pkgConfig: pkgConfig, providers: providers, targets: targets, dependencies: dependencies, exclude: exclude)
     }
 }
 
@@ -330,34 +325,40 @@ extension PackageDescription.Target.Dependency {
 }
 
 extension PackageDescription.Product {
-    fileprivate static func fromJSON(_ json: JSON) -> PackageDescription.Product {
+
+    fileprivate static func fromJSON(_ json: JSON) -> [PackageDescription.Product] {
+        guard case .dictionary(let topLevelDict) = json else { fatalError("unexpected item") }
+        guard case .array(let array)? = topLevelDict["products"] else { fatalError("unexpected item") }
+        return array.map(Product.init)
+    }
+
+    private init(_ json: JSON) {
         guard case .dictionary(let dict) = json else { fatalError("unexpected item") }
         guard case .string(let name)? = dict["name"] else { fatalError("missing item") }
-        guard case .string(let productType)? = dict["product_type"] else { fatalError("missing item") }
-        guard case .array(let targetsJSON)? = dict["targets"] else { fatalError("missing item") }
+        guard case .string(let productType)? = dict["type"] else { fatalError("missing item") }
+        guard case .array(let targetsJSON)? = dict["modules"] else { fatalError("missing item") }
 
         let targets: [String] = targetsJSON.map {
             guard case JSON.string(let string) = $0 else { fatalError("invalid item") }
             return string
         }
+        self.init(name: name, type: ProductType(productType), modules: targets)
+    }
+}
 
-        switch productType {
+extension PackageDescription.ProductType {
+    fileprivate init(_ string: String) {
+        switch string {
         case "exe":
-            return PackageDescription.Product.Executable(name: name, targets: targets)
-        case "lib":
-            let type: PackageDescription.Product.LibraryProduct.LibraryType?
-            switch dict["type"] {
-            case .string("static")?:
-                type = .static
-            case .string("dynamic")?:
-                type = .dynamic
-            case .null?:
-                type = nil
-            default: fatalError("unexpected item")
-            }
-            return PackageDescription.Product.Library(name: name, type: type, targets: targets)
+            self = .Executable		
+        case "a":
+            self = .Library(.Static)
+        case "dylib":
+            self = .Library(.Dynamic)
+        case "test":
+            self = .Test
         default:
-            fatalError("unexpected item")
+            fatalError("invalid string \(string)")
         }
     }
 }

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -37,6 +37,9 @@ public struct Manifest {
     /// The raw package description.
     public let package: PackageDescription.Package
 
+    /// The raw product descriptions.
+    public let legacyProducts: [PackageDescription.Product]
+
     /// The version this package was loaded from, if known.
     public let version: Version?
 
@@ -45,10 +48,17 @@ public struct Manifest {
         return package.name
     }
 
-    public init(path: AbsolutePath, url: String, package: PackageDescription.Package, version: Version?) {
+    public init(
+        path: AbsolutePath,
+        url: String,
+        package: PackageDescription.Package,
+        legacyProducts: [PackageDescription.Product] = [],
+        version: Version?
+    ) {
         self.path = path
         self.url = url
         self.package = package
+        self.legacyProducts = legacyProducts
         self.version = version
     }
 }

--- a/Tests/PackageLoadingTests/ConventionTests.swift
+++ b/Tests/PackageLoadingTests/ConventionTests.swift
@@ -642,63 +642,6 @@ class ConventionTests: XCTestCase {
         }
     }
 
-    func testProducts() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-            "/Sources/exe/main.swift",
-            "/Sources/Foo/Foo.swift",
-            "/Sources/Bar/Bar.swift",
-            "/Sources/Tests/FooTests/Foo.swift",
-            "/Sources/Tests/BarTests/Bar.swift"
-        )
-
-        let package = PackageDescription.Package(
-            name: "pkg", 
-            products: [
-                .Library(name: "libpmS", type: .static, targets: ["Foo", "Bar"]),
-                .Library(name: "libpmD", type: .dynamic, targets: ["Foo", "Bar"]),
-                .Library(name: "libpmA", targets: ["Foo"]),
-                .Executable(name: "executable", targets: ["exe", "Foo"]),
-            ]
-        )
-
-        PackageBuilderTester(package, in: fs) { result in
-            result.checkModule("exe") { moduleResult in
-                moduleResult.check(c99name: "exe", type: .executable, isTest: false)
-                moduleResult.checkSources(root: "/Sources/exe", paths: "main.swift")
-            }
-
-            result.checkModule("Foo") { moduleResult in
-                moduleResult.check(c99name: "Foo", type: .library, isTest: false)
-                moduleResult.checkSources(root: "/Sources/Foo", paths: "Foo.swift")
-            }
-
-            result.checkModule("Bar") { moduleResult in
-                moduleResult.check(c99name: "Bar", type: .library, isTest: false)
-                moduleResult.checkSources(root: "/Sources/Bar", paths: "Bar.swift")
-            }
-
-            result.checkProduct("libpmS") { productResult in
-                productResult.check(type: .library(.static), modules: ["Bar", "Foo"])
-            }
-
-            result.checkProduct("libpmD") { productResult in
-                productResult.check(type: .library(.dynamic), modules: ["Bar", "Foo"])
-            }
-
-            result.checkProduct("libpmA") { productResult in
-                productResult.check(type: .library(.dynamic), modules: ["Foo"])
-            }
-
-            result.checkProduct("executable") { productResult in
-                productResult.check(type: .executable, modules: ["Foo", "exe"])
-            }
-
-            result.checkProduct("exe") { productResult in
-                productResult.check(type: .executable, modules: ["exe"])
-            }
-        }
-    }
-
     func testTestsProduct() throws {
         // Make sure product name and test module name are different in single module package.
         var fs = InMemoryFileSystem(emptyFiles:
@@ -752,28 +695,6 @@ class ConventionTests: XCTestCase {
             result.checkProduct("FooPackageTests") { productResult in
                 productResult.check(type: .test, modules: ["BarTests", "FooTests"])
             }
-        }
-    }
-
-    func testBadProducts() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-            "/Sources/Foo/Foo.swift"
-        )
-
-        let package = PackageDescription.Package(
-            name: "pkg", 
-            products: [
-                .Library(name: "libpm", type: .dynamic, targets: ["Foo", "Bar"]),
-            ]
-        )
-
-        PackageBuilderTester(package, in: fs) { result in
-            result.checkDiagnostic("the product named libpm references a module that could not be found: Bar fix: reference only valid modules from the product")
-        }
-
-        package.products = [.Library(name: "libpm", type: .dynamic, targets: [])]
-        PackageBuilderTester(package, in: fs) { result in
-            result.checkDiagnostic("the product named libpm doesn\'t reference any modules fix: reference one or more modules from the product")
         }
     }
 
@@ -1034,8 +955,6 @@ class ConventionTests: XCTestCase {
         ("testLooseSourceFileInTestsDir", testLooseSourceFileInTestsDir),
         ("testManifestTargetDeclErrors", testManifestTargetDeclErrors),
         ("testModuleMapLayout", testModuleMapLayout),
-        ("testProducts", testProducts),
-        ("testBadProducts", testBadProducts),
         ("testVersionSpecificManifests", testVersionSpecificManifests),
         ("testTestsProduct", testTestsProduct),
         ("testInvalidManifestConfigForNonSystemModules", testInvalidManifestConfigForNonSystemModules),
@@ -1155,7 +1074,7 @@ final class PackageBuilderTester {
             self.product = product
         }
 
-        func check(type: ProductType, modules: [String], file: StaticString = #file, line: UInt = #line) {
+        func check(type: PackageModel.ProductType, modules: [String], file: StaticString = #file, line: UInt = #line) {
             XCTAssertEqual(product.type, type, file: file, line: line)
             XCTAssertEqual(product.modules.map{$0.name}.sorted(), modules.sorted(), file: file, line: line)
         }

--- a/Tests/PackageLoadingTests/JSONSerializationTests.swift
+++ b/Tests/PackageLoadingTests/JSONSerializationTests.swift
@@ -23,7 +23,7 @@ class JSONSerializationTests: XCTestCase {
 
     func testSimple() {
         let package = Package(name: "Simple")
-        assertEqual(package: package, expected: "{\"dependencies\": [], \"exclude\": [], \"name\": \"Simple\", \"products\": [], \"targets\": []}")
+        assertEqual(package: package, expected: "{\"dependencies\": [], \"exclude\": [], \"name\": \"Simple\", \"targets\": []}")
     }
     
     func testDependencies() {
@@ -33,7 +33,7 @@ class JSONSerializationTests: XCTestCase {
                 .Package(url: "https://github.com/apple/llvm.git", majorVersion: 2)
         ]
         let package = Package(name: "WithDeps", pkgConfig: nil, providers: nil, targets: [], dependencies: deps, exclude: [])
-        assertEqual(package: package, expected: "{\"dependencies\": [{\"url\": \"https://github.com/apple/swift.git\", \"version\": {\"lowerBound\": \"3.0.0\", \"upperBound\": \"3.9223372036854775807.9223372036854775807\"}}, {\"url\": \"https://github.com/apple/llvm.git\", \"version\": {\"lowerBound\": \"2.0.0\", \"upperBound\": \"2.9223372036854775807.9223372036854775807\"}}], \"exclude\": [], \"name\": \"WithDeps\", \"products\": [], \"targets\": []}")
+        assertEqual(package: package, expected: "{\"dependencies\": [{\"url\": \"https://github.com/apple/swift.git\", \"version\": {\"lowerBound\": \"3.0.0\", \"upperBound\": \"3.9223372036854775807.9223372036854775807\"}}, {\"url\": \"https://github.com/apple/llvm.git\", \"version\": {\"lowerBound\": \"2.0.0\", \"upperBound\": \"2.9223372036854775807.9223372036854775807\"}}], \"exclude\": [], \"name\": \"WithDeps\", \"targets\": []}")
     }
 
     func testPkgConfig() {
@@ -42,43 +42,26 @@ class JSONSerializationTests: XCTestCase {
                             .Apt("AptPackage")
                             ]
         let package = Package(name: "PkgPackage", pkgConfig: "PkgPackage-1.0", providers: providers)
-        assertEqual(package: package, expected: "{\"dependencies\": [], \"exclude\": [], \"name\": \"PkgPackage\", \"pkgConfig\": \"PkgPackage-1.0\", \"products\": [], \"providers\": [{\"name\": \"Brew\", \"value\": \"BrewPackage\"}, {\"name\": \"Apt\", \"value\": \"AptPackage\"}], \"targets\": []}")
+        assertEqual(package: package, expected: "{\"dependencies\": [], \"exclude\": [], \"name\": \"PkgPackage\", \"pkgConfig\": \"PkgPackage-1.0\", \"providers\": [{\"name\": \"Brew\", \"value\": \"BrewPackage\"}, {\"name\": \"Apt\", \"value\": \"AptPackage\"}], \"targets\": []}")
     }
 
     func testExclude() {
         let package = Package(name: "Exclude", exclude: ["pikachu", "bulbasaur"])
-        assertEqual(package: package, expected: "{\"dependencies\": [], \"exclude\": [\"pikachu\", \"bulbasaur\"], \"name\": \"Exclude\", \"products\": [], \"targets\": []}")
+        assertEqual(package: package, expected: "{\"dependencies\": [], \"exclude\": [\"pikachu\", \"bulbasaur\"], \"name\": \"Exclude\", \"targets\": []}")
     }
     
     func testTargets() {
         let t1 = Target(name: "One")
         let t2 = Target(name: "Two", dependencies: [.Target(name: "One")])
         let package = Package(name: "Targets", targets: [t1, t2])
-        assertEqual(package: package, expected: "{\"dependencies\": [], \"exclude\": [], \"name\": \"Targets\", \"products\": [], \"targets\": [{\"dependencies\": [], \"name\": \"One\"}, {\"dependencies\": [\"One\"], \"name\": \"Two\"}]}")
+        assertEqual(package: package, expected: "{\"dependencies\": [], \"exclude\": [], \"name\": \"Targets\", \"targets\": [{\"dependencies\": [], \"name\": \"One\"}, {\"dependencies\": [\"One\"], \"name\": \"Two\"}]}")
     }
     
-    func testProducts() {
-        var product: PackageDescription.Product
-
-        product = .Executable(name: "exe", targets: ["foo", "bar"])
-        XCTAssertEqual(product.toJSON().toString(), "{\"name\": \"exe\", \"product_type\": \"exe\", \"targets\": [\"foo\", \"bar\"]}")
-
-        product = .Library(name: "lib", targets: ["foo", "bar"])
-        XCTAssertEqual(product.toJSON().toString(), "{\"name\": \"lib\", \"product_type\": \"lib\", \"targets\": [\"foo\", \"bar\"], \"type\": null}")
-
-        product = .Library(name: "lib", type: .static, targets: ["foo", "bar"])
-        XCTAssertEqual(product.toJSON().toString(), "{\"name\": \"lib\", \"product_type\": \"lib\", \"targets\": [\"foo\", \"bar\"], \"type\": \"static\"}")
-
-        product = .Library(name: "lib", type: .dynamic, targets: ["foo", "bar"])
-        XCTAssertEqual(product.toJSON().toString(), "{\"name\": \"lib\", \"product_type\": \"lib\", \"targets\": [\"foo\", \"bar\"], \"type\": \"dynamic\"}")
-    }
-
     static var allTests = [
         ("testSimple", testSimple),
         ("testDependencies", testDependencies),
         ("testPkgConfig", testPkgConfig),
         ("testExclude", testExclude),
         ("testTargets", testTargets),
-        ("testProducts", testProducts),
     ]
 }

--- a/Tests/PackageLoadingTests/ManifestTests.swift
+++ b/Tests/PackageLoadingTests/ManifestTests.swift
@@ -194,21 +194,18 @@ class ManifestTests: XCTestCase {
         let stream = BufferedOutputByteStream()
         stream <<< "import PackageDescription" <<< "\n"
         stream <<< "let package = Package(" <<< "\n"
-        stream <<< "    name: \"Foo\"," <<< "\n"
-        stream <<< "    products: [" <<< "\n"
-        stream <<< "    .Library(name: \"libfooA\", targets: [\"Foo\"])," <<< "\n"
-        stream <<< "    .Library(name: \"libfooS\", type: .static, targets: [\"Foo\"])," <<< "\n"
-        stream <<< "    .Library(name: \"libfooD\", type: .dynamic, targets: [\"Foo\"])," <<< "\n"
-        stream <<< "    .Executable(name: \"exe\", targets: [\"Bar\"])," <<< "\n"
-        stream <<< "    ])" <<< "\n" <<< "\n"
+        stream <<< "    name: \"Foo\"" <<< "\n"
+        stream <<< ")" <<< "\n" <<< "\n"
+        stream <<< "products.append(Product(name: \"libfooD\", type: .Library(.Dynamic), modules: [\"Foo\"]))" <<< "\n"
+        stream <<< "products.append(Product(name: \"libfooS\", type: .Library(.Static), modules: [\"Foo\"]))" <<< "\n"
+        stream <<< "products.append(Product(name: \"exe\", type: .Executable, modules: [\"Foo\"]))" <<< "\n"
 
         let manifest = try loadManifest(stream.bytes)
-        let products = Dictionary(items: manifest.package.products.map{ ($0.name, $0) })
+        let products = Dictionary(items: manifest.legacyProducts.map{ ($0.name, $0) })
 
-        XCTAssertEqual(products["libfooA"], .Library(name: "libfooA", targets: ["Foo"]))
-        XCTAssertEqual(products["libfooS"], .Library(name: "libfooS", type: .static, targets: ["Foo"]))
-        XCTAssertEqual(products["libfooD"], .Library(name: "libfooD", type: .dynamic, targets: ["Foo"]))
-        XCTAssertEqual(products["exe"], .Executable(name: "exe", targets: ["Bar"]))
+        XCTAssertEqual(products["libfooD"], PackageDescription.Product(name: "libfooD", type: .Library(.Dynamic), modules: ["Foo"]))
+        XCTAssertEqual(products["libfooS"], PackageDescription.Product(name: "libfooS", type: .Library(.Static), modules: ["Foo"]))
+        XCTAssertEqual(products["exe"], PackageDescription.Product(name: "exe", type: .Executable, modules: ["Foo"]))
     }
 
     func testSwiftInterpreterErrors() throws {
@@ -254,6 +251,7 @@ class ManifestTests: XCTestCase {
         ("testInvalidTargetName", testInvalidTargetName),
         ("testVersionSpecificLoading", testVersionSpecificLoading),
         ("testRuntimeManifestErrors", testRuntimeManifestErrors),
+        ("testProducts", testProducts),
         ("testSwiftInterpreterErrors", testSwiftInterpreterErrors),
     ]
 }

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -324,7 +324,7 @@ def parse_manifest():
         r'Target\(.*?name: "(.*?)",\n *dependencies: (\[.*?\])\)',
         re.DOTALL | re.MULTILINE)
     product_pattern = re.compile(
-        r'Library\([\n ]*name: \"(.*?)\",[\n ]*type: (.*?),[\n ]*targets: (\[.*?\])[\n ]*\)',
+        r'Product\([\n ]*name: \"(.*?)\",[\n ]*type: (.*?),[\n ]*modules: (\[.*?\])[\n ]*\)',
         re.DOTALL | re.MULTILINE)
 
     # Load the manifest as a string (we always assume UTF-8 encoding).
@@ -340,13 +340,13 @@ def parse_manifest():
     targets = list(map(make_target, target_pattern.finditer(manifest_data)))
 
     # Extract the product definitions.
-    # Note: This only deals with library products (as that is all we need for now).
     def make_product(match):
         name = match.group(1)
         try:
             type = {
-                '.dynamic': ProductType.DYNAMIC_LIBRARY,
-                '.static': ProductType.STATIC_LIBRARY
+                '.Executable': ProductType.EXECUTABLE,
+                '.Library(.Dynamic)': ProductType.DYNAMIC_LIBRARY,
+                '.Library(.Static)': ProductType.STATIC_LIBRARY
             }[match.group(2)]
         except:
             error("unknown type '%s for product '%s' in manifest" % (match.group(2), name))


### PR DESCRIPTION
This API was removed when implementing the product proposal but is being
restored to keep compatibility with current Swift 3 packages. The new
API will be introduced in the PackageDescription4 module.