### PR TITLE
[Basic] Conform diagnostic data to CustomStringConvertible

### DIFF
--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -160,8 +160,15 @@ extension ManagedDependency.State: JSONMappable, JSONSerializable {
 /// Represents a collection of managed dependency which are persisted on disk.
 public final class ManagedDependencies: SimplePersistanceProtocol {
 
-    enum Error: Swift.Error {
+    enum Error: Swift.Error, CustomStringConvertible {
         case dependencyNotFound(name: String)
+
+        var description: String {
+            switch self {
+            case .dependencyNotFound(let name):
+                return "Could not find dependency '\(name)'"
+            }
+        }
     }
 
     /// The current state of managed dependencies.


### PR DESCRIPTION
DiagnosticData already contain information to conform it to
CustomStringConvertible. This is useful when a DiagnosticData is being
used as an Swift.Error.

-- <rdar://problem/32742631> Improve error text when a dependency is not in edit mode