### PR TITLE
[Build] Add lang std flag per source file

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -193,9 +193,6 @@ public final class ClangTargetDescription {
       #endif
         args += ["-fblocks"]
         args += ["-fmodules", "-fmodule-name=" + target.c99name]
-        if let languageStandard = clangTarget.languageStandard {
-            args += ["-std=\(languageStandard)"]
-        }
         args += ["-I", clangTarget.includeDir.asString]
         args += additionalFlags
         args += moduleCacheArgs

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -796,14 +796,10 @@ public final class PackageBuilder {
 
             let sources = Sources(paths: cSources, root: potentialModule.path)
 
-            // Select the right language standard.
-            let isCXX = sources.containsCXXFiles
-            let languageStandard = isCXX ? manifest.package.cxxLanguageStandard?.rawValue : manifest.package.cLanguageStandard?.rawValue 
-
             return ClangTarget(
                 name: potentialModule.name,
-                isCXX: isCXX,
-                languageStandard: languageStandard,
+                cLanguageStandard: manifest.package.cLanguageStandard?.rawValue,
+                cxxLanguageStandard: manifest.package.cxxLanguageStandard?.rawValue,
                 includeDir: publicHeadersPath,
                 isTest: potentialModule.isTest,
                 sources: sources,

--- a/Sources/PackageModel/Module.swift
+++ b/Sources/PackageModel/Module.swift
@@ -140,13 +140,16 @@ public class ClangTarget: Target {
     /// True if this is a C++ target.
     public let isCXX: Bool
 
-    /// The C or C++ language standard flag.
-    public let languageStandard: String?
+    /// The C language standard flag.
+    public let cLanguageStandard: String?
+
+    /// The C++ language standard flag.
+    public let cxxLanguageStandard: String?
 
     public init(
         name: String,
-        isCXX: Bool,
-        languageStandard: String?,
+        cLanguageStandard: String?,
+        cxxLanguageStandard: String?,
         includeDir: AbsolutePath,
         isTest: Bool = false,
         sources: Sources,
@@ -154,10 +157,10 @@ public class ClangTarget: Target {
         productDependencies: [(name: String, package: String?)] = []
     ) {
         assert(includeDir.contains(sources.root), "\(includeDir) should be contained in the source root \(sources.root)")
-        assert(sources.containsCXXFiles == isCXX)
         let type: Kind = isTest ? .test : sources.computeModuleType()
-        self.isCXX = isCXX
-        self.languageStandard = languageStandard
+        self.isCXX = sources.containsCXXFiles
+        self.cLanguageStandard = cLanguageStandard
+        self.cxxLanguageStandard = cxxLanguageStandard
         self.includeDir = includeDir
         super.init(
             name: name,

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -146,7 +146,7 @@ class ModuleMapGeneration: XCTestCase {
 
 func ModuleMapTester(_ name: String, includeDir: String = "include", in fileSystem: FileSystem, _ body: (ModuleMapResult) -> Void) {
     let includeDir = AbsolutePath.root.appending(component: includeDir)
-    let target = ClangTarget(name: name, isCXX: false, languageStandard: nil, includeDir: includeDir, isTest: false, sources: Sources(paths: [], root: .root))
+    let target = ClangTarget(name: name, cLanguageStandard: nil, cxxLanguageStandard: nil, includeDir: includeDir, isTest: false, sources: Sources(paths: [], root: .root))
     let warningStream = BufferedOutputByteStream()
     var generator = ModuleMapGenerator(for: target, fileSystem: fileSystem, warningStream: warningStream)
     var diagnostics = Set<String>()


### PR DESCRIPTION
We were adding language standard flag per target which is wrong because
a Clang target can contain mixed C and C++ files.

- <rdar://problem/35782488> [SR-6430]: [SwiftPM] Build error passing invalid C standard to a C source file