### PR TITLE
Rename compatibleSwiftVersions to swiftLanguageVersions

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -222,8 +222,8 @@ public final class SwiftTargetDescription {
     fileprivate var additionalFlags: [String] = []
 
     /// The compatible swift versions for this target.
-    var compatibleSwiftVersions: [Int]? {
-        return (module.underlyingModule as! SwiftModule).compatibleSwiftVersions
+    var swiftLanguageVersions: [Int]? {
+        return (module.underlyingModule as! SwiftModule).swiftLanguageVersions
     }
 
     /// If this target is a test target.
@@ -574,11 +574,11 @@ public class BuildPlan {
         // Ensure that the module sources are compatible with current version of tools.
         // Note that we don't actually make use of these flags during compilation because
         // of the compiler bug https://bugs.swift.org/browse/SR-3791.
-        if let compatibleSwiftVersions = swiftTarget.compatibleSwiftVersions {
+        if let swiftLanguageVersions = swiftTarget.swiftLanguageVersions {
             let majorToolsVersion = buildParameters.toolsVersion.major
-            guard compatibleSwiftVersions.contains(majorToolsVersion) else {
+            guard swiftLanguageVersions.contains(majorToolsVersion) else {
                 throw Error.incompatibleToolsVersions(
-                    target: swiftTarget.module.name, required: compatibleSwiftVersions, current: majorToolsVersion)
+                    target: swiftTarget.module.name, required: swiftLanguageVersions, current: majorToolsVersion)
             }
         }
 

--- a/Sources/PackageDescription/Package.swift
+++ b/Sources/PackageDescription/Package.swift
@@ -64,7 +64,7 @@ public final class Package {
     public var dependencies: [Dependency]
 
     /// The list of swift versions, this package is compatible with.
-    public var compatibleSwiftVersions: [Int]?
+    public var swiftLanguageVersions: [Int]?
 
     /// The list of folders to exclude.
     public var exclude: [String]
@@ -76,7 +76,7 @@ public final class Package {
         providers: [SystemPackageProvider]? = nil,
         targets: [Target] = [],
         dependencies: [Dependency] = [],
-        compatibleSwiftVersions: [Int]? = nil,
+        swiftLanguageVersions: [Int]? = nil,
         exclude: [String] = []
     ) {
         self.name = name
@@ -84,7 +84,7 @@ public final class Package {
         self.providers = providers
         self.targets = targets
         self.dependencies = dependencies
-        self.compatibleSwiftVersions = compatibleSwiftVersions
+        self.swiftLanguageVersions = swiftLanguageVersions
         self.exclude = exclude
 
         // Add custom exit handler to cause package to be dumped at exit, if requested.
@@ -170,8 +170,8 @@ extension Package {
         if let providers = self.providers {
             dict["providers"] = .array(providers.map { $0.toJSON() })
         }
-        if let compatibleSwiftVersions = self.compatibleSwiftVersions {
-            dict["compatibleSwiftVersions"] = .array(compatibleSwiftVersions.map(JSON.int))
+        if let swiftLanguageVersions = self.swiftLanguageVersions {
+            dict["swiftLanguageVersions"] = .array(swiftLanguageVersions.map(JSON.int))
         }
         return .dictionary(dict)
     }

--- a/Sources/PackageDescription4/Package.swift
+++ b/Sources/PackageDescription4/Package.swift
@@ -89,7 +89,7 @@ public final class Package {
     public var dependencies: [Dependency]
 
     /// The list of swift versions, this package is compatible with.
-    public var compatibleSwiftVersions: [Int]?
+    public var swiftLanguageVersions: [Int]?
 
     /// The list of folders to exclude.
     public var exclude: [String]
@@ -102,7 +102,7 @@ public final class Package {
         targets: [Target] = [],
         products: [Product] = [],
         dependencies: [Dependency] = [],
-        compatibleSwiftVersions: [Int]? = nil,
+        swiftLanguageVersions: [Int]? = nil,
         exclude: [String] = []
     ) {
         self.name = name
@@ -111,7 +111,7 @@ public final class Package {
         self.targets = targets
         self.products = products
         self.dependencies = dependencies
-        self.compatibleSwiftVersions = compatibleSwiftVersions
+        self.swiftLanguageVersions = swiftLanguageVersions
         self.exclude = exclude
 
         // Add custom exit handler to cause package to be dumped at exit, if requested.
@@ -239,8 +239,8 @@ extension Package {
         if let providers = self.providers {
             dict["providers"] = .array(providers.map { $0.toJSON() })
         }
-        if let compatibleSwiftVersions = self.compatibleSwiftVersions {
-            dict["compatibleSwiftVersions"] = .array(compatibleSwiftVersions.map(JSON.int))
+        if let swiftLanguageVersions = self.swiftLanguageVersions {
+            dict["swiftLanguageVersions"] = .array(swiftLanguageVersions.map(JSON.int))
         }
         return .dictionary(dict)
     }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -557,7 +557,7 @@ public struct PackageBuilder {
                 sources: Sources(paths: swiftSources, root: potentialModule.path),
                 dependencies: moduleDependencies,
                 productDependencies: productDeps,
-                compatibleSwiftVersions: manifest.package.compatibleSwiftVersions)
+                swiftLanguageVersions: manifest.package.swiftLanguageVersions)
         } else {
             // No Swift sources, so we expect to have C sources, and we create a C module.
             guard swiftSources.isEmpty else { throw Module.Error.mixedSources(potentialModule.path.asString) }

--- a/Sources/PackageLoading/PackageDescription4Loader.swift
+++ b/Sources/PackageLoading/PackageDescription4Loader.swift
@@ -66,10 +66,10 @@ extension PackageDescription4.Package {
         }
 
         // Parse the compatible swift versions.
-        var compatibleSwiftVersions: [Int]? = nil
-        if case .array(let array)? = package["compatibleSwiftVersions"] {
-            compatibleSwiftVersions = array.map{
-                guard case .int(let value) = $0 else { fatalError("compatibleSwiftVersions contains non int element") }
+        var swiftLanguageVersions: [Int]? = nil
+        if case .array(let array)? = package["swiftLanguageVersions"] {
+            swiftLanguageVersions = array.map{
+                guard case .int(let value) = $0 else { fatalError("swiftLanguageVersions contains non int element") }
                 return value
             }
         }
@@ -90,7 +90,7 @@ extension PackageDescription4.Package {
             targets: targets,
             products: products,
             dependencies: dependencies,
-            compatibleSwiftVersions: compatibleSwiftVersions,
+            swiftLanguageVersions: swiftLanguageVersions,
             exclude: exclude)
     }
 }

--- a/Sources/PackageLoading/PackageDescriptionLoader.swift
+++ b/Sources/PackageLoading/PackageDescriptionLoader.swift
@@ -61,10 +61,10 @@ extension PackageDescription.Package {
         }
 
         // Parse the compatible swift versions.
-        var compatibleSwiftVersions: [Int]? = nil
-        if case .array(let array)? = package["compatibleSwiftVersions"] {
-            compatibleSwiftVersions = array.map{
-                guard case .int(let value) = $0 else { fatalError("compatibleSwiftVersions contains non int element") }
+        var swiftLanguageVersions: [Int]? = nil
+        if case .array(let array)? = package["swiftLanguageVersions"] {
+            swiftLanguageVersions = array.map{
+                guard case .int(let value) = $0 else { fatalError("swiftLanguageVersions contains non int element") }
                 return value
             }
         }
@@ -84,7 +84,7 @@ extension PackageDescription.Package {
             providers: providers,
             targets: targets,
             dependencies: dependencies,
-            compatibleSwiftVersions: compatibleSwiftVersions,
+            swiftLanguageVersions: swiftLanguageVersions,
             exclude: exclude)
     }
 }

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -162,10 +162,10 @@ extension Manifest.RawPackage {
         }
     }
 
-    public var compatibleSwiftVersions: [Int]? {
+    public var swiftLanguageVersions: [Int]? {
         switch self {
-        case .v3(let package): return package.compatibleSwiftVersions
-        case .v4(let package): return package.compatibleSwiftVersions
+        case .v3(let package): return package.swiftLanguageVersions
+        case .v4(let package): return package.swiftLanguageVersions
         }
     }
 }

--- a/Sources/PackageModel/Module.swift
+++ b/Sources/PackageModel/Module.swift
@@ -64,14 +64,14 @@ public class SwiftModule: Module {
 
     /// Create an executable Swift module from linux main test manifest file.
     init(linuxMain: AbsolutePath, name: String, dependencies: [Module]) {
-        self.compatibleSwiftVersions = nil
+        self.swiftLanguageVersions = nil
         let sources = Sources(paths: [linuxMain], root: linuxMain.parentDirectory)
         super.init(name: name, type: .executable, sources: sources, dependencies: dependencies)
     }
 
     /// The list of swift versions, this module is compatible with.
     // FIXME: This should be lifted to a build settings structure once we have that.
-    public let compatibleSwiftVersions: [Int]?
+    public let swiftLanguageVersions: [Int]?
 
     public init(
         name: String,
@@ -79,10 +79,10 @@ public class SwiftModule: Module {
         sources: Sources,
         dependencies: [Module] = [],
         productDependencies: [(name: String, package: String?)] = [],
-        compatibleSwiftVersions: [Int]? = nil
+        swiftLanguageVersions: [Int]? = nil
     ) {
         let type: ModuleType = isTest ? .test : sources.computeModuleType()
-        self.compatibleSwiftVersions = compatibleSwiftVersions
+        self.swiftLanguageVersions = swiftLanguageVersions
         super.init(
             name: name,
             type: type,

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -244,7 +244,7 @@ final class BuildPlanTests: XCTestCase {
                 name: "Foo",
                 targets: [.init(name: "Foo", dependencies: ["Bar"])],
                 dependencies: [.Package(url: "/Bar", majorVersion: 1)],
-                compatibleSwiftVersions: [2, ToolsVersion.currentToolsVersion.major]),
+                swiftLanguageVersions: [2, ToolsVersion.currentToolsVersion.major]),
         ], root: "/Foo", in: fs)
 
         let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(), graph: g, fileSystem: fs))
@@ -284,7 +284,7 @@ final class BuildPlanTests: XCTestCase {
 
         // Tools version not set.
         do {
-            foo.compatibleSwiftVersions = nil
+            foo.swiftLanguageVersions = nil
             let version = ToolsVersion(version: "4.0.0")
             let graph = loadMockPackageGraph(["/Foo": foo, "/Bar": Package(name: "Bar")], root: "/Foo", in: fs)
             let result = BuildPlanResult(plan:
@@ -295,7 +295,7 @@ final class BuildPlanTests: XCTestCase {
 
         // Compatible Swift version present.
         do {
-            foo.compatibleSwiftVersions = [3, 4, 5]
+            foo.swiftLanguageVersions = [3, 4, 5]
             let version = ToolsVersion(version: "4.0.0")
             let graph = loadMockPackageGraph(["/Foo": foo, "/Bar": Package(name: "Bar")], root: "/Foo", in: fs)
             let result = BuildPlanResult(plan:
@@ -306,7 +306,7 @@ final class BuildPlanTests: XCTestCase {
 
         // Compatible Swift version not present.
         do {
-            foo.compatibleSwiftVersions = [3, 5]
+            foo.swiftLanguageVersions = [3, 5]
             let version = ToolsVersion(version: "4.0.0")
             let graph = loadMockPackageGraph(["/Foo": foo, "/Bar": Package(name: "Bar")], root: "/Foo", in: fs)
 
@@ -321,10 +321,10 @@ final class BuildPlanTests: XCTestCase {
 
         // Dependency not compatible.
         do {
-            foo.compatibleSwiftVersions = nil
+            foo.swiftLanguageVersions = nil
             let bar = Package(
                 name: "Bar",
-                compatibleSwiftVersions: [3])
+                swiftLanguageVersions: [3])
             let version = ToolsVersion(version: "4.0.0")
             let graph = loadMockPackageGraph(["/Foo": foo, "/Bar": bar], root: "/Foo", in: fs)
 

--- a/Tests/FunctionalTests/ToolsVersionTests.swift
+++ b/Tests/FunctionalTests/ToolsVersionTests.swift
@@ -87,7 +87,7 @@ class ToolsVersionTests: XCTestCase {
             try fs.writeFileContents(primaryPath.appending(component: "Package.swift")) {
                 $0 <<< "import PackageDescription\n"
                 $0 <<< "let package = Package(name: \"Primary\", dependencies: [.Package(url: \"../Dep\", majorVersion: 1)], "
-                $0 <<< "compatibleSwiftVersions: [1000])"
+                $0 <<< "swiftLanguageVersions: [1000])"
             }
             _ = try SwiftPMProduct.SwiftPackage.execute(
                 ["tools-version", "--set-current"], chdir: primaryPath).chomp()
@@ -102,7 +102,7 @@ class ToolsVersionTests: XCTestCase {
             try fs.writeFileContents(primaryPath.appending(component: "Package.swift")) {
                 $0 <<< "import PackageDescription\n"
                 $0 <<< "let package = Package(name: \"Primary\", dependencies: [.Package(url: \"../Dep\", majorVersion: 1)], "
-                $0 <<< "compatibleSwiftVersions: [\(ToolsVersion.currentToolsVersion.major), 1000])"
+                $0 <<< "swiftLanguageVersions: [\(ToolsVersion.currentToolsVersion.major), 1000])"
             }
             _ = try SwiftPMProduct.SwiftPackage.execute(
                 ["tools-version", "--set-current"], chdir: primaryPath).chomp()

--- a/Tests/PackageLoadingTests/ConventionTests.swift
+++ b/Tests/PackageLoadingTests/ConventionTests.swift
@@ -170,7 +170,7 @@ class ConventionTests: XCTestCase {
             "/Tests/fooTests/bar.swift"
             )
 
-        let package = PackageDescription4.Package(name: "pkg", compatibleSwiftVersions: [3, 4])
+        let package = PackageDescription4.Package(name: "pkg", swiftLanguageVersions: [3, 4])
         PackageBuilderTester(package, in: fs) { result in
             result.checkModule("foo") { moduleResult in
                 moduleResult.check(c99name: "foo", type: .executable)
@@ -1176,13 +1176,13 @@ final class PackageBuilderTester {
             guard case let swiftModule as SwiftModule = module else {
                 return XCTFail("\(module) is not a swift module", file: file, line: line)
             }
-            switch (swiftModule.compatibleSwiftVersions, versions) {
+            switch (swiftModule.swiftLanguageVersions, versions) {
             case (nil, nil):
                 break
             case (let lhs?, let rhs?):
                 XCTAssertEqual(lhs, rhs, file: file, line: line)
             default:
-                XCTFail("\(swiftModule.compatibleSwiftVersions.debugDescription) is not equal to \(versions.debugDescription)", file: file, line: line)
+                XCTFail("\(swiftModule.swiftLanguageVersions.debugDescription) is not equal to \(versions.debugDescription)", file: file, line: line)
             }
         }
     }

--- a/Tests/PackageLoadingTests/ManifestTests.swift
+++ b/Tests/PackageLoadingTests/ManifestTests.swift
@@ -195,26 +195,26 @@ class ManifestTests: XCTestCase {
         stream <<< "import PackageDescription" <<< "\n"
         stream <<< "let package = Package(" <<< "\n"
         stream <<< "   name: \"Foo\"," <<< "\n"
-        stream <<< "   compatibleSwiftVersions: [3, 4]" <<< "\n"
+        stream <<< "   swiftLanguageVersions: [3, 4]" <<< "\n"
         stream <<< ")" <<< "\n"
         var manifest = try loadManifest(stream.bytes)
-        XCTAssertEqual(manifest.package.compatibleSwiftVersions ?? [], [3, 4])
+        XCTAssertEqual(manifest.package.swiftLanguageVersions ?? [], [3, 4])
 
         stream = BufferedOutputByteStream()
         stream <<< "import PackageDescription" <<< "\n"
         stream <<< "let package = Package(" <<< "\n"
         stream <<< "   name: \"Foo\"," <<< "\n"
-        stream <<< "   compatibleSwiftVersions: []" <<< "\n"
+        stream <<< "   swiftLanguageVersions: []" <<< "\n"
         stream <<< ")" <<< "\n"
         manifest = try loadManifest(stream.bytes)
-        XCTAssertEqual(manifest.package.compatibleSwiftVersions!, [])
+        XCTAssertEqual(manifest.package.swiftLanguageVersions!, [])
 
         stream = BufferedOutputByteStream()
         stream <<< "import PackageDescription" <<< "\n"
         stream <<< "let package = Package(" <<< "\n"
         stream <<< "   name: \"Foo\")" <<< "\n"
         manifest = try loadManifest(stream.bytes)
-        XCTAssert(manifest.package.compatibleSwiftVersions == nil)
+        XCTAssert(manifest.package.swiftLanguageVersions == nil)
     }
 
     func testRuntimeManifestErrors() throws {

--- a/Tests/PackageLoadingTests/PD4LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4LoadingTests.swift
@@ -114,20 +114,20 @@ class PackageDescription4LoadingTests: XCTestCase {
         stream <<< "import PackageDescription" <<< "\n"
         stream <<< "let package = Package(" <<< "\n"
         stream <<< "   name: \"Foo\"," <<< "\n"
-        stream <<< "   compatibleSwiftVersions: [3, 4]" <<< "\n"
+        stream <<< "   swiftLanguageVersions: [3, 4]" <<< "\n"
         stream <<< ")" <<< "\n"
         loadManifest(stream.bytes) { manifest in
-            XCTAssertEqual(manifest.package.compatibleSwiftVersions ?? [], [3, 4])
+            XCTAssertEqual(manifest.package.swiftLanguageVersions ?? [], [3, 4])
         }
 
         stream = BufferedOutputByteStream()
         stream <<< "import PackageDescription" <<< "\n"
         stream <<< "let package = Package(" <<< "\n"
         stream <<< "   name: \"Foo\"," <<< "\n"
-        stream <<< "   compatibleSwiftVersions: []" <<< "\n"
+        stream <<< "   swiftLanguageVersions: []" <<< "\n"
         stream <<< ")" <<< "\n"
         loadManifest(stream.bytes) { manifest in
-            XCTAssertEqual(manifest.package.compatibleSwiftVersions!, [])
+            XCTAssertEqual(manifest.package.swiftLanguageVersions!, [])
         }
 
         stream = BufferedOutputByteStream()
@@ -135,7 +135,7 @@ class PackageDescription4LoadingTests: XCTestCase {
         stream <<< "let package = Package(" <<< "\n"
         stream <<< "   name: \"Foo\")" <<< "\n"
         loadManifest(stream.bytes) { manifest in
-            XCTAssert(manifest.package.compatibleSwiftVersions == nil)
+            XCTAssert(manifest.package.swiftLanguageVersions == nil)
         }
     }
 


### PR DESCRIPTION
This was incorrectly named.

- https://bugs.swift.org/browse/SR-4125