### PR TITLE
[BuildPlan] Strip invalid flags from link command

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -305,12 +305,24 @@ public final class ProductBuildDescription {
         self.buildParameters = buildParameters
     }
 
+    /// Strips the arguments which should *never* be passed to Swift compiler
+    /// when we're linking the product.
+    ///
+    /// We might want to get rid of this method once Swift driver can strip the
+    /// flags itself, <rdar://problem/31215562>.
+    private func stripInvalidArguments(_ args: [String]) -> [String] {
+        let invalidArguments: Set<String> = [
+            "-wmo", "-whole-module-optimization",
+        ]
+        return args.filter{ !invalidArguments.contains($0) }
+    }
+
     /// The arguments to link and create this product.
     public func linkArguments() -> [String] {
         var args = [buildParameters.toolchain.swiftCompiler.asString]
         args += buildParameters.toolchain.swiftPlatformArgs
         args += buildParameters.linkerFlags
-        args += buildParameters.swiftCompilerFlags
+        args += stripInvalidArguments(buildParameters.swiftCompilerFlags)
         args += additionalFlags
 
         if buildParameters.configuration == .debug {


### PR DESCRIPTION
This strips the -wmo flag from link command if it was manually passed
during swift build invocation. It causes compilation failure right now.
We might not want to keep this long term once compiler strips the flag
itself so this is workaround for now. Having wmo in debug mode is a
valid use-case which we plan to properly support using build settings in
future.

-- <rdar://problem/30985305>