### PR TITLE
Generate xcodeproj files with defaultConfigurationName set to Release

### DIFF
--- a/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
+++ b/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
@@ -354,7 +354,7 @@ extension Xcode.BuildSettingsTable: PropertyListSerializable {
         // FIXME: What is this, and why are we setting it?
         dict["defaultConfigurationIsVisible"] = .string("0")
         // FIXME: Should we allow this to be set in the model?
-        dict["defaultConfigurationName"] = .string("Debug")
+        dict["defaultConfigurationName"] = .string("Release")
         return dict
     }
 }

--- a/Tests/XcodeprojTests/FunctionalTests.swift
+++ b/Tests/XcodeprojTests/FunctionalTests.swift
@@ -25,7 +25,7 @@ class FunctionalTests: XCTestCase {
             let pbx = prefix.appending(component: "Library.xcodeproj")
             XCTAssertDirectoryExists(pbx)
             XCTAssertXcodeBuild(project: pbx)
-            let build = prefix.appending(components: "build", "Debug")
+            let build = prefix.appending(components: "build", "Release")
             XCTAssertDirectoryExists(build.appending(component: "Library.framework"))
         }
 #endif
@@ -42,7 +42,7 @@ class FunctionalTests: XCTestCase {
             XCTAssertFileExists(pbx.appending(component: "SeaLib_Info.plist"))
 
             XCTAssertXcodeBuild(project: pbx)
-            let build = prefix.appending(components: "build", "Debug")
+            let build = prefix.appending(components: "build", "Release")
             XCTAssertDirectoryExists(build.appending(component: "SeaLib.framework"))
             XCTAssertFileExists(build.appending(component: "SeaExec"))
             XCTAssertFileExists(build.appending(component: "CExec"))
@@ -80,7 +80,7 @@ class FunctionalTests: XCTestCase {
             let pbx = moduleUser.appending(component: "SystemModuleUser.xcodeproj")
             XCTAssertDirectoryExists(pbx)
             XCTAssertXcodeBuild(project: pbx)
-            XCTAssertFileExists(moduleUser.appending(components: "build", "Debug", "SystemModuleUser"))
+            XCTAssertFileExists(moduleUser.appending(components: "build", "Release", "SystemModuleUser"))
         }
 #endif
     }
@@ -92,7 +92,7 @@ class FunctionalTests: XCTestCase {
             let pbx = prefix.appending(component: "PackageWithNonc99NameModules.xcodeproj")
             XCTAssertDirectoryExists(pbx)
             XCTAssertXcodeBuild(project: pbx)
-            let build = prefix.appending(components: "build", "Debug")
+            let build = prefix.appending(components: "build", "Release")
             XCTAssertDirectoryExists(build.appending(component: "A_B.framework"))
             XCTAssertDirectoryExists(build.appending(component: "B_C.framework"))
             XCTAssertDirectoryExists(build.appending(component: "C_D.framework"))
@@ -158,6 +158,10 @@ func XCTAssertXcodeBuild(project: AbsolutePath, file: StaticString = #file, line
         if localFileSystem.exists(swiftCompilerPath) {
             stream <<< "SWIFT_LIBRARY_PATH = " <<< swiftLibraryPath.asString <<< "\n"
         }
+        
+        // We don't need dSYM generated for tests
+        stream <<< "DEBUG_INFORMATION_FORMAT = dwarf\n"
+        
         try localFileSystem.writeFileContents(xcconfig, bytes: stream.bytes)
 
         try Process.checkNonZeroExit(

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -49,7 +49,7 @@ class GenerateXcodeprojTests: XCTestCase {
                        Debug
                        Release
                
-                   If no build configuration is specified and -scheme is not passed then "Debug" is used.
+                   If no build configuration is specified and -scheme is not passed then "Release" is used.
                
                    Schemes:
                        DummyProjectName-Package


### PR DESCRIPTION
It is Xcode's behavior to generate xcodeproj files with Release being the default configuration for command line builds.   When you use Swift Package Manager however to generate an xcodeproj file it sets the default (i.e. command line) build to be Debug.   This causes problems when other projects depend on this default value.   For example apple/swift-protobuf#708 -- in that case the xcodeproj file was changed but if swift package manager were ever used to regenerate the project file then the expected default of Release would get overwritten.