### PR TITLE
SR-4083 Generated projects should have an aggregate target for every product that doesn't have any other target

### DIFF
--- a/Sources/Xcodeproj/XcodeProjectModel.swift
+++ b/Sources/Xcodeproj/XcodeProjectModel.swift
@@ -75,7 +75,7 @@ public struct Xcode {
         
         /// Creates and adds a new target (which does not initially have any
         /// build phases).
-        public func addTarget(productType: Target.ProductType, name: String) -> Target {
+        public func addTarget(productType: Target.ProductType?, name: String) -> Target {
             let target = Target(productType: productType, name: name)
             targets.append(target)
             return target
@@ -153,7 +153,7 @@ public struct Xcode {
     public class Target {
         var name: String
         var productName: String
-        var productType: ProductType
+        var productType: ProductType?
         var buildSettings: BuildSettingsTable
         var buildPhases: [BuildPhase]
         var productReference: FileReference?
@@ -167,7 +167,7 @@ public struct Xcode {
             case unitTest = "com.apple.product-type.bundle.unit-test"
             var asString: String { return rawValue }
         }
-        init(productType: ProductType, name: String) {
+        init(productType: ProductType?, name: String) {
             self.name = name
             self.productType = productType
             self.productName = name

--- a/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
+++ b/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
@@ -130,9 +130,10 @@ extension Xcode.Target: PropertyListSerializable {
 
     /// Called by the Serializer to serialize the Target.
     fileprivate func serialize(to serializer: PropertyListSerializer) -> [String: PropertyList] {
-        // Create a `PBXNativeTarget` plist dictionary.
+        // Create either a `PBXNativeTarget` or an `PBXAggregateTarget` plist
+        // dictionary (depending on whether or not we have a product type).
         var dict = [String: PropertyList]()
-        dict["isa"] = .string("PBXNativeTarget")
+        dict["isa"] = .string(productType == nil ? "PBXAggregateTarget" : "PBXNativeTarget")
         dict["name"] = .string(name)
         // Build settings are a bit tricky; in Xcode, each is stored in a named
         // XCBuildConfiguration object, and the list of build configurations is
@@ -169,7 +170,9 @@ extension Xcode.Target: PropertyListSerializable {
             .identifier(serializer.serialize(object: TargetDependency(target: dep.target)))
         })
         dict["productName"] = .string(productName)
-        dict["productType"] = .string(productType.asString)
+        if let productType = productType {
+            dict["productType"] = .string(productType.asString)
+        }
         if let productReference = productReference {
             dict["productReference"] = .identifier(serializer.id(of: productReference))
         }

--- a/Tests/XcodeprojTests/XcodeProjectModelTests.swift
+++ b/Tests/XcodeprojTests/XcodeProjectModelTests.swift
@@ -84,7 +84,7 @@ class XcodeProjectModelTests: XCTestCase {
         let srcFileRef1 = srcGroup.addFileReference(path: "Source File 1.swift")
         let srcFileRef2 = srcGroup.addFileReference(path: "Source File 2.swift")
         
-        // Add a target.
+        // Add a target that builds an executable.
         let target = proj.addTarget(productType: .executable, name: "My App")
         XCTAssert(target.name == "My App")
         XCTAssert(target.productType == .executable)
@@ -97,6 +97,12 @@ class XcodeProjectModelTests: XCTestCase {
         let srcBldFile2 = srcPhase.addBuildFile(fileRef: srcFileRef2)
         XCTAssert(srcBldFile1.fileRef === srcFileRef1)
         XCTAssert(srcBldFile2.fileRef === srcFileRef2)
+        
+        // Add an aggregate target (one that doesn't have a product type).
+        let aggTarget = proj.addTarget(productType: nil, name: "Aggregate")
+        XCTAssert(aggTarget.name == "Aggregate")
+        XCTAssert(aggTarget.productType == nil)
+        XCTAssert(aggTarget.buildPhases.isEmpty)
         
         let _ = proj.generatePlist()
     }


### PR DESCRIPTION
This adds to the Xcode project generation logic so that, after adding all the targets for the modules in a package and its dependencies, it also adds an aggregate target for each of the products that doesn’t already have a target with the same name.  This makes it possible to build all the modules that go into a defined product in a single build in Xcode.

As for the implementation: I am on the fence about whether it's most appropriate to say that an aggregate target has no product type (i.e. to make the product type optional) or whether to say that there is a new product type called "none".  The former feels to be a philosophically better fit, and is what diffs show.  If there is a lot of feedback that the other way is better, then we could certainly implement it that way instead.