### PR TITLE
[Documentation] Fix broken links to Target Format Reference in Usage.md

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -50,7 +50,7 @@ get started, create a directory and run `swift package init` command:
 This will create the directory structure needed for a library package with a
 target and the corresponding test target to write unit tests. A library package
 can contain multiple targets as explained in [Target Format
-Reference](Reference.md#target-format-reference).
+Reference](PackageDescriptionV3.md#target-format-reference).
 
 ### Create an executable package
 
@@ -67,7 +67,7 @@ get started:
 This creates the directory structure needed for executable targets. Any target
 can be turned into a executable target if there is a `main.swift` present in
 its sources. Complete reference for layout is
-[here](Reference.md#target-format-reference).
+[here](PackageDescriptionV3.md#target-format-reference).
 
 ## Define Dependencies
 

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -50,7 +50,7 @@ get started, create a directory and run `swift package init` command:
 This will create the directory structure needed for a library package with a
 target and the corresponding test target to write unit tests. A library package
 can contain multiple targets as explained in [Target Format
-Reference](PackageDescriptionV3.md#target-format-reference).
+Reference](PackageDescriptionV4.md#target-format-reference).
 
 ### Create an executable package
 
@@ -67,7 +67,7 @@ get started:
 This creates the directory structure needed for executable targets. Any target
 can be turned into a executable target if there is a `main.swift` present in
 its sources. Complete reference for layout is
-[here](PackageDescriptionV3.md#target-format-reference).
+[here](PackageDescriptionV4.md#target-format-reference).
 
 ## Define Dependencies
 


### PR DESCRIPTION
Hey guys! I was browsing the documentation and found two broken links for Target Format Reference. They were targeting (now) non-existing `Reference.md` file, so I've changed it to `PackageDescriptionV3.md`. I figured that `Usage.md` still uses V3 syntax so I pointed to V3 instead of V4.

As this is my first PR, please let me know if I messed up anything 😅 Cheers!