### PR TITLE
[ManifestLoader] Further restrict the sandbox profile

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -264,8 +264,6 @@ private func sandboxProfile() -> String {
     // These are required by the Swift compiler.
     stream <<< "(allow process*)" <<< "\n"
     stream <<< "(allow sysctl*)" <<< "\n"
-    stream <<< "(allow mach*)" <<< "\n"
-    stream <<< "(allow signal)" <<< "\n"
     // Allow writing in temporary locations.
     stream <<< "(allow file-write*" <<< "\n"
     stream <<< "    (subpath \"/private/var\")" <<< "\n"


### PR DESCRIPTION
We don't need mach* and it is very unsecure because it allows
communication to processes like nsurlsessiond.

-- <rdar://problem/31213658>