### PR TITLE
[clibc] Include fts.h without angular brackets

### DIFF
--- a/Sources/clibc/include/clibc.h
+++ b/Sources/clibc/include/clibc.h
@@ -1,1 +1,1 @@
-#include <fts.h>
+#include "fts.h"


### PR DESCRIPTION
-- <rdar://problem/31715187>

Looks like using angular bracket causes Redefinition of module clibc errors
when the same modulemap is found in more than one location.