### PR TITLE
[PackageModel] Add product dependencies

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -269,16 +269,21 @@ public final class ProductBuildDescription {
     }
 
     /// The objects in this product.
-    let objects: [AbsolutePath]
+    // Computed during build planning.
+    fileprivate(set) var objects: [AbsolutePath] = []
 
-    /// Any addition flags to be added. These flags are expected to be computed during build planning.
+    /// The dynamic libraries this product needs to link with.
+    // Computed during build planning.
+    fileprivate(set) var dylibs: [ProductBuildDescription] = []
+
+    /// Any additional flags to be added. These flags are expected to be computed during build planning.
     fileprivate var additionalFlags: [String] = []
 
     /// Create a build description for a product.
-    init(product: ResolvedProduct, objects: [AbsolutePath], buildParameters: BuildParameters) {
+    init(product: ResolvedProduct, buildParameters: BuildParameters) {
+        assert(product.type != .library(.automatic), "Automatic type libraries should not be described.")
         self.product = product
         self.buildParameters = buildParameters
-        self.objects = objects
     }
 
     /// The arguments to link and create this product.
@@ -295,6 +300,7 @@ public final class ProductBuildDescription {
         args += ["-L", buildParameters.buildPath.asString]
         args += ["-o", binary.asString]
         args += ["-module-name", product.name]
+        args += dylibs.map{ "-l" + $0.product.name }
 
         switch product.type {
         case .library(.automatic):
@@ -338,13 +344,18 @@ public class BuildPlan {
     /// The target build description map.
     public let targetMap: [ResolvedModule: TargetDescription]
 
+    /// The product build description map.
+    public let productMap: [ResolvedProduct: ProductBuildDescription]
+
     /// The build targets.
     public var targets: AnySequence<TargetDescription> {
         return AnySequence(targetMap.values)
     }
 
     /// The products in this plan.
-    public let buildProducts: [ProductBuildDescription]
+    public var buildProducts: AnySequence<ProductBuildDescription> {
+        return AnySequence(productMap.values)
+    }
 
     /// Build plan delegate.
     public let delegate: BuildPlanDelegate?
@@ -366,8 +377,6 @@ public class BuildPlan {
 
         // Create build target description for each module which we need to plan.
         var targetMap = [ResolvedModule: TargetDescription]()
-        // FIXME: Instead of operating on modules here, we should get all the products we want to build and
-        // then build up a list of modules from that.
         for module in graph.modules {
              switch module.underlyingModule {
              case is SwiftModule:
@@ -382,31 +391,25 @@ public class BuildPlan {
              }
         }
 
-        // Create product description for each product we have in the package graph.
-        self.buildProducts = graph.products().map { product in
-            // Collect all library objects.
-            var objects = product.allModules.filter{ $0.type == .library || $0.type == .test }.flatMap{ targetMap[$0]!.objects }
-
-            // Add objects from main module, if product is an executable.
-            if product.type == .executable {
-                let target = targetMap[product.executableModule]!
-                objects += target.objects
-            }
-
+        var productMap: [ResolvedProduct: ProductBuildDescription] = [:]
+        // Create product description for each product we have in the package graph except
+        // for automatic libraries because they don't produce any output.
+        for product in graph.products where product.type != .library(.automatic) {
           #if os(Linux)
             // FIXME: Create a target for LinuxMain file on linux.
             // This will go away once it is possible to auto detect tests.
             if product.type == .test {
-                let linuxMainModule = product.createLinuxMainModule()
-                let target = SwiftTargetDescription(module: linuxMainModule, buildParameters: buildParameters, isTestTarget: true)
+                let linuxMainModule = product.linuxMainModule
+                let target = SwiftTargetDescription(
+                    module: linuxMainModule, buildParameters: buildParameters, isTestTarget: true)
                 targetMap[linuxMainModule] = .swift(target)
-                objects += target.objects
             }
           #endif
-
-            return ProductBuildDescription(product: product, objects: objects, buildParameters: buildParameters)
+            productMap[product] = ProductBuildDescription(
+                product: product, buildParameters: buildParameters)
         }
 
+        self.productMap = productMap
         self.targetMap = targetMap
         // Finally plan these targets.
         plan()
@@ -426,35 +429,110 @@ public class BuildPlan {
 
         // Plan products.
         for buildProduct in buildProducts {
-            var linkCpp = false
+            plan(buildProduct)
+        }
+        // FIXME: We need to find out if any product has a target on which it depends 
+        // both static and dynamically and then issue a suitable diagnostic or auto
+        // handle that situation.
+    }
 
-            for module in buildProduct.product.allModules {
-                switch module.underlyingModule {
-                case let module as CModule:
-                    // Add pkgConfig libs arguments.
-                    buildProduct.additionalFlags += pkgConfig(for: module).libs
-                case let module as ClangModule:
-                    if module.containsCppFiles {
-                        linkCpp = true
-                    }
-                default: break
-                }
+    /// Plan a product.
+    private func plan(_ buildProduct: ProductBuildDescription) {
+        // Compute the product's dependency.
+        let dependencies = computeDependencies(of: buildProduct.product)
+        // Add flags for system modules.
+        for systemModule in dependencies.systemModules {
+            guard case let module as CModule = systemModule.underlyingModule else {
+                fatalError("This should not be possible.")
             }
-            // Link C++ if needed.
-            // Note: This will come from build settings in future.
-            if linkCpp {
+            // Add pkgConfig libs arguments.
+            buildProduct.additionalFlags += pkgConfig(for: module).libs
+        }
+
+        // Link C++ if needed.
+        // Note: This will come from build settings in future.
+        for target in dependencies.staticTargets {
+            if case let module as ClangModule = target.underlyingModule, module.containsCppFiles {
               #if os(macOS)
                 buildProduct.additionalFlags += ["-lc++"]
               #else
                 buildProduct.additionalFlags += ["-lstdc++"]
               #endif
+                break
             }
         }
+
+        buildProduct.dylibs = dependencies.dylibs.map{ productMap[$0]! }
+        buildProduct.objects = dependencies.staticTargets.flatMap{ targetMap[$0]!.objects }
+
+    }
+
+    /// Computes the dependencies of a product.
+    private func computeDependencies(
+        of product: ResolvedProduct
+    ) -> (dylibs: [ResolvedProduct], staticTargets: [ResolvedModule], systemModules: [ResolvedModule]) {
+
+        // Sort the product targets in topological order.
+        let nodes = product.modules.map(ResolvedModule.Dependency.target)
+        let allTargets = try! topologicalSort(nodes, successors: { dependency in
+            switch dependency {
+            // Include all the depenencies of a target.
+            case .target(let target):
+                return target.dependencies
+
+            // For a product dependency, we only include its content only if we
+            // need to statically link it.
+            case .product(let product):
+                switch product.type {
+                case .library(.automatic), .library(.static):
+                    return product.modules.map(ResolvedModule.Dependency.target)
+                case .library(.dynamic), .test, .executable:
+                    return []
+                }
+            }
+        })
+
+        // Create empty arrays to collect our results.
+        var (linkLibraries, staticTargets, systemModules) = ([ResolvedProduct](), [ResolvedModule](), [ResolvedModule]())
+
+        for dependency in allTargets {
+            switch dependency {
+            case .target(let target):
+                switch target.type {
+                // Include executable and tests only if they're top level contents 
+                // of the product. Otherwise they are just build time dependency.
+                case .executable, .test:
+                    if product.modules.contains(target) {
+                        staticTargets.append(target)
+                    }
+                // Library targets should always be included.
+                case .library:
+                    staticTargets.append(target)
+                // Add system module targets to system modules array.
+                case .systemModule:
+                    systemModules.append(target)
+                }
+
+            case .product(let product):
+                // Add the dynamic products to array of libraries to link.
+                if product.type == .library(.dynamic) {
+                    linkLibraries.append(product)
+                }
+            }
+        }
+
+      #if os(Linux)
+        if product.type == .test {
+            staticTargets.append(product.linuxMainModule)
+        }
+      #endif
+
+        return (linkLibraries, staticTargets, systemModules)
     }
 
     /// Plan a Clang target.
     private func plan(clangTarget: ClangTargetDescription) {
-        for dependency in clangTarget.module.dependencies {
+        for dependency in clangTarget.module.recursiveDependencies {
             switch dependency.underlyingModule {
             case let module as ClangModule where module.type == .library:
                 // Setup search paths for C dependencies:

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -131,7 +131,7 @@ public class SwiftTestTool: SwiftTool<TestToolOptions> {
         //
         // FIXME: We should also check if the package has any test
         // modules, which isn't trivial (yet).
-        let testProducts = graph.products().filter{
+        let testProducts = graph.products.filter{
             if case .test = $0.type {
                 return true
             } else {

--- a/Sources/PackageGraph/PackageGraph.swift
+++ b/Sources/PackageGraph/PackageGraph.swift
@@ -20,34 +20,42 @@ public struct PackageGraph {
     /// with the root packages.
     public let packages: [ResolvedPackage]
 
-    /// Returns list of all modules (reachable from root packages) in the graph.
-    // FIXME: This can create inconsistency between what we compile and what we link.
-    // Clients should always get the products and then operate on that instead of asking for modules.
+    /// Returns list of all targets (reachable from root targets) in the graph.
     public let modules: [ResolvedModule]
+
+    /// Contains all the products of the root packages and the product dependencies of the root targets.
+    /// i.e. this array will not contain the products which are not needed to be built.
+    public let products: [ResolvedProduct]
 
     /// Returns true if a given module is present in root packages.
     public func isInRootPackages(_ module: ResolvedModule) -> Bool {
         // FIXME: This can be easily cached.
         return rootPackages.flatMap{$0.modules}.contains(module)
     }
-    
+
     /// Construct a package graph directly.
     public init(rootPackages: [ResolvedPackage]) {
         self.rootPackages = rootPackages
         self.packages = try! topologicalSort(rootPackages, successors: { $0.dependencies })
-        self.modules = try! topologicalSort(rootPackages.flatMap{$0.modules}, successors: { $0.dependencies })
-    }
 
-    /// A sequence of all of the products in the graph.
-    ///
-    /// This yields all products in topological order starting with the root package.
-    public func products(includingExternalTestProducts: Bool = false) -> AnySequence<ResolvedProduct> {
-        return AnySequence(packages.lazy.flatMap{ package -> [ResolvedProduct] in
-            if self.rootPackages.contains(package) {
-                return package.products
-            } else {
-                return package.products.filter{ $0.type != .test }
+        // Compute the root targets.
+        let rootTargets = rootPackages.flatMap{$0.modules}.map(ResolvedModule.Dependency.target)
+        // Find all the dependencies of the root targets.
+        let dependencies = try! topologicalSort(rootTargets, successors: { $0.dependencies })
+
+        // Separate out the products and targets but maintain their topological order.
+        var targets: [ResolvedModule] = []
+        var products = rootPackages.flatMap{$0.products}
+        for dependency in dependencies {
+            switch dependency {
+            case .target(let target):
+                targets.append(target)
+            case .product(let product):
+                products.append(product)
             }
-        })
+        }
+
+        self.modules = targets
+        self.products = products
     }
 }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -59,8 +59,11 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(lib, ["-Onone", "-g", "-enable-testing", "-j8", "-DSWIFT_PACKAGE", "-module-cache-path", "/path/to/build/debug/ModuleCache"])
 
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), ["/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug",
-             "-o", "/path/to/build/debug/exe", "-module-name", "exe", 
-             "-emit-executable", "/path/to/build/debug/lib.build/lib.swift.o", "/path/to/build/debug/exe.build/main.swift.o"])
+            "-o", "/path/to/build/debug/exe", "-module-name", "exe", 
+            "-emit-executable",
+            "/path/to/build/debug/exe.build/main.swift.o",
+            "/path/to/build/debug/lib.build/lib.swift.o",
+        ])
     }
 
     func testBasicReleasePackage() throws {
@@ -117,7 +120,10 @@ final class BuildPlanTests: XCTestCase {
 
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), ["/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug",
             "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable", 
-            "/path/to/build/debug/lib.build/lib.c.o", "/path/to/build/debug/extlib.build/extlib.c.o", "/path/to/build/debug/exe.build/main.c.o"])
+            "/path/to/build/debug/exe.build/main.c.o",
+            "/path/to/build/debug/lib.build/lib.c.o",
+            "/path/to/build/debug/extlib.build/extlib.c.o",
+        ])
     }
 
     func testSwiftCMixed() throws {
@@ -145,7 +151,11 @@ final class BuildPlanTests: XCTestCase {
         let exe = try result.target(for: "exe").swiftTarget().compileArguments()
         XCTAssertEqual(exe, ["-Onone", "-g", "-enable-testing", "-j8", "-DSWIFT_PACKAGE", "-Xcc", "-fmodule-map-file=/path/to/build/debug/lib.build/module.modulemap", "-I", "/Pkg/Sources/lib/include", "-module-cache-path", "/path/to/build/debug/ModuleCache"])
 
-        XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), ["/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable", "/path/to/build/debug/lib.build/lib.c.o", "/path/to/build/debug/exe.build/main.swift.o"])
+        XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), ["/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug",
+            "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable",
+            "/path/to/build/debug/exe.build/main.swift.o",
+            "/path/to/build/debug/lib.build/lib.c.o",
+        ])
     }
 
     func testTestModule() throws {
@@ -255,7 +265,7 @@ private struct BuildPlanResult {
     }
 
     func checkProductsCount(_ count: Int, file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(plan.buildProducts.count, count, file: file, line: line)
+        XCTAssertEqual(plan.productMap.count, count, file: file, line: line)
     }
 
     func target(for name: String) throws -> TargetDescription {

--- a/Tests/PackageLoadingTests/ConventionTests.swift
+++ b/Tests/PackageLoadingTests/ConventionTests.swift
@@ -961,7 +961,8 @@ class ConventionTests: XCTestCase {
 /// - Throws: ModuleError, ProductError
 private func loadPackage(_ package: PackageDescription.Package, path: AbsolutePath, in fs: FileSystem, warningStream: OutputByteStream) throws -> PackageModel.Package {
     let manifest = Manifest(path: path.appending(component: Manifest.filename), url: "", package: package, version: nil)
-    let builder = PackageBuilder(manifest: manifest, path: path, fileSystem: fs, warningStream: warningStream)
+    let builder = PackageBuilder(
+        manifest: manifest, path: path, fileSystem: fs, warningStream: warningStream, createImplicitProduct: false)
     return try builder.construct()
 }
 

--- a/Tests/PackageLoadingTests/ManifestTests.swift
+++ b/Tests/PackageLoadingTests/ManifestTests.swift
@@ -112,7 +112,7 @@ class ManifestTests: XCTestCase {
         fixture(name: "Miscellaneous/PackageWithInvalidTargets") { (prefix: AbsolutePath) in
             do {
                 let manifest = try manifestLoader.loadFile(path: prefix.appending(component: "Package.swift"), baseURL: prefix.asString, version: nil)
-                _ = try PackageBuilder(manifest: manifest, path: prefix).construct()
+                _ = try PackageBuilder(manifest: manifest, path: prefix, createImplicitProduct: false).construct()
             } catch ModuleError.modulesNotFound(let moduleNames) {
                 XCTAssertEqual(Set(moduleNames), Set(["Bake", "Fake"]))
             } catch {

--- a/Tests/PackageModelTests/ModuleTests.swift
+++ b/Tests/PackageModelTests/ModuleTests.swift
@@ -18,7 +18,7 @@ private extension ResolvedModule {
         self.init(
             module: SwiftModule(
                 name: name, isTest: false, sources: Sources(paths: [], root: AbsolutePath("/")), dependencies: []),
-            dependencies: deps)
+            dependencies: deps.map(ResolvedModule.Dependency.target))
     }
 }
 


### PR DESCRIPTION
Instead of creating target dependency for each external target, allow
targets to have a product dependency. We implicitly create products for
each external package containing all library modules and then establish
a dependency. This will be more explicit in Swift 4 manifest.