### PR TITLE
[Commands] Fix host destination resolution w.r.t. relative launch path.

### DIFF
--- a/Sources/Commands/Destination.swift
+++ b/Sources/Commands/Destination.swift
@@ -55,7 +55,11 @@ public struct Destination {
     public let extraCPPFlags: [String]
 
     /// Returns the bin directory for the host.
-    private static func hostBinDir() -> AbsolutePath {
+    ///
+    /// - Parameter originalWorkingDirectory: The working directory when the program was launched.
+    private static func hostBinDir(
+        originalWorkingDirectory: AbsolutePath = currentWorkingDirectory
+    ) -> AbsolutePath {
       #if Xcode
         // For Xcode, set bin directory to the build directory containing the fake
         // toolchain created during bootstraping. This is obviously not production ready
@@ -70,14 +74,18 @@ public struct Destination {
             .parentDirectory.parentDirectory.appending(components: ".build", "debug")
       #else
         return AbsolutePath(
-            CommandLine.arguments[0], relativeTo: currentWorkingDirectory).parentDirectory
+            CommandLine.arguments[0], relativeTo: originalWorkingDirectory).parentDirectory
       #endif
     }
 
     /// The destination describing the host OS.
-    public static func hostDestination(_ binDir: AbsolutePath? = nil) throws -> Destination {
+    public static func hostDestination(
+        _ binDir: AbsolutePath? = nil,
+        originalWorkingDirectory: AbsolutePath = currentWorkingDirectory
+    ) throws -> Destination {
         // Select the correct binDir.
-        let binDir = binDir ?? Destination.hostBinDir()
+        let binDir = binDir ?? Destination.hostBinDir(
+            originalWorkingDirectory: originalWorkingDirectory)
 
       #if os(macOS)
         // Get the SDK.

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -65,6 +65,9 @@ private class ToolWorkspaceDelegate: WorkspaceDelegate {
 }
 
 public class SwiftTool<Options: ToolOptions> {
+    /// The original working directory.
+    let originalWorkingDirectory: AbsolutePath
+    
     /// The options of this tool.
     let options: Options
 
@@ -104,7 +107,9 @@ public class SwiftTool<Options: ToolOptions> {
     ///
     /// - parameter args: The command line arguments to be passed to this tool.
     public init(toolName: String, usage: String, overview: String, args: [String]) {
-
+        // Capture the original working directory ASAP.
+        originalWorkingDirectory = currentWorkingDirectory
+        
         // Create the parser.
         parser = ArgumentParser(
             commandName: "swift \(toolName)",
@@ -400,7 +405,8 @@ public class SwiftTool<Options: ToolOptions> {
     /// Lazily compute the host toolchain used to compile the package description.
     private lazy var _hostToolchain: Result<UserToolchain, AnyError> = {
         return Result(anyError: {
-            try UserToolchain(destination: Destination.hostDestination())
+            try UserToolchain(destination: Destination.hostDestination(
+                        originalWorkingDirectory: self.originalWorkingDirectory))
         })
     }()
 


### PR DESCRIPTION
 - This fixes the host destination binary path resolution when the tool is used
   with -C.

 - https://bugs.swift.org/browse/SR-4910