### PR TITLE
[Workspace] Add diagnostics location for manifests loaded by workspace

### DIFF
--- a/Sources/Basic/DiagnosticsEngine.swift
+++ b/Sources/Basic/DiagnosticsEngine.swift
@@ -256,7 +256,7 @@ public protocol DiagnosticsScope {
     func url(describing id: DiagnosticID, for diagnostic: Diagnostic?) -> String?
 }
 
-public class DiagnosticsEngine {
+public class DiagnosticsEngine: CustomStringConvertible {
     /// The diagnostics produced by the engine.
     public var diagnostics: [Diagnostic] = []
 
@@ -269,5 +269,15 @@ public class DiagnosticsEngine {
 
     public func emit(data: DiagnosticData, location: DiagnosticLocation) {
         diagnostics.append(Diagnostic(id: type(of: data).id, location: location, data: data))
+    }
+
+    public var description: String {
+        let stream = BufferedOutputByteStream()
+        stream <<< "["
+        for diag in diagnostics {
+            stream <<< diag.localizedDescription <<< ", "
+        }
+        stream <<< "]"
+        return stream.bytes.asString!
     }
 }

--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -115,6 +115,10 @@ func print(diagnostic: Diagnostic) {
         return
     }
 
+    if !(diagnostic.location is UnknownLocation) {
+        writer.write(diagnostic.location.localizedDescription)
+        writer.write("\n")
+    }
     writer.write(diagnostic.localizedDescription)
     writer.write("\n")
 }

--- a/Sources/Utility/Diagnostics.swift
+++ b/Sources/Utility/Diagnostics.swift
@@ -86,11 +86,14 @@ extension DiagnosticsEngine {
     ///     - closure: Closure to wrap.
     /// - Returns: Returns the return value of the closure wrapped
     ///   into an optional. If the closure throws, nil is returned.
-    public func wrap<T>(_ closure: () throws -> T) -> T? {
+    public func wrap<T>(
+        with constuctLocation: @autoclosure () -> (DiagnosticLocation) = UnknownLocation.location,
+        _ closure: () throws -> T
+    ) -> T? {
         do {
             return try closure()
         } catch {
-            emit(error)
+            emit(error, location: constuctLocation())
             return nil
         }
     }

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -247,7 +247,7 @@ public enum WorkspaceDiagnostics {
                 $0 <<< "The package at"
                 $0 <<< { "'\($0.editPath.asString)'" }
                 $0 <<< "is"
-                $0 <<< { $0.destinationPackage }
+                $0 <<< { $0.destinationPackage ?? "<unknown>" }
                 $0 <<< "but was expecting"
                 $0 <<< { $0.expectedPackage }
             })
@@ -259,6 +259,21 @@ public enum WorkspaceDiagnostics {
         public let expectedPackage: String
         
         /// The package found at the edit location.
-        public let destinationPackage: String
+        public let destinationPackage: String?
+    }
+}
+
+/// Represents the location of a package.
+public struct PackageLocation: DiagnosticLocation {
+
+    /// The path to the package.
+    public let packagePath: AbsolutePath
+
+    public init(packagePath: AbsolutePath) {
+        self.packagePath = packagePath
+    }
+
+    public var localizedDescription: String {
+        return packagePath.asString
     }
 }


### PR DESCRIPTION
This adds path of the package to the diagnostics of manifest parse errors for
the manifests loaded inside workspace, which includes root and the edited
manifests.

Part of <rdar://problem/31342256> SwiftPM diagnostics should have proper location where possible