### PR TITLE
[RepositoryManager] Update serialized repo dictionary on repo removal

### DIFF
--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -350,6 +350,7 @@ public class RepositoryManager {
                 return
             }
             repositories[repository.url] = nil
+            serializedRepositories[repository.url] = nil
             let repositoryPath = path.appending(handle.subpath)
             try fileSystem.removeFileTree(repositoryPath)
             try self.persistence.saveState(self)

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -213,6 +213,14 @@ class RepositoryManagerTests: XCTestCase {
 
             // Remove the repo.
             try manager.remove(repository: dummyRepo)
+
+            // Check removing the repo updates the persistent file.
+            do {
+                let checkoutsStateFile = path.appending(component: "checkouts-state.json")
+                let jsonData = try JSON(bytes: localFileSystem.readFileContents(checkoutsStateFile))
+                XCTAssertEqual(jsonData.dictionary?["object"]?.dictionary?["repositories"]?.dictionary?[dummyRepo.url], nil)
+            }
+
             // We should get a new handle now because we deleted the exisiting repository.
             XCTNonNil(prevHandle) {
                 try XCTAssert($0 !== manager.lookupSynchronously(repository: dummyRepo))


### PR DESCRIPTION
We were basically not updating checkout-state.json when we removed
repositories.

<rdar://problem/36705254> SwiftPM isn't removing things from checkouts-state.json even when it removes the repo