### PR TITLE
 [Utility] Rename COMMANDS to POSITIONAL ARGUMENTS

### DIFF
--- a/Sources/Utility/ArgumentParser.swift
+++ b/Sources/Utility/ArgumentParser.swift
@@ -895,7 +895,7 @@ public final class ArgumentParser {
 
         if positionalArguments.count > 0 {
             stream <<< "\n\n"
-            stream <<< "COMMANDS:"
+            stream <<< "POSITIONAL ARGUMENTS:"
             for argument in positionalArguments.lazy.sorted(by: {$0.name < $1.name}) {
                 guard let usage = argument.usage else { continue }
                 print(formatted: argument.name, usage: usage, on: stream)


### PR DESCRIPTION
- <rdar://problem/33851991> `swift run --help` says COMMANDS where it should say OPTIONS