### PR TITLE
Implement llbuild manifest caching

### DIFF
--- a/Fixtures/ValidLayouts/SingleModule/ExecutableNew/.gitignore
+++ b/Fixtures/ValidLayouts/SingleModule/ExecutableNew/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/Fixtures/ValidLayouts/SingleModule/ExecutableNew/Package.swift
+++ b/Fixtures/ValidLayouts/SingleModule/ExecutableNew/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "ExecutableNew",
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "ExecutableNew",
+            dependencies: []),
+    ]
+)

--- a/Fixtures/ValidLayouts/SingleModule/ExecutableNew/README.md
+++ b/Fixtures/ValidLayouts/SingleModule/ExecutableNew/README.md
@@ -1,0 +1,3 @@
+# ExecutableNew
+
+A description of this package.

--- a/Fixtures/ValidLayouts/SingleModule/ExecutableNew/Sources/ExecutableNew/main.swift
+++ b/Fixtures/ValidLayouts/SingleModule/ExecutableNew/Sources/ExecutableNew/main.swift
@@ -1,0 +1,1 @@
+print("Hello, world!")

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -72,6 +72,9 @@ public struct BuildParameters {
     /// If should link the Swift stdlib statically.
     public let shouldLinkStaticSwiftStdlib: Bool
 
+    /// If should enable llbuild manifest caching.
+    public let shouldEnableManifestCaching: Bool
+
     /// Checks if stdout stream is tty.
     fileprivate let isTTY: Bool = {
         guard let stream = stdoutStream as? LocalFileOutputByteStream else {
@@ -79,6 +82,14 @@ public struct BuildParameters {
         }
         return TerminalController.isTTY(stream)
     }()
+    
+    public var regenerateManifestToken: AbsolutePath {
+        return dataPath.appending(components: "..", "regenerate-token")
+    }
+    
+    public var llbuildManifest: AbsolutePath {
+        return dataPath.appending(components: "..", configuration.dirname + ".yaml")
+    }
 
     public init(
         dataPath: AbsolutePath,
@@ -87,7 +98,8 @@ public struct BuildParameters {
         destinationTriple: Triple = Triple.hostTriple,
         flags: BuildFlags,
         toolsVersion: ToolsVersion = ToolsVersion.currentToolsVersion,
-        shouldLinkStaticSwiftStdlib: Bool = false
+        shouldLinkStaticSwiftStdlib: Bool = false,
+        shouldEnableManifestCaching: Bool = false
     ) {
         self.dataPath = dataPath
         self.configuration = configuration
@@ -96,6 +108,7 @@ public struct BuildParameters {
         self.flags = flags
         self.toolsVersion = toolsVersion
         self.shouldLinkStaticSwiftStdlib = shouldLinkStaticSwiftStdlib
+        self.shouldEnableManifestCaching = shouldEnableManifestCaching
     }
 }
 

--- a/Sources/Build/ToolProtocol.swift
+++ b/Sources/Build/ToolProtocol.swift
@@ -43,6 +43,7 @@ struct ShellTool: ToolProtocol {
     let inputs: [String]
     let outputs: [String]
     let args: [String]
+    let allowMissingInputs: Bool
 
     func append(to stream: OutputByteStream) {
         stream <<< "    tool: shell\n"
@@ -56,6 +57,9 @@ struct ShellTool: ToolProtocol {
             stream <<< "    args: " <<< Format.asJSON(arg) <<< "\n"
         } else {
             stream <<< "    args: " <<< Format.asJSON(args) <<< "\n"
+        }
+        if allowMissingInputs {
+            stream <<< "    allow-missing-inputs: " <<< Format.asJSON(true) <<< "\n"
         }
     }
 }

--- a/Sources/Build/llbuild.swift
+++ b/Sources/Build/llbuild.swift
@@ -117,14 +117,71 @@ public struct LLBuildManifestGenerator {
             stream <<< "  " <<< Format.asJSON(target.name)
             stream <<< ": " <<< Format.asJSON(target.outputs.values) <<< "\n"
         }
+        
+        stream <<< "  " <<< Format.asJSON("regenerate")
+        stream <<< ": " <<< Format.asJSON([plan.buildParameters.regenerateManifestToken.asString])
+        stream <<< "\n"
+
         stream <<< "default: " <<< Format.asJSON(targets.main.name) <<< "\n"
+
+        // Add manifest regeneration directory nodes as directory structure.
+        let manifestRegenerationInputs = self.manifestRegenerationInputs()
+        if let manifestRegenerationInputs = manifestRegenerationInputs, !manifestRegenerationInputs.dirs.isEmpty {
+            stream <<< "nodes:\n"
+            for dir in manifestRegenerationInputs.dirs {
+                stream <<< "  " <<< Format.asJSON(dir) <<< ":\n"
+                stream <<< "    is-directory-structure: true\n"
+            }
+        }
+        
         stream <<< "commands: \n"
         for command in targets.allCommands.sorted(by: { $0.name < $1.name }) {
             stream <<< "  " <<< Format.asJSON(command.name) <<< ":\n"
             command.tool.append(to: stream)
             stream <<< "\n"
         }
+
+        if let manifestRegenerationInputs = manifestRegenerationInputs {
+            // Add command for computing manifest regeneration.
+            let regenerationCommand = ShellTool(
+                description: "",
+                inputs: manifestRegenerationInputs.dirs + manifestRegenerationInputs.files,
+                outputs: [plan.buildParameters.regenerateManifestToken.asString],
+                args: ["echo 1 >> " + plan.buildParameters.regenerateManifestToken.asString],
+                allowMissingInputs: true
+            )
+            stream <<< "  " <<< Format.asJSON(plan.buildParameters.regenerateManifestToken.asString) <<< ":\n"
+            regenerationCommand.append(to: stream)
+        }
+        
         try localFileSystem.writeFileContents(path, bytes: stream.bytes)
+    }
+    
+    private func manifestRegenerationInputs() -> (dirs: [String], files: [String])? {
+        // If manifest caching is not enabled, just return nil from here.
+        guard plan.buildParameters.shouldEnableManifestCaching else { return nil }
+
+        var directoryNodesToTrack: [AbsolutePath] = []
+        var filesToTrack: [AbsolutePath] = []
+        
+        let graph = plan.graph
+        
+        for package in graph.packages {
+            // Track the package manifest.
+            // FIXME: We also need to add the resolved file here.
+            filesToTrack.append(package.underlyingPackage.manifest.path)
+            
+            if graph.isRootPackage(package) {
+                // Track individual targets for root packages.
+                for target in package.targets {
+                    directoryNodesToTrack.append(target.sources.root)
+                }
+            } else {
+                // Track the entire package and their package manifest.
+                directoryNodesToTrack.append(package.path)
+            }
+        }
+        return (directoryNodesToTrack.map({ $0.asString + "/" }), filesToTrack.map({ $0.asString }))
     }
 
     /// Create a llbuild target for a product description.
@@ -141,7 +198,9 @@ public struct LLBuildManifestGenerator {
                 description: "Linking \(buildProduct.binary.prettyPath())",
                 inputs: inputs.map({ $0.asString }),
                 outputs: [buildProduct.binary.asString],
-                args: buildProduct.linkArguments())
+                args: buildProduct.linkArguments(),
+                allowMissingInputs: false
+            )
         }
 
         var target = Target(name: buildProduct.product.llbuildTargetName)

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -45,6 +45,9 @@ public class ToolOptions {
 
     /// If should link the Swift stdlib statically.
     public var shouldLinkStaticSwiftStdlib = false
+    
+    /// If should enable llbuild manifest caching.
+    public var shouldEnableManifestCaching = false
 
     public required init() {}
 }

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -52,8 +52,19 @@ public class SwiftBuildTool: SwiftTool<BuildToolOptions> {
           #endif
 
             guard let subset = options.buildSubset(diagnostics: diagnostics) else { return }
-            let plan = try buildPlan()
-            try build(plan: plan, subset: subset)
+          
+            // Check if we need to generate the llbuild manifest.
+            let buildParameters = try self.buildParameters()
+            let regenerateManifest = try shouldRegenerateManifest(parameters: buildParameters)
+          
+            if regenerateManifest {
+                // Create the build plan and build normally.
+                let plan = try BuildPlan(buildParameters: buildParameters, graph: loadPackageGraph())
+                try build(plan: plan, subset: subset)
+            } else {
+                // Otherwise, run llbuild directly.
+                try build(parameters: buildParameters, subset: subset)
+            }
 
         case .binPath:
             try print(buildParameters().buildPath.asString)

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -196,7 +196,7 @@ public class SwiftTestTool: SwiftTool<TestToolOptions> {
     ///
     /// - Returns: The path to the test binary.
     private func buildTestsIfNeeded(_ options: TestToolOptions) throws -> AbsolutePath {
-        let buildPlan = try self.buildPlan()
+        let buildPlan = try BuildPlan(buildParameters: self.buildParameters(), graph: loadPackageGraph())
         if options.shouldBuildTests {
             try build(plan: buildPlan, subset: .allIncludingTests)
         }

--- a/Sources/PackageGraph/PackageGraph.swift
+++ b/Sources/PackageGraph/PackageGraph.swift
@@ -38,6 +38,11 @@ public struct PackageGraph {
         return rootPackages.flatMap({ $0.targets }).contains(target)
     }
 
+    public func isRootPackage(_ package: ResolvedPackage) -> Bool {
+        // FIXME: This can be easily cached.
+        return rootPackages.contains(package)
+    }
+
     /// Construct a package graph directly.
     public init(rootPackages: [ResolvedPackage], rootDependencies: [ResolvedPackage] = []) {
         self.rootPackages = rootPackages


### PR DESCRIPTION
This uses the new directory structure feature of llbuild to compute if
manifest generation is required. We use a command to write a token file
inside the build directory and regenerate the manifest file if the token
file is written. This saves a lot of time in builds where directory
structure hasn't changed. This feature is off by default and can be
enabled by using the flag --enable-build-manifest-caching.
  

- [x] Add some tests
- [ ] Need to detect manifest generated by old swiftpm and regenerate
  