### PR TITLE
Include additionalSearchPaths when loading PkgConfig dependencies

### DIFF
--- a/Sources/Utility/PkgConfig.swift
+++ b/Sources/Utility/PkgConfig.swift
@@ -86,7 +86,11 @@ public struct PkgConfig {
         if !parser.dependencies.isEmpty {
             for dep in parser.dependencies {
                 // FIXME: This is wasteful, we should be caching the PkgConfig result.
-                let pkg = try PkgConfig(name: dep)
+                let pkg = try PkgConfig(
+                    name: dep, 
+                    additionalSearchPaths: additionalSearchPaths, 
+                    fileSystem: fileSystem
+                )
                 cFlags += pkg.cFlags
                 libs += pkg.libs
             }

--- a/Tests/PackageLoadingTests/Inputs/Dependency.pc
+++ b/Tests/PackageLoadingTests/Inputs/Dependency.pc
@@ -1,0 +1,3 @@
+Name: Dependency
+Cflags: -I/path/to/dependency/include
+Libs: -L/path/to/dependency/lib

--- a/Tests/PackageLoadingTests/Inputs/Dependent.pc
+++ b/Tests/PackageLoadingTests/Inputs/Dependent.pc
@@ -1,0 +1,4 @@
+Name: Dependent
+Cflags: -I/path/to/dependent/include
+Libs: -L/path/to/dependent/lib
+Requires: Dependency


### PR DESCRIPTION
When loading dependencies of a `PkgConfig` file, the `additionalSearchPaths` and `fileSystem` arguments were ignored.  This was causing problems with a  Homebrew-installed OpenSSL, since's it's `.pc` file just depends on `libssl` and `libcrypto`, which were not found since their path was in `additionalSearchPaths`.