### PR TITLE
[SR-6049] Made FileSystem into a reference type to fix crash

### DIFF
--- a/Sources/SourceControl/InMemoryGitRepository.swift
+++ b/Sources/SourceControl/InMemoryGitRepository.swift
@@ -243,8 +243,8 @@ extension InMemoryGitRepository: Repository {
     }
 
     public func openFileView(revision: Revision) throws -> FileSystem {
-        var fs: FileSystem = history[revision.identifier]!.fileSystem
-        return RerootedFileSystemView(&fs, rootedAt: path)
+        let fs: FileSystem = history[revision.identifier]!.fileSystem
+        return RerootedFileSystemView(fs, rootedAt: path)
     }
 }
 

--- a/Tests/BasicTests/FileSystemTests.swift
+++ b/Tests/BasicTests/FileSystemTests.swift
@@ -72,7 +72,7 @@ class FileSystemTests: XCTestCase {
     }
 
     func testLocalCreateDirectory() throws {
-        var fs = Basic.localFileSystem
+        let fs = Basic.localFileSystem
         
         let tmpDir = try TemporaryDirectory(prefix: #function, removeTreeOnDeinit: true)
         do {
@@ -93,7 +93,7 @@ class FileSystemTests: XCTestCase {
     }
 
     func testLocalReadWriteFile() throws {
-        var fs = Basic.localFileSystem
+        let fs = Basic.localFileSystem
         
         let tmpDir = try TemporaryDirectory(prefix: #function, removeTreeOnDeinit: true)
         // Check read/write of a simple file.
@@ -148,7 +148,7 @@ class FileSystemTests: XCTestCase {
 
     func testRemoveFileTree() throws {
         mktmpdir { path in
-            try removeFileTreeTester(fs: &localFileSystem, basePath: path)
+            try removeFileTreeTester(fs: localFileSystem, basePath: path)
         }
     }
 
@@ -299,8 +299,8 @@ class FileSystemTests: XCTestCase {
     }
 
     func testInMemRemoveFileTree() throws {
-        var fs = InMemoryFileSystem() as FileSystem
-        try removeFileTreeTester(fs: &fs, basePath: .root)
+        let fs = InMemoryFileSystem() as FileSystem
+        try removeFileTreeTester(fs: fs, basePath: .root)
     }
 
 
@@ -308,12 +308,12 @@ class FileSystemTests: XCTestCase {
 
     func testRootedFileSystem() throws {
         // Create the test file system.
-        var baseFileSystem = InMemoryFileSystem() as FileSystem
+        let baseFileSystem = InMemoryFileSystem() as FileSystem
         try baseFileSystem.createDirectory(AbsolutePath("/base/rootIsHere/subdir"), recursive: true)
         try baseFileSystem.writeFileContents(AbsolutePath("/base/rootIsHere/subdir/file"), bytes: "Hello, world!")
 
         // Create the rooted file system.
-        var rerootedFileSystem = RerootedFileSystemView(&baseFileSystem, rootedAt: AbsolutePath("/base/rootIsHere"))
+        let rerootedFileSystem = RerootedFileSystemView(baseFileSystem, rootedAt: AbsolutePath("/base/rootIsHere"))
 
         // Check that it has the appropriate view.
         XCTAssert(rerootedFileSystem.exists(AbsolutePath("/subdir")))
@@ -330,7 +330,7 @@ class FileSystemTests: XCTestCase {
     func testSetAttribute() throws {
       #if os(macOS)
         mktmpdir { path in
-            var fs = Basic.localFileSystem
+            let fs = Basic.localFileSystem
 
             let dir = path.appending(component: "dir")
             let foo = dir.appending(component: "foo")
@@ -394,7 +394,7 @@ class FileSystemTests: XCTestCase {
 /// - Parameters:
 ///   - fs: The filesystem to test on.
 ///   - basePath: The path at which the temporary file strucutre should be created.
-private func removeFileTreeTester(fs: inout FileSystem, basePath path: AbsolutePath, file: StaticString = #file, line: UInt = #line) throws {
+private func removeFileTreeTester(fs: FileSystem, basePath path: AbsolutePath, file: StaticString = #file, line: UInt = #line) throws {
     // Test removing folders.
     let folders = path.appending(components: "foo", "bar", "baz")
     try fs.createDirectory(folders, recursive: true)

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -138,7 +138,7 @@ final class PackageToolTests: XCTestCase {
 
     func testInitEmpty() throws {
         mktmpdir { tmpPath in
-            var fs = localFileSystem
+            let fs = localFileSystem
             let path = tmpPath.appending(component: "Foo")
             try fs.createDirectory(path)
             _ = try execute(["-C", path.asString, "init", "--type", "empty"])
@@ -150,7 +150,7 @@ final class PackageToolTests: XCTestCase {
 
     func testInitExecutable() throws {
         mktmpdir { tmpPath in
-            var fs = localFileSystem
+            let fs = localFileSystem
             let path = tmpPath.appending(component: "Foo")
             try fs.createDirectory(path)
             _ = try execute(["-C", path.asString, "init", "--type", "executable"])
@@ -168,7 +168,7 @@ final class PackageToolTests: XCTestCase {
 
     func testInitLibrary() throws {
         mktmpdir { tmpPath in
-            var fs = localFileSystem
+            let fs = localFileSystem
             let path = tmpPath.appending(component: "Foo")
             try fs.createDirectory(path)
             _ = try execute(["-C", path.asString, "init"])
@@ -437,7 +437,7 @@ final class PackageToolTests: XCTestCase {
 
     func testSymlinkedDependency() {
         mktmpdir { path in
-            var fs = localFileSystem
+            let fs = localFileSystem
             let root = path.appending(components: "root")
             let dep = path.appending(components: "dep")
             let depSym = path.appending(components: "depSym")

--- a/Tests/FunctionalTests/ToolsVersionTests.swift
+++ b/Tests/FunctionalTests/ToolsVersionTests.swift
@@ -21,7 +21,7 @@ class ToolsVersionTests: XCTestCase {
 
     func testToolsVersion() throws {
         mktmpdir { path in
-            var fs = localFileSystem
+            let fs = localFileSystem
 
             // Create a repo for the dependency to test against.
             let depPath = path.appending(component: "Dep")

--- a/Tests/FunctionalTests/VersionSpecificTests.swift
+++ b/Tests/FunctionalTests/VersionSpecificTests.swift
@@ -20,7 +20,7 @@ class VersionSpecificTests: XCTestCase {
     /// Functional tests of end-to-end support for version specific dependency resolution.
     func testEndToEndResolution() throws {
         mktmpdir { path in
-            var fs = localFileSystem
+            let fs = localFileSystem
 
             // Create a repo for the dependency to test against.
             let depPath = path.appending(component: "Dep")

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -55,7 +55,7 @@ class DependencyResolverPerfTests: XCTestCasePerf {
 
     func testPrefilterPerf() {
         mktmpdir { path in
-            var fs = localFileSystem
+            let fs = localFileSystem
             let dep = path.appending(components: "dep")
 
             // Create dependency.

--- a/Tests/UtilityTests/SimplePersistenceTests.swift
+++ b/Tests/UtilityTests/SimplePersistenceTests.swift
@@ -180,7 +180,7 @@ class SimplePersistenceTests: XCTestCase {
     }
 
     func testCanLoadFromOldSchema() throws {
-        var fs = InMemoryFileSystem()
+        let fs = InMemoryFileSystem()
         let stateFile = AbsolutePath.root.appending(components: "subdir", "state.json")
         try fs.writeFileContents(stateFile) {
             $0 <<< """

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -21,7 +21,7 @@ class InitTests: XCTestCase {
     
     func testInitPackageEmpty() throws {
         mktmpdir { tmpPath in
-            var fs = localFileSystem
+            let fs = localFileSystem
             let path = tmpPath.appending(component: "Foo")
             try fs.createDirectory(path)
             
@@ -46,7 +46,7 @@ class InitTests: XCTestCase {
     
     func testInitPackageExecutable() throws {
         mktmpdir { tmpPath in
-            var fs = localFileSystem
+            let fs = localFileSystem
             let path = tmpPath.appending(component: "Foo")
             try fs.createDirectory(path)
 
@@ -87,7 +87,7 @@ class InitTests: XCTestCase {
 
     func testInitPackageLibrary() throws {
         mktmpdir { tmpPath in
-            var fs = localFileSystem
+            let fs = localFileSystem
             let path = tmpPath.appending(component: "Foo")
             try fs.createDirectory(path)
 
@@ -127,7 +127,7 @@ class InitTests: XCTestCase {
     
     func testInitPackageSystemModule() throws {
         mktmpdir { tmpPath in
-            var fs = localFileSystem
+            let fs = localFileSystem
             let path = tmpPath.appending(component: "Foo")
             try fs.createDirectory(path)
             

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -97,7 +97,7 @@ final class PinsStoreTests: XCTestCase {
     }
 
     func testLoadingSchema1() throws {
-        var fs = InMemoryFileSystem()
+        let fs = InMemoryFileSystem()
         let pinsFile = AbsolutePath("/pinsfile.txt")
 
         try fs.writeFileContents(pinsFile) {

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -123,7 +123,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testInterpreterFlags() throws {
-        var fs = localFileSystem
+        let fs = localFileSystem
         mktmpdir { path in
             let foo = path.appending(component: "foo")
             try fs.writeFileContents(foo.appending(component: "Package.swift")) {
@@ -1633,7 +1633,7 @@ private class TestWorkspaceDelegate: WorkspaceDelegate {
 private final class TestWorkspace {
 
     let sandbox: AbsolutePath
-    var fs: FileSystem
+    let fs: FileSystem
     let roots: [TestPackage]
     let packages: [TestPackage]
     var manifestLoader: MockManifestLoader


### PR DESCRIPTION
The FileSystem protocol is now class only.
The RootedFileSystem is now a class.
All tests pass. 