### PR TITLE
[WIP] [SR-6277] Fix for streaming git and json output to standard i/o stream

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -174,6 +174,10 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             describe(graph.rootPackages[0].underlyingPackage, in: options.describeMode, on: stdoutStream)
 
         case .dumpPackage:
+            
+            let workspace = try getActiveWorkspace()
+            (workspace.delegate as? ToolWorkspaceDelegate)?.shouldOutputToStdErr = true
+
             let graph = try loadPackageGraph()
             let manifest = graph.rootPackages[0].manifest
             print(try manifest.jsonString())

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -55,8 +55,9 @@ struct TargetNotFoundDiagnostic: DiagnosticData {
     let targetName: String
 }
 
-internal class ToolWorkspaceDelegate: WorkspaceDelegate {
-    
+class ToolWorkspaceDelegate: WorkspaceDelegate {
+    /// Setting this flag to true allows us to output to stderr. Otherwise we output to stdout
+    /// Defaults to false,
     var shouldOutputToStdErr: Bool = false
     
     func packageGraphWillLoad(
@@ -103,8 +104,9 @@ internal class ToolWorkspaceDelegate: WorkspaceDelegate {
         output("warning: " + message)
     }
     
+    /// Output to either stdout or stderr depending on whether `shouldOutputToStdErr` is set
     func output(_ message: String) {
-        let stdStream = (shouldOutputToStdErr) ? stderrStream : stdoutStream
+        let stdStream = shouldOutputToStdErr ? stderrStream : stdoutStream
         stdStream.write(message + "\n")
         stdStream.flush()
     }

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -55,8 +55,10 @@ struct TargetNotFoundDiagnostic: DiagnosticData {
     let targetName: String
 }
 
-private class ToolWorkspaceDelegate: WorkspaceDelegate {
-
+internal class ToolWorkspaceDelegate: WorkspaceDelegate {
+    
+    var shouldOutputToStdErr: Bool = false
+    
     func packageGraphWillLoad(
         currentGraph: PackageGraph,
         dependencies: AnySequence<ManagedDependency>,
@@ -65,39 +67,46 @@ private class ToolWorkspaceDelegate: WorkspaceDelegate {
     }
 
     func fetchingWillBegin(repository: String) {
-        print("Fetching \(repository)")
+        output("Fetching \(repository)")
     }
 
     func fetchingDidFinish(repository: String, diagnostic: Diagnostic?) {
     }
 
     func repositoryWillUpdate(_ repository: String) {
-        print("Updating \(repository)")
+        output("Updating \(repository)")
     }
 
     func repositoryDidUpdate(_ repository: String) {
+        output("Updated \(repository)")
     }
     
     func dependenciesUpToDate() {
-        print("Everything is already up-to-date")
+        output("Everything is already up-to-date")
     }
 
     func cloning(repository: String) {
-        print("Cloning \(repository)")
+        output("Cloning \(repository)")
     }
 
     func checkingOut(repository: String, atReference reference: String, to path: AbsolutePath) {
         // FIXME: This is temporary output similar to old one, we will need to figure
         // out better reporting text.
-        print("Resolving \(repository) at \(reference)")
+        output("Resolving \(repository) at \(reference)")
     }
 
     func removing(repository: String) {
-        print("Removing \(repository)")
+        output("Removing \(repository)")
     }
 
     func warning(message: String) {
-        print("warning: " + message)
+        output("warning: " + message)
+    }
+    
+    func output(_ message: String) {
+        let stdStream = (shouldOutputToStdErr) ? stderrStream : stdoutStream
+        stdStream.write(message + "\n")
+        stdStream.flush()
     }
 
     func managedDependenciesDidUpdate(_ dependencies: AnySequence<ManagedDependency>) {


### PR DESCRIPTION
This PR fixes SR-6277.

Now if `dump-package` is called the git output log is streamed to stderr and the json ouput is streamed to stdout.

This can be tested on the command line by calling:
```
swift-package --package-path "path to swiftpm enabled repo" dump-package > stdout.log 2> stderr.log
```
This is still work in progress because I still need to write tests. (@hartbit will provide some assistance)
