### PR TITLE
[SR-3689] Persist editable package state when the package is not in Manifest

### DIFF
--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -56,7 +56,7 @@ public final class ManagedDependency: JSONMappable, JSONSerializable {
     ///
     /// This information is useful so it can be restored when users 
     /// unedit a package.
-    let basedOn: ManagedDependency?
+    var basedOn: ManagedDependency?
 
     init(
         name: String,


### PR DESCRIPTION
Solves https://bugs.swift.org/browse/SR-3689 

This PR persists the editable package state in the `managedDependecies` even when the package no longer exist in manifest.