### PR TITLE
FIX: hasUnpushedCommits for detatched HEAD

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -325,9 +325,9 @@ public class GitRepository: Repository, WorkingCheckout {
 
     public func hasUnpushedCommits() throws -> Bool {
         return try queue.sync {
-            let hasOutput = try Process.checkNonZeroExit(
-                args: Git.tool, "-C", path.asString, "log", "--branches", "--not", "--remotes").chomp().isEmpty
-            return !hasOutput
+            let output = try Process.checkNonZeroExit(
+                args: Git.tool, "-C", path.asString, "branch", "-r", "--contains", "HEAD").chomp()
+            return output.isEmpty
         }
     }
 

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -323,21 +323,15 @@ public class GitRepository: Repository, WorkingCheckout {
 
     // MARK: Working Checkout Interface
 
-    internal func _areAllBranchesPushed() throws -> Bool {
-        let unpushedBranches = try Process.checkNonZeroExit(
-            args: Git.tool, "-C", path.asString, "log", "--branches", "--not", "--remotes").chomp()
-        return unpushedBranches.isEmpty
-    }
-
-    internal func _isHeadOnRemote() throws -> Bool {
-        let upstreamBranches = try Process.checkNonZeroExit(
-            args: Git.tool, "-C", path.asString, "branch", "-r", "--contains", "HEAD").chomp()
-        return !upstreamBranches.isEmpty
-    }
-
+    /// Returns true if any branches or HEAD are not pushed to remote.
     public func hasUnpushedCommits() throws -> Bool {
         return try queue.sync {
-            return try !_areAllBranchesPushed() || !_isHeadOnRemote()
+            let unpushedBranches = try Process.checkNonZeroExit(
+                args: Git.tool, "-C", path.asString, "log", "--branches", "--not", "--remotes").chomp()
+            guard unpushedBranches.isEmpty else { return true }
+            let upstreamBranches = try Process.checkNonZeroExit(
+                args: Git.tool, "-C", path.asString, "branch", "-r", "--contains", "HEAD").chomp()
+            return upstreamBranches.isEmpty
         }
     }
 

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -356,8 +356,20 @@ class GitRepositoryTests: XCTestCase {
 
             // We should have commits which are not pushed.
             XCTAssert(try checkoutRepo.hasUnpushedCommits())
-            // Push the changes and check again.
+            
+            // Detach the current HEAD
+            try systemQuietly([Git.tool, "-C", checkoutPath.asString, "checkout", "--detach"])
+            
+            // The detached HEAD should still not be pushed.
+            XCTAssert(try checkoutRepo.hasUnpushedCommits())
+            
+            // Restore the branch, push the changes and check again.
+            try checkoutTestRepo.checkout(revision: Revision(identifier: "master"))
             try checkoutTestRepo.push(remote: "origin", branch: "master")
+            XCTAssertFalse(try checkoutRepo.hasUnpushedCommits())
+            
+            // Detach again, the changes should still be pushed.
+            try systemQuietly([Git.tool, "-C", checkoutPath.asString, "checkout", "--detach"])
             XCTAssertFalse(try checkoutRepo.hasUnpushedCommits())
         }
     }

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -405,13 +405,10 @@ class GitRepositoryTests: XCTestCase {
             let pushedCommit = try checkoutTestRepo.getCurrentRevision()
             try checkoutTestRepo.checkout(revision: Revision(identifier: "master"))
             
-            // Remove the upstream, so we can delete the local branch.
+            // Delete the branch so hasUnpushedCommits won't return true because of unpushed branches.
             try systemQuietly([Git.tool, "-C", checkoutPath.asString, "branch", "--force", "-d", "new-branch"])
             
             try checkoutTestRepo.checkout(revision: pushedCommit)
-            
-            // Verify there are no unpushed commits on branches.
-            XCTAssert(try checkoutTestRepo._areAllBranchesPushed())
             
             // The detached HEAD should no longer have unpushed changes.
             XCTAssertFalse(try checkoutTestRepo.hasUnpushedCommits())


### PR DESCRIPTION
> **SR-2815**: GitRepository.hasUnpushedCommits() can not detect commits made when on a detached head
> The current method used to detect unpushed commits doesn't work if the commit was made from a detached head.


Closes [SR-2815](https://bugs.swift.org/browse/SR-2815).