### PR TITLE
Fix label for "Test Target" search paths in docs

### DIFF
--- a/Documentation/PackageDescriptionV4.md
+++ b/Documentation/PackageDescriptionV4.md
@@ -20,7 +20,7 @@ relative path of the target is declared, the Package Manager will look for
 a directory matching the name of the target in these places:
 
 Regular targets: package root, Sources, Source, src, srcs.  
-Regular targets: Tests, package root, Sources, Source, src, srcs. 
+Test targets: Tests, package root, Sources, Source, src, srcs. 
 
 ## Package Manifest File Format Reference
 


### PR DESCRIPTION
I'm pretty sure this one should be "Test Targets" :)