### PR TITLE
expanding guards in UserToolchain

### DIFF
--- a/Sources/Utility/misc.swift
+++ b/Sources/Utility/misc.swift
@@ -62,12 +62,12 @@ public func getEnvSearchPaths(
 /// * Otherwise, in provided search paths.
 ///
 /// - Parameters:
-///   - value: The value from environment variable.
+///   - filename: The name of the file to find.
 ///   - cwd: The current working directory to look in.
-///   - searchPath: The additional search path to look in if not found in cwd.
+///   - searchPaths: The additional search paths to look in if not found in cwd.
 /// - Returns: Valid path to executable if present, otherwise nil.
 public func lookupExecutablePath(
-    inEnvValue value: String?,
+    filename value: String?,
     currentWorkingDirectory cwd: AbsolutePath = currentWorkingDirectory,
     searchPaths: [AbsolutePath] = []
     ) -> AbsolutePath? {

--- a/Tests/UtilityTests/miscTests.swift
+++ b/Tests/UtilityTests/miscTests.swift
@@ -52,22 +52,22 @@ class miscTests: XCTestCase {
             let pathEnv = [path.appending(component: "pathEnv2"), pathEnv1]
             
             // nil and empty string should fail.
-            XCTAssertNil(lookupExecutablePath(inEnvValue: nil, currentWorkingDirectory: path, searchPaths: pathEnv))
-            XCTAssertNil(lookupExecutablePath(inEnvValue: "", currentWorkingDirectory: path, searchPaths: pathEnv))
+            XCTAssertNil(lookupExecutablePath(filename: nil, currentWorkingDirectory: path, searchPaths: pathEnv))
+            XCTAssertNil(lookupExecutablePath(filename: "", currentWorkingDirectory: path, searchPaths: pathEnv))
             
             // Absolute path to a binary should return it.
-            var exec = lookupExecutablePath(inEnvValue: pathEnvClang.asString, currentWorkingDirectory: path, searchPaths: pathEnv)
+            var exec = lookupExecutablePath(filename: pathEnvClang.asString, currentWorkingDirectory: path, searchPaths: pathEnv)
             XCTAssertEqual(exec, pathEnvClang)
             
             // This should lookup from PATH variable since executable is not present in cwd.
-            exec = lookupExecutablePath(inEnvValue: "clang", currentWorkingDirectory: path, searchPaths: pathEnv)
+            exec = lookupExecutablePath(filename: "clang", currentWorkingDirectory: path, searchPaths: pathEnv)
             XCTAssertEqual(exec, pathEnvClang)
             
             // Create the binary relative to cwd.
             let clang = path.appending(component: "clang")
             try localFileSystem.writeFileContents(clang, bytes: "")
             // We should now find clang which is in cwd.
-            exec = lookupExecutablePath(inEnvValue: "clang", currentWorkingDirectory: path, searchPaths: pathEnv)
+            exec = lookupExecutablePath(filename: "clang", currentWorkingDirectory: path, searchPaths: pathEnv)
             XCTAssertEqual(exec, clang)
         }
     }


### PR DESCRIPTION
 - resolved several FIXME with isExecutableFile checks
 - added a directory check for the SDK
 - updated variable names to better represent what was being passed
 - updated corresponding tests

changes pulled out from https://github.com/apple/swift-package-manager/pull/994 into their own PR