### PR TITLE
add tools-directory to Ubuntu cross toolchain builder

### DIFF
--- a/Utilities/build_ubuntu_cross_compilation_toolchain
+++ b/Utilities/build_ubuntu_cross_compilation_toolchain
@@ -242,7 +242,7 @@ cat > "$cross_tc_basename/ubuntu-xenial-destination.json" <<EOF
         "-fPIC"
     ],
     "extra-swiftc-flags": [
-        "-use-ld=gold"
+        "-use-ld=gold", "-tools-directory", "$(pwd)/$cross_tc_basename/$xc_tc_name/usr/bin"
     ]
 }
 EOF


### PR DESCRIPTION
apologies, forgot to add the `-tools-directory` flag which would result in the toolchain only working if `ld.gold` is in your `$PATH` (which is unlikely).