### PR TITLE
Revert "Segregate builds into target platform sub-folders"

### DIFF
--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -36,7 +36,7 @@ public class SwiftBuildTool: SwiftTool<BuildToolOptions> {
             let graph = try loadPackageGraph()
             // If we don't have any targets in root package, we're done.
             guard !graph.rootPackages[0].targets.isEmpty else { break }
-            try build(plan: buildPlan(graph: graph, config: options.config), includingTests: options.buildTests)
+            try build(graph: graph, includingTests: options.buildTests, config: options.config)
 
         case .version:
             print(Versioning.currentVersion.completeDisplayString)

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -124,9 +124,8 @@ public class SwiftTestTool: SwiftTool<TestToolOptions> {
     /// - Returns: The path to the test binary.
     private func buildTestsIfNeeded(_ options: TestToolOptions) throws -> AbsolutePath {
         let graph = try loadPackageGraph()
-        let buildPlan = try self.buildPlan(graph: graph, config: options.config)
         if options.shouldBuildTests {
-            try build(plan: buildPlan, includingTests: true)
+            try build(graph: graph, includingTests: true, config: options.config)
         }
 
         // See the logic in `PackageLoading`'s `PackageExtensions.swift`.
@@ -145,7 +144,8 @@ public class SwiftTestTool: SwiftTool<TestToolOptions> {
         } else if testProducts.count > 1 {
             throw TestError.multipleTestProducts
         } else {
-            return buildPlan.buildParameters.buildPath
+            return buildPath
+                .appending(RelativePath(options.config.dirname))
                 .appending(component: testProducts[0].name + ".xctest")
         }
     }

--- a/Sources/TestSupport/misc.swift
+++ b/Sources/TestSupport/misc.swift
@@ -20,7 +20,6 @@ import POSIX
 import SourceControl
 import Utility
 import Workspace
-import Commands
 
 #if os(macOS)
 import class Foundation.Bundle
@@ -308,13 +307,6 @@ public func waitForFile(_ path: AbsolutePath) -> Bool {
         }
     }
     return false
-}
-
-fileprivate let _cachedHostTarget = try! Destination.hostDestination().target
-public extension Destination {
-    public static var hostTarget: String {
-        return _cachedHostTarget
-    }
 }
 
 extension Process {

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -192,7 +192,7 @@ final class PackageToolTests: XCTestCase {
             _ = try SwiftPMProduct.SwiftPackage.execute(["edit", "baz", "--branch", "bugfix"], chdir: fooPath, printIfError: true)
 
             // Path to the executable.
-            let exec = [fooPath.appending(components: ".build", Destination.hostTarget, "debug", "foo").asString]
+            let exec = [fooPath.appending(components: ".build", "debug", "foo").asString]
 
             // We should see it now in packages directory.
             let editsPath = fooPath.appending(components: "Packages", "bar")
@@ -265,8 +265,8 @@ final class PackageToolTests: XCTestCase {
 
             // Build it.
             XCTAssertBuilds(packageRoot)
-            XCTAssertFileExists(packageRoot.appending(components: ".build", Destination.hostTarget, "debug", "Bar"))
-            XCTAssert(isDirectory(packageRoot.appending(components: ".build", Destination.hostTarget)))
+            XCTAssertFileExists(packageRoot.appending(components: ".build", "debug", "Bar"))
+            XCTAssert(isDirectory(packageRoot.appending(component: ".build")))
 
             // Clean, and check for removal of the build directory but not Packages.
             _ = try execute(["clean"], chdir: packageRoot)
@@ -282,12 +282,12 @@ final class PackageToolTests: XCTestCase {
 
             // Build it.
             XCTAssertBuilds(packageRoot)
-            XCTAssertFileExists(packageRoot.appending(components: ".build", Destination.hostTarget, "debug", "Bar"))
-            XCTAssert(isDirectory(packageRoot.appending(components: ".build", Destination.hostTarget)))
+            XCTAssertFileExists(packageRoot.appending(components: ".build", "debug", "Bar"))
+            XCTAssert(isDirectory(packageRoot.appending(component: ".build")))
             // Clean, and check for removal of the build directory but not Packages.
 
             _ = try execute(["clean"], chdir: packageRoot)
-            XCTAssert(!exists(packageRoot.appending(components: ".build", Destination.hostTarget, "debug", "Bar")))
+            XCTAssert(!exists(packageRoot.appending(components: ".build", "debug", "Bar")))
             XCTAssertFalse(try localFileSystem.getDirectoryContents(packageRoot.appending(components: ".build", "repositories")).isEmpty)
 
             // Fully clean.
@@ -347,7 +347,7 @@ final class PackageToolTests: XCTestCase {
                 let buildOutput = try SwiftPMProduct.SwiftBuild.execute([], chdir: fooPath, printIfError: true)
                 return buildOutput
             }
-            let exec = [fooPath.appending(components: ".build", Destination.hostTarget, "debug", "foo").asString]
+            let exec = [fooPath.appending(components: ".build", "debug", "foo").asString]
 
             // Build and sanity check.
             _ = try build()

--- a/Tests/FunctionalTests/ClangModuleTests.swift
+++ b/Tests/FunctionalTests/ClangModuleTests.swift
@@ -9,7 +9,7 @@
 */
 
 import XCTest
-import Commands
+
 import TestSupport
 import Basic
 import PackageModel
@@ -34,7 +34,7 @@ class ClangModulesTestCase: XCTestCase {
     func testSingleModuleFlatCLibrary() {
         fixture(name: "ClangModules/CLibraryFlat") { prefix in
             XCTAssertBuilds(prefix)
-            let debugPath = prefix.appending(components: ".build", Destination.hostTarget, "debug")
+            let debugPath = prefix.appending(components: ".build", "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
         }
     }
@@ -42,7 +42,7 @@ class ClangModulesTestCase: XCTestCase {
     func testSingleModuleCLibraryInSources() {
         fixture(name: "ClangModules/CLibrarySources") { prefix in
             XCTAssertBuilds(prefix)
-            let debugPath = prefix.appending(components: ".build", Destination.hostTarget, "debug")
+            let debugPath = prefix.appending(components: ".build", "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
         }
     }
@@ -50,7 +50,7 @@ class ClangModulesTestCase: XCTestCase {
     func testMixedSwiftAndC() {
         fixture(name: "ClangModules/SwiftCMixed") { prefix in
             XCTAssertBuilds(prefix)
-            let debugPath = prefix.appending(components: ".build", Destination.hostTarget, "debug")
+            let debugPath = prefix.appending(components: ".build", "debug")
             XCTAssertFileExists(debugPath.appending(component: "SeaExec"))
             var output = try Process.checkNonZeroExit(args: debugPath.appending(component: "SeaExec").asString)
             XCTAssertEqual(output, "a = 5\n")
@@ -62,7 +62,7 @@ class ClangModulesTestCase: XCTestCase {
         // This also has a user provided modulemap i.e. package manager will not generate it.
         fixture(name: "ClangModules/SwiftCMixed2") { prefix in
             XCTAssertBuilds(prefix)
-            let debugPath = prefix.appending(components: ".build", Destination.hostTarget, "debug")
+            let debugPath = prefix.appending(components: ".build", "debug")
             let output = try Process.checkNonZeroExit(args: debugPath.appending(component: "SeaExec").asString)
             XCTAssertEqual(output, "a = 5\n")
         }
@@ -72,7 +72,7 @@ class ClangModulesTestCase: XCTestCase {
         fixture(name: "DependencyResolution/External/SimpleCDep") { prefix in
             let packageRoot = prefix.appending(component: "Bar")
             XCTAssertBuilds(packageRoot)
-            let debugPath = prefix.appending(components: "Bar", ".build", Destination.hostTarget, "debug")
+            let debugPath = prefix.appending(components: "Bar", ".build", "debug")
             XCTAssertFileExists(debugPath.appending(component: "Bar"))
             let path = try SwiftPMProduct.packagePath(for: "Foo", packageRoot: packageRoot)
             XCTAssertEqual(GitRepository(path: path).tags, ["1.2.3"])
@@ -82,7 +82,7 @@ class ClangModulesTestCase: XCTestCase {
     func testiquoteDep() {
         fixture(name: "ClangModules/CLibraryiquote") { prefix in
             XCTAssertBuilds(prefix)
-            let debugPath = prefix.appending(components: ".build", Destination.hostTarget, "debug")
+            let debugPath = prefix.appending(components: ".build", "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Bar.c.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
         }
@@ -92,7 +92,7 @@ class ClangModulesTestCase: XCTestCase {
         fixture(name: "DependencyResolution/External/CUsingCDep") { prefix in
             let packageRoot = prefix.appending(component: "Bar")
             XCTAssertBuilds(packageRoot)
-            let debugPath = prefix.appending(components: "Bar", ".build", Destination.hostTarget, "debug")
+            let debugPath = prefix.appending(components: "Bar", ".build", "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Sea.c.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
             let path = try SwiftPMProduct.packagePath(for: "Foo", packageRoot: packageRoot)
@@ -103,7 +103,7 @@ class ClangModulesTestCase: XCTestCase {
     func testCExecutable() {
         fixture(name: "ValidLayouts/SingleModule/CExecutable") { prefix in
             XCTAssertBuilds(prefix)
-            let debugPath = prefix.appending(components: ".build", Destination.hostTarget, "debug")
+            let debugPath = prefix.appending(components: ".build", "debug")
             XCTAssertFileExists(debugPath.appending(component: "CExecutable"))
             let output = try Process.checkNonZeroExit(args: debugPath.appending(component: "CExecutable").asString)
             XCTAssertEqual(output, "hello 5")
@@ -115,7 +115,7 @@ class ClangModulesTestCase: XCTestCase {
         fixture(name: "DependencyResolution/External/CUsingCDep2") { prefix in
             let packageRoot = prefix.appending(component: "Bar")
             XCTAssertBuilds(packageRoot)
-            let debugPath = prefix.appending(components: "Bar", ".build", Destination.hostTarget, "debug")
+            let debugPath = prefix.appending(components: "Bar", ".build", "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Sea.c.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
             let path = try SwiftPMProduct.packagePath(for: "Foo", packageRoot: packageRoot)
@@ -126,7 +126,7 @@ class ClangModulesTestCase: XCTestCase {
     func testModuleMapGenerationCases() {
         fixture(name: "ClangModules/ModuleMapGenerationCases") { prefix in
             XCTAssertBuilds(prefix)
-            let debugPath = prefix.appending(components: ".build", Destination.hostTarget, "debug")
+            let debugPath = prefix.appending(components: ".build", "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Jaz.c.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "main.swift.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "FlatInclude.c.o")
@@ -138,7 +138,7 @@ class ClangModulesTestCase: XCTestCase {
         // Try building a fixture which needs extra flags to be able to build.
         fixture(name: "ClangModules/CDynamicLookup") { prefix in
             XCTAssertBuilds(prefix, Xld: ["-undefined", "dynamic_lookup"])
-            let debugPath = prefix.appending(components: ".build", Destination.hostTarget, "debug")
+            let debugPath = prefix.appending(components: ".build", "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
         }
     }
@@ -148,7 +148,7 @@ class ClangModulesTestCase: XCTestCase {
         fixture(name: "ClangModules/ObjCmacOSPackage") { prefix in
             // Build the package.
             XCTAssertBuilds(prefix)
-            XCTAssertDirectoryContainsFile(dir: prefix.appending(components: ".build", Destination.hostTarget, "debug"), filename: "HelloWorldExample.m.o")
+            XCTAssertDirectoryContainsFile(dir: prefix.appending(components: ".build", "debug"), filename: "HelloWorldExample.m.o")
             // Run swift-test on package.
             XCTAssertSwiftTest(prefix)
         }

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 
 import Basic
-import Commands
+
 import TestSupport
 import SourceControl
 
@@ -20,7 +20,7 @@ class DependencyResolutionTests: XCTestCase {
         fixture(name: "DependencyResolution/Internal/Simple") { prefix in
             XCTAssertBuilds(prefix)
 
-            let output = try Process.checkNonZeroExit(args: prefix.appending(components: ".build", Destination.hostTarget, "debug", "Foo").asString)
+            let output = try Process.checkNonZeroExit(args: prefix.appending(components: ".build", "debug", "Foo").asString)
             XCTAssertEqual(output, "Foo\nBar\n")
         }
     }
@@ -35,7 +35,7 @@ class DependencyResolutionTests: XCTestCase {
         fixture(name: "DependencyResolution/Internal/Complex") { prefix in
             XCTAssertBuilds(prefix)
 
-            let output = try Process.checkNonZeroExit(args: prefix.appending(components: ".build", Destination.hostTarget, "debug", "Foo").asString)
+            let output = try Process.checkNonZeroExit(args: prefix.appending(components: ".build", "debug", "Foo").asString)
             XCTAssertEqual(output, "meiow Baz\n")
         }
     }
@@ -52,7 +52,7 @@ class DependencyResolutionTests: XCTestCase {
 
             let packageRoot = prefix.appending(component: "Bar")
             XCTAssertBuilds(packageRoot)
-            XCTAssertFileExists(prefix.appending(components: "Bar", ".build", Destination.hostTarget, "debug", "Bar"))
+            XCTAssertFileExists(prefix.appending(components: "Bar", ".build", "debug", "Bar"))
             let path = try SwiftPMProduct.packagePath(for: "Foo", packageRoot: packageRoot)
             XCTAssert(GitRepository(path: path).tags.contains("1.2.3"))
         }
@@ -61,7 +61,7 @@ class DependencyResolutionTests: XCTestCase {
     func testExternalComplex() {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
             XCTAssertBuilds(prefix.appending(component: "app"))
-            let output = try Process.checkNonZeroExit(args: prefix.appending(components: "app", ".build", Destination.hostTarget, "debug", "Dealer").asString)
+            let output = try Process.checkNonZeroExit(args: prefix.appending(components: "app", ".build", "debug", "Dealer").asString)
             XCTAssertEqual(output, "♣︎K\n♣︎Q\n♣︎J\n♣︎10\n♣︎9\n♣︎8\n♣︎7\n♣︎6\n♣︎5\n♣︎4\n")
         }
     }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -72,9 +72,9 @@ class MiscellaneousTestCase: XCTestCase {
 
         fixture(name: "Miscellaneous/ExcludeDiagnostic1") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix.appending(components: ".build", Destination.hostTarget, "debug", "BarLib.swiftmodule"))
-            XCTAssertFileExists(prefix.appending(components: ".build", Destination.hostTarget, "debug", "FooBarLib.swiftmodule"))
-            XCTAssertNoSuchPath(prefix.appending(components: ".build", Destination.hostTarget, "debug", "FooLib.swiftmodule"))
+            XCTAssertFileExists(prefix.appending(components: ".build", "debug", "BarLib.swiftmodule"))
+            XCTAssertFileExists(prefix.appending(components: ".build", "debug", "FooBarLib.swiftmodule"))
+            XCTAssertNoSuchPath(prefix.appending(components: ".build", "debug", "FooLib.swiftmodule"))
         }
     }
 
@@ -95,7 +95,7 @@ class MiscellaneousTestCase: XCTestCase {
 
         fixture(name: "Miscellaneous/ExcludeDiagnostic3") { prefix in
             XCTAssertBuilds(prefix.appending(component: "App"))
-            let buildDir = prefix.appending(components: "App", ".build", Destination.hostTarget, "debug")
+            let buildDir = prefix.appending(components: "App", ".build", "debug")
             XCTAssertFileExists(buildDir.appending(component: "App"))
             XCTAssertFileExists(buildDir.appending(component: "top"))
             XCTAssertFileExists(buildDir.appending(component: "bottom.swiftmodule"))
@@ -109,7 +109,7 @@ class MiscellaneousTestCase: XCTestCase {
 
         fixture(name: "Miscellaneous/ExcludeDiagnostic4") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix.appending(components: ".build", Destination.hostTarget, "debug", "FooPackage.swiftmodule"))
+            XCTAssertFileExists(prefix.appending(components: ".build", "debug", "FooPackage.swiftmodule"))
         }
     }
 
@@ -119,7 +119,7 @@ class MiscellaneousTestCase: XCTestCase {
 
         fixture(name: "Miscellaneous/ExcludeDiagnostic5") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix.appending(components: ".build", Destination.hostTarget, "debug", "FooPackage.swiftmodule"))
+            XCTAssertFileExists(prefix.appending(components: ".build", "debug", "FooPackage.swiftmodule"))
         }
     }
 
@@ -130,7 +130,7 @@ class MiscellaneousTestCase: XCTestCase {
 
         fixture(name: "Miscellaneous/ExactDependencies") { prefix in
             XCTAssertBuilds(prefix.appending(component: "app"))
-            let buildDir = prefix.appending(components: "app", ".build", Destination.hostTarget, "debug")
+            let buildDir = prefix.appending(components: "app", ".build", "debug")
             XCTAssertFileExists(buildDir.appending(component: "FooExec"))
             XCTAssertFileExists(buildDir.appending(component: "FooLib1.swiftmodule"))
             XCTAssertFileExists(buildDir.appending(component: "FooLib2.swiftmodule"))
@@ -255,7 +255,7 @@ class MiscellaneousTestCase: XCTestCase {
     */
     func testInternalDependencyEdges() {
         fixture(name: "Miscellaneous/DependencyEdges/Internal") { prefix in
-            let execpath = prefix.appending(components: ".build", Destination.hostTarget, "debug", "Foo").asString
+            let execpath = prefix.appending(components: ".build", "debug", "Foo").asString
 
             XCTAssertBuilds(prefix)
             var output = try Process.checkNonZeroExit(args: execpath)
@@ -279,7 +279,7 @@ class MiscellaneousTestCase: XCTestCase {
     */
     func testExternalDependencyEdges1() {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
-            let execpath = prefix.appending(components: "app", ".build", Destination.hostTarget, "debug", "Dealer").asString
+            let execpath = prefix.appending(components: "app", ".build", "debug", "Dealer").asString
 
             let packageRoot = prefix.appending(component: "app")
             XCTAssertBuilds(packageRoot)
@@ -306,7 +306,7 @@ class MiscellaneousTestCase: XCTestCase {
      */
     func testExternalDependencyEdges2() {
         fixture(name: "Miscellaneous/DependencyEdges/External") { prefix in
-            let execpath = [prefix.appending(components: "root", ".build", Destination.hostTarget, "debug", "dep2").asString]
+            let execpath = [prefix.appending(components: "root", ".build", "debug", "dep2").asString]
 
             let packageRoot = prefix.appending(component: "root")
             XCTAssertBuilds(prefix.appending(component: "root"))
@@ -330,11 +330,11 @@ class MiscellaneousTestCase: XCTestCase {
     func testProducts() {
         fixture(name: "Products/StaticLibrary") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix.appending(components: ".build", Destination.hostTarget, "debug", "libProductName.a"))
+            XCTAssertFileExists(prefix.appending(components: ".build", "debug", "libProductName.a"))
         }
         fixture(name: "Products/DynamicLibrary") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix.appending(components: ".build", Destination.hostTarget, "debug", "libProductName.\(dynamicLibraryExtension)"))
+            XCTAssertFileExists(prefix.appending(components: ".build", "debug", "libProductName.\(dynamicLibraryExtension)"))
         }
     }
 
@@ -353,7 +353,7 @@ class MiscellaneousTestCase: XCTestCase {
     func testSpaces() {
         fixture(name: "Miscellaneous/Spaces Fixture") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix.appending(components: ".build", Destination.hostTarget, "debug", "Module_Name_1.build", "Foo.swift.o"))
+            XCTAssertFileExists(prefix.appending(components: ".build", "debug", "Module_Name_1.build", "Foo.swift.o"))
         }
     }
 
@@ -425,7 +425,7 @@ class MiscellaneousTestCase: XCTestCase {
             let env = ["PKG_CONFIG_PATH": prefix.asString]
             _ = try executeSwiftBuild(moduleUser, env: env)
 
-            XCTAssertFileExists(moduleUser.appending(components: ".build", Destination.hostTarget, "debug", "SystemModuleUserClang"))
+            XCTAssertFileExists(moduleUser.appending(components: ".build", "debug", "SystemModuleUserClang"))
         }
     }
 

--- a/Tests/FunctionalTests/ModuleMapTests.swift
+++ b/Tests/FunctionalTests/ModuleMapTests.swift
@@ -9,7 +9,7 @@
 */
 
 import XCTest
-import Commands
+
 import TestSupport
 import Basic
 import Utility
@@ -25,7 +25,7 @@ class ModuleMapsTestCase: XCTestCase {
     private func fixture(name: String, cModuleName: String, rootpkg: String, body: @escaping (AbsolutePath, [String]) throws -> Void) {
         TestSupport.fixture(name: name) { prefix in
             let input = prefix.appending(components: cModuleName, "C", "foo.c")
-            let outdir = prefix.appending(components: rootpkg, ".build", Destination.hostTarget, "debug")
+            let outdir = prefix.appending(components: rootpkg, ".build", "debug")
             try makeDirectories(outdir)
             let output = outdir.appending(component: "libfoo.\(dylib)")
             try systemQuietly(["clang", "-shared", input.asString, "-o", output.asString])
@@ -44,9 +44,9 @@ class ModuleMapsTestCase: XCTestCase {
 
             XCTAssertBuilds(prefix.appending(component: "App"), Xld: Xld)
 
-            let debugout = try Process.checkNonZeroExit(args: prefix.appending(components: "App", ".build", Destination.hostTarget, "debug", "App").asString)
+            let debugout = try Process.checkNonZeroExit(args: prefix.appending(RelativePath("App/.build/debug/App")).asString)
             XCTAssertEqual(debugout, "123\n")
-            let releaseout = try Process.checkNonZeroExit(args: prefix.appending(components: "App", ".build", Destination.hostTarget, "release", "App").asString)
+            let releaseout = try Process.checkNonZeroExit(args: prefix.appending(RelativePath("App/.build/release/App")).asString)
             XCTAssertEqual(releaseout, "123\n")
         }
     }
@@ -58,7 +58,7 @@ class ModuleMapsTestCase: XCTestCase {
 
             func verify(_ conf: String, file: StaticString = #file, line: UInt = #line) throws {
                 let expectedOutput = "calling Y.bar()\nY.bar() called\nX.foo() called\n123\n"
-                let out = try Process.checkNonZeroExit(args: prefix.appending(components: "packageA", ".build", Destination.hostTarget, conf, "packageA").asString)
+                let out = try Process.checkNonZeroExit(args: prefix.appending(components: "packageA", ".build", conf, "packageA").asString)
                 XCTAssertEqual(out, expectedOutput)
             }
 

--- a/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
+++ b/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
@@ -12,7 +12,6 @@ import Basic
 import TestSupport
 import XCTest
 import Utility
-import Commands
 
 class SwiftPMXCTestHelperTests: XCTestCase {
     func testBasicXCTestHelper() {
@@ -20,7 +19,7 @@ class SwiftPMXCTestHelperTests: XCTestCase {
         fixture(name: "Miscellaneous/SwiftPMXCTestHelper") { prefix in
             // Build the package.
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix.appending(components: ".build", Destination.hostTarget, "debug", "SwiftPMXCTestHelper.swiftmodule"))
+            XCTAssertFileExists(prefix.appending(components: ".build", "debug", "SwiftPMXCTestHelper.swiftmodule"))
             // Run swift-test on package.
             XCTAssertSwiftTest(prefix)
             // Expected output dictionary.
@@ -37,7 +36,7 @@ class SwiftPMXCTestHelperTests: XCTestCase {
               ] as Array<Dictionary<String, Any>>]] as Array<Dictionary<String, Any>>
             ] as Dictionary<String, Any> as NSDictionary
             // Run the XCTest helper tool and check result.
-            XCTAssertXCTestHelper(prefix.appending(components: ".build", Destination.hostTarget, "debug", "SwiftPMXCTestHelperPackageTests.xctest"), testCases: testCases)
+            XCTAssertXCTestHelper(prefix.appending(components: ".build", "debug", "SwiftPMXCTestHelperPackageTests.xctest"), testCases: testCases)
         }
       #endif
     }

--- a/Tests/FunctionalTests/ToolsVersionTests.swift
+++ b/Tests/FunctionalTests/ToolsVersionTests.swift
@@ -13,7 +13,7 @@ import XCTest
 import Basic
 import Utility
 import TestSupport
-import Commands
+
 import PackageModel
 import SourceControl
 
@@ -72,7 +72,7 @@ class ToolsVersionTests: XCTestCase {
 
             // Build the primary package.
             _ = try SwiftPMProduct.SwiftBuild.execute([], chdir: primaryPath)
-            let exe = primaryPath.appending(components: ".build", Destination.hostTarget, "debug", "Primary").asString
+            let exe = primaryPath.appending(components: ".build", "debug", "Primary").asString
             // v1 should get selected because v1.0.1 depends on a (way) higher set of tools.
             XCTAssertEqual(try Process.checkNonZeroExit(args: exe).chomp(), "foo@1.0")
 

--- a/Tests/FunctionalTests/ValidLayoutTests.swift
+++ b/Tests/FunctionalTests/ValidLayoutTests.swift
@@ -9,7 +9,7 @@
 */
 
 import XCTest
-import Commands
+
 import TestSupport
 import Basic
 import Utility
@@ -22,7 +22,7 @@ class ValidLayoutsTests: XCTestCase {
     func testSingleModuleLibrary() {
         runLayoutFixture(name: "SingleModule/Library") { prefix in
             XCTAssertBuilds(prefix)
-            let debugPath = prefix.appending(components: ".build", Destination.hostTarget, "debug")
+            let debugPath = prefix.appending(components: ".build", "debug")
             XCTAssertFileExists(debugPath.appending(component: "Library.swiftmodule"))
         }
     }
@@ -30,7 +30,7 @@ class ValidLayoutsTests: XCTestCase {
     func testSingleModuleExecutable() {
         runLayoutFixture(name: "SingleModule/Executable") { prefix in
             XCTAssertBuilds(prefix)
-            let debugPath = prefix.appending(components: ".build", Destination.hostTarget, "debug")
+            let debugPath = prefix.appending(components: ".build", "debug")
             XCTAssertFileExists(debugPath.appending(component: "Executable"))
         }
     }
@@ -38,7 +38,7 @@ class ValidLayoutsTests: XCTestCase {
     func testSingleModuleSubfolderWithSwiftSuffix() {
         fixture(name: "ValidLayouts/SingleModule/SubfolderWithSwiftSuffix", file: #file, line: #line) { prefix in
             XCTAssertBuilds(prefix)
-            let debugPath = prefix.appending(components: ".build", Destination.hostTarget, "debug")
+            let debugPath = prefix.appending(components: ".build", "debug")
             XCTAssertFileExists(debugPath.appending(component: "Bar.swiftmodule"))
         }
     }
@@ -46,7 +46,7 @@ class ValidLayoutsTests: XCTestCase {
     func testMultipleModulesLibraries() {
         runLayoutFixture(name: "MultipleModules/Libraries") { prefix in
             XCTAssertBuilds(prefix)
-            let debugPath = prefix.appending(components: ".build", Destination.hostTarget, "debug")
+            let debugPath = prefix.appending(components: ".build", "debug")
             for x in ["Bar", "Baz", "Foo"] {
                 XCTAssertFileExists(debugPath.appending(component: "\(x).swiftmodule"))
             }
@@ -56,7 +56,7 @@ class ValidLayoutsTests: XCTestCase {
     func testMultipleModulesExecutables() {
         runLayoutFixture(name: "MultipleModules/Executables") { prefix in
             XCTAssertBuilds(prefix)
-            let debugPath = prefix.appending(components: ".build", Destination.hostTarget, "debug")
+            let debugPath = prefix.appending(components: ".build", "debug")
             for x in ["Bar", "Baz", "Foo"] {
                 let output = try Process.checkNonZeroExit(args: debugPath.appending(component: x).asString)
                 XCTAssertEqual(output, "\(x)\n")

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -13,7 +13,6 @@ import TestSupport
 import Basic
 import PackageModel
 import Workspace
-import Commands
 
 class InitTests: XCTestCase {
 
@@ -79,8 +78,8 @@ class InitTests: XCTestCase {
             
             // Try building it
             XCTAssertBuilds(path)
-            XCTAssertFileExists(path.appending(components: ".build", Destination.hostTarget, "debug", "Foo"))
-            XCTAssertFileExists(path.appending(components: ".build", Destination.hostTarget, "debug", "Foo.swiftmodule"))
+            XCTAssertFileExists(path.appending(components: ".build", "debug", "Foo"))
+            XCTAssertFileExists(path.appending(components: ".build", "debug", "Foo.swiftmodule"))
         }
     }
 
@@ -120,7 +119,7 @@ class InitTests: XCTestCase {
 
             // Try building it
             XCTAssertBuilds(path)
-            XCTAssertFileExists(path.appending(components: ".build", Destination.hostTarget, "debug", "Foo.swiftmodule"))
+            XCTAssertFileExists(path.appending(components: ".build", "debug", "Foo.swiftmodule"))
         }
     }
     
@@ -167,7 +166,7 @@ class InitTests: XCTestCase {
 
         // Try building it.
         XCTAssertBuilds(packageRoot)
-        XCTAssertFileExists(packageRoot.appending(components: ".build", Destination.hostTarget, "debug", "some_package.swiftmodule"))
+        XCTAssertFileExists(packageRoot.appending(components: ".build", "debug", "some_package.swiftmodule"))
     }
     
     static var allTests = [

--- a/Tests/XcodeprojTests/FunctionalTests.swift
+++ b/Tests/XcodeprojTests/FunctionalTests.swift
@@ -10,9 +10,8 @@
 
 import XCTest
 
-import Basic
-import Commands
 import TestSupport
+import Basic
 import PackageModel
 import Utility
 import Xcodeproj
@@ -114,7 +113,7 @@ class FunctionalTests: XCTestCase {
         // Now we use a fixture for both the system library wrapper and the text executable.
         fixture(name: "Miscellaneous/SystemModules") { prefix in
             XCTAssertBuilds(prefix.appending(component: "TestExec"), Xld: ["-L/tmp/"])
-            XCTAssertFileExists(prefix.appending(components: "TestExec", ".build", Destination.hostTarget, "debug", "TestExec"))
+            XCTAssertFileExists(prefix.appending(components: "TestExec", ".build", "debug", "TestExec"))
             let fakeDir = prefix.appending(component: "CFake")
             XCTAssertDirectoryExists(fakeDir)
             let execDir = prefix.appending(component: "TestExec")

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -833,14 +833,8 @@ def main():
             raise SystemExit("unknown build action: %r" % (action,))
 
     # Compute the build paths.
-    if platform.system() == 'Darwin':
-        build_target = "x86_64-apple-macosx10.10"
-    else:
-        build_target = 'x86_64-unknown-linux'
-
     build_path = os.path.join(g_project_root, args.build_path)
     sandbox_path = os.path.join(build_path, ".bootstrap")
-    target_path = os.path.join(build_path, build_target)
 
     # If the action is "clean", just remove the bootstrap and build directories.
     if "clean" in build_actions:
@@ -884,9 +878,8 @@ def main():
         processed_runtimes[version] = process_runtime_libraries(
                 build, args, lib_path)
 
-    
-    libdir = os.path.join(target_path, "lib")
-    bindir = os.path.join(target_path, conf)
+    libdir = os.path.join(build_path, "lib")
+    bindir = os.path.join(build_path, conf)
     mkdir_p(bindir)
     bootstrapped_product = os.path.join(bindir, "swift-build-stage1")
 
@@ -900,7 +893,7 @@ def main():
         if os.path.isdir(libdir) and not os.path.islink(libdir):
             # TODO remove, here to prevent revlock incremental CI build failures
             shutil.rmtree(libdir)
-        symlink_force(os.path.join(sandbox_path, "lib"), target_path)
+        symlink_force(os.path.join(sandbox_path, "lib"), build_path)
 
         if args.foundation_path:
             libswiftdir = os.path.join(sandbox_path, "lib", "swift", "linux")
@@ -997,11 +990,11 @@ def main():
     if result != 0:
         error("build failed with exit status %d" % (result,))
 
-    swift_package_path = os.path.join(target_path, conf, "swift-package")
-    swift_build_path = os.path.join(target_path, conf, "swift-build")
-    swift_test_path = os.path.join(target_path, conf, "swift-test")
+    swift_package_path = os.path.join(build_path, conf, "swift-package")
+    swift_build_path = os.path.join(build_path, conf, "swift-build")
+    swift_test_path = os.path.join(build_path, conf, "swift-test")
     swiftpm_xctest_helper_path = os.path.join(
-        target_path, conf, "swiftpm-xctest-helper")
+        build_path, conf, "swiftpm-xctest-helper")
 
     # If testing, run each of the test bundles.
     if "test" in build_actions:
@@ -1121,7 +1114,7 @@ def main():
         # Copy the libSwiftPM library.
         # FIXME: This shouldn't require so much knowledge of the manifest.
         # FIXME: We should handle what happens if it's a static library.
-        src_path = os.path.join(target_path, conf, libswiftpm_product.product_name)
+        src_path = os.path.join(build_path, conf, libswiftpm_product.product_name)
         dst_path = os.path.join(libswiftpm_library_dir, libswiftpm_product.product_name)
         cmd = ["rsync", "-a", src_path, dst_path]
         note("copying %s: %s" % (os.path.basename(src_path), ' '.join(cmd)))
@@ -1177,7 +1170,7 @@ def main():
             elif target.is_swift:
                 # Copy swiftmodule and swiftdoc i.e. headers of the Swift target.
                 for suffix in [".swiftmodule", ".swiftdoc"]:
-                    src_path = os.path.join(target_path, conf, target.name + suffix)
+                    src_path = os.path.join(build_path, conf, target.name + suffix)
                     if not os.path.exists(src_path):
                         continue
                     dst_path = os.path.join(libswiftpm_modules_dir, target.name + suffix)


### PR DESCRIPTION
Reverts apple/swift-package-manager#1181

This is causing perf and unit test failures when running from Xcode project. Reverting for now.