### PR TITLE
Rename boolean properties to follow guidelines

### DIFF
--- a/Sources/Basic/TemporaryFile.swift
+++ b/Sources/Basic/TemporaryFile.swift
@@ -165,7 +165,7 @@ public final class TemporaryDirectory {
     public let path: AbsolutePath
 
     /// If true, try to remove the whole directory tree before deallocating.
-    let removeTreeOnDeinit: Bool
+    let shouldRemoveTreeOnDeinit: Bool
 
     /// Creates a temporary directory which is automatically removed when the object of this class goes out of scope.
     ///
@@ -178,7 +178,7 @@ public final class TemporaryDirectory {
     ///
     /// - Throws: MakeDirectoryError
     public init(dir: AbsolutePath? = nil, prefix: String = "TemporaryDirectory", removeTreeOnDeinit: Bool = false) throws {
-        self.removeTreeOnDeinit = removeTreeOnDeinit
+        self.shouldRemoveTreeOnDeinit = removeTreeOnDeinit
         self.prefix = prefix
         // Construct path to the temporary directory.
         let path = determineTempDirectory(dir).appending(RelativePath(prefix + ".XXXXXX"))
@@ -197,7 +197,7 @@ public final class TemporaryDirectory {
 
     /// Remove the temporary file before deallocating.
     deinit {
-        if removeTreeOnDeinit {
+        if shouldRemoveTreeOnDeinit {
             let _ = try? FileManager.default.removeItem(atPath: path.asString)
         } else {
             rmdir(path.asString)

--- a/Sources/Basic/Thread.swift
+++ b/Sources/Basic/Thread.swift
@@ -23,11 +23,11 @@ final public class Thread {
     private var finishedCondition: Condition
 
     /// A boolean variable to track if this thread has finished executing its task.
-    private var finished: Bool
+    private var isFinished: Bool
 
     /// Creates an instance of thread class with closure to be executed when start() is called.
     public init(task: @escaping () -> Void) {
-        finished = false
+        isFinished = false
         finishedCondition = Condition()
 
         // Wrap the task with condition notifying any other threads blocked due to this thread.
@@ -35,10 +35,10 @@ final public class Thread {
         // runs, skip the use of finishedCondition.
         let theTask = { [weak self] in
             if let strongSelf = self {
-                precondition(!strongSelf.finished)
+                precondition(!strongSelf.isFinished)
                 strongSelf.finishedCondition.whileLocked {
                     task()
-                    strongSelf.finished = true
+                    strongSelf.isFinished = true
                     strongSelf.finishedCondition.broadcast()
                 }
             } else {
@@ -58,7 +58,7 @@ final public class Thread {
     /// Blocks the calling thread until this thread is finished execution.
     public func join() {
         finishedCondition.whileLocked {
-            while !finished {
+            while !isFinished {
                 finishedCondition.wait()
             }
         }

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -631,7 +631,7 @@ public class BuildPlan {
             return pkgConfigCache[module]!
         }
         // If there is no pc file on system and we have an available provider, emit a warning.
-        if let provider = result.provider, result.noPcFile {
+        if let provider = result.provider, result.couldNotFindConfigFile {
             delegate?.warning(message: "you may be able to install \(result.pkgConfigName) using your system-packager:")
             delegate?.warning(message: provider.installText)
         } else if let error = result.error {

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -22,16 +22,16 @@ public class ToolOptions {
     public var chdir: AbsolutePath?
 
     /// Enable prefetching in resolver which will kick off parallel git cloning.
-    public var enableResolverPrefetching = false
+    public var shouldEnableResolverPrefetching = false
 
     /// If print version option was passed.
-    public var printVersion: Bool = false
+    public var shouldPrintVersion: Bool = false
 
     /// The verbosity of informational output.
     public var verbosity: Int = 0
 
     /// Disables parsing manifest in a sandbox.
-    public var disableManifestSandbox = false
+    public var shouldDisableManifestSandbox = false
 
     public required init() {}
 }

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -73,7 +73,7 @@ public class SwiftBuildTool: SwiftTool<BuildToolOptions> {
 public class BuildToolOptions: ToolOptions {
     /// Returns the mode in which the build tool should run.
     func mode() throws -> BuildToolMode {
-        if printVersion {
+        if shouldPrintVersion {
             return .version
         }
         // Get the build configuration or assume debug.

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -119,16 +119,16 @@ public class SwiftTool<Options: ToolOptions> {
         binder.bind(
             option: parser.add(option: "--enable-prefetching", kind: Bool.self, 
             usage: "Enable prefetching in resolver"),
-            to: { $0.enableResolverPrefetching = $1 })
+            to: { $0.shouldEnableResolverPrefetching = $1 })
 
         binder.bind(
             option: parser.add(option: "--disable-manifest-sandbox", kind: Bool.self,
             usage: "Disable using the sandbox when parsing manifests on macOS"),
-            to: { $0.disableManifestSandbox = $1 })
+            to: { $0.shouldDisableManifestSandbox = $1 })
 
         binder.bind(
             option: parser.add(option: "--version", kind: Bool.self),
-            to: { $0.printVersion = $1 })
+            to: { $0.shouldPrintVersion = $1 })
 
         // If manifest should be assumed to be PackageDescription4.
         // This is temporary and will go away when the compiler bumps its major version to 4.
@@ -218,7 +218,7 @@ public class SwiftTool<Options: ToolOptions> {
             toolsVersionLoader: ToolsVersionLoader(),
             delegate: delegate,
             repositoryProvider: provider,
-            enableResolverPrefetching: options.enableResolverPrefetching
+            isResolverPrefetchingEnabled: options.shouldEnableResolverPrefetching
         )
         _workspace = workspace
         return workspace
@@ -324,7 +324,7 @@ public class SwiftTool<Options: ToolOptions> {
         return Result(anyError: {
             try ManifestLoader(
                 resources: self.getToolchain(),
-                enableManifestSandbox: !self.options.disableManifestSandbox
+                isManifestSandboxEnabled: !self.options.shouldDisableManifestSandbox
             )
         })
     }()

--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -780,7 +780,7 @@ public class DependencyResolver<
     public let delegate: Delegate
 
     /// Should resolver prefetch the containers.
-    private let enablePrefetching: Bool
+    private let isPrefetchingEnabled: Bool
 
     /// Contains any error encountered during dependency resolution.
     // FIXME: @testable private
@@ -794,12 +794,12 @@ public class DependencyResolver<
     /// repositories from network when trying to partially resolve the constraints.
     ///
     /// Note that the input constraints will always be fetched.
-    public var incompleteMode = false
+    public var isInIncompleteMode = false
 
-    public init(_ provider: Provider, _ delegate: Delegate, enablePrefetching: Bool = false) {
+    public init(_ provider: Provider, _ delegate: Delegate, isPrefetchingEnabled: Bool = false) {
         self.provider = provider
         self.delegate = delegate
-        self.enablePrefetching = enablePrefetching
+        self.isPrefetchingEnabled = isPrefetchingEnabled
     }
 
     /// Execute the resolution algorithm to find a valid assignment of versions.
@@ -877,7 +877,7 @@ public class DependencyResolver<
                 constraints: constraints,
                 into: assignment, subjectTo: allConstraints, excluding: allExclusions).lazy.map{ result in
                 // We might not have a complete result in incomplete mode.
-                if !self.incompleteMode {
+                if !self.isInIncompleteMode {
                     assert(result.checkIfValidAndComplete())
                 }
                 return result
@@ -915,7 +915,7 @@ public class DependencyResolver<
 
                 // Since we don't want to request additional containers in incomplete
                 // mode, remove any dependency that we don't already have.
-                if self.incompleteMode {
+                if self.isInIncompleteMode {
                     constraints = constraints.filter{ self.containers[$0.identifier] != nil }
                 }
 
@@ -958,7 +958,7 @@ public class DependencyResolver<
         var allConstraints = allConstraints
 
         // Never prefetch when running in incomplete mode.
-        if !incompleteMode && enablePrefetching {
+        if !isInIncompleteMode && isPrefetchingEnabled {
             // Ask all of these containers upfront to do async cloning.
             for constraint in constraints {
                 provider.getContainer(for: constraint.identifier) { _ in }

--- a/Sources/PackageGraph/PackageGraphLoader.swift
+++ b/Sources/PackageGraph/PackageGraphLoader.swift
@@ -67,7 +67,7 @@ public struct PackageGraphLoader {
         externalManifests: [Manifest],
         engine: DiagnosticsEngine,
         fileSystem: FileSystem = localFileSystem,
-        createMultipleTestProducts: Bool = false
+        shouldCreateMultipleTestProducts: Bool = false
     ) -> PackageGraph {
 
         let allManifests: [Manifest]
@@ -99,7 +99,7 @@ public struct PackageGraphLoader {
                 path: packagePath,
                 fileSystem: fileSystem,
                 isRootPackage: isRootPackage,
-                createMultipleTestProducts: createMultipleTestProducts
+                shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts
             )
 
             do {

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -101,14 +101,14 @@ extension ManifestLoaderProtocol {
 public final class ManifestLoader: ManifestLoaderProtocol {
 
     let resources: ManifestResourceProvider
-    let enableManifestSandbox: Bool
+    let isManifestSandboxEnabled: Bool
 
     public init(
         resources: ManifestResourceProvider,
-        enableManifestSandbox: Bool = true
+        isManifestSandboxEnabled: Bool = true
     ) {
         self.resources = resources
-        self.enableManifestSandbox = enableManifestSandbox
+        self.isManifestSandboxEnabled = isManifestSandboxEnabled
     }
 
     public func load(
@@ -215,7 +215,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         // If enabled, use sandbox-exec on macOS. This provides some safety against
         // arbitrary code execution when parsing manifest files. We only allow
         // the permissions which are absolutely necessary for manifest parsing.
-        if enableManifestSandbox {
+        if isManifestSandboxEnabled {
             cmd += ["sandbox-exec", "-p", sandboxProfile()]
         }
       #endif

--- a/Sources/PackageLoading/Module+PkgConfig.swift
+++ b/Sources/PackageLoading/Module+PkgConfig.swift
@@ -31,7 +31,7 @@ public struct PkgConfigResult {
     public let error: Swift.Error?
 
     /// If the pc file was not found.
-    public var noPcFile: Bool {
+    public var couldNotFindConfigFile: Bool {
         switch error {
             case PkgConfigError.couldNotFindConfigFile?: return true
             default: return false

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -217,10 +217,10 @@ public struct PackageBuilder {
     /// Create multiple test products.
     ///
     /// If set to true, one test product will be created for each test target.
-    private let createMultipleTestProducts: Bool
+    private let shouldCreateMultipleTestProducts: Bool
 
     /// Returns true if the loaded manifest version is v3.
-    private var v3Manifest: Bool {
+    private var isVersion3Manifest: Bool {
         switch manifest.package {
         case .v3: return true
         case .v4: return false
@@ -243,14 +243,14 @@ public struct PackageBuilder {
         fileSystem: FileSystem = localFileSystem,
         warningStream: OutputByteStream = stdoutStream,
         isRootPackage: Bool,
-        createMultipleTestProducts: Bool = false
+        shouldCreateMultipleTestProducts: Bool = false
     ) {
         self.isRootPackage = isRootPackage
         self.manifest = manifest
         self.packagePath = path
         self.fileSystem = fileSystem
         self.warningStream = warningStream
-        self.createMultipleTestProducts = createMultipleTestProducts
+        self.shouldCreateMultipleTestProducts = shouldCreateMultipleTestProducts
     }
     
     /// Build a new package following the conventions.
@@ -502,7 +502,7 @@ public struct PackageBuilder {
             // For test modules, add dependencies to its base module, if it has
             // no explicit dependency. We only do this for v3 manifests to
             // maintain compatibility.
-            if v3Manifest && potentialModule.isTest && deps.isEmpty {
+            if isVersion3Manifest && potentialModule.isTest && deps.isEmpty {
                 if let baseModule = modules[potentialModule.basename] {
                     deps.append(baseModule)
                 }
@@ -635,7 +635,7 @@ public struct PackageBuilder {
         }
 
         // If enabled, create one test product for each test target.
-        if createMultipleTestProducts {
+        if shouldCreateMultipleTestProducts {
             for testTarget in testModules {
                 let product = Product(name: testTarget.name, type: .test, modules: [testTarget])
                 products.append(product)

--- a/Sources/Workspace/PinsStore.swift
+++ b/Sources/Workspace/PinsStore.swift
@@ -63,8 +63,8 @@ public final class PinsStore {
     /// The pins map.
     fileprivate(set) var pinsMap: [String: Pin]
 
-    /// Autopin enabled or disabled. Autopin is enabled by default.
-    public fileprivate(set) var autoPin: Bool
+    /// Auto-pin enabled or disabled. Auto-pinned is enabled by default.
+    public fileprivate(set) var isAutoPinEnabled: Bool
 
     /// The current pins.
     public var pins: AnySequence<Pin> {
@@ -87,13 +87,13 @@ public final class PinsStore {
             statePath: pinsFile,
             prettyPrint: true)
         pinsMap = [:]
-        autoPin = true
+        isAutoPinEnabled = true
         _ = try self.persistence.restoreState(self)
     }
 
     /// Update the autopin setting. Writes the setting to pins file.
     public func setAutoPin(on value: Bool) throws {
-        autoPin = value
+        isAutoPinEnabled = value
         try saveState()
     }
 
@@ -131,7 +131,7 @@ public final class PinsStore {
     @discardableResult
     public func unpin(package: String) throws -> Pin {
         // Ensure autopin is not on.
-        guard !autoPin else {
+        guard !isAutoPinEnabled else {
             throw PinOperationError.autoPinEnabled
         }
         // The repo should already be pinned.
@@ -167,7 +167,7 @@ extension PinsStore: SimplePersistanceProtocol {
     }
     
     public func restore(from json: JSON) throws {
-        self.autoPin = try json.get("autoPin")
+        self.isAutoPinEnabled = try json.get("autoPin")
         self.pinsMap = try Dictionary(items: json.get("pins").map{($0.package, $0)})
     }
 
@@ -175,7 +175,7 @@ extension PinsStore: SimplePersistanceProtocol {
     public func toJSON() -> JSON {
         return JSON([
             "pins": pins.sorted{$0.package < $1.package}.toJSON(),
-            "autoPin": autoPin,
+            "autoPin": isAutoPinEnabled,
         ])
     }
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -230,7 +230,7 @@ public class Workspace {
     let managedDependencies: LoadableResult<ManagedDependencies>
 
     /// Enable prefetching containers in resolver.
-    let enableResolverPrefetching: Bool
+    let isResolverPrefetchingEnabled: Bool
 
     /// Create a new package workspace.
     ///
@@ -256,7 +256,7 @@ public class Workspace {
         delegate: WorkspaceDelegate,
         fileSystem: FileSystem = localFileSystem,
         repositoryProvider: RepositoryProvider = GitRepositoryProvider(),
-        enableResolverPrefetching: Bool = false
+        isResolverPrefetchingEnabled: Bool = false
     ) {
         self.delegate = delegate
         self.dataPath = dataPath
@@ -264,7 +264,7 @@ public class Workspace {
         self.manifestLoader = manifestLoader
         self.currentToolsVersion = currentToolsVersion
         self.toolsVersionLoader = toolsVersionLoader
-        self.enableResolverPrefetching = enableResolverPrefetching 
+        self.isResolverPrefetchingEnabled = isResolverPrefetchingEnabled
 
         let repositoriesPath = self.dataPath.appending(component: "repositories")
         self.repositoryManager = RepositoryManager(
@@ -773,7 +773,7 @@ public class Workspace {
     /// Otherwise, only currently pinned packages are repinned.
     private func repinPackages(_ pinsStore: PinsStore, dependencyManifests: DependencyManifests) throws {
         // If autopin is on, pin everything and return.
-        if pinsStore.autoPin {
+        if pinsStore.isAutoPinEnabled {
             return try pinAll(
                 pinsStore: pinsStore,
                 dependencyManifests: dependencyManifests,
@@ -902,7 +902,7 @@ public class Workspace {
         constraints: [RepositoryPackageConstraint]
     ) throws -> [(container: WorkspaceResolverDelegate.Identifier, binding: BoundVersion)] {
         let resolverDelegate = WorkspaceResolverDelegate()
-        let resolver = DependencyResolver(containerProvider, resolverDelegate, enablePrefetching: enableResolverPrefetching)
+        let resolver = DependencyResolver(containerProvider, resolverDelegate, isPrefetchingEnabled: isResolverPrefetchingEnabled)
         return try resolver.resolve(constraints: constraints)
     }
 
@@ -1043,7 +1043,7 @@ public class Workspace {
                 externalManifests: currentManifests.dependencies.map{$0.manifest},
                 engine: engine,
                 fileSystem: fileSystem,
-                createMultipleTestProducts: createMultipleTestProducts
+                shouldCreateMultipleTestProducts: createMultipleTestProducts
             )
         }
 
@@ -1069,7 +1069,7 @@ public class Workspace {
                 rootManifests: currentManifests.roots, engine: engine)
 
             // If autopin is enabled, reset and pin everything.
-            if pinsStore.autoPin && !engine.hasErrors() {
+            if pinsStore.isAutoPinEnabled && !engine.hasErrors() {
                 try self.pinAll(
                      pinsStore: pinsStore,
                      dependencyManifests: updatedManifests!,
@@ -1084,7 +1084,7 @@ public class Workspace {
             externalManifests: updatedManifests?.dependencies.map{$0.manifest} ?? [],
             engine: engine,
             fileSystem: fileSystem,
-            createMultipleTestProducts: createMultipleTestProducts
+            shouldCreateMultipleTestProducts: createMultipleTestProducts
         )
     }
 

--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -25,12 +25,12 @@ public struct XcodeprojOptions {
     public let xcconfigOverrides: AbsolutePath?
 
     /// Whether code coverage should be enabled in the generated scheme.
-    public let enableCodeCoverage: Bool
+    public let isCodeCoverageEnabled: Bool
     
-    public init(flags: BuildFlags = BuildFlags(), xcconfigOverrides: AbsolutePath? = nil, enableCodeCoverage: Bool? = nil) {
+    public init(flags: BuildFlags = BuildFlags(), xcconfigOverrides: AbsolutePath? = nil, isCodeCoverageEnabled: Bool? = nil) {
         self.flags = flags
         self.xcconfigOverrides = xcconfigOverrides
-        self.enableCodeCoverage = enableCodeCoverage ?? false
+        self.isCodeCoverageEnabled = isCodeCoverageEnabled ?? false
     }
 }
 
@@ -73,7 +73,7 @@ public func generate(outputDir: AbsolutePath, projectName: String, graph: Packag
    /// it has all tests associated so CMD+U works
     let schemeName = "\(projectName).xcscheme"
     try open(schemesDir.appending(RelativePath(schemeName))) { stream in
-        xcscheme(container: xcodeprojPath.relative(to: srcroot).asString, graph: graph, enableCodeCoverage: options.enableCodeCoverage, printer: stream)
+        xcscheme(container: xcodeprojPath.relative(to: srcroot).asString, graph: graph, codeCoverageEnabled: options.isCodeCoverageEnabled, printer: stream)
     }
 
 ////// we generate this file to ensure our main scheme is listed

--- a/Sources/Xcodeproj/xcscheme().swift
+++ b/Sources/Xcodeproj/xcscheme().swift
@@ -11,7 +11,7 @@
 import PackageGraph
 import PackageModel
 
-func xcscheme(container: String, graph: PackageGraph, enableCodeCoverage: Bool, printer print: (String) -> Void) {
+func xcscheme(container: String, graph: PackageGraph, codeCoverageEnabled: Bool, printer print: (String) -> Void) {
     print("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
     print("<Scheme LastUpgradeVersion = \"9999\" version = \"1.3\">")
     print("  <BuildAction parallelizeBuildables = \"YES\" buildImplicitDependencies = \"YES\">")
@@ -44,7 +44,7 @@ func xcscheme(container: String, graph: PackageGraph, enableCodeCoverage: Bool, 
     print("    selectedDebuggerIdentifier = \"Xcode.DebuggerFoundation.Debugger.LLDB\"")
     print("    selectedLauncherIdentifier = \"Xcode.DebuggerFoundation.Launcher.LLDB\"")
     print("    shouldUseLaunchSchemeArgsEnv = \"YES\"")
-    print("    codeCoverageEnabled = \"\(enableCodeCoverage ? "YES" : "NO")\">")
+    print("    codeCoverageEnabled = \"\(codeCoverageEnabled ? "YES" : "NO")\">")
     print("    <Testables>")
 
     // Create testable references.

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -359,7 +359,7 @@ final class PackageToolTests: XCTestCase {
             // Test pins file.
             do {
                 let pinsStore = try PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem)
-                XCTAssert(pinsStore.autoPin)
+                XCTAssert(pinsStore.isAutoPinEnabled)
                 XCTAssertEqual(pinsStore.pins.map{$0}.count, 2)
                 for pkg in ["bar", "baz"] {
                     let pin = pinsStore.pinsMap[pkg]!
@@ -379,14 +379,14 @@ final class PackageToolTests: XCTestCase {
             do {
                 try execute("pin", "--enable-autopin")
                 let pinsStore = try PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem)
-                XCTAssert(pinsStore.autoPin)
+                XCTAssert(pinsStore.isAutoPinEnabled)
             }
 
             // Disable autopin.
             do {
                 try execute("pin", "--disable-autopin")
                 let pinsStore = try PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem)
-                XCTAssertFalse(pinsStore.autoPin)
+                XCTAssertFalse(pinsStore.isAutoPinEnabled)
             }
 
             // Try to pin bar.

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -134,7 +134,7 @@ class DependencyResolverPerfTests: XCTestCasePerf {
         mktmpdir { path in
             let testHelper = try GitRepositoryResolutionHelper(path)
             measure {
-                let result = testHelper.resolve(enablePrefetching: true)
+                let result = testHelper.resolve(prefetchingEnabled: true)
                 XCTAssertEqual(result.count, 5)
             }
         }
@@ -257,12 +257,12 @@ struct GitRepositoryResolutionHelper {
         return manifestGraph.rootManifest.package.dependencyConstraints()
     }
 
-    func resolve(enablePrefetching: Bool = false) -> [(container: RepositorySpecifier, binding: BoundVersion)] {
+    func resolve(prefetchingEnabled: Bool = false) -> [(container: RepositorySpecifier, binding: BoundVersion)] {
         let repositoriesPath = path.appending(component: "repositories")
         _ = try? systemQuietly(["rm", "-r", repositoriesPath.asString])
         let repositoryManager = RepositoryManager(path: repositoriesPath, provider: GitRepositoryProvider(), delegate: DummyRepositoryManagerDelegate())
         let containerProvider = RepositoryPackageContainerProvider(repositoryManager: repositoryManager, manifestLoader: manifestGraph.manifestLoader)
-        let resolver = DependencyResolver(containerProvider, DummyResolverDelegate(), enablePrefetching: enablePrefetching)
+        let resolver = DependencyResolver(containerProvider, DummyResolverDelegate(), isPrefetchingEnabled: prefetchingEnabled)
         let result = try! resolver.resolve(constraints: constraints)
         return result
     }

--- a/Tests/PackageGraphTests/DependencyResolverTests.swift
+++ b/Tests/PackageGraphTests/DependencyResolverTests.swift
@@ -564,7 +564,7 @@ class DependencyResolverTests: XCTestCase {
         ])
 
         let resolver = MockDependencyResolver(provider, MockResolverDelegate())
-        resolver.incompleteMode = true
+        resolver.isInIncompleteMode = true
 
         // First, try to resolve to a non-existant version.
         XCTAssertThrows(DependencyResolverError.unsatisfiable) {

--- a/Tests/PackageLoadingTests/ConventionTests.swift
+++ b/Tests/PackageLoadingTests/ConventionTests.swift
@@ -1057,7 +1057,7 @@ class ConventionTests: XCTestCase {
             "/Tests/barTests/bar.swift"
         )
         let package = PackageDescription4.Package(name: "pkg")
-        PackageBuilderTester(.v4(package), createMultipleTestProducts: true, in: fs) { result in
+        PackageBuilderTester(.v4(package), shouldCreateMultipleTestProducts: true, in: fs) { result in
             result.checkModule("foo") { _ in }
             result.checkModule("fooTests") { _ in }
             result.checkModule("barTests") { _ in }
@@ -1069,7 +1069,7 @@ class ConventionTests: XCTestCase {
             }
         }
 
-        PackageBuilderTester(.v4(package), createMultipleTestProducts: false, in: fs) { result in
+        PackageBuilderTester(.v4(package), shouldCreateMultipleTestProducts: false, in: fs) { result in
             result.checkModule("foo") { _ in }
             result.checkModule("fooTests") { _ in }
             result.checkModule("barTests") { _ in }
@@ -1132,13 +1132,13 @@ final class PackageBuilderTester {
     private var uncheckedDiagnostics = Set<String>()
 
     /// Setting this to true will disable checking for any unchecked diagnostics prodcuted by PackageBuilder during loading process.
-    var ignoreDiagnostics: Bool = false
+    var ignoresDiagnostics: Bool = false
 
     /// Contains the modules which have not been checked yet.
     private var uncheckedModules = Set<Module>()
 
     /// Setting this to true will disable checking for any unchecked module.
-    var ignoreOtherModules: Bool = false
+    var ignoresOtherModules: Bool = false
 
     @discardableResult
     convenience init(
@@ -1168,7 +1168,7 @@ final class PackageBuilderTester {
     init(
         _ package: Manifest.RawPackage,
         path: AbsolutePath = .root,
-        createMultipleTestProducts: Bool = false,
+        shouldCreateMultipleTestProducts: Bool = false,
         in fs: FileSystem,
         file: StaticString = #file,
         line: UInt = #line,
@@ -1180,7 +1180,7 @@ final class PackageBuilderTester {
             // FIXME: We should allow customizing root package boolean.
             let builder = PackageBuilder(
                 manifest: manifest, path: path, fileSystem: fs, warningStream: warningStream,
-                isRootPackage: true, createMultipleTestProducts: createMultipleTestProducts)
+                isRootPackage: true, shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts)
             let loadedPackage = try builder.construct()
             result = .package(loadedPackage)
             uncheckedModules = Set(loadedPackage.modules)
@@ -1197,12 +1197,12 @@ final class PackageBuilderTester {
     }
 
     private func validateDiagnostics(file: StaticString, line: UInt) {
-        guard !ignoreDiagnostics && !uncheckedDiagnostics.isEmpty else { return }
+        guard !ignoresDiagnostics && !uncheckedDiagnostics.isEmpty else { return }
         XCTFail("Unchecked diagnostics: \(uncheckedDiagnostics)", file: file, line: line)
     }
 
     private func validateCheckedModules(file: StaticString, line: UInt) {
-        guard !ignoreOtherModules && !uncheckedModules.isEmpty else { return }
+        guard !ignoresOtherModules && !uncheckedModules.isEmpty else { return }
         XCTFail("Unchecked modules: \(uncheckedModules)", file: file, line: line)
     }
 

--- a/Tests/PackageLoadingTests/PkgConfigTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigTests.swift
@@ -56,7 +56,7 @@ class PkgConfigTests: XCTestCase {
             case nil:
                 XCTFail("Expected a provider here")
             }
-            XCTAssertTrue(result.noPcFile)
+            XCTAssertTrue(result.couldNotFindConfigFile)
             switch result.error {
                 case PkgConfigError.couldNotFindConfigFile?: break
                 default: 
@@ -73,7 +73,7 @@ class PkgConfigTests: XCTestCase {
             XCTAssertEqual(result.libs, ["-L/usr/da/lib", "-lSystemModule", "-lok"])
             XCTAssertNil(result.provider)
             XCTAssertNil(result.error)
-            XCTAssertFalse(result.noPcFile)
+            XCTAssertFalse(result.couldNotFindConfigFile)
         }
 
         // Pc file with non whitelisted flags.
@@ -83,7 +83,7 @@ class PkgConfigTests: XCTestCase {
             XCTAssertEqual(result.cFlags, [])
             XCTAssertEqual(result.libs, [])
             XCTAssertNil(result.provider)
-            XCTAssertFalse(result.noPcFile)
+            XCTAssertFalse(result.couldNotFindConfigFile)
             switch result.error {
             case PkgConfigError.nonWhitelistedFlags(let desc)?:
                 XCTAssertEqual(desc, "Non whitelisted flags found: [\"-DBlackListed\"] in pc file Bar")

--- a/Tests/UtilityTests/ArgumentParserTests.swift
+++ b/Tests/UtilityTests/ArgumentParserTests.swift
@@ -34,7 +34,7 @@ struct Options {
     }
     var branch: String?
     var package: String!
-    var verbose: Bool = false
+    var isVerbose: Bool = false
     var xld = [String]()
     var flags = Flags(xswiftc: [], xlinker: [])
     var foo: String?
@@ -149,7 +149,7 @@ class ArgumentParserTests: XCTestCase {
 
         binder.bind(
             option: parser.add(option: "--verbose", kind: Bool.self),
-            to: { $0.verbose = $1 })
+            to: { $0.isVerbose = $1 })
 
         binder.bindArray(
             option: parser.add(option: "-Xld", kind: Array<String>.self),
@@ -167,7 +167,7 @@ class ArgumentParserTests: XCTestCase {
 
         XCTAssertEqual(options.branch, "bugfix")
         XCTAssertEqual(options.package, "MyPkg")
-        XCTAssertEqual(options.verbose, true)
+        XCTAssertEqual(options.isVerbose, true)
         XCTAssertEqual(options.xld, ["foo", "bar"])
         XCTAssertEqual(options.flags.xlinker, ["a"])
         XCTAssertEqual(options.flags.xswiftc, ["b"])

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -38,7 +38,7 @@ final class PinsStoreTests: XCTestCase {
         // Pins file should not be created right now.
         XCTAssert(!fs.exists(pinsFile))
         XCTAssert(store.pins.map{$0}.isEmpty)
-        XCTAssert(store.autoPin)
+        XCTAssert(store.isAutoPinEnabled)
 
         try store.pin(package: foo, repository: fooRepo, state: state, reason: "bad")
         XCTAssert(fs.exists(pinsFile))
@@ -46,24 +46,24 @@ final class PinsStoreTests: XCTestCase {
         // Test autopin toggle and persistence.
         do {
             let store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
-            XCTAssert(store.autoPin)
+            XCTAssert(store.isAutoPinEnabled)
             try store.setAutoPin(on: false)
-            XCTAssertFalse(store.autoPin)
+            XCTAssertFalse(store.isAutoPinEnabled)
         }
         do {
             let store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
-            XCTAssertFalse(store.autoPin)
+            XCTAssertFalse(store.isAutoPinEnabled)
             try store.setAutoPin(on: true)
-            XCTAssert(store.autoPin)
+            XCTAssert(store.isAutoPinEnabled)
         }
         do {
             let store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
-            XCTAssert(store.autoPin)
+            XCTAssert(store.isAutoPinEnabled)
         }
 
         // Load the store again from disk.
         let store2 = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
-        XCTAssert(store2.autoPin)
+        XCTAssert(store2.isAutoPinEnabled)
         // Test basics on the store.
         for s in [store, store2] {
             XCTAssert(s.pins.map{$0}.count == 1)


### PR DESCRIPTION
I renamed boolean properties to follow the guideline: “Uses of Boolean methods and properties should read as assertions about the receiver when the use is nonmutating, e.g. x.isEmpty, line1.intersects(line2).”

I followed a convention of naming Option properties with should (ex: `shouldPrintVersion`) for clarity.