### PR TITLE
[Utility] Create directory before writing the persistence file

### DIFF
--- a/Sources/Utility/SimplePersistence.swift
+++ b/Sources/Utility/SimplePersistence.swift
@@ -123,6 +123,7 @@ public final class SimplePersistence {
         // Set the object, keeping any keys in object which we don't know about.
         json["object"] = merge(old: json["object"], new: object.toJSON())
 
+        try fileSystem.createDirectory(statePath.parentDirectory, recursive: true)
         // FIXME: This should write atomically.
         try fileSystem.writeFileContents(
             statePath, bytes: JSON(json).toBytes(prettyPrint: self.prettyPrint))

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -297,6 +297,9 @@ final class PackageToolTests: XCTestCase {
             // Fully clean.
             _ = try execute(["reset"], packagePath: packageRoot)
             XCTAssertFalse(isDirectory(buildPath))
+
+            // Test that we can successfully run reset again.
+            _ = try execute(["reset"], packagePath: packageRoot)
         }
     }
 

--- a/Tests/UtilityTests/SimplePersistenceTests.swift
+++ b/Tests/UtilityTests/SimplePersistenceTests.swift
@@ -25,7 +25,7 @@ fileprivate class Foo: SimplePersistanceProtocol {
         self.persistence = SimplePersistence(
             fileSystem: fileSystem,
             schemaVersion: 1,
-            statePath: AbsolutePath.root.appending(component: "state.json")
+            statePath: AbsolutePath.root.appending(components: "subdir", "state.json")
         )
     }
 
@@ -60,7 +60,7 @@ fileprivate enum Bar {
             self.persistence = SimplePersistence(
                 fileSystem: fileSystem,
                 schemaVersion: 1,
-                statePath: AbsolutePath.root.appending(component: "state.json")
+                statePath: AbsolutePath.root.appending(components: "subdir", "state.json")
             )
         }
 
@@ -86,7 +86,7 @@ fileprivate enum Bar {
             self.persistence = SimplePersistence(
                 fileSystem: fileSystem,
                 schemaVersion: 1,
-                statePath: AbsolutePath.root.appending(component: "state.json")
+                statePath: AbsolutePath.root.appending(components: "subdir", "state.json")
             )
         }
 
@@ -107,7 +107,7 @@ fileprivate enum Bar {
 class SimplePersistenceTests: XCTestCase {
     func testBasics() throws {
         let fs = InMemoryFileSystem()
-        let stateFile = AbsolutePath.root.appending(component: "state.json")
+        let stateFile = AbsolutePath.root.appending(components: "subdir", "state.json")
         let foo = Foo(int: 1, path: AbsolutePath("/hello"), fileSystem: fs)
         // Restoring right now should return false because state is not present.
         XCTAssertFalse(try foo.restore())
@@ -141,7 +141,7 @@ class SimplePersistenceTests: XCTestCase {
         // Test that we don't overwrite the json in case we find keys we don't need.
 
         let fs = InMemoryFileSystem()
-        let stateFile = AbsolutePath.root.appending(component: "state.json")
+        let stateFile = AbsolutePath.root.appending(components: "subdir", "state.json")
 
         // Create and save v2 object.
         let v2 = Bar.V2(int: 100, string: "hello", fileSystem: fs)


### PR DESCRIPTION
The save state method of persistence did not create the parent directory
before writing the disk. This causes an error when build directory is
not present and the save state method is called.

-- https://bugs.swift.org/browse/SR-5707