### PR TITLE
Introduce Package Identity

### DIFF
--- a/Sources/Commands/SwiftPackageResolveTool.swift
+++ b/Sources/Commands/SwiftPackageResolveTool.swift
@@ -60,14 +60,14 @@ extension SwiftPackageTool {
                 // FIXME: It would be nice to show information on the resulting
                 // constraints, e.g., how much latitude do we have on particular
                 // dependencies.
-                print("  \(container.url): \(binding.description)")
+                print("  \(container.repository.url): \(binding.description)")
             }
         case .json:
             let json = JSON.dictionary([
                 "name": .string(manifest.name),
                 "constraints": .array(constraints.map({ $0.toJSON() })),
                 "containers": .array(resolver.containers.values.map({ $0.toJSON() })),
-                "result": .dictionary(Dictionary(items: result.map({ ($0.0.url, JSON.string($0.1.description)) }))),
+                "result": .dictionary(Dictionary(items: result.map({ ($0.0.repository.url, JSON.string($0.1.description)) }))),
             ])
             print(json.toString())
         }
@@ -76,7 +76,7 @@ extension SwiftPackageTool {
 
 // MARK: - JSON Convertible
 
-extension PackageContainerConstraint where T == RepositorySpecifier {
+extension PackageContainerConstraint where T == PackageReference {
     public func toJSON() -> JSON {
         let requirement: JSON
         switch self.requirement {
@@ -89,7 +89,7 @@ extension PackageContainerConstraint where T == RepositorySpecifier {
             requirement = .string("revision")
         }
         return .dictionary([
-            "identifier": .string(identifier.url),
+            "identifier": .string(identifier.repository.url),
             "requirement": requirement,
         ])
     }
@@ -127,7 +127,7 @@ extension RepositoryPackageContainer: JSONSerializable {
         })
 
         return .dictionary([
-            "identifier": .string(identifier.url),
+            "identifier": .string(identifier.repository.url),
             "versions": .dictionary(Dictionary(items: depByVersions)),
         ])
     }

--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -36,6 +36,14 @@ public struct PackageGraphRoot {
         /// The requirement of the package.
         public let requirement: Requirement
 
+        /// Create the package reference object for the dependency.
+        public func createPackageRef() -> PackageReference {
+            return PackageReference(
+                identity: PackageReference.computeIdentity(packageURL: url),
+                repository: RepositorySpecifier(url: url)
+            )
+        }
+
         public init(
             url: String,
             requirement: Requirement,
@@ -64,7 +72,9 @@ public struct PackageGraphRoot {
         let constraints = manifests.flatMap({ $0.package.dependencyConstraints() })
         return constraints + dependencies.map({
             RepositoryPackageConstraint(
-                container: RepositorySpecifier(url: $0.url), requirement: $0.requirement.toConstraintRequirement())
+                container: $0.createPackageRef(),
+                requirement: $0.requirement.toConstraintRequirement()
+            )
         })
     }
 }

--- a/Sources/PackageGraph/RawPackageConstraints.swift
+++ b/Sources/PackageGraph/RawPackageConstraints.swift
@@ -9,15 +9,26 @@
 */
 
 import PackageModel
+import PackageDescription4
 import SourceControl
+
+extension PackageDescription4.Package.Dependency {
+    /// Create the package reference object for the dependency.
+    public func createPackageRef() -> PackageReference {
+        return PackageReference(
+            identity: PackageReference.computeIdentity(packageURL: url),
+            repository: RepositorySpecifier(url: url)
+        )
+    }
+}
 
 extension Manifest.RawPackage {
 
     /// Constructs constraints of the dependencies in the raw package.
     public func dependencyConstraints() -> [RepositoryPackageConstraint] {
         return dependencies.map({
-            RepositoryPackageConstraint(
-                container: RepositorySpecifier(url: $0.url),
+            return RepositoryPackageConstraint(
+                container: $0.createPackageRef(),
                 requirement: $0.requirement.toConstraintRequirement())
         })
     }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -186,11 +186,14 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         }
         let json = try JSON(string: jsonString)
 
+        // The loaded manifest object.
+        let manifest: Manifest
+
         // Load the correct version from JSON.
         switch manifestVersion {
         case .three:
             let pd = try loadPackageDescription(json, baseURL: baseURL)
-            return Manifest(
+            manifest = Manifest(
                 path: inputPath,
                 url: baseURL,
                 package: .v3(pd.package),
@@ -200,10 +203,15 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
         case .four:
             let package = try loadPackageDescription4(json, baseURL: baseURL)
-            return Manifest(
-                path: inputPath, url: baseURL, package: .v4(package),
-                version: version, interpreterFlags: parseResult.interpreterFlags)
+            manifest = Manifest(
+                path: inputPath,
+                url: baseURL,
+                package: .v4(package),
+                version: version,
+                interpreterFlags: parseResult.interpreterFlags)
         }
+
+        return manifest
     }
 
     /// Parse the manifest at the given path to JSON.

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -84,7 +84,7 @@ public enum ResolverDiagnostics {
 
         static func toString(_ constraint: RepositoryPackageConstraint) -> String {
             let stream = BufferedOutputByteStream()
-            stream <<< constraint.identifier.url <<< " @ "
+            stream <<< constraint.identifier.repository.url <<< " @ "
 
             switch constraint.requirement {
             case .versionSet(let set):

--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -10,6 +10,7 @@
 
 import Basic
 import PackageGraph
+import PackageModel
 import SourceControl
 import Utility
 
@@ -39,11 +40,8 @@ public final class ManagedDependency: JSONMappable, JSONSerializable {
         }
     }
 
-    /// The name of the dependency i.e. the package name.
-    public let name: String
-
-    /// The specifier for the dependency.
-    public let repository: RepositorySpecifier
+    /// The package reference.
+    public let packageRef: PackageReference
 
     /// The state of the managed dependency.
     public let state: State
@@ -59,13 +57,11 @@ public final class ManagedDependency: JSONMappable, JSONSerializable {
     var basedOn: ManagedDependency?
 
     init(
-        name: String,
-        repository: RepositorySpecifier,
+        packageRef: PackageReference,
         subpath: RelativePath,
         checkoutState: CheckoutState
     ) {
-        self.name = name
-        self.repository = repository
+        self.packageRef = packageRef
         self.state = .checkout(checkoutState)
         self.basedOn = nil
         self.subpath = subpath
@@ -77,9 +73,8 @@ public final class ManagedDependency: JSONMappable, JSONSerializable {
         unmanagedPath: AbsolutePath?
     ) {
         assert(dependency.state.isCheckout)
-        self.name = dependency.name
         self.basedOn = dependency
-        self.repository = dependency.repository
+        self.packageRef = dependency.packageRef
         self.subpath = subpath
         self.state = .edited(unmanagedPath)
     }
@@ -95,8 +90,7 @@ public final class ManagedDependency: JSONMappable, JSONSerializable {
     }
 
     public init(json: JSON) throws {
-        self.name = try json.get("name")
-        self.repository = try json.get("repositoryURL")
+        self.packageRef = try json.get("packageRef")
         self.subpath = try RelativePath(json.get("subpath"))
         self.basedOn = json.get("basedOn")
         self.state = try json.get("state")
@@ -104,8 +98,7 @@ public final class ManagedDependency: JSONMappable, JSONSerializable {
 
     public func toJSON() -> JSON {
         return .init([
-            "name": name,
-            "repositoryURL": repository.url,
+            "packageRef": packageRef.toJSON(),
             "subpath": subpath.asString,
             "basedOn": basedOn.toJSON(),
             "state": state,
@@ -171,8 +164,16 @@ public final class ManagedDependencies: SimplePersistanceProtocol {
         }
     }
 
+    /// The schema version of the resolved file.
+    ///
+    /// * 2: Package identity.
+    /// * 1: Initial version.
+    static let schemaVersion: Int = 2
+
     /// The current state of managed dependencies.
-    private var dependencyMap: [RepositorySpecifier: ManagedDependency]
+    ///
+    /// Key -> package identity.
+    private var dependencyMap: [String: ManagedDependency]
 
     /// Path to the state file.
     let statePath: AbsolutePath
@@ -187,7 +188,7 @@ public final class ManagedDependencies: SimplePersistanceProtocol {
         self.statePath = statePath
         self.persistence = SimplePersistence(
             fileSystem: fileSystem,
-            schemaVersion: 1,
+            schemaVersion: ManagedDependencies.schemaVersion,
             statePath: statePath)
 
         // Load the state from disk, if possible.
@@ -201,33 +202,26 @@ public final class ManagedDependencies: SimplePersistanceProtocol {
         do {
             try self.persistence.restoreState(self)
         } catch {
-            // FIXME: We should emit a warning here.
+            // FIXME: We should emit a warning here using the diagnostic engine.
+            print("\(error)")
         }
     }
 
-    public subscript(_ url: String) -> ManagedDependency? {
-        return dependencyMap[RepositorySpecifier(url: url)]
-    }
-
-    public subscript(_ repository: RepositorySpecifier) -> ManagedDependency? {
+    public subscript(forIdentity identity: String) -> ManagedDependency? {
         get {
-            return dependencyMap[repository]
+            assert(identity == identity.lowercased())
+            return dependencyMap[identity]
         }
         set {
-            dependencyMap[repository] = newValue
+            assert(identity == identity.lowercased())
+            dependencyMap[identity] = newValue
         }
-    }
-
-    /// Returns the dependency given a name, if found.
-    subscript(forName name: String) -> ManagedDependency? {
-        // FIXME: Improve complexity to O(1).
-        return dependencyMap.values.first(where: { $0.name == name })
     }
 
     /// Returns the dependency given a name.
-    func dependency(forName name: String) throws -> ManagedDependency {
-        guard let dependency = self[forName: name] else {
-            throw Error.dependencyNotFound(name: name)
+    func dependency(forIdentity identity: String) throws -> ManagedDependency {
+        guard let dependency = self[forIdentity: identity] else {
+            throw Error.dependencyNotFound(name: identity)
         }
         return dependency 
     }
@@ -247,7 +241,7 @@ public final class ManagedDependencies: SimplePersistanceProtocol {
 
     public func restore(from json: JSON) throws {
         self.dependencyMap = try Dictionary(items:
-            json.get("dependencies").map({ ($0.repository, $0) })
+            json.get("dependencies").map({ ($0.packageRef.identity, $0) })
         )
     }
 

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -376,8 +376,8 @@ final class PackageToolTests: XCTestCase {
                 XCTAssertEqual(pinsStore.pins.map{$0}.count, 2)
                 for pkg in ["bar", "baz"] {
                     let pin = pinsStore.pinsMap[pkg]!
-                    XCTAssertEqual(pin.package, pkg)
-                    XCTAssert(pin.repository.url.hasSuffix(pkg))
+                    XCTAssertEqual(pin.packageRef.identity, pkg)
+                    XCTAssert(pin.packageRef.repository.url.hasSuffix(pkg))
                     XCTAssertEqual(pin.state.version, "1.2.3")
                 }
             }

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -98,7 +98,8 @@ class DependencyResolverPerfTests: XCTestCasePerf {
                 repositoryManager: repositoryManager, manifestLoader: ManifestLoader(resources: Resources.default))
 
             let resolver = DependencyResolver(containerProvider, GitRepositoryResolutionHelper.DummyResolverDelegate())
-            let constraints = RepositoryPackageConstraint(container: RepositorySpecifier(url: dep.asString), versionRequirement: .range("1.0.0"..<"2.0.0"))
+            let container = PackageReference(identity: "dep", repository: RepositorySpecifier(url: dep.asString))
+            let constraints = RepositoryPackageConstraint(container: container, versionRequirement: .range("1.0.0"..<"2.0.0"))
             let result = try! resolver.resolve(constraints: [constraints])
             XCTAssert(result.count == 1)
 
@@ -316,7 +317,7 @@ struct GitRepositoryResolutionHelper {
         return manifestGraph.rootManifest.package.dependencyConstraints()
     }
 
-    func resolve(prefetchingEnabled: Bool = false) -> [(container: RepositorySpecifier, binding: BoundVersion)] {
+    func resolve(prefetchingEnabled: Bool = false) -> [(container: PackageReference, binding: BoundVersion)] {
         let repositoriesPath = path.appending(component: "repositories")
         _ = try? systemQuietly(["rm", "-r", repositoriesPath.asString])
         let repositoryManager = RepositoryManager(path: repositoriesPath, provider: GitRepositoryProvider(), delegate: DummyRepositoryManagerDelegate())

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -12,6 +12,7 @@ import XCTest
 
 import Basic
 import Utility
+import PackageGraph
 import TestSupport
 import SourceControl
 @testable import Workspace
@@ -26,12 +27,14 @@ final class PinsStoreTests: XCTestCase {
         let fooRepo = RepositorySpecifier(url: "/foo")
         let barRepo = RepositorySpecifier(url: "/bar")
         let revision = Revision(identifier: "81513c8fd220cf1ed1452b98060cd80d3725c5b7")
+        let fooRef = PackageReference(identity: foo, repository: fooRepo)
+        let barRef = PackageReference(identity: bar, repository: barRepo)
 
         let state = CheckoutState(revision: revision, version: v1)
-        let pin = PinsStore.Pin(package: foo, repository: fooRepo, state: state)
+        let pin = PinsStore.Pin(packageRef: fooRef, state: state)
         // We should be able to round trip from JSON.
         XCTAssertEqual(try PinsStore.Pin(json: pin.toJSON()), pin)
-        
+
         let fs = InMemoryFileSystem()
         let pinsFile = AbsolutePath("/pinsfile.txt")
         var store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
@@ -39,7 +42,7 @@ final class PinsStoreTests: XCTestCase {
         XCTAssert(!fs.exists(pinsFile))
         XCTAssert(store.pins.map{$0}.isEmpty)
 
-        store.pin(package: foo, repository: fooRepo, state: state)
+        store.pin(packageRef: fooRef, state: state)
         try store.saveState()
 
         XCTAssert(fs.exists(pinsFile))
@@ -51,16 +54,16 @@ final class PinsStoreTests: XCTestCase {
             XCTAssert(s.pins.map{$0}.count == 1)
             XCTAssertEqual(s.pinsMap[bar], nil)
             let fooPin = s.pinsMap[foo]!
-            XCTAssertEqual(fooPin.package, foo)
+            XCTAssertEqual(fooPin.packageRef, fooRef)
             XCTAssertEqual(fooPin.state.version, v1)
             XCTAssertEqual(fooPin.state.revision, revision)
             XCTAssertEqual(fooPin.state.description, v1.description)
         }
-        
+
         // We should be able to pin again.
-        store.pin(package: foo, repository: fooRepo, state: state)
-        store.pin(package: foo, repository: fooRepo, state: CheckoutState(revision: revision, version: "1.0.2"))
-        store.pin(package: bar, repository: barRepo, state: state)
+        store.pin(packageRef: fooRef, state: state)
+        store.pin(packageRef: fooRef, state: CheckoutState(revision: revision, version: "1.0.2"))
+        store.pin(packageRef: barRef, state: state)
         try store.saveState()
 
         store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
@@ -68,7 +71,7 @@ final class PinsStoreTests: XCTestCase {
 
         // Test branch pin.
         do {
-            store.pin(package: bar, repository: barRepo, state: CheckoutState(revision: revision, branch: "develop"))
+            store.pin(packageRef: barRef, state: CheckoutState(revision: revision, branch: "develop"))
             try store.saveState()
             store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
 
@@ -81,7 +84,7 @@ final class PinsStoreTests: XCTestCase {
 
         // Test revision pin.
         do {
-            store.pin(package: bar, repository: barRepo, state: CheckoutState(revision: revision))
+            store.pin(packageRef: barRef, state: CheckoutState(revision: revision))
             try store.saveState()
             store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
 


### PR DESCRIPTION
    Introduce Package Identity

    Package identity will be used to uniquely identify packages during
    dependency resolution.

    By default, the package identity is the basename of the package
    repository URL. In future, the package references in the manifest file
    will be allowed to override the name that should be used instead of the
    basename. The package identity should always match (case insenstive for
    now) the name of the package. This will be enforced via error checking
    in future, i.e., once we have the API for overriding.

    The commit will make dependency resolver to use the package identity
    instead of package URL. The package graph is still constructed using the
    package URL but that will be updated as well in upcoming commits.