### PR TITLE
Migrate Workspace reset & edit to use diagnostics

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -57,7 +57,7 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             try getActiveWorkspace().clean(with: diagnostics)
 
         case .reset:
-            try getActiveWorkspace().reset()
+            try getActiveWorkspace().reset(with: diagnostics)
 
         case .resolve:
             // NOTE: This command is currently undocumented, and is for
@@ -101,13 +101,13 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             // Create revision object if provided by user.
             let revision = options.editOptions.revision.flatMap({ Revision(identifier: $0) })
             // Put the dependency in edit mode.
-            try workspace.edit(
+            workspace.edit(
                 dependency: dependency,
                 packageName: manifest.name,
+                diagnostics: diagnostics,
                 path: options.editOptions.path,
                 revision: revision,
-                checkoutBranch: options.editOptions.checkoutBranch
-            )
+                checkoutBranch: options.editOptions.checkoutBranch)
 
         case .unedit:
             let packageName = options.editOptions.packageName!

--- a/Sources/Utility/Diagnostics.swift
+++ b/Sources/Utility/Diagnostics.swift
@@ -94,4 +94,21 @@ extension DiagnosticsEngine {
             return nil
         }
     }
+    
+    /// Wrap a throwing closure, returning a success boolean and
+    /// emitting any thrown errors.
+    ///
+    /// - Parameters:
+    ///     - closure: Closure to wrap.
+    /// - Returns: Returns true if the wrapped closure did not throw
+    ///   and false otherwise.
+    public func wrap(_ closure: () throws -> Void) -> Bool {
+        do {
+            try closure()
+            return true
+        } catch {
+            emit(error)
+            return false
+        }
+    }
 }


### PR DESCRIPTION
Added an override of `DiagnosticsEngine.wrap` that helps wrapping Void returning throwing closures.