### PR TITLE
Extra process guards

### DIFF
--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -151,7 +151,10 @@ private func _handle(_ error: Any) {
         }
         stream <<< result.arguments.map{$0.shellEscaped()}.joined(separator: " ")
         print(error: stream.bytes.asString!)
-        
+
+    case Process.Error.missingExecutableProgram(let program):
+        print(error: "Unable to find an executable \(program)")
+
     default:
         print(error: error)
     }

--- a/Sources/Utility/misc.swift
+++ b/Sources/Utility/misc.swift
@@ -54,7 +54,7 @@ public func getEnvSearchPaths(
 }
 
 /// Lookup an executable path from an environment variable value, current working
-/// directory or search paths.
+/// directory or search paths. Only return a value that is both found and executable.
 ///
 /// This method searches in the following order:
 /// * If env value is a valid absolute path, return it.
@@ -77,7 +77,7 @@ public func lookupExecutablePath(
     }
     // We have a value, but it could be an absolute or a relative path.
     let path = AbsolutePath(value, relativeTo: cwd)
-    if exists(path) {
+    if localFileSystem.isExecutableFile(path){
         return path
     }
     // Ensure the value is not a path.
@@ -87,7 +87,7 @@ public func lookupExecutablePath(
     // Try to locate in search paths.
     for path in searchPaths {
         let exec = path.appending(component: value)
-        if exists(exec) {
+        if localFileSystem.isExecutableFile(exec) {
             return exec
         }
     }

--- a/Tests/UtilityTests/miscTests.swift
+++ b/Tests/UtilityTests/miscTests.swift
@@ -50,7 +50,9 @@ class miscTests: XCTestCase {
             let pathEnvClang = pathEnv1.appending(component: "clang")
             try localFileSystem.writeFileContents(pathEnvClang, bytes: "")
             let pathEnv = [path.appending(component: "pathEnv2"), pathEnv1]
-            
+
+            try! Process.checkNonZeroExit(args: "chmod", "+x", pathEnvClang.asString)
+
             // nil and empty string should fail.
             XCTAssertNil(lookupExecutablePath(filename: nil, currentWorkingDirectory: path, searchPaths: pathEnv))
             XCTAssertNil(lookupExecutablePath(filename: "", currentWorkingDirectory: path, searchPaths: pathEnv))
@@ -63,9 +65,10 @@ class miscTests: XCTestCase {
             exec = lookupExecutablePath(filename: "clang", currentWorkingDirectory: path, searchPaths: pathEnv)
             XCTAssertEqual(exec, pathEnvClang)
             
-            // Create the binary relative to cwd.
+            // Create the binary relative to cwd and make it executable.
             let clang = path.appending(component: "clang")
             try localFileSystem.writeFileContents(clang, bytes: "")
+            try! Process.checkNonZeroExit(args: "chmod", "+x", clang.asString)
             // We should now find clang which is in cwd.
             exec = lookupExecutablePath(filename: "clang", currentWorkingDirectory: path, searchPaths: pathEnv)
             XCTAssertEqual(exec, clang)


### PR DESCRIPTION
Following on from earlier PR (https://github.com/apple/swift-package-manager/pull/921) and bug SR-3275 - adding in the mechanisms to support the extra guard logic for validating that an executable file (i.e. git, etc) exists, and making the results when it doesn't exist more consistent across all the various underlying toolchains.

Here for visibility and feedback...

Next steps:
- [x] rebase after https://github.com/apple/swift-package-manager/pull/1002 & https://github.com/apple/swift-package-manager/pull/1003 merged
- [x] add in string output handling for new errors enums in Commands/Errors.swift
- [x] add in relevant tests to validate
