### PR TITLE
[SourceControl] Set GIT_TERMINAL_PROMPT=0 when launching git

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -38,7 +38,8 @@ public class GitRepositoryProvider: RepositoryProvider {
         // FIXME: We need infrastructure in this subsystem for reporting
         // status information.
 
-        let process = Process(args: Git.tool, "clone", "--mirror", repository.url, path.asString)
+        let process = Process(
+            args: Git.tool, "clone", "--mirror", repository.url, path.asString, environment: Git.environment)
         // Add to process set.
         try processSet?.add(process)
         // Launch the process.
@@ -292,7 +293,7 @@ public class GitRepository: Repository, WorkingCheckout {
     public func fetch() throws {
         try queue.sync {
             try Process.checkNonZeroExit(
-                args: Git.tool, "-C", path.asString, "remote", "update", "-p")
+                args: Git.tool, "-C", path.asString, "remote", "update", "-p", environment: Git.environment)
             self.tagsCache = nil
         }
     }
@@ -361,7 +362,7 @@ public class GitRepository: Repository, WorkingCheckout {
     /// Initializes and updates the submodules, if any, and cleans left over the files and directories using git-clean.
     private func updateSubmoduleAndClean() throws {
         try Process.checkNonZeroExit(
-            args: Git.tool, "-C", path.asString, "submodule", "update", "--init", "--recursive")
+            args: Git.tool, "-C", path.asString, "submodule", "update", "--init", "--recursive", environment: Git.environment)
         try Process.checkNonZeroExit(
             args: Git.tool, "-C", path.asString, "clean", "-ffdx")
     }

--- a/Sources/Utility/Git.swift
+++ b/Sources/Utility/Git.swift
@@ -8,6 +8,8 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import class Foundation.ProcessInfo
+
 extension Version {
     static func vprefix(_ string: String) -> Version? {
         if string.characters.first == "v" {
@@ -68,5 +70,17 @@ public class Git {
         } catch {
             return false
         }
+    }
+
+    /// Returns the environment variables for launching the git subprocess.
+    ///
+    /// This contains the current environment with custom overrides for using
+    /// git from swift build.
+    public static var environment: [String: String] {
+        var env = ProcessInfo.processInfo.environment
+        // Disable terminal prompts in git. This will make git error out and return
+        // when it needs a user/pass etc instead of hanging the terminal (SR-3981).
+        env["GIT_TERMINAL_PROMPT"] = "0"
+        return env
     }
 }


### PR DESCRIPTION
This will make git error out when it needs user/pass input.
This isn't ideal because we should be able to accept these inputs from
swift tools but it is better than just hanging which happens currently.

See https://bugs.swift.org/browse/SR-3981