### PR TITLE
[WIP] [SR-4830] Propagate colors from compiler output for swiftc

### DIFF
--- a/Sources/Basic/TerminalController.swift
+++ b/Sources/Basic/TerminalController.swift
@@ -61,11 +61,16 @@ public final class TerminalController {
     /// Constructs the instance if the stream is a tty.
     public init?(stream: LocalFileOutputByteStream) {
         // Make sure this file stream is tty.
-        guard isatty(fileno(stream.filePointer)) != 0 else {
+        guard TerminalController.isTTY(stream) else {
             return nil
         }
         width = TerminalController.terminalWidth() ?? 80 // Assume default if we are not able to determine.
         self.stream = stream
+    }
+
+    /// Checks if passed file stream is tty.
+    public static func isTTY(_ stream: LocalFileOutputByteStream) -> Bool {
+        return isatty(fileno(stream.filePointer)) != 0
     }
 
     /// Tries to get the terminal width first using COLUMNS env variable and

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -57,6 +57,14 @@ public struct BuildParameters {
     public var swiftCompilerFlags: [String] {
         var flags = self.flags.cCompilerFlags.flatMap({ ["-Xcc", $0] })
         flags += self.flags.swiftCompilerFlags
+
+        let stream = stdoutStream as? LocalFileOutputByteStream
+        let terminalController = stream.flatMap({ TerminalController(stream: $0) })
+        // Add extra flags if stdout is tty
+        if terminalController != nil {
+            flags += ["-Xfrontend", "-color-diagnostics"]
+        }
+
         flags += verbosity.ccArgs
         return flags
     }


### PR DESCRIPTION
Hi.

This PR addresses [this ticket](https://bugs.swift.org/browse/SR-4830).

- [x] Propagate colors from compiler output for swiftc.
- [ ] Add tests for this case.

I'm not personally sure if `terminalController != nil` is best check possible, but i had a problem where in more specific check `isatty(fileno(stream.filePointer)) != 0` actual `filePointer` is internal for another target, so we're not able to access it from BuildParameters.

Would appreciate feedback before i will dig into tests for this.