### PR TITLE
Improve diagnostic messages

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -24,7 +24,7 @@ struct FetchDeprecatedDiagnostic: DiagnosticData {
         name: "org.swift.diags.fetch-deprecated",
         defaultBehavior: .warning,
         description: {
-            $0 <<< "'fetch' command is deprecated, use 'resolve' command instead."
+            $0 <<< "'fetch' command is deprecated; use 'resolve' instead"
         }
     )
 }

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -24,7 +24,7 @@ struct SpecifierDeprecatedDiagnostic: DiagnosticData {
         name: "org.swift.diags.specifier-deprecated",
         defaultBehavior: .warning,
         description: {
-            $0 <<< "'--specifier' option is deprecated, use '--filter' instead."
+            $0 <<< "'--specifier' option is deprecated; use '--filter' instead"
         }
     )
 }
@@ -36,7 +36,7 @@ struct NoMatchingTestsWarning: DiagnosticData {
         name: "org.swift.diags.no-matching-tests",
         defaultBehavior: .note,
         description: {
-            $0 <<< "the filter predicate did not match any test case"
+            $0 <<< "'--filter' predicate did not match any test case"
         }
     )
 }

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -25,7 +25,7 @@ struct ChdirDeprecatedDiagnostic: DiagnosticData {
         name: "org.swift.diags.chdir-deprecated",
         defaultBehavior: .warning,
         description: {
-            $0 <<< "the '--chdir/-C' option is deprecated; use '--package-path' instead"
+            $0 <<< "'--chdir/-C' option is deprecated; use '--package-path' instead"
         }
     )
 }

--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -20,8 +20,9 @@ public enum PackageBuilderDiagnostics {
             name: "org.swift.diags.pkg-builder.nosources",
             defaultBehavior: .warning,
             description: {
-                $0 <<< "The target" <<< { $0.target } <<< "in package" <<< { $0.package }
-                $0 <<< "does not contain any valid source files."
+                $0 <<< "target" <<< { "'\($0.target)'" }
+                $0 <<< "in package" <<< { "'\($0.package)'" }
+                $0 <<< "contains no valid source files"
             }
         )
     
