### PR TITLE
cross compilation support (configurable destinations)

### DIFF
--- a/Sources/Build/Toolchain.swift
+++ b/Sources/Build/Toolchain.swift
@@ -15,17 +15,20 @@ public protocol Toolchain {
     /// Path of the `swiftc` compiler.
     var swiftCompiler: AbsolutePath { get }
 
-    /// Platform-specific arguments for Swift compiler.
-    var swiftPlatformArgs: [String] { get }
-
     /// Path of the `clang` compiler.
     var clangCompiler: AbsolutePath { get }
 
-    /// Platform-specific arguments for Clang compiler.
-    var clangPlatformArgs: [String] { get }
+    /// Additional flags to be passed to the C compiler.
+    var extraCCFlags: [String] { get }
 
-    /// Path of the default SDK (a.k.a. "sysroot"), if any.
-    var defaultSDK: AbsolutePath? { get }
+    /// Additional flags to be passed to the Swift compiler.
+    var extraSwiftCFlags: [String] { get }
+
+    /// Additional flags to be passed when compiling with C++.
+    var extraCPPFlags: [String] { get }
+
+    /// The dynamic library extension, for e.g. dylib, so.
+    var dynamicLibraryExtension: String { get }
 }
 
 extension AbsolutePath {

--- a/Sources/Commands/Destination.swift
+++ b/Sources/Commands/Destination.swift
@@ -1,0 +1,178 @@
+import Basic
+import Utility
+import POSIX
+
+enum DestinationError: Swift.Error {
+    /// Couldn't find the Xcode installation.
+    case invalidInstallation(String)
+
+    /// The schema version is invalid.
+    case invalidSchemaVersion
+}
+
+extension DestinationError: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .invalidSchemaVersion:
+            return "unsupported destination file schema version"
+        case .invalidInstallation(let problem):
+            return problem
+        }
+    }
+}
+
+/// The compilation destination, has information about everything that's required for a certain destination.
+public struct Destination {
+
+    /// The clang/LLVM triple describing the target OS and architecture.
+    ///
+    /// The triple has the general format <arch><sub>-<vendor>-<sys>-<abi>, where:
+    ///  - arch = x86_64, i386, arm, thumb, mips, etc.
+    ///  - sub = for ex. on ARM: v5, v6m, v7a, v7m, etc.
+    ///  - vendor = pc, apple, nvidia, ibm, etc.
+    ///  - sys = none, linux, win32, darwin, cuda, etc.
+    ///  - abi = eabi, gnu, android, macho, elf, etc.
+    ///
+    /// for more information see //https://clang.llvm.org/docs/CrossCompilation.html
+    public let target: String
+
+    /// The SDK used to compile for the destination.
+    public let sdk: AbsolutePath
+
+    /// The binDir in the containing the compilers/linker to be used for the compilation.
+    public let binDir: AbsolutePath
+
+    /// The file extension for dynamic libraries (eg. `.so` or `.dylib`)
+    public let dynamicLibraryExtension: String
+
+    /// Additional flags to be passed to the C compiler.
+    public let extraCCFlags: [String]
+
+    /// Additional flags to be passed to the Swift compiler.
+    public let extraSwiftCFlags: [String]
+
+    /// Additional flags to be passed when compiling with C++.
+    public let extraCPPFlags: [String]
+
+    /// Returns the bin directory for the host.
+    private static func hostBinDir() -> AbsolutePath {
+      #if Xcode
+        // For Xcode, set bin directory to the build directory containing the fake
+        // toolchain created during bootstraping. This is obviously not production ready
+        // and only exists as a development utility right now.
+        //
+        // This also means that we should have bootstrapped with the same Swift toolchain
+        // we're using inside Xcode otherwise we will not be able to load the runtime libraries.
+        //
+        // FIXME: We may want to allow overriding this using an env variable but that
+        // doesn't seem urgent or extremely useful as of now.
+        return AbsolutePath(#file).parentDirectory
+            .parentDirectory.parentDirectory.appending(components: ".build", "debug")
+      #endif
+      return AbsolutePath(
+        CommandLine.arguments[0], relativeTo: currentWorkingDirectory).parentDirectory
+    }
+
+    /// The destination describing the host OS.
+    public static func hostDestination(_ binDir: AbsolutePath? = nil) throws -> Destination {
+        // Select the correct binDir.
+        let binDir = binDir ?? Destination.hostBinDir()
+
+      #if os(macOS)
+        // Get the SDK.
+        let sdkPath: AbsolutePath
+        if let value = lookupExecutablePath(filename: getenv("SYSROOT")) {
+            sdkPath = value
+        } else {
+            // No value in env, so search for it.
+            let sdkPathStr = try Process.checkNonZeroExit(
+                args: "xcrun", "--sdk", "macosx", "--show-sdk-path").chomp()
+            guard !sdkPathStr.isEmpty else {
+                throw DestinationError.invalidInstallation("could not find default SDK")
+            }
+            sdkPath = AbsolutePath(sdkPathStr)
+        }
+
+        // Compute common arguments for clang and swift.
+        // This is currently just frameworks path.
+        let commonArgs = Destination.sdkPlatformFrameworkPath().map({ ["-F", $0.asString] }) ?? []
+
+        return Destination(
+            target: "x86_64-apple-macosx10.10",
+            sdk: sdkPath,
+            binDir: binDir,
+            dynamicLibraryExtension: "dylib",
+            extraCCFlags: ["-arch", "x86_64", "-mmacosx-version-min=10.10"] + commonArgs,
+            extraSwiftCFlags: commonArgs,
+            extraCPPFlags: ["-lc++"]
+        )
+      #else
+        return Destination(
+            target: "linux-unknown-x86_64",
+            sdk: .root,
+            binDir: binDir,
+            dynamicLibraryExtension: "so",
+            extraCCFlags: ["-fPIC"],
+            extraSwiftCFlags: [],
+            extraCPPFlags: ["-lstdc++"]
+        )
+      #endif
+    }
+
+    /// Returns macosx sdk platform framework path.
+    public static func sdkPlatformFrameworkPath() -> AbsolutePath? {
+        if let path = _sdkPlatformFrameworkPath {
+            return path
+        }
+        let platformPath = try? Process.checkNonZeroExit(
+            args: "xcrun", "--sdk", "macosx", "--show-sdk-platform-path").chomp()
+
+        if let platformPath = platformPath, !platformPath.isEmpty {
+           _sdkPlatformFrameworkPath = AbsolutePath(platformPath).appending(
+                components: "Developer", "Library", "Frameworks")
+        }
+        return _sdkPlatformFrameworkPath
+    }
+    /// Cache storage for sdk platform path.
+    private static var _sdkPlatformFrameworkPath: AbsolutePath? = nil
+
+  #if os(macOS)
+    /// Returns the host's dynamic library extension.
+    public static let hostDynamicLibraryExtension = "dylib"
+  #else
+    /// Returns the host's dynamic library extension.
+    public static let hostDynamicLibraryExtension = "so"
+  #endif
+}
+
+public extension Destination {
+
+    /// Load a Destination description from a JSON representation from disk.
+    public init(fromFile path: AbsolutePath, fileSystem: FileSystem = localFileSystem) throws {
+        let json = try JSON(bytes: fileSystem.readFileContents(path))
+        try self.init(json: json)
+    }
+}
+
+extension Destination: JSONMappable {
+
+    /// The current schema version.
+    static let schemaVersion = 1
+
+    public init(json: JSON) throws {
+
+        // Check schema version.
+        guard try json.get("version") == Destination.schemaVersion else {
+            throw DestinationError.invalidSchemaVersion
+        }
+
+        try self.init(target: json.get("target"),
+            sdk: AbsolutePath(json.get("sdk")),
+            binDir: AbsolutePath(json.get("toolchain-bin-dir")),
+            dynamicLibraryExtension: json.get("dynamic-library-extension"),
+            extraCCFlags: json.get("extra-cc-flags"),
+            extraSwiftCFlags: json.get("extra-swiftc-flags"),
+            extraCPPFlags: json.get("extra-cpp-flags")
+        )
+    }
+}

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -33,5 +33,8 @@ public class ToolOptions {
     /// Disables sandboxing when executing subprocesses.
     public var shouldDisableSandbox = false
 
+    /// Path to the compilation destination describing JSON file.
+    public var customCompileDestination: AbsolutePath?
+
     public required init() {}
 }

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -219,7 +219,7 @@ public class SwiftTestTool: SwiftTool<TestToolOptions> {
         var env = ProcessInfo.processInfo.environment
         // Add the sdk platform path if we have it. If this is not present, we
         // might always end up failing.
-        if let sdkPlatformFrameworksPath = try getToolchain().sdkPlatformFrameworksPath {
+        if let sdkPlatformFrameworksPath = Destination.sdkPlatformFrameworkPath() {
             env["DYLD_FRAMEWORK_PATH"] = sdkPlatformFrameworksPath.asString
         }
         try Process.checkNonZeroExit(arguments: args, environment: env)

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -67,14 +67,6 @@ public class Product {
         self.targets = targets
         self.linuxMain = linuxMain 
     }
-
-    // FIXME: This needs to be come from a toolchain object, not the host
-    // configuration.
-#if os(macOS)
-    public static let dynamicLibraryExtension = "dylib"
-#else
-    public static let dynamicLibraryExtension = "so"
-#endif
 }
 
 extension Product: CustomStringConvertible {

--- a/Sources/TestSupport/Resources.swift
+++ b/Sources/TestSupport/Resources.swift
@@ -9,6 +9,7 @@
 */
 
 import Basic
+import Build
 import Foundation
 import Commands
 import PackageLoading
@@ -34,7 +35,7 @@ public class Resources: ManifestResourceProvider {
 
   #if os(macOS)
     public var sdkPlatformFrameworksPath: AbsolutePath {
-        return toolchain.sdkPlatformFrameworksPath!
+        return Destination.sdkPlatformFrameworkPath()!
     }
   #endif
 
@@ -53,6 +54,6 @@ public class Resources: ManifestResourceProvider {
       #else
         binDir = AbsolutePath(CommandLine.arguments[0], relativeTo: currentWorkingDirectory).parentDirectory
       #endif
-        toolchain = try! UserToolchain(binDir)
+        toolchain = try! UserToolchain(destination: Destination.hostDestination(binDir))
     }
 }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -11,6 +11,7 @@
 import XCTest
 import TestSupport
 import Basic
+import struct Commands.Destination
 import PackageModel
 import Utility
 import libc
@@ -19,6 +20,11 @@ import class Foundation.ProcessInfo
 typealias ProcessID = Basic.Process.ProcessID
 
 class MiscellaneousTestCase: XCTestCase {
+
+    private var dynamicLibraryExtension: String {
+        return Destination.hostDynamicLibraryExtension
+    }
+
     func testPrintsSelectedDependencyVersion() {
 
         // verifies the stdout contains information about
@@ -328,7 +334,7 @@ class MiscellaneousTestCase: XCTestCase {
         }
         fixture(name: "Products/DynamicLibrary") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix.appending(components: ".build", "debug", "libProductName.\(Product.dynamicLibraryExtension)"))
+            XCTAssertFileExists(prefix.appending(components: ".build", "debug", "libProductName.\(dynamicLibraryExtension)"))
         }
     }
 
@@ -397,7 +403,7 @@ class MiscellaneousTestCase: XCTestCase {
             let systemModule = prefix.appending(component: "SystemModule")
             // Create a shared library.
             let input = systemModule.appending(components: "Sources", "SystemModule.c")
-            let output =  systemModule.appending(component: "libSystemModule.\(Product.dynamicLibraryExtension)")
+            let output =  systemModule.appending(component: "libSystemModule.\(dynamicLibraryExtension)")
             try systemQuietly(["clang", "-shared", input.asString, "-o", output.asString])
 
             let pcFile = prefix.appending(component: "libSystemModule.pc")

--- a/Tests/XcodeprojTests/FunctionalTests.swift
+++ b/Tests/XcodeprojTests/FunctionalTests.swift
@@ -55,7 +55,7 @@ class FunctionalTests: XCTestCase {
             let systemModule = prefix.appending(component: "SystemModule")
             // Create a shared library.
             let input = systemModule.appending(components: "Sources", "SystemModule.c")
-            let output =  systemModule.appending(component: "libSystemModule.\(Product.dynamicLibraryExtension)")
+            let output =  systemModule.appending(component: "libSystemModule.dylib")
             try systemQuietly(["clang", "-shared", input.asString, "-o", output.asString])
 
             let pcFile = prefix.appending(component: "libSystemModule.pc")

--- a/Utilities/build_ubuntu_cross_compilation_toolchain
+++ b/Utilities/build_ubuntu_cross_compilation_toolchain
@@ -233,9 +233,9 @@ fix_glibc_modulemap "$cross_tc_basename/$xc_tc_name/usr/lib/swift/linux/x86_64/g
 
 cat > "$cross_tc_basename/ubuntu-xenial-destination.json" <<EOF
 {
-    "version": "1",
+    "version": 1,
     "sdk": "$(pwd)/$cross_tc_basename/$linux_sdk_name",
-    "toolchain": "$(pwd)/$cross_tc_basename/$xc_tc_name",
+    "toolchain-bin-dir": "$(pwd)/$cross_tc_basename/$xc_tc_name/usr/bin",
     "target": "linux-unknown-x86_64",
     "dynamic-library-extension": "so",
     "extra-cc-flags": [
@@ -243,6 +243,9 @@ cat > "$cross_tc_basename/ubuntu-xenial-destination.json" <<EOF
     ],
     "extra-swiftc-flags": [
         "-use-ld=gold", "-tools-directory", "$(pwd)/$cross_tc_basename/$xc_tc_name/usr/bin"
+    ],
+    "extra-cpp-flags": [
+        "-lstdc++"
     ]
 }
 EOF


### PR DESCRIPTION
# General

This adds _experimental_ support for cross compilation or more precisely configurable destinations for binaries to SwiftPM. The basic idea is that you hand a JSON file in the format described below to SwiftPM (ie. `swift build --destination my-destination.json`). SwiftPM will then invoke the `swiftc`/`clang` with the appropriate arguments. The `--destination` switch is optional and if omitted SwiftPM will use the destination as appropriate for the host OS as it previously did.

# `destination.json` File Format

    {
        "version": 1,
        "sdk": <path to the SDK for the target platform: String>,
        "toolchain-bin-dir": <path to the toolchain's bin dir: String>,
        "target": <LLVM target triple: String>,
        "extra-cc-flags": <extra C compiler arguments: [String]>,
        "extra-swiftc-flags": <extra Swift compiler arguments: [String]>,
        "dynamic-library-extension": <extension of dynamic library files: String>,
        "extra-cpp-flags": <extra C++ compiler flags: [String]>
    }

## Example: compile for macOS on macOS

    {
        "version": 1,
        "sdk": "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/",
        "toolchain-bin-dir": "/Library/Developer/Toolchains/swift-3.1-RELEASE.xctoolchain/usr/bin",
        "target": "x86_64-apple-macosx10.10",
        "extra-cc-flags": [
            "-arch", "x86_64",
            "-mmacosx-version-min=10.10"
        ],
        "extra-swiftc-flags": [],
        "extra-cpp-flags": ["-lc++"],
        "dynamic-library-extension": "dylib"
    }

## Example: compile for Ubuntu Linux on macOS (SDK required)

    {
        "version": 1,
        "sdk": "/Users/johannes/cross-toolchain/ubuntu-xenial.sdk",
        "toolchain-bin-dir": "/Users/johannes/cross-toolchain/swift.xctoolchain/usr/bin",
        "target": "linux-unknown-x86_64",
        "dynamic-library-extension": "so",
        "extra-cc-flags": [
            "-fPIC"
        ],
        "extra-swiftc-flags": [
            "-use-ld=gold"
        ],
        "extra-cpp-flags": ["-lstdc++"]
    }

# Some Words About Cross Compilation

To cross compile a binary, you will need a cross compilation toolchain which consists of the toolchain itself and an SDK. For example compiling an iPhone binary from your Mac will use `/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk` or similar. If you want to compile a Swift binary for say Ubuntu Xenial on your Mac, you'll need the following pieces of software

 - a compiler being able to cross compile ✅ (`swiftc` and `clang` are able to do that)
 - the basic Swift libraries (like `libswiftCore`) for Ubuntu ✅ (that's part of the Swift distribution for Ubuntu)
 - an SDK for Ubuntu Linux ✅ (that can be assembled from the `.deb` packages available from Ubuntu)
 - an ELF linker that runs on macOS ✅ (the [gold linker](https://sourceware.org/binutils/) from the GNU binutils can be compiled on macOS)

In other words, all the pieces of software are available for free online, they just need to be assembled in the correct way. An example script to do that all for Ubuntu Xenial can be found in a [separate PR](https://github.com/apple/swift-package-manager/pull/1099).