### PR TITLE
[Commands] Resolve symlinks of allowed dir

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -372,7 +372,7 @@ public class SwiftTool<Options: ToolOptions> {
         // against arbitrary code execution. We only allow the permissions which
         // are absolutely necessary for performing a build.
         if !options.shouldDisableSandbox {
-            let allowedDirectories = [buildPath, resolveSymlinks(BuildParameters.swiftpmTestCache)]
+            let allowedDirectories = [buildPath, BuildParameters.swiftpmTestCache].map(resolveSymlinks)
             args += ["sandbox-exec", "-p", sandboxProfile(allowedDirectories: allowedDirectories)]
         }
       #endif


### PR DESCRIPTION
We need to resolve symlinks of allowed dir in sandbox otherwise we don't
get write access to them.

-- <rdar://problem/32761929> [SR-5155]: Cannot use symlinked .build folder
-- https://bugs.swift.org/browse/SR-5155