### PR TITLE
[Workspace] Add loadGraphData() method

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -44,6 +44,9 @@ private class ToolWorkspaceDelegate: WorkspaceDelegate {
     func warning(message: String) {
         print("warning: " + message)
     }
+
+    func managedDependenciesDidUpdate(_ dependencies: AnySequence<ManagedDependency>) {
+    }
 }
 
 public class SwiftTool<Options: ToolOptions> {


### PR DESCRIPTION
-- <rdar://problem/31573326> Workspace should have a method that returns PackageGraph + mapping of ResolvePackage -> ManagedDependency