### PR TITLE
[Basic] Add trailing newline to pretty-printed JSON

### DIFF
--- a/Sources/Basic/JSON.swift
+++ b/Sources/Basic/JSON.swift
@@ -94,6 +94,9 @@ extension JSON {
     public func toBytes(prettyPrint: Bool = false) -> ByteString {
         let stream = BufferedOutputByteStream()
         write(to: stream, indent: prettyPrint ? 0 : nil)
+        if prettyPrint {
+            stream.write("\n")
+        }
         return stream.bytes
     }
     

--- a/Tests/BasicTests/JSONTests.swift
+++ b/Tests/BasicTests/JSONTests.swift
@@ -90,7 +90,7 @@ class JSONTests: XCTestCase {
             "    2"                       + "\n" +
             "  ],"                        + "\n" +
             "  \"last\": \"doe\""         + "\n" +
-            "}"
+            "}"                           + "\n"
 
         XCTAssertEqual(person.toString(prettyPrint: true), str)
     }


### PR DESCRIPTION
The `Package.pins` file is currently written without a newline character
on the last line.
Make it a proper text file by appending one `\n` to the `ByteString`
which is generated from the JSON.