### PR TITLE
[SourceControl] Remove "needsFetch" from RepositoryManager

### DIFF
--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -165,8 +165,8 @@ class RepositoryManagerTests: XCTestCase {
             XCTNonNil(prevHandle) {
                 try XCTAssert($0 === manager.lookupSynchronously(repository: dummyRepo))
             }
-            // We should not have refetched because we just cloned this repo.
-            XCTAssertEqual(provider.numFetches, 0)
+            // Since we looked up this repo again, we should have made a fetch call.
+            XCTAssertEqual(provider.numFetches, 1)
 
             // Remove the repo.
             try manager.remove(repository: dummyRepo)


### PR DESCRIPTION
This property doesn't work well when the RepositoryManager object is long lived.
There could be updates published to a dependency and we won't fetch it until
RepositoryManager is recreated.