### PR TITLE
[Resolver] Add option to pre-filter the container versions

### DIFF
--- a/Sources/Commands/SwiftPackageResolveTool.swift
+++ b/Sources/Commands/SwiftPackageResolveTool.swift
@@ -121,7 +121,7 @@ extension VersionSetSpecifier: JSONSerializable {
 
 extension RepositoryPackageContainer: JSONSerializable {
     public func toJSON() -> JSON {
-        let depByVersions = versions.flatMap({ version -> (String, JSON)? in
+        let depByVersions = versions(filter: { _ in true }).flatMap({ version -> (String, JSON)? in
             // Ignore if we can't load the dependencies.
             guard let deps = try? getDependencies(at: version) else { return nil }
             return (version.description, JSON.array(deps.map({ $0.toJSON() })))

--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -199,7 +199,7 @@ public protocol PackageContainer {
     /// The list will be returned in sorted order, with the latest version *first*.
     /// All versions will not be requested at once. Resolver will request the next one only 
     /// if the previous one did not satisfy all constraints.
-    var versions: AnySequence<Version> { get }
+    func versions(filter isIncluded: (Version) -> Bool) -> AnySequence<Version>
 
     /// Fetch the declared dependencies for a particular version.
     ///
@@ -936,7 +936,7 @@ public class DependencyResolver<
     ) -> AnySequence<AssignmentSet> {
         func validVersions(_ container: Container, in versionSet: VersionSetSpecifier) -> AnySequence<Version> {
             let exclusions = allExclusions[container.identifier] ?? Set()
-            return AnySequence(container.versions.lazy.filter({
+            return AnySequence(container.versions(filter: {
                 versionSet.contains($0) && !exclusions.contains($0)
             }))
         }

--- a/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
@@ -93,8 +93,8 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
     public let identifier: RepositorySpecifier
 
     /// The available version list (in reverse order).
-    public var versions: AnySequence<Version> {
-        return AnySequence(reversedVersions.lazy.filter({
+    public func versions(filter isIncluded: (Version) -> Bool) -> AnySequence<Version> {
+        return AnySequence(reversedVersions.filter(isIncluded).lazy.filter({
             guard let toolsVersion = try? self.toolsVersion(for: $0),
                   self.currentToolsVersion >= toolsVersion else {
                 return false

--- a/Sources/TestSupport/MockDependencyResolver.swift
+++ b/Sources/TestSupport/MockDependencyResolver.swift
@@ -78,7 +78,10 @@ public final class MockPackageContainer: PackageContainer {
         return name
     }
 
-    public let versions: AnySequence<Version>
+    public let _versions: [Version]
+    public func versions(filter isIncluded: (Version) -> Bool) -> AnySequence<Version> {
+        return AnySequence(_versions.filter(isIncluded))
+    }
 
     public func getDependencies(at version: Version) -> [MockPackageConstraint] {
         requestedVersions.insert(version)
@@ -110,7 +113,7 @@ public final class MockPackageContainer: PackageContainer {
     ) {
         self.name = name
         let versions = dependencies.keys.flatMap(Version.init(string:))
-        self.versions = AnySequence(versions.sorted().reversed())
+        self._versions = versions.sorted().reversed()
         self.dependencies = dependencies
     }
 }

--- a/Tests/PackageGraphTests/DependencyResolverTests.swift
+++ b/Tests/PackageGraphTests/DependencyResolverTests.swift
@@ -816,7 +816,7 @@ private func allPossibleAssignments(for provider: MockPackagesProvider) -> AnySe
         //
         // FIXME: It would be nice to be lazy here...
         let otherAssignments = allPossibleAssignments(for: containers)
-        return otherAssignments + container.versions.reversed().flatMap{ version in
+        return otherAssignments + container.versions(filter: { _ in true }).reversed().flatMap{ version in
             return otherAssignments.map{ assignment in
                 var assignment = assignment
                 assignment[container] = .version(version)

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -248,21 +248,21 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         do {
             let provider = createProvider(ToolsVersion(version: "3.1.0"))
             let container = try await { provider.getContainer(for: specifier, completion: $0) }
-            let v = container.versions.map{$0}
+            let v = container.versions(filter: { _ in true }).map{$0}
             XCTAssertEqual(v, ["1.0.1", "1.0.0"])
         }
 
         do {
             let provider = createProvider(ToolsVersion(version: "4.0.0"))
             let container = try await { provider.getContainer(for: specifier, completion: $0) }
-            let v = container.versions.map{$0}
+            let v = container.versions(filter: { _ in true }).map{$0}
             XCTAssertEqual(v, ["1.0.2", "1.0.1", "1.0.0"])
         }
 
         do {
             let provider = createProvider(ToolsVersion(version: "3.0.0"))
             let container = try await { provider.getContainer(for: specifier, completion: $0) }
-            let v = container.versions.map{$0}
+            let v = container.versions(filter: { _ in true }).map{$0}
             XCTAssertEqual(v, [])
         }
     }


### PR DESCRIPTION
This gives us a performance boost when we are iterating versions because we
don't need to parse the tools version of versions who will always be rejected
anyway.

-- <rdar://problem/31652875> Turn PackageContainer's versions property into a method which accepts a filter closure