### PR TITLE
Make package initialization create a default README.md

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -62,6 +62,7 @@ public final class InitPackage {
         // FIXME: We should form everything we want to write, then validate that
         // none of it exists, and then act.
         try writeManifestFile()
+        try writeREADMEFile()
         try writeGitIgnore()
         try writeSources()
         try writeModuleMap()
@@ -95,6 +96,19 @@ public final class InitPackage {
         // Write the current tools version.
         try writeToolsVersion(
             at: manifest.parentDirectory, version: version, fs: &localFileSystem)
+    }
+    
+    private func writeREADMEFile() throws {
+        let readme = destinationPath.appending(component: "README.md")
+        guard exists(readme) == false else {
+            return
+        }
+        
+        try writePackageFile(readme) { stream in
+            stream <<< "# \(pkgname)\n"
+            stream <<< "\n"
+            stream <<< "A description of this package.\n"
+        }
     }
     
     private func writeGitIgnore() throws {

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -37,6 +37,7 @@ class InitTests: XCTestCase {
 
             // Verify basic file system content that we expect in the package
             XCTAssert(fs.exists(path.appending(component: "Package.swift")))
+            XCTAssert(fs.exists(path.appending(component: "README.md")))
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources")), [])
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Tests")), [])
         }
@@ -62,11 +63,16 @@ class InitTests: XCTestCase {
             
             // Verify basic file system content that we expect in the package
             let manifest = path.appending(component: "Package.swift")
-            let contents = try localFileSystem.readFileContents(manifest).asString!
-            let version = "\(ToolsVersion.currentToolsVersion.major).\(ToolsVersion.currentToolsVersion.minor)"
-            XCTAssertTrue(contents.hasPrefix("// swift-tools-version:\(version)\n"))
-            
             XCTAssertTrue(fs.exists(manifest))
+            let manifestContents = try localFileSystem.readFileContents(manifest).asString!
+            let version = "\(ToolsVersion.currentToolsVersion.major).\(ToolsVersion.currentToolsVersion.minor)"
+            XCTAssertTrue(manifestContents.hasPrefix("// swift-tools-version:\(version)\n"))
+            
+            let readme = path.appending(component: "README.md")
+            XCTAssertTrue(fs.exists(readme))
+            let readmeContents = try localFileSystem.readFileContents(readme).asString!
+            XCTAssertTrue(readmeContents.hasPrefix("# Foo\n"))
+
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources")), ["main.swift"])
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Tests")), [])
             
@@ -95,7 +101,17 @@ class InitTests: XCTestCase {
             XCTAssert(progressMessages.count > 0)
 
             // Verify basic file system content that we expect in the package
-            XCTAssert(fs.exists(path.appending(component: "Package.swift")))
+            let manifest = path.appending(component: "Package.swift")
+            XCTAssertTrue(fs.exists(manifest))
+            let manifestContents = try localFileSystem.readFileContents(manifest).asString!
+            let version = "\(ToolsVersion.currentToolsVersion.major).\(ToolsVersion.currentToolsVersion.minor)"
+            XCTAssertTrue(manifestContents.hasPrefix("// swift-tools-version:\(version)\n"))
+
+            let readme = path.appending(component: "README.md")
+            XCTAssertTrue(fs.exists(readme))
+            let readmeContents = try localFileSystem.readFileContents(readme).asString!
+            XCTAssertTrue(readmeContents.hasPrefix("# Foo\n"))
+
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources")), ["Foo.swift"])
             XCTAssertEqual(
                 try fs.getDirectoryContents(path.appending(component: "Tests")).sorted(),
@@ -126,6 +142,7 @@ class InitTests: XCTestCase {
 
             // Verify basic file system content that we expect in the package
             XCTAssert(fs.exists(path.appending(component: "Package.swift")))
+            XCTAssert(fs.exists(path.appending(component: "README.md")))
             XCTAssert(fs.exists(path.appending(component: "module.modulemap")))
         }
     }


### PR DESCRIPTION
As a way to encourage people to document their packages, start new packages off with a skeletal README.md.

Extend the tests too validate this. (I also tweaked the library test to do the same kind of manifest content validation that the executable test was already doing so that these two primary package types have the same level of validation.)