### PR TITLE
Use --filter instead of deprecated option

### DIFF
--- a/Documentation/Development.md
+++ b/Documentation/Development.md
@@ -92,7 +92,7 @@ $ cd swiftpm
 $ .build/debug/swift-build
 
 # Run a single test.
-$ .build/debug/swift-test -s BasicTests.GraphAlgorithmsTests/testCycleDetection
+$ .build/debug/swift-test --filter BasicTests.GraphAlgorithmsTests/testCycleDetection
 ```
 
 Note: If you make any changes to `PackageDescription` or `PackageDescription4`


### PR DESCRIPTION
'-s' option is deprecated, so it is better to use '--filter' option instead.