### PR TITLE
[PackageGraph] Fix prerelease resolution behaviour

### DIFF
--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -91,7 +91,7 @@ public enum VersionSetSpecifier: Equatable, CustomStringConvertible {
         case .empty:
             return false
         case .range(let range):
-            return range.contains(version)
+            return range.contains(version: version)
         case .any:
             return true
         case .exact(let v):

--- a/Sources/TestSupport/misc.swift
+++ b/Sources/TestSupport/misc.swift
@@ -33,7 +33,6 @@ import class Foundation.Bundle
 /// the name were a relative path.
 public func fixture(
     name: String,
-    tags: [String] = [],
     file: StaticString = #file,
     line: UInt = #line,
     body: (AbsolutePath) throws -> Void
@@ -71,25 +70,13 @@ public func fixture(
             // Invoke the block, passing it the path of the copied fixture.
             try body(dstDir)
         } else {
-            // Not a single package, so we expect it to be a directory of packages.
-            var versions = tags
-            func popVersion() -> String {
-                if versions.isEmpty {
-                    return "1.2.3"
-                } else if versions.count == 1 {
-                    return versions.first!
-                } else {
-                    return versions.removeFirst()
-                }
-            }
-
             // Copy each of the package directories and construct a git repo in it.
             for fileName in try! localFileSystem.getDirectoryContents(fixtureDir).sorted() {
                 let srcDir = fixtureDir.appending(component: fileName)
                 guard isDirectory(srcDir) else { continue }
                 let dstDir = tmpDir.path.appending(component: fileName)
                 try systemQuietly("cp", "-R", "-H", srcDir.asString, dstDir.asString)
-                initGitRepo(dstDir, tag: popVersion(), addFile: false)
+                initGitRepo(dstDir, tag: "1.2.3", addFile: false)
             }
 
             // Invoke the block, passing it the path of the copied fixture.

--- a/Sources/Utility/Version.swift
+++ b/Sources/Utility/Version.swift
@@ -71,6 +71,10 @@ extension Version: Hashable {
 
 extension Version: Comparable {
 
+    func isEqualWithoutPrerelease(_ other: Version) -> Bool {
+        return major == other.major && minor == other.minor && patch == other.patch
+    }
+
     public static func < (lhs: Version, rhs: Version) -> Bool {
         let lhsComparators = [lhs.major, lhs.minor, lhs.patch]
         let rhsComparators = [rhs.major, rhs.minor, rhs.patch]
@@ -196,5 +200,57 @@ extension Version: JSONMappable, JSONSerializable {
 
     public func toJSON() -> JSON {
         return .string(description)
+    }
+}
+
+// MARK:- Range operations
+
+extension ClosedRange where Bound == Version {
+    /// Marked as unavailable because we have custom rules for contains.
+    public func contains(_ element: Version) -> Bool {
+        // Unfortunately, we can't use unavailable here.
+        fatalError("contains(_:) is unavailable, use contains(version:)")
+    }
+}
+
+// Disabled because compiler hits an assertion https://bugs.swift.org/browse/SR-5014
+#if false
+extension CountableRange where Bound == Version {
+    /// Marked as unavailable because we have custom rules for contains.
+    public func contains(_ element: Version) -> Bool {
+        // Unfortunately, we can't use unavailable here.
+        fatalError("contains(_:) is unavailable, use contains(version:)")
+    }
+}
+#endif
+
+extension Range where Bound == Version {
+    /// Marked as unavailable because we have custom rules for contains.
+    public func contains(_ element: Version) -> Bool {
+        // Unfortunately, we can't use unavailable here.
+        fatalError("contains(_:) is unavailable, use contains(version:)")
+    }
+}
+
+extension Range where Bound == Version {
+
+    public func contains(version: Version) -> Bool {
+        // Special cases if version contains prerelease identifiers.
+        if !version.prereleaseIdentifiers.isEmpty {
+            // If the ranage does not contain prerelease identifiers, return false.
+            if lowerBound.prereleaseIdentifiers.isEmpty && upperBound.prereleaseIdentifiers.isEmpty {
+                return false
+            }
+
+            // At this point, one of the bounds contains prerelease identifiers.
+            //
+            // Reject 2.0.0-alpha when upper bound is 2.0.0.
+            if upperBound.prereleaseIdentifiers.isEmpty && upperBound.isEqualWithoutPrerelease(version) {
+                return false
+            }
+        }
+
+        // Otherwise, apply normal contains rules.
+        return version >= lowerBound && version < upperBound
     }
 }

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -42,11 +42,10 @@ class DependencyResolutionTests: XCTestCase {
 
     /// Check resolution of a trivial package with one dependency.
     func testExternalSimple() {
-        // This will tag 'Foo' with 1.0.0, to start.
-        fixture(name: "DependencyResolution/External/Simple", tags: ["1.0.0"]) { prefix in
+        fixture(name: "DependencyResolution/External/Simple") { prefix in
             // Add several other tags to check version selection.
             let repo = GitRepository(path: prefix.appending(components: "Foo"))
-            for tag in ["1.1.0", "1.2.0", "1.2.3"] {
+            for tag in ["1.1.0", "1.2.0"] {
                 try repo.tag(name: tag)
             }
 

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -30,10 +30,10 @@ class MiscellaneousTestCase: XCTestCase {
         // verifies the stdout contains information about
         // the selected version of the package
 
-        fixture(name: "DependencyResolution/External/Simple", tags: ["1.3.5"]) { prefix in
+        fixture(name: "DependencyResolution/External/Simple") { prefix in
             let output = try executeSwiftBuild(prefix.appending(component: "Bar"))
             XCTAssertTrue(output.contains("Resolving"))
-            XCTAssertTrue(output.contains("at 1.3.5"))
+            XCTAssertTrue(output.contains("at 1.2.3"))
         }
     }
 
@@ -146,12 +146,6 @@ class MiscellaneousTestCase: XCTestCase {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
             XCTAssertBuilds(prefix.appending(component: "app"))
             XCTAssertBuilds(prefix.appending(component: "app"))
-            XCTAssertBuilds(prefix.appending(component: "app"))
-        }
-    }
-
-    func testDependenciesWithVPrefixTagsWork() {
-        fixture(name: "DependencyResolution/External/Complex", tags: ["v1.2.3"]) { prefix in
             XCTAssertBuilds(prefix.appending(component: "app"))
         }
     }
@@ -524,7 +518,6 @@ class MiscellaneousTestCase: XCTestCase {
         ("testCanBuildMoreThanTwiceWithExternalDependencies", testCanBuildMoreThanTwiceWithExternalDependencies),
         ("testNoArgumentsExitsWithOne", testNoArgumentsExitsWithOne),
         ("testCompileFailureExitsGracefully", testCompileFailureExitsGracefully),
-        ("testDependenciesWithVPrefixTagsWork", testDependenciesWithVPrefixTagsWork),
         ("testCanBuildIfADependencyAlreadyCheckedOut", testCanBuildIfADependencyAlreadyCheckedOut),
         ("testCanBuildIfADependencyClonedButThenAborted", testCanBuildIfADependencyClonedButThenAborted),
         ("testTipHasNoPackageSwift", testTipHasNoPackageSwift),

--- a/Tests/FunctionalTests/ValidLayoutTests.swift
+++ b/Tests/FunctionalTests/ValidLayoutTests.swift
@@ -64,29 +64,6 @@ class ValidLayoutsTests: XCTestCase {
         }
     }
 
-    func testPackageIdentifiers() {
-        #if os(macOS)
-            // this because sort orders vary on Linux on Mac currently
-            let tags = ["1.3.4-alpha.beta.gamma1", "1.2.3+24", "1.2.3", "1.2.3-beta5"]
-        #else
-            let tags = ["1.2.3", "1.2.3-beta5", "1.3.4-alpha.beta.gamma1", "1.2.3+24"]
-        #endif
-        
-        fixture(name: "DependencyResolution/External/Complex", tags: tags) { prefix in
-            let packageRoot = prefix.appending(component: "app")
-            XCTAssertBuilds(packageRoot, configurations: [.Debug])
-
-            var path = try SwiftPMProduct.packagePath(for: "deck-of-playing-cards", packageRoot: packageRoot)
-            XCTAssertEqual(GitRepository(path: path).tags, ["1.2.3-beta5"])
-
-            path = try SwiftPMProduct.packagePath(for: "FisherYates", packageRoot: packageRoot)
-            XCTAssertEqual(GitRepository(path: path).tags, ["1.3.4-alpha.beta.gamma1"])
-
-            path = try SwiftPMProduct.packagePath(for: "PlayingCard", packageRoot: packageRoot)
-            XCTAssertEqual(GitRepository(path: path).tags, ["1.2.3+24"])
-        }
-    }
-
     func testMadeValidWithExclude() {
         fixture(name: "ValidLayouts/MadeValidWithExclude/Case1") { prefix in
             XCTAssertBuilds(prefix)
@@ -111,7 +88,6 @@ class ValidLayoutsTests: XCTestCase {
         ("testSingleModuleSubfolderWithSwiftSuffix", testSingleModuleSubfolderWithSwiftSuffix),
         ("testMultipleModulesLibraries", testMultipleModulesLibraries),
         ("testMultipleModulesExecutables", testMultipleModulesExecutables),
-        ("testPackageIdentifiers", testPackageIdentifiers),
         ("testMadeValidWithExclude", testMadeValidWithExclude),
         ("testExtraCommandLineFlags", testExtraCommandLineFlags),
     ]

--- a/Tests/PackageGraphTests/DependencyResolverTests.swift
+++ b/Tests/PackageGraphTests/DependencyResolverTests.swift
@@ -691,6 +691,41 @@ class DependencyResolverTests: XCTestCase {
         }
     }
 
+    func testPrereleaseResolve() throws {
+        let provider = MockPackagesProvider(containers: [
+            MockPackageContainer(name: "A", dependencies: [
+                "1.0.0": [],
+                "1.0.1": [],
+                "1.0.1-alpha": [],
+                "1.0.5-alpha": [],
+                "1.0.6-beta": [],
+                "1.1.0-alpha": [],
+                "1.1.6-beta": [],
+                "2.0.0-alpha": [],
+                "2.0.0-beta": [],
+                "2.0.0": [],
+            ]),
+        ])
+
+        func check(range: Range<Version> , result version: Version, file: StaticString = #file, line: UInt = #line) {
+            let resolver = MockDependencyResolver(provider, MockResolverDelegate())
+            let result = try! resolver.resolve(constraints: [
+                MockPackageConstraint(container: "A", versionRequirement: .range(range)),
+            ])
+            XCTAssertEqual(result, ["A": .version(version)])
+        }
+
+        check(range: "1.0.0"..<"2.0.0", result: "1.0.1")
+        check(range: "1.0.0"..<"1.1.0", result: "1.0.1")
+
+        check(range: "1.0.0-alpha"..<"2.0.0", result: "1.1.6-beta")
+        check(range: "1.0.0-alpha"..<"2.0.0-alpha", result: "1.1.6-beta")
+        check(range: "1.0.0"..<"2.0.0-beta", result: "2.0.0-alpha")
+        check(range: "1.0.0-alpha"..<"1.1.0", result: "1.0.6-beta")
+        check(range: "1.0.0-alpha"..<"1.1.0-beta", result: "1.1.0-alpha")
+        check(range: "1.0.0"..<"1.1.0-beta", result: "1.1.0-alpha")
+    }
+
     static var allTests = [
         ("testBasics", testBasics),
         ("testVersionSetSpecifier", testVersionSetSpecifier),
@@ -705,6 +740,7 @@ class DependencyResolverTests: XCTestCase {
         ("testUnversionedConstraint", testUnversionedConstraint),
         ("testIncompleteMode", testIncompleteMode),
         ("testDiagnostics", testDiagnostics),
+        ("testPrereleaseResolve", testPrereleaseResolve),
     ]
 }
 

--- a/Tests/UtilityTests/VersionTests.swift
+++ b/Tests/UtilityTests/VersionTests.swift
@@ -210,6 +210,82 @@ class VersionTests: XCTestCase {
         }
     }
 
+    func testContains() {
+        do {
+            let range: Range<Version> = "1.0.0"..<"2.0.0"
+
+            XCTAssertTrue(range.contains(version: "1.0.0"))
+            XCTAssertTrue(range.contains(version: "1.5.0"))
+            XCTAssertTrue(range.contains(version: "1.9.99999"))
+            XCTAssertTrue(range.contains(version: "1.9.99999+1232"))
+
+            XCTAssertFalse(range.contains(version: "1.0.0-alpha"))
+            XCTAssertFalse(range.contains(version: "1.5.0-alpha"))
+            XCTAssertFalse(range.contains(version: "2.0.0-alpha"))
+            XCTAssertFalse(range.contains(version: "2.0.0"))
+        }
+
+        do {
+            let range: Range<Version> = "1.0.0"..<"2.0.0-beta"
+
+            XCTAssertTrue(range.contains(version: "1.0.0"))
+            XCTAssertTrue(range.contains(version: "1.5.0"))
+            XCTAssertTrue(range.contains(version: "1.9.99999"))
+            XCTAssertTrue(range.contains(version: "1.0.1-alpha"))
+            XCTAssertTrue(range.contains(version: "2.0.0-alpha"))
+
+            XCTAssertFalse(range.contains(version: "1.0.0-alpha"))
+            XCTAssertFalse(range.contains(version: "2.0.0"))
+            XCTAssertFalse(range.contains(version: "2.0.0-beta"))
+            XCTAssertFalse(range.contains(version: "2.0.0-clpha"))
+        }
+
+        do {
+            let range: Range<Version> = "1.0.0-alpha"..<"2.0.0"
+            XCTAssertTrue(range.contains(version: "1.0.0"))
+            XCTAssertTrue(range.contains(version: "1.5.0"))
+            XCTAssertTrue(range.contains(version: "1.9.99999"))
+            XCTAssertTrue(range.contains(version: "1.0.0-alpha"))
+            XCTAssertTrue(range.contains(version: "1.0.0-beta"))
+            XCTAssertTrue(range.contains(version: "1.0.1-alpha"))
+
+            XCTAssertFalse(range.contains(version: "2.0.0-alpha"))
+            XCTAssertFalse(range.contains(version: "2.0.0-beta"))
+            XCTAssertFalse(range.contains(version: "2.0.0-clpha"))
+            XCTAssertFalse(range.contains(version: "2.0.0"))
+        }
+
+        do {
+            let range: Range<Version> = "1.0.0"..<"1.1.0"
+            XCTAssertTrue(range.contains(version: "1.0.0"))
+            XCTAssertTrue(range.contains(version: "1.0.9"))
+
+            XCTAssertFalse(range.contains(version: "1.1.0"))
+            XCTAssertFalse(range.contains(version: "1.2.0"))
+            XCTAssertFalse(range.contains(version: "1.5.0"))
+            XCTAssertFalse(range.contains(version: "2.0.0"))
+            XCTAssertFalse(range.contains(version: "1.0.0-beta"))
+            XCTAssertFalse(range.contains(version: "1.0.10-clpha"))
+            XCTAssertFalse(range.contains(version: "1.1.0-alpha"))
+        }
+
+        do {
+            let range: Range<Version> = "1.0.0"..<"1.1.0-alpha"
+            XCTAssertTrue(range.contains(version: "1.0.0"))
+            XCTAssertTrue(range.contains(version: "1.0.9"))
+            XCTAssertTrue(range.contains(version: "1.0.1-beta"))
+            XCTAssertTrue(range.contains(version: "1.0.10-clpha"))
+
+            XCTAssertFalse(range.contains(version: "1.1.0"))
+            XCTAssertFalse(range.contains(version: "1.2.0"))
+            XCTAssertFalse(range.contains(version: "1.5.0"))
+            XCTAssertFalse(range.contains(version: "2.0.0"))
+            XCTAssertFalse(range.contains(version: "1.0.0-alpha"))
+            XCTAssertFalse(range.contains(version: "1.1.0-alpha"))
+            XCTAssertFalse(range.contains(version: "1.1.0-beta"))
+        }
+    }
+
     static var allTests = [
         ("testEquality", testEquality),
         ("testHashable", testHashable),
@@ -218,5 +294,6 @@ class VersionTests: XCTestCase {
         ("testFromString", testFromString),
         ("testOrder", testOrder),
         ("testRange", testRange),
+        ("testContains", testContains),
     ]
 }


### PR DESCRIPTION
-- <rdar://problem/31214600> Allow picking prerelease tags only when there is a prerelease in the version range
-- https://bugs.swift.org/browse/SR-1039