### PR TITLE
Fix Markdown in PackageDescription API Version 4

### DIFF
--- a/Documentation/PackageDescriptionV4.md
+++ b/Documentation/PackageDescriptionV4.md
@@ -93,7 +93,7 @@ This property should only be used for system module packages. It can be used to
 provide _hints_ for users to install a System Module using a system package
 manager like homebrew, apt-get etc.
 
-_NOTE: SwiftPM will *never* execute the command, and only provide suggestions.
+_NOTE: SwiftPM will *never* execute the command, and only provide suggestions._
 
 ```swift
 import PackageDescription

--- a/Documentation/PackageDescriptionV4.md
+++ b/Documentation/PackageDescriptionV4.md
@@ -93,7 +93,7 @@ This property should only be used for system module packages. It can be used to
 provide _hints_ for users to install a System Module using a system package
 manager like homebrew, apt-get etc.
 
-_NOTE: SwiftPM will *never* execute the command, and only provide suggestions._
+_NOTE: SwiftPM will **never** execute the command, and only provide suggestions._
 
 ```swift
 import PackageDescription


### PR DESCRIPTION
I think it's a small thing, but I fix Markdown in PackageDescription API Version 4.