### PR TITLE
Improve the manifest generation

### DIFF
--- a/Sources/Build/Command.swift
+++ b/Sources/Build/Command.swift
@@ -29,12 +29,16 @@ struct Target {
     /// to a client wanting to control the build.
     let name: String
 
-    /// A list of commands to run when building the target.  A command may be
+    /// A list of outputs that represent the target.
+    var outputs: [String]
+
+    /// A list of commands the target requires. A command may be
     /// in multiple targets, or might not be in any target at all.
     var cmds: SortedArray<Command>
 
     init(name: String) {
         self.name = name
+        self.outputs = []
         self.cmds = SortedArray<Command>(areInIncreasingOrder: <)
     }
 }

--- a/Sources/Build/ToolProtocol.swift
+++ b/Sources/Build/ToolProtocol.swift
@@ -26,6 +26,17 @@ protocol ToolProtocol {
     func append(to stream: OutputByteStream)
 }
 
+struct PhonyTool: ToolProtocol {
+    let inputs: [String]
+    let outputs: [String]
+
+    func append(to stream: OutputByteStream) {
+        stream <<< "    tool: phony\n"
+        stream <<< "    inputs: " <<< Format.asJSON(inputs) <<< "\n"
+        stream <<< "    outputs: " <<< Format.asJSON(outputs) <<< "\n"
+    }
+}
+
 struct ShellTool: ToolProtocol {
     let description: String
     let inputs: [String]


### PR DESCRIPTION
Contains two improvements:
* Remove `swift.o` target ouputs (only `.swiftmodule` is necessary for Swift)
* Generate a LLBuild target for each SwiftPM target

The `main` and `test` targets are kept to allow building the whole package in a single llbuild command.