### PR TITLE
[Build] Fix rpath path for linux

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -404,6 +404,11 @@ public final class ProductBuildDescription {
             }
             args += ["-emit-executable"]
         }
+      #if os(Linux)
+        // On linux, set rpath such that dynamic libraries are looked up
+        // adjacent to the product. This happens by default on macOS.
+        args += ["-Xlinker", "-rpath=$ORIGIN"]
+      #endif
         args += objects.map({ $0.asString })
         return args
     }


### PR DESCRIPTION
-- <rdar://problem/33395793> Unable to run test targets having dynamic library as a dependency on linux