### PR TITLE
Revert "[SR-5918] Add diagnostic error for duplicate product names"

### DIFF
--- a/Sources/PackageGraph/PackageGraphLoader.swift
+++ b/Sources/PackageGraph/PackageGraphLoader.swift
@@ -211,12 +211,6 @@ private func createResolvedPackages(
             .filter({ $0.product.type != .test })
         let productDependencyMap = productDependencies.createDictionary({ ($0.product.name, $0) })
 
-        // Establish if there are multiple products with the same name.
-        let duplicateProductNames = Set(packageBuilder.products.map { $0.product.name }.findDuplicates())
-        for duplicateProductName in duplicateProductNames {
-            diagnostics.emit(ModuleError.duplicateProduct(duplicateProductName), location: diagnosticLocation())
-        }
-
         // Establish dependencies in each target.
         for targetBuilder in packageBuilder.targets {
             // If a target with similar name was encountered before, we emit a diagnostic.

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -32,9 +32,6 @@ public enum ModuleError: Swift.Error {
     /// Indicates two targets with the same name.
     case duplicateModule(String)
 
-    /// Indicates two products with the same name.
-    case duplicateProduct(String)
-
     /// One or more referenced targets could not be found.
     case modulesNotFound([String])
 
@@ -71,8 +68,6 @@ extension ModuleError: CustomStringConvertible {
         switch self {
         case .duplicateModule(let name):
             return "multiple targets named '\(name)'"
-        case .duplicateProduct(let name):
-            return "multiple products named '\(name)'"
         case .modulesNotFound(let targets):
             let targets = targets.joined(separator: ", ")
             return "could not find target(s): \(targets); use the 'path' property in the Swift 4 manifest to set a custom target path"

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -136,35 +136,6 @@ class PackageGraphTests: XCTestCase {
         XCTAssertEqual(diagnostics.diagnostics[0].localizedDescription, "multiple targets named 'Bar'")
     }
 
-    func testDuplicateProducts() throws {
-        let fs = InMemoryFileSystem(emptyFiles:
-            "/Foo/Sources/Bar/source.swift",
-            "/Bar/source.swift"
-        )
-
-        let diagnostics = DiagnosticsEngine()
-        _ = loadMockPackageGraph4([
-            "/Foo": Package(
-                name: "Bar",
-                products: [
-                    .library(name: "Bar", targets: ["Bar"]),
-                    .library(name: "Bar", targets: ["Bar"]),
-                    .library(name: "Bar", targets: ["Bar"]),
-                    .library(name: "Boo", targets: ["Bar"]),
-                    .library(name: "Boo", targets: ["Bar"])
-                ],
-                targets: [
-                    .target(name: "Bar"),
-                ]),
-            ], root: "/Foo", diagnostics: diagnostics, in: fs)
-
-        let multipleBarDiagnostics = diagnostics.diagnostics.filter { $0.localizedDescription == "multiple products named 'Bar'" }
-        let multipleBooDiagnostics = diagnostics.diagnostics.filter { $0.localizedDescription == "multiple products named 'Boo'" }
-
-        XCTAssertEqual(multipleBarDiagnostics.count, 1)
-        XCTAssertEqual(multipleBooDiagnostics.count, 1)
-    }
-
     func testEmptyDependency() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Foo/Sources/Foo/foo.swift",
@@ -205,7 +176,6 @@ class PackageGraphTests: XCTestCase {
         ("testCycle", testCycle),
         ("testProductDependencies", testProductDependencies),
         ("testTestTargetDeclInExternalPackage", testTestTargetDeclInExternalPackage),
-        ("testDuplicateProducts", testDuplicateProducts),
         ("testEmptyDependency", testEmptyDependency),
     ]
 }


### PR DESCRIPTION
Reverts apple/swift-package-manager#1393

Reverting because this broke the [Plank](https://github.com/pinterest/plank) package. While re-fixing this issue, we should make sure we have a test case that would have caught the failure in the plank package.

```
git clone https://github.com/pinterest/plank
cd plank
git checkout 91d26a0974583e7d216b5192f738c5d9dd57da6a
swift build
error: multiple products named 'plank'
```

See: https://bugs.swift.org/browse/SR-6488