@@ -39,8 +40,9 @@ public enum PackageBuilderDiagnostics {
             name: "org.swift.diags.pkg-builder.nosources",
             defaultBehavior: .warning,
             description: {
-                $0 <<< "Ignoring target" <<< { $0.target } <<< "in package" <<< { $0.package }
-                $0 <<< "as C language in tests is not supported yet." 
+                $0 <<< "ignoring target" <<< { "'\($0.target)'" }
+                $0 <<< "in package" <<< { "'\($0.package)';" }
+                $0 <<< "C language in tests is not yet supported"
             }
         )
 

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -57,7 +57,7 @@ public enum ResolverDiagnostics {
             type: Unsatisfiable.self,
             name: "org.swift.diags.resolver.unsatisfiable",
             description: {
-                $0 <<< "The dependency graph is unresolvable."
+                $0 <<< "dependency graph is unresolvable;"
                 $0 <<< .substitution({
                     let `self` = $0 as! Unsatisfiable
 
@@ -65,7 +65,7 @@ public enum ResolverDiagnostics {
                     if self.dependencies.isEmpty && self.pins.isEmpty {
                         return ""
                     }
-                    var diag = "Found these conflicting requirements:"
+                    var diag = "found these conflicting requirements:"
                     let indent = "    "
 
                     if !self.dependencies.isEmpty {
@@ -124,9 +124,7 @@ public enum WorkspaceDiagnostics {
             type: UncommitedChanges.self,
             name: "org.swift.diags.workspace.uncommited-changes",
             description: {
-                $0 <<< "The repository"
-                $0 <<< { "'\($0.repositoryPath.asString)'" }
-                $0 <<< "has uncommited changes"
+                $0 <<< "repository" <<< { "'\($0.repositoryPath.asString)'" } <<< "has uncommited changes"
             })
     
         /// The local path to the repository.
@@ -140,9 +138,7 @@ public enum WorkspaceDiagnostics {
             type: UnpushedChanges.self,
             name: "org.swift.diags.workspace.unpushed-changes",
             description: {
-                $0 <<< "The repository"
-                $0 <<< { "'\($0.repositoryPath.asString)'" }
-                $0 <<< "has unpushed changes"
+                $0 <<< "repository" <<< { "'\($0.repositoryPath.asString)'" } <<< "has unpushed changes"
             })
         
         /// The local path to the repository.
@@ -156,13 +152,11 @@ public enum WorkspaceDiagnostics {
             type: DependencyAlreadyInEditMode.self,
             name: "org.swift.diags.workspace.dependency-already-in-edit-mode",
             description: {
-                $0 <<< "The dependency"
-                $0 <<< { "'\($0.dependencyURL)'" }
-                $0 <<< "is already in edit mode"
+                $0 <<< "dependency" <<< { "'\($0.dependencyName)'" } <<< "already in edit mode"
             })
         
-        /// The URL of the dependency being edited.
-        public let dependencyURL: String
+        /// The name of the dependency being edited.
+        public let dependencyName: String
     }
     
     /// The diagnostic triggered when the unedit operation fails because the dependency
@@ -172,13 +166,11 @@ public enum WorkspaceDiagnostics {
             type: DependencyNotInEditMode.self,
             name: "org.swift.diags.workspace.dependency-not-in-edit-mode",
             description: {
-                $0 <<< "The dependency"
-                $0 <<< { "'\($0.dependencyURL)'" }
-                $0 <<< "is not in edit mode"
+                $0 <<< "dependency" <<< { "'\($0.dependencyName)'" } <<< "not in edit mode"
             })
         
-        /// The URL of the dependency being unedited.
-        public let dependencyURL: String
+        /// The name of the dependency being unedited.
+        public let dependencyName: String
     }
     
     /// The diagnostic triggered when the edit operation fails because the branch
@@ -188,14 +180,8 @@ public enum WorkspaceDiagnostics {
             type: BranchAlreadyExists.self,
             name: "org.swift.diags.workspace.branch-already-exists",
             description: {
-                $0 <<< "The branch"
-                $0 <<< { $0.branch }
-                $0 <<< "already exists on dependency"
-                $0 <<< { "'\($0.dependencyURL)'" }
+                $0 <<< "branch" <<< { $0.branch } <<< "already exists"
             })
-        
-        /// The URL of the dependency being edited.
-        public let dependencyURL: String
         
         /// The branch to create.
         public let branch: String
@@ -208,14 +194,8 @@ public enum WorkspaceDiagnostics {
             type: RevisionDoesNotExist.self,
             name: "org.swift.diags.workspace.revision-does-not-exist",
             description: {
-                $0 <<< "The revision"
-                $0 <<< { $0.revision }
-                $0 <<< "does not exist on dependency"
-                $0 <<< { "'\($0.dependencyURL)'" }
+                $0 <<< "revision" <<< { $0.revision } <<< "does not exist"
             })
-        
-        /// The URL of the dependency being edited.
-        public let dependencyURL: String
         
         /// The revision requested.
         public let revision: String
@@ -227,12 +207,9 @@ public enum WorkspaceDiagnostics {
             type: IncompatibleToolsVersion.self,
             name: "org.swift.diags.workspace.incompatible-tools-version",
             description: {
-                $0 <<< "The package at"
-                $0 <<< { "'\($0.rootPackagePath.asString)'" }
-                $0 <<< "requires a minimum Swift tools version of"
-                $0 <<< { $0.requiredToolsVersion.description }
-                $0 <<< "but currently at"
-                $0 <<< { $0.currentToolsVersion.description }
+                $0 <<< "package at" <<< { "'\($0.rootPackagePath.asString)'" }
+                $0 <<< "requires a minimum Swift tools version of" <<< { $0.requiredToolsVersion.description }
+                $0 <<< "but currently at" <<< { $0.currentToolsVersion.description }
             })
         
         /// The path of the package.
@@ -252,12 +229,9 @@ public enum WorkspaceDiagnostics {
             type: MismatchingDestinationPackage.self,
             name: "org.swift.diags.workspace.mismatching-destination-package",
             description: {
-                $0 <<< "The package at"
-                $0 <<< { "'\($0.editPath.asString)'" }
-                $0 <<< "is"
-                $0 <<< { $0.destinationPackage ?? "<unknown>" }
-                $0 <<< "but was expecting"
-                $0 <<< { $0.expectedPackage }
+                $0 <<< "package at" <<< { "'\($0.editPath.asString)'" }
+                $0 <<< "is" <<< { $0.destinationPackage ?? "<unknown>" }
+                $0 <<< "but was expecting" <<< { $0.expectedPackage }
             })
         
         /// The path to be edited to.
@@ -280,9 +254,8 @@ public enum WorkspaceDiagnostics {
             name: "org.swift.diags.workspace.checked-out-dependency-missing",
             defaultBehavior: .warning,
             description: {
-                $0 <<< "The dependency"
-                $0 <<< { "'\($0.packageName)'" }
-                $0 <<< "is missing and has been cloned again."
+                $0 <<< "dependency" <<< { "'\($0.packageName)'" } <<< "is missing;"
+                $0 <<< "cloning again"
             })
 
         /// The package name of the dependency.
@@ -297,9 +270,8 @@ public enum WorkspaceDiagnostics {
             name: "org.swift.diags.workspace.edited-dependency-missing",
             defaultBehavior: .warning,
             description: {
-                $0 <<< "The dependency"
-                $0 <<< { "'\($0.packageName)'" }
-                $0 <<< "was being edited but is missing. Falling back to original checkout."
+                $0 <<< "dependency" <<< { "'\($0.packageName)'" } <<< "was being edited but is missing;"
+                $0 <<< "falling back to original checkout"
             })
         
         /// The package name of the dependency.
@@ -314,13 +286,10 @@ public enum WorkspaceDiagnostics {
             name: "org.swift.diags.workspace.edit-revision-not-used",
             defaultBehavior: .warning,
             description: {
-                $0 <<< "The dependency"
-                $0 <<< { "'\($0.packageName)'" }
-                $0 <<< "already exists at the edit destination. Not using revision"
-                $0 <<< { "'\($0.revisionIdentifier)'" }
-                $0 <<< "."
+                $0 <<< "dependency" <<< { "'\($0.packageName)'" } <<< "already exists at the edit destination;"
+                $0 <<< "not using revision" <<< { "'\($0.revisionIdentifier)'" }
             })
-        
+
         /// The package name of the dependency.
         public let packageName: String
 
@@ -336,13 +305,10 @@ public enum WorkspaceDiagnostics {
             name: "org.swift.diags.workspace.edit-branch-not-used",
             defaultBehavior: .warning,
             description: {
-                $0 <<< "The dependency"
-                $0 <<< { "'\($0.packageName)'" }
-                $0 <<< "already exists at the edit destination. Not checking-out branch"
-                $0 <<< { "'\($0.branchName)'" }
-                $0 <<< "."
+                $0 <<< "dependency" <<< { "'\($0.packageName)'" } <<< "already exists at the edit destination;"
+                $0 <<< "not checking-out branch" <<< { "'\($0.branchName)'" }
             })
-        
+
         /// The package name of the dependency.
         public let packageName: String
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -372,7 +372,7 @@ extension Workspace {
             return
         }
         guard case .checkout(let currentState) = dependency.state else {
-            let error = WorkspaceDiagnostics.DependencyAlreadyInEditMode(dependencyURL: dependency.repository.url)
+            let error = WorkspaceDiagnostics.DependencyAlreadyInEditMode(dependencyName: packageName)
             return diagnostics.emit(error)
         }
 
@@ -590,7 +590,7 @@ extension Workspace {
         let dependency = try managedDependencies.dependency(forName: packageName)
 
         guard case .checkout(let checkoutState) = dependency.state else {
-            throw WorkspaceDiagnostics.DependencyAlreadyInEditMode(dependencyURL: dependency.repository.url)
+            throw WorkspaceDiagnostics.DependencyAlreadyInEditMode(dependencyName: packageName)
         }
 
         // If a path is provided then we use it as destination. If not, we
@@ -633,14 +633,10 @@ extension Workspace {
 
             // Do preliminary checks on branch and revision, if provided.
             if let branch = checkoutBranch, repo.exists(revision: Revision(identifier: branch)) {
-                throw WorkspaceDiagnostics.BranchAlreadyExists(
-                    dependencyURL: dependency.repository.url,
-                    branch: branch)
+                throw WorkspaceDiagnostics.BranchAlreadyExists(branch: branch)
             }
             if let revision = revision, !repo.exists(revision: revision) {
-                throw WorkspaceDiagnostics.RevisionDoesNotExist(
-                    dependencyURL: dependency.repository.url,
-                    revision: revision.identifier)
+                throw WorkspaceDiagnostics.RevisionDoesNotExist(revision: revision.identifier)
             }
 
             try handle.cloneCheckout(to: destination, editable: true)
@@ -683,7 +679,7 @@ extension Workspace {
         switch dependency.state {
         // If the dependency isn't in edit mode, we can't unedit it.
         case .checkout:
-            throw WorkspaceDiagnostics.DependencyNotInEditMode(dependencyURL: dependency.repository.url)
+            throw WorkspaceDiagnostics.DependencyNotInEditMode(dependencyName: dependency.name)
 
         case .edited(let path):
             if path != nil {

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -207,7 +207,7 @@ final class PackageToolTests: XCTestCase {
             try localFileSystem.writeFileContents(editsPath.appending(components: "Sources", "bar.swift"), bytes: "public let theValue = 88888\n")
             let buildOutput = try build()
 
-            XCTAssert(buildOutput.contains("The dependency 'baz' was being edited but is missing. Falling back to original checkout."))
+            XCTAssert(buildOutput.contains("dependency 'baz' was being edited but is missing; falling back to original checkout"))
             // We should be able to see that modification now.
             XCTAssertEqual(try Process.checkNonZeroExit(arguments: exec), "88888\n")
             // The branch of edited package should be the one we provided when putting it in edit mode.
@@ -421,7 +421,7 @@ final class PackageToolTests: XCTestCase {
                     try execute("resolve", "bar", printError: false)
                     XCTFail("This should have been an error")
                 } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                    XCTAssert(stderr.contains("bar' is already in edit mode"), stderr)
+                    XCTAssertEqual(stderr, "error: dependency 'bar' already in edit mode\n")
                 }
                 try execute("unedit", "bar")
             }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -41,7 +41,7 @@ class MiscellaneousTestCase: XCTestCase {
         // Tests that a package with no source files doesn't error.
         fixture(name: "Miscellaneous/Empty") { prefix in
             let output = try executeSwiftBuild(prefix, configuration: .Debug)
-            let expected = "warning: The target Empty in package Empty does not contain any valid source files."
+            let expected = "warning: target 'Empty' in package 'Empty' contains no valid source files"
             XCTAssert(output.contains(expected), "unexpected output: \(output)")
         }
     }
@@ -50,7 +50,7 @@ class MiscellaneousTestCase: XCTestCase {
         // Tests a package with no source files but a dependency.
         fixture(name: "Miscellaneous/ExactDependencies") { prefix in
             let output = try executeSwiftBuild(prefix.appending(component: "EmptyWithDependency"))
-            let expected = "warning: The target EmptyWithDependency in package EmptyWithDependency does not contain any valid source files."
+            let expected = "warning: target 'EmptyWithDependency' in package 'EmptyWithDependency' contains no valid source files"
             XCTAssert(output.contains(expected), "unexpected output: \(output)")
             // We should only build the modules that are needed to be built. If
             // we have a dependency package but no way to reach some module in

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -417,7 +417,7 @@ class PackageBuilderTests: XCTestCase {
 
     func testNoSources() throws {
         PackageBuilderTester("NoSources", in: InMemoryFileSystem()) { result in
-            result.checkDiagnostic("The target NoSources in package NoSources does not contain any valid source files.")
+            result.checkDiagnostic("target 'NoSources' in package 'NoSources' contains no valid source files")
         }
     }
 
@@ -466,7 +466,7 @@ class PackageBuilderTests: XCTestCase {
             }
 
           #if os(Linux)
-            result.checkDiagnostic("Ignoring target MyPackageTests in package MyPackage as C language in tests is not supported yet.")
+            result.checkDiagnostic("ignoring target 'MyPackageTests' in package 'MyPackage'; C language in tests is not yet supported")
           #endif
         }
     }
@@ -683,7 +683,7 @@ class PackageBuilderTests: XCTestCase {
             "/Sources/pkg2/readme.txt")
         package = PackageDescription.Package(name: "pkg", targets: [.init(name: "pkg1", dependencies: ["pkg2"])])
         PackageBuilderTester(package, in: fs) { result in
-            result.checkDiagnostic("The target pkg2 in package pkg does not contain any valid source files.")
+            result.checkDiagnostic("target 'pkg2' in package 'pkg' contains no valid source files")
             result.checkModule("pkg1") { moduleResult in
                 moduleResult.check(c99name: "pkg1", type: .library)
                 moduleResult.checkSources(root: "/Sources/pkg1", paths: "Foo.swift")
@@ -918,14 +918,14 @@ class PackageBuilderTests: XCTestCase {
         var fs = InMemoryFileSystem()
         try fs.createDirectory(AbsolutePath("/Sources/Module"), recursive: true)
         PackageBuilderTester("MyPackage", in: fs) { result in
-            result.checkDiagnostic("The target Module in package MyPackage does not contain any valid source files.")
+            result.checkDiagnostic("target 'Module' in package 'MyPackage' contains no valid source files")
         }
 
         fs = InMemoryFileSystem(emptyFiles:
             "/Sources/Module/foo.swift")
         try fs.createDirectory(AbsolutePath("/Tests/ModuleTests"), recursive: true)
         PackageBuilderTester("MyPackage", in: fs) { result in
-            result.checkDiagnostic("The target ModuleTests in package MyPackage does not contain any valid source files.")
+            result.checkDiagnostic("target 'ModuleTests' in package 'MyPackage' contains no valid source files")
             result.checkModule("Module")
         }
     }

--- a/Tests/PackageLoadingTests/PackageBuilderV4Tests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderV4Tests.swift
@@ -538,7 +538,7 @@ class PackageBuilderV4Tests: XCTestCase {
                     .target(name: "pkg2"),
             ])
             PackageBuilderTester(package, in: fs) { result in
-                result.checkDiagnostic("The target pkg2 in package pkg does not contain any valid source files.")
+                result.checkDiagnostic("target 'pkg2' in package 'pkg' contains no valid source files")
                 result.checkModule("pkg1") { moduleResult in
                     moduleResult.check(c99name: "pkg1", type: .library)
                     moduleResult.checkSources(root: "/Sources/pkg1", paths: "Foo.swift")

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -1472,7 +1472,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertFalse(diagnostics.hasErrors)
             XCTAssertTrue(diagnostics.diagnostics.contains(where: {
                 $0.behavior == .warning &&
-                $0.localizedDescription == "The dependency 'A' was being edited but is missing. Falling back to original checkout."
+                $0.localizedDescription == "dependency 'A' was being edited but is missing; falling back to original checkout"
             }))
         }
     }
@@ -1616,7 +1616,7 @@ final class WorkspaceTests: XCTestCase {
             let diagnostics = DiagnosticsEngine()
             workspace.loadPackageGraph(rootPackages: roots, diagnostics: diagnostics)
             let errorDesc = diagnostics.diagnostics[0].localizedDescription
-            XCTAssertEqual(errorDesc, "The package at '/root1' requires a minimum Swift tools version of 4.0.0 but currently at 3.1.0")
+            XCTAssertEqual(errorDesc, "package at '/root1' requires a minimum Swift tools version of 4.0.0 but currently at 3.1.0")
         }
     }
 
@@ -1802,7 +1802,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertFalse(diagnostics.hasErrors)
             XCTAssertTrue(diagnostics.diagnostics.contains(where: {
                 $0.behavior == .warning &&
-                $0.localizedDescription == "The dependency 'Foo' is missing and has been cloned again."
+                $0.localizedDescription == "dependency 'Foo' is missing; cloning again"
             }))
             XCTAssertTrue(isDirectory(workspace.checkoutsPath))
         }
@@ -1994,7 +1994,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Check that we produce error.
         DiagnosticsEngineTester(diagnostics) { result in
-            result.check(diagnostic: .contains("graph is unresolvable."), behavior: .error)
+            result.check(diagnostic: .contains("dependency graph is unresolvable;"), behavior: .error)
         }
 
         // There should be no extra fetches.


### PR DESCRIPTION
This is a first pass on the text of diagnostics to make them follow the style convention: https://github.com/apple/swift/blob/master/docs/Diagnostics.md

Some errors are still defined using the `FixableError` protocol. That's my next step.