### PR TITLE
Improve the manifest generation

### DIFF
--- a/Sources/Build/Command.swift
+++ b/Sources/Build/Command.swift
@@ -29,12 +29,16 @@ struct Target {
     /// to a client wanting to control the build.
     let name: String
 
-    /// A list of commands to run when building the target.  A command may be
+    /// A list of outputs that represent the target.
+    var outputs: [String]
+
+    /// A list of commands the target requires. A command may be
     /// in multiple targets, or might not be in any target at all.
     var cmds: SortedArray<Command>
 
     init(name: String) {
         self.name = name
+        self.outputs = []
         self.cmds = SortedArray<Command>(areInIncreasingOrder: <)
     }
 }

--- a/Sources/Build/ToolProtocol.swift
+++ b/Sources/Build/ToolProtocol.swift
@@ -26,6 +26,17 @@ protocol ToolProtocol {
     func append(to stream: OutputByteStream)
 }
 
+struct PhonyTool: ToolProtocol {
+    let inputs: [String]
+    let outputs: [String]
+
+    func append(to stream: OutputByteStream) {
+        stream <<< "    tool: phony\n"
+        stream <<< "    inputs: " <<< Format.asJSON(inputs) <<< "\n"
+        stream <<< "    outputs: " <<< Format.asJSON(outputs) <<< "\n"
+    }
+}
+
 struct ShellTool: ToolProtocol {
     let description: String
     let inputs: [String]

--- a/Sources/Build/llbuild.swift
+++ b/Sources/Build/llbuild.swift
@@ -33,22 +33,39 @@ public struct LLBuildManifestGenerator {
         /// Test target.
         private(set) var test = Target(name: "test")
 
+        /// All targets.
+        var allTargets: [Target] {
+            return [main, test] + otherTargets
+        }
+
         /// All commands.
         private(set) var allCommands = SortedArray<Command>(areInIncreasingOrder: <)
 
-        /// Append a command.
-        mutating func append(_ command: Command, isTest: Bool) {
-            append([command], isTest: isTest)
-        }
+        /// Other targets.
+        private var otherTargets: [Target] = []
 
-        /// Append an array of commands.
-        mutating func append(_ commands: [Command], isTest: Bool) {
+        /// Append a command.
+        mutating func append(_ target: Target, isTest: Bool) {
+            // Create a phony command with a virtual output node that represents the target.
+            let virtualNodeName = "<\(target.name)>"
+            let phonyTool = PhonyTool(inputs: target.outputs, outputs: [virtualNodeName])
+            let phonyCommand = Command(name: "<C.\(target.name)>", tool: phonyTool)
+
+            // Use the phony command as dependency.
+            var newTarget = target
+            newTarget.outputs = [virtualNodeName]
+            newTarget.cmds.insert(phonyCommand)
+            otherTargets.append(newTarget)
+
             if !isTest {
-                main.cmds += commands
+                main.outputs += newTarget.outputs
+                main.cmds += newTarget.cmds
             }
+
             // Always build everything for the test target.
-            test.cmds += commands
-            allCommands += commands
+            test.outputs += newTarget.outputs
+            test.cmds += newTarget.cmds
+            allCommands += newTarget.cmds
         }
     }
 
@@ -60,15 +77,15 @@ public struct LLBuildManifestGenerator {
         for buildTarget in plan.targets {
             switch buildTarget {
             case .swift(let target):
-                targets.append(createSwiftCommand(target), isTest: target.isTestTarget)
+                targets.append(createSwiftCompileTarget(target), isTest: target.isTestTarget)
             case .clang(let target):
-                targets.append(createClangCommands(target), isTest: target.isTestTarget)
+                targets.append(createClangCompileTarget(target), isTest: target.isTestTarget)
             }
         }
 
         // Create command for all products in the plan.
         for buildProduct in plan.buildProducts {
-            targets.append(createLinkCommand(buildProduct), isTest: buildProduct.product.type == .test)
+            targets.append(createProductTarget(buildProduct), isTest: buildProduct.product.type == .test)
         }
 
         // Write the manifest.
@@ -77,9 +94,9 @@ public struct LLBuildManifestGenerator {
         stream <<< "  name: swift-build\n"
         stream <<< "tools: {}\n"
         stream <<< "targets:\n"
-        for target in [targets.test, targets.main] {
+        for target in targets.allTargets {
             stream <<< "  " <<< Format.asJSON(target.name)
-            stream <<< ": " <<< Format.asJSON(target.cmds.flatMap({ $0.tool.outputs })) <<< "\n"
+            stream <<< ": " <<< Format.asJSON(target.outputs) <<< "\n"
         }
         stream <<< "default: " <<< Format.asJSON(targets.main.name) <<< "\n"
         stream <<< "commands: \n"
@@ -91,8 +108,8 @@ public struct LLBuildManifestGenerator {
         try localFileSystem.writeFileContents(path, bytes: stream.bytes)
     }
 
-    /// Create link command for products.
-    private func createLinkCommand(_ buildProduct: ProductBuildDescription) -> Command {
+    /// Create a llbuild target for a product description.
+    private func createProductTarget(_ buildProduct: ProductBuildDescription) -> Target {
         let tool: ToolProtocol
         // Create archive tool for static library and shell tool for rest of the products.
         if buildProduct.product.type == .library(.static) {
@@ -107,11 +124,15 @@ public struct LLBuildManifestGenerator {
                 outputs: [buildProduct.binary.asString],
                 args: buildProduct.linkArguments())
         }
-        return Command(name: buildProduct.targetName, tool: tool)
+
+        var target = Target(name: buildProduct.targetName)
+        target.outputs = tool.outputs
+        target.cmds.insert(Command(name: buildProduct.commandName, tool: tool))
+        return target
     }
 
-    /// Create command for Swift target description.
-    private func createSwiftCommand(_ target: SwiftTargetDescription) -> Command {
+    /// Create a llbuild target for a Swift target description.
+    private func createSwiftCompileTarget(_ target: SwiftTargetDescription) -> Target {
         // Compute inital inputs.
         var inputs = SortedArray<String>()
         inputs += target.target.sources.paths.map({ $0.asString })
@@ -151,13 +172,17 @@ public struct LLBuildManifestGenerator {
             }
         }
 
+        var buildTarget = Target(name: target.target.targetName)
+        // The target only cares about the module output.
+        buildTarget.outputs = [target.moduleOutputPath.asString]
         let tool = SwiftCompilerTool(target: target, inputs: inputs.values)
-        return Command(name: target.target.targetName, tool: tool)
+        buildTarget.cmds.insert(Command(name: target.target.commandName, tool: tool))
+        return buildTarget
     }
 
-    /// Create commands for Clang targets.
-    private func createClangCommands(_ target: ClangTargetDescription) -> [Command] {
-        return target.compilePaths().map({ path in
+    /// Create a llbuild target for a Clang target description.
+    private func createClangCompileTarget(_ target: ClangTargetDescription) -> Target {
+        let commands: [Command] = target.compilePaths().map({ path in
             var args = target.basicArguments()
             args += ["-MD", "-MT", "dependencies", "-MF", path.deps.asString]
             args += ["-c", path.source.asString, "-o", path.object.asString]
@@ -170,12 +195,22 @@ public struct LLBuildManifestGenerator {
                 deps: path.deps.asString)
             return Command(name: path.object.asString, tool: clang)
         })
+
+        // For Clang, the target requires all command outputs.
+        var buildTarget = Target(name: target.target.targetName)            
+        buildTarget.outputs = commands.flatMap({ $0.tool.outputs })
+        buildTarget.cmds += commands
+        return buildTarget
     }
 }
 
 extension ResolvedTarget {
     var targetName: String {
-        return "<\(name).module>"
+        return "\(name).module"
+    }
+
+    var commandName: String {
+        return "C.\(targetName)"
     }
 }
 
@@ -183,15 +218,19 @@ extension ProductBuildDescription {
     public var targetName: String {
         switch product.type {
         case .library(.dynamic):
-            return "<\(product.name).dylib>"
+            return "\(product.name).dylib"
         case .test:
-            return "<\(product.name).test>"
+            return "\(product.name).test"
         case .library(.static):
-            return "<\(product.name).a>"
+            return "\(product.name).a"
         case .library(.automatic):
             fatalError()
         case .executable:
-            return "<\(product.name).exe>"
+            return "\(product.name).exe"
         }
+    }
+
+    var commandName: String {
+        return "C.\(targetName)"
     }
 }


### PR DESCRIPTION
Contains two improvements:
* Remove swift.o target inputs (only .swiftmodule is necessary)
* Generate a LLBuild target for each SwiftPM target
* Create phony targets to simplify target dependencies