### PR TITLE
Ensure that targets in the generated Xcode project are output in a sorted order

### DIFF
--- a/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
+++ b/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
@@ -64,7 +64,9 @@ extension Xcode.Project: PropertyListSerializable {
             dict["productRefGroup"] = .identifier(serializer.id(of: productGroup))
         }
         dict["projectDirPath"] = .string(projectDir)
-        dict["targets"] = .array(targets.map({ target in
+        // Ensure that targets are output in a sorted order.
+        let sortedTargets = targets.sorted(by: { $0.name < $1.name })
+        dict["targets"] = .array(sortedTargets.map({ target in
             .identifier(serializer.serialize(object: target))
         }))
         return dict

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -41,10 +41,10 @@ class GenerateXcodeprojTests: XCTestCase {
             XCTAssertEqual(output, """
                Information about project "DummyProjectName":
                    Targets:
-                       FooPackageDescription
                        DummyModuleName
                        Foo
-               
+                       FooPackageDescription
+
                    Build Configurations:
                        Debug
                        Release


### PR DESCRIPTION
This PR changes pbxproj generation to output targets in a sorted order.

It would be nice to do the same for the Xcode schemes, but given that they are left alone across regenerations I haven't attempted to tackle that.