### PR TITLE
Allow dynamic access to parsed arguments by name

### DIFF
--- a/Tests/UtilityTests/ArgumentParserTests.swift
+++ b/Tests/UtilityTests/ArgumentParserTests.swift
@@ -82,6 +82,9 @@ class ArgumentParserTests: XCTestCase {
         XCTAssertEqual(args.get(inputFiles) ?? [], ["input1", "input2"])
         XCTAssertEqual(args.get(outputFiles) ?? [], ["output1", "output2"])
         XCTAssertEqual(args.get(remaining) ?? [], ["--foo", "-Xld", "bar"])
+        XCTAssertEqual(try args.get("--verbose") as Int?, 2)
+        XCTAssertEqual(try args.get("input files") as [String]? ?? [], ["input1", "input2"])
+        XCTAssertEqual(try args.get("invalid") as Int?, nil)
 
         let stream = BufferedOutputByteStream()
         parser.printUsage(on: stream)
@@ -134,6 +137,15 @@ class ArgumentParserTests: XCTestCase {
         } catch ArgumentParserError.invalidValue(let option, let error) {
             XCTAssertEqual(option, "--verbosity")
             XCTAssertEqual(error, ArgumentConversionError.typeMismatch(value: "yes", expectedType: Int.self))
+        }
+
+        do {
+            let results = try parser.parse(["foo", "--verbosity", "2"])
+            _ = try results.get("--verbosity") as String?
+            XCTFail("unexpected success")
+        } catch ArgumentParserError.invalidValue(let value, let error) {
+            XCTAssertEqual(value, "--verbosity")
+            XCTAssertEqual(error, ArgumentConversionError.typeMismatch(value: "2", expectedType: String.self))
         }
 
         do {
@@ -198,6 +210,8 @@ class ArgumentParserTests: XCTestCase {
         let foo = parser.add(option: "--foo", kind: String.self, usage: "The foo option")
         let bar = parser.add(option: "--bar", shortName: "-b", kind: String.self, usage: "The bar option")
 
+        let parentArg = parser.add(option: "--parent", kind: String.self, usage: "The parent option")
+
         let parserA = parser.add(subparser: "a", overview: "A!")
         let branchOption = parserA.add(option: "--branch", kind: String.self, usage: "The branch to use")
 
@@ -211,13 +225,15 @@ class ArgumentParserTests: XCTestCase {
         XCTAssertEqual(args.get(noFlyOption), nil)
         XCTAssertEqual(args.subparser(parser), "a")
 
-        args = try parser.parse(["--bar", "bar", "--foo", "foo", "b", "--no-fly"])
+        args = try parser.parse(["--parent", "p", "--bar", "bar", "--foo", "foo", "b", "--no-fly"])
 
         XCTAssertEqual(args.get(foo), "foo")
         XCTAssertEqual(args.get(bar), "bar")
         XCTAssertEqual(args.get(branchOption), nil)
         XCTAssertEqual(args.get(noFlyOption), true)
         XCTAssertEqual(args.subparser(parser), "b")
+        XCTAssertEqual(args.get(parentArg), "p")
+        XCTAssertEqual(try args.get("--parent") as String?, "p")
 
         do {
             args = try parser.parse(["c"])
@@ -251,6 +267,7 @@ class ArgumentParserTests: XCTestCase {
         XCTAssert(usage.contains("USAGE: SomeBinary sample parser"))
         XCTAssert(usage.contains("  --bar, -b   The bar option"))
         XCTAssert(usage.contains("  --foo       The foo option"))
+        XCTAssert(usage.contains("  --parent    The parent option"))
         XCTAssert(usage.contains("SUBCOMMANDS:"))
         XCTAssert(usage.contains("  b           B!"))
         XCTAssert(usage.contains("--help"))


### PR DESCRIPTION
> Note that this PR aims to improve the public `Utility` library for 3rd parties.

At the moment the only way to get access to the parsed arguments from `ArgumentParser.Result` is to pass in the original argument instance. This method of argument lookup becomes tricky in more dynamic uses of the parser, for example when different arguments are generated at runtime, or many commands share the same arguments.

Currently the argument instance must be saved somewhere so it can be passed into the `ArgumentParser.Result` after parsing. This is hard  as there are many different types of arguments, and they don't all fit nicely into a standard Array or Dictionary. 
This could be solved by making `AnyArgument` public (increases public API surface area and leaks an implementation detail)) or with the use of `ArgumentBinder` (a workaround).

This PR takes a different approach however and adds a `get(name: String) -> Any` function to `ArgumentParser.Result` for more dynamic use cases. This required changing `ArgumentParser.Result.result` from `[AnyArgument: Any]` to `[String: Any]`. This doesn't change any behaviour however as `AnyArgument` was using `name` for `Hashable` conformance anyway, so this in fact reduces the allocation of pointless `AnyArgument` values.

This change is backwards compatible and only includes an additional function to the public API.