### PR TITLE
[SR-5624] Fix to bring "dependencies" key to the last order of json 

### DIFF
--- a/Sources/Basic/DictionaryLiteralExtensions.swift
+++ b/Sources/Basic/DictionaryLiteralExtensions.swift
@@ -1,0 +1,40 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+// Can't conform a protocol explicitly with certain where clause for now but it'd be resolved by SE-0143.
+// ref: https://github.com/apple/swift-evolution/blob/master/proposals/0143-conditional-conformances.md
+// MARK: CustomStringConvertible
+extension DictionaryLiteral where Key: CustomStringConvertible, Value: CustomStringConvertible {
+    /// A string that represents the contents of the dictionary literal.
+    public var description: String {
+        let lastCount = self.count - 1
+        var desc = "["
+        for (i, item) in self.enumerated() {
+            desc.append("\(item.key.description): \(item.value.description)")
+            desc.append(i == lastCount ? "]" : ", ")
+        }
+        return desc
+    }
+}
+
+// MARK: Equatable
+extension DictionaryLiteral where Key: Equatable, Value: Equatable {
+    public static func ==(lhs: DictionaryLiteral, rhs: DictionaryLiteral) -> Bool {
+        if lhs.count != rhs.count {
+            return false
+        }
+        for i in 0..<lhs.count {
+            if lhs[i].key != rhs[i].key || lhs[i].value != rhs[i].value {
+                return false
+            }
+        }
+        return true
+    }
+}

--- a/Sources/Commands/show-dependencies.swift
+++ b/Sources/Commands/show-dependencies.swift
@@ -98,7 +98,7 @@ private final class DotDumper: DependenciesDumper {
 private final class JSONDumper: DependenciesDumper {
     func dump(dependenciesOf rootpkg: ResolvedPackage) {
         func convert(_ package: ResolvedPackage) -> JSON {
-            return .dictionary([
+            return .orderedDictionary([
                     "name": .string(package.name),
                     "url": .string(package.manifest.url),
                     "version": .string(package.manifest.version?.description ?? "unspecified"),

--- a/Tests/BasicTests/DictionaryLiteralExtensionsTests.swift
+++ b/Tests/BasicTests/DictionaryLiteralExtensionsTests.swift
@@ -1,0 +1,35 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import Basic
+
+class DictionaryLiteralExtensionsTests: XCTestCase {
+
+    func testDescription() {
+        XCTAssertEqual(DictionaryLiteral(dictionaryLiteral: ("foo", 1)).description, "[foo: 1]")
+        XCTAssertEqual(DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2)).description, "[foo: 1, bar: 2]")
+    }
+
+    func testEquality() {
+        XCTAssertTrue(DictionaryLiteral(dictionaryLiteral: ("foo", 1)) == DictionaryLiteral(dictionaryLiteral: ("foo", 1)))
+        XCTAssertTrue(DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2)) == DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2)))
+
+        XCTAssertFalse(DictionaryLiteral(dictionaryLiteral: ("no-foo", 1), ("bar", 2)) == DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2)))
+        XCTAssertFalse(DictionaryLiteral(dictionaryLiteral: ("foo", 0), ("bar", 2)) == DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2)))
+        XCTAssertFalse(DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2), ("hoge", 3)) == DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2)))
+        XCTAssertFalse(DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2)) == DictionaryLiteral(dictionaryLiteral: ("bar", 2), ("foo", 1)))
+    }
+
+    static var allTests = [
+        ("testDescription", testDescription),
+        ("testEquality", testEquality),
+    ]
+}

--- a/Tests/BasicTests/JSONTests.swift
+++ b/Tests/BasicTests/JSONTests.swift
@@ -25,6 +25,7 @@ class JSONTests: XCTestCase {
         XCTAssertEqual(encode(.string("hi")), "\"hi\"")
         XCTAssertEqual(encode(.array([.int(1), .string("hi")])), "[1, \"hi\"]")
         XCTAssertEqual(encode(.dictionary(["a": .int(1), "b": .string("hi")])), "{\"a\": 1, \"b\": \"hi\"}")
+        XCTAssertEqual(encode(.orderedDictionary(["b": .string("hi"), "a": .int(1)])), "{\"b\": \"hi\", \"a\": 1}")
     }
     
     func testDecoding() {

--- a/Tests/BasicTests/XCTestManifests.swift
+++ b/Tests/BasicTests/XCTestManifests.swift
@@ -22,6 +22,7 @@ public func allTests() -> [XCTestCaseEntry] {
         testCase(DeltaAlgorithmTests.allTests),
         testCase(DiagnosticsEngineTests.allTests),
         testCase(DictionaryExtensionTests.allTests),
+        testCase(DictionaryLiteralExtensionsTests.allTests),
         testCase(FileAccessTests.allTests),
         testCase(FileSystemTests.allTests),
         testCase(GraphAlgorithmsTests.allTests),


### PR DESCRIPTION
## Issue

- https://bugs.swift.org/browse/SR-5624

## Overview

Note: I created https://github.com/apple/swift-package-manager/pull/1306 before but as I got https://github.com/apple/swift-package-manager/pull/1306 feedback so re-created new PR.

Again, this PR includes the following attempt.

- Fix to bring "dependencies" key to the last order of output json.
  - Add orderedDictionary to JSON which holds an ordered dictionary with DictionaryLiteral.
  - conform CustomStringConvertible and Equatable protocols to DictionaryLiteral.
  - Fix to use orderedDictionary in JSONDumper to hold an order of json.
  - Add unit tests for the changes.
