### PR TITLE
Init package refactor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -84,7 +84,7 @@ let package = Package(
         Target(
             /** High level functionality */
             name: "Workspace",
-            dependencies: ["Basic", "Build", "PackageGraph", "SourceControl", "Xcodeproj"]),
+            dependencies: ["Basic", "Build", "PackageGraph", "PackageModel", "SourceControl", "Xcodeproj"]),
 
         // MARK: Commands
         

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -15,6 +15,7 @@ import PackageLoading
 import SourceControl
 import Utility
 import Xcodeproj
+import Workspace
 
 /// Errors encountered duing the package tool operations.
 enum PackageToolOperationError: Swift.Error {
@@ -45,7 +46,10 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             print(Versioning.currentVersion.completeDisplayString)
 
         case .initPackage:
-            let initPackage = try InitPackage(mode: options.initMode)
+            let initPackage = try InitPackage(destinationPath: currentWorkingDirectory, packageType: options.initMode)
+            initPackage.progressReporter = { message in
+                print(message)
+            }
             try initPackage.writePackageStructure()
 
         case .clean:
@@ -281,7 +285,7 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
         let initPackageParser = parser.add(subparser: PackageMode.initPackage.rawValue, overview: "Initialize a new package")
         binder.bind(
             option: initPackageParser.add(
-                option: "--type", kind: InitMode.self,
+                option: "--type", kind: InitPackage.PackageType.self,
                 usage: "empty|library|executable|system-module"),
             to: { $0.initMode = $1 })
 
@@ -382,7 +386,7 @@ public class PackageToolOptions: ToolOptions {
     var mode: PackageMode = .help
 
     var describeMode: DescribeMode = .text
-    var initMode: InitMode = .library
+    var initMode: InitPackage.PackageType = .library
 
     var inputPath: AbsolutePath?
     var showDepsMode: ShowDependenciesMode = .text
@@ -445,6 +449,6 @@ public enum PackageMode: String, StringEnumArgument {
     case help
 }
 
-extension InitMode: StringEnumArgument {}
+extension InitPackage.PackageType: StringEnumArgument {}
 extension ShowDependenciesMode: StringEnumArgument {}
 extension DescribeMode: StringEnumArgument {}

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -1,68 +1,64 @@
 /*
  This source file is part of the Swift.org open source project
-
+ 
  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
-
+ 
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import Basic
 import PackageModel
 
-private extension FileSystem {
-    /// Write to a file from a stream producer.
-    mutating func writeFileContents(_ path: AbsolutePath, body: (OutputByteStream) -> ()) throws {
-        let contents = BufferedOutputByteStream()
-        body(contents)
-        try createDirectory(path.parentDirectory, recursive: true)
-        try writeFileContents(path, bytes: contents.bytes)
-    }
-}
-
-private enum InitError: Swift.Error {
-    case manifestAlreadyExists
-}
-
-extension InitError: CustomStringConvertible {
-    var description: String {
-        switch self {
-        case .manifestAlreadyExists:
-            return "a manifest file already exists in this directory"
+/// Create an initial template package.
+public final class InitPackage {
+    /// Represents a package type for the purposes of initialization.
+    public enum PackageType: String, CustomStringConvertible {
+        case empty = "empty"
+        case library = "library"
+        case executable = "executable"
+        case systemModule = "system-module"
+        
+        public var description: String {
+            return rawValue
         }
     }
-}
-
-/// Create an initial template package.
-final class InitPackage {
-    let rootd = currentWorkingDirectory
-
-    /// The mode in use.
-    let mode: InitMode
-
-    /// The name of the example package to create.
+    
+    /// A block that will be called to report progress during package creation
+    public var progressReporter: ((String) -> Void)?
+    
+    /// Where to crerate the new package
+    let destinationPath: AbsolutePath
+    
+    /// The type of package to create.
+    let packageType: PackageType
+    
+    /// The name of the package to create.
     let pkgname: String
-
-    /// The name of the example module to create.
+    
+    /// The name of the module to create.
     var moduleName: String
-
-    /// The name of the example type to create (within the package).
+    
+    /// The name of the type to create (within the package).
     var typeName: String {
         return moduleName
     }
     
-    init(mode: InitMode) throws {
-        self.mode = mode
-        let dirname = rootd.basename
+    /// Create an instance that can create a package of the given packageType at the given destinationPath
+    public init(destinationPath: AbsolutePath, packageType: PackageType) throws {
+        self.packageType = packageType
+        self.destinationPath = destinationPath
+        let dirname = destinationPath.basename
         assert(!dirname.isEmpty)  // a base name is never empty
         self.pkgname = dirname
         self.moduleName = dirname.mangledToC99ExtendedIdentifier()
     }
-    
-    func writePackageStructure() throws {
-        print("Creating \(mode) package: \(pkgname)")
 
+    /// Actually creates the new package at the destinationPath
+    public func writePackageStructure() throws {
+        progressReporter?("Creating \(packageType) package: \(pkgname)")
+        
         // FIXME: We should form everything we want to write, then validate that
         // none of it exists, and then act.
         try writeManifestFile()
@@ -71,18 +67,18 @@ final class InitPackage {
         try writeModuleMap()
         try writeTests()
     }
-
+    
     private func writePackageFile(_ path: AbsolutePath, body: (OutputByteStream) -> ()) throws {
-        print("Creating \(path.relative(to: rootd).asString)")
+        progressReporter?("Creating \(path.relative(to: destinationPath).asString)")
         try localFileSystem.writeFileContents(path, body: body)
     }
     
     private func writeManifestFile() throws {
-        let manifest = rootd.appending(component: Manifest.filename)
+        let manifest = destinationPath.appending(component: Manifest.filename)
         guard exists(manifest) == false else {
             throw InitError.manifestAlreadyExists
         }
-
+        
         try writePackageFile(manifest) { stream in
             stream <<< "\nimport PackageDescription\n"
             stream <<< "\n"
@@ -90,23 +86,23 @@ final class InitPackage {
             stream <<< "    name: \"\(pkgname)\"\n"
             stream <<< ")\n"
         }
-
+        
         // Create a tools version with current version but with patch set to zero.
         // We do this to avoid adding unnecessary constraints to patch versions, if
         // the package really needs it, they should add it manually.
         let version = ToolsVersion.currentToolsVersion.zeroedPatch
-
+        
         // Write the current tools version.
         try writeToolsVersion(
             at: manifest.parentDirectory, version: version, fs: &localFileSystem)
     }
     
     private func writeGitIgnore() throws {
-        let gitignore = rootd.appending(component: ".gitignore")
+        let gitignore = destinationPath.appending(component: ".gitignore")
         guard exists(gitignore) == false else {
             return
-        } 
-    
+        }
+        
         try writePackageFile(gitignore) { stream in
             stream <<< ".DS_Store\n"
             stream <<< "/.build\n"
@@ -116,25 +112,25 @@ final class InitPackage {
     }
     
     private func writeSources() throws {
-        if mode == .systemModule {
+        if packageType == .systemModule {
             return
         }
-        let sources = rootd.appending(component: "Sources")
+        let sources = destinationPath.appending(component: "Sources")
         guard exists(sources) == false else {
             return
         }
-        print("Creating \(sources.relative(to: rootd).asString)/")
+        progressReporter?("Creating \(sources.relative(to: destinationPath).asString)/")
         try makeDirectories(sources)
-
-        if mode == .empty {
+        
+        if packageType == .empty {
             return
         }
-
-        let sourceFileName = (mode == .executable) ? "main.swift" : "\(typeName).swift"
+        
+        let sourceFileName = (packageType == .executable) ? "main.swift" : "\(typeName).swift"
         let sourceFile = sources.appending(RelativePath(sourceFileName))
-
+        
         try writePackageFile(sourceFile) { stream in
-            switch mode {
+            switch packageType {
             case .library:
                 stream <<< "struct \(typeName) {\n\n"
                 stream <<< "    var text = \"Hello, World!\"\n"
@@ -148,10 +144,10 @@ final class InitPackage {
     }
     
     private func writeModuleMap() throws {
-        if mode != .systemModule {
+        if packageType != .systemModule {
             return
         }
-        let modulemap = rootd.appending(component: "module.modulemap")
+        let modulemap = destinationPath.appending(component: "module.modulemap")
         guard exists(modulemap) == false else {
             return
         }
@@ -166,18 +162,18 @@ final class InitPackage {
     }
     
     private func writeTests() throws {
-        if mode == .systemModule {
+        if packageType == .systemModule {
             return
         }
-        let tests = rootd.appending(component: "Tests")
+        let tests = destinationPath.appending(component: "Tests")
         guard exists(tests) == false else {
             return
         }
-        print("Creating \(tests.relative(to: rootd).asString)/")
+        progressReporter?("Creating \(tests.relative(to: destinationPath).asString)/")
         try makeDirectories(tests)
-
+        
         // Only libraries are testable for now.
-        if mode == .library {
+        if packageType == .library {
             try writeLinuxMain(testsPath: tests)
             try writeTestFileStubs(testsPath: tests)
         }
@@ -195,7 +191,7 @@ final class InitPackage {
     
     private func writeTestFileStubs(testsPath: AbsolutePath) throws {
         let testModule = testsPath.appending(RelativePath(pkgname + Module.testModuleNameSuffix))
-        print("Creating \(testModule.relative(to: rootd).asString)/")
+        progressReporter?("Creating \(testModule.relative(to: destinationPath).asString)/")
         try makeDirectories(testModule)
         
         try writePackageFile(testModule.appending(RelativePath("\(moduleName)Tests.swift"))) { stream in
@@ -216,33 +212,30 @@ final class InitPackage {
             stream <<< "}\n"
         }
     }
+
 }
 
-/// Represents a package type for the purposes of initialization.
-enum InitMode: CustomStringConvertible {
-    case empty, library, executable, systemModule
+// Private helpers
 
-    init?(rawValue: String) {
-        switch rawValue.lowercased() {
-        case "empty":
-            self = .empty
-        case "library":
-            self = .library
-        case "executable":
-            self = .executable
-        case "system-module":
-            self = .systemModule
-        default:
-            return nil
-        }
+private extension FileSystem {
+    /// Write to a file from a stream producer.
+    mutating func writeFileContents(_ path: AbsolutePath, body: (OutputByteStream) -> ()) throws {
+        let contents = BufferedOutputByteStream()
+        body(contents)
+        try createDirectory(path.parentDirectory, recursive: true)
+        try writeFileContents(path, bytes: contents.bytes)
     }
+}
 
+private enum InitError: Swift.Error {
+    case manifestAlreadyExists
+}
+
+extension InitError: CustomStringConvertible {
     var description: String {
         switch self {
-            case .empty: return "empty"
-            case .library: return "library"
-            case .executable: return "executable"
-            case .systemModule: return "system-module"
+        case .manifestAlreadyExists:
+            return "a manifest file already exists in this directory"
         }
     }
 }

--- a/Sources/Workspace/ToolsVersionWriter.swift
+++ b/Sources/Workspace/ToolsVersionWriter.swift
@@ -39,10 +39,10 @@ public func writeToolsVersion(at path: AbsolutePath, version: ToolsVersion, fs: 
     try fs.writeFileContents(file, bytes: stream.bytes)
 }
 
-extension ToolsVersion {
+public extension ToolsVersion {
 
     /// Returns the tools version with zeroed patch number.
-    var zeroedPatch: ToolsVersion {
+    public var zeroedPatch: ToolsVersion {
         return ToolsVersion(version: Version(major, minor, 0))
     }
 }

--- a/Tests/CommandsTests/XCTestManifests.swift
+++ b/Tests/CommandsTests/XCTestManifests.swift
@@ -16,7 +16,6 @@ public func allTests() -> [XCTestCaseEntry] {
         testCase(BuildToolTests.allTests),
         testCase(PackageToolTests.allTests),
         testCase(TestToolTests.allTests),
-        testCase(ToolsVersionWriterTests.allTests),
         testCase(UserToolchainTests.allTests),
     ]
 }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -346,22 +346,6 @@ class MiscellaneousTestCase: XCTestCase {
         }
     }
 
-    func testInitPackageNonc99Directory() throws {
-        let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
-        XCTAssertTrue(localFileSystem.isDirectory(tempDir.path))
-
-        // Create a directory with non c99name.
-        let packageRoot = tempDir.path.appending(component: "some-package")
-        try localFileSystem.createDirectory(packageRoot)
-        XCTAssertTrue(localFileSystem.isDirectory(packageRoot))
-
-        // Run package init.
-        _ = try SwiftPMProduct.SwiftPackage.execute(["init"], chdir: packageRoot, printIfError: true)
-        // Try building it.
-        XCTAssertBuilds(packageRoot)
-        XCTAssertFileExists(packageRoot.appending(components: ".build", "debug", "some_package.swiftmodule"))
-    }
-
     func testSecondBuildIsNullInModulemapGen() throws {
         // Make sure that swiftpm doesn't rebuild second time if the modulemap is being generated.
         fixture(name: "ClangModules/SwiftCMixed") { prefix in
@@ -531,7 +515,6 @@ class MiscellaneousTestCase: XCTestCase {
         ("testSpaces", testSpaces),
         ("testSecondBuildIsNullInModulemapGen", testSecondBuildIsNullInModulemapGen),
         ("testSwiftTestParallel", testSwiftTestParallel),
-        ("testInitPackageNonc99Directory", testInitPackageNonc99Directory),
         ("testOverridingSwiftcArguments", testOverridingSwiftcArguments),
         ("testPkgConfigClangModules", testPkgConfigClangModules),
         ("testCanKillSubprocessOnSigInt", testCanKillSubprocessOnSigInt),

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -1,0 +1,163 @@
+/*
+ This source file is part of the Swift.org open source project
+ 
+ Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+ 
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import XCTest
+import TestSupport
+import Basic
+import PackageModel
+import Workspace
+
+class InitTests: XCTestCase {
+
+    // MARK: Basic package creation for each package type.
+    
+    func testInitPackageEmpty() throws {
+        mktmpdir { tmpPath in
+            var fs = localFileSystem
+            let path = tmpPath.appending(component: "Foo")
+            try fs.createDirectory(path)
+            
+            // Create the package
+            let initPackage = try InitPackage(destinationPath: path, packageType: InitPackage.PackageType.empty)
+            var progressMessages = [String]()
+            initPackage.progressReporter = { message in
+                progressMessages.append(message)
+            }
+            try initPackage.writePackageStructure()
+
+            // Not picky about the specific progress messages, just checking that we got some.
+            XCTAssert(progressMessages.count > 0)
+
+            // Verify basic file system content that we expect in the package
+            XCTAssert(fs.exists(path.appending(component: "Package.swift")))
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources")), [])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Tests")), [])
+        }
+    }
+    
+    func testInitPackageExecutable() throws {
+        mktmpdir { tmpPath in
+            var fs = localFileSystem
+            let path = tmpPath.appending(component: "Foo")
+            try fs.createDirectory(path)
+
+            // Create the package
+            let initPackage = try InitPackage(destinationPath: path, packageType: InitPackage.PackageType.executable)
+            var progressMessages = [String]()
+            initPackage.progressReporter = { message in
+                progressMessages.append(message)
+            }
+            try initPackage.writePackageStructure()
+
+            // Not picky about the specific progress messages, just checking that we got some.
+            XCTAssert(progressMessages.count > 0)
+
+            
+            // Verify basic file system content that we expect in the package
+            let manifest = path.appending(component: "Package.swift")
+            let contents = try localFileSystem.readFileContents(manifest).asString!
+            let version = "\(ToolsVersion.currentToolsVersion.major).\(ToolsVersion.currentToolsVersion.minor)"
+            XCTAssertTrue(contents.hasPrefix("// swift-tools-version:\(version)\n"))
+            
+            XCTAssertTrue(fs.exists(manifest))
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources")), ["main.swift"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Tests")), [])
+            
+            // Try building it
+            XCTAssertBuilds(path)
+            XCTAssertFileExists(path.appending(components: ".build", "debug", "Foo"))
+            XCTAssertFileExists(path.appending(components: ".build", "debug", "Foo.swiftmodule"))
+        }
+    }
+
+    func testInitPackageLibrary() throws {
+        mktmpdir { tmpPath in
+            var fs = localFileSystem
+            let path = tmpPath.appending(component: "Foo")
+            try fs.createDirectory(path)
+
+            // Create the package
+            let initPackage = try InitPackage(destinationPath: path, packageType: InitPackage.PackageType.library)
+            var progressMessages = [String]()
+            initPackage.progressReporter = { message in
+                progressMessages.append(message)
+            }
+            try initPackage.writePackageStructure()
+
+            // Not picky about the specific progress messages, just checking that we got some.
+            XCTAssert(progressMessages.count > 0)
+
+            // Verify basic file system content that we expect in the package
+            XCTAssert(fs.exists(path.appending(component: "Package.swift")))
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources")), ["Foo.swift"])
+            XCTAssertEqual(
+                try fs.getDirectoryContents(path.appending(component: "Tests")).sorted(),
+                ["FooTests", "LinuxMain.swift"])
+
+            // Try building it
+            XCTAssertBuilds(path)
+            XCTAssertFileExists(path.appending(components: ".build", "debug", "Foo.swiftmodule"))
+        }
+    }
+    
+    func testInitPackageSystemModule() throws {
+        mktmpdir { tmpPath in
+            var fs = localFileSystem
+            let path = tmpPath.appending(component: "Foo")
+            try fs.createDirectory(path)
+            
+            // Create the package
+            let initPackage = try InitPackage(destinationPath: path, packageType: InitPackage.PackageType.systemModule)
+            var progressMessages = [String]()
+            initPackage.progressReporter = { message in
+                progressMessages.append(message)
+            }
+            try initPackage.writePackageStructure()
+            
+            // Not picky about the specific progress messages, just checking that we got some.
+            XCTAssert(progressMessages.count > 0)
+
+            // Verify basic file system content that we expect in the package
+            XCTAssert(fs.exists(path.appending(component: "Package.swift")))
+            XCTAssert(fs.exists(path.appending(component: "module.modulemap")))
+        }
+    }
+    
+    // MARK: Special case testing
+    
+    func testInitPackageNonc99Directory() throws {
+        let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
+        XCTAssertTrue(localFileSystem.isDirectory(tempDir.path))
+        
+        // Create a directory with non c99name.
+        let packageRoot = tempDir.path.appending(component: "some-package")
+        try localFileSystem.createDirectory(packageRoot)
+        XCTAssertTrue(localFileSystem.isDirectory(packageRoot))
+        
+        // Create the package
+        let initPackage = try InitPackage(destinationPath: packageRoot, packageType: InitPackage.PackageType.library)
+        initPackage.progressReporter = { message in
+        }
+        try initPackage.writePackageStructure()
+
+        // Try building it.
+        XCTAssertBuilds(packageRoot)
+        XCTAssertFileExists(packageRoot.appending(components: ".build", "debug", "some_package.swiftmodule"))
+    }
+    
+    static var allTests = [
+        ("testInitPackageEmpty", testInitPackageEmpty),
+        ("testInitPackageExecutable", testInitPackageExecutable),
+        ("testInitPackageLibrary", testInitPackageLibrary),
+        ("testInitPackageSystemModule", testInitPackageSystemModule),
+        ("testInitPackageNonc99Directory", testInitPackageNonc99Directory),
+    ]
+
+}

--- a/Tests/WorkspaceTests/ToolsVersionWriterTests.swift
+++ b/Tests/WorkspaceTests/ToolsVersionWriterTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 import Basic
 import PackageModel
-@testable import Commands
+import Workspace
 
 class ToolsVersionWriterTests: XCTestCase {
 
@@ -21,7 +21,7 @@ class ToolsVersionWriterTests: XCTestCase {
         var stream = BufferedOutputByteStream()
         stream <<< ""
 
-        writeToolsVersion(stream) { result in
+        writeToolsVersionCover(stream) { result in
             XCTAssertEqual(result, "// swift-tools-version:4.1.2\n")
         }
 
@@ -29,7 +29,7 @@ class ToolsVersionWriterTests: XCTestCase {
         stream = BufferedOutputByteStream()
         stream <<< "\n"
 
-        writeToolsVersion(stream) { result in
+        writeToolsVersionCover(stream) { result in
             XCTAssertEqual(result, "// swift-tools-version:4.1.2\n\n")
         }
 
@@ -37,7 +37,7 @@ class ToolsVersionWriterTests: XCTestCase {
         stream = BufferedOutputByteStream()
         stream <<< "let package = ... " <<< "\n"
 
-        writeToolsVersion(stream) { result in
+        writeToolsVersionCover(stream) { result in
             XCTAssertEqual(result, "// swift-tools-version:4.1.2\nlet package = ... \n")
         }
 
@@ -46,7 +46,7 @@ class ToolsVersionWriterTests: XCTestCase {
         stream <<< "// swift-tools-version:3.1.2\n"
         stream <<< "..."
 
-        writeToolsVersion(stream) { result in
+        writeToolsVersionCover(stream) { result in
             XCTAssertEqual(result, "// swift-tools-version:4.1.2\n...")
         }
 
@@ -55,7 +55,7 @@ class ToolsVersionWriterTests: XCTestCase {
         stream <<< "// swift-tools-version:3.1.2\n"
         stream <<< "..."
 
-        writeToolsVersion(stream, version: ToolsVersion(version: "2.1.0")) { result in
+        writeToolsVersionCover(stream, version: ToolsVersion(version: "2.1.0")) { result in
             XCTAssertEqual(result, "// swift-tools-version:2.1\n...")
         }
 
@@ -64,7 +64,7 @@ class ToolsVersionWriterTests: XCTestCase {
         stream <<< "// swift-tool-version:3.1.2\n"
         stream <<< "..."
 
-        writeToolsVersion(stream) { result in
+        writeToolsVersionCover(stream) { result in
             XCTAssertEqual(result, "// swift-tools-version:4.1.2\n// swift-tool-version:3.1.2\n...")
         }
 
@@ -73,7 +73,7 @@ class ToolsVersionWriterTests: XCTestCase {
         stream <<< "// swift-tools-version:-3.1.2\n"
         stream <<< "..."
 
-        writeToolsVersion(stream) { result in
+        writeToolsVersionCover(stream) { result in
             XCTAssertEqual(result, "// swift-tools-version:4.1.2\n...")
         }
 
@@ -82,7 +82,7 @@ class ToolsVersionWriterTests: XCTestCase {
         stream <<< "// swift-tools-version:-3.1.2;hello\n"
         stream <<< "..."
 
-        writeToolsVersion(stream) { result in
+        writeToolsVersionCover(stream) { result in
             // Note: Right now we lose the metadata but if we ever start using it, we should preserve it.
             XCTAssertEqual(result, "// swift-tools-version:4.1.2\n...")
         }
@@ -94,7 +94,7 @@ class ToolsVersionWriterTests: XCTestCase {
         XCTAssertEqual(ToolsVersion(version: "6.0.129").zeroedPatch.description, "6.0.0")
     }
 
-    func writeToolsVersion(
+    func writeToolsVersionCover(
         _ stream: BufferedOutputByteStream,
         version: ToolsVersion = ToolsVersion(version: "4.1.2"),
         _ result: (ByteString) -> Void
@@ -107,7 +107,7 @@ class ToolsVersionWriterTests: XCTestCase {
             try fs.createDirectory(file.parentDirectory, recursive: true)
             try fs.writeFileContents(file, bytes: stream.bytes)
 
-            try Commands.writeToolsVersion(
+            try writeToolsVersion(
                 at: file.parentDirectory, version: version, fs: &fs)
 
             result(try fs.readFileContents(file))

--- a/Tests/WorkspaceTests/XCTestManifests.swift
+++ b/Tests/WorkspaceTests/XCTestManifests.swift
@@ -13,7 +13,9 @@ import XCTest
 #if !os(macOS)
 public func allTests() -> [XCTestCaseEntry] {
     return [
+        testCase(InitTests.allTests),
         testCase(PinsStoreTests.allTests),
+        testCase(ToolsVersionWriterTests.allTests),
         testCase(WorkspaceTests.allTests),
     ]
 }


### PR DESCRIPTION
This pull request is motivated by the ongoing hoisting of functionality that may be of use to clients other than the command line tools into the SwiftPM library.

The main change here is to move the InitPackage class from the Commands module to the Workspace module so it will be included in the library. This required also moving the new ToolsVersionWriter. Some tests were migrated as well, and a new test suite was added to test the InitPackage class directly as part of WorkspaceTests in addition to the command-line based tests in CommandsTests for package creation.

The pull request is split into two commits. The first moves all the functional code and the second moves and adds tests.