### PR TITLE
adding guards for missing inputs into Process

### DIFF
--- a/Sources/Utility/Process.swift
+++ b/Sources/Utility/Process.swift
@@ -105,6 +105,12 @@ public struct ProcessResult: CustomStringConvertible {
 /// Note: This class is thread safe.
 public final class Process: ObjectIdentifierProtocol {
 
+    /// Errors when attempting to invoke a process
+    public enum Error: Swift.Error {
+        /// Missing arguments to invoke a process
+        case missingArguments
+    }
+
     /// Typealias for process id type.
     public typealias ProcessID = pid_t
 
@@ -163,6 +169,10 @@ public final class Process: ObjectIdentifierProtocol {
     public func launch() throws {
         precondition(!launched, "It is not allowed to launch the same process object again.")
         launched = true
+
+        guard arguments.count > 0, !arguments[0].isEmpty else {
+            throw Error.missingArguments
+        }
 
         // Initialize the spawn attributes.
       #if os(macOS)

--- a/Tests/UtilityTests/ProcessTests.swift
+++ b/Tests/UtilityTests/ProcessTests.swift
@@ -54,6 +54,33 @@ class ProcessTests: XCTestCase {
         XCTAssert(outputCount == count)
     }
 
+    func testEmptyArguments() throws {
+        do {
+            let output = try Process.checkNonZeroExit(args: "")
+            XCTFail("Unexpected success for empty arguments\(output)")
+        } catch Process.Error.missingArguments {
+            XCTAssertTrue(true)
+        }
+    }
+
+    func testEmptyArgumentArray() throws {
+        do {
+            let output = try Process.checkNonZeroExit(arguments: [String]())
+            XCTFail("Unexpected success for empty arguments\(output)")
+        } catch Process.Error.missingArguments {
+            XCTAssertTrue(true)
+        }
+    }
+
+    func testMissingArguments() throws {
+        do {
+            let output = try Process.checkNonZeroExit()
+            XCTFail("Unexpected success for empty arguments\(output)")
+        } catch Process.Error.missingArguments {
+            XCTAssertTrue(true)
+        }
+    }
+
     func testCheckNonZeroExit() throws {
         do {
             let output = try Process.checkNonZeroExit(args: "echo", "hello")
@@ -169,6 +196,9 @@ class ProcessTests: XCTestCase {
     static var allTests = [
         ("testBasics", testBasics),
         ("testCheckNonZeroExit", testCheckNonZeroExit),
+        ("testMissingArguments", testMissingArguments),
+        ("testEmptyArguments", testEmptyArguments),
+        ("testEmptyArgumentArray", testEmptyArgumentArray),
         ("testPopen", testPopen),
         ("testSignals", testSignals),
         ("testThreadSafetyOnWaitUntilExit", testThreadSafetyOnWaitUntilExit),


### PR DESCRIPTION
 - created enum with new error set for Process prior to a result being
   created
 - guards to validate that at least one argument is provided, and that
   it isn't an empty string
 - corresponding tests to validate