### PR TITLE
Respect swiftc flags for building shared libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The `SWIFT_EXEC` environment variable specifies the `swiftc` executable path use
 
 For extensive documentation on using Swift Package Manager, creating packages, and more, see [Documentation](Documentation).
 
-For additional documentation on developing the Swift Package Manager itself, see [Documentation/Internals](Documentation/Internals).
+For additional documentation on developing the Swift Package Manager itself, see [Documentation/Development](Documentation/Development.md).
 
 ---
 

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -661,7 +661,7 @@ def process_runtime_libraries(build, args, lib_path):
         # We include an RPATH entry so that the Swift libraries can be found
         # relative to where it will be installed (in 'lib/swift/pm/...').
         runtime_lib_path = os.path.join(lib_path, "libPackageDescription.so")
-        cmd = [args.swiftc_path, "-Xlinker", "-shared", "-o", runtime_lib_path,
+        cmd = [args.swiftc_path, "-emit-library", "-o", runtime_lib_path,
                "-Xlinker", "--whole-archive",
                "-Xlinker", input_lib_path,
                "-Xlinker", "--no-whole-archive", "-lswiftGlibc",
@@ -680,14 +680,7 @@ def process_runtime_libraries(build, args, lib_path):
         # Unqoute any quoted characters.
         link_cmd = [arg.replace("\\", "") for arg in link_cmd]
 
-        # Drop any .o files, and the -Xlinker which precedes '-shared'.
-        try:
-            idx = link_cmd.index("-shared")
-        except:
-            idx = -1
-        if idx == -1 or link_cmd[idx - 1] != "-Xlinker":
-            raise SystemExit("unable to understand 'swiftc' driver commands")
-        del link_cmd[idx - 1]
+        # Drop any .o files
         cmd = [arg for arg in link_cmd
                if arg.endswith(("swift_begin.o", "swift_end.o")) or
                (not arg.endswith((".o", ".autolink")))]


### PR DESCRIPTION
SwiftPM bootstrap script uses `swiftc` invocation to infer clang flags to pass to clang invocation afterwards. However, since `swiftc` wasn't told we are trying to build a library, it would default to an executable and add `-pie` flag, which isn't appropriate.

See: https://github.com/apple/swift/pull/11669 for more details of why was this causing (minor) problems.