### PR TITLE
"Revert "[Resolver] Turn on parallel cloning by default""

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -22,7 +22,7 @@ public class ToolOptions {
     public var chdir: AbsolutePath?
 
     /// Enable prefetching in resolver which will kick off parallel git cloning.
-    public var shouldEnableResolverPrefetching = true
+    public var shouldEnableResolverPrefetching = false
 
     /// If print version option was passed.
     public var shouldPrintVersion: Bool = false

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -140,12 +140,9 @@ public class SwiftTool<Options: ToolOptions> {
             to: { $0.chdir = $1.path })
 
         binder.bind(
-            option: parser.add(option: "--enable-prefetching", kind: Bool.self, usage: ""),
+            option: parser.add(option: "--enable-prefetching", kind: Bool.self,
+            usage: "Enable prefetching in resolver"),
             to: { $0.shouldEnableResolverPrefetching = $1 })
-
-        binder.bind(
-            option: parser.add(option: "--disable-prefetching", kind: Bool.self, usage: ""),
-            to: { $0.shouldEnableResolverPrefetching = !$1 })
 
         binder.bind(
             option: parser.add(option: "--disable-sandbox", kind: Bool.self,


### PR DESCRIPTION
Reverts apple/swift-package-manager#1211


Unfortunately there is a non-deterministic test failure on linux.

https://ci.swift.org/job/swift-PR-Linux-smoke-test/8102/console
https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-16_10/3821/

```
Test Suite 'Selected tests' started at 2017-05-22 20:54:56.411
Test Suite 'PackageToolTests' started at 2017-05-22 20:54:56.412
Test Case 'PackageToolTests.testUpdate' started at 2017-05-22 20:54:56.414
/home/buildnode/jenkins/workspace/swift-PR-Linux-smoke-test/branch-master/swiftpm/Tests/CommandsTests/PackageToolTests.swift:75: error: PackageToolTests.testUpdate : XCTAssertEqual failed: ("["1.2.3"]") is not equal to ("["1.2.3", "1.2.4"]") - 
Test Case 'PackageToolTests.testUpdate' failed (1.032 seconds)
Test Suite 'PackageToolTests' failed at 2017-05-22 20:54:57.447
	 Executed 1 test, with 1 failure (0 unexpected) in 1.032 (1.032) seconds
Test Suite 'Selected tests' failed at 2017-05-22 20:54:57.447
	 Executed 1 test, with 1 failure (0 unexpected) in 1.032 (1.032) seconds--- bootstrap: error: tests failed with exit status 1

```