### PR TITLE
Fix a link to the section for C language targets.

### DIFF
--- a/Documentation/PackageDescriptionV3.md
+++ b/Documentation/PackageDescriptionV3.md
@@ -65,7 +65,7 @@ Note: It is possible to have C, C++, Objective-C and Objective-C++ sources as
 part of a C language target. Swift targets can import C language targets but
 not vice versa.
 
-Read more on C language targets [here](#c-language-targets).
+Read more on C language targets [here](Usage.md#c-language-targets).
 
 ### Test Target Layouts
 


### PR DESCRIPTION
 This pull request fixes a link to the section about C language targets. The link got broken by [renaming files](https://github.com/apple/swift-package-manager/commit/4ee5feda08e7f9d760a4bc1397500fc23ec5bb29).