### PR TITLE
Use truncatingBitPattern instead of the newer methods

### DIFF
--- a/Sources/PackageDescription/Version.swift
+++ b/Sources/PackageDescription/Version.swift
@@ -62,7 +62,7 @@ extension Version: Hashable {
         if let build = buildMetadataIdentifier {
             result = (result &* mul) ^ UInt64(bitPattern: Int64(build.hashValue))
         }
-        return Int(truncatingIfNeeded: result)
+        return Int(truncatingBitPattern: result)
     }
 }
 

--- a/Sources/PackageDescription4/Version.swift
+++ b/Sources/PackageDescription4/Version.swift
@@ -63,7 +63,7 @@ extension Version: Hashable {
         result = (result &* mul) ^ UInt64(bitPattern: Int64(patch.hashValue))
         result = prereleaseIdentifiers.reduce(result, { ($0 &* mul) ^ UInt64(bitPattern: Int64($1.hashValue)) })
         result = buildMetadataIdentifiers.reduce(result, { ($0 &* mul) ^ UInt64(bitPattern: Int64($1.hashValue)) })
-        return Int(truncatingIfNeeded: result)
+        return Int(truncatingBitPattern: result)
     }
 }
 

--- a/Sources/Utility/Version.swift
+++ b/Sources/Utility/Version.swift
@@ -65,7 +65,7 @@ extension Version: Hashable {
         result = (result &* mul) ^ UInt64(bitPattern: Int64(patch.hashValue))
         result = prereleaseIdentifiers.reduce(result, { ($0 &* mul) ^ UInt64(bitPattern: Int64($1.hashValue)) })
         result = buildMetadataIdentifiers.reduce(result, { ($0 &* mul) ^ UInt64(bitPattern: Int64($1.hashValue)) })
-        return Int(truncatingIfNeeded: result)
+        return Int(truncatingBitPattern: result)
     }
 }
 


### PR DESCRIPTION
We can switch back to the new methods once we start building in the Swift 4 mode.