### PR TITLE
[SPM] [Fix] Dynamic libraries now are resolved recursively

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -388,8 +388,15 @@ public final class ProductBuildDescription {
         args += ["-L", buildParameters.buildPath.asString]
         args += ["-o", binary.asString]
         args += ["-module-name", product.name]
-        args += dylibs.map({ "-l" + $0.product.name })
-
+        
+        func dylibsIn(product: ProductBuildDescription) -> [ProductBuildDescription] {
+            return product.dylibs.reduce([product], {$0 + dylibsIn(product: $1)})
+        }
+        
+        // Go through the nested dynamic libraries and add them
+        // FIXME: Use a better algorithm, because if there is a cyclic dependency an error will occur
+        args += dylibs.reduce([], {$0 + dylibsIn(product: $1)}).map({ "-l" + $0.product.name })
+        
         switch product.type {
         case .library(.automatic):
             fatalError()

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -525,22 +525,28 @@ final class BuildPlanTests: XCTestCase {
             return prev && args.contains("-l\(dependencyName)")
         }))
         
+        let standardPrefixArrayCount = 8
+        
         var suffix: String = ""
         #if os(macOS)
-            XCTAssertEqual(args.suffix(2),
+            let macOSSuffixArrayCount = 2
+            XCTAssertEqual(args.suffix(macOSSuffixArrayCount),
                            ["-emit-\(type.rawValue)",
                             "/path/to/build/debug/\(moduleName).build/\(type == .library ? "source" : "main").swift.o"
                 ])
             suffix = type == .library ? ".dylib" : ""
+            XCTAssertEqual(args.count, standardPrefixArrayCount + macOSSuffixArrayCount + dependencyStrings.count)
         #else
-            XCTAssertEqual(args.suffix(4),
+            let linuxSuffixArrayCount = 4
+            XCTAssertEqual(args.suffix(linuxSuffixArrayCount),
                            ["-emit-\(type.rawValue)",
                             "-Xlinker", "-rpath=$ORIGIN",
                             "/path/to/build/debug/\(moduleName).build/\(type == .library ? "source" : "main").swift.o"
                 ])
             suffix = type == .library ? ".dylib" : ""
+            XCTAssertEqual(args.count, standardPrefixArrayCount + linuxSuffixArrayCount + dependencyStrings.count)
         #endif
-        XCTAssertEqual(args.prefix(8),
+        XCTAssertEqual(args.prefix(standardPrefixArrayCount),
                        ["/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug",
                         "-o", "/path/to/build/debug/\((type == .library ? "lib" : "") + moduleName)\(suffix)", "-module-name", moduleName])
         
@@ -623,7 +629,7 @@ final class BuildPlanTests: XCTestCase {
         assertArgsAreCorrect(fooLinkArgs,
                              for: "Foo",
                              with: ["FirstOrder1", "FirstOrder2",
-                                    "SecondOrder1", "SecondOrder2", "SecondOrder3", "SecondOrder4",
+                                    "SecondOrder1", "SecondOrder1", "SecondOrder3", "SecondOrder4",
                                     "ThirdOrder1", "ThirdOrder2", "ThirdOrder3", "ThirdOrder4",
                                     "ThirdOrder5", "ThirdOrder6", "ThirdOrder7", "ThirdOrder8"],
                              of: .executable)


### PR DESCRIPTION
I found an issue when you try to use dynamically linked libraries
The libraries are not recursively linked

**For example:**
If you clone the Apple's example for Swift Package Manager itself (Dealer)
And edit the packages and make the library type of each of them .dynamic
And try to "swift build"
It will NOT link

This pull request is just a primitive solution, it doesn't check for cyclic dylibs dependcies

Tried to use the supplied graph algorithm, but ProductBuildDescription is not Hashable
Didn't want to extend it and make a lot of changes

This is tested on Apple's example itself (Dealer) and succeeded