### PR TITLE
[Utility] Fix `printUsage` for ArgumentParser

### DIFF
--- a/Sources/Utility/ArgumentParser.swift
+++ b/Sources/Utility/ArgumentParser.swift
@@ -835,10 +835,11 @@ public final class ArgumentParser {
         let padding = 2
 
         let maxWidth: Int
-        // Figure out the max width based on argument length or choose the default width if max width is longer
-        // than the default width.
-        if let maxArgument = (positionalArguments + optionArguments).map({ $0.name.count }).max(),
-            maxArgument < maxWidthDefault {
+        // Determine the max width based on argument length or choose the
+        // default width if max width is longer than the default width.
+        if let maxArgument = (positionalArguments + optionArguments).map({
+            [$0.name, $0.shortName].flatMap({ $0 }).joined(separator: ", ").count
+        }).max(), maxArgument < maxWidthDefault {
             maxWidth = maxArgument + padding + 1
         } else {
             maxWidth = maxWidthDefault
@@ -849,15 +850,15 @@ public final class ArgumentParser {
             // Start with a new line and add some padding.
             stream <<< "\n" <<< Format.asRepeating(string: " ", count: padding)
             let count = argument.count
-            // If the argument name is more than the set width take the whole
-            // line for it, otherwise we can fit everything in one line.
+            // If the argument is longer than the max width, print the usage
+            // on a new line. Otherwise, print the usage on the same line.
             if count >= maxWidth - padding {
                 stream <<< argument <<< "\n"
-                // Align full width because we on a new line.
+                // Align full width because usage is to be printed on a new line.
                 stream <<< Format.asRepeating(string: " ", count: maxWidth + padding)
             } else {
                 stream <<< argument
-                // Align to the remaining empty space we have.
+                // Align to the remaining empty space on the line.
                 stream <<< Format.asRepeating(string: " ", count: maxWidth - count)
             }
             stream <<< usage
@@ -876,7 +877,7 @@ public final class ArgumentParser {
         if optionArguments.count > 0 {
             stream <<< "\n\n"
             stream <<< "OPTIONS:"
-            for argument in optionArguments.lazy.sorted(by: {$0.name < $1.name}) {
+            for argument in optionArguments.lazy.sorted(by: { $0.name < $1.name }) {
                 guard let usage = argument.usage else { continue }
                 // Create name with its shortname, if available.
                 let name = [argument.name, argument.shortName].flatMap({ $0 }).joined(separator: ", ")

--- a/Tests/UtilityTests/ArgumentParserTests.swift
+++ b/Tests/UtilityTests/ArgumentParserTests.swift
@@ -196,6 +196,7 @@ class ArgumentParserTests: XCTestCase {
     func testSubparser() throws {
         let parser = ArgumentParser(commandName: "SomeBinary", usage: "sample parser", overview: "Sample overview")
         let foo = parser.add(option: "--foo", kind: String.self, usage: "The foo option")
+        let bar = parser.add(option: "--bar", shortName: "-b", kind: String.self, usage: "The bar option")
 
         let parserA = parser.add(subparser: "a", overview: "A!")
         let branchOption = parserA.add(option: "--branch", kind: String.self, usage: "The branch to use")
@@ -203,15 +204,17 @@ class ArgumentParserTests: XCTestCase {
         let parserB = parser.add(subparser: "b", overview: "B!")
         let noFlyOption = parserB.add(option: "--no-fly", kind: Bool.self, usage: "Should you fly?")
 
-        var args = try parser.parse(["--foo", "foo", "a", "--branch", "bugfix"])
+        var args = try parser.parse(["--foo", "foo", "--bar", "bar", "a", "--branch", "bugfix"])
         XCTAssertEqual(args.get(foo), "foo")
+        XCTAssertEqual(args.get(bar), "bar")
         XCTAssertEqual(args.get(branchOption), "bugfix")
         XCTAssertEqual(args.get(noFlyOption), nil)
         XCTAssertEqual(args.subparser(parser), "a")
 
-        args = try parser.parse(["--foo", "foo", "b", "--no-fly"])
+        args = try parser.parse(["--bar", "bar", "--foo", "foo", "b", "--no-fly"])
 
         XCTAssertEqual(args.get(foo), "foo")
+        XCTAssertEqual(args.get(bar), "bar")
         XCTAssertEqual(args.get(branchOption), nil)
         XCTAssertEqual(args.get(noFlyOption), true)
         XCTAssertEqual(args.subparser(parser), "b")
@@ -246,9 +249,10 @@ class ArgumentParserTests: XCTestCase {
 
         XCTAssert(usage.contains("OVERVIEW: Sample overview"))
         XCTAssert(usage.contains("USAGE: SomeBinary sample parser"))
-        XCTAssert(usage.contains("  --foo   The foo option"))
+        XCTAssert(usage.contains("  --bar, -b   The bar option"))
+        XCTAssert(usage.contains("  --foo       The foo option"))
         XCTAssert(usage.contains("SUBCOMMANDS:"))
-        XCTAssert(usage.contains("  b       B!"))
+        XCTAssert(usage.contains("  b           B!"))
         XCTAssert(usage.contains("--help"))
 
         stream = BufferedOutputByteStream()


### PR DESCRIPTION
Fixed a formatting bug in `ArgumentParser.printUsage` where `maxWidth` only took argument name width into account, ignoring the width of the argument short name and `", "` separator.

Incorrect output was produced, like the following:
```
OPTIONS:
  --bar, -b
            The bar option
  --foo     The foo option
```

After this fix, the output is:
```
OPTIONS:
  --bar, -b   The bar option
  --foo       The foo option
```

Since there isn't a dedicated test case for `printUsage`, I edited an existing parser test to check for this correct functionality.