### PR TITLE
Fix SR-5031

### DIFF
--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -36,7 +36,6 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         public var description: String {
             switch self {
             case .malformed(let versionSpecifier, let file):
-                let file = file.appending(component: ToolsVersion.toolsVersionFileName)
                 return "The version specifier '\(versionSpecifier)' in '\(file.asString)' is not valid"
             }
         }
@@ -44,7 +43,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
 
     public func load(at path: AbsolutePath, fileSystem: FileSystem) throws -> ToolsVersion {
         // The file which contains the tools version.
-        let file = path.appending(component: ToolsVersion.toolsVersionFileName)
+        let file = Manifest.path(atPackagePath: path, fileSystem: fileSystem)
         guard fileSystem.isFile(file) else {
             return ToolsVersion.defaultToolsVersion
         }
@@ -61,7 +60,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
             let misspellings = ["swift-tool", "tool-version"]
             if let firstLine = ByteString(splitted[0]).asString,
                misspellings.first(where: firstLine.lowercased().contains) != nil {
-                throw Error.malformed(specifier: firstLine, file: path)
+                throw Error.malformed(specifier: firstLine, file: file)
             }
             // Otherwise assume the default.
             return ToolsVersion.defaultToolsVersion
@@ -69,7 +68,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
 
         // Ensure we can construct the version from the specifier.
         guard let version = ToolsVersion(string: versionSpecifier) else {
-            throw Error.malformed(specifier: versionSpecifier, file: path)
+            throw Error.malformed(specifier: versionSpecifier, file: file)
         }
         return version
     }

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -11,6 +11,7 @@
 import Basic
 import PackageDescription
 import PackageDescription4
+import Utility
 
 /// The supported manifest versions.
 public enum ManifestVersion: Int {
@@ -26,6 +27,23 @@ public final class Manifest: ObjectIdentifierProtocol, CustomStringConvertible {
 
     /// The standard filename for the manifest.
     public static var filename = basename + ".swift"
+
+    /// Returns the manifest at the given package path.
+    ///
+    /// Version specific manifest is chosen if present, otherwise path to regular
+    /// manfiest is returned.
+    public static func path(
+        atPackagePath packagePath: AbsolutePath,
+        fileSystem: FileSystem
+    ) -> AbsolutePath {
+        for versionSpecificKey in Versioning.currentVersionSpecificKeys {
+            let versionSpecificPath = packagePath.appending(component: Manifest.basename + versionSpecificKey + ".swift")
+            if fileSystem.isFile(versionSpecificPath) {
+                return versionSpecificPath
+            }
+        }
+        return packagePath.appending(component: filename)
+    }
 
     /// The standard basename for the manifest.
     public static var basename = "Package"

--- a/Sources/PackageModel/ToolsVersion.swift
+++ b/Sources/PackageModel/ToolsVersion.swift
@@ -16,9 +16,6 @@ import Utility
 /// Tools version represents version of the Swift toolchain.
 public struct ToolsVersion: CustomStringConvertible, Comparable {
 
-    /// The name of the file which contains tools version.
-    public static let toolsVersionFileName = Manifest.filename
-
     /// The default tool version if a the tools version file is absent.
     public static let defaultToolsVersion = ToolsVersion(version: "3.1.0")
 

--- a/Sources/Workspace/ToolsVersionWriter.swift
+++ b/Sources/Workspace/ToolsVersionWriter.swift
@@ -19,7 +19,7 @@ import Utility
 ///   - path: The path of the package.
 ///   - version: The version to write.
 public func writeToolsVersion(at path: AbsolutePath, version: ToolsVersion, fs: inout FileSystem) throws {
-    let file = path.appending(component: ToolsVersion.toolsVersionFileName)
+    let file = path.appending(component: Manifest.filename)
     assert(fs.isFile(file), "Tools version file not present")
 
     // Get the current contents of the file.


### PR DESCRIPTION
- Add `Manifest.versionSpecificManifest(path:fileSystem:)`
- Use `Manifest.versionSpecificManifest(path:fileSystem:)` instead of manipulating path with `Manifest.filename`
- Remove `ToolsVersion.toolsVersionFileName`