### PR TITLE
[Commands] Add some Swift compiler path to the sandbox

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -550,6 +550,9 @@ private func sandboxProfile(allowedDirectories: [AbsolutePath]) -> String {
         stream <<< "    (regex #\"^\(directory.asString)/xcrun.*\")" <<< "\n"
         // For autolink files.
         stream <<< "    (regex #\"^\(directory.asString)/.*\\.(swift|c)-[0-9a-f]+\\.autolink\")" <<< "\n"
+        // These paths are used the Switch compiler.
+        stream <<< "    (regex #\"^\(directory.asString)/inputs.*\")" <<< "\n"
+        stream <<< "    (regex #\"^\(directory.asString)/sources.*\")" <<< "\n"
     }
     for directory in allowedDirectories {
         stream <<< "    (subpath \"\(directory.asString)\")" <<< "\n"


### PR DESCRIPTION
-- <rdar://problem/33378806> [SR-5491]: LLVM ERROR: IO failure on output stream.
-- https://bugs.swift.org/browse/SR-5061