### PR TITLE
PathArgument for separating between string and path arguments

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -286,17 +286,17 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
         let generateXcodeParser = parser.add(subparser: PackageMode.generateXcodeproj.rawValue, overview: "Generates an Xcode project")
         binder.bind(
             generateXcodeParser.add(
-                option: "--xcconfig-overrides", kind: String.self,
+                option: "--xcconfig-overrides", kind: PathArgument.self,
                 usage: "Path to xcconfig file"),
             generateXcodeParser.add(
                 option: "--enable-code-coverage", kind: Bool.self,
                 usage: "Enable code coverage in the generated project"),
             generateXcodeParser.add(
-                option: "--output", kind: String.self,
+                option: "--output", kind: PathArgument.self,
                 usage: "Path where the Xcode project should be generated"),
             to: { 
-                $0.xcodeprojOptions = XcodeprojOptions(flags: $0.buildFlags, xcconfigOverrides: $0.absolutePathRelativeToWorkingDir($1), enableCodeCoverage: $2)
-                $0.outputPath = $0.absolutePathRelativeToWorkingDir($3) })
+                $0.xcodeprojOptions = XcodeprojOptions(flags: $0.buildFlags, xcconfigOverrides: $1?.path, enableCodeCoverage: $2)
+                $0.outputPath = $3?.path })
 
         let pinParser = parser.add(subparser: PackageMode.pin.rawValue, overview: "Perform pinning operations on a package.")
         binder.bind(

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -115,15 +115,15 @@ public class SwiftTool<Options: ToolOptions> {
 
         binder.bind(
             option: parser.add(
-                option: "--build-path", kind: String.self, 
+                option: "--build-path", kind: PathArgument.self,
                 usage: "Specify build/cache directory [default: ./.build]"),
-            to: { $0.buildPath = $0.absolutePathRelativeToWorkingDir($1) })
+            to: { $0.buildPath = $1.path })
 
         binder.bind(
             option: parser.add(
-                option: "--chdir", shortName: "-C", kind: String.self,
+                option: "--chdir", shortName: "-C", kind: PathArgument.self,
                 usage: "Change working directory before any other operation"),
-            to: { $0.chdir = $0.absolutePathRelativeToWorkingDir($1) })
+            to: { $0.chdir = $1.path })
 
         binder.bind(
             option: parser.add(option: "--color", kind: ColorWrap.Mode.self,

--- a/Sources/TestSupportExecutable/main.swift
+++ b/Sources/TestSupportExecutable/main.swift
@@ -48,6 +48,7 @@ class HandlerTest {
 enum Mode: String {
     case fileLockTest
     case interruptHandlerTest
+    case absolutePath
     case help
 }
 
@@ -59,6 +60,7 @@ struct Options {
     }
     var fileLockOptions: FileLockOptions?
     var temporaryFile: AbsolutePath?
+    var absolutePath: AbsolutePath?
     var mode = Mode.help
 }
 
@@ -84,6 +86,11 @@ do {
         positional: intHandlerParser.add(positional: "temporary file", kind: String.self, usage: "Path to temp file"),
         to: { $0.temporaryFile = AbsolutePath($1) })
 
+    let absolutePathParser = parser.add(subparser: Mode.absolutePath.rawValue, overview: "Print the absolute path for the given relative path")
+    binder.bind(
+        positional: absolutePathParser.add(positional: "relative path", kind: PathArgument.self, usage: "Relative path to return absolute path for"),
+        to: { $0.absolutePath = $1.path })
+
     binder.bind(
         parser: parser,
         to: { $0.mode = Mode(rawValue: $1)! })
@@ -99,6 +106,8 @@ do {
     case .interruptHandlerTest:
         let handlerTest = try HandlerTest(options.temporaryFile!)
         handlerTest.run()
+    case .absolutePath:
+        print(options.absolutePath!.asString)
     case .help:
         parser.printUsage(on: stdoutStream)
     }

--- a/Sources/Utility/ArgumentParser.swift
+++ b/Sources/Utility/ArgumentParser.swift
@@ -113,6 +113,21 @@ extension StringEnumArgument {
 }
 
 
+/// An argument representing a path (file / directory).
+///
+/// The path is resolved in the current working directory.
+public struct PathArgument: ArgumentKind {
+    public let path: AbsolutePath
+
+    public init?(arg: String) {
+        path = AbsolutePath(arg, relativeTo: currentWorkingDirectory)
+    }
+
+    public init(parser: inout ArgumentParserProtocol) throws {
+        path = AbsolutePath(try parser.associatedArgumentValue ?? parser.next(), relativeTo: currentWorkingDirectory)
+    }
+}
+
 /// A protocol representing positional or options argument.
 protocol ArgumentProtocol: Hashable {
     /// The argument kind of this argument for eg String, Bool etc.

--- a/Tests/UtilityTests/ArgumentParserTests.swift
+++ b/Tests/UtilityTests/ArgumentParserTests.swift
@@ -10,6 +10,7 @@
 
 import XCTest
 import Basic
+import TestSupport
 import Utility
 
 enum SampleEnum: String {
@@ -367,6 +368,21 @@ class ArgumentParserTests: XCTestCase {
         }
     }
 
+    func testPathArgument() {
+        // relative path
+        do {
+            let actual = try! SwiftPMProduct.TestSupportExecutable.execute(["absolutePath", "some/path"]).chomp()
+            let expected = currentWorkingDirectory.appending(RelativePath("some/path")).asString
+            XCTAssertEqual(actual, expected)
+        }
+
+        // absolute path
+        do {
+            let actual = try! SwiftPMProduct.TestSupportExecutable.execute(["absolutePath", "/bin/echo"]).chomp()
+            XCTAssertEqual(actual, "/bin/echo")
+        }
+    }
+
     static var allTests = [
         ("testBasics", testBasics),
         ("testErrors", testErrors),
@@ -375,5 +391,6 @@ class ArgumentParserTests: XCTestCase {
         ("testSubsubparser", testSubsubparser),
         ("testSubparserBinder", testSubparserBinder),
         ("testOptionalPositionalArg", testOptionalPositionalArg),
+        ("testPathArgument", testPathArgument),
     ]
 }


### PR DESCRIPTION
This PR is split off from #843 per Ankit's request. It lays the ground-work for #843.