### PR TITLE
Explicit handling of substrings

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -715,7 +715,7 @@ private struct PotentialModule: Hashable {
             fatalError("\(type(of: self)) should be a test module to access basename.")
         }
         precondition(name.hasSuffix(Module.testModuleNameSuffix))
-        return name[name.startIndex..<name.index(name.endIndex, offsetBy: -Module.testModuleNameSuffix.characters.count)]
+        return String(name[name.startIndex..<name.index(name.endIndex, offsetBy: -Module.testModuleNameSuffix.characters.count)])
     }
 
     var hashValue: Int {

--- a/Sources/Utility/StringExtensions.swift
+++ b/Sources/Utility/StringExtensions.swift
@@ -17,10 +17,10 @@ extension String {
     public func chomp(separator: String? = nil) -> String {
         func scrub(_ separator: String) -> String {
             var E = endIndex
-            while self[startIndex..<E].hasSuffix(separator) && E > startIndex {
+            while String(self[startIndex..<E]).hasSuffix(separator) && E > startIndex {
                 E = index(before: E)
             }
-            return self[startIndex..<E]
+            return String(self[startIndex..<E])
         }
 
         if let separator = separator {

--- a/Sources/Utility/misc.swift
+++ b/Sources/Utility/misc.swift
@@ -19,7 +19,7 @@ public func getClangVersion(versionOutput: String) -> (major: Int, minor: Int)? 
         return nil
     }
     let versionStartIndex = clangVersionString.index(clangVersionString.startIndex, offsetBy: versionStringPrefix.utf8.count)
-    let versionString = clangVersionString[versionStartIndex..<clangVersionString.endIndex]
+    let versionString: String = clangVersionString[versionStartIndex..<clangVersionString.endIndex]
     // Split major minor patch etc.
     let versions = versionString.utf8.split(separator: UInt8(ascii: ".")).flatMap(String.init)
     guard versions.count > 1, let major = Int(versions[0]), let minor = Int(versions[1]) else {

--- a/Sources/swiftpm-xctest-helper/main.swift
+++ b/Sources/swiftpm-xctest-helper/main.swift
@@ -62,7 +62,7 @@ func run() throws {
                 var methodName = test.description.characters.split(whereSeparator: splitSet.contains).map(String.init)[2]
                 // Unmangle names for Swift test cases which throw.
                 if methodName.hasSuffix("AndReturnError") {
-                    methodName = methodName[methodName.startIndex..<methodName.index(methodName.endIndex, offsetBy: -14)]
+                    methodName = String(methodName[methodName.startIndex..<methodName.index(methodName.endIndex, offsetBy: -14)])
                 }
                 return ["name": methodName]
             }


### PR DESCRIPTION
It is possible that at some point in future substring will be a separate type. This changes are not strictly necessary at the moment, but make the package manager codebase future-proof.

In short, it's just a bunch of calls to `String.init(_:String)` which are highly likely to be optimized away and not have any runtime impact whatsoever.