### PR TITLE
Collect output from successful tests in parallel execution mode [SR-6487]

### DIFF
--- a/Fixtures/Miscellaneous/ParallelTestsPkg/Tests/ParallelTestsPkgTests/ParallelTestsFailureTests.swift
+++ b/Fixtures/Miscellaneous/ParallelTestsPkg/Tests/ParallelTestsPkgTests/ParallelTestsFailureTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import ParallelTestsPkg
+
+class ParallelTestsFailureTests: XCTestCase {
+
+    func testSureFailure() {
+        XCTFail("Giving up is the only sure way to fail.")
+    }
+    
+    static var allTests : [(String, (ParallelTestsFailureTests) -> () throws -> Void)] {
+        return [
+            ("testSureFailure", testSureFailure),
+        ]
+    }
+}


### PR DESCRIPTION
From the ticket:
> The ‘swift test --parallel’ command currently discards the output of successful tests and instead shows a status bar, only showing full output for failed tests.
> 
> It would be useful for debugging/analysis purposes to be able to access test output for both successful and unsuccessful tests
