### PR TITLE
Use `SWIFT_EXEC` for executing `swift-build-tool` and importing `PackageDescription`

### DIFF
--- a/Sources/Commands/UserToolchain.swift
+++ b/Sources/Commands/UserToolchain.swift
@@ -77,10 +77,10 @@ public struct UserToolchain: Toolchain {
         }
 
         // Get the binDir from destination.
-        let binDir = destination.binDir
+        let binDir = lookup(fromEnv: "SWIFT_EXEC")?.appending(components: "..") ?? destination.binDir
 
         // First look in env and then in bin dir.
-        swiftCompiler = lookup(fromEnv: "SWIFT_EXEC") ?? binDir.appending(component: "swiftc")
+        swiftCompiler = binDir.appending(component: "swiftc")
 
         // Check that it's valid in the file system.
         guard localFileSystem.isExecutableFile(swiftCompiler) else {


### PR DESCRIPTION
Fixes [SR-6371](https://bugs.swift.org/browse/SR-6371)