### PR TITLE
[RepositoryManager] Dispatch callbacks on a serial queue

### DIFF
--- a/Sources/TestSupport/XCTAssertHelpers.swift
+++ b/Sources/TestSupport/XCTAssertHelpers.swift
@@ -117,3 +117,19 @@ public func XCTAssertThrows<T: Swift.Error>(
         XCTFail("unexpected error thrown", file: file, line: line)
     }
 }
+
+public func XCTNonNil<T>( 
+   _ optional: T?,
+   file: StaticString = #file,
+   line: UInt = #line,
+   _ body: (T) throws -> Void
+) {
+    guard let optional = optional else {
+        return XCTFail("Unexpected nil value", file: file, line: line)
+    }
+    do {
+        try body(optional)
+    } catch {
+        XCTFail("Unexpected error \(error)", file: file, line: line)
+    }
+}


### PR DESCRIPTION
Callbacks on a concurrent queue caused test failures sometimes because the
delegate block was not guaranteed to be dispatched before the completion block.
Moving this to a serial queue resolves the issue, however this also means that
recursive lookups are not possible.

-- - https://bugs.swift.org/browse/SR-4496