### PR TITLE
Shell completion of dependencies and executables

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -806,7 +806,7 @@ SwiftPM ships with completion scripts for both Bash and ZSH. These files should 
 Use the following commands to install the Bash completions to `~/.swift-package-complete.bash` and automatically load them using your `~/.bash_profile` file.
 
 ```bash
-swift package generate-completion-script bash > ~/.swift-package-complete.bash
+swift package completion-tool --generate-shell-script bash > ~/.swift-package-complete.bash
 echo -e "source ~/.swift-package-complete.bash\n" >> ~/.bash_profile
 source ~/.swift-package-complete.bash
 ```
@@ -817,7 +817,7 @@ Use the following commands to install the ZSH completions to `~/.zsh/_swift`. Yo
 
 ```bash
 mkdir ~/.zsh
-swift package generate-completion-script zsh > ~/.zsh/_swift
+swift package completion-tool --generate-shell-script zsh > ~/.zsh/_swift
 echo -e "fpath=(~/.zsh \$fpath)\n" >> ~/.zshrc
 compinit
 ```

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -806,7 +806,7 @@ SwiftPM ships with completion scripts for both Bash and ZSH. These files should 
 Use the following commands to install the Bash completions to `~/.swift-package-complete.bash` and automatically load them using your `~/.bash_profile` file.
 
 ```bash
-swift package completion-tool --generate-shell-script bash > ~/.swift-package-complete.bash
+swift package completion-tool generate-bash-script > ~/.swift-package-complete.bash
 echo -e "source ~/.swift-package-complete.bash\n" >> ~/.bash_profile
 source ~/.swift-package-complete.bash
 ```
@@ -817,7 +817,7 @@ Use the following commands to install the ZSH completions to `~/.zsh/_swift`. Yo
 
 ```bash
 mkdir ~/.zsh
-swift package completion-tool --generate-shell-script zsh > ~/.zsh/_swift
+swift package completion-tool generate-zsh-script > ~/.zsh/_swift
 echo -e "fpath=(~/.zsh \$fpath)\n" >> ~/.zshrc
 compinit
 ```

--- a/Sources/Commands/Completions+bash.swift
+++ b/Sources/Commands/Completions+bash.swift
@@ -77,11 +77,11 @@ func bash_template(on stream: OutputByteStream) {
         }
 
         _swift_dependency() {
-            COMPREPLY=( $(compgen -W "$(swift package show-dependencies --format flatlist)" -- $cur) )
+            COMPREPLY=( $(compgen -W "$(swift package completion-tool --list-dependencies)" -- $cur) )
         }
 
         _swift_executable() {
-            COMPREPLY=( $(compgen -W "$(swift package describe --executables)" -- $cur) )
+            COMPREPLY=( $(compgen -W "$(swift package completion-tool --list-executables)" -- $cur) )
         }
 
 

--- a/Sources/Commands/Completions+bash.swift
+++ b/Sources/Commands/Completions+bash.swift
@@ -77,11 +77,11 @@ func bash_template(on stream: OutputByteStream) {
         }
 
         _swift_dependency() {
-            COMPREPLY=( $(compgen -W "$(\(dependencies))" -- $cur) )
+            COMPREPLY=( $(compgen -W "$(swift package show-dependencies --format flatlist)" -- $cur) )
         }
 
         _swift_executable() {
-            COMPREPLY=( $(compgen -W "$(\(executables))" -- $cur) )
+            COMPREPLY=( $(compgen -W "$(swift package describe --executables)" -- $cur) )
         }
 
 

--- a/Sources/Commands/Completions+bash.swift
+++ b/Sources/Commands/Completions+bash.swift
@@ -12,6 +12,9 @@ import Foundation
 import Basic
 import Utility
 
+let listDependenciesCommand = "swift package \(PackageMode.completionTool.rawValue) \(PackageToolOptions.CompletionToolMode.listDependencies.rawValue)"
+let listExecutablesCommand = "swift package \(PackageMode.completionTool.rawValue) \(PackageToolOptions.CompletionToolMode.listExecutables.rawValue)"
+
 /// Template for Bash completion script.
 ///
 /// - Parameter stream: output stream to write the script to.
