### PR TITLE
[Workspace] Make non-editable checkouts immutable

### DIFF
--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -285,6 +285,7 @@ class MiscellaneousTestCase: XCTestCase {
             sleep(1)
 
             let path = try SwiftPMProduct.packagePath(for: "FisherYates", packageRoot: packageRoot)
+            try localFileSystem.set(attribute: .mutable, path: path, recursive: true)
             try localFileSystem.writeFileContents(path.appending(components: "src", "Fisher-Yates_Shuffle.swift"), bytes: "public extension Collection{ func shuffle() -> [Iterator.Element] {return []} }\n\npublic extension MutableCollection where Index == Int { mutating func shuffleInPlace() { for (i, _) in enumerated() { self[i] = self[0] } }}\n\npublic let shuffle = true")
 
             XCTAssertBuilds(prefix.appending(component: "app"))
@@ -311,6 +312,7 @@ class MiscellaneousTestCase: XCTestCase {
             sleep(1)
 
             let path = try SwiftPMProduct.packagePath(for: "dep1", packageRoot: packageRoot)
+            try localFileSystem.set(attribute: .mutable, path: path, recursive: true)
             try localFileSystem.writeFileContents(path.appending(components: "Foo.swift"), bytes: "public let foo = \"Goodbye\"")
 
             XCTAssertBuilds(prefix.appending(component: "root"))

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -2065,8 +2065,12 @@ final class WorkspaceTests: XCTestCase {
             let diagnostics = DiagnosticsEngine()
             let delegate = TestWorkspaceDelegate()
             let workspace = Workspace.createWith(rootPackage: barRoot, delegate: delegate)
+
             workspace.loadPackageGraph(rootPackages: [barRoot], diagnostics: diagnostics)
+
+            try localFileSystem.set(attribute: .mutable, path: workspace.checkoutsPath, recursive: true)
             try removeFileTree(workspace.checkoutsPath)
+
             workspace.loadPackageGraph(rootPackages: [barRoot], diagnostics: diagnostics)
             XCTAssertFalse(diagnostics.hasErrors)
             XCTAssertTrue(delegate.warnings.contains(where: { $0.hasPrefix("Foo") && $0.hasSuffix(" is missing and has been cloned again.") }))


### PR DESCRIPTION
-- <rdar://problem/31286403> Unedited Swift package sources should be read-only