### PR TITLE
SIGUNUSED was removed in glibc 2.26, replaced with SIGSYS

### DIFF
--- a/Sources/Basic/Process.swift
+++ b/Sources/Basic/Process.swift
@@ -258,7 +258,7 @@ public final class Process: ObjectIdentifierProtocol {
         // modify, so we have to take care about the set we use.
         var mostSignals = sigset_t()
         sigemptyset(&mostSignals)
-        for i in 1 ..< SIGUNUSED {
+        for i in 1 ..< SIGSYS {
             if i == SIGKILL || i == SIGSTOP {
                 continue
             }


### PR DESCRIPTION
This is identical to issue as https://bugs.swift.org/browse/SR-6409; the resolution is to change SIGUNUSED to SIGSYS which is defined with the same value (31).