### PR TITLE
[Build] Add link argument for C dependencies in test products

### DIFF
--- a/Sources/Build/Command.link(SwiftModule).swift
+++ b/Sources/Build/Command.link(SwiftModule).swift
@@ -69,6 +69,7 @@ extension Command {
             args += ["-module-name", product.name]
             // Link all the Clang Module's objects into XCTest executable.
             objects += product.modules.flatMap{ $0 as? ClangModule }.flatMap{ ClangModuleBuildMetadata(module: $0, prefix: prefix, otherArgs: []).objects }
+            args += product.clangModuleLinkArguments()
           #if os(macOS)
             args += ["-Xlinker", "-bundle"]
 


### PR DESCRIPTION
Missed adding -l in test products when we switched to manually adding
the link flags instead of generating the link directive in modulemap.

Fixes: https://bugs.swift.org/browse/SR-3816