### PR TITLE
[SR-5918] Add diagnostic error for duplicate product names

### DIFF
--- a/Sources/PackageGraph/PackageGraphLoader.swift
+++ b/Sources/PackageGraph/PackageGraphLoader.swift
@@ -211,6 +211,12 @@ private func createResolvedPackages(
             .filter({ $0.product.type != .test })
         let productDependencyMap = productDependencies.createDictionary({ ($0.product.name, $0) })
 
+        // Establish if there are multiple products with the same name.
+        let duplicateProductNames = Set(packageBuilder.products.map { $0.product.name }.findDuplicates())
+        for duplicateProductName in duplicateProductNames {
+            diagnostics.emit(ModuleError.duplicateProduct(duplicateProductName), location: diagnosticLocation())
+        }
+
         // Establish dependencies in each target.
         for targetBuilder in packageBuilder.targets {
             // If a target with similar name was encountered before, we emit a diagnostic.

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -32,6 +32,9 @@ public enum ModuleError: Swift.Error {
     /// Indicates two targets with the same name.
     case duplicateModule(String)
 
+    /// Indicates two products with the same name.
+    case duplicateProduct(String)
+
     /// One or more referenced targets could not be found.
     case modulesNotFound([String])
 
@@ -68,6 +71,8 @@ extension ModuleError: CustomStringConvertible {
         switch self {
         case .duplicateModule(let name):
             return "multiple targets named '\(name)'"
+        case .duplicateProduct(let name):
+            return "multiple products named '\(name)'"
         case .modulesNotFound(let targets):
             let targets = targets.joined(separator: ", ")
             return "could not find target(s): \(targets); use the 'path' property in the Swift 4 manifest to set a custom target path"

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -136,6 +136,35 @@ class PackageGraphTests: XCTestCase {
         XCTAssertEqual(diagnostics.diagnostics[0].localizedDescription, "multiple targets named 'Bar'")
     }
 
+    func testDuplicateProducts() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Foo/Sources/Bar/source.swift",
+            "/Bar/source.swift"
+        )
+
+        let diagnostics = DiagnosticsEngine()
+        _ = loadMockPackageGraph4([
+            "/Foo": Package(
+                name: "Bar",
+                products: [
+                    .library(name: "Bar", targets: ["Bar"]),
+                    .library(name: "Bar", targets: ["Bar"]),
+                    .library(name: "Bar", targets: ["Bar"]),
+                    .library(name: "Boo", targets: ["Bar"]),
+                    .library(name: "Boo", targets: ["Bar"])
+                ],
+                targets: [
+                    .target(name: "Bar"),
+                ]),
+            ], root: "/Foo", diagnostics: diagnostics, in: fs)
+
+        let multipleBarDiagnostics = diagnostics.diagnostics.filter { $0.localizedDescription == "multiple products named 'Bar'" }
+        let multipleBooDiagnostics = diagnostics.diagnostics.filter { $0.localizedDescription == "multiple products named 'Boo'" }
+
+        XCTAssertEqual(multipleBarDiagnostics.count, 1)
+        XCTAssertEqual(multipleBooDiagnostics.count, 1)
+    }
+
     func testEmptyDependency() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Foo/Sources/Foo/foo.swift",
@@ -176,6 +205,7 @@ class PackageGraphTests: XCTestCase {
         ("testCycle", testCycle),
         ("testProductDependencies", testProductDependencies),
         ("testTestTargetDeclInExternalPackage", testTestTargetDeclInExternalPackage),
+        ("testDuplicateProducts", testDuplicateProducts),
         ("testEmptyDependency", testEmptyDependency),
     ]
 }


### PR DESCRIPTION
Fixes [SR-5918](https://bugs.swift.org/browse/SR-5918) by @lightsprint09, @hartbit and myself at [Swift Alps](https://theswiftalps.com).