### PR TITLE
[Xcodeproj] Avoid generating `module.modulemap` if umbrella header exists, on creating the clangModule target

### DIFF
--- a/Sources/Xcodeproj/XcodeProjectModel.swift
+++ b/Sources/Xcodeproj/XcodeProjectModel.swift
@@ -288,6 +288,13 @@ public struct Xcode {
         init(fileRef: FileReference) {
             self.fileRef = fileRef
         }
+
+        var settings = Settings()
+
+        /// A set of file settings.
+        public struct Settings {
+            var ATTRIBUTES: [String]?
+        }
     }
     
     /// A table of build settings, which for the sake of simplicity consists

--- a/Sources/Xcodeproj/XcodeProjectModel.swift
+++ b/Sources/Xcodeproj/XcodeProjectModel.swift
@@ -321,6 +321,7 @@ public struct Xcode {
             // Note: although some of these build settings sound like booleans,
             // they are all either strings or arrays of strings, because even
             // a boolean may be a macro reference expression.
+            var CLANG_ENABLE_MODULES: String?
             var CLANG_ENABLE_OBJC_ARC: String?
             var COMBINE_HIDPI_IMAGES: String?
             var COPY_PHASE_STRIP: String?

--- a/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
+++ b/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
@@ -268,6 +268,13 @@ extension Xcode.BuildFile: PropertyListSerializable {
         if let fileRef = fileRef {
             dict["fileRef"] = .identifier(serializer.id(of: fileRef))
         }
+        var settingsDict = [String: PropertyList]()
+        if let attributes = settings.ATTRIBUTES?.map(PropertyList.string) {
+            settingsDict["ATTRIBUTES"] = .array(attributes)
+        }
+        if !settingsDict.isEmpty {
+            dict["settings"] = .dictionary(settingsDict)
+        }
         return dict
     }
 }

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -478,17 +478,34 @@ func xcodeProject(
             if fileSystem.isFile(clangModule.moduleMapPath) {
                 moduleMapPath = clangModule.moduleMapPath
                 isGenerated = false
+
+                includeGroup.addFileReference(path: moduleMapPath.asString, name: moduleMapPath.basename)
+                // Save this modulemap path mapped to module so we can later wire it up for its dependees.
+                modulesToModuleMap[module] = (moduleMapPath, isGenerated)
             } else {
-                // Generate and drop the modulemap inside Xcodeproj folder.
-                let path = xcodeprojPath.appending(components: "GeneratedModuleMap", clangModule.c99name)
-                var moduleMapGenerator = ModuleMapGenerator(for: clangModule, fileSystem: fileSystem)
-                try moduleMapGenerator.generateModuleMap(inDir: path)
-                moduleMapPath = path.appending(component: moduleMapFilename)
-                isGenerated = true
+                let umbrellaHeaderName = clangModule.c99name + ".h"
+                if includeGroup.subitems.contains(where: { $0.path == umbrellaHeaderName }) {
+                    // if umbrellaHeader exists, we can use module.
+                    targetSettings.common.CLANG_ENABLE_MODULES = "YES"
+                    targetSettings.common.DEFINES_MODULE = "YES"
+                    let headerPhase = target.addHeadersBuildPhase()
+                    for case let header as Xcode.FileReference in includeGroup.subitems {
+                        let buildFile = headerPhase.addBuildFile(fileRef: header)
+                        buildFile.settings.ATTRIBUTES = ["Public"]
+                    }
+                } else {
+                    // Generate and drop the modulemap inside Xcodeproj folder.
+                    let path = xcodeprojPath.appending(components: "GeneratedModuleMap", clangModule.c99name)
+                    var moduleMapGenerator = ModuleMapGenerator(for: clangModule, fileSystem: fileSystem)
+                    try moduleMapGenerator.generateModuleMap(inDir: path)
+                    moduleMapPath = path.appending(component: moduleMapFilename)
+                    isGenerated = true
+
+                    includeGroup.addFileReference(path: moduleMapPath.asString, name: moduleMapPath.basename)
+                    // Save this modulemap path mapped to module so we can later wire it up for its dependees.
+                    modulesToModuleMap[module] = (moduleMapPath, isGenerated)
+                }
             }
-            includeGroup.addFileReference(path: moduleMapPath.asString, name: moduleMapPath.basename)
-            // Save this modulemap path mapped to module so we can later wire it up for its dependees.
-            modulesToModuleMap[module] = (moduleMapPath, isGenerated)
         }
     }
     

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -357,6 +357,7 @@ func xcodeProject(
         }
         
         if module.isTest {
+            targetSettings.common.CLANG_ENABLE_MODULES = "YES"
             targetSettings.common.EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES"
             targetSettings.common.LD_RUNPATH_SEARCH_PATHS = ["@loader_path/../Frameworks", "@loader_path/Frameworks"]
         }


### PR DESCRIPTION
This PR increases the portability of generated Xcode project by reducing the use of `module.modulemap` which absolute path contains.

- If clang module has umbrella header:
  - Add headers to `HeadersBuildPhase`
  - Set `CLANG_ENABLE_MODULES` = `YES`
  - Set `DEFINES_MODULE` = `YES`
  - Don’t generate `module.modulemap`
- Set `CLANG_ENABLE_MODULES` =` YES` to test target so that we can import clang module.

In the course of testing to create a package written only in Objective-C, I came up with this change.
e.g: https://github.com/norio-nomura/GTMNSString_HTML