### PR TITLE
[Workspace] Don't abort loading graph on first error

### DIFF
--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -52,7 +52,6 @@ extension Error: FixableError {
 }
 
 public func handle(error: Any) -> Never {
-
     switch error {
 
     // If we got instance of any error, handle the underlying error.
@@ -66,14 +65,15 @@ public func handle(error: Any) -> Never {
         }
 
     default:
-        handle(error)
+        _handle(error)
     }
 
     // Exit with non zero exit-code.
     exit(1)
 }
 
-private func handle(_ error: Any) {
+// The name has underscore because of SR-4015.
+private func _handle(_ error: Any) {
 
     switch error {
     case ToolsVersionLoader.Error.malformed(let versionSpecifier, _):

--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -59,6 +59,12 @@ public func handle(error: Any) -> Never {
     case let anyError as AnyError:
         handle(error: anyError.underlyingError)
 
+    // Handle each of the error from Errors structure.
+    case let errors as Errors:
+        for error in errors.errors {
+            handle(error: error)
+        }
+
     default:
         handle(error)
     }

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -32,7 +32,8 @@ public class SwiftBuildTool: SwiftTool<BuildToolOptions> {
             // See: <rdar://problem/28108951> SR-2299 Swift isn't using Gold by default on stock 14.04.
             checkClangVersion()
           #endif
-            let graph = try loadPackage()
+
+            let graph = try loadPackageGraph()
             // If we don't have any modules in root package, we're done.
             guard !graph.rootPackages[0].modules.isEmpty else { break }
             try build(graph: graph, includingTests: options.buildTests, config: options.config)

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -82,7 +82,7 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             // Get the current workspace.
             let workspace = try getActiveWorkspace()
             try workspace.loadPackageGraph()
-            let manifests = try workspace.loadDependencyManifests()
+            let manifests = try workspace.loadDependencyManifests(workspace.loadRootManifests())
             // Look for the package's manifest.
             guard let (manifest, dependency) = manifests.lookup(package: packageName) else {
                 throw PackageToolOperationError.packageNotFound
@@ -98,7 +98,7 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             }
             let workspace = try getActiveWorkspace()
             try workspace.loadPackageGraph()
-            let manifests = try workspace.loadDependencyManifests()
+            let manifests = try workspace.loadDependencyManifests(workspace.loadRootManifests())
             // Look for the package's manifest.
             guard let editedDependency = manifests.lookup(package: packageName)?.dependency else {
                 throw PackageToolOperationError.packageNotFound
@@ -186,9 +186,9 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             }
             let workspace = try getActiveWorkspace()
             // Load the package graph.
-            _ = try workspace.loadPackageGraph()
+            try workspace.loadPackageGraph()
             // Load the dependencies.
-            let manifests = try workspace.loadDependencyManifests()
+            let manifests = try workspace.loadDependencyManifests(workspace.loadRootManifests())
             // Lookup the dependency to pin.
             guard let (_, dependency) = manifests.lookup(package: packageName) else {
                 throw PackageToolOperationError.packageNotFound

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -71,17 +71,21 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             // We repin either on explicit repin option or if autopin is enabled.
             let repin = options.repin || workspace.pinsStore.autoPin
             try workspace.updateDependencies(repin: repin)
+
         case .fetch:
-            _ = try loadPackage()
+            try loadPackageGraph()
 
         case .edit:
             // Make sure we have all the options required for editing the package.
             guard let packageName = options.editOptions.packageName, (options.editOptions.revision != nil || options.editOptions.checkoutBranch != nil) else {
                 throw PackageToolOperationError.insufficientOptions(usage: editUsage)
             }
+
+            // Load the package graph.
+            try loadPackageGraph()
+
             // Get the current workspace.
             let workspace = try getActiveWorkspace()
-            try workspace.loadPackageGraph()
             let manifests = try workspace.loadDependencyManifests(workspace.loadRootManifests())
             // Look for the package's manifest.
             guard let (manifest, dependency) = manifests.lookup(package: packageName) else {
@@ -96,8 +100,11 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             guard let packageName = options.editOptions.packageName else {
                 throw PackageToolOperationError.insufficientOptions(usage: uneditUsage)
             }
+
+            // Load the package graph.
+            try loadPackageGraph()
+
             let workspace = try getActiveWorkspace()
-            try workspace.loadPackageGraph()
             let manifests = try workspace.loadDependencyManifests(workspace.loadRootManifests())
             // Look for the package's manifest.
             guard let editedDependency = manifests.lookup(package: packageName)?.dependency else {
@@ -106,7 +113,7 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             try workspace.unedit(dependency: editedDependency, forceRemove: options.editOptions.forceRemove)
 
         case .showDependencies:
-            let graph = try loadPackage()
+            let graph = try loadPackageGraph()
             dumpDependenciesOf(rootPackage: graph.rootPackages[0], mode: options.showDepsMode)
 
         case .toolsVersion:
@@ -134,7 +141,7 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             }
 
         case .generateXcodeproj:
-            let graph = try loadPackage()
+            let graph = try loadPackageGraph()
 
             let projectName: String
             let dstdir: AbsolutePath
@@ -156,7 +163,7 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             print("generated:", outpath.prettyPath)
 
         case .describe:
-            let graph = try loadPackage()
+            let graph = try loadPackageGraph()
             describe(graph.rootPackages[0].underlyingPackage, in: options.describeMode, on: stdoutStream)
 
         case .dumpPackage:
@@ -175,18 +182,19 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
                 let workspace = try getActiveWorkspace()
                 return try workspace.pinsStore.setAutoPin(on: enableAutoPin)
             }
+
+            // Load the package graph.
+            try loadPackageGraph()
+
             // Pin all dependencies if requested.
             if options.pinOptions.pinAll {
-                let workspace = try getActiveWorkspace()
-                return try workspace.pinAll()
+                return try getActiveWorkspace().pinAll()
             }
             // Ensure we have the package name at this point.
             guard let packageName = options.pinOptions.packageName else {
                 throw PackageToolOperationError.insufficientOptions(usage: pinUsage)
             }
             let workspace = try getActiveWorkspace()
-            // Load the package graph.
-            try workspace.loadPackageGraph()
             // Load the dependencies.
             let manifests = try workspace.loadDependencyManifests(workspace.loadRootManifests())
             // Lookup the dependency to pin.
@@ -204,6 +212,7 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
                 at: options.pinOptions.version.flatMap(Version.init(string:)) ?? dependency.currentVersion!,
                 reason: options.pinOptions.message
             )
+
         case .unpin:
             guard let packageName = options.pinOptions.packageName else {
                 fatalError("Expected package name from parser")

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -123,7 +123,7 @@ public class SwiftTestTool: SwiftTool<TestToolOptions> {
     ///
     /// - Returns: The path to the test binary.
     private func buildTestsIfNeeded(_ options: TestToolOptions) throws -> AbsolutePath {
-        let graph = try loadPackage()
+        let graph = try loadPackageGraph()
         if options.buildTests {
             try build(graph: graph, includingTests: true, config: options.config)
         }

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -238,11 +238,16 @@ public class SwiftTool<Options: ToolOptions> {
         fatalError("Must be implmented by subclasses")
     }
 
-    /// Fetch and load the complete package at the given path.
-    func loadPackage() throws -> PackageGraph {
+    /// Fetch and load the complete package graph.
+    @discardableResult
+    func loadPackageGraph() throws -> PackageGraph {
         let workspace = try getActiveWorkspace()
         // Fetch and load the package graph.
-        return try workspace.loadPackageGraph()
+        let graph = workspace.loadPackageGraph()
+        guard graph.errors.isEmpty else {
+            throw Errors(graph.errors)
+        }
+        return graph
     }
 
     /// Returns the user toolchain.

--- a/Sources/PackageGraph/PackageGraph.swift
+++ b/Sources/PackageGraph/PackageGraph.swift
@@ -33,8 +33,12 @@ public struct PackageGraph {
         return rootPackages.flatMap{$0.modules}.contains(module)
     }
 
+    /// The errors encountered while loading the package graph.
+    public let errors: [Swift.Error]
+
     /// Construct a package graph directly.
-    public init(rootPackages: [ResolvedPackage]) {
+    public init(rootPackages: [ResolvedPackage], errors: [Swift.Error] = []) {
+        self.errors = errors
         self.rootPackages = rootPackages
         self.packages = try! topologicalSort(rootPackages, successors: { $0.dependencies })
 

--- a/Sources/TestSupport/misc.swift
+++ b/Sources/TestSupport/misc.swift
@@ -19,6 +19,7 @@ import PackageModel
 import POSIX
 import SourceControl
 import Utility
+import Workspace
 
 #if os(macOS)
 import class Foundation.Bundle
@@ -161,7 +162,7 @@ public func systemQuietly(_ args: String...) throws {
 }
 
 /// Loads a mock package graph based on package packageMap dictionary provided where key is path to a package.
-public func loadMockPackageGraph(_ packageMap: [String: PackageDescription.Package], root: String, in fs: FileSystem) throws -> PackageGraph {
+public func loadMockPackageGraph(_ packageMap: [String: PackageDescription.Package], root: String, in fs: FileSystem) -> PackageGraph {
     var externalManifests = [Manifest]()
     var rootManifest: Manifest!
     for (url, package) in packageMap {
@@ -177,10 +178,10 @@ public func loadMockPackageGraph(_ packageMap: [String: PackageDescription.Packa
             externalManifests.append(manifest)
         }
     }
-    return try PackageGraphLoader().load(rootManifests: [rootManifest], externalManifests: externalManifests, fileSystem: fs)
+    return PackageGraphLoader().load(rootManifests: [rootManifest], externalManifests: externalManifests, fileSystem: fs)
 }
 
-public func loadMockPackageGraph4(_ packageMap: [String: PackageDescription4.Package], root: String, in fs: FileSystem) throws -> PackageGraph {
+public func loadMockPackageGraph4(_ packageMap: [String: PackageDescription4.Package], root: String, in fs: FileSystem) -> PackageGraph {
     var externalManifests = [Manifest]()
     var rootManifest: Manifest!
     for (url, package) in packageMap {
@@ -196,7 +197,7 @@ public func loadMockPackageGraph4(_ packageMap: [String: PackageDescription4.Pac
             externalManifests.append(manifest)
         }
     }
-    return try PackageGraphLoader().load(rootManifests: [rootManifest], externalManifests: externalManifests, fileSystem: fs)
+    return PackageGraphLoader().load(rootManifests: [rootManifest], externalManifests: externalManifests, fileSystem: fs)
 }
 
 /// Temporary override environment variables

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -47,7 +47,7 @@ final class BuildPlanTests: XCTestCase {
                 Target(name: "exe", dependencies: ["lib"]),
             ]
         )
-        let graph = try loadMockPackageGraph(["/Pkg": pkg], root: "/Pkg", in: fs)
+        let graph = loadMockPackageGraph(["/Pkg": pkg], root: "/Pkg", in: fs)
         let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(), graph: graph))
  
         result.checkProductsCount(1)
@@ -71,7 +71,7 @@ final class BuildPlanTests: XCTestCase {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Pkg/Sources/exe/main.swift"
         )
-        let graph = try loadMockPackageGraph(["/Pkg": Package(name: "Pkg")], root: "/Pkg", in: fs)
+        let graph = loadMockPackageGraph(["/Pkg": Package(name: "Pkg")], root: "/Pkg", in: fs)
         let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(config: .release), graph: graph))
 
         result.checkProductsCount(1)
@@ -100,7 +100,7 @@ final class BuildPlanTests: XCTestCase {
                 .Package(url: "/ExtPkg", majorVersion: 1),
             ]
         )
-        let graph = try loadMockPackageGraph(["/Pkg": pkg, "/ExtPkg": Package(name: "ExtPkg")], root: "/Pkg", in: fs)
+        let graph = loadMockPackageGraph(["/Pkg": pkg, "/ExtPkg": Package(name: "ExtPkg")], root: "/Pkg", in: fs)
         let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(), graph: graph, fileSystem: fs))
  
         result.checkProductsCount(1)
@@ -139,7 +139,7 @@ final class BuildPlanTests: XCTestCase {
                 Target(name: "exe", dependencies: ["lib"]),
             ]
         )
-        let graph = try loadMockPackageGraph(["/Pkg": pkg], root: "/Pkg", in: fs)
+        let graph = loadMockPackageGraph(["/Pkg": pkg], root: "/Pkg", in: fs)
         let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(), graph: graph, fileSystem: fs))
         result.checkProductsCount(1)
         result.checkTargetsCount(2)
@@ -164,7 +164,7 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Sources/Foo/foo.swift",
             "/Pkg/Tests/FooTests/foo.swift"
         )
-        let graph = try loadMockPackageGraph(["/Pkg": Package(name: "Pkg")], root: "/Pkg", in: fs)
+        let graph = loadMockPackageGraph(["/Pkg": Package(name: "Pkg")], root: "/Pkg", in: fs)
         let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(), graph: graph, fileSystem: fs))
         result.checkProductsCount(1)
       #if os(macOS)
