### PR TITLE
Fix error with the .build/conf symink for SwiftPM

### DIFF
--- a/Sources/Commands/Destination.swift
+++ b/Sources/Commands/Destination.swift
@@ -84,8 +84,8 @@ public struct Destination {
         originalWorkingDirectory: AbsolutePath = currentWorkingDirectory
     ) throws -> Destination {
         // Select the correct binDir.
-        let binDir = binDir ?? Destination.hostBinDir(
-            originalWorkingDirectory: originalWorkingDirectory)
+        let binDir = resolveSymlinks(binDir ?? Destination.hostBinDir(
+            originalWorkingDirectory: originalWorkingDirectory))
 
       #if os(macOS)
         // Get the SDK.


### PR DESCRIPTION
`Destination` and `UserToolchain` use the binary path to calculate the library path. But because none of them resolve symlinks, they incorrectly calculate the library path when run through the `.build/conf` symlink. Solved by making `Destination.hostDestination` resolve symlinks on `binDir`.