### PR TITLE
Expose a way to get manifest interpreter flags

### DIFF
--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -71,12 +71,16 @@ public final class Manifest: ObjectIdentifierProtocol, CustomStringConvertible {
         }
     }
 
+    /// The flags that were used to interprete the manifest.
+    public let interpreterFlags: [String]
+
     public init(
         path: AbsolutePath,
         url: String,
         package: RawPackage,
         legacyProducts: [PackageDescription.Product] = [],
-        version: Version?
+        version: Version?,
+        interpreterFlags: [String] = []
     ) {
         if case .v4 = package {
             precondition(legacyProducts.isEmpty, "Legacy products are not supported in v4 manifest.")
@@ -86,6 +90,7 @@ public final class Manifest: ObjectIdentifierProtocol, CustomStringConvertible {
         self.package = package
         self.legacyProducts = legacyProducts
         self.version = version
+        self.interpreterFlags = interpreterFlags
     }
 
     public var description: String {

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1002,6 +1002,17 @@ extension Workspace {
         }
     }
 
+    /// Returns manifest interpreter flags for a package.
+    public func interpreterFlags(for packagePath: AbsolutePath) -> [String] {
+        // We ignore all failures here and return empty array.
+        guard let manifestLoader = self.manifestLoader as? ManifestLoader,
+              let toolsVersion = try? toolsVersionLoader.load(at: packagePath, fileSystem: fileSystem),
+              currentToolsVersion >= toolsVersion else {
+            return []
+        }
+        return manifestLoader.interpreterFlags(for: toolsVersion.manifestVersion)
+    }
+
     /// Loads the given manifest, if it is present in the managed dependencies.
     fileprivate func loadManifest(forDependencyURL url: String, diagnostics: DiagnosticsEngine) -> Manifest? {
         // Check if this dependency is available.

--- a/Tests/PackageLoadingTests/PD4LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4LoadingTests.swift
@@ -80,6 +80,7 @@ class PackageDescription4LoadingTests: XCTestCase {
             XCTAssertEqual(manifest.manifestVersion, .four)
             XCTAssertEqual(manifest.package.targets, [])
             XCTAssertEqual(manifest.package.dependencies, [])
+            XCTAssertNotNil(manifest.interpreterFlags.first(where: { $0.contains("/swift/pm/4") }))
         }
     }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -162,6 +162,13 @@ final class WorkspaceTests: XCTestCase {
             try testRepo.tag(name: "test-tag")
             let currentRevision = try testRepo.getCurrentRevision()
 
+            // Test interpreter flags.
+            do {
+                let workspace = Workspace.createWith(rootPackage: path)
+                let flags = workspace.interpreterFlags(for: path)
+                XCTAssertNotNil(flags.first(where: { $0.contains("/swift/pm/3") }))
+            }
+
             // Create the initial workspace.
             do {
                 let workspace = Workspace.createWith(rootPackage: path)


### PR DESCRIPTION
-- <rdar://problem/31858267> libSwiftPM should expose a way to get manifest interpreter flags