### PR TITLE
Accept prerelease and build identifier in tools version

### DIFF
--- a/Sources/Basic/NSRegularExpressionShim.swift
+++ b/Sources/Basic/NSRegularExpressionShim.swift
@@ -8,13 +8,14 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
+import Foundation
 
-#if !os(macOS)
-public func allTests() -> [XCTestCaseEntry] {
-    return [
-        testCase(ModuleDependencyTests.allTests),
-        testCase(ToolsVersionTests.allTests),
-    ]
+#if os(macOS)
+// Compatibility shim.
+// <rdar://problem/30488747> NSTextCheckingResult doesn't have range(at:) method
+extension NSTextCheckingResult {
+    public func range(at idx: Int) -> NSRange {
+        return rangeAt(idx)
+    }
 }
 #endif

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -86,13 +86,3 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
     // * The text between the above string and `;` or string end becomes the tools version specifier.
     static let regex = try! NSRegularExpression(pattern: "^// swift-tools-version:(.*?)(?:;.*|$)", options: [.caseInsensitive])
 }
-
-#if os(macOS)
-// Compatibility shim.
-// <rdar://problem/30488747> NSTextCheckingResult doesn't have range(at:) method
-extension NSTextCheckingResult {
-    fileprivate func range(at idx: Int) -> NSRange {
-        return rangeAt(idx)
-    }
-}
-#endif

--- a/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
@@ -33,7 +33,9 @@ class ToolsVersionLoaderTests: XCTestCase {
 
         let validVersions = [
             "// swift-tools-version:3.1"                : (3, 1, 0, "3.1.0"),
+            "// swift-tools-version:3.1-dev"            : (3, 1, 0, "3.1.0"),
             "// swift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
+            "// swift-tools-version:5.8.0-dev.al+sha.x" : (5, 8, 0, "5.8.0"),
             "// swift-tools-version:3.1.2"              : (3, 1, 2, "3.1.2"),
             "// swift-tools-version:3.1.2;"             : (3, 1, 2, "3.1.2"),
             "// swift-tools-vErsion:3.1.2;;;;;"         : (3, 1, 2, "3.1.2"),

--- a/Tests/PackageModelTests/ToolsVersionTests.swift
+++ b/Tests/PackageModelTests/ToolsVersionTests.swift
@@ -1,0 +1,76 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+import PackageModel
+
+class ToolsVersionTests: XCTestCase {
+
+    func testBasics() throws {
+
+        let validVersions = [
+            "3.1.0"                         : "3.1.0",
+            "4.0"                           : "4.0.0",
+            "0000104.0000000.4444"          : "104.0.4444",
+            "1.2.3-alpha.beta+1011"         : "1.2.3",
+            "1.2-alpha.beta+1011"           : "1.2.0",
+            "1.0.0-alpha+001"               : "1.0.0",
+            "1.0.0+20130313144700"          : "1.0.0",
+            "1.0.0-beta+exp.sha.5114f85"    : "1.0.0",
+            "1.0.0-alpha"                   : "1.0.0",
+            "1.0.0-alpha.1"                 : "1.0.0",
+            "1.0.0-0.3.7"                   : "1.0.0",
+            "1.0.0-x.7.z.92"                : "1.0.0",
+            "1.0.0-alpha.beta"              : "1.0.0",
+            "1.0.0-beta"                    : "1.0.0",
+            "1.0.0-beta.2"                  : "1.0.0",
+            "1.0.0-beta.11"                 : "1.0.0",
+            "1.0.0-rc.1"                    : "1.0.0",
+            "1.0.0"                         : "1.0.0",
+            "1.2.3-4"                       : "1.2.3",
+            "2.7.2+asdf"                    : "2.7.2",
+            "1.2.3-a.b.c.10.d.5"            : "1.2.3",
+            "2.7.2-foo+bar"                 : "2.7.2",
+            "1.2.3-alpha.10.beta.0"         : "1.2.3",
+            "1.2.3-al.10.beta.0+bu.uni.ra"  : "1.2.3",
+            "1.2-al.10.beta.0+bu.uni.ra"    : "1.2.0",
+        ]
+
+        for (version, expected) in validVersions {
+            guard let toolsVersion = ToolsVersion(string: version) else {
+                return XCTFail("Couldn't form a version with string: \(version)")
+            }
+            XCTAssertEqual(toolsVersion.description, expected)
+        }
+
+        let invalidVersions = [
+            "1.2.3.4",
+            "1.2-al..beta.0+bu.uni.ra",
+            "1.2.33-al..beta.0+bu.uni.ra",
+            ".1.0.0-x.7.z.92",
+            "1.0.0-alpha.beta+",
+            "1.0.0beta",
+            "1.0.0-",
+            "1.-2.3",
+            "1.2.3d",
+        ]
+
+        for version in invalidVersions {
+            if let toolsVersion = ToolsVersion(string: version) {
+                XCTFail("Form an invalid version \(toolsVersion) with string: \(version)")
+            }
+        }
+    }
+
+    static var allTests = [
+        ("testBasics", testBasics),
+    ]
+}

--- a/Tests/WorkspaceTests/ToolsVersionWriterTests.swift
+++ b/Tests/WorkspaceTests/ToolsVersionWriterTests.swift
@@ -86,6 +86,12 @@ class ToolsVersionWriterTests: XCTestCase {
             // Note: Right now we lose the metadata but if we ever start using it, we should preserve it.
             XCTAssertEqual(result, "// swift-tools-version:4.1.2\n...")
         }
+
+        // Try to write a version with prerelease and build meta data.
+        let toolsVersion = ToolsVersion(version: "4.1.2-alpha.beta+sha.1234")
+        writeToolsVersionCover(stream, version: toolsVersion) { result in
+            XCTAssertEqual(result, "// swift-tools-version:4.1.2\n...")
+        }
     }
 
     func testZeroedPatchVersion() {


### PR DESCRIPTION
This will make tools version accept prerelease and build identifier i.e.
tools version can be formed using a valid semver 2.0 string. However we
will ignore these extra information right now, and only consider the
major, minor and patch part of the versions. For e.g.:


|Input| Interpreted Version|
|-----| -------------------|
|3.0.0                    |         3.0.0|
3.1.0-dev             |          3.1.0|
|3.1-dev+sha.123|           3.1.0|

- https://bugs.swift.org/browse/SR-4129