### PR TITLE
[SR-5624] Fix to bring "dependencies" key to the last order of output json

### DIFF
--- a/Sources/Basic/JSON.swift
+++ b/Sources/Basic/JSON.swift
@@ -92,9 +92,9 @@ extension JSON: Equatable {
 
 extension JSON {
     /// Encode a JSON item into a string of bytes.
-    public func toBytes(prettyPrint: Bool = false, contentsKeyOrder: (String, String) -> Bool = {a, b in a < b}) -> ByteString {
+    public func toBytes(prettyPrint: Bool = false, sortingKeysBy: (String, String) -> Bool = { $0 < $1 }) -> ByteString {
         let stream = BufferedOutputByteStream()
-        write(to: stream, indent: prettyPrint ? 0 : nil, contentsKeyOrder: contentsKeyOrder)
+        write(to: stream, indent: prettyPrint ? 0 : nil, sortingKeysBy: sortingKeysBy)
         if prettyPrint {
             stream.write("\n")
         }
@@ -102,8 +102,8 @@ extension JSON {
     }
 
     /// Encode a JSON item into a JSON string
-    public func toString(prettyPrint: Bool = false, contentsKeyOrder: (String, String) -> Bool = {a, b in a < b}) -> String {
-        guard let contents = self.toBytes(prettyPrint: prettyPrint, contentsKeyOrder: contentsKeyOrder).asString else {
+    public func toString(prettyPrint: Bool = false, sortingKeysBy: (String, String) -> Bool = { $0 < $1 }) -> String {
+        guard let contents = self.toBytes(prettyPrint: prettyPrint, sortingKeysBy: sortingKeysBy).asString else {
             fatalError("Failed to serialize JSON: \(self)")
         }
         return contents
@@ -116,7 +116,7 @@ extension JSON: ByteStreamable {
         write(to: stream, indent: nil)
     }
 
-    public func write(to stream: OutputByteStream, indent: Int?, contentsKeyOrder: (String, String) -> Bool = {a, b in a < b}) {
+    public func write(to stream: OutputByteStream, indent: Int?, sortingKeysBy areInIncreasingOrder: (String, String) -> Bool = { $0 < $1 }) {
         func indentStreamable(offset: Int? = nil) -> ByteStreamable {
             return Format.asRepeating(string: " ", count: indent.flatMap({ $0 + (offset ?? 0) }) ?? 0)
         }
@@ -143,7 +143,7 @@ extension JSON: ByteStreamable {
             stream <<< (shouldIndent ? "\n" : "") <<< indentStreamable() <<< "]"
         case .dictionary(let contents):
             stream <<< "{" <<< (shouldIndent ? "\n" : "")
-            for (i, key) in contents.keys.sorted(by: contentsKeyOrder).enumerated() {
+            for (i, key) in contents.keys.sorted(by: areInIncreasingOrder).enumerated() {
                 if i != 0 { stream <<< "," <<< (shouldIndent ? "\n" : " ") }
                 stream <<<  indentStreamable(offset: 2) <<< Format.asJSON(key) <<< ": "
                 contents[key]!.write(to: stream, indent: indent.flatMap({ $0 + 2 }))

--- a/Sources/Basic/JSON.swift
+++ b/Sources/Basic/JSON.swift
@@ -92,9 +92,9 @@ extension JSON: Equatable {
 
 extension JSON {
     /// Encode a JSON item into a string of bytes.
-    public func toBytes(prettyPrint: Bool = false) -> ByteString {
+    public func toBytes(prettyPrint: Bool = false, contentsKeyOrder: (String, String) -> Bool = {a, b in a < b}) -> ByteString {
         let stream = BufferedOutputByteStream()
-        write(to: stream, indent: prettyPrint ? 0 : nil)
+        write(to: stream, indent: prettyPrint ? 0 : nil, contentsKeyOrder: contentsKeyOrder)
         if prettyPrint {
             stream.write("\n")
         }
@@ -102,8 +102,8 @@ extension JSON {
     }
 
     /// Encode a JSON item into a JSON string
-    public func toString(prettyPrint: Bool = false) -> String {
-        guard let contents = self.toBytes(prettyPrint: prettyPrint).asString else {
+    public func toString(prettyPrint: Bool = false, contentsKeyOrder: (String, String) -> Bool = {a, b in a < b}) -> String {
+        guard let contents = self.toBytes(prettyPrint: prettyPrint, contentsKeyOrder: contentsKeyOrder).asString else {
             fatalError("Failed to serialize JSON: \(self)")
         }
         return contents
@@ -116,7 +116,7 @@ extension JSON: ByteStreamable {
         write(to: stream, indent: nil)
     }
 
-    public func write(to stream: OutputByteStream, indent: Int?) {
+    public func write(to stream: OutputByteStream, indent: Int?, contentsKeyOrder: (String, String) -> Bool = {a, b in a < b}) {
         func indentStreamable(offset: Int? = nil) -> ByteStreamable {
             return Format.asRepeating(string: " ", count: indent.flatMap({ $0 + (offset ?? 0) }) ?? 0)
         }
@@ -142,9 +142,8 @@ extension JSON: ByteStreamable {
             }
             stream <<< (shouldIndent ? "\n" : "") <<< indentStreamable() <<< "]"
         case .dictionary(let contents):
-            // We always output in a deterministic order.
             stream <<< "{" <<< (shouldIndent ? "\n" : "")
-            for (i, key) in contents.keys.sorted().enumerated() {
+            for (i, key) in contents.keys.sorted(by: contentsKeyOrder).enumerated() {
                 if i != 0 { stream <<< "," <<< (shouldIndent ? "\n" : " ") }
                 stream <<<  indentStreamable(offset: 2) <<< Format.asJSON(key) <<< ": "
                 contents[key]!.write(to: stream, indent: indent.flatMap({ $0 + 2 }))

--- a/Sources/Commands/show-dependencies.swift
+++ b/Sources/Commands/show-dependencies.swift
@@ -107,7 +107,13 @@ private final class JSONDumper: DependenciesDumper {
                 ])
         }
 
-        print(convert(rootpkg).toString(prettyPrint: true))
+        print(convert(rootpkg).toString(prettyPrint: true, contentsKeyOrder: contentsKeyOrder(a:b:)))
+    }
+
+    /// To bring `dependencies` key to the last order.
+    /// See: https://bugs.swift.org/browse/SR-5624
+    func contentsKeyOrder(a: String, b: String) -> Bool {
+        return b == "dependencies" ? a > b : a < b
     }
 }
 

--- a/Sources/Commands/show-dependencies.swift
+++ b/Sources/Commands/show-dependencies.swift
@@ -107,13 +107,13 @@ private final class JSONDumper: DependenciesDumper {
                 ])
         }
 
-        print(convert(rootpkg).toString(prettyPrint: true, contentsKeyOrder: contentsKeyOrder(a:b:)))
+        print(convert(rootpkg).toString(prettyPrint: true, sortingKeysBy: sortingKeysBy(a:b:)))
     }
 
     /// To bring `dependencies` key to the last order.
     /// See: https://bugs.swift.org/browse/SR-5624
-    func contentsKeyOrder(a: String, b: String) -> Bool {
-        return b == "dependencies" ? a > b : a < b
+    func sortingKeysBy(a: String, b: String) -> Bool {
+        return (a < b && a != "dependencies") || b == "dependencies"
     }
 }
 

--- a/Tests/BasicTests/JSONTests.swift
+++ b/Tests/BasicTests/JSONTests.swift
@@ -30,12 +30,12 @@ class JSONTests: XCTestCase {
     func testEncodingWithContentsKeyOrder() {
         // Test encoding with customized contents key order.
         func encode(_ item: JSON) -> String {
-            /// See: https://bugs.swift.org/browse/SR-5624
-            func contentsKeyOrder(a: String, b: String) -> Bool {
-                return b == "dependencies" ? a > b : a < b
+            // See: https://bugs.swift.org/browse/SR-5624
+            func sortingKeysBy(a: String, b: String) -> Bool {
+                return (a < b && a != "dependencies") || b == "dependencies"
             }
 
-            return item.toBytes(contentsKeyOrder: contentsKeyOrder(a:b:)).asString ?? "<unrepresentable>"
+            return item.toBytes(sortingKeysBy: sortingKeysBy(a:b:)).asString ?? "<unrepresentable>"
         }
 
         XCTAssertEqual(encode(.dictionary(["name": .string("name"), "url": .string("url"), "version": .string("version"), "path": .string("path"), "dependencies": .array([.string("dependencies")])])),

--- a/Tests/BasicTests/JSONTests.swift
+++ b/Tests/BasicTests/JSONTests.swift
@@ -26,6 +26,21 @@ class JSONTests: XCTestCase {
         XCTAssertEqual(encode(.array([.int(1), .string("hi")])), "[1, \"hi\"]")
         XCTAssertEqual(encode(.dictionary(["a": .int(1), "b": .string("hi")])), "{\"a\": 1, \"b\": \"hi\"}")
     }
+
+    func testEncodingWithContentsKeyOrder() {
+        // Test encoding with customized contents key order.
+        func encode(_ item: JSON) -> String {
+            /// See: https://bugs.swift.org/browse/SR-5624
+            func contentsKeyOrder(a: String, b: String) -> Bool {
+                return b == "dependencies" ? a > b : a < b
+            }
+
+            return item.toBytes(contentsKeyOrder: contentsKeyOrder(a:b:)).asString ?? "<unrepresentable>"
+        }
+
+        XCTAssertEqual(encode(.dictionary(["name": .string("name"), "url": .string("url"), "version": .string("version"), "path": .string("path"), "dependencies": .array([.string("dependencies")])])),
+                       "{\"name\": \"name\", \"path\": \"path\", \"url\": \"url\", \"version\": \"version\", \"dependencies\": [\"dependencies\"]}")
+    }
     
     func testDecoding() {
         // Test the basics of encoding each object type.
@@ -97,6 +112,7 @@ class JSONTests: XCTestCase {
 
     static var allTests = [
         ("testEncoding", testEncoding),
+        ("testEncodingWithContentsKeyOrder", testEncodingWithContentsKeyOrder),
         ("testDecoding", testDecoding),
         ("testStringInitalizer", testStringInitalizer),
         ("testPrettyPrinting", testPrettyPrinting),


### PR DESCRIPTION
## Issue

- https://bugs.swift.org/browse/SR-5624

## Overview

This PR includes the following attempt.

- Fix to bring "dependencies" key to the last order of output json.
  - Fix to inject a function which determines order of contents keys of JSON when writing the contents to `OutputByteStream`.
  - Define a specific function to alter the json order in `JsonDumper`.
  - Add unit test case for the change.
