### PR TITLE
[PackageLoading] Supress warnings in Package.swift

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -245,7 +245,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         cmd += [resources.swiftCompiler.asString]
         cmd += ["--driver-mode=swift"]
         cmd += verbosity.ccArgs
-        cmd += ["-L", runtimePath, "-lPackageDescription"]
+        cmd += ["-L", runtimePath, "-lPackageDescription", "-suppress-warnings"]
         cmd += interpreterFlags
         cmd += [manifestPath.asString]
 

--- a/Tests/PackageLoadingTests/PD4LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4LoadingTests.swift
@@ -371,6 +371,27 @@ class PackageDescription4LoadingTests: XCTestCase {
         }
     }
 
+    func testManifestWithWarnings() {
+        let stream = BufferedOutputByteStream()
+        stream <<< """
+            import PackageDescription
+            func foo() {
+                let a = 5
+            }
+            let package = Package(
+                name: "Trivial"
+            )
+            """
+
+        loadManifest(stream.bytes) { manifest in
+            XCTAssertEqual(manifest.name, "Trivial")
+            XCTAssertEqual(manifest.manifestVersion, .four)
+            XCTAssertEqual(manifest.package.targets, [])
+            XCTAssertEqual(manifest.package.dependencies, [])
+        }
+    }
+    
+
     static var allTests = [
         ("testCTarget", testCTarget),
         ("testCompatibleSwiftVersions", testCompatibleSwiftVersions),
@@ -383,5 +404,6 @@ class PackageDescription4LoadingTests: XCTestCase {
         ("testTrivial", testTrivial),
         ("testUnavailableAPIs", testUnavailableAPIs),
         ("testLanguageStandards", testLanguageStandards),
+        ("testManifestWithWarnings", testManifestWithWarnings),
     ]
 }


### PR DESCRIPTION
We end up thinking there are parsing errors if compiler spits out some
warnings.
- <rdar://problem/36324891> Warnings in Package.swift break build