### PR TITLE
Revert "Improve the manifest generation"

### DIFF
--- a/Sources/Build/Command.swift
+++ b/Sources/Build/Command.swift
@@ -29,16 +29,12 @@ struct Target {
     /// to a client wanting to control the build.
     let name: String
 
-    /// A list of outputs that represent the target.
-    var outputs: [String]
-
-    /// A list of commands the target requires. A command may be
+    /// A list of commands to run when building the target.  A command may be
     /// in multiple targets, or might not be in any target at all.
     var cmds: SortedArray<Command>
 
     init(name: String) {
         self.name = name
-        self.outputs = []
         self.cmds = SortedArray<Command>(areInIncreasingOrder: <)
     }
 }

--- a/Sources/Build/ToolProtocol.swift
+++ b/Sources/Build/ToolProtocol.swift
@@ -26,17 +26,6 @@ protocol ToolProtocol {
     func append(to stream: OutputByteStream)
 }
 
-struct PhonyTool: ToolProtocol {
-    let inputs: [String]
-    let outputs: [String]
-
-    func append(to stream: OutputByteStream) {
-        stream <<< "    tool: phony\n"
-        stream <<< "    inputs: " <<< Format.asJSON(inputs) <<< "\n"
-        stream <<< "    outputs: " <<< Format.asJSON(outputs) <<< "\n"
-    }
-}
-
 struct ShellTool: ToolProtocol {
     let description: String
     let inputs: [String]


### PR DESCRIPTION
Reverts apple/swift-package-manager#1265

Reverting until we can figure out why are we getting such errors on incremental builds:
https://ci.swift.org/job/swift-PR-Linux/8955/consoleFull#-1176476349ee1a197b-acac-4b17-83cf-a53b95139a76

```
<unknown>:0: error: cycle detected while building: target 'test' -> node '<Basic.module>' -> command '<Basic.module>' -> node '/home/buildnode/jenkins/workspace/swift-PR-Linux/branch-master/buildbot_linux/swiftpm-linux-x86_64/x86_64-unknown-linux/release/Basic.swiftmodule' -> command '<Basic.module>'
```