### PR TITLE
Try to diagnose more misspellings of the swift-tools-version comment

### DIFF
--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -45,6 +45,16 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
 
         // Get the version specifier string from tools version file.
         guard let versionSpecifier = ToolsVersionLoader.split(contents).versionSpecifier else {
+            // Try to diagnose if there is a misspelling of the swift-tools-version comment.
+            let splitted = contents.contents.split(separator: UInt8(ascii: "\n"), maxSplits: 1, omittingEmptySubsequences: false)
+            let misspellings = [
+                "swift-tool", "tool-version",
+            ]
+            if let firstLine = ByteString(splitted[0]).asString,
+               misspellings.first(where: firstLine.lowercased().contains) != nil {
+                throw Error.malformed(specifier: firstLine, file: path)
+            }
+            // Otherwise assume the default.
             return ToolsVersion.defaultToolsVersion
         }
 

--- a/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
@@ -84,38 +84,21 @@ class ToolsVersionLoaderTests: XCTestCase {
             }
         }
 
-        try load("//swift-tool-version:6.1.0\n") { toolsVersion in
+        try load("// \n// swift-tools-version:6.1.0\n") { toolsVersion in
             XCTAssertEqual(toolsVersion, ToolsVersion.defaultToolsVersion)
         }
 
-        try load("//  swift-tool-version:6.1.0\n") { toolsVersion in
-            XCTAssertEqual(toolsVersion, ToolsVersion.defaultToolsVersion)
-        }
+        assertFailure("//swift-tools-:6.1.0\n", "//swift-tools-:6.1.0")
+        assertFailure("//swift-tool-version:6.1.0\n", "//swift-tool-version:6.1.0")
+        assertFailure("//  swift-tool-version:6.1.0\n", "//  swift-tool-version:6.1.0")
+        assertFailure("// swift-tool-version:6.1.0\n", "// swift-tool-version:6.1.0")
+        assertFailure("noway// swift-tools-version:6.1.0\n", "noway// swift-tools-version:6.1.0")
+        assertFailure("// swift-tool-version:2.1.0\n// swift-tools-version:6.1.0\n", "// swift-tool-version:2.1.0")
 
-        try load("// swift-tool-version:6.1.0\n") { toolsVersion in
-            XCTAssertEqual(toolsVersion, ToolsVersion.defaultToolsVersion)
-        }
-
-        try load("// swift-tools-version 6.1.0\n") { toolsVersion in
-            XCTAssertEqual(toolsVersion, ToolsVersion.defaultToolsVersion)
-        }
-
-        try load("//// swift-tools-version:6.1.0\n") { toolsVersion in
-            XCTAssertEqual(toolsVersion, ToolsVersion.defaultToolsVersion)
-        }
-
-        try load("// haha swift-tools-version:6.1.0\n") { toolsVersion in
-            XCTAssertEqual(toolsVersion, ToolsVersion.defaultToolsVersion)
-        }
-
-        try load("noway// swift-tools-version:6.1.0\n") { toolsVersion in
-            XCTAssertEqual(toolsVersion, ToolsVersion.defaultToolsVersion)
-        }
-
-        try load("// swift-tools-version 6.1.0\n") { toolsVersion in
-            XCTAssertEqual(toolsVersion, ToolsVersion.defaultToolsVersion)
-        }
-
+        assertFailure("// haha swift-tools-version:6.1.0\n", "// haha swift-tools-version:6.1.0")
+        assertFailure("//// swift-tools-version:6.1.0\n", "//// swift-tools-version:6.1.0")
+        assertFailure("// swift-tools-version 6.1.0\n", "// swift-tools-version 6.1.0")
+        assertFailure("// swift-tOols-Version 6.1.0\n", "// swift-tOols-Version 6.1.0")
         assertFailure("// swift-tools-version:6.1.2.0\n", "6.1.2.0")
         assertFailure("// swift-tools-version:-1.1.2\n", "-1.1.2")
         assertFailure("// swift-tools-version:3.1hello", "3.1hello")
@@ -128,8 +111,8 @@ class ToolsVersionLoaderTests: XCTestCase {
             }
             XCTFail("unexpected success", file: file, line: line)
         } catch ToolsVersionLoader.Error.malformed(let specifier, let path) {
-            XCTAssertEqual(specifier, theSpecifier)
-            XCTAssertEqual(path, AbsolutePath("/pkg"))
+            XCTAssertEqual(specifier, theSpecifier, file: file, line: line)
+            XCTAssertEqual(path, AbsolutePath("/pkg"), file: file, line: line)
         } catch {
             XCTFail("Failed with error \(error)")
         }


### PR DESCRIPTION
Previously we only considered misspellings if we at least matched
'// swift-tools-version:', with this change we will consider a tools
version comment a misspelling if the first line starts with // and
contains the string 'swift-tools-version' (but doesn't match our regex).

- https://bugs.swift.org/browse/SR-4134