### PR TITLE
[Utility] Add -help option to print usage

### DIFF
--- a/Sources/Utility/ArgumentParser.swift
+++ b/Sources/Utility/ArgumentParser.swift
@@ -445,7 +445,7 @@ public final class ArgumentParser {
 
         while let arg = argumentsIterator.next() {
             // If argument is help then just print usage and exit.
-            if arg == "-h" || arg == "--help" {
+            if arg == "-h" || arg == "-help" || arg == "--help" {
                 printUsage(on: stdoutStream)
                 exit(0)
             } else if isPositional(argument: arg) {

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -20,7 +20,7 @@ final class BuildToolTests: XCTestCase {
     }
     
     func testUsage() throws {
-        XCTAssert(try execute(["--help"]).contains("USAGE: swift build"))
+        XCTAssert(try execute(["-help"]).contains("USAGE: swift build"))
     }
 
     func testVersion() throws {


### PR DESCRIPTION
We now support -h, -help and --help to print usage.

- https://bugs.swift.org/browse/SR-4121