### PR TITLE
[Workspace] Make (un)edit work with package name

### DIFF
--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -218,12 +218,17 @@ public final class ManagedDependencies: SimplePersistanceProtocol {
         }
     }
 
-    /// Returns the dependency given a name.
-    func dependency(forIdentity identity: String) throws -> ManagedDependency {
-        guard let dependency = self[forIdentity: identity] else {
-            throw Error.dependencyNotFound(name: identity)
+    /// Returns the dependency given a name or identity.
+    func dependency(forNameOrIdentity nameOrIdentity: String) throws -> ManagedDependency {
+        if let dependency = self[forIdentity: nameOrIdentity.lowercased()] {
+            return dependency
         }
-        return dependency 
+        for value in values {
+            if value.packageRef.name == nameOrIdentity {
+                return value
+            }
+        }
+        throw Error.dependencyNotFound(name: nameOrIdentity)
     }
 
     func reset() throws {

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -365,7 +365,7 @@ extension Workspace {
         root: PackageGraphRootInput,
         diagnostics: DiagnosticsEngine
     ) throws {
-        let dependency = try managedDependencies.dependency(forIdentity: packageName.lowercased())
+        let dependency = try managedDependencies.dependency(forNameOrIdentity: packageName)
         try unedit(dependency: dependency, forceRemove: forceRemove, root: root, diagnostics: diagnostics)
     }
 
@@ -392,7 +392,7 @@ extension Workspace {
         diagnostics: DiagnosticsEngine
     ) {
         // Look up the dependency and check if we can pin it.
-        guard let dependency = diagnostics.wrap({ try managedDependencies.dependency(forIdentity: packageName.lowercased()) }) else {
+        guard let dependency = diagnostics.wrap({ try managedDependencies.dependency(forNameOrIdentity: packageName) }) else {
             return
         }
         guard case .checkout(let currentState) = dependency.state else {
@@ -617,7 +617,7 @@ extension Workspace {
         diagnostics: DiagnosticsEngine
     ) throws {
         // Look up the dependency and check if we can edit it.
-        let dependency = try managedDependencies.dependency(forIdentity: packageName.lowercased())
+        let dependency = try managedDependencies.dependency(forNameOrIdentity: packageName)
 
         guard case .checkout(let checkoutState) = dependency.state else {
             throw WorkspaceDiagnostics.DependencyAlreadyInEditMode(dependencyName: packageName)

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -1430,7 +1430,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // There should still be an entry for `foo`, which we can unedit.
-        let editedDependency = try ws.managedDependencies.dependency(forIdentity: "foo")
+        let editedDependency = try ws.managedDependencies.dependency(forNameOrIdentity: "foo")
         XCTAssertNil(editedDependency.basedOn)
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .edited(nil))


### PR DESCRIPTION
- <rdar://problem/35853802> swift package edit <package-name> --path <path> fails

Edit had stopped working with package names when I landed package
identity. This patch fixes that problem.