@@ -77,11 +80,11 @@ func bash_template(on stream: OutputByteStream) {
         }
 
         _swift_dependency() {
-            COMPREPLY=( $(compgen -W "$(swift package completion-tool --list-dependencies)" -- $cur) )
+            COMPREPLY=( $(compgen -W "$(\(listDependenciesCommand))" -- $cur) )
         }
 
         _swift_executable() {
-            COMPREPLY=( $(compgen -W "$(swift package completion-tool --list-executables)" -- $cur) )
+            COMPREPLY=( $(compgen -W "$(\(listExecutablesCommand))" -- $cur) )
         }
 
 

--- a/Sources/Commands/Completions+bash.swift
+++ b/Sources/Commands/Completions+bash.swift
@@ -76,6 +76,15 @@ func bash_template(on stream: OutputByteStream) {
             esac
         }
 
+        _swift_dependency() {
+            COMPREPLY=( $(compgen -W "$(\(dependencies))" -- $cur) )
+        }
+
+        _swift_executable() {
+            COMPREPLY=( $(compgen -W "$(\(executables))" -- $cur) )
+        }
+
+
         """
 
     SwiftBuildTool(args: []).parser.generateCompletionScript(for: .bash, on: stream)

--- a/Sources/Commands/Completions+zsh.swift
+++ b/Sources/Commands/Completions+zsh.swift
@@ -64,13 +64,13 @@ func zsh_template(on stream: OutputByteStream) {
 
         _swift_dependency() {
             local dependencies
-            dependencies=( $(swift package completion-tool --list-dependencies) )
+            dependencies=( $(\(listDependenciesCommand)) )
             _describe '' dependencies
         }
 
         _swift_executable() {
             local executables
-            executables=( $(swift package completion-tool --list-executables) )
+            executables=( $(\(listExecutablesCommand)) )
             _describe '' executables
         }
 

--- a/Sources/Commands/Completions+zsh.swift
+++ b/Sources/Commands/Completions+zsh.swift
@@ -12,6 +12,9 @@ import Foundation
 import Basic
 import Utility
 
+let dependencies = "swift package show-dependencies | grep -oE '── (.*)<' | sed -E 's/── (.*)</\\1/'"
+let executables = "swift package describe | grep 'Type: executable' -B 3 | grep 'Name:' | sed -e 's/    Name: //'"
+
 /// Template for ZSH completion script.
 ///
 /// - Parameter stream: output stream to write the script to.
@@ -60,6 +63,18 @@ func zsh_template(on stream: OutputByteStream) {
                     esac
                     ;;
             esac
+        }
+
+        _swift_dependency() {
+            local dependencies
+            dependencies=( $(\(dependencies)) )
+            _describe '' dependencies
+        }
+
+        _swift_executable() {
+            local executables
+            executables=( $(\(executables)) )
+            _describe '' executables
         }
 
 

--- a/Sources/Commands/Completions+zsh.swift
+++ b/Sources/Commands/Completions+zsh.swift
@@ -12,9 +12,6 @@ import Foundation
 import Basic
 import Utility
 
-let dependencies = "swift package show-dependencies | grep -oE '── (.*)<' | sed -E 's/── (.*)</\\1/'"
-let executables = "swift package describe | grep 'Type: executable' -B 3 | grep 'Name:' | sed -e 's/    Name: //'"
-
 /// Template for ZSH completion script.
 ///
 /// - Parameter stream: output stream to write the script to.
@@ -67,13 +64,13 @@ func zsh_template(on stream: OutputByteStream) {
 
         _swift_dependency() {
             local dependencies
-            dependencies=( $(\(dependencies)) )
+            dependencies=( $(swift package show-dependencies --format flatlist) )
             _describe '' dependencies
         }
 
         _swift_executable() {
             local executables
-            executables=( $(\(executables)) )
+            executables=( $(swift package describe --executables) )
             _describe '' executables
         }
 

--- a/Sources/Commands/Completions+zsh.swift
+++ b/Sources/Commands/Completions+zsh.swift
@@ -64,13 +64,13 @@ func zsh_template(on stream: OutputByteStream) {
 
         _swift_dependency() {
             local dependencies
-            dependencies=( $(swift package show-dependencies --format flatlist) )
+            dependencies=( $(swift package completion-tool --list-dependencies) )
             _describe '' dependencies
         }
 
         _swift_executable() {
             local executables
-            executables=( $(swift package describe --executables) )
+            executables=( $(swift package completion-tool --list-executables) )
             _describe '' executables
         }
 

--- a/Sources/Commands/Describe.swift
+++ b/Sources/Commands/Describe.swift
@@ -29,14 +29,6 @@ func describe(_ package: Package, in mode: DescribeMode, on stream: OutputByteSt
     stream.flush()
 }
 
-func describeExecutableNames(_ package: Package, on stream: OutputByteStream) {
-    let executables = package.targets.filter { $0.type == .executable }
-    for executable in executables {
-        stream <<< "\(executable.name)\n"
-    }
-    stream.flush()
-}
-
 extension Package: JSONSerializable {
 
     func describe(on stream: OutputByteStream) {

--- a/Sources/Commands/Describe.swift
+++ b/Sources/Commands/Describe.swift
@@ -29,6 +29,14 @@ func describe(_ package: Package, in mode: DescribeMode, on stream: OutputByteSt
     stream.flush()
 }
 
+func describeExecutableNames(_ package: Package, on stream: OutputByteStream) {
+    let executables = package.targets.filter { $0.type == .executable }
+    for executable in executables {
+        stream <<< "\(executable.name)\n"
+    }
+    stream.flush()
+}
+
 extension Package: JSONSerializable {
 
     func describe(on stream: OutputByteStream) {

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -214,9 +214,10 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
         let editParser = parser.add(subparser: PackageMode.edit.rawValue, overview: "Put a package in editable mode")
         binder.bind(
             positional: editParser.add(
-                positional: "name", kind: DependencyName.self,
-                usage: "The name of the package to edit"),
-            to: { $0.editOptions.packageName = $1.name })
+                positional: "name", kind: String.self,
+                usage: "The name of the package to edit",
+                completion: .function("_swift_dependency")),
+            to: { $0.editOptions.packageName = $1 })
         binder.bind(
             editParser.add(
                 option: "--revision", kind: String.self,
@@ -253,9 +254,10 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             overview: "Remove a package from editable mode")
         binder.bind(
             positional: uneditParser.add(
-                positional: "name", kind: DependencyName.self,
-                usage: "The name of the package to unedit"),
-            to: { $0.editOptions.packageName = $1.name })
+                positional: "name", kind: String.self,
+                usage: "The name of the package to unedit",
+                completion: .function("_swift_dependency")),
+            to: { $0.editOptions.packageName = $1 })
         binder.bind(
             option: uneditParser.add(
                 option: "--force", kind: Bool.self,
@@ -324,9 +326,10 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             overview: "Resolve package dependencies")
         binder.bind(
             positional: resolveParser.add(
-                positional: "name", kind: DependencyName.self, optional: true,
-                usage: "The name of the package to resolve"),
-            to: { $0.resolveOptions.packageName = $1.name })
+                positional: "name", kind: String.self, optional: true,
+                usage: "The name of the package to resolve",
+                completion: .function("_swift_dependency")),
+            to: { $0.resolveOptions.packageName = $1 })
 
         binder.bind(
             resolveParser.add(

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -189,7 +189,12 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
                 dumpDependenciesOf(rootPackage: graph.rootPackages[0], mode: .flatlist)
             case .listExecutables?:
                 let graph = try loadPackageGraph()
-                describeExecutableNames(graph.rootPackages[0].underlyingPackage, on: stdoutStream)
+                let package = graph.rootPackages[0].underlyingPackage
+                let executables = package.targets.filter { $0.type == .executable }
+                for executable in executables {
+                    stdoutStream <<< "\(executable.name)\n"
+                }
+                stdoutStream.flush()
             default:
                 preconditionFailure("somehow we ended up with an invalid positional argument")
             }

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -206,9 +206,9 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
         let editParser = parser.add(subparser: PackageMode.edit.rawValue, overview: "Put a package in editable mode")
         binder.bind(
             positional: editParser.add(
-                positional: "name", kind: String.self,
+                positional: "name", kind: DependencyName.self,
                 usage: "The name of the package to edit"),
-            to: { $0.editOptions.packageName = $1 })
+            to: { $0.editOptions.packageName = $1.name })
         binder.bind(
             editParser.add(
                 option: "--revision", kind: String.self,
@@ -245,9 +245,9 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             overview: "Remove a package from editable mode")
         binder.bind(
             positional: uneditParser.add(
-                positional: "name", kind: String.self,
+                positional: "name", kind: DependencyName.self,
                 usage: "The name of the package to unedit"),
-            to: { $0.editOptions.packageName = $1 })
+            to: { $0.editOptions.packageName = $1.name })
         binder.bind(
             option: uneditParser.add(
                 option: "--force", kind: Bool.self,
@@ -316,9 +316,9 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             overview: "Resolve package dependencies")
         binder.bind(
             positional: resolveParser.add(
-                positional: "name", kind: String.self, optional: true,
+                positional: "name", kind: DependencyName.self, optional: true,
                 usage: "The name of the package to resolve"),
-            to: { $0.resolveOptions.packageName = $1 })
+            to: { $0.resolveOptions.packageName = $1.name })
 
         binder.bind(
             resolveParser.add(

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -177,11 +177,12 @@ public class SwiftRunTool: SwiftTool<RunToolOptions> {
             to: { $0.shouldBuild = !$1 })
         
         binder.bindArray(
-            positional: parser.add(positional: "executable", kind: [ExecutableName].self, optional: true, strategy: .remaining,
-                usage: "The executable to run"),
+            positional: parser.add(
+                positional: "executable", kind: [String].self, optional: true, strategy: .remaining,
+                usage: "The executable to run", completion: .function("_swift_executable")),
             to: {
-                $0.executable = $1.first!.name
-                $0.arguments = Array($1.dropFirst().map { $0.name })
+                $0.executable = $1.first!
+                $0.arguments = Array($1.dropFirst())
             })
     }
 }

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -177,11 +177,11 @@ public class SwiftRunTool: SwiftTool<RunToolOptions> {
             to: { $0.shouldBuild = !$1 })
         
         binder.bindArray(
-            positional: parser.add(positional: "executable", kind: [String].self, optional: true, strategy: .remaining,
+            positional: parser.add(positional: "executable", kind: [ExecutableName].self, optional: true, strategy: .remaining,
                 usage: "The executable to run"),
             to: {
-                $0.executable = $1.first!
-                $0.arguments = Array($1.dropFirst())
+                $0.executable = $1.first!.name
+                $0.arguments = Array($1.dropFirst().map { $0.name })
             })
     }
 }

--- a/Sources/Commands/show-dependencies.swift
+++ b/Sources/Commands/show-dependencies.swift
@@ -20,6 +20,8 @@ func dumpDependenciesOf(rootPackage: ResolvedPackage, mode: ShowDependenciesMode
         dumper = DotDumper()
     case .json:
         dumper = JSONDumper()
+    case .flatlist:
+        dumper = FlatListDumper()
     }
     dumper.dump(dependenciesOf: rootPackage)
 }
@@ -57,6 +59,22 @@ private final class PlainTextDumper: DependenciesDumper {
             recursiveWalk(packages: rootpkg.dependencies)
         } else {
             print("No external dependencies found")
+        }
+    }
+}
+
+private final class FlatListDumper: DependenciesDumper {
+    func dump(dependenciesOf rootpkg: ResolvedPackage) {
+        func recursiveWalk(packages: [ResolvedPackage]) {
+            for package in packages {
+                print(package.name)
+                if !package.dependencies.isEmpty {
+                    recursiveWalk(packages: package.dependencies)
+                }
+            }
+        }
+        if !rootpkg.dependencies.isEmpty {
+            recursiveWalk(packages: rootpkg.dependencies)
         }
     }
 }
@@ -112,7 +130,7 @@ private final class JSONDumper: DependenciesDumper {
 }
 
 enum ShowDependenciesMode: CustomStringConvertible {
-    case text, dot, json
+    case text, dot, json, flatlist
 
     init?(rawValue: String) {
         switch rawValue.lowercased() {
@@ -122,6 +140,8 @@ enum ShowDependenciesMode: CustomStringConvertible {
            self = .dot
         case "json":
            self = .json
+        case "flatlist":
+            self = .flatlist
         default:
             return nil
         }
@@ -132,6 +152,7 @@ enum ShowDependenciesMode: CustomStringConvertible {
         case .text: return "text"
         case .dot: return "dot"
         case .json: return "json"
+        case .flatlist: return "flatlist"
         }
     }
 }

--- a/Sources/Utility/ArgumentParser.swift
+++ b/Sources/Utility/ArgumentParser.swift
@@ -116,6 +116,8 @@ public enum ShellCompletion {
     case none
     case unspecified
     case filename
+    case executable
+    case dependency
     case values([(value: String, description: String)])
 }
 
@@ -198,6 +200,26 @@ public struct PathArgument: ArgumentKind {
     }
 
     public static var completion: ShellCompletion = .filename
+}
+
+public struct ExecutableName: ArgumentKind {
+    public let name: String
+
+    public init(argument: String) throws {
+        name = argument
+    }
+
+    public static var completion: ShellCompletion = .executable
+}
+
+public struct DependencyName: ArgumentKind {
+    public let name: String
+
+    public init(argument: String) throws {
+        name = argument
+    }
+
+    public static var completion: ShellCompletion = .dependency
 }
 
 /// An enum representing the strategy to parse argument values.

--- a/Sources/Utility/ArgumentParser.swift
+++ b/Sources/Utility/ArgumentParser.swift
@@ -110,14 +110,15 @@ public enum Shell: String, StringEnumArgument {
 /// - none:        Offers no completions at all; e.g. for string identifier
 /// - unspecified: No specific completions, will offer tool's completions
 /// - filename:    Offers filename completions
+/// - function:    Custom function for generating completions. Must be
+///                provided in the script's scope.
 /// - values:      Offers completions from predefined list. A description
 ///                can be provided which is shown in some shells, like zsh.
 public enum ShellCompletion {
     case none
     case unspecified
     case filename
-    case executable
-    case dependency
+    case function(String)
     case values([(value: String, description: String)])
 }
 
@@ -209,7 +210,7 @@ public struct ExecutableName: ArgumentKind {
         name = argument
     }
 
-    public static var completion: ShellCompletion = .executable
+    public static var completion: ShellCompletion = .function("_swift_executable")
 }
 
 public struct DependencyName: ArgumentKind {
@@ -219,7 +220,7 @@ public struct DependencyName: ArgumentKind {
         name = argument
     }
 
-    public static var completion: ShellCompletion = .dependency
+    public static var completion: ShellCompletion = .function("_swift_dependency")
 }
 
 /// An enum representing the strategy to parse argument values.

--- a/Sources/Utility/ArgumentParser.swift
+++ b/Sources/Utility/ArgumentParser.swift
@@ -203,26 +203,6 @@ public struct PathArgument: ArgumentKind {
     public static var completion: ShellCompletion = .filename
 }
 
-public struct ExecutableName: ArgumentKind {
-    public let name: String
-
-    public init(argument: String) throws {
-        name = argument
-    }
-
-    public static var completion: ShellCompletion = .function("_swift_executable")
-}
-
-public struct DependencyName: ArgumentKind {
-    public let name: String
-
-    public init(argument: String) throws {
-        name = argument
-    }
-
-    public static var completion: ShellCompletion = .function("_swift_dependency")
-}
-
 /// An enum representing the strategy to parse argument values.
 public enum ArrayParsingStrategy {
     /// Will parse only the next argument and append all values together: `-Xcc -Lfoo -Xcc -Lbar`.
@@ -290,6 +270,9 @@ protocol ArgumentProtocol: Hashable {
     /// The usage text associated with this argument. Used to generate complete help string.
     var usage: String? { get }
 
+    /// The shell completions to offer as values for this argument.
+    var completion: ShellCompletion { get }
+
     /// Parses and returns the argument values from the parser.
     ///
     // FIXME: Because `ArgumentKindTy`` can't conform to `ArgumentKind`, this
@@ -334,12 +317,15 @@ public final class OptionArgument<Kind>: ArgumentProtocol {
 
     let usage: String?
 
-    init(name: String, shortName: String?, strategy: ArrayParsingStrategy, usage: String?) {
+    let completion: ShellCompletion
+
+    init(name: String, shortName: String?, strategy: ArrayParsingStrategy, usage: String?, completion: ShellCompletion) {
         precondition(!isPositional(argument: name))
         self.name = name
         self.shortName = shortName
         self.strategy = strategy
         self.usage = usage
+        self.completion = completion
     }
 
     func parse(_ kind: ArgumentKind.Type, with parser: inout ArgumentParserProtocol) throws -> [ArgumentKind] {
@@ -388,12 +374,15 @@ public final class PositionalArgument<Kind>: ArgumentProtocol {
 
     let usage: String?
 
-    init(name: String, strategy: ArrayParsingStrategy, optional: Bool, usage: String?) {
+    let completion: ShellCompletion
+
+    init(name: String, strategy: ArrayParsingStrategy, optional: Bool, usage: String?, completion: ShellCompletion) {
         precondition(isPositional(argument: name))
         self.name = name
         self.strategy = strategy
         self.isOptional = optional
         self.usage = usage
+        self.completion = completion
     }
 
     func parse(_ kind: ArgumentKind.Type, with parser: inout ArgumentParserProtocol) throws -> [ArgumentKind] {
@@ -439,6 +428,8 @@ final class AnyArgument: ArgumentProtocol, CustomStringConvertible {
 
     let usage: String?
 
+    let completion: ShellCompletion
+
     /// The argument kind this holds, used while initializing that argument.
     let kind: ArgumentKind.Type
 
@@ -455,6 +446,7 @@ final class AnyArgument: ArgumentProtocol, CustomStringConvertible {
         self.strategy = argument.strategy
         self.isOptional = argument.isOptional
         self.usage = argument.usage
+        self.completion = argument.completion
         self.parseClosure = argument.parse(_:with:)
         isArray = false
     }
@@ -467,6 +459,7 @@ final class AnyArgument: ArgumentProtocol, CustomStringConvertible {
         self.strategy = argument.strategy
         self.isOptional = argument.isOptional
         self.usage = argument.usage
+        self.completion = argument.completion
         self.parseClosure = argument.parse(_:with:)
         isArray = true
     }
@@ -640,11 +633,12 @@ public final class ArgumentParser {
         option: String,
         shortName: String? = nil,
         kind: T.Type,
-        usage: String? = nil
+        usage: String? = nil,
+        completion: ShellCompletion? = nil
     ) -> OptionArgument<T> {
         assert(!optionArguments.contains(where: { $0.name == option }), "Can not define an option twice")
 
-        let argument = OptionArgument<T>(name: option, shortName: shortName, strategy: .oneByOne, usage: usage)
+        let argument = OptionArgument<T>(name: option, shortName: shortName, strategy: .oneByOne, usage: usage, completion: completion ?? T.completion)
         optionArguments.append(AnyArgument(argument))
         return argument
     }
@@ -655,11 +649,12 @@ public final class ArgumentParser {
         shortName: String? = nil,
         kind: [T].Type,
         strategy: ArrayParsingStrategy = .upToNextOption,
-        usage: String? = nil
+        usage: String? = nil,
+        completion: ShellCompletion? = nil
     ) -> OptionArgument<[T]> {
         assert(!optionArguments.contains(where: { $0.name == option }), "Can not define an option twice")
 
-        let argument = OptionArgument<[T]>(name: option, shortName: shortName, strategy: strategy, usage: usage)
+        let argument = OptionArgument<[T]>(name: option, shortName: shortName, strategy: strategy, usage: usage, completion: completion ?? T.completion)
         optionArguments.append(AnyArgument(argument))
         return argument
     }
@@ -671,7 +666,8 @@ public final class ArgumentParser {
         positional: String,
         kind: T.Type,
         optional: Bool = false,
-        usage: String? = nil
+        usage: String? = nil,
+        completion: ShellCompletion? = nil
     ) -> PositionalArgument<T> {
         precondition(subparsers.isEmpty, "Positional arguments are not supported with subparsers")
         precondition(canAcceptPositionalArguments, "Can not accept more positional arguments")
@@ -680,7 +676,7 @@ public final class ArgumentParser {
             canAcceptPositionalArguments = false
         }
 
-        let argument = PositionalArgument<T>(name: positional, strategy: .oneByOne, optional: optional, usage: usage)
+        let argument = PositionalArgument<T>(name: positional, strategy: .oneByOne, optional: optional, usage: usage, completion: completion ?? T.completion)
         positionalArguments.append(AnyArgument(argument))
         return argument
     }
@@ -693,7 +689,8 @@ public final class ArgumentParser {
         kind: [T].Type,
         optional: Bool = false,
         strategy: ArrayParsingStrategy = .upToNextOption,
-        usage: String? = nil
+        usage: String? = nil,
+        completion: ShellCompletion? = nil
     ) -> PositionalArgument<[T]> {
         precondition(subparsers.isEmpty, "Positional arguments are not supported with subparsers")
         precondition(canAcceptPositionalArguments, "Can not accept more positional arguments")
@@ -702,7 +699,7 @@ public final class ArgumentParser {
             canAcceptPositionalArguments = false
         }
 
-        let argument = PositionalArgument<[T]>(name: positional, strategy: strategy, optional: optional, usage: usage)
+        let argument = PositionalArgument<[T]>(name: positional, strategy: strategy, optional: optional, usage: usage, completion: completion ?? T.completion)
         positionalArguments.append(AnyArgument(argument))
         return argument
     }

--- a/Sources/Utility/ArgumentParserShellCompletion.swift
+++ b/Sources/Utility/ArgumentParserShellCompletion.swift
@@ -135,7 +135,7 @@ extension ArgumentParser {
     }
 
     fileprivate func generateBashCompletion(_ argument: AnyArgument, on stream: OutputByteStream) {
-        switch argument.kind.completion {
+        switch argument.completion {
         case .none:
             // return; no value to complete
             stream <<< "            return\n"
@@ -264,7 +264,7 @@ extension ArgumentParser {
             .replace(in: argument.usage ?? " ", with: "")
             .replacingOccurrences(of: "\"", with: "\\\"")
 
-        switch argument.kind.completion {
+        switch argument.completion {
         case .none: stream <<< ":\(message): "
         case .unspecified: break
         case .filename: stream <<< ":\(message):_files"

--- a/Sources/Utility/ArgumentParserShellCompletion.swift
+++ b/Sources/Utility/ArgumentParserShellCompletion.swift
@@ -154,6 +154,18 @@ extension ArgumentParser {
                             return
 
                 """
