### PR TITLE
[Xcodeproj] Use TOOLCHAIN_DIR macro for manifest indexing

### DIFF
--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -71,7 +71,13 @@ func xcodeProject(
             productType: .framework, name: "\(package.name)PackageDescription")
         let compilePhase = pdTarget.addSourcesBuildPhase()
         compilePhase.addBuildFile(fileRef: manifestFileRef)
-        pdTarget.buildSettings.common.OTHER_SWIFT_FLAGS += package.manifest.interpreterFlags
+
+        var interpreterFlags = package.manifest.interpreterFlags
+        if !interpreterFlags.isEmpty {
+            // Patch the interpreter flags to use Xcode supported toolchain macro instead of the resolved path.
+            interpreterFlags[3] = "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/" + String(package.manifest.manifestVersion.rawValue)
+        }
+        pdTarget.buildSettings.common.OTHER_SWIFT_FLAGS += interpreterFlags
         pdTarget.buildSettings.common.SWIFT_VERSION = "\(package.manifest.manifestVersion.rawValue).0"
         pdTarget.buildSettings.common.LD = "/usr/bin/true"
     }

--- a/Tests/XcodeprojTests/FunctionalTests.swift
+++ b/Tests/XcodeprojTests/FunctionalTests.swift
@@ -157,6 +157,7 @@ func XCTAssertXcodeBuild(project: AbsolutePath, file: StaticString = #file, line
         let swiftLibraryPath = resolveSymlinks(swiftCompilerPath).appending(components: "..", "..", "lib", "swift", "macosx")
         if localFileSystem.exists(swiftCompilerPath) {
             stream <<< "SWIFT_LIBRARY_PATH = " <<< swiftLibraryPath.asString <<< "\n"
+            stream <<< "TOOLCHAIN_DIR = " <<< swiftCompilerPath.appending(components: "..", "..").asString <<< "\n"
         }
         
         // We don't need dSYM generated for tests

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -945,6 +945,11 @@ def main():
             shutil.rmtree(libdir)
         symlink_force(os.path.join(sandbox_path, "lib"), target_path)
 
+        # To simulate usr/lib directory.
+        usrdir = os.path.join(target_path, "usr")
+        mkdir_p(usrdir)
+        symlink_force(os.path.join(sandbox_path, "lib"), usrdir)
+
         if args.foundation_path:
             libswiftdir = os.path.join(sandbox_path, "lib", "swift", "linux")
             mkdir_p(libswiftdir)


### PR DESCRIPTION
Instead of using the resolved path at time of generating, use
TOOLCHAIN_DIR macro which has the correct value according to the
toolchain selected in Xcode.

https://bugs.swift.org/browse/SR-6190