### PR TITLE
[SR-6064] Warn on unused dependencies

### DIFF
--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -1230,7 +1230,7 @@ final class WorkspaceTests: XCTestCase {
                 TestPackage(
                     name: "Root",
                     targets: [
-                        TestTarget(name: "Root", dependencies: ["Foo"]),
+                        TestTarget(name: "Root", dependencies: ["Foo", "Bar"]),
                     ],
                     products: [],
                     dependencies: [
@@ -1456,7 +1456,7 @@ final class WorkspaceTests: XCTestCase {
                 TestPackage(
                     name: "Root",
                     targets: [
-                        TestTarget(name: "Root", dependencies: ["Foo"]),
+                        TestTarget(name: "Root", dependencies: ["Foo", "Bar"]),
                     ],
                     products: [],
                     dependencies: [


### PR DESCRIPTION
Fixed at SwiftAlps with the help of @JohnSundell, @melbic, @mekanics and two other attendees.

It was chosen to not trigger this warning when the unused-dependency contains an executable product, to not warn on the valid use-case that #1381 allows.