### PR TITLE
[BuildPlan] Always add -fblocks when compiling C targets

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -188,6 +188,7 @@ public final class ClangTargetDescription {
       #if os(macOS)
         args += ["-fobjc-arc"]
       #endif
+        args += ["-fblocks"]
         args += ["-fmodules", "-fmodule-name=" + target.c99name]
         if let languageStandard = clangTarget.languageStandard {
             args += ["-std=\(languageStandard)"]

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -210,7 +210,7 @@ final class BuildPlanTests: XCTestCase {
       #if os(macOS)
         args += ["-fobjc-arc"]
       #endif
-        args += ["-fmodules", "-fmodule-name=extlib",
+        args += ["-fblocks", "-fmodules", "-fmodule-name=extlib",
             "-I", "/ExtPkg/Sources/extlib/include", "-fmodules-cache-path=/path/to/build/debug/ModuleCache"]
         XCTAssertEqual(ext.basicArguments(), args)
         XCTAssertEqual(ext.objects, [AbsolutePath("/path/to/build/debug/extlib.build/extlib.c.o")])
@@ -221,7 +221,7 @@ final class BuildPlanTests: XCTestCase {
       #if os(macOS)
         args += ["-fobjc-arc"]
       #endif
-        args += ["-fmodules", "-fmodule-name=exe",
+        args += ["-fblocks", "-fmodules", "-fmodule-name=exe",
             "-I", "/Pkg/Sources/exe/include", "-iquote", "/Pkg/Sources/lib/include", "-I", "/ExtPkg/Sources/extlib/include",
             "-fmodules-cache-path=/path/to/build/debug/ModuleCache"]
         XCTAssertEqual(exe.basicArguments(), args)
@@ -316,7 +316,7 @@ final class BuildPlanTests: XCTestCase {
       #if os(macOS)
         args += ["-fobjc-arc"]
       #endif
-        args += ["-fmodules", "-fmodule-name=lib", "-I", "/Pkg/Sources/lib/include",
+        args += ["-fblocks", "-fmodules", "-fmodule-name=lib", "-I", "/Pkg/Sources/lib/include",
             "-fmodules-cache-path=/path/to/build/debug/ModuleCache"]
         XCTAssertEqual(lib.basicArguments(), args)
         XCTAssertEqual(lib.objects, [AbsolutePath("/path/to/build/debug/lib.build/lib.c.o")])
@@ -593,18 +593,18 @@ final class BuildPlanTests: XCTestCase {
 
         let exe = try result.target(for: "exe").clangTarget()
     #if os(macOS)
-        XCTAssertEqual(exe.basicArguments(), ["-g", "-O0", "-fobjc-arc", "-fmodules", "-fmodule-name=exe", "-I", "/Pkg/Sources/exe/include", "-fmodules-cache-path=/path/to/build/debug/ModuleCache"])
+        XCTAssertEqual(exe.basicArguments(), ["-g", "-O0", "-fobjc-arc","-fblocks",  "-fmodules", "-fmodule-name=exe", "-I", "/Pkg/Sources/exe/include", "-fmodules-cache-path=/path/to/build/debug/ModuleCache"])
     #else
-        XCTAssertEqual(exe.basicArguments(), ["-g", "-O0", "-fmodules", "-fmodule-name=exe", "-I", "/Pkg/Sources/exe/include", "-fmodules-cache-path=/path/to/build/debug/ModuleCache"])
+        XCTAssertEqual(exe.basicArguments(), ["-g", "-O0","-fblocks",  "-fmodules", "-fmodule-name=exe", "-I", "/Pkg/Sources/exe/include", "-fmodules-cache-path=/path/to/build/debug/ModuleCache"])
     #endif
         XCTAssertEqual(exe.objects, [AbsolutePath("/path/to/build/debug/exe.build/main.c.o")])
         XCTAssertEqual(exe.moduleMap, nil)
 
         let lib = try result.target(for: "lib").clangTarget()
     #if os(macOS)
-        XCTAssertEqual(lib.basicArguments(), ["-g", "-O0", "-fobjc-arc", "-fmodules", "-fmodule-name=lib", "-I", "/Pkg/Sources/lib/include", "-fmodules-cache-path=/path/to/build/debug/ModuleCache"])
+        XCTAssertEqual(lib.basicArguments(), ["-g", "-O0", "-fobjc-arc","-fblocks",  "-fmodules", "-fmodule-name=lib", "-I", "/Pkg/Sources/lib/include", "-fmodules-cache-path=/path/to/build/debug/ModuleCache"])
     #else
-        XCTAssertEqual(lib.basicArguments(), ["-g", "-O0", "-fmodules", "-fmodule-name=lib", "-I", "/Pkg/Sources/lib/include", "-fmodules-cache-path=/path/to/build/debug/ModuleCache"])
+        XCTAssertEqual(lib.basicArguments(), ["-g", "-O0","-fblocks",  "-fmodules", "-fmodule-name=lib", "-I", "/Pkg/Sources/lib/include", "-fmodules-cache-path=/path/to/build/debug/ModuleCache"])
     #endif
         XCTAssertEqual(lib.objects, [AbsolutePath("/path/to/build/debug/lib.build/lib.cpp.o")])
         XCTAssertEqual(lib.moduleMap, AbsolutePath("/path/to/build/debug/lib.build/module.modulemap"))


### PR DESCRIPTION
<rdar://problem/28109524> [SR-6178]: Pass -fblocks to clang for C language targets

Currently, blocks in C libraries will only work if the C target is being imported by a Swift target and that Swift target imports Dispatch. This isn't very optimal but its better than passing -Xcc -fblocks on the command line. This will not cause any issues if the C target is not using blocks. We can track always linking against blocks runtime as an enhancement.