### PR TITLE
Fix linux clang/LLVM target triple

### DIFF
--- a/Sources/Commands/Destination.swift
+++ b/Sources/Commands/Destination.swift
@@ -109,7 +109,7 @@ public struct Destination {
         )
       #else
         return Destination(
-            target: "linux-unknown-x86_64",
+            target: "x86_64-unknown-linux",
             sdk: .root,
             binDir: binDir,
             dynamicLibraryExtension: "so",


### PR DESCRIPTION
I'm no expert but this seems to better correspond to the documentation for targe triples.