### PR TITLE
[SwiftTool] Pass static stdlib option to build plan

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -497,7 +497,9 @@ public class SwiftTool<Options: ToolOptions> {
             dataPath: buildPath.appending(component: toolchain.destination.target),
             configuration: options.configuration,
             toolchain: toolchain,
-            flags: options.buildFlags)
+            flags: options.buildFlags,
+            shouldLinkStaticSwiftStdlib: options.shouldLinkStaticSwiftStdlib
+        )
     }
 
     /// Lazily compute the destination toolchain.


### PR DESCRIPTION
- <rdar://problem/33861492> -static-swift-stdlib doesn't work