+        case .dependency:
+            stream <<< """
+                            _swift_dependency
+                            return
+
+                """
+        case .executable:
+            stream <<< """
+                            _swift_executable
+                            return
+
+                """
         }
     }
 
@@ -268,6 +280,8 @@ extension ArgumentParser {
                 stream <<< " '\(value)[\(description)]'"
             }
             stream <<< "}"
+        case .dependency: stream <<< ":\(message):_swift_dependency"
+        case .executable: stream <<< ":\(message):_swift_executable"
         }
     }
 }

--- a/Sources/Utility/ArgumentParserShellCompletion.swift
+++ b/Sources/Utility/ArgumentParserShellCompletion.swift
@@ -154,15 +154,9 @@ extension ArgumentParser {
                             return
 
                 """
-        case .dependency:
+        case .function(let name):
             stream <<< """
-                            _swift_dependency
-                            return
-
-                """
-        case .executable:
-            stream <<< """
-                            _swift_executable
+                            \(name)
                             return
 
                 """
@@ -280,8 +274,7 @@ extension ArgumentParser {
                 stream <<< " '\(value)[\(description)]'"
             }
             stream <<< "}"
-        case .dependency: stream <<< ":\(message):_swift_dependency"
-        case .executable: stream <<< ":\(message):_swift_executable"
+        case .function(let name): stream <<< ":\(message):\(name)"
         }
     }
 }


### PR DESCRIPTION
This PR enables shell completions for dependencies:

```
$ swift package edit A[tab]
$ swift package edit Alamofire
```

and executables:

```
$ swift run [tab]
$ swift run lark-generate-client
```