### PR TITLE
[PerfTests] Add workaround to always build the perf tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -121,7 +121,7 @@ let package = Package(
             dependencies: ["TestSupport", "TestSupportExecutable"]),
         Target(
             name: "BasicPerformanceTests",
-            dependencies: ["Basic"]),
+            dependencies: ["Basic", "TestSupport"]),
         Target(
             name: "BuildTests",
             dependencies: ["Build", "TestSupport"]),

--- a/Sources/TestSupport/XCTestCasePerf.swift
+++ b/Sources/TestSupport/XCTestCasePerf.swift
@@ -1,0 +1,26 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+/// A helper class to write performance tests for SwiftPM.
+///
+/// Subclasses of this will always build the tests but only run
+/// run the tests when ENABLE_PERF_TESTS is defined. This is very
+/// useful because we always want to be able to compile the perf tests
+/// even if they are not run locally.
+open class XCTestCasePerf: XCTestCase {
+
+  #if os(macOS) && !ENABLE_PERF_TESTS
+    override open class func defaultTestSuite() -> XCTestSuite {
+        return XCTestSuite()
+    }
+  #endif
+}

--- a/Tests/BasicPerformanceTests/ByteStringPerfTests.swift
+++ b/Tests/BasicPerformanceTests/ByteStringPerfTests.swift
@@ -11,10 +11,9 @@
 import XCTest
 
 import Basic
+import TestSupport
 
-#if ENABLE_PERF_TESTS
-
-class ByteStringPerfTests: XCTestCase {
+class ByteStringPerfTests: XCTestCasePerf {
     func testInitialization() {
         let listOfStrings: [String] = (0..<10).map { "This is the number: \($0)!\n" }
         let expectedTotalCount = listOfStrings.map({ $0.utf8.count }).reduce(0, +)
@@ -31,5 +30,3 @@ class ByteStringPerfTests: XCTestCase {
         }
     }
 }
-
-#endif

--- a/Tests/BasicPerformanceTests/OutputByteStreamPerfTests.swift
+++ b/Tests/BasicPerformanceTests/OutputByteStreamPerfTests.swift
@@ -11,8 +11,8 @@
 import XCTest
 
 import Basic
+import TestSupport
 
-#if ENABLE_PERF_TESTS
 
 struct ByteSequence: Sequence {
     let bytes16 = [UInt8](repeating: 0, count: 1 << 4)
@@ -36,7 +36,7 @@ struct ByteSequenceIterator: IteratorProtocol {
     }
 }
 
-class OutputByteStreamPerfTests: XCTestCase {
+class OutputByteStreamPerfTests: XCTestCasePerf {
 
     func test1MBOfSequence_X10() {
         let sequence = ByteSequence()
@@ -217,5 +217,3 @@ class OutputByteStreamPerfTests: XCTestCase {
         }
     }
 }
-
-#endif

--- a/Tests/BasicPerformanceTests/PathPerfTests.swift
+++ b/Tests/BasicPerformanceTests/PathPerfTests.swift
@@ -11,10 +11,9 @@
 import XCTest
 
 import Basic
+import TestSupport
 
-#if ENABLE_PERF_TESTS
-
-class PathPerfTests: XCTestCase {
+class PathPerfTests: XCTestCasePerf {
     
     /// Tests creating very long AbsolutePaths by joining path components.
     func testJoinPerf_X100000() {
@@ -33,5 +32,3 @@ class PathPerfTests: XCTestCase {
     
     // FIXME: We will obviously want a lot more tests here.
 }
-    
-#endif

--- a/Tests/BasicPerformanceTests/StringConversionsPerfTests.swift
+++ b/Tests/BasicPerformanceTests/StringConversionsPerfTests.swift
@@ -11,10 +11,9 @@
 import XCTest
 
 import Basic
+import TestSupport
 
-#if ENABLE_PERF_TESTS
-
-class StringConversionsPerfTests: XCTestCase {
+class StringConversionsPerfTests: XCTestCasePerf {
     func testLongString() {
         let string = Array(0..<2000).map{ _ in "hello world"}.joined(separator: " ")
         measure {
@@ -29,5 +28,3 @@ class StringConversionsPerfTests: XCTestCase {
         }
     }
 }
-
-#endif

--- a/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
+++ b/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
@@ -13,9 +13,7 @@ import TestSupport
 import Basic
 import Utility
 
-#if ENABLE_PERF_TESTS
-
-class BuildPerfTests: XCTestCase {
+class BuildPerfTests: XCTestCasePerf {
     let resources = Resources()
 
     @discardableResult
@@ -69,5 +67,3 @@ class BuildPerfTests: XCTestCase {
         }
     }
 }
-
-#endif

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -18,12 +18,10 @@ import struct Utility.Version
 
 import TestSupport
 
-#if ENABLE_PERF_TESTS
-
 private let v1: Version = "1.0.0"
 private let v1Range: VersionSetSpecifier = .range("1.0.0" ..< "2.0.0")
 
-class DependencyResolverPerfTests: XCTestCase {
+class DependencyResolverPerfTests: XCTestCasePerf {
 
     func testTrivalResolution_X1000() {
         let N = 1000
@@ -143,7 +141,7 @@ class DependencyResolverPerfTests: XCTestCase {
     }
 }
 
-class DependencyResolverRealWorldPerfTests: XCTestCase {
+class DependencyResolverRealWorldPerfTests: XCTestCasePerf {
 
     func testKitura_X100() throws {
         try runPackageTest(name: "kitura.json", N: 100)
@@ -283,5 +281,3 @@ struct GitRepositoryResolutionHelper {
         }
     }
 }
-
-#endif

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -16,9 +16,7 @@ import PackageDescription
 import PackageModel
 import TestSupport
 
-#if ENABLE_PERF_TESTS
-
-class PackageGraphPerfTests: XCTestCase {
+class PackageGraphPerfTests: XCTestCasePerf {
 
     func testLoading100Packages() throws {
         let N = 100
@@ -58,5 +56,3 @@ class PackageGraphPerfTests: XCTestCase {
         }
     }
 }
-
-#endif

--- a/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
+++ b/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
@@ -14,9 +14,7 @@ import Basic
 import TestSupport
 import PackageLoading
 
-#if ENABLE_PERF_TESTS
-
-class ManifestLoadingPerfTests: XCTestCase {
+class ManifestLoadingPerfTests: XCTestCasePerf {
     let manifestLoader = ManifestLoader(resources: Resources())
 
     func write(_ bytes: ByteString, body: (AbsolutePath) -> ()) {
@@ -68,5 +66,3 @@ class ManifestLoadingPerfTests: XCTestCase {
         }
     }
 }
-
-#endif


### PR DESCRIPTION
They will still run only when ENABLE_PERF_TESTS is defined.