### PR TITLE
[Commands] Ignore regen check failures

### DIFF
--- a/Sources/Build/llbuild.swift
+++ b/Sources/Build/llbuild.swift
@@ -117,10 +117,12 @@ public struct LLBuildManifestGenerator {
             stream <<< "  " <<< Format.asJSON(target.name)
             stream <<< ": " <<< Format.asJSON(target.outputs.values) <<< "\n"
         }
-        
-        stream <<< "  " <<< Format.asJSON("regenerate")
-        stream <<< ": " <<< Format.asJSON([plan.buildParameters.regenerateManifestToken.asString])
-        stream <<< "\n"
+
+        if plan.buildParameters.shouldEnableManifestCaching {
+            stream <<< "  " <<< Format.asJSON("regenerate")
+            stream <<< ": " <<< Format.asJSON([plan.buildParameters.regenerateManifestToken.asString])
+            stream <<< "\n"
+        }
 
         stream <<< "default: " <<< Format.asJSON(targets.main.name) <<< "\n"
 

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -439,10 +439,16 @@ public class SwiftTool<Options: ToolOptions> {
         
         // Check if we need to generate the llbuild manifest.
         var regenerateManifest = true
-        if localFileSystem.isFile(parameters.llbuildManifest) {
+        regenCheck: if localFileSystem.isFile(parameters.llbuildManifest) {
             // Run the target which computes if regeneration is needed.
             let args = [try getToolchain().llbuild.asString, "-f", parameters.llbuildManifest.asString, "regenerate"]
-            try Process.checkNonZeroExit(arguments: args)
+            do {
+                try Process.checkNonZeroExit(arguments: args)
+            } catch {
+                // Regenerate the manifest if this fails for some reason.
+                warning(message: "Failed to run the regeneration check: \(error)")
+                break regenCheck
+            }
             if !localFileSystem.isFile(parameters.regenerateManifestToken) {
                 return true
             }


### PR DESCRIPTION
Previously, we would fail while switching between swift build and swift
build --enable-build-manifest-caching. This should fix that problem.