### PR TITLE
More efficient SortedArray.insert(contentsOf:)

### DIFF
--- a/Sources/Basic/SortedArray.swift
+++ b/Sources/Basic/SortedArray.swift
@@ -96,12 +96,12 @@ public struct SortedArray<Element>: CustomStringConvertible {
             if areInIncreasingOrder(lhs, rhs) {
                 elements[index] = rhs
                 rhsIndex -= 1
-                guard rhsIndex >= 0 else { break }
+                guard rhsIndex >= newElements.startIndex else { break }
                 rhs = newElements[rhsIndex]
             } else {
                 elements[index] = lhs
                 lhsIndex -= 1
-                guard lhsIndex >= 0 else { break }
+                guard lhsIndex >= elements.startIndex else { break }
                 lhs = elements[lhsIndex]
             }
         }

--- a/Sources/Basic/SortedArray.swift
+++ b/Sources/Basic/SortedArray.swift
@@ -88,14 +88,6 @@ public struct SortedArray<Element>: CustomStringConvertible {
         // resized without requiring instantiated elements.
         elements.append(contentsOf: newElements)
 
-        // NOTE: Experimentally this seemed to be the inflection point where
-        // the constant overheads of this implementation outweighed the better
-        // O(n) versus O(n log(n)) complexity.
-        guard elements.count > 1000 else {
-            elements.sort(by: areInIncreasingOrder)
-            return
-        }
-
         var lhs = elements[lhsIndex], rhs = newElements[rhsIndex]
 
         // Equivalent to a merge sort, "pop" and append the max elemeent of

--- a/Sources/Basic/SortedArray.swift
+++ b/Sources/Basic/SortedArray.swift
@@ -59,14 +59,55 @@ public struct SortedArray<Element>: CustomStringConvertible {
     
     /// Insert the given sequence, maintaining the sort order.
     public mutating func insert<S: Sequence>(contentsOf newElements: S) where S.Iterator.Element == Element {
+        var newElements = newElements.sorted(by: areInIncreasingOrder)
+        guard !newElements.isEmpty else {
+            return
+        }
+        guard !elements.isEmpty else {
+            elements = newElements
+            return
+        }
+
+        var lhsIndex = elements.endIndex - 1
+        var rhsIndex = newElements.endIndex - 1
+
+        elements.reserveCapacity(elements.count + newElements.count)
+
+        // TODO: If SortedArray moves to stdlib an _ArrayBuffer can be used
+        // instead, this can then be removed as _ArrayBuffer can be resized
+        // without requiring instantiated elements.
         elements.append(contentsOf: newElements)
-        elements.sort(by: areInIncreasingOrder)
+
+        var lhs = elements[lhsIndex], rhs = newElements[rhsIndex]
+
+        // Equivalent to a merge sort, "pop" and append the max elemeent of
+        // each array until either array is empty
+        for index in elements.indices.reversed() {
+            if areInIncreasingOrder(lhs, rhs) {
+                elements[index] = rhs
+                rhsIndex -= 1
+                guard rhsIndex >= 0 else { break }
+                rhs = newElements[rhsIndex]
+            }
+            else {
+                elements[index] = lhs
+                lhsIndex -= 1
+                guard lhsIndex >= 0 else { break }
+                lhs = elements[lhsIndex]
+            }
+        }
+        // any remaining new elements were smaller than all old elements
+        // so the remaining new elements can safely replace the prefix.
+        if rhsIndex >= 0 {
+            elements.replaceSubrange(0 ... rhsIndex,
+                                     with: newElements[0 ... rhsIndex])
+        }
     }
 
-	/// Returns the values as an array.
-	public var values: [Element] {
-		return elements
-	}
+    /// Returns the values as an array.
+    public var values: [Element] {
+        return elements
+    }
     
     public var description: String {
         return "<SortedArray: \(elements)>"

--- a/Sources/Basic/SortedArray.swift
+++ b/Sources/Basic/SortedArray.swift
@@ -24,6 +24,7 @@ public struct SortedArray<Element>: CustomStringConvertible {
         self.areInIncreasingOrder = areInIncreasingOrder
     }
 
+    /// Create a sorted array with the given sequence and comparison predicate.
     public init<S: Sequence>(
         _ newElements: S,
         areInIncreasingOrder: @escaping (Element, Element) -> Bool)

--- a/Sources/Basic/SortedArray.swift
+++ b/Sources/Basic/SortedArray.swift
@@ -23,6 +23,15 @@ public struct SortedArray<Element>: CustomStringConvertible {
         self.elements = []
         self.areInIncreasingOrder = areInIncreasingOrder
     }
+
+    public init<S: Sequence>(
+        _ newElements: S,
+        areInIncreasingOrder: @escaping (Element, Element) -> Bool)
+    where S.Iterator.Element == Element
+    {
+        self.elements = newElements.sorted(by: areInIncreasingOrder)
+        self.areInIncreasingOrder = areInIncreasingOrder
+    }
     
     /// Insert the given element, maintaining the sort order.
     public mutating func insert(_ newElement: Element) {

--- a/Sources/Basic/SortedArray.swift
+++ b/Sources/Basic/SortedArray.swift
@@ -78,6 +78,14 @@ public struct SortedArray<Element>: CustomStringConvertible {
         // resized without requiring instantiated elements.
         elements.append(contentsOf: newElements)
 
+        // NOTE: Experimentally this seemed to be the inflection point where
+        // the constant overheads of this implementation outweighed the better
+        // O(n) versus O(n log(n)) complexity.
+        guard elements.count > 1000 else {
+            elements.sort(by: areInIncreasingOrder)
+            return
+        }
+
         var lhs = elements[lhsIndex], rhs = newElements[rhsIndex]
 
         // Equivalent to a merge sort, "pop" and append the max elemeent of

--- a/Sources/Basic/SortedArray.swift
+++ b/Sources/Basic/SortedArray.swift
@@ -73,7 +73,7 @@ public struct SortedArray<Element>: CustomStringConvertible {
 
         elements.reserveCapacity(elements.count + newElements.count)
 
-        // TODO: If SortedArray moves to stdlib an _ArrayBuffer can be used
+        // NOTE: If SortedArray moves to stdlib an _ArrayBuffer can be used
         // instead, this can then be removed as _ArrayBuffer can be resized
         // without requiring instantiated elements.
         elements.append(contentsOf: newElements)
@@ -81,26 +81,27 @@ public struct SortedArray<Element>: CustomStringConvertible {
         var lhs = elements[lhsIndex], rhs = newElements[rhsIndex]
 
         // Equivalent to a merge sort, "pop" and append the max elemeent of
-        // each array until either array is empty
+        // each array until either array is empty.
         for index in elements.indices.reversed() {
             if areInIncreasingOrder(lhs, rhs) {
                 elements[index] = rhs
                 rhsIndex -= 1
                 guard rhsIndex >= 0 else { break }
                 rhs = newElements[rhsIndex]
-            }
-            else {
+            } else {
                 elements[index] = lhs
                 lhsIndex -= 1
                 guard lhsIndex >= 0 else { break }
                 lhs = elements[lhsIndex]
             }
         }
-        // any remaining new elements were smaller than all old elements
+
+        // Any remaining new elements were smaller than all old elements
         // so the remaining new elements can safely replace the prefix.
         if rhsIndex >= 0 {
-            elements.replaceSubrange(0 ... rhsIndex,
-                                     with: newElements[0 ... rhsIndex])
+            elements.replaceSubrange(
+                0 ... rhsIndex,
+                with: newElements[0 ... rhsIndex])
         }
     }
 

--- a/Sources/Basic/SortedArray.swift
+++ b/Sources/Basic/SortedArray.swift
@@ -69,7 +69,7 @@ public struct SortedArray<Element>: CustomStringConvertible {
     
     /// Insert the given sequence, maintaining the sort order.
     public mutating func insert<S: Sequence>(contentsOf newElements: S) where S.Iterator.Element == Element {
-        var newElements = newElements.sorted(by: areInIncreasingOrder)
+        var newElements: Array = newElements.sorted(by: areInIncreasingOrder)
         guard !newElements.isEmpty else {
             return
         }

--- a/Sources/Basic/SortedArray.swift
+++ b/Sources/Basic/SortedArray.swift
@@ -74,8 +74,8 @@ public struct SortedArray<Element>: CustomStringConvertible {
         elements.reserveCapacity(elements.count + newElements.count)
 
         // NOTE: If SortedArray moves to stdlib an _ArrayBuffer can be used
-        // instead, this can then be removed as _ArrayBuffer can be resized
-        // without requiring instantiated elements.
+        // instead. This append can then be removed as _ArrayBuffer can be
+        // resized without requiring instantiated elements.
         elements.append(contentsOf: newElements)
 
         var lhs = elements[lhsIndex], rhs = newElements[rhsIndex]

--- a/Tests/BasicPerformanceTests/SortedArrayPerfTests.swift
+++ b/Tests/BasicPerformanceTests/SortedArrayPerfTests.swift
@@ -11,7 +11,17 @@
 import TestSupport
 import Basic
 
+private let magnitude = 5000
+
+private func prng(_ seed: Int) -> Int {
+    return (seed &* 1299827) % magnitude
+}
+
 class SortedArrayPerfTests: XCTestCasePerf {
+
+    private let firstSequence = (0..<(magnitude*2)).map(prng)
+    private let secondSequence = ((magnitude*1)..<(magnitude*3)).map(prng)
+
     func testPerformanceOfSortedArrayInAscendingOrder() {
         
         measure() {
@@ -19,6 +29,32 @@ class SortedArrayPerfTests: XCTestCasePerf {
             for i in 1...1000 {
                 arr.insert(i)
             }
+        }
+    }
+
+    func testPerformanceOfSortedArrayInsertWithDuplicates() {
+        @inline(never)
+        func insert<T, S: Sequence>(_ sequence: S, into array: inout SortedArray<T>) where S.Iterator.Element == T {
+            for element in sequence {
+                array.insert(element)
+            }
+        }
+
+        var arr = SortedArray<Int>(areInIncreasingOrder: <)
+        arr.insert(contentsOf: firstSequence)
+
+        measure() {
+            insert(self.secondSequence, into: &arr)
+        }
+    }
+
+    func testPerformanceOfSortedArrayInsertContentsOfWithDuplicates() {
+
+        var arr = SortedArray<Int>(areInIncreasingOrder: <)
+        arr.insert(contentsOf: firstSequence)
+
+        measure() {
+            arr.insert(contentsOf: self.secondSequence)
         }
     }
 }

--- a/Tests/BasicPerformanceTests/SortedArrayPerfTests.swift
+++ b/Tests/BasicPerformanceTests/SortedArrayPerfTests.swift
@@ -40,4 +40,15 @@ class SortedArrayPerfTests: XCTestCasePerf {
             arr.insert(contentsOf: 60_000..<180_000)
         }
     }
+
+    func testPerformanceOfSmallSortedArrayInsertContentsOfWithDuplicates() {
+        let initial = SortedArray<Int>(0..<100, areInIncreasingOrder: <)
+
+        measure() {
+            for _ in 1...2000 {
+                var arr = initial
+                arr.insert(contentsOf: 50..<150)
+            }
+        }
+    }
 }

--- a/Tests/BasicPerformanceTests/SortedArrayPerfTests.swift
+++ b/Tests/BasicPerformanceTests/SortedArrayPerfTests.swift
@@ -19,38 +19,36 @@ private func prng(_ seed: Int) -> Int {
 
 class SortedArrayPerfTests: XCTestCasePerf {
 
-    private let firstSequence = (0..<(magnitude*2)).map(prng)
-    private let secondSequence = ((magnitude*1)..<(magnitude*3)).map(prng)
+    private let startSequence = (0..<(magnitude*2)).map(prng)
+    private let overlappingSequence = ((magnitude*1)..<(magnitude*3)).map(prng)
+
+    private var arr: SortedArray<Int> = .init(areInIncreasingOrder: <)
+
+    override func setUp() {
+        arr = .init(areInIncreasingOrder: <)
+        arr.insert(contentsOf: startSequence)
+    }
 
     func testPerformanceOfSortedArrayInAscendingOrder() {
         
         measure() {
-            var arr = SortedArray<Int>(areInIncreasingOrder: <)
             for i in 1...1000 {
-                arr.insert(i)
+                self.arr.insert(i)
             }
         }
     }
 
     func testPerformanceOfSortedArrayInsertWithDuplicates() {
-
         measure() {
-            var arr = SortedArray<Int>(areInIncreasingOrder: <)
-            for element in self.firstSequence {
-                arr.insert(element)
-            }
-            for element in self.secondSequence {
-                arr.insert(element)
+            for element in self.overlappingSequence {
+                self.arr.insert(element)
             }
         }
     }
 
     func testPerformanceOfSortedArrayInsertContentsOfWithDuplicates() {
-
         measure() {
-            var arr = SortedArray<Int>(areInIncreasingOrder: <)
-            arr.insert(contentsOf: self.firstSequence)
-            arr.insert(contentsOf: self.secondSequence)
+            self.arr.insert(contentsOf: self.overlappingSequence)
         }
     }
 }

--- a/Tests/BasicPerformanceTests/SortedArrayPerfTests.swift
+++ b/Tests/BasicPerformanceTests/SortedArrayPerfTests.swift
@@ -11,44 +11,33 @@
 import TestSupport
 import Basic
 
-private let magnitude = 5000
-
-private func prng(_ seed: Int) -> Int {
-    return (seed &* 1299827) % magnitude
-}
-
 class SortedArrayPerfTests: XCTestCasePerf {
-
-    private let startSequence = (0..<(magnitude*2)).map(prng)
-    private let overlappingSequence = ((magnitude*1)..<(magnitude*3)).map(prng)
-
-    private var arr: SortedArray<Int> = .init(areInIncreasingOrder: <)
-
-    override func setUp() {
-        arr = .init(areInIncreasingOrder: <)
-        arr.insert(contentsOf: startSequence)
-    }
-
     func testPerformanceOfSortedArrayInAscendingOrder() {
-        
         measure() {
-            for i in 1...1000 {
-                self.arr.insert(i)
+            var arr = SortedArray<Int>(areInIncreasingOrder: <)
+            for i in 1...200_000 {
+                arr.insert(i)
             }
         }
     }
 
     func testPerformanceOfSortedArrayInsertWithDuplicates() {
+        let initial = SortedArray<Int>(0..<80_000, areInIncreasingOrder: <)
+        
         measure() {
-            for element in self.overlappingSequence {
-                self.arr.insert(element)
+            var arr = initial
+            for element in 40_000..<120_000 {
+                arr.insert(element)
             }
         }
     }
 
     func testPerformanceOfSortedArrayInsertContentsOfWithDuplicates() {
+        let initial = SortedArray<Int>(0..<120_000, areInIncreasingOrder: <)
+        
         measure() {
-            self.arr.insert(contentsOf: self.overlappingSequence)
+            var arr = initial
+            arr.insert(contentsOf: 60_000..<180_000)
         }
     }
 }

--- a/Tests/BasicPerformanceTests/SortedArrayPerfTests.swift
+++ b/Tests/BasicPerformanceTests/SortedArrayPerfTests.swift
@@ -33,27 +33,23 @@ class SortedArrayPerfTests: XCTestCasePerf {
     }
 
     func testPerformanceOfSortedArrayInsertWithDuplicates() {
-        @inline(never)
-        func insert<T, S: Sequence>(_ sequence: S, into array: inout SortedArray<T>) where S.Iterator.Element == T {
-            for element in sequence {
-                array.insert(element)
-            }
-        }
-
-        var arr = SortedArray<Int>(areInIncreasingOrder: <)
-        arr.insert(contentsOf: firstSequence)
 
         measure() {
-            insert(self.secondSequence, into: &arr)
+            var arr = SortedArray<Int>(areInIncreasingOrder: <)
+            for element in self.firstSequence {
+                arr.insert(element)
+            }
+            for element in self.secondSequence {
+                arr.insert(element)
+            }
         }
     }
 
     func testPerformanceOfSortedArrayInsertContentsOfWithDuplicates() {
 
-        var arr = SortedArray<Int>(areInIncreasingOrder: <)
-        arr.insert(contentsOf: firstSequence)
-
         measure() {
+            var arr = SortedArray<Int>(areInIncreasingOrder: <)
+            arr.insert(contentsOf: self.firstSequence)
             arr.insert(contentsOf: self.secondSequence)
         }
     }

--- a/Tests/BasicTests/SortedArrayTests.swift
+++ b/Tests/BasicTests/SortedArrayTests.swift
@@ -76,6 +76,18 @@ class SortedArrayTests: XCTestCase {
         XCTAssertEqual(arr.values, [1, 2, 3, 4, 5, 6, 7])
     }
 
+    func testSortedArrayInsertSlice() throws {
+        let target = [0, 1, 2, 3, 4, 5, 6]
+        var arr = SortedArray<Int>(areInIncreasingOrder: <)
+        arr.insert(contentsOf: target[2...2])
+
+        arr.insert(contentsOf: target[0...1])
+        XCTAssertEqual(arr.values, [0, 1, 2])
+
+        arr.insert(contentsOf: target[3...6])
+        XCTAssertEqual(arr.values, target)
+    }
+
     func testSortedArrayWithValues() throws {
         let arr = SortedArray<Int>([5, 4, 3, 2, 1], areInIncreasingOrder: <)
         XCTAssertEqual(arr.values, [1, 2, 3, 4, 5])

--- a/Tests/BasicTests/SortedArrayTests.swift
+++ b/Tests/BasicTests/SortedArrayTests.swift
@@ -36,6 +36,9 @@ class SortedArrayTests: XCTestCase {
         
         arr.insert(198)
         XCTAssertEqual(arr.values, [-13, -13, 0, 0, 1, 2, 2, 3, 3, 9, 13, 14, 15, 100, 198, 198])
+        
+        arr.insert(contentsOf: [-15, -14])
+        XCTAssertEqual(arr.values, [-15, -14, -13, -13, 0, 0, 1, 2, 2, 3, 3, 9, 13, 14, 15, 100, 198, 198])
     }
     
     func testSortedArrayInDescendingOrder() throws {

--- a/Tests/BasicTests/SortedArrayTests.swift
+++ b/Tests/BasicTests/SortedArrayTests.swift
@@ -64,9 +64,15 @@ class SortedArrayTests: XCTestCase {
         arr.insert(198)
         XCTAssertEqual(arr.values, [198, 198, 100, 15, 14, 13, 9, 3, 3, 2, 2, 1, 0, 0, -13, -13])
     }
+
+    func testSortedArrayWithValues() throws {
+        let arr = SortedArray<Int>([5, 4, 3, 2, 1], areInIncreasingOrder: <)
+        XCTAssertEqual(arr.values, [1, 2, 3, 4, 5])
+    }
     
     static var allTests = [
         ("testSortedArrayInAscendingOrder", testSortedArrayInAscendingOrder),
-        ("testSortedArrayInDescendingOrder", testSortedArrayInDescendingOrder)
+        ("testSortedArrayInDescendingOrder", testSortedArrayInDescendingOrder),
+        ("testSortedArrayWithValues", testSortedArrayWithValues)
     ]
 }

--- a/Tests/BasicTests/SortedArrayTests.swift
+++ b/Tests/BasicTests/SortedArrayTests.swift
@@ -65,6 +65,17 @@ class SortedArrayTests: XCTestCase {
         XCTAssertEqual(arr.values, [198, 198, 100, 15, 14, 13, 9, 3, 3, 2, 2, 1, 0, 0, -13, -13])
     }
 
+    func testSortedArrayInsertIntoSmallerArray() throws {
+        var arr = SortedArray<Int>(areInIncreasingOrder: <)
+        arr.insert(contentsOf: [3])
+
+        arr.insert(contentsOf: [1, 2])
+        XCTAssertEqual(arr.values, [1, 2, 3])
+
+        arr.insert(contentsOf: [4, 5, 6, 7])
+        XCTAssertEqual(arr.values, [1, 2, 3, 4, 5, 6, 7])
+    }
+
     func testSortedArrayWithValues() throws {
         let arr = SortedArray<Int>([5, 4, 3, 2, 1], areInIncreasingOrder: <)
         XCTAssertEqual(arr.values, [1, 2, 3, 4, 5])
@@ -73,6 +84,7 @@ class SortedArrayTests: XCTestCase {
     static var allTests = [
         ("testSortedArrayInAscendingOrder", testSortedArrayInAscendingOrder),
         ("testSortedArrayInDescendingOrder", testSortedArrayInDescendingOrder),
+        ("testSortedArrayInsertIntoSmallerArray", testSortedArrayInsertIntoSmallerArray),
         ("testSortedArrayWithValues", testSortedArrayWithValues)
     ]
 }


### PR DESCRIPTION
Uses the equivalent of a single pass of a merge-sort to make the `SortedArray.insert(contentsOf:)` more efficient.

This allows the algorithm to go from `O((a+b) log(a+b))` to `O(a + b log (b))`. Where `a` is the size of the current array, and `b` is the size of the new elements. If `b` is already sorted (i.e. another `SortedArray`) then an efficient `sort` function will mean this runs in `O(a + b)`.

The new performance tests should demonstrate the improvements when compared, assuming the element count is suitably large:
> testPerformanceOfSortedArrayInsertWithDuplicates()
> testPerformanceOfSortedArrayInsertContentsOfWithDuplicates()

**Note** I needed to add `-swift-version 3` to `Other Swift Flags`

**Note** Insertion times are negligible for a `magnitude` of less than 1000. Performance on my machine is actually slightly worse for a `magnitude` less than 1000. However it gets significantly better for values of `magnitude` higher than 1000. I suspect this is because of `elements.append(contentsOf: newElements)` and constant overheads.