### PR TITLE
[Commands] Use user namespaced temporary directory

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -18,6 +18,7 @@ import SourceControl
 import Utility
 import Workspace
 import libc
+import func Foundation.NSUserName
 
 struct ChdirDeprecatedDiagnostic: DiagnosticData {
     static let id = DiagnosticID(
@@ -432,7 +433,8 @@ public class SwiftTool<Options: ToolOptions> {
         assert(isFile(yaml), "llbuild manifest not present: \(yaml.asString)")
 
         // Create a temporary directory for the build process.
-        let tempDir = Basic.determineTempDirectory().appending(component: "swiftpm")
+        let tempDirName = "org.swift.swiftpm.\(NSUserName())"
+        let tempDir = Basic.determineTempDirectory().appending(component: tempDirName)
         try localFileSystem.createDirectory(tempDir, recursive: true)
 
         // Run the swift-build-tool with the generated manifest.


### PR DESCRIPTION
SwiftPM overrides the TMPDIR variable when invoking the build tool so all tools write their temporary content to this directory instead of arbitrary locations. This can cause permission issues in linux when there are multiple users trying to access the same directory. This patch adds the username in the name of the temp directory so each user gets their own.

- <rdar://problem/34130627> [SR-5788]: SwiftPM uses global tmp directory
- https://bugs.swift.org/browse/SR-5788