### PR TITLE
[Build] Link static swift stdlib by default on macOS

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -66,18 +66,23 @@ public struct BuildParameters {
     /// The tools version to use.
     public let toolsVersion: ToolsVersion
 
+    /// If should link the Swift stdlib statically.
+    public let shouldLinkStaticSwiftStdlib: Bool
+
     public init(
         dataPath: AbsolutePath,
         configuration: Configuration,
         toolchain: Toolchain,
         flags: BuildFlags,
-        toolsVersion: ToolsVersion = ToolsVersion.currentToolsVersion
+        toolsVersion: ToolsVersion = ToolsVersion.currentToolsVersion,
+        shouldLinkStaticSwiftStdlib: Bool = false
     ) {
         self.dataPath = dataPath
         self.configuration = configuration
         self.toolchain = toolchain
         self.flags = flags
         self.toolsVersion = toolsVersion
+        self.shouldLinkStaticSwiftStdlib = shouldLinkStaticSwiftStdlib
     }
 }
 
@@ -390,6 +395,13 @@ public final class ProductBuildDescription {
         case .library(.dynamic):
             args += ["-emit-library"]
         case .executable:
+            // Link the Swift stdlib statically if requested.
+            if buildParameters.shouldLinkStaticSwiftStdlib {
+                // FIXME: This does not work for linux yet (SR-648).
+              #if os(macOS)
+                args += ["-static-stdlib"]
+              #endif
+            }
             args += ["-emit-executable"]
         }
         args += objects.map({ $0.asString })

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -43,5 +43,8 @@ public class ToolOptions {
     /// Path to the compilation destination describing JSON file.
     public var customCompileDestination: AbsolutePath?
 
+    /// If should link the Swift stdlib statically.
+    public var shouldLinkStaticSwiftStdlib = false
+
     public required init() {}
 }

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -205,6 +205,16 @@ public class SwiftTool<Options: ToolOptions> {
                 usage: "Increase verbosity of informational output"),
             to: { $0.verbosity = $1 ? 1 : 0 })
 
+        binder.bind(
+            option: parser.add(option: "--no-static-swift-stdlib", kind: Bool.self,
+                usage: "Do not link Swift stdlib statically"),
+            to: { $0.shouldLinkStaticSwiftStdlib = !$1 })
+
+        binder.bind(
+            option: parser.add(option: "--static-swift-stdlib", kind: Bool.self,
+                usage: "Link Swift stdlib statically"),
+            to: { $0.shouldLinkStaticSwiftStdlib = $1 })
+
         // Let subclasses bind arguments.
         type(of: self).defineArguments(parser: parser, binder: binder)
 
@@ -432,7 +442,9 @@ public class SwiftTool<Options: ToolOptions> {
                 dataPath: buildPath,
                 configuration: options.configuration,
                 toolchain: try getToolchain(),
-                flags: options.buildFlags),
+                flags: options.buildFlags,
+                shouldLinkStaticSwiftStdlib: options.shouldLinkStaticSwiftStdlib
+            ),
             graph: try loadPackageGraph(),
             delegate: self)
     }


### PR DESCRIPTION
-- <rdar://problem/32618121> [SR-648]: swift package manager should produce statically linked binaries