### PR TITLE
[PackageLoading] Fix path edge cases in V4 target defs

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -521,13 +521,7 @@ public final class PackageBuilder {
                     return packagePath
                 }
 
-                let path: AbsolutePath
-
-                if subpath.hasPrefix("/") {
-                    path = AbsolutePath(subpath)
-                } else {
-                    path = AbsolutePath(subpath, relativeTo: packagePath)
-                }
+                let path = AbsolutePath(subpath, relativeTo: packagePath)
 
                 // Make sure the target is inside the package root.
                 guard path.contains(packagePath) else {

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -520,7 +520,15 @@ public final class PackageBuilder {
                 if subpath == "" || subpath == "." {
                     return packagePath
                 }
-                let path = packagePath.appending(RelativePath(subpath))
+
+                let path: AbsolutePath
+
+                if subpath.hasPrefix("/") {
+                    path = AbsolutePath(subpath)
+                } else {
+                    path = AbsolutePath(subpath, relativeTo: packagePath)
+                }
+
                 // Make sure the target is inside the package root.
                 guard path.contains(packagePath) else {
                     throw ModuleError.targetOutsidePackage(package: manifest.name, target: target.name)


### PR DESCRIPTION
Fix [SR-4793](https://bugs.swift.org/browse/SR-4793): SwiftPM Gives three different error messages for different types of invalid paths