### PR TITLE
[PackageGraph] Remove all unversioned constraints from debugging algo

### DIFF
--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -1292,6 +1292,11 @@ private struct ResolverDebugger<
             }
         }
 
+        // Remove the unversioned constraints which may be added as result of the above loop.
+        dependencies = dependencies.filter({ dep in
+            return !inputDependencies.contains(where: { $0.identifier == dep.identifier && $0.requirement == .unversioned })
+        })
+
         // Put the resolver in incomplete mode to avoid cloning new repositories.
         resolver.isInIncompleteMode = true
 


### PR DESCRIPTION
<rdar://problem/36921520> Fatal error: This should never be called: file Sources/PackageGraph/RepositoryPackageContainerProvider.swift, line 210

This fatal error happens under the following conditions:
1. You have an edited dependency
2. The edit dependency is in the root package
3. Your dependency graph is unresolvable