### PR TITLE
[SR-4327] adding usage to swift-build CLI for --build-tests

### DIFF
--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -45,7 +45,8 @@ public class SwiftBuildTool: SwiftTool<BuildToolOptions> {
 
     override class func defineArguments(parser: ArgumentParser, binder: ArgumentBinder<BuildToolOptions>) {
         binder.bind(
-            option: parser.add(option: "--build-tests", kind: Bool.self),
+            option: parser.add(option: "--build-tests", kind: Bool.self,
+                usage: "Build the both source and test targets"),
             to: { $0.buildTests = $1 })
 
         binder.bind(


### PR DESCRIPTION
- adds usage to expose `--build-tests` to `swift build -h`
- resolves [SR-4327](https://bugs.swift.org/browse/SR-4327)
