### PR TITLE
align format of test classes under BasicTests package

### DIFF
--- a/Tests/BasicTests/CStringArrayTests.swift
+++ b/Tests/BasicTests/CStringArrayTests.swift
@@ -6,7 +6,7 @@
 
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+*/
 
 import XCTest
 import Basic

--- a/Tests/BasicTests/CollectionAlgorithmsTests.swift
+++ b/Tests/BasicTests/CollectionAlgorithmsTests.swift
@@ -1,11 +1,11 @@
 /*
-This source file is part of the Swift.org open source project
+ This source file is part of the Swift.org open source project
 
-Copyright 2016 Apple Inc. and the Swift project authors
-Licensed under Apache License v2.0 with Runtime Library Exception
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
 
-See http://swift.org/LICENSE.txt for license information
-See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
 import XCTest

--- a/Tests/BasicTests/CollectionExtensionsTests.swift
+++ b/Tests/BasicTests/CollectionExtensionsTests.swift
@@ -6,7 +6,7 @@
 
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+*/
 
 import XCTest
 import Basic

--- a/Tests/BasicTests/DictionaryExtensionsTests.swift
+++ b/Tests/BasicTests/DictionaryExtensionsTests.swift
@@ -1,11 +1,11 @@
 /*
-This source file is part of the Swift.org open source project
+ This source file is part of the Swift.org open source project
 
-Copyright 2016 Apple Inc. and the Swift project authors
-Licensed under Apache License v2.0 with Runtime Library Exception
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
 
-See http://swift.org/LICENSE.txt for license information
-See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
 import XCTest

--- a/Tests/BasicTests/GraphAlgorithmsTests.swift
+++ b/Tests/BasicTests/GraphAlgorithmsTests.swift
@@ -1,11 +1,11 @@
 /*
-This source file is part of the Swift.org open source project
+ This source file is part of the Swift.org open source project
 
-Copyright 2016 Apple Inc. and the Swift project authors
-Licensed under Apache License v2.0 with Runtime Library Exception
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
 
-See http://swift.org/LICENSE.txt for license information
-See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
 import XCTest

--- a/Tests/BasicTests/KeyedPairTests.swift
+++ b/Tests/BasicTests/KeyedPairTests.swift
@@ -1,11 +1,11 @@
 /*
-This source file is part of the Swift.org open source project
+ This source file is part of the Swift.org open source project
 
-Copyright 2016 Apple Inc. and the Swift project authors
-Licensed under Apache License v2.0 with Runtime Library Exception
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
 
-See http://swift.org/LICENSE.txt for license information
-See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
 import XCTest

--- a/Tests/BasicTests/OrderedSetTests.swift
+++ b/Tests/BasicTests/OrderedSetTests.swift
@@ -1,11 +1,11 @@
 /*
-This source file is part of the Swift.org open source project
+ This source file is part of the Swift.org open source project
 
-Copyright 2016 Apple Inc. and the Swift project authors
-Licensed under Apache License v2.0 with Runtime Library Exception
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
 
-See http://swift.org/LICENSE.txt for license information
-See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
 import XCTest

--- a/Tests/BasicTests/ProcessSetTests.swift
+++ b/Tests/BasicTests/ProcessSetTests.swift
@@ -6,7 +6,7 @@
  
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+*/
 
 import XCTest
 import Basic

--- a/Tests/BasicTests/ProcessTests.swift
+++ b/Tests/BasicTests/ProcessTests.swift
@@ -6,7 +6,7 @@
  
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+*/
 
 import TestSupport
 import XCTest

--- a/Tests/BasicTests/RegExTests.swift
+++ b/Tests/BasicTests/RegExTests.swift
@@ -6,7 +6,7 @@
  
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+*/
 
 import XCTest
 import Basic

--- a/Tests/BasicTests/ResultTests.swift
+++ b/Tests/BasicTests/ResultTests.swift
@@ -1,11 +1,11 @@
 /*
-This source file is part of the Swift.org open source project
+ This source file is part of the Swift.org open source project
 
-Copyright 2016 Apple Inc. and the Swift project authors
-Licensed under Apache License v2.0 with Runtime Library Exception
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
 
-See http://swift.org/LICENSE.txt for license information
-See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
 import XCTest

--- a/Tests/BasicTests/SHA256Tests.swift
+++ b/Tests/BasicTests/SHA256Tests.swift
@@ -1,11 +1,11 @@
 /*
-This source file is part of the Swift.org open source project
+ This source file is part of the Swift.org open source project
 
-Copyright 2016 Apple Inc. and the Swift project authors
-Licensed under Apache License v2.0 with Runtime Library Exception
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
 
-See http://swift.org/LICENSE.txt for license information
-See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
 import XCTest

--- a/Tests/BasicTests/StringConversionsTests.swift
+++ b/Tests/BasicTests/StringConversionsTests.swift
@@ -1,11 +1,11 @@
 /*
-This source file is part of the Swift.org open source project
+ This source file is part of the Swift.org open source project
 
-Copyright 2016 Apple Inc. and the Swift project authors
-Licensed under Apache License v2.0 with Runtime Library Exception
+ Copyright 2016 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
 
-See http://swift.org/LICENSE.txt for license information
-See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
 import XCTest

--- a/Tests/BasicTests/miscTests.swift
+++ b/Tests/BasicTests/miscTests.swift
@@ -6,7 +6,7 @@
 
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
- */
+*/
 
 import XCTest
 import TestSupport


### PR DESCRIPTION
## Overview

- Sorry for nitpicking...
  - I just found some of test doc were not well formatted so align each format of test classes under BasicTests package.