### PR TITLE
[PackageGraph] Add support for "local" packages in resolver

### DIFF
--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -238,6 +238,11 @@ public protocol PackageContainer {
     /// - Throws: If the revision could not be resolved; this will abort
     ///   dependency resolution completely.
     func getDependencies(at revision: String) throws -> [PackageContainerConstraint<Identifier>]
+
+    /// Fetch the dependencies of an unversioned package container.
+    ///
+    /// NOTE: This method should not be called on a versioned container.
+    func getUnversionedDependencies() throws -> [PackageContainerConstraint<Identifier>]
 }
 
 /// An interface for resolving package containers.
@@ -273,12 +278,12 @@ public struct PackageContainerConstraint<T: PackageContainerIdentifier>: CustomS
         case revision(String)
 
         /// Un-versioned requirement i.e. a version should not resolved.
-        case unversioned([PackageContainerConstraint<Identifier>])
+        case unversioned
 
         public static func == (lhs: Requirement, rhs: Requirement) -> Bool {
             switch (lhs, rhs) {
-            case (.unversioned(let lhs), .unversioned(let rhs)):
-                return lhs == rhs
+            case (.unversioned, .unversioned):
+                return true
             case (.unversioned, _):
                 return false
             case (.revision(let lhs), .revision(let rhs)):
@@ -441,12 +446,8 @@ public struct PackageContainerConstraintSet<C: PackageContainer>: Collection {
             var result = self
             result.constraints[identifier] = .versionSet(intersection)
             return result
-        case (.unversioned(let newConstraints), .unversioned(let currentConstraints)):
-            // Two unversioned requirements can only merge if they both impose the same constraints.
-            if newConstraints == currentConstraints {
-                return self
-            }
-            return nil
+        case (.unversioned, .unversioned):
+            return self
         case (.unversioned, _):
             // Unversioned requirements always *wins*.
             var result = self
@@ -977,7 +978,10 @@ public class DependencyResolver<
         }
 
         switch allConstraints[container.identifier] {
-        case .unversioned(let constraints):
+        case .unversioned:
+            guard let constraints = self.safely({ try container.getUnversionedDependencies() }) else {
+                return AnySequence([])
+            }
             // Merge the dependencies of unversioned constraint into the assignment.
             return merge(constraints: constraints, binding: .unversioned)
 
@@ -1299,7 +1303,7 @@ private struct ResolverDebugger<
 
             // Set all disallowed packages to unversioned, so they stay out of resolution.
             constraints += disallowedPackages.map({
-                Constraint(container: $0, requirement: .unversioned([]))
+                Constraint(container: $0, requirement: .unversioned)
             })
 
             let allowedPins = Set(allowedChanges.flatMap({ $0.allowedPin }))

--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -40,7 +40,7 @@ public struct PackageGraphRoot {
         public func createPackageRef() -> PackageReference {
             return PackageReference(
                 identity: PackageReference.computeIdentity(packageURL: url),
-                repository: RepositorySpecifier(url: url)
+                path: url
             )
         }
 

--- a/Sources/PackageGraph/RawPackageConstraints.swift
+++ b/Sources/PackageGraph/RawPackageConstraints.swift
@@ -17,7 +17,7 @@ extension PackageDescription4.Package.Dependency {
     public func createPackageRef() -> PackageReference {
         return PackageReference(
             identity: PackageReference.computeIdentity(packageURL: url),
-            repository: RepositorySpecifier(url: url)
+            path: url
         )
     }
 }

--- a/Sources/TestSupport/MockDependencyResolver.swift
+++ b/Sources/TestSupport/MockDependencyResolver.swift
@@ -80,6 +80,8 @@ public final class MockPackageContainer: PackageContainer {
 
     let dependencies: [String: [Dependency]]
 
+    public var unversionedDeps: [MockPackageConstraint] = []
+
     /// Contains the versions for which the dependencies were requested by resolver using getDependencies().
     public var requestedVersions: Set<Version> = []
 
@@ -102,6 +104,10 @@ public final class MockPackageContainer: PackageContainer {
             let (name, requirement) = value
             return MockPackageConstraint(container: name, requirement: requirement)
         })
+    }
+
+    public func getUnversionedDependencies() -> [MockPackageConstraint] {
+        return unversionedDeps
     }
 
     public convenience init(

--- a/Sources/TestSupport/MockManifestLoader.swift
+++ b/Sources/TestSupport/MockManifestLoader.swift
@@ -13,6 +13,7 @@ import func XCTest.XCTFail
 import Basic
 import PackageModel
 import PackageLoading
+import PackageGraph
 import Utility
 
 public enum MockManifestLoaderError: Swift.Error {
@@ -34,7 +35,7 @@ public struct MockManifestLoader: ManifestLoaderProtocol {
         public let version: Version?
 
         public init(url: String, version: Version? = nil) {
-            self.url = url
+            self.url = PackageReference.computeIdentity(packageURL: url)
             self.version = version
         }
 
@@ -60,7 +61,7 @@ public struct MockManifestLoader: ManifestLoaderProtocol {
         manifestVersion: ManifestVersion,
         fileSystem: FileSystem?
     ) throws -> PackageModel.Manifest {
-        let key = Key(url: baseURL, version: version)
+        let key = Key(url: PackageReference.computeIdentity(packageURL: baseURL), version: version)
         if let result = manifests[key] {
             return result
         }

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -91,10 +91,8 @@ public enum ResolverDiagnostics {
                 stream <<< set.description
             case .revision(let revision):
                 stream <<< revision
-            case .unversioned(let constraints):
-                stream <<< "unversioned ("
-                stream <<< constraints.map({ $0.description }).joined(separator: ", ")
-                stream <<< ")"
+            case .unversioned:
+                stream <<< "unversioned"
             }
 
             return stream.bytes.asString!

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -98,7 +98,7 @@ class DependencyResolverPerfTests: XCTestCasePerf {
                 repositoryManager: repositoryManager, manifestLoader: ManifestLoader(resources: Resources.default))
 
             let resolver = DependencyResolver(containerProvider, GitRepositoryResolutionHelper.DummyResolverDelegate())
-            let container = PackageReference(identity: "dep", repository: RepositorySpecifier(url: dep.asString))
+            let container = PackageReference(identity: "dep", path: dep.asString)
             let constraints = RepositoryPackageConstraint(container: container, versionRequirement: .range("1.0.0"..<"2.0.0"))
             let result = try! resolver.resolve(constraints: [constraints])
             XCTAssert(result.count == 1)

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -36,7 +36,7 @@ private class MockRepository: Repository {
     }
 
     var packageRef: PackageReference {
-        return PackageReference(identity: url.lowercased(), repository: specifier)
+        return PackageReference(identity: url.lowercased(), path: url)
     }
 
     var tags: [String] {
@@ -254,7 +254,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         let provider = RepositoryPackageContainerProvider(
                 repositoryManager: repositoryManager,
                 manifestLoader: MockManifestLoader(manifests: [:]))
-        let ref = PackageReference(identity: "foo", repository: specifier)
+        let ref = PackageReference(identity: "foo", path: repoPath.asString)
         let container = try await { provider.getContainer(for: ref, completion: $0) }
         let v = container.versions(filter: { _ in true }).map{$0}
         XCTAssertEqual(v, ["2.0.3", "1.0.3", "1.0.2", "1.0.1", "1.0.0"])
@@ -303,7 +303,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
 
         do {
             let provider = createProvider(ToolsVersion(version: "3.1.0"))
-            let ref = PackageReference(identity: "foo", repository: specifier)
+            let ref = PackageReference(identity: "foo", path: specifier.url)
             let container = try await { provider.getContainer(for: ref, completion: $0) }
             let v = container.versions(filter: { _ in true }).map{$0}
             XCTAssertEqual(v, ["1.0.1", "1.0.0"])
@@ -311,7 +311,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
 
         do {
             let provider = createProvider(ToolsVersion(version: "4.0.0"))
-            let ref = PackageReference(identity: "foo", repository: specifier)
+            let ref = PackageReference(identity: "foo", path: specifier.url)
             let container = try await { provider.getContainer(for: ref, completion: $0) }
             let v = container.versions(filter: { _ in true }).map{$0}
             XCTAssertEqual(v, ["1.0.2", "1.0.1", "1.0.0"])
@@ -319,7 +319,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
 
         do {
             let provider = createProvider(ToolsVersion(version: "3.0.0"))
-            let ref = PackageReference(identity: "foo", repository: specifier)
+            let ref = PackageReference(identity: "foo", path: specifier.url)
             let container = try await { provider.getContainer(for: ref, completion: $0) }
             let v = container.versions(filter: { _ in true }).map{$0}
             XCTAssertEqual(v, [])

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -27,8 +27,8 @@ final class PinsStoreTests: XCTestCase {
         let fooRepo = RepositorySpecifier(url: "/foo")
         let barRepo = RepositorySpecifier(url: "/bar")
         let revision = Revision(identifier: "81513c8fd220cf1ed1452b98060cd80d3725c5b7")
-        let fooRef = PackageReference(identity: foo, repository: fooRepo)
-        let barRef = PackageReference(identity: bar, repository: barRepo)
+        let fooRef = PackageReference(identity: foo, path: fooRepo.url)
+        let barRef = PackageReference(identity: bar, path: barRepo.url)
 
         let state = CheckoutState(revision: revision, version: v1)
         let pin = PinsStore.Pin(packageRef: fooRef, state: state)

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -154,7 +154,7 @@ final class WorkspaceTests: XCTestCase {
             // Create a test repository.
             let testRepoPath = path.appending(component: "test-repo")
             let testRepoSpec = RepositorySpecifier(url: testRepoPath.asString)
-            let testRepoRef = PackageReference(identity: "test-repo", repository: testRepoSpec)
+            let testRepoRef = PackageReference(identity: "test-repo", path: testRepoSpec.url)
             try makeDirectories(testRepoPath)
             initGitRepo(testRepoPath)
             let testRepo = GitRepository(path: testRepoPath)
@@ -265,7 +265,7 @@ final class WorkspaceTests: XCTestCase {
             for name in ["A", "AA"] {
                 let revision = try GitRepository(path: AbsolutePath(graph.repo(name).url)).getCurrentRevision()
                 let state = CheckoutState(revision: revision, version: v1)
-                let packageRef = PackageReference(identity: name.lowercased(), repository: graph.repo(name))
+                let packageRef = PackageReference(identity: name.lowercased(), path: graph.repo(name).url)
                 _ = try workspace.clone(package: packageRef, at: state)
             }
 
@@ -311,7 +311,7 @@ final class WorkspaceTests: XCTestCase {
             for name in ["A"] {
                 let revision = try GitRepository(path: AbsolutePath(manifestGraph.repo(name).url)).getCurrentRevision()
                 let state = CheckoutState(revision: revision, version: v1)
-                let packageRef = PackageReference(identity: name.lowercased(), repository: manifestGraph.repo(name))
+                let packageRef = PackageReference(identity: name.lowercased(), path: manifestGraph.repo(name).url)
                 _ = try workspace.clone(package: packageRef, at: state)
             }
 
@@ -395,7 +395,7 @@ final class WorkspaceTests: XCTestCase {
             for name in ["A"] {
                 let revision = try GitRepository(path: AbsolutePath(manifestGraph.repo(name).url)).getCurrentRevision()
                 let state = CheckoutState(revision: revision, version: v1)
-                let packageRef = PackageReference(identity: name.lowercased(), repository: manifestGraph.repo(name))
+                let packageRef = PackageReference(identity: name.lowercased(), path: manifestGraph.repo(name).url)
                 _ = try workspace.clone(package: packageRef, at: state)
             }
 
@@ -625,7 +625,7 @@ final class WorkspaceTests: XCTestCase {
             // Create a test repository.
             let testRepoPath = path.appending(component: "test-repo")
             let testRepoSpec = RepositorySpecifier(url: testRepoPath.asString)
-            let testRepoRef = PackageReference(identity: "test-repo", repository: testRepoSpec)
+            let testRepoRef = PackageReference(identity: "test-repo", path: testRepoSpec.url)
             try makeDirectories(testRepoPath)
             initGitRepo(testRepoPath)
 
@@ -1880,9 +1880,9 @@ final class WorkspaceTests: XCTestCase {
         let aRepo = RepositorySpecifier(url: "/A")
         let bRepo = RepositorySpecifier(url: "/B")
         let cRepo = RepositorySpecifier(url: "/C")
-        let aRef = PackageReference(identity: "a", repository: aRepo)
-        let bRef = PackageReference(identity: "b", repository: bRepo)
-        let cRef = PackageReference(identity: "c", repository: cRepo)
+        let aRef = PackageReference(identity: "a", path: aRepo.url)
+        let bRef = PackageReference(identity: "b", path: bRepo.url)
+        let cRef = PackageReference(identity: "c", path: cRepo.url)
         let v1 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.0")
         let v1_1 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.1")
         let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")


### PR DESCRIPTION
A local package is a package present on the file system which may or may
not be under a git repository. These packages should be used as-is and
should not be cloned or managed by SwiftPM. Example of such packages
are: root, edited, local dependencies and multi-package packages.

So far, we only cared about edited packages during the resolution and
used unversioned requirement to handle them. This commit extends that
logic but instead of pre-loading the requirements from an unversioned
package, the container API now has a method to fetch dependencies of
unversioned package.