### PR TITLE
[PackageLoading] Do not call realpath() the base URLs

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -18,7 +18,7 @@ import func POSIX.getenv
 public struct BuildParameters {
 
     /// Path to the module cache directory to use for SwiftPM's own tests.
-    public static let swiftpmTestCache = resolveSymlinks(determineTempDirectory()).appending(component: "org.swift.swiftpm.tests-1")
+    public static let swiftpmTestCache = resolveSymlinks(determineTempDirectory()).appending(component: "org.swift.swiftpm.tests-3")
 
     /// Returns the directory to be used for module cache.
     fileprivate var moduleCache: AbsolutePath {

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -177,19 +177,6 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
         guard baseURL.chuzzle() != nil else { fatalError() }  //TODO
 
-        // Attempt to canonicalize the URL.
-        //
-        // This is important when the baseURL is a file system path, so that the
-        // URLs embedded into the manifest are canonical.
-        //
-        // FIXME: We really shouldn't be handling this here and in this fashion.
-        var baseURL = baseURL
-        if URL.scheme(baseURL) == nil {
-            if let resolved = try? realpath(baseURL) {
-                baseURL = resolved
-            }
-        }
-
         // Compute the actual input file path.
         let path: AbsolutePath = isDirectory(inputPath) ? inputPath.appending(component: Manifest.filename) : inputPath
 

--- a/Sources/TestSupport/FileSystemExtensions.swift
+++ b/Sources/TestSupport/FileSystemExtensions.swift
@@ -48,3 +48,14 @@ extension InMemoryFileSystem {
         }
     }
 }
+
+extension FileSystem {
+    /// Print the contents of the directory. Only for debugging purposes.
+    public func dump(directory path: AbsolutePath) {
+        do {
+        print(try getDirectoryContents(path))
+        } catch {
+            print(String(describing: error))
+        }
+    }
+}

--- a/Sources/TestSupport/GitRepositoryExtensions.swift
+++ b/Sources/TestSupport/GitRepositoryExtensions.swift
@@ -16,6 +16,11 @@ import SourceControl
 /// Note: These are not thread safe.
 public extension GitRepository {
 
+    /// Create the repository using git init.
+    func create() throws {
+        try systemQuietly([Git.tool, "-C", path.asString, "init"])
+    }
+
     /// Returns current branch name. If HEAD is on a detached state, this returns HEAD.
     func currentBranch() throws -> String {
         return try Process.checkNonZeroExit(


### PR DESCRIPTION
I am not sure why this was done in the first place. This causes issues when
local packages are symlink.

-- <rdar://problem/30119928> Handle /tmp paths being normalized into
/private/tmp on macOS