### PR TITLE
[Workspace] Compute missing package identity instead of missing URL

### DIFF
--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -267,7 +267,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertFalse(diagnostics.hasErrors)
             XCTAssertEqual(manifests.root.manifests[0], graph.rootManifest)
             // B should be missing.
-            XCTAssertEqual(manifests.missingURLs(), ["//B"])
+            XCTAssertEqual(manifests.missingPackageIdentities(), ["b"])
             XCTAssertEqual(manifests.dependencies.map{$0.manifest.name}.sorted(), ["A", "AA"])
             let aManifest = graph.manifest("A", version: v1)
             XCTAssertEqual(manifests.lookup(manifest: "A"), aManifest)


### PR DESCRIPTION
Since root packages can be used as dependencies, we needed to switch to
computing missing package identities and not missing URLs.