### PR TITLE
<rdar://problem/31709046> Generate v4 manifests from Creating library…

### DIFF
--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -145,11 +145,11 @@ final class PackageToolTests: XCTestCase {
 
             let manifest = path.appending(component: "Package.swift")
             let contents = try localFileSystem.readFileContents(manifest).asString!
-            let version = "\(ToolsVersion.defaultToolsVersion.major).\(ToolsVersion.defaultToolsVersion.minor)"
+            let version = "\(InitPackage.newPackageToolsVersion.major).\(InitPackage.newPackageToolsVersion.minor)"
             XCTAssertTrue(contents.hasPrefix("// swift-tools-version:\(version)\n"))
 
             XCTAssertTrue(fs.exists(manifest))
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources")), ["main.swift"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "Foo")), ["main.swift"])
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Tests")), [])
         }
     }
@@ -161,7 +161,7 @@ final class PackageToolTests: XCTestCase {
             try fs.createDirectory(path)
             _ = try execute(["-C", path.asString, "init"])
             XCTAssert(fs.exists(path.appending(component: "Package.swift")))
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources")), ["Foo.swift"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "Foo")), ["Foo.swift"])
             XCTAssertEqual(
                 try fs.getDirectoryContents(path.appending(component: "Tests")).sorted(),
                 ["FooTests", "LinuxMain.swift"])

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -65,7 +65,7 @@ class InitTests: XCTestCase {
             let manifest = path.appending(component: "Package.swift")
             XCTAssertTrue(fs.exists(manifest))
             let manifestContents = try localFileSystem.readFileContents(manifest).asString!
-            let version = "\(ToolsVersion.defaultToolsVersion.major).\(ToolsVersion.defaultToolsVersion.minor)"
+            let version = "\(InitPackage.newPackageToolsVersion.major).\(InitPackage.newPackageToolsVersion.minor)"
             XCTAssertTrue(manifestContents.hasPrefix("// swift-tools-version:\(version)\n"))
             
             let readme = path.appending(component: "README.md")
@@ -73,7 +73,7 @@ class InitTests: XCTestCase {
             let readmeContents = try localFileSystem.readFileContents(readme).asString!
             XCTAssertTrue(readmeContents.hasPrefix("# Foo\n"))
 
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources")), ["main.swift"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "Foo")), ["main.swift"])
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Tests")), [])
             
             // Try building it
@@ -104,7 +104,7 @@ class InitTests: XCTestCase {
             let manifest = path.appending(component: "Package.swift")
             XCTAssertTrue(fs.exists(manifest))
             let manifestContents = try localFileSystem.readFileContents(manifest).asString!
-            let version = "\(ToolsVersion.defaultToolsVersion.major).\(ToolsVersion.defaultToolsVersion.minor)"
+            let version = "\(InitPackage.newPackageToolsVersion.major).\(InitPackage.newPackageToolsVersion.minor)"
             XCTAssertTrue(manifestContents.hasPrefix("// swift-tools-version:\(version)\n"))
 
             let readme = path.appending(component: "README.md")
@@ -112,7 +112,7 @@ class InitTests: XCTestCase {
             let readmeContents = try localFileSystem.readFileContents(readme).asString!
             XCTAssertTrue(readmeContents.hasPrefix("# Foo\n"))
 
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources")), ["Foo.swift"])
+            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "Foo")), ["Foo.swift"])
             XCTAssertEqual(
                 try fs.getDirectoryContents(path.appending(component: "Tests")).sorted(),
                 ["FooTests", "LinuxMain.swift"])


### PR DESCRIPTION
This introduces a specific version that new package creation will target. This is made separate from currentToolsVersion because that will update over time and the content for new package creation will need to change when the version we want to generate for changes. And it is separate from defaultToolsVersion because that's pretty fixed (used for when a package does not specify tools version) and we need to evolve the new package format.

In addition we make the new package tools version 4.0, update the manifest generation to be compatible and to explicitly declare targets and products. And, we change to generate a module sub-dir in Sources.