### PR TITLE
[PackageLoading] Allow passing -sdk to compiler when parsing manifest

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -365,7 +365,7 @@ public class SwiftTool<Options: ToolOptions> {
     private lazy var _manifestLoader: Result<ManifestLoader, AnyError> = {
         return Result(anyError: {
             try ManifestLoader(
-                resources: self.getToolchain(),
+                resources: self.getToolchain().manifestResources,
                 isManifestSandboxEnabled: !self.options.shouldDisableSandbox
             )
         })

--- a/Sources/Commands/UserToolchain.swift
+++ b/Sources/Commands/UserToolchain.swift
@@ -21,7 +21,18 @@ import Utility
     private let whichClangArgs = ["which", "clang"]
 #endif
 
-public struct UserToolchain: Toolchain, ManifestResourceProvider {
+/// Concrete object for manifest resource provider.
+private struct UserManifestResources: ManifestResourceProvider {
+    let swiftCompiler: AbsolutePath
+    let libDir: AbsolutePath
+    let sdkRoot: AbsolutePath?
+}
+
+public struct UserToolchain: Toolchain {
+
+    /// The manifest resource provider.
+    public let manifestResources: ManifestResourceProvider
+
     /// Path of the `swiftc` compiler.
     public let swiftCompiler: AbsolutePath
 
@@ -30,9 +41,6 @@ public struct UserToolchain: Toolchain, ManifestResourceProvider {
 
     /// Path to llbuild.
     let llbuild: AbsolutePath
-
-    /// Path to SwiftPM library directory containing runtime libraries.
-    public let libDir: AbsolutePath
 
     /// Path of the default SDK (a.k.a. "sysroot"), if any.
     public let defaultSDK: AbsolutePath?
@@ -70,8 +78,6 @@ public struct UserToolchain: Toolchain, ManifestResourceProvider {
                 filename: getenv(fromEnv),
                 searchPaths: envSearchPaths)
         }
-
-        libDir = binDir.parentDirectory.appending(components: "lib", "swift", "pm")
 
         // First look in env and then in bin dir.
         swiftCompiler = lookup(fromEnv: "SWIFT_EXEC") ?? binDir.appending(component: "swiftc")
@@ -138,6 +144,11 @@ public struct UserToolchain: Toolchain, ManifestResourceProvider {
       #else
         defaultSDK = nil
       #endif
-    }
 
+        manifestResources = UserManifestResources(
+            swiftCompiler: swiftCompiler,
+            libDir: binDir.parentDirectory.appending(components: "lib", "swift", "pm"),
+            sdkRoot: defaultSDK
+        )
+    }
 }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -38,6 +38,19 @@ public protocol ManifestResourceProvider {
 
     /// The path of the library resources.
     var libDir: AbsolutePath { get }
+
+    /// The path to SDK root.
+    ///
+    /// If provided, it will be passed to the swift interpreter.
+    var sdkRoot: AbsolutePath? { get }
+}
+
+/// Default implemention for the resource provider.
+public extension ManifestResourceProvider {
+
+    var sdkRoot: AbsolutePath? {
+        return nil
+    }
 }
 
 /// The supported manifest versions.
@@ -241,6 +254,12 @@ public final class ManifestLoader: ManifestLoaderProtocol {
     #if os(macOS)
         cmd += ["-target", "x86_64-apple-macosx10.10"]
     #endif
+
+        // Add sdk, if provided in the resources.
+        if let sdkRoot = resources.sdkRoot {
+            cmd += ["-sdk", sdkRoot.asString]
+        }
+
         cmd += [manifestPath.asString]
 
         // Create and open a temporary file to write json to.

--- a/Sources/TestSupport/Resources.swift
+++ b/Sources/TestSupport/Resources.swift
@@ -25,11 +25,11 @@ private func bundleRoot() -> AbsolutePath {
 public class Resources: ManifestResourceProvider {
 
     public var swiftCompiler: AbsolutePath {
-        return toolchain.swiftCompiler
+        return toolchain.manifestResources.swiftCompiler
     }
 
     public var libDir: AbsolutePath {
-        return toolchain.libDir
+        return toolchain.manifestResources.libDir
     }
 
   #if os(macOS)


### PR DESCRIPTION
Also separate out manifest resource provider from user toolchain.