### PR TITLE
[Workspace] Don't try to associate all packages with managed dependency

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -556,16 +556,17 @@ extension Workspace {
 
         // Create the dependency map by associating each resolved package with its corresponding managed dependency.
         let managedDependenciesByIdentity = Dictionary(items: managedDependencies.values.map({ ($0.packageRef.identity, $0) }))
-        let dependencyMap: [ResolvedPackage: ManagedDependency] = Dictionary(items: graph.packages.map({ package in
+        let dependencyMap = graph.packages.flatMap({ package -> (ResolvedPackage, ManagedDependency)? in
             // FIXME: We should use package name directly once this radar is fixed:
             // <rdar://problem/33693433> Ensure that identity and package name
             // are the same once we have an API to specify identity in the
             // manifest file
             let identity = PackageReference.computeIdentity(packageURL: package.manifest.url)
-            return (package, managedDependenciesByIdentity[identity]!)
-        }))
+            guard let dependency = managedDependenciesByIdentity[identity] else { return nil }
+            return (package, dependency)
+        })
 
-        return (graph, dependencyMap)
+        return (graph, Dictionary(items: dependencyMap))
     }
 
     /// Loads and returns manifests at the given paths.

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -1844,7 +1844,7 @@ final class WorkspaceTests: XCTestCase {
             fileSystem: fs,
             repositoryProvider: provider)
         let diagnostics = DiagnosticsEngine()
-        let root = WorkspaceRoot(packages: [], dependencies: [
+        let root = WorkspaceRoot(packages: [path], dependencies: [
             .init(url: "/RootPkg/B", requirement: .exact(v1.asPD4Version), location: "rootB"),
             .init(url: "/RootPkg/A", requirement: .exact(v1.asPD4Version), location: "rootA"),
         ])
@@ -1853,8 +1853,8 @@ final class WorkspaceTests: XCTestCase {
 
         // Sanity.
         XCTAssertFalse(diagnostics.hasErrors)
-        XCTAssertEqual(data.graph.rootPackages, [])
-        XCTAssertEqual(data.graph.packages.map{$0.name}.sorted(), ["A", "B"])
+        XCTAssertEqual(data.graph.rootPackages.map{$0.name}, ["Root"])
+        XCTAssertEqual(data.graph.packages.map{$0.name}.sorted(), ["A", "B", "Root"])
 
         // Check package association.
         XCTAssertEqual(data.dependencyMap[data.graph.lookup("A")]?.packageRef.identity, "a")


### PR DESCRIPTION
The root packages do not have a managed dependency entry so we can't
associate all packages in the graph with a managed dependency. This was
a regression from package identity refactor. Updated the graph data test
to have a root package, so this doesn't happen in future.