### PR TITLE
Fix new redundant conformance constraint warnings

### DIFF
--- a/Sources/Basic/Await.swift
+++ b/Sources/Basic/Await.swift
@@ -14,7 +14,7 @@
 ///                   should be passed to the async method's completion handler.
 /// - Returns: The value wrapped by the async method's result.
 /// - Throws: The error wrapped by the async method's result
-public func await<T, ErrorType: Swift.Error>(_ body: (@escaping (Result<T, ErrorType>) -> Void) -> Void) throws -> T {
+public func await<T, ErrorType>(_ body: (@escaping (Result<T, ErrorType>) -> Void) -> Void) throws -> T {
     let condition = Condition()
     var result: Result<T, ErrorType>? = nil
     body { theResult in

--- a/Sources/Basic/DiagnosticsEngine.swift
+++ b/Sources/Basic/DiagnosticsEngine.swift
@@ -39,7 +39,7 @@ public class DiagnosticDescriptionBuilder<Data: DiagnosticData> {
 }
 
 @discardableResult
-public func <<<<T: DiagnosticData>(
+public func <<<<T>(
     builder: DiagnosticDescriptionBuilder<T>,
     string: String
 ) -> DiagnosticDescriptionBuilder<T> {
@@ -48,7 +48,7 @@ public func <<<<T: DiagnosticData>(
 }
 
 @discardableResult
-public func <<<<T: DiagnosticData, P: DiagnosticParameter>(
+public func <<<<T, P: DiagnosticParameter>(
     builder: DiagnosticDescriptionBuilder<T>,
     accessor: @escaping (T) -> P
 ) -> DiagnosticDescriptionBuilder<T> {
@@ -57,7 +57,7 @@ public func <<<<T: DiagnosticData, P: DiagnosticParameter>(
 }
 
 @discardableResult
-public func <<<<T: DiagnosticData>(
+public func <<<<T>(
     builder: DiagnosticDescriptionBuilder<T>,
     fragment: DiagnosticID.DescriptionFragment
 ) -> DiagnosticDescriptionBuilder<T> {
@@ -144,7 +144,7 @@ public class DiagnosticID: ObjectIdentifierProtocol {
     ///     
     ///         let count: Int
     ///     }
-    public init<T: DiagnosticData>(
+    public init<T>(
         type: T.Type,
         name: String,
         defaultBehavior: Diagnostic.Behavior = .error,

--- a/Sources/Basic/GraphAlgorithms.swift
+++ b/Sources/Basic/GraphAlgorithms.swift
@@ -18,7 +18,7 @@ public enum GraphError: Swift.Error {
 /// NOTE: The relation is *not* assumed to be reflexive; i.e. the result will
 /// not automatically include `nodes` unless present in the relation defined by
 /// `successors`.
-public func transitiveClosure<T: Hashable>(
+public func transitiveClosure<T>(
     _ nodes: [T], successors: (T) throws -> [T]
 ) rethrows -> Set<T> {
     var result = Set<T>()

--- a/Sources/Basic/KeyedPair.swift
+++ b/Sources/Basic/KeyedPair.swift
@@ -46,6 +46,6 @@ public struct KeyedPair<T, K: Hashable>: Hashable {
         return key.hashValue
     }
 }    
-public func ==<T, K: Hashable>(lhs: KeyedPair<T, K>, rhs: KeyedPair<T, K>) -> Bool {
+public func ==<T, K>(lhs: KeyedPair<T, K>, rhs: KeyedPair<T, K>) -> Bool {
     return lhs.key == rhs.key
 }

--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -685,7 +685,7 @@ struct VersionAssignmentSet<C: PackageContainer>: Equatable, Sequence {
         }
     }
 }
-func ==<C: PackageContainer>(lhs: VersionAssignmentSet<C>, rhs: VersionAssignmentSet<C>) -> Bool {
+func ==<C>(lhs: VersionAssignmentSet<C>, rhs: VersionAssignmentSet<C>) -> Bool {
     if lhs.assignments.count != rhs.assignments.count { return false }
     for (container, lhsBinding) in lhs {
         switch rhs[container] {


### PR DESCRIPTION
A new version of the compiler probably generated a new warning when generic type protocol conformance constraints are redundant. Example:

```
func foo<T,E : Error>(r: Result<T,E>) { }
//             ^ Error is redundant because Result already declares that conformance
```