### PR TITLE
Don’t include test targets from non-root packages

### DIFF
--- a/Sources/TestSupport/PackageGraphTester.swift
+++ b/Sources/TestSupport/PackageGraphTester.swift
@@ -34,8 +34,7 @@ public final class PackageGraphResult {
 
     public func check(targets: String..., file: StaticString = #file, line: UInt = #line) {
         XCTAssertEqual(
-            graph.packages
-                .flatMap{ $0.targets }
+            graph.allTargets
                 .filter{ $0.type != .test }
                 .map{ $0.name }
                 .sorted(), targets.sorted(), file: file, line: line)
@@ -43,20 +42,14 @@ public final class PackageGraphResult {
 
     public func check(testModules: String..., file: StaticString = #file, line: UInt = #line) {
         XCTAssertEqual(
-            graph.packages
-                .flatMap{ $0.targets }
+            graph.allTargets
                 .filter{ $0.type == .test }
                 .map{ $0.name }
                 .sorted(), testModules.sorted(), file: file, line: line)
     }
 
     public func find(target: String) -> ResolvedTarget? {
-        for pkg in graph.packages {
-            if let target = pkg.targets.first(where: { $0.name == target }) {
-                return target
-            }
-        }
-        return nil
+        return graph.allTargets.first(where: { $0.name == target })
     }
 
     public func check(dependencies: String..., target name: String, file: StaticString = #file, line: UInt = #line) {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -143,15 +143,13 @@ final class BuildPlanTests: XCTestCase {
             graph: graph,
             fileSystem: fileSystem))
 
-        XCTAssertEqual(Set(result.productMap.keys), ["BPackageTests", "APackageTests"])
+        XCTAssertEqual(Set(result.productMap.keys), ["APackageTests"])
       #if os(macOS)
-        XCTAssertEqual(Set(result.targetMap.keys), ["ATarget", "BTarget", "ATargetTests", "BTargetTests"])
+        XCTAssertEqual(Set(result.targetMap.keys), ["ATarget", "BTarget", "ATargetTests"])
       #else
         XCTAssertEqual(Set(result.targetMap.keys), [
             "APackageTests",
             "ATarget",
-            "BPackageTests",
-            "BTargetTests",
             "ATargetTests",
             "BTarget"
         ])

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -40,7 +40,7 @@ class PackageGraphTests: XCTestCase {
         PackageGraphTester(g) { result in
             result.check(packages: "Bar", "Foo", "Baz")
             result.check(targets: "Bar", "Foo", "Baz", "FooDep")
-            result.check(testModules: "BazTests", "FooTests")
+            result.check(testModules: "BazTests")
             result.check(dependencies: "FooDep", target: "Foo")
             result.check(dependencies: "Foo", target: "Bar")
             result.check(dependencies: "Bar", target: "Baz")
@@ -117,7 +117,7 @@ class PackageGraphTests: XCTestCase {
         PackageGraphTester(g) { result in
             result.check(packages: "Bar", "Foo")
             result.check(targets: "Bar", "Foo")
-            result.check(testModules: "BarTests", "SomeTests")
+            result.check(testModules: "BarTests")
         }
     }
 


### PR DESCRIPTION
This fixes [SR-6559](https://bugs.swift.org/browse/SR-6559) so that `PackageGraph` does not list test targets and test products from non-root packages. As a result, `swift-test` will not find any when looking for test products.