@@ -198,7 +198,7 @@ final class BuildPlanTests: XCTestCase {
                 .Package(url: "/Clibgit", majorVersion: 1),
             ]
         )
-        let graph = try loadMockPackageGraph(["/Pkg": pkg, "/Clibgit": Package(name: "Clinbgit")], root: "/Pkg", in: fs)
+        let graph = loadMockPackageGraph(["/Pkg": pkg, "/Clibgit": Package(name: "Clinbgit")], root: "/Pkg", in: fs)
         let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(), graph: graph, fileSystem: fs))
         result.checkProductsCount(1)
         result.checkTargetsCount(1)
@@ -219,7 +219,7 @@ final class BuildPlanTests: XCTestCase {
                 Target(name: "exe", dependencies: ["lib"]),
             ]
         )
-        let graph = try loadMockPackageGraph(["/Pkg": pkg], root: "/Pkg", in: fs)
+        let graph = loadMockPackageGraph(["/Pkg": pkg], root: "/Pkg", in: fs)
         let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(), graph: graph, fileSystem: fs))
         result.checkProductsCount(1)
         result.checkTargetsCount(2)
@@ -238,7 +238,7 @@ final class BuildPlanTests: XCTestCase {
             "/Bar/source.swift"
         )
 
-        let g = try loadMockPackageGraph4([
+        let g = loadMockPackageGraph4([
             "/Bar": .init(name: "Bar", products: [.Library(name: "Bar", type: .dynamic, targets: ["Bar"])]),
             "/Foo": .init(
                 name: "Foo",
@@ -286,7 +286,7 @@ final class BuildPlanTests: XCTestCase {
         do {
             foo.compatibleSwiftVersions = nil
             let version = ToolsVersion(version: "4.0.0")
-            let graph = try loadMockPackageGraph(["/Foo": foo, "/Bar": Package(name: "Bar")], root: "/Foo", in: fs)
+            let graph = loadMockPackageGraph(["/Foo": foo, "/Bar": Package(name: "Bar")], root: "/Foo", in: fs)
             let result = BuildPlanResult(plan:
                 try BuildPlan(buildParameters: mockBuildParameters(version), graph: graph, fileSystem: fs))
             result.checkProductsCount(1)
@@ -297,7 +297,7 @@ final class BuildPlanTests: XCTestCase {
         do {
             foo.compatibleSwiftVersions = [3, 4, 5]
             let version = ToolsVersion(version: "4.0.0")
-            let graph = try loadMockPackageGraph(["/Foo": foo, "/Bar": Package(name: "Bar")], root: "/Foo", in: fs)
+            let graph = loadMockPackageGraph(["/Foo": foo, "/Bar": Package(name: "Bar")], root: "/Foo", in: fs)
             let result = BuildPlanResult(plan:
                 try BuildPlan(buildParameters: mockBuildParameters(version), graph: graph, fileSystem: fs))
             result.checkProductsCount(1)
@@ -308,7 +308,7 @@ final class BuildPlanTests: XCTestCase {
         do {
             foo.compatibleSwiftVersions = [3, 5]
             let version = ToolsVersion(version: "4.0.0")
-            let graph = try loadMockPackageGraph(["/Foo": foo, "/Bar": Package(name: "Bar")], root: "/Foo", in: fs)
+            let graph = loadMockPackageGraph(["/Foo": foo, "/Bar": Package(name: "Bar")], root: "/Foo", in: fs)
 
             do {
                 _ = try BuildPlan(buildParameters: mockBuildParameters(version), graph: graph, fileSystem: fs)
@@ -326,7 +326,7 @@ final class BuildPlanTests: XCTestCase {
                 name: "Bar",
                 compatibleSwiftVersions: [3])
             let version = ToolsVersion(version: "4.0.0")
-            let graph = try loadMockPackageGraph(["/Foo": foo, "/Bar": bar], root: "/Foo", in: fs)
+            let graph = loadMockPackageGraph(["/Foo": foo, "/Bar": bar], root: "/Foo", in: fs)
 
             do {
                 _ = try BuildPlan(buildParameters: mockBuildParameters(version), graph: graph, fileSystem: fs)

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -51,8 +51,9 @@ class PackageGraphPerfTests: XCTestCasePerf {
         }
         
         measure {
-            let g = try! PackageGraphLoader().load(rootManifests: rootManifests, externalManifests: externalManifests, fileSystem: fs)
+            let g = PackageGraphLoader().load(rootManifests: rootManifests, externalManifests: externalManifests, fileSystem: fs)
             XCTAssertEqual(g.packages.count, N)
+            XCTAssertTrue(g.packages.isEmpty)
         }
     }
 }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -224,10 +224,11 @@ final class WorkspaceTests: XCTestCase {
             }
 
             // Load the package graph.
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
 
             // Validate the graph has the correct basic structure.
             XCTAssertEqual(graph.packages.count, 2)
+            XCTAssertTrue(graph.errors.isEmpty)
             XCTAssertEqual(graph.packages.map{ $0.name }.sorted(), ["A", "Root"])
         }
     }
@@ -245,7 +246,8 @@ final class WorkspaceTests: XCTestCase {
             fs: fs
         )
         let workspace = try Workspace.createWith(rootPackage: path, manifestLoader: manifestGraph.manifestLoader, delegate: TestWorkspaceDelegate(), fileSystem: fs, repositoryProvider: manifestGraph.repoProvider!)
-        let graph = try workspace.loadPackageGraph()
+        let graph = workspace.loadPackageGraph()
+        XCTAssertTrue(graph.errors.isEmpty)
         XCTAssertEqual(graph.packages.count, 2)
         XCTAssertEqual(graph.packages.map{ $0.name }.sorted(), ["A", "Root"])
     }
@@ -290,7 +292,8 @@ final class WorkspaceTests: XCTestCase {
             }
 
             // Load the package graph.
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
 
             // Test the delegates.
             XCTAssertEqual(delegate.fetched.sorted(), manifestGraph.repos.values.map{$0.url}.sorted())
@@ -349,7 +352,8 @@ final class WorkspaceTests: XCTestCase {
                 XCTAssert(delegate.removed.isEmpty)
 
                 // Load the package graph.
-                let graph = try workspace.loadPackageGraph()
+                let graph = workspace.loadPackageGraph()
+                XCTAssertTrue(graph.errors.isEmpty)
 
                 // Test the delegates.
                 XCTAssert(delegate.fetched.count == 2)
@@ -387,7 +391,8 @@ final class WorkspaceTests: XCTestCase {
                 XCTAssertEqual(delegate.checkedOut[repoPath.asString], "1.0.1")
                 XCTAssertEqual(delegate.removed, [manifestGraph.repo("AA").url])
 
-                let graph = try workspace.loadPackageGraph()
+                let graph = workspace.loadPackageGraph()
+                XCTAssertTrue(graph.errors.isEmpty)
                 XCTAssert(graph.packages.filter{ $0.name == "A" }.first!.version == "1.0.1")
                 XCTAssertEqual(graph.packages.map{ $0.name }.sorted(), ["A", "Root"])
                 XCTAssertEqual(delegate.removed.sorted(), [manifestGraph.repo("AA").url])
@@ -451,7 +456,8 @@ final class WorkspaceTests: XCTestCase {
             // Create the workspace.
             let workspace = try Workspace.createWith(rootPackage: path, manifestLoader: manifestGraph.manifestLoader, delegate: TestWorkspaceDelegate())
             // Load the package graph.
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
             // Sanity checks.
             XCTAssertEqual(graph.packages.count, 2)
             XCTAssertEqual(graph.packages.map{ $0.name }.sorted(), ["A", "Root"])
@@ -526,7 +532,8 @@ final class WorkspaceTests: XCTestCase {
             // Create the workspace.
             let workspace = try Workspace.createWith(rootPackage: path, manifestLoader: manifestGraph.manifestLoader, delegate: TestWorkspaceDelegate())
             // Load the package graph.
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
             let manifests = try workspace.loadDependencyManifests()
             guard let aManifest = manifests.lookup(manifest: "A") else {
                 return XCTFail("Expected manifest for package A not found")
@@ -570,7 +577,8 @@ final class WorkspaceTests: XCTestCase {
             // Create the workspace.
             let workspace = try Workspace.createWith(rootPackage: path, manifestLoader: manifestGraph.manifestLoader, delegate: TestWorkspaceDelegate())
             // Load the package graph.
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
             // Sanity checks.
             XCTAssertEqual(graph.packages.count, 2)
             XCTAssertEqual(graph.packages.map{ $0.name }.sorted(), ["A", "Root"])
@@ -645,7 +653,8 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             let workspace = newWorkspace()
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
             XCTAssert(graph.lookup("A").version == v1)
             try workspace.reset()
         }
@@ -655,7 +664,8 @@ final class WorkspaceTests: XCTestCase {
         // We should still get v1 even though an update is available.
         do {
             let workspace = newWorkspace()
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
             XCTAssert(graph.lookup("A").version == v1)
             try workspace.reset()
         }
@@ -664,7 +674,8 @@ final class WorkspaceTests: XCTestCase {
         do {
             let workspace = newWorkspace()
             try workspace.updateDependencies()
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
             XCTAssert(graph.lookup("A").version == v1)
         }
 
@@ -672,7 +683,8 @@ final class WorkspaceTests: XCTestCase {
         do {
             let workspace = newWorkspace()
             try workspace.updateDependencies(repin: true)
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
             XCTAssert(graph.lookup("A").version == "1.0.1")
             XCTAssert(graph.lookup("AA").version == v1)
             // We should have pin for AA automatically.
@@ -692,13 +704,14 @@ final class WorkspaceTests: XCTestCase {
         // Pin at A at v1.
         do {
             let workspace = newWorkspace()
-            _ = try workspace.loadPackageGraph()
+            _ = workspace.loadPackageGraph()
             let manifests = try workspace.loadDependencyManifests()
             guard let (_, dep) = manifests.lookup(package: "A") else {
                 return XCTFail("Expected manifest for package A not found")
             }
             try workspace.pin(dependency: dep, packageName: "A", at: v1)
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
             XCTAssert(graph.lookup("A").version == v1)
         }
 
@@ -706,7 +719,8 @@ final class WorkspaceTests: XCTestCase {
         do {
             let workspace = newWorkspace()
             try workspace.updateDependencies(repin: true)
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
             XCTAssert(graph.lookup("A").version == "1.0.1")
             XCTAssert(graph.lookup("AA").version == v1)
             XCTAssertNotNil(workspace.pinsStore.pinsMap["A"])
@@ -765,7 +779,8 @@ final class WorkspaceTests: XCTestCase {
         // Package graph should load 1.0.1.
         do {
             let workspace = newWorkspace()
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
             XCTAssert(graph.lookup("A").version == "1.0.1")
         }
 
@@ -775,7 +790,8 @@ final class WorkspaceTests: XCTestCase {
         // Package graph should load v1.
         do {
             let workspace = newWorkspace()
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
             XCTAssert(graph.lookup("A").version == "1.0.0")
         }
 
@@ -789,7 +805,8 @@ final class WorkspaceTests: XCTestCase {
         // Package graph should load 1.0.1.
         do {
             let workspace = newWorkspace()
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
             XCTAssert(graph.lookup("A").version == "1.0.1")
         }
 
@@ -800,7 +817,8 @@ final class WorkspaceTests: XCTestCase {
         do {
             let workspace = newWorkspace()
             try workspace.updateDependencies()
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
             XCTAssert(graph.lookup("A").version == "1.0.0")
         }
 
@@ -808,7 +826,8 @@ final class WorkspaceTests: XCTestCase {
         do {
             let workspace = newWorkspace()
             try workspace.updateDependencies(repin: true)
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
             XCTAssert(graph.lookup("A").version == "1.0.1")
         }
     }
@@ -843,7 +862,8 @@ final class WorkspaceTests: XCTestCase {
         // Package graph should load v1.
         do {
             let workspace = newWorkspace()
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
             XCTAssert(graph.lookup("A").version == v1)
             XCTAssert(graph.lookup("B").version == v1)
         }
@@ -863,7 +883,8 @@ final class WorkspaceTests: XCTestCase {
         // Loading the workspace now should load v1 of both dependencies.
         do {
             let workspace = newWorkspace()
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
             XCTAssert(graph.lookup("A").version == v1)
             XCTAssert(graph.lookup("B").version == v1)
         }
@@ -872,7 +893,8 @@ final class WorkspaceTests: XCTestCase {
         do {
             let workspace = newWorkspace()
             try workspace.updateDependencies()
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
             XCTAssert(graph.lookup("A").version == v1)
             XCTAssert(graph.lookup("B").version == v1)
         }
@@ -888,7 +910,8 @@ final class WorkspaceTests: XCTestCase {
         // Loading the workspace now should load 1.0.1 of both dependencies.
         do {
             let workspace = newWorkspace()
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
             XCTAssert(graph.lookup("A").version == "1.0.1")
             XCTAssert(graph.lookup("B").version == "1.0.1")
         }
@@ -924,7 +947,8 @@ final class WorkspaceTests: XCTestCase {
         // Load and pin the dependencies.
         do {
             let workspace = newWorkspace()
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
             XCTAssert(graph.lookup("A").version == v1)
             XCTAssert(graph.lookup("B").version == v1)
             try workspace.pinAll()
@@ -939,7 +963,8 @@ final class WorkspaceTests: XCTestCase {
         do {
             let workspace = newWorkspace()
             try workspace.updateDependencies(repin: true)
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
             XCTAssert(graph.lookup("A").version == "1.0.1")
             XCTAssert(graph.lookup("B").version == "1.0.1")
         }
@@ -987,7 +1012,7 @@ final class WorkspaceTests: XCTestCase {
         // Pinning at v1 should work.
         do {
             let workspace = newWorkspace()
-            _ = try workspace.loadPackageGraph()
+            _ = workspace.loadPackageGraph()
             try pin(at: v1)
             try workspace.reset()
         }
@@ -997,7 +1022,8 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             let workspace = newWorkspace()
-            let graph = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
             XCTAssert(graph.lookup("A").version == v1)
             // Pinning non existant version should fail.
             XCTAssertThrows(DependencyResolverError.unsatisfiable) {
@@ -1045,13 +1071,10 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // We should not be able to load package graph.
-        XCTAssertThrows(DependencyResolverError.unsatisfiable) {
-            _ = try newWorkspace().loadPackageGraph()
-        }
-
-        // We should not be able to pin all.
-        XCTAssertThrows(DependencyResolverError.unsatisfiable) {
-            _ = try newWorkspace().pinAll()
+        do {
+            let graph = newWorkspace().loadPackageGraph()
+            XCTAssertEqual(graph.errors.count, 1)
+            // DependencyResolverError.unsatisfiable
         }
     }
 
@@ -1086,7 +1109,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             let workspace = newWorkspace()
             try workspace.pinsStore.setAutoPin(on: false)
-            _ = try workspace.loadPackageGraph()
+            _ = workspace.loadPackageGraph()
             let manifests = try workspace.loadDependencyManifests()
             guard let (_, dep) = manifests.lookup(package: "B") else {
                 return XCTFail("Expected manifest for package B not found")
@@ -1099,7 +1122,8 @@ final class WorkspaceTests: XCTestCase {
         do {
             let workspace = newWorkspace()
             try workspace.updateDependencies(repin: true)
-            let g = try workspace.loadPackageGraph()
+            let g = workspace.loadPackageGraph()
+            XCTAssertTrue(g.errors.isEmpty)
             XCTAssert(g.lookup("A").version == v1)
             XCTAssert(g.lookup("B").version == v1)
             try workspace.reset()
@@ -1109,7 +1133,8 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             let workspace = newWorkspace()
-            let g = try workspace.loadPackageGraph()
+            let g = workspace.loadPackageGraph()
+            XCTAssertTrue(g.errors.isEmpty)
             XCTAssert(g.lookup("A").version == "1.0.1")
             // FIXME: We also cloned B because it has a pin.
             XCTAssertNotNil(workspace.dependencyMap[manifestGraph.repo("B")])
@@ -1120,7 +1145,8 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertTrue(delegate.warnings.isEmpty)
             try workspace.updateDependencies(repin: true)
             XCTAssertEqual(delegate.warnings, ["Consider unpinning B, it is pinned at 1.0.0 but the dependency is not present."])
-            let g = try workspace.loadPackageGraph()
+            let g = workspace.loadPackageGraph()
+            XCTAssertTrue(g.errors.isEmpty)
             XCTAssert(g.lookup("A").version == "1.0.1")
             // This dependency should be removed on updating dependencies because it is not referenced anywhere.
             XCTAssertNil(workspace.dependencyMap[manifestGraph.repo("B")])
@@ -1222,10 +1248,8 @@ final class WorkspaceTests: XCTestCase {
 
             do {
                 let workspace = try createWorkspace()
-                _ = try workspace.loadPackageGraph()
-                XCTFail("unexpected success")
-            } catch let errors as Errors {
-                switch errors.errors[0] {
+                let graph = workspace.loadPackageGraph()
+                switch graph.errors[0] {
                 case WorkspaceOperationError.noRegisteredPackages: break
                 default: XCTFail()
                 }
@@ -1247,7 +1271,8 @@ final class WorkspaceTests: XCTestCase {
                 for root in roots[0..<2] {
                     workspace.registerPackage(at: root)
                 }
-                let graph = try workspace.loadPackageGraph()
+                let graph = workspace.loadPackageGraph()
+                XCTAssertTrue(graph.errors.isEmpty)
                 XCTAssertEqual(graph.packages.map{ $0.name }.sorted(), ["A", "B", "C", "root1", "root2"])
                 XCTAssertEqual(graph.rootPackages.map{ $0.name }.sorted(), ["root1", "root2"])
                 XCTAssertEqual(graph.lookup("A").version, "1.5.0")
@@ -1267,7 +1292,8 @@ final class WorkspaceTests: XCTestCase {
                 for root in roots {
                     workspace.registerPackage(at: root)
                 }
-                let graph = try workspace.loadPackageGraph()
+                let graph = workspace.loadPackageGraph()
+                XCTAssertTrue(graph.errors.isEmpty)
                 XCTAssertEqual(graph.packages.map{ $0.name }.sorted(), ["A", "B", "C", "D", "root1", "root2", "root3"])
                 XCTAssertEqual(graph.rootPackages.map{ $0.name }.sorted(), ["root1", "root2", "root3"])
                 XCTAssertEqual(graph.lookup("A").version, v1)
@@ -1277,7 +1303,8 @@ final class WorkspaceTests: XCTestCase {
 
                 // Remove one of the packages.
                 try workspace.unregisterPackage(at: roots[2])
-                let newGraph = try workspace.loadPackageGraph()
+                let newGraph = workspace.loadPackageGraph()
+                XCTAssertTrue(newGraph.errors.isEmpty)
                 XCTAssertEqual(newGraph.packages.map{ $0.name }.sorted(), ["A", "B", "C", "root1", "root2"])
                 XCTAssertEqual(newGraph.rootPackages.map{ $0.name }.sorted(), ["root1", "root2"])
                 XCTAssertEqual(newGraph.lookup("A").version, "1.5.0")
@@ -1299,7 +1326,7 @@ final class WorkspaceTests: XCTestCase {
 
             let delegate = TestWorkspaceDelegate()
             let workspace = try Workspace.createWith(rootPackage: path, manifestLoader: manifestGraph.manifestLoader, delegate: delegate)
-            let _ = try workspace.loadPackageGraph()
+            workspace.loadPackageGraph()
 
             // Put A in edit mode.
             let aManifest = try workspace.loadDependencyManifests().lookup(manifest: "A")!
@@ -1313,7 +1340,7 @@ final class WorkspaceTests: XCTestCase {
             // Remove edited checkout.
             try removeFileTree(workspace.editablesPath)
             delegate.warnings.removeAll()
-            let _ = try workspace.loadPackageGraph()
+            workspace.loadPackageGraph()
             XCTAssertTrue(delegate.warnings[0].hasSuffix("A was being edited but has been removed, falling back to original checkout."))
         }
     }
@@ -1340,7 +1367,7 @@ final class WorkspaceTests: XCTestCase {
 
             do {
                 let workspace = try createWorkspace()
-                _ = try workspace.loadPackageGraph()
+                workspace.loadPackageGraph()
                 let manifests = try workspace.loadDependencyManifests()
 
                 let bDependency = manifests.lookup(package: "B")!.dependency
@@ -1417,10 +1444,9 @@ final class WorkspaceTests: XCTestCase {
         // We should be able to load when no there is no swift-tools-version defined.
         do {
             let workspace = try createWorkspace(ToolsVersion(version: "3.1.0"))
-            _ = try workspace.loadPackageGraph()
-        } catch {
-            print(error)
-        }
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
+        } 
 
         // Limit root0 to 3.1.0
         try fs.writeFileContents(swiftVersion(for: roots[0]), bytes: "// swift-tools-version:3.1")
@@ -1428,7 +1454,8 @@ final class WorkspaceTests: XCTestCase {
         // Test one root package having swift-version.
         do {
             let workspace = try createWorkspace(ToolsVersion(version: "4.0.0"))
-            _ = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
         }
 
         // Limit root1 to 4.0.0
@@ -1437,16 +1464,16 @@ final class WorkspaceTests: XCTestCase {
         // Test both having swift-version but different.
         do {
             let workspace = try createWorkspace(ToolsVersion(version: "4.0.0"))
-            _ = try workspace.loadPackageGraph()
+            let graph = workspace.loadPackageGraph()
+            XCTAssertTrue(graph.errors.isEmpty)
         }
 
         // Failing case.
         do {
             let workspace = try createWorkspace(ToolsVersion(version: "3.1.0"))
-            _ = try workspace.loadPackageGraph()
-            XCTFail()
-        } catch let errors as Errors {
-            switch errors.errors[0] {
+            let graph = workspace.loadPackageGraph()
+
+            switch graph.errors[0] {
             case WorkspaceOperationError.incompatibleToolsVersion(let rootPackage, let required, let current):
                 XCTAssertEqual(rootPackage, roots[1])
                 XCTAssertEqual(required.description, "4.0.0")

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -23,7 +23,8 @@ class GenerateXcodeprojTests: XCTestCase {
         mktmpdir { dstdir in
             let fileSystem = InMemoryFileSystem(emptyFiles: "/Sources/DummyModuleName/source.swift")
 
-            let graph = try loadMockPackageGraph(["/": Package(name: "Foo")], root: "/", in: fileSystem)
+            let graph = loadMockPackageGraph(["/": Package(name: "Foo")], root: "/", in: fileSystem)
+            XCTAssertTrue(graph.errors.isEmpty)
 
             let projectName = "DummyProjectName"
             let outpath = try Xcodeproj.generate(outputDir: dstdir, projectName: projectName, graph: graph, options: XcodeprojOptions())
@@ -47,7 +48,7 @@ class GenerateXcodeprojTests: XCTestCase {
 
     func testXcconfigOverrideValidatesPath() throws {
         let fileSystem = InMemoryFileSystem(emptyFiles: "/Bar/bar.swift")
-        let graph = try loadMockPackageGraph(["/Bar": Package(name: "Bar")], root: "/Bar", in: fileSystem)
+        let graph = loadMockPackageGraph(["/Bar": Package(name: "Bar")], root: "/Bar", in: fileSystem)
 
         let options = XcodeprojOptions(xcconfigOverrides: AbsolutePath("/doesntexist"))
         do {
@@ -65,7 +66,7 @@ class GenerateXcodeprojTests: XCTestCase {
         let moduleName = "Modules"
         let warningStream = BufferedOutputByteStream()
         let fileSystem = InMemoryFileSystem(emptyFiles: "/Sources/\(moduleName)/example.swift")
-        let graph = try loadMockPackageGraph(["/Sources": Package(name: moduleName)], root: "/Sources", in: fileSystem)
+        let graph = loadMockPackageGraph(["/Sources": Package(name: moduleName)], root: "/Sources", in: fileSystem)
 
         _ = try xcodeProject(xcodeprojPath: AbsolutePath.root.appending(component: "xcodeproj"),
                              graph: graph, extraDirs: [], options: XcodeprojOptions(), fileSystem: fileSystem,

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -31,7 +31,7 @@ class PackageGraphTests: XCTestCase {
           "/Overrides.xcconfig"
       )
 
-        let g = try loadMockPackageGraph([
+        let g = loadMockPackageGraph([
             "/Foo": Package(name: "Foo"),
             "/Bar": Package(name: "Bar", dependencies: [.Package(url: "/Foo", majorVersion: 1)]),
         ], root: "/Bar", in: fs)
@@ -120,7 +120,7 @@ class PackageGraphTests: XCTestCase {
           "/Bar/Sources/Sea2/Sea2.c",
           "/Bar/Sources/swift/main.swift"
       )
-      let g = try loadMockPackageGraph([
+      let g = loadMockPackageGraph([
           "/Bar": Package(name: "Bar", targets: [Target(name: "swift", dependencies: ["Sea", "Sea2"])]),
       ], root: "/Bar", in: fs)
       let project = try xcodeProject(xcodeprojPath: AbsolutePath("/Bar/build").appending(component: "xcodeproj"), graph: g, extraDirs: [], options: XcodeprojOptions(), fileSystem: fs)
@@ -152,7 +152,7 @@ class PackageGraphTests: XCTestCase {
             "/Pkg/Tests/LibraryTests/aTest.swift"
         )
         
-        let g = try loadMockPackageGraph([
+        let g = loadMockPackageGraph([
             "/Pkg": Package(name: "Pkg", targets: [Target(name: "LibraryTests", dependencies: ["Library", "HelperTool"])]),
             ], root: "/Pkg", in: fs)
         


### PR DESCRIPTION
This will continue loading all root manifests even if one of them fail
to load.