### PR TITLE
[Process] Include failing command output in error description.

### DIFF
--- a/Sources/Basic/Process.swift
+++ b/Sources/Basic/Process.swift
@@ -554,6 +554,7 @@ extension ProcessResult.Error: CustomStringConvertible {
             case .signalled(let signal):
                 stream <<< "signalled(\(signal)): "
             }
+ 
             // Strip sandbox information from arguments to keep things pretty.
             var args = result.arguments
             // This seems a little fragile.
@@ -561,6 +562,17 @@ extension ProcessResult.Error: CustomStringConvertible {
                 args = args.suffix(from: 3).map({$0})
             }
             stream <<< args.map({ $0.shellEscaped() }).joined(separator: " ")
+
+            // Include the output, if present.
+            if let output = try? result.utf8Output() {
+                // We indent the output to keep it visually separated from everything else.
+                let indentation = "    "
+                stream <<< " output:\n" <<< indentation <<< output.replacingOccurrences(of: "\n", with: "\n" + indentation)
+                if !output.hasSuffix("\n") {
+                    stream <<< "\n"
+                }
+            }
+            
             return stream.bytes.asString!
         }
     }


### PR DESCRIPTION
 - This description probably should never be what we display to the user, but
   currently it sometimes is, and when subprocesses fail for obscure reasons it
   can be impossible to diagnose the issue since we don't show the captured
   output.