### PR TITLE
[Commands] Use the original cwd to compute outpath

### DIFF
--- a/Sources/Basic/PathShims.swift
+++ b/Sources/Basic/PathShims.swift
@@ -214,16 +214,13 @@ public class RecursibleDirectoryContentsGenerator: IteratorProtocol, Sequence {
 extension AbsolutePath {
     /// Returns a path suitable for display to the user (if possible, it is made
     /// to be relative to the current working directory).
-    /// - Note: Therefore this function relies on the working directory's not
-    /// changing during execution.
-    public var prettyPath: String {
-        let currDir = currentWorkingDirectory
+    public func prettyPath(cwd: AbsolutePath = currentWorkingDirectory) -> String {
         // FIXME: Instead of string prefix comparison we should add a proper API
         // to AbsolutePath to determine ancestry.
-        if self == currDir {
+        if self == cwd {
             return "."
-        } else if self.asString.hasPrefix(currDir.asString + "/") {
-            return "./" + self.relative(to: currDir).asString
+        } else if self.asString.hasPrefix(cwd.asString + "/") {
+            return "./" + self.relative(to: cwd).asString
         } else {
             return self.asString
         }

--- a/Sources/Build/llbuild.swift
+++ b/Sources/Build/llbuild.swift
@@ -138,7 +138,7 @@ public struct LLBuildManifestGenerator {
         } else {
             let inputs = buildProduct.objects + buildProduct.dylibs.map({ $0.binary })
             tool = ShellTool(
-                description: "Linking \(buildProduct.binary.prettyPath)",
+                description: "Linking \(buildProduct.binary.prettyPath())",
                 inputs: inputs.map({ $0.asString }),
                 outputs: [buildProduct.binary.asString],
                 args: buildProduct.linkArguments())

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -168,7 +168,7 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
                 graph: graph,
                 options: options.xcodeprojOptions)
 
-            print("generated:", outpath.prettyPath)
+            print("generated:", outpath.prettyPath(cwd: originalWorkingDirectory))
 
         case .describe:
             let graph = try loadPackageGraph()


### PR DESCRIPTION
The pretty outpath is computed wrong when we change the working
directory during execution. This patch uses the original cwd to compute
the outpath.

- <rdar://problem/35841891> swift package generate-xcodeproj outputs location without accounting for --package-path