### PR TITLE
[Commands] Add sdk platform path only if its present

### DIFF
--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -213,7 +213,11 @@ public class SwiftTestTool: SwiftTool<TestToolOptions> {
         let tempFile = try TemporaryFile()
         let args = [SwiftTestTool.xctestHelperPath().asString, path.asString, tempFile.path.asString]
         var env = ProcessInfo.processInfo.environment
-        env["DYLD_FRAMEWORK_PATH"] = try getToolchain().sdkPlatformFrameworksPath.asString
+        // Add the sdk platform path if we have it. If this is not present, we
+        // might always end up failing.
+        if let sdkPlatformFrameworksPath = try getToolchain().sdkPlatformFrameworksPath {
+            env["DYLD_FRAMEWORK_PATH"] = sdkPlatformFrameworksPath.asString
+        }
         try Process.checkNonZeroExit(arguments: args, environment: env)
         // Read the temporary file's content.
         let data = try fopen(tempFile.path).readFileContents()

--- a/Sources/TestSupport/Resources.swift
+++ b/Sources/TestSupport/Resources.swift
@@ -35,7 +35,7 @@ public class Resources: ManifestResourceProvider {
 
   #if os(macOS)
     public var sdkPlatformFrameworksPath: AbsolutePath {
-        return toolchain.sdkPlatformFrameworksPath
+        return toolchain.sdkPlatformFrameworksPath!
     }
   #endif
 


### PR DESCRIPTION
This might mean we will fail to run test when SDK is not present but
swift build will still work.

- <rdar://problem/30813768>