### PR TITLE
[Tests] Re-enable the two disabled tests causing CI failure

### DIFF
--- a/Tests/FunctionalTests/ClangModuleTests.swift
+++ b/Tests/FunctionalTests/ClangModuleTests.swift
@@ -144,9 +144,7 @@ class ClangModulesTestCase: XCTestCase {
     }
     
     func testObjectiveCPackageWithTestTarget(){
-      // Disable until https://bugs.swift.org/browse/SR-4419 is fixed.
-#if false
-#if os(macOS)
+      #if os(macOS)
         fixture(name: "ClangModules/ObjCmacOSPackage") { prefix in
             // Build the package.
             XCTAssertBuilds(prefix)
@@ -154,8 +152,7 @@ class ClangModulesTestCase: XCTestCase {
             // Run swift-test on package.
             XCTAssertSwiftTest(prefix)
         }
-#endif
-#endif
+      #endif
     }
 
     static var allTests = [

--- a/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
+++ b/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
@@ -15,10 +15,7 @@ import Utility
 
 class SwiftPMXCTestHelperTests: XCTestCase {
     func testBasicXCTestHelper() {
-      // Reenable when https://bugs.swift.org/browse/SR-4419 is fixed.
-#if false
-#if os(macOS)
-
+      #if os(macOS)
         fixture(name: "Miscellaneous/SwiftPMXCTestHelper") { prefix in
             // Build the package.
             XCTAssertBuilds(prefix)
@@ -41,8 +38,7 @@ class SwiftPMXCTestHelperTests: XCTestCase {
             // Run the XCTest helper tool and check result.
             XCTAssertXCTestHelper(prefix.appending(components: ".build", "debug", "SwiftPMXCTestHelperPackageTests.xctest"), testCases: testCases)
         }
-#endif
-#endif
+      #endif
     }
     
     static var allTests = [


### PR DESCRIPTION
It looks like a simple case of out of date ModuleCache. These tests shouldn't
fail unless the cache is still outdated, in which case we should purge it from
the CI machine.

-- https://bugs.swift.org/browse/SR-4419