### PR TITLE
[PackageGraph] Include package name in the package reference

### DIFF
--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -243,6 +243,13 @@ public protocol PackageContainer {
     ///
     /// NOTE: This method should not be called on a versioned container.
     func getUnversionedDependencies() throws -> [PackageContainerConstraint<Identifier>]
+
+    /// Get the updated identifier at a bound version.
+    ///
+    /// This can be used by the containers to fill in the missing information that is obtained
+    /// after the container is available. The updated identifier is returned in result of the
+    /// dependency resolution.
+    func getUpdatedIdentifier(at boundVersion: BoundVersion) throws -> Identifier
 }
 
 /// An interface for resolving package containers.
@@ -897,7 +904,11 @@ public class DependencyResolver<
     /// - Returns: A satisfying assignment of containers and their version binding.
     /// - Throws: DependencyResolverError, or errors from the underlying package provider.
     public func resolve(constraints: [Constraint]) throws -> [(container: Identifier, binding: BoundVersion)] {
-        return try resolveAssignment(constraints: constraints).map({ ($0.0.identifier, $0.1) })
+        return try resolveAssignment(constraints: constraints).map({ assignment in
+            let (container, binding) = assignment
+            // Get the updated identifier from the container.
+            return try (container.getUpdatedIdentifier(at: binding), binding)
+        })
     }
 
     /// Execute the resolution algorithm to find a valid assignment of versions.

--- a/Sources/TestSupport/MockDependencyResolver.swift
+++ b/Sources/TestSupport/MockDependencyResolver.swift
@@ -71,7 +71,8 @@ public enum MockLoadingError: Error {
     case unknownModule
 }
 
-public final class MockPackageContainer: PackageContainer {
+public class MockPackageContainer: PackageContainer {
+
     public typealias Identifier = String
 
     public typealias Dependency = (container: Identifier, requirement: MockPackageConstraint.Requirement)
@@ -110,6 +111,10 @@ public final class MockPackageContainer: PackageContainer {
         return unversionedDeps
     }
 
+    public func getUpdatedIdentifier(at boundVersion: BoundVersion) throws -> String {
+        return name
+    }
+
     public convenience init(
         name: Identifier,
         dependenciesByVersion: [Version: [(container: Identifier, versionRequirement: VersionSetSpecifier)]]
@@ -131,6 +136,12 @@ public final class MockPackageContainer: PackageContainer {
         let versions = dependencies.keys.flatMap(Version.init(string:))
         self._versions = versions.sorted().reversed()
         self.dependencies = dependencies
+    }
+}
+
+public class MockPackageContainer2: MockPackageContainer {
+    public override func getUpdatedIdentifier(at boundVersion: BoundVersion) throws -> String {
+        return name + "-name"
     }
 }
 

--- a/Tests/PackageGraphTests/DependencyResolverTests.swift
+++ b/Tests/PackageGraphTests/DependencyResolverTests.swift
@@ -52,14 +52,15 @@ class DependencyResolverTests: XCTestCase {
                         v1: [(container: "B", versionRequirement: v1Range)]]),
                 MockPackageContainer(name: "B", dependenciesByVersion: [
                         v1: [(container: "C", versionRequirement: v1Range)]]),
-                MockPackageContainer(name: "C", dependenciesByVersion: [
+                // We use MockPackageContainer2 here to check the updated identifier API.
+                MockPackageContainer2(name: "C", dependenciesByVersion: [
                         v1: [], v2: []])])
 
         let delegate = MockResolverDelegate()
         let resolver = DependencyResolver(provider, delegate)
         let packages = try resolver.resolve(constraints: [
                 MockPackageConstraint(container: "A", versionRequirement: v1Range)])
-        XCTAssertEqual(packages.map{ $0.container }.sorted(), ["A", "B", "C"])
+        XCTAssertEqual(packages.map{ $0.container }.sorted(), ["A", "B", "C-name"])
     }
 
     func testVersionSetSpecifier() {


### PR DESCRIPTION
The package name will now be available in the dependency resolver
result. We can eventually store the package name in our state file to
look up packages by their name.