### PR TITLE
Make algorithms generic over IndexDistance

### DIFF
--- a/Fixtures/DependencyResolution/External/Complex/FisherYates/src/Fisher-Yates_Shuffle.swift
+++ b/Fixtures/DependencyResolution/External/Complex/FisherYates/src/Fisher-Yates_Shuffle.swift
@@ -13,18 +13,20 @@ public extension Collection {
     }
 }
 
-public extension MutableCollection where Index == Int, IndexDistance == Int {
+public extension MutableCollection {
+    /// Shuffles the contents of this collection.
     mutating func shuffleInPlace() {
-        guard count > 1 else { return }
-
-        for i in 0..<count - 1 {
+        let c = count
+        guard c > 1 else { return }
+        
+        for (firstUnshuffled, unshuffledCount) in zip(indices, stride(from: c, to: 1, by: -1)) {
 #if os(macOS) || os(iOS)
-            let j = Int(arc4random_uniform(UInt32(count - i))) + i
+            let d = arc4random_uniform(numericCast(unshuffledCount))
 #else
-            let j = Int(random() % (count - i)) + i
+            let d = numericCast(random()) % unshuffledCount
 #endif
-            guard i != j else { continue }
-            swap(&self[i], &self[j])
+            let i = index(firstUnshuffled, offsetBy: numericCast(d))
+            swapAt(firstUnshuffled, i)
         }
     }
 }

--- a/Fixtures/DependencyResolution/External/IgnoreIndirectTests/FisherYates/src/Fisher-Yates_Shuffle.swift
+++ b/Fixtures/DependencyResolution/External/IgnoreIndirectTests/FisherYates/src/Fisher-Yates_Shuffle.swift
@@ -13,18 +13,20 @@ public extension Collection {
     }
 }
 
-public extension MutableCollection where Index == Int, IndexDistance == Int {
+public extension MutableCollection {
+    /// Shuffles the contents of this collection.
     mutating func shuffleInPlace() {
-        guard count > 1 else { return }
-
-        for i in 0..<count - 1 {
+        let c = count
+        guard c > 1 else { return }
+        
+        for (firstUnshuffled, unshuffledCount) in zip(indices, stride(from: c, to: 1, by: -1)) {
 #if os(macOS) || os(iOS)
-            let j = Int(arc4random_uniform(UInt32(count - i))) + i
+            let d = arc4random_uniform(numericCast(unshuffledCount))
 #else
-            let j = Int(random() % (count - i)) + i
+            let d = numericCast(random()) % unshuffledCount
 #endif
-            guard i != j else { continue }
-            swap(&self[i], &self[j])
+            let i = index(firstUnshuffled, offsetBy: numericCast(d))
+            swapAt(firstUnshuffled, i)
         }
     }
 }


### PR DESCRIPTION
A PR on the swift repo, https://github.com/apple/swift/pull/12641, attempts to remove `IndexDistance`.

SwiftPM currently has a couple of places where it constrains `IndexDistance` to `Int`. This PR changes those places to work with any `IndexDistance` so we can remove it on the swift repo without source-breaking SwiftPM.

(we're working on the source compatibility story for this for other code outside swift-* stuff, but would be good to be able to test/land the change on master in the mean-time)