### PR TITLE
Rename compatibleSwiftVersions to swiftLanguageVersions

### DIFF
--- a/Sources/Build/describe().swift
+++ b/Sources/Build/describe().swift
@@ -49,10 +49,10 @@ public func describe(
             // Ensure that the module sources are compatible with current version of tools.
             // Note that we don't actually make use of these flags during compilation because
             // of the compiler bug https://bugs.swift.org/browse/SR-3791.
-            if let compatibleSwiftVersions = module.compatibleSwiftVersions {
-                guard compatibleSwiftVersions.contains(toolsVersion.major) else {
+            if let swiftLanguageVersions = module.swiftLanguageVersions {
+                guard swiftLanguageVersions.contains(toolsVersion.major) else {
                     throw Error.incompatibleToolsVersions(
-                        module: module.name, required: compatibleSwiftVersions, current: toolsVersion.major)
+                        module: module.name, required: swiftLanguageVersions, current: toolsVersion.major)
                 }
             }
 

--- a/Sources/PackageDescription/Package.swift
+++ b/Sources/PackageDescription/Package.swift
@@ -64,7 +64,7 @@ public final class Package {
     public var dependencies: [Dependency]
 
     /// The list of swift versions, this package is compatible with.
-    public var compatibleSwiftVersions: [Int]?
+    public var swiftLanguageVersions: [Int]?
 
     /// The list of folders to exclude.
     public var exclude: [String]
@@ -76,7 +76,7 @@ public final class Package {
         providers: [SystemPackageProvider]? = nil,
         targets: [Target] = [],
         dependencies: [Dependency] = [],
-        compatibleSwiftVersions: [Int]? = nil,
+        swiftLanguageVersions: [Int]? = nil,
         exclude: [String] = []
     ) {
         self.name = name
@@ -84,7 +84,7 @@ public final class Package {
         self.providers = providers
         self.targets = targets
         self.dependencies = dependencies
-        self.compatibleSwiftVersions = compatibleSwiftVersions
+        self.swiftLanguageVersions = swiftLanguageVersions
         self.exclude = exclude
 
         // Add custom exit handler to cause package to be dumped at exit, if requested.
@@ -170,8 +170,8 @@ extension Package {
         if let providers = self.providers {
             dict["providers"] = .array(providers.map { $0.toJSON() })
         }
-        if let compatibleSwiftVersions = self.compatibleSwiftVersions {
-            dict["compatibleSwiftVersions"] = .array(compatibleSwiftVersions.map(JSON.int))
+        if let swiftLanguageVersions = self.swiftLanguageVersions {
+            dict["swiftLanguageVersions"] = .array(swiftLanguageVersions.map(JSON.int))
         }
         return .dictionary(dict)
     }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -249,10 +249,10 @@ extension PackageDescription.Package {
         }
 
         // Parse the compatible swift versions.
-        var compatibleSwiftVersions: [Int]? = nil
-        if case .array(let array)? = package["compatibleSwiftVersions"] {
-            compatibleSwiftVersions = array.map{
-                guard case .int(let value) = $0 else { fatalError("compatibleSwiftVersions contains non int element") }
+        var swiftLanguageVersions: [Int]? = nil
+        if case .array(let array)? = package["swiftLanguageVersions"] {
+            swiftLanguageVersions = array.map{
+                guard case .int(let value) = $0 else { fatalError("swiftLanguageVersions contains non int element") }
                 return value
             }
         }
@@ -272,7 +272,7 @@ extension PackageDescription.Package {
             providers: providers,
             targets: targets,
             dependencies: dependencies,
-            compatibleSwiftVersions: compatibleSwiftVersions,
+            swiftLanguageVersions: swiftLanguageVersions,
             exclude: exclude)
     }
 }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -537,7 +537,7 @@ public struct PackageBuilder {
                 isTest: potentialModule.isTest,
                 sources: Sources(paths: swiftSources, root: potentialModule.path),
                 dependencies: moduleDependencies,
-                compatibleSwiftVersions: manifest.package.compatibleSwiftVersions)
+                swiftLanguageVersions: manifest.package.swiftLanguageVersions)
         } else {
             // No Swift sources, so we expect to have C sources, and we create a C module.
             guard swiftSources.isEmpty else { throw Module.Error.mixedSources(potentialModule.path.asString) }

--- a/Sources/PackageModel/Module.swift
+++ b/Sources/PackageModel/Module.swift
@@ -67,14 +67,14 @@ public class SwiftModule: Module {
 
     /// The list of swift versions, this module is compatible with.
     // FIXME: This should be lifted to a build settings structure once we have that.
-    public let compatibleSwiftVersions: [Int]?
+    public let swiftLanguageVersions: [Int]?
 
     public init(
         name: String,
         isTest: Bool = false,
         sources: Sources,
         dependencies: [Module] = [],
-        compatibleSwiftVersions: [Int]? = nil
+        swiftLanguageVersions: [Int]? = nil
     ) {
         // Compute the module type.
         let isLibrary = !sources.relativePaths.contains { path in
@@ -83,7 +83,7 @@ public class SwiftModule: Module {
             return file.hasPrefix("main.") && file.characters.filter({$0 == "."}).count == 1
         }
         let type: ModuleType = isLibrary ? .library : .executable
-        self.compatibleSwiftVersions = compatibleSwiftVersions
+        self.swiftLanguageVersions = swiftLanguageVersions
         super.init(name: name, type: type, sources: sources, isTest: isTest, dependencies: dependencies)
     }
 }

--- a/Tests/FunctionalTests/ToolsVersionTests.swift
+++ b/Tests/FunctionalTests/ToolsVersionTests.swift
@@ -87,7 +87,7 @@ class ToolsVersionTests: XCTestCase {
             try fs.writeFileContents(primaryPath.appending(component: "Package.swift")) {
                 $0 <<< "import PackageDescription\n"
                 $0 <<< "let package = Package(name: \"Primary\", dependencies: [.Package(url: \"../Dep\", majorVersion: 1)], "
-                $0 <<< "compatibleSwiftVersions: [1000])"
+                $0 <<< "swiftLanguageVersions: [1000])"
             }
             _ = try SwiftPMProduct.SwiftPackage.execute(
                 ["tools-version", "--set-current"], chdir: primaryPath).chomp()
@@ -102,7 +102,7 @@ class ToolsVersionTests: XCTestCase {
             try fs.writeFileContents(primaryPath.appending(component: "Package.swift")) {
                 $0 <<< "import PackageDescription\n"
                 $0 <<< "let package = Package(name: \"Primary\", dependencies: [.Package(url: \"../Dep\", majorVersion: 1)], "
-                $0 <<< "compatibleSwiftVersions: [\(ToolsVersion.currentToolsVersion.major), 1000])"
+                $0 <<< "swiftLanguageVersions: [\(ToolsVersion.currentToolsVersion.major), 1000])"
             }
             _ = try SwiftPMProduct.SwiftPackage.execute(
                 ["tools-version", "--set-current"], chdir: primaryPath).chomp()

--- a/Tests/PackageLoadingTests/ConventionTests.swift
+++ b/Tests/PackageLoadingTests/ConventionTests.swift
@@ -170,7 +170,7 @@ class ConventionTests: XCTestCase {
             "/Tests/fooTests/bar.swift"
             )
 
-        let package = PackageDescription.Package(name: "pkg", compatibleSwiftVersions: [3, 4])
+        let package = PackageDescription.Package(name: "pkg", swiftLanguageVersions: [3, 4])
         PackageBuilderTester(package, in: fs) { result in
             result.checkModule("foo") { moduleResult in
                 moduleResult.check(c99name: "foo", type: .executable, isTest: false)
@@ -1151,13 +1151,13 @@ final class PackageBuilderTester {
             guard case let swiftModule as SwiftModule = module else {
                 return XCTFail("\(module) is not a swift module", file: file, line: line)
             }
-            switch (swiftModule.compatibleSwiftVersions, versions) {
+            switch (swiftModule.swiftLanguageVersions, versions) {
             case (nil, nil):
                 break
             case (let lhs?, let rhs?):
                 XCTAssertEqual(lhs, rhs, file: file, line: line)
             default:
-                XCTFail("\(swiftModule.compatibleSwiftVersions.debugDescription) is not equal to \(versions.debugDescription)", file: file, line: line)
+                XCTFail("\(swiftModule.swiftLanguageVersions.debugDescription) is not equal to \(versions.debugDescription)", file: file, line: line)
             }
         }
 

--- a/Tests/PackageLoadingTests/ManifestTests.swift
+++ b/Tests/PackageLoadingTests/ManifestTests.swift
@@ -178,26 +178,26 @@ class ManifestTests: XCTestCase {
         stream <<< "import PackageDescription" <<< "\n"
         stream <<< "let package = Package(" <<< "\n"
         stream <<< "   name: \"Foo\"," <<< "\n"
-        stream <<< "   compatibleSwiftVersions: [3, 4]" <<< "\n"
+        stream <<< "   swiftLanguageVersions: [3, 4]" <<< "\n"
         stream <<< ")" <<< "\n"
         var manifest = try loadManifest(stream.bytes)
-        XCTAssertEqual(manifest.package.compatibleSwiftVersions ?? [], [3, 4])
+        XCTAssertEqual(manifest.package.swiftLanguageVersions ?? [], [3, 4])
 
         stream = BufferedOutputByteStream()
         stream <<< "import PackageDescription" <<< "\n"
         stream <<< "let package = Package(" <<< "\n"
         stream <<< "   name: \"Foo\"," <<< "\n"
-        stream <<< "   compatibleSwiftVersions: []" <<< "\n"
+        stream <<< "   swiftLanguageVersions : []" <<< "\n"
         stream <<< ")" <<< "\n"
         manifest = try loadManifest(stream.bytes)
-        XCTAssertEqual(manifest.package.compatibleSwiftVersions!, [])
+        XCTAssertEqual(manifest.package.swiftLanguageVersions!, [])
 
         stream = BufferedOutputByteStream()
         stream <<< "import PackageDescription" <<< "\n"
         stream <<< "let package = Package(" <<< "\n"
         stream <<< "   name: \"Foo\")" <<< "\n"
         manifest = try loadManifest(stream.bytes)
-        XCTAssert(manifest.package.compatibleSwiftVersions == nil)
+        XCTAssert(manifest.package.swiftLanguageVersions == nil)
     }
 
     func testRuntimeManifestErrors() throws {


### PR DESCRIPTION
This was incorrectly named.

- https://bugs.swift.org/browse/SR-4125