### PR TITLE
[PackageLoading] Add option to create multiple test products

### DIFF
--- a/Sources/PackageGraph/PackageGraphLoader.swift
+++ b/Sources/PackageGraph/PackageGraphLoader.swift
@@ -66,7 +66,8 @@ public struct PackageGraphLoader {
         rootManifests: [Manifest],
         externalManifests: [Manifest],
         engine: DiagnosticsEngine,
-        fileSystem: FileSystem = localFileSystem
+        fileSystem: FileSystem = localFileSystem,
+        createMultipleTestProducts: Bool = false
     ) -> PackageGraph {
 
         let allManifests: [Manifest]
@@ -97,7 +98,8 @@ public struct PackageGraphLoader {
                 manifest: manifest,
                 path: packagePath,
                 fileSystem: fileSystem,
-                isRootPackage: isRootPackage
+                isRootPackage: isRootPackage,
+                createMultipleTestProducts: createMultipleTestProducts
             )
 
             do {

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1016,7 +1016,8 @@ public class Workspace {
     @discardableResult
     public func loadPackageGraph(
         rootPackages: [AbsolutePath],
-        engine: DiagnosticsEngine
+        engine: DiagnosticsEngine,
+        createMultipleTestProducts: Bool = false
     ) -> PackageGraph {
         // Ensure the cache path exists and validate that edited dependencies.
         do {
@@ -1041,7 +1042,8 @@ public class Workspace {
                 rootManifests: rootManifests,
                 externalManifests: currentManifests.dependencies.map{$0.manifest},
                 engine: engine,
-                fileSystem: fileSystem
+                fileSystem: fileSystem,
+                createMultipleTestProducts: createMultipleTestProducts
             )
         }
 
@@ -1081,7 +1083,8 @@ public class Workspace {
             rootManifests: currentManifests.roots,
             externalManifests: updatedManifests?.dependencies.map{$0.manifest} ?? [],
             engine: engine,
-            fileSystem: fileSystem
+            fileSystem: fileSystem,
+            createMultipleTestProducts: createMultipleTestProducts
         )
     }
 


### PR DESCRIPTION
Clients can set createMultipleTestProducts to true to get one test
product per test target.

-- <rdar://problem/30913360>