### PR TITLE
Add formatting for and/or english lists

### DIFF
--- a/Sources/Basic/Process.swift
+++ b/Sources/Basic/Process.swift
@@ -224,7 +224,8 @@ public final class Process: ObjectIdentifierProtocol {
 
         // Print the arguments if we are verbose.
         if self.verbose {
-            stdoutStream <<< arguments.map({ $0.shellEscaped() }).joined(separator: " ") <<< "\n"
+            stdoutStream <<< Format.asSeparatedList(arguments, transform: { $0.shellEscaped() }, separator: " ")
+            stdoutStream <<< "\n"
             stdoutStream.flush()
         }
 
@@ -560,7 +561,7 @@ extension ProcessResult.Error: CustomStringConvertible {
             if args.first == "sandbox-exec", args.count > 3 {
                 args = args.suffix(from: 3).map({$0})
             }
-            stream <<< args.map({ $0.shellEscaped() }).joined(separator: " ")
+            stream <<< Format.asSeparatedList(args, transform: { $0.shellEscaped() }, separator: " ")
             return stream.bytes.asString!
         }
     }

--- a/Sources/Commands/Describe.swift
+++ b/Sources/Commands/Describe.swift
@@ -66,7 +66,8 @@ extension Target: JSONSerializable {
         stream <<< Format.asRepeating(string: " ", count: indent)
             <<< "Path: " <<< sources.root.asString <<< "\n"
         stream <<< Format.asRepeating(string: " ", count: indent)
-            <<< "Sources: " <<< sources.relativePaths.map({ $0.asString }).joined(separator: ", ") <<< "\n"
+            <<< "Sources: " <<< Format.asSeparatedList(sources.relativePaths, transform: { $0.asString }, separator: ", ")
+            <<< "\n"
     }
 
     public func toJSON() -> JSON {

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -93,7 +93,7 @@ public enum ResolverDiagnostics {
                 stream <<< revision
             case .unversioned(let constraints):
                 stream <<< "unversioned ("
-                stream <<< constraints.map({ $0.description }).joined(separator: ", ")
+                stream <<< Format.asSeparatedList(constraints, transform: { $0.description }, separator: ", ")
                 stream <<< ")"
             }
 

--- a/Tests/BasicTests/OutputByteStreamTests.swift
+++ b/Tests/BasicTests/OutputByteStreamTests.swift
@@ -124,7 +124,11 @@ class OutputByteStreamTests: XCTestCase {
         }
 
         do {
-            let stream = BufferedOutputByteStream()
+            var stream = BufferedOutputByteStream()
+            stream <<< Format.asSeparatedList(["hello"], separator: ", ")
+            XCTAssertEqual(stream.bytes, "hello")
+
+            stream = BufferedOutputByteStream()
             stream <<< Format.asSeparatedList(["hello", "world"], separator: ", ")
             XCTAssertEqual(stream.bytes, "hello, world")
         }
@@ -134,9 +138,71 @@ class OutputByteStreamTests: XCTestCase {
                 let value: String
                 init(_ value: String) { self.value = value }
             }
-            let stream = BufferedOutputByteStream()
+            
+            var stream = BufferedOutputByteStream()
+            stream <<< Format.asSeparatedList([MyThing("hello")], transform: { $0.value }, separator: ", ")
+            XCTAssertEqual(stream.bytes, "hello")
+
+            stream = BufferedOutputByteStream()
             stream <<< Format.asSeparatedList([MyThing("hello"), MyThing("world")], transform: { $0.value }, separator: ", ")
             XCTAssertEqual(stream.bytes, "hello, world")
+        }
+
+        do {
+            var stream = BufferedOutputByteStream()
+            stream <<< Format.asEnglishList(["blue"], type: .conjunction)
+            XCTAssertEqual(stream.bytes, "blue")
+
+            stream = BufferedOutputByteStream()
+            stream <<< Format.asEnglishList(["blue"], type: .disjunction)
+            XCTAssertEqual(stream.bytes, "blue")
+
+            stream = BufferedOutputByteStream()
+            stream <<< Format.asEnglishList(["blue", "white"], type: .conjunction)
+            XCTAssertEqual(stream.bytes, "blue and white")
+
+            stream = BufferedOutputByteStream()
+            stream <<< Format.asEnglishList(["blue", "white"], type: .disjunction)
+            XCTAssertEqual(stream.bytes, "blue or white")
+
+            stream = BufferedOutputByteStream()
+            stream <<< Format.asEnglishList(["blue", "white", "red"], type: .conjunction)
+            XCTAssertEqual(stream.bytes, "blue, white, and red")
+
+            stream = BufferedOutputByteStream()
+            stream <<< Format.asEnglishList(["blue", "white", "red"], type: .disjunction)
+            XCTAssertEqual(stream.bytes, "blue, white, or red")
+        }
+        
+        do {
+            struct MyThing {
+                let value: String
+                init(_ value: String) { self.value = value }
+            }
+
+            var stream = BufferedOutputByteStream()
+            stream <<< Format.asEnglishList([MyThing("blue")], transform: { $0.value }, type: .conjunction)
+            XCTAssertEqual(stream.bytes, "blue")
+
+            stream = BufferedOutputByteStream()
+            stream <<< Format.asEnglishList([MyThing("blue")], transform: { $0.value }, type: .disjunction)
+            XCTAssertEqual(stream.bytes, "blue")
+
+            stream = BufferedOutputByteStream()
+            stream <<< Format.asEnglishList([MyThing("blue"), MyThing("white")], transform: { $0.value }, type: .conjunction)
+            XCTAssertEqual(stream.bytes, "blue and white")
+
+            stream = BufferedOutputByteStream()
+            stream <<< Format.asEnglishList([MyThing("blue"), MyThing("white")], transform: { $0.value }, type: .disjunction)
+            XCTAssertEqual(stream.bytes, "blue or white")
+
+            stream = BufferedOutputByteStream()
+            stream <<< Format.asEnglishList([MyThing("blue"), MyThing("white"), MyThing("red")], transform: { $0.value }, type: .conjunction)
+            XCTAssertEqual(stream.bytes, "blue, white, and red")
+
+            stream = BufferedOutputByteStream()
+            stream <<< Format.asEnglishList([MyThing("blue"), MyThing("white"), MyThing("red")], transform: { $0.value }, type: .disjunction)
+            XCTAssertEqual(stream.bytes, "blue, white, or red")
         }
 
         do {


### PR DESCRIPTION
I also did a small amount of cleanup by using `Format.asSeparatedList` is places where it could be taken advantage of.