### PR TITLE
[XcodeprojTests] Fix parse it test

### DIFF
--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -38,7 +38,7 @@ class GenerateXcodeprojTests: XCTestCase {
             let output = try Process.checkNonZeroExit(
                 args: "env", "-u", "TOOLCHAINS", "xcodebuild", "-list", "-project", outpath.asString).chomp()
 
-            XCTAssertEqual(output, """
+            XCTAssertTrue(output.hasPrefix("""
                Information about project "DummyProjectName":
                    Targets:
                        DummyModuleName
@@ -53,7 +53,7 @@ class GenerateXcodeprojTests: XCTestCase {
                
                    Schemes:
                        DummyProjectName-Package
-               """)
+               """))
         }
       #endif
     }


### PR DESCRIPTION
Looks like Xcode now auto-generates schemes for all targets.

- <rdar://problem/35814586> Swift CI: Swift incremental (Tools Opt+Assert, Stdlib Opt+Assert) (internal-swift-4.1-branch)