### PR TITLE
Fix inconsistency when using operators outside of the scope

### DIFF
--- a/Sources/Basic/ByteString.swift
+++ b/Sources/Basic/ByteString.swift
@@ -100,9 +100,10 @@ extension ByteString: Hashable {
         }
         return result
     }
-}
-public func == (lhs: ByteString, rhs: ByteString) -> Bool {
-    return lhs.contents == rhs.contents
+    
+    public static func == (lhs: ByteString, rhs: ByteString) -> Bool {
+        return lhs.contents == rhs.contents
+    }
 }
 
 /// ByteStreamable conformance for a ByteString.

--- a/Sources/Basic/JSON.swift
+++ b/Sources/Basic/JSON.swift
@@ -67,23 +67,24 @@ extension JSON: CustomStringConvertible {
 }
 
 /// Equatable conformance.
-extension JSON: Equatable { }
-public func == (lhs: JSON, rhs: JSON) -> Bool {
-    switch (lhs, rhs) {
-    case (.null, .null): return true
-    case (.null, _): return false
-    case (.bool(let a), .bool(let b)): return a == b
-    case (.bool, _): return false
-    case (.int(let a), .int(let b)): return a == b
-    case (.int, _): return false
-    case (.double(let a), .double(let b)): return a == b
-    case (.double, _): return false
-    case (.string(let a), .string(let b)): return a == b
-    case (.string, _): return false
-    case (.array(let a), .array(let b)): return a == b
-    case (.array, _): return false
-    case (.dictionary(let a), .dictionary(let b)): return a == b
-    case (.dictionary, _): return false
+extension JSON: Equatable {
+    public static func == (lhs: JSON, rhs: JSON) -> Bool {
+        switch (lhs, rhs) {
+        case (.null, .null): return true
+        case (.null, _): return false
+        case (.bool(let a), .bool(let b)): return a == b
+        case (.bool, _): return false
+        case (.int(let a), .int(let b)): return a == b
+        case (.int, _): return false
+        case (.double(let a), .double(let b)): return a == b
+        case (.double, _): return false
+        case (.string(let a), .string(let b)): return a == b
+        case (.string, _): return false
+        case (.array(let a), .array(let b)): return a == b
+        case (.array, _): return false
+        case (.dictionary(let a), .dictionary(let b)): return a == b
+        case (.dictionary, _): return false
+        }
     }
 }
 

--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -296,24 +296,26 @@ extension AbsolutePath : Hashable {
 }
 
 // Make absolute paths Equatable.
-extension AbsolutePath : Equatable { }
-public func == (lhs: AbsolutePath, rhs: AbsolutePath) -> Bool {
-    return lhs.asString == rhs.asString
+extension AbsolutePath : Equatable {
+    public static func == (lhs: AbsolutePath, rhs: AbsolutePath) -> Bool {
+        return lhs.asString == rhs.asString
+    }
 }
 
 // Make absolute paths Comparable.
-extension AbsolutePath : Comparable { }
-public func < (lhs: AbsolutePath, rhs: AbsolutePath) -> Bool {
-    return lhs.asString < rhs.asString
-}
-public func <= (lhs: AbsolutePath, rhs: AbsolutePath) -> Bool {
-    return lhs.asString <= rhs.asString
-}
-public func >= (lhs: AbsolutePath, rhs: AbsolutePath) -> Bool {
-    return lhs.asString >= rhs.asString
-}
-public func > (lhs: AbsolutePath, rhs: AbsolutePath) -> Bool {
-    return lhs.asString > rhs.asString
+extension AbsolutePath : Comparable {
+    public static func < (lhs: AbsolutePath, rhs: AbsolutePath) -> Bool {
+        return lhs.asString < rhs.asString
+    }
+    public static func <= (lhs: AbsolutePath, rhs: AbsolutePath) -> Bool {
+        return lhs.asString <= rhs.asString
+    }
+    public static func >= (lhs: AbsolutePath, rhs: AbsolutePath) -> Bool {
+        return lhs.asString >= rhs.asString
+    }
+    public static func > (lhs: AbsolutePath, rhs: AbsolutePath) -> Bool {
+        return lhs.asString > rhs.asString
+    }
 }
 
 /// Make absolute paths CustomStringConvertible.
@@ -332,9 +334,10 @@ extension RelativePath : Hashable {
 }
 
 // Make relative paths Equatable.
-extension RelativePath : Equatable { }
-public func == (lhs: RelativePath, rhs: RelativePath) -> Bool {
-    return lhs.asString == rhs.asString
+extension RelativePath : Equatable {
+    public static func == (lhs: RelativePath, rhs: RelativePath) -> Bool {
+        return lhs.asString == rhs.asString
+    }
 }
 
 /// Make relative paths CustomStringConvertible.

--- a/Sources/PackageDescription/Package.swift
+++ b/Sources/PackageDescription/Package.swift
@@ -122,16 +122,18 @@ extension SystemPackageProvider {
 }
 
 // MARK: Equatable
-extension Package : Equatable { }
-public func == (lhs: Package, rhs: Package) -> Bool {
-    return (lhs.name == rhs.name &&
-        lhs.targets == rhs.targets &&
-        lhs.dependencies == rhs.dependencies)
+extension Package : Equatable {
+    public static func == (lhs: Package, rhs: Package) -> Bool {
+        return (lhs.name == rhs.name &&
+            lhs.targets == rhs.targets &&
+            lhs.dependencies == rhs.dependencies)
+    }
 }
 
-extension Package.Dependency : Equatable { }
-public func == (lhs: Package.Dependency, rhs: Package.Dependency) -> Bool {
-    return lhs.url == rhs.url && lhs.versionRange == rhs.versionRange
+extension Package.Dependency : Equatable {
+    public static func == (lhs: Package.Dependency, rhs: Package.Dependency) -> Bool {
+        return lhs.url == rhs.url && lhs.versionRange == rhs.versionRange
+    }
 }
 
 // MARK: Package JSON serialization

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -47,16 +47,18 @@ extension Target.Dependency : ExpressibleByStringLiteral {
 
 // MARK: Equatable
 
-extension Target : Equatable { }
-public func == (lhs: Target, rhs: Target) -> Bool {
-    return (lhs.name == rhs.name &&
-        lhs.dependencies == rhs.dependencies)
+extension Target : Equatable {
+    public static func == (lhs: Target, rhs: Target) -> Bool {
+        return (lhs.name == rhs.name &&
+            lhs.dependencies == rhs.dependencies)
+    }
 }
 
-extension Target.Dependency : Equatable { }
-public func == (lhs: Target.Dependency, rhs: Target.Dependency) -> Bool {
-    switch (lhs, rhs) {
-    case (.Target(let a), .Target(let b)):
-        return a == b
+extension Target.Dependency : Equatable {
+    public static func == (lhs: Target.Dependency, rhs: Target.Dependency) -> Bool {
+        switch (lhs, rhs) {
+        case (.Target(let a), .Target(let b)):
+            return a == b
+        }
     }
 }

--- a/Sources/PackageDescription/Version.swift
+++ b/Sources/PackageDescription/Version.swift
@@ -33,18 +33,18 @@ public struct Version {
 
 // MARK: Equatable
 
-extension Version: Equatable {}
-
-public func == (v1: Version, v2: Version) -> Bool {
-    guard v1.major == v2.major && v1.minor == v2.minor && v1.patch == v2.patch else {
-        return false
+extension Version: Equatable {
+    public static func == (v1: Version, v2: Version) -> Bool {
+        guard v1.major == v2.major && v1.minor == v2.minor && v1.patch == v2.patch else {
+            return false
+        }
+        
+        if v1.prereleaseIdentifiers != v2.prereleaseIdentifiers {
+            return false
+        }
+        
+        return v1.buildMetadataIdentifier == v2.buildMetadataIdentifier
     }
-
-    if v1.prereleaseIdentifiers != v2.prereleaseIdentifiers {
-        return false
-    }
-
-    return v1.buildMetadataIdentifier == v2.buildMetadataIdentifier
 }
 
 // MARK: Hashable
@@ -68,44 +68,44 @@ extension Version: Hashable {
 
 // MARK: Comparable
 
-extension Version: Comparable {}
-
-public func < (lhs: Version, rhs: Version) -> Bool {
-    let lhsComparators = [lhs.major, lhs.minor, lhs.patch]
-    let rhsComparators = [rhs.major, rhs.minor, rhs.patch]
-
-    if lhsComparators != rhsComparators {
-        return lhsComparators.lexicographicallyPrecedes(rhsComparators)
-    }
-
-    guard lhs.prereleaseIdentifiers.count > 0 else {
-        return false // Non-prerelease lhs >= potentially prerelease rhs
-    }
-
-    guard rhs.prereleaseIdentifiers.count > 0 else {
-        return true // Prerelease lhs < non-prerelease rhs 
-    }
-
-    let zippedIdentifiers = zip(lhs.prereleaseIdentifiers, rhs.prereleaseIdentifiers)
-    for (lhsPrereleaseIdentifier, rhsPrereleaseIdentifier) in zippedIdentifiers {
-        if lhsPrereleaseIdentifier == rhsPrereleaseIdentifier {
-            continue
+extension Version: Comparable {
+    public static func < (lhs: Version, rhs: Version) -> Bool {
+        let lhsComparators = [lhs.major, lhs.minor, lhs.patch]
+        let rhsComparators = [rhs.major, rhs.minor, rhs.patch]
+        
+        if lhsComparators != rhsComparators {
+            return lhsComparators.lexicographicallyPrecedes(rhsComparators)
         }
-
-        let typedLhsIdentifier: Any = Int(lhsPrereleaseIdentifier) ?? lhsPrereleaseIdentifier
-        let typedRhsIdentifier: Any = Int(rhsPrereleaseIdentifier) ?? rhsPrereleaseIdentifier
-
-        switch (typedLhsIdentifier, typedRhsIdentifier) {
+        
+        guard lhs.prereleaseIdentifiers.count > 0 else {
+            return false // Non-prerelease lhs >= potentially prerelease rhs
+        }
+        
+        guard rhs.prereleaseIdentifiers.count > 0 else {
+            return true // Prerelease lhs < non-prerelease rhs
+        }
+        
+        let zippedIdentifiers = zip(lhs.prereleaseIdentifiers, rhs.prereleaseIdentifiers)
+        for (lhsPrereleaseIdentifier, rhsPrereleaseIdentifier) in zippedIdentifiers {
+            if lhsPrereleaseIdentifier == rhsPrereleaseIdentifier {
+                continue
+            }
+            
+            let typedLhsIdentifier: Any = Int(lhsPrereleaseIdentifier) ?? lhsPrereleaseIdentifier
+            let typedRhsIdentifier: Any = Int(rhsPrereleaseIdentifier) ?? rhsPrereleaseIdentifier
+            
+            switch (typedLhsIdentifier, typedRhsIdentifier) {
             case let (int1 as Int, int2 as Int): return int1 < int2
             case let (string1 as String, string2 as String): return string1 < string2
             case (is Int, is String): return true // Int prereleases < String prereleases
             case (is String, is Int): return false
-        default:
-            return false
+            default:
+                return false
+            }
         }
+        
+        return lhs.prereleaseIdentifiers.count < rhs.prereleaseIdentifiers.count
     }
-
-    return lhs.prereleaseIdentifiers.count < rhs.prereleaseIdentifiers.count
 }
 
 // MARK: BidirectionalIndexType

--- a/Sources/PackageDescription4/Version.swift
+++ b/Sources/PackageDescription4/Version.swift
@@ -45,7 +45,7 @@ public struct Version {
 
 extension Version: Hashable {
 
-    static public func == (lhs: Version, rhs: Version) -> Bool {
+    public static func == (lhs: Version, rhs: Version) -> Bool {
         return lhs.major == rhs.major &&
                lhs.minor == rhs.minor &&
                lhs.patch == rhs.patch &&

--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -120,25 +120,26 @@ public enum VersionSetSpecifier: Equatable, CustomStringConvertible {
             return version.description
         }
     }
-}
-public func == (_ lhs: VersionSetSpecifier, _ rhs: VersionSetSpecifier) -> Bool {
-    switch (lhs, rhs) {
-    case (.any, .any):
-        return true
-    case (.any, _):
-        return false
-    case (.empty, .empty):
-        return true
-    case (.empty, _):
-        return false
-    case (.range(let lhs), .range(let rhs)):
-        return lhs == rhs
-    case (.range, _):
-        return false
-    case (.exact(let lhs), .exact(let rhs)):
-        return lhs == rhs
-    case (.exact, _):
-        return false
+    
+    public static func == (_ lhs: VersionSetSpecifier, _ rhs: VersionSetSpecifier) -> Bool {
+        switch (lhs, rhs) {
+        case (.any, .any):
+            return true
+        case (.any, _):
+            return false
+        case (.empty, .empty):
+            return true
+        case (.empty, _):
+            return false
+        case (.range(let lhs), .range(let rhs)):
+            return lhs == rhs
+        case (.range, _):
+            return false
+        case (.exact(let lhs), .exact(let rhs)):
+            return lhs == rhs
+        case (.exact, _):
+            return false
+        }
     }
 }
 
@@ -341,25 +342,26 @@ public enum BoundVersion: Equatable, CustomStringConvertible {
             return identifier
         }
     }
-}
-public func == (_ lhs: BoundVersion, _ rhs: BoundVersion) -> Bool {
-    switch (lhs, rhs) {
-    case (.excluded, .excluded):
-        return true
-    case (.excluded, _):
-        return false
-    case (.version(let lhs), .version(let rhs)):
-        return lhs == rhs
-    case (.version, _):
-        return false
-    case (.revision(let lhs), .revision(let rhs)):
-        return lhs == rhs
-    case (.revision, _):
-        return false
-    case (.unversioned, .unversioned):
-        return true
-    case (.unversioned, _):
-        return false
+    
+    public static func == (_ lhs: BoundVersion, _ rhs: BoundVersion) -> Bool {
+        switch (lhs, rhs) {
+        case (.excluded, .excluded):
+            return true
+        case (.excluded, _):
+            return false
+        case (.version(let lhs), .version(let rhs)):
+            return lhs == rhs
+        case (.version, _):
+            return false
+        case (.revision(let lhs), .revision(let rhs)):
+            return lhs == rhs
+        case (.revision, _):
+            return false
+        case (.unversioned, .unversioned):
+            return true
+        case (.unversioned, _):
+            return false
+        }
     }
 }
 
@@ -1314,7 +1316,7 @@ private struct ResolverDebugger<
             }
         }
 
-        static func ==(lhs: ResolverChange, rhs: ResolverChange) -> Bool {
+        static func == (lhs: ResolverChange, rhs: ResolverChange) -> Bool {
             switch (lhs, rhs) {
             case (.allowPackage(let lhs), .allowPackage(let rhs)):
                 return lhs == rhs

--- a/Sources/PackageModel/Package.swift
+++ b/Sources/PackageModel/Package.swift
@@ -86,7 +86,7 @@ public final class Package {
         self.testTargetSearchPath = testTargetSearchPath
     }
 
-    public enum Error: Swift.Error, Equatable {
+    public enum Error: Swift.Error {
         case noManifest(baseURL: String, version: String?)
         case noOrigin(String)
     }
@@ -100,21 +100,23 @@ extension Package: CustomStringConvertible {
 
 extension Package: Hashable, Equatable {
     public var hashValue: Int { return ObjectIdentifier(self).hashValue }
+    
+    public static func == (lhs: Package, rhs: Package) -> Bool {
+        return ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
+    }
 }
 
-public func == (lhs: Package, rhs: Package) -> Bool {
-    return ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
-}
-
-public func == (lhs: Package.Error, rhs: Package.Error) -> Bool {
-    switch (lhs, rhs) {
-    case let (.noManifest(lhs), .noManifest(rhs)):
-        return lhs.baseURL == rhs.baseURL && lhs.version == rhs.version
-    case (.noManifest, _):
-        return false
-    case let (.noOrigin(lhs), .noOrigin(rhs)):
-        return lhs == rhs
-    case (.noOrigin, _):
-        return false
+extension Package.Error: Equatable {
+    public static func == (lhs: Package.Error, rhs: Package.Error) -> Bool {
+        switch (lhs, rhs) {
+        case let (.noManifest(lhs), .noManifest(rhs)):
+            return lhs.baseURL == rhs.baseURL && lhs.version == rhs.version
+        case (.noManifest, _):
+            return false
+        case let (.noOrigin(lhs), .noOrigin(rhs)):
+            return lhs == rhs
+        case (.noOrigin, _):
+            return false
+        }
     }
 }

--- a/Sources/SourceControl/Repository.swift
+++ b/Sources/SourceControl/Repository.swift
@@ -11,7 +11,7 @@
 import Basic
 
 /// Specifies a repository address.
-public struct RepositorySpecifier: Hashable, CustomStringConvertible {
+public struct RepositorySpecifier {
     /// The URL of the repository.
     public let url: String
 
@@ -31,17 +31,22 @@ public struct RepositorySpecifier: Hashable, CustomStringConvertible {
         let basename = url.components(separatedBy: "/").last!
         return basename + "-" + String(url.hashValue)
     }
+}
 
+extension RepositorySpecifier: Hashable {
     public var hashValue: Int {
         return url.hashValue
     }
+    
+    public static func == (lhs: RepositorySpecifier, rhs: RepositorySpecifier) -> Bool {
+        return lhs.url == rhs.url
+    }
+}
 
+extension RepositorySpecifier: CustomStringConvertible {
     public var description: String {
         return "RepositorySpecifier(\(url))"
     }
-}
-public func == (lhs: RepositorySpecifier, rhs: RepositorySpecifier) -> Bool {
-    return lhs.url == rhs.url
 }
 
 extension RepositorySpecifier: JSONMappable, JSONSerializable {

--- a/Sources/TestSupport/MockManifestLoader.swift
+++ b/Sources/TestSupport/MockManifestLoader.swift
@@ -41,6 +41,10 @@ public struct MockManifestLoader: ManifestLoaderProtocol {
         public var hashValue: Int {
             return url.hashValue ^ (version?.hashValue ?? 0)
         }
+        
+        public static func == (lhs: MockManifestLoader.Key, rhs: MockManifestLoader.Key) -> Bool {
+            return lhs.url == rhs.url && lhs.version == rhs.version
+        }
     }
 
     public let manifests: [Key: Manifest]
@@ -62,7 +66,4 @@ public struct MockManifestLoader: ManifestLoaderProtocol {
         }
         throw MockManifestLoaderError.unknownRequest("\(key)")
     }
-}
-public func == (lhs: MockManifestLoader.Key, rhs: MockManifestLoader.Key) -> Bool {
-    return lhs.url == rhs.url && lhs.version == rhs.version
 }


### PR DESCRIPTION
Fix small inconsistency when using operators required by Protocol outside of the adopter’s scope