### PR TITLE
Use `tool` variable rather than hard-coded executable name

### DIFF
--- a/Sources/Utility/Git.swift
+++ b/Sources/Utility/Git.swift
@@ -66,7 +66,7 @@ public class Git {
     /// Returns true if the git reference name is well formed.
     public static func checkRefFormat(ref: String) -> Bool {
         do {
-            let result = try Process.popen(args: "git", "check-ref-format", "--allow-onelevel", ref)
+            let result = try Process.popen(args: tool, "check-ref-format", "--allow-onelevel", ref)
             return result.exitStatus == .terminated(code: 0)
         } catch {
             return false


### PR DESCRIPTION
`checkRefFormat` launches a git process using a string literal executable name `"git"`, but a public var `tool` with the same value is declared only a few lines above. It seems like the intent was to use that variable to specify the git executable.