### PR TITLE
[PackageBuilder] Add new search rules for linux main file

### DIFF
--- a/Sources/PackageModel/Module.swift
+++ b/Sources/PackageModel/Module.swift
@@ -63,6 +63,9 @@ public class Target: ObjectIdentifierProtocol {
 
 public class SwiftTarget: Target {
 
+    /// The file name of linux main file.
+    public static let linuxMainBasename = "LinuxMain.swift"
+
     /// Create an executable Swift target from linux main test manifest file.
     init(linuxMain: AbsolutePath, name: String, dependencies: [Target]) {
         self.swiftLanguageVersions = nil

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -50,15 +50,22 @@ public class Product {
     /// the product, but not necessarily their transitive dependencies.
     public let targets: [Target]
 
-    public init(name: String, type: ProductType, targets: [Target]) {
+    /// The path to linux main file.
+    public let linuxMain: AbsolutePath?
+
+    public init(name: String, type: ProductType, targets: [Target], linuxMain: AbsolutePath? = nil) {
         precondition(!targets.isEmpty)
         if type == .executable {
             assert(targets.filter({ $0.type == .executable }).count == 1,
                    "Executable products should have exactly one executable target.")
         }
+        if linuxMain != nil {
+            assert(type == .test, "Linux main should only be set on test products")
+        }
         self.name = name
         self.type = type
         self.targets = targets
+        self.linuxMain = linuxMain 
     }
 
     public var outname: RelativePath {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -182,6 +182,7 @@ final class BuildPlanTests: XCTestCase {
     func testTestModule() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Pkg/Sources/Foo/foo.swift",
+            "/Pkg/Tests/LinuxMain.swift",
             "/Pkg/Tests/FooTests/foo.swift"
         )
         let graph = loadMockPackageGraph(["/Pkg": Package(name: "Pkg")], root: "/Pkg", in: fs)

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -1139,6 +1139,10 @@ final class PackageBuilderTester {
             XCTAssertEqual(product.type, type, file: file, line: line)
             XCTAssertEqual(product.targets.map{$0.name}.sorted(), targets.sorted(), file: file, line: line)
         }
+
+        func check(linuxMainPath: String, file: StaticString = #file, line: UInt = #line) {
+            XCTAssertEqual(product.linuxMain, AbsolutePath(linuxMainPath), file: file, line: line)
+        }
     }
 
     final class ModuleResult {

--- a/Tests/XcodeprojTests/FunctionalTests.swift
+++ b/Tests/XcodeprojTests/FunctionalTests.swift
@@ -37,8 +37,7 @@ class FunctionalTests: XCTestCase {
             XCTAssertXcodeprojGen(prefix)
             let pbx = prefix.appending(component: "SwiftCMixed.xcodeproj")
             XCTAssertDirectoryExists(pbx)
-            // Ensure we have plists for library and test targets.
-            XCTAssertFileExists(pbx.appending(component: "SeaLibTests_Info.plist"))
+            // Ensure we have plist for the library target.
             XCTAssertFileExists(pbx.appending(component: "SeaLib_Info.plist"))
 
             XCTAssertXcodeBuild(project: pbx)


### PR DESCRIPTION
XCTest on linux doesn't support dynamic test discovery and requires the list of
test cases in order to run them. The Package Manager allows declaring the test
cases using `LinuxMain.swift` file. This file is expected to be found in Tests
directory, but with custom target layouts feature, it is possible to relocate
the test targets. To handle this, expand the rule for finding `LinuxMain.swift`.
The new rule searchs for `LinuxMain.swift` adjacent to any test target,
iterating upto the package root. It is an error to have multiple
`LinuxMain.swift` files.

-- <rdar://problem/31585721> Figure out how to handle LinuxMain with custom targets layout