### PR TITLE
WIP: A start at a resillient PinStore that holds onto errors rather than throwing errors in the initializers

### DIFF
--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -312,7 +312,8 @@ final class PackageToolTests: XCTestCase {
 
             // Test pins file.
             do {
-                let pinsStore = try PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem)
+                let pinsStore = PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem)
+                XCTAssert(!pinsStore.hasError)
                 XCTAssert(pinsStore.autoPin)
                 XCTAssertEqual(pinsStore.pins.map{$0}.count, 2)
                 for pkg in ["bar", "baz"] {
@@ -332,21 +333,24 @@ final class PackageToolTests: XCTestCase {
             // Enable autopin.
             do {
                 try execute("pin", "--enable-autopin")
-                let pinsStore = try PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem)
+                let pinsStore = PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem)
+                XCTAssert(!pinsStore.hasError)
                 XCTAssert(pinsStore.autoPin)
             }
 
             // Disable autopin.
             do {
                 try execute("pin", "--disable-autopin")
-                let pinsStore = try PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem)
+                let pinsStore = PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem)
+                XCTAssert(!pinsStore.hasError)
                 XCTAssertFalse(pinsStore.autoPin)
             }
 
             // Try to pin bar.
             do {
                 try execute("pin", "bar")
-                let pinsStore = try PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem)
+                let pinsStore = PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem)
+                XCTAssert(!pinsStore.hasError)
                 XCTAssertEqual(pinsStore.pinsMap["bar"]!.state.version, "1.2.3")
             }
 
@@ -375,7 +379,8 @@ final class PackageToolTests: XCTestCase {
             // We should be able to revert to a older version.
             do {
                 try execute("pin", "bar", "--version", "1.2.3", "--message", "bad deppy")
-                let pinsStore = try PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem)
+                let pinsStore = PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem)
+                XCTAssert(!pinsStore.hasError)
                 XCTAssertEqual(pinsStore.pinsMap["bar"]!.reason, "bad deppy")
                 XCTAssertEqual(pinsStore.pinsMap["bar"]!.state.version, "1.2.3")
                 try checkBar(5)
@@ -385,7 +390,9 @@ final class PackageToolTests: XCTestCase {
             do {
                 try execute("unpin", "bar")
                 try execute("update")
-                XCTAssertEqual(try PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem).pinsMap["bar"], nil)
+                let pinsStore = PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem)
+                XCTAssertEqual(pinsStore.pinsMap["bar"], nil)
+                XCTAssert(!pinsStore.hasError)
                 try checkBar(6)
             }
 
@@ -404,7 +411,8 @@ final class PackageToolTests: XCTestCase {
             // Try pinning all the dependencies.
             do {
                 try execute("pin", "--all")
-                let pinsStore = try PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem)
+                let pinsStore = PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem)
+                XCTAssert(!pinsStore.hasError)
                 XCTAssertEqual(pinsStore.pinsMap["bar"]!.state.version, "1.2.4")
                 XCTAssertEqual(pinsStore.pinsMap["baz"]!.state.version, "1.2.3")
             }

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -34,7 +34,8 @@ final class PinsStoreTests: XCTestCase {
         
         let fs = InMemoryFileSystem()
         let pinsFile = AbsolutePath("/pinsfile.txt")
-        var store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
+        var store = PinsStore(pinsFile: pinsFile, fileSystem: fs)
+        XCTAssert(!store.hasError)
         // Pins file should not be created right now.
         XCTAssert(!fs.exists(pinsFile))
         XCTAssert(store.pins.map{$0}.isEmpty)
@@ -45,24 +46,28 @@ final class PinsStoreTests: XCTestCase {
 
         // Test autopin toggle and persistence.
         do {
-            var store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
+            var store = PinsStore(pinsFile: pinsFile, fileSystem: fs)
+            XCTAssert(!store.hasError)
             XCTAssert(store.autoPin)
             try store.setAutoPin(on: false)
             XCTAssertFalse(store.autoPin)
         }
         do {
-            var store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
+            var store = PinsStore(pinsFile: pinsFile, fileSystem: fs)
+            XCTAssert(!store.hasError)
             XCTAssertFalse(store.autoPin)
             try store.setAutoPin(on: true)
             XCTAssert(store.autoPin)
         }
         do {
-            let store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
+            let store = PinsStore(pinsFile: pinsFile, fileSystem: fs)
+            XCTAssert(!store.hasError)
             XCTAssert(store.autoPin)
         }
 
         // Load the store again from disk.
-        let store2 = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
+        let store2 = PinsStore(pinsFile: pinsFile, fileSystem: fs)
+        XCTAssert(!store.hasError)
         XCTAssert(store2.autoPin)
         // Test basics on the store.
         for s in [store, store2] {
@@ -114,6 +119,19 @@ final class PinsStoreTests: XCTestCase {
             XCTAssertEqual(barPin.state.revision, revision)
             XCTAssertEqual(barPin.state.description, revision.identifier)
         }
+    }
+    
+    func testErrors() throws {
+        // Create a broken pinfile.
+        let fs = InMemoryFileSystem()
+        let pinsFile = AbsolutePath("/pinsfile.txt")
+        try fs.writeFileContents(pinsFile, bytes: ByteString(encodingAsUTF8: "this pinfile is malformed"))
+        
+        // Try to instantiate a `PinsStore` from it.
+        let store = PinsStore(pinsFile: pinsFile, fileSystem: fs)
+        XCTAssert(store.hasError)
+        
+        // We should go on to check the nature of the error here, and that it can be resolved.
     }
 
     func testLoadingV1() throws {


### PR DESCRIPTION
Note:  this is a Work-in-Progress PR to foster discussion around the general approach.  While the plan is to evolve it into something mergeable, there is no suggestion that this PR is ready without further discussion.

Currently, many of the critical objects used by the Workspace throw errors in their initializers.  Since these objects are referenced by non-optional properties in the higher-level objects, the initializers for those higher-level objects have to throw as well.  The result is that, if there is any error anywhere in the object graph, it isn’t possible to instantiate a Workspace.  This includes, for example, a malformed `.pins` file on disk, which prevent a Workspace from being instantiated at all.

This is a serious problem for `libSwiftPM`.  The approach, of which this WIP branch is a start, is to make the initializers not throw but instead record the errors and then check for them before performing semantically meaningful operations.  Objects with errors can still be queried, but any attempt to perform operations on them (especially operations that could end up overwriting files etc) will throw an error that informs that client that the operation can’t be performed because of a prior error, and that wraps the original error.

We will definitely need to discuss the form of the errors (i.e. we should have a type for diagnostics, and should be able to handle things like note/warning/error distinctions etc.  We also need to discuss what a protocol should look like that encapsulates some of this functionality and APIs.  Additionally, the client code will need to be updated to account for the fact that operations can throw (though, since most operations can already throw, this should not be an undue burden).

PinsStore is the first type to be converted since it is a leaf type.  The others, up to and including Workspace itself, need to be similarly modified.  We can do that by extending this PR or through new PRs.