### PR TITLE
Migrate Workspace.clean to the diagnostics system

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -54,7 +54,7 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             try initPackage.writePackageStructure()
 
         case .clean:
-            try getActiveWorkspace().clean()
+            try getActiveWorkspace().clean(with: diagnostics)
 
         case .reset:
             try getActiveWorkspace().reset()

--- a/Sources/Utility/Diagnostics.swift
+++ b/Sources/Utility/Diagnostics.swift
@@ -70,5 +70,21 @@ extension DiagnosticsEngine {
         location: DiagnosticLocation = UnknownLocation.location
      ) {
         emit(data: convertible.diagnosticData, location: location)
+	}
+
+    /// Wrap a throwing closure, returning an optional value and
+    /// emitting any thrown errors.
+    ///
+    /// - Parameters:
+    ///     - closure: Closure to wrap.
+    /// - Returns: Returns the return value of the closure wrapped
+    ///   into an optional. If the closure throws, nil is returned.
+    public func wrap<T>(_ closure: () throws -> T) -> T? {
+        do {
+            return try closure()
+        } catch {
+            emit(error)
+            return nil
+        }
     }
 }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -447,7 +447,9 @@ final class WorkspaceTests: XCTestCase {
             XCTAssert(localFileSystem.exists(buildArtifact))
             XCTAssert(localFileSystem.exists(checkoutPath))
 
-            try workspace.clean()
+            let diagnostics = DiagnosticsEngine()
+            workspace.clean(with: diagnostics)
+            XCTAssertFalse(diagnostics.hasErrors())
 
             XCTAssertEqual(try workspace.managedDependencies.load().values.map{ $0.repository }, [testRepoSpec])
             XCTAssert(localFileSystem.exists(workspace.dataPath))


### PR DESCRIPTION
Made Workspace.clean non-throwing and accept a `DiagnosticsEngine`.

While doing so, I found it quite useful to define a `wrap` method on `DiagnosticsEngine` that allows us to wrap a throwing function into a Optional returning function, feeding the engine on error. It’s a more generally useful version of `LoadableResult.load(diagnostics:)`, so took the liberty to remove that function.