### PR TITLE
[Xcodeproj] Generate Info.plist for library and test modules

### DIFF
--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -93,7 +93,7 @@ public func generate(outputDir: AbsolutePath, projectName: String, graph: Packag
         print("</plist>")
     }
 
-    for module in graph.modules where module.type == .library {
+    for module in graph.modules where module.type == .library || module.type == .test {
         ///// For framework targets, generate module.c99Name_Info.plist files in the 
         ///// directory that Xcode project is generated
         let name = module.infoPlistFileName

--- a/Tests/XcodeprojTests/FunctionalTests.swift
+++ b/Tests/XcodeprojTests/FunctionalTests.swift
@@ -37,6 +37,10 @@ class FunctionalTests: XCTestCase {
             XCTAssertXcodeprojGen(prefix)
             let pbx = prefix.appending(component: "SwiftCMixed.xcodeproj")
             XCTAssertDirectoryExists(pbx)
+            // Ensure we have plists for library and test targets.
+            XCTAssertFileExists(pbx.appending(component: "SeaLibTests_Info.plist"))
+            XCTAssertFileExists(pbx.appending(component: "SeaLib_Info.plist"))
+
             XCTAssertXcodeBuild(project: pbx)
             let build = prefix.appending(components: "build", "Debug")
             XCTAssertDirectoryExists(build.appending(component: "SeaLib.framework"))


### PR DESCRIPTION
I broke this when rolling test property on modules to module type enum.