### PR TITLE
[gardening] Fix typo in method name

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -298,7 +298,7 @@ public class GitRepository: Repository, WorkingCheckout {
         }
     }
 
-    public func hasUncommitedChanges() -> Bool {
+    public func hasUncommittedChanges() -> Bool {
         // Only a work tree can have changes.
         guard isWorkingRepo else { return false }
         return queue.sync {

--- a/Sources/SourceControl/InMemoryGitRepository.swift
+++ b/Sources/SourceControl/InMemoryGitRepository.swift
@@ -172,7 +172,7 @@ public final class InMemoryGitRepository {
         tagsMap[name] = head.hash
     }
 
-    public func hasUncommitedChanges() -> Bool {
+    public func hasUncommittedChanges() -> Bool {
         return isDirty
     }
 

--- a/Sources/SourceControl/Repository.swift
+++ b/Sources/SourceControl/Repository.swift
@@ -185,7 +185,7 @@ public protocol WorkingCheckout {
 
     /// This check for any modified state of the repository and returns true
     /// if there are uncommited changes.
-    func hasUncommitedChanges() -> Bool
+    func hasUncommittedChanges() -> Bool
 
     /// Check out the given tag.
     func checkout(tag: String) throws

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -740,7 +740,7 @@ extension Workspace {
         // Check for uncommited and unpushed changes if force removal is off.
         if !forceRemove {
             let workingRepo = try repositoryManager.provider.openCheckout(at: path)
-            guard !workingRepo.hasUncommitedChanges() else {
+            guard !workingRepo.hasUncommittedChanges() else {
                 throw WorkspaceDiagnostics.UncommitedChanges(repositoryPath: path)
             }
             guard try !workingRepo.hasUnpushedCommits() else {
@@ -1525,7 +1525,7 @@ extension Workspace {
         // Remove the checkout.
         let dependencyPath = checkoutsPath.appending(dependencyToRemove.subpath)
         let checkedOutRepo = try repositoryManager.provider.openCheckout(at: dependencyPath)
-        guard !checkedOutRepo.hasUncommitedChanges() else {
+        guard !checkedOutRepo.hasUncommittedChanges() else {
             throw WorkspaceDiagnostics.UncommitedChanges(repositoryPath: dependencyPath)
         }
 

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -403,19 +403,19 @@ class GitRepositoryTests: XCTestCase {
             try localFileSystem.writeFileContents(testRepoPath.appending(component: "test.txt"), bytes: "Hi")
             let repo = GitRepository(path: testRepoPath)
 
-            XCTAssert(repo.hasUncommitedChanges())
+            XCTAssert(repo.hasUncommittedChanges())
 
             try repo.stage(file: "test.txt")
 
-            XCTAssert(repo.hasUncommitedChanges())
+            XCTAssert(repo.hasUncommittedChanges())
 
             try repo.commit()
 
-            XCTAssertFalse(repo.hasUncommitedChanges())
+            XCTAssertFalse(repo.hasUncommittedChanges())
 
             // Modify the file in the repo.
             try localFileSystem.writeFileContents(repo.path.appending(component: "test.txt"), bytes: "Hello")
-            XCTAssert(repo.hasUncommitedChanges())
+            XCTAssert(repo.hasUncommittedChanges())
         }
     }
 
@@ -470,19 +470,19 @@ class GitRepositoryTests: XCTestCase {
             XCTAssertEqual(try repo.currentBranch(), "TestBranch")
             // Create some random file.
             try createAndStageTestFile()
-            XCTAssert(repo.hasUncommitedChanges())
+            XCTAssert(repo.hasUncommittedChanges())
             // Checkout current revision again, the test file should go away.
             let currentRevision = try repo.getCurrentRevision()
             try repo.checkout(revision: currentRevision)
-            XCTAssertFalse(repo.hasUncommitedChanges())
+            XCTAssertFalse(repo.hasUncommittedChanges())
             // We should be on detached head.
             XCTAssertEqual(try repo.currentBranch(), "HEAD")
 
             // Try again and checkout to a previous branch.
             try createAndStageTestFile()
-            XCTAssert(repo.hasUncommitedChanges())
+            XCTAssert(repo.hasUncommittedChanges())
             try repo.checkout(revision: Revision(identifier: "TestBranch"))
-            XCTAssertFalse(repo.hasUncommitedChanges())
+            XCTAssertFalse(repo.hasUncommittedChanges())
             XCTAssertEqual(try repo.currentBranch(), "TestBranch")
 
             do {

--- a/Tests/SourceControlTests/InMemoryGitRepositoryTests.swift
+++ b/Tests/SourceControlTests/InMemoryGitRepositoryTests.swift
@@ -22,53 +22,53 @@ class InMemoryGitRepositoryTests: XCTestCase {
         let repo = InMemoryGitRepository(path: .root, fs: fs)
 
         try repo.createDirectory(AbsolutePath("/new-dir/subdir"), recursive: true)
-        XCTAssertTrue(!repo.hasUncommitedChanges())
+        XCTAssertTrue(!repo.hasUncommittedChanges())
         let filePath = AbsolutePath("/new-dir/subdir").appending(component: "new-file.txt")
 
         try repo.writeFileContents(filePath, bytes: "one")
         XCTAssertEqual(try repo.readFileContents(filePath), "one")
-        XCTAssertTrue(repo.hasUncommitedChanges())
+        XCTAssertTrue(repo.hasUncommittedChanges())
 
         let firstCommit = repo.commit()
-        XCTAssertTrue(!repo.hasUncommitedChanges())
+        XCTAssertTrue(!repo.hasUncommittedChanges())
 
         XCTAssertEqual(try repo.readFileContents(filePath), "one")
         XCTAssertEqual(try fs.readFileContents(filePath), "one")
 
         try repo.writeFileContents(filePath, bytes: "two")
         XCTAssertEqual(try repo.readFileContents(filePath), "two")
-        XCTAssertTrue(repo.hasUncommitedChanges())
+        XCTAssertTrue(repo.hasUncommittedChanges())
 
         let secondCommit = repo.commit()
-        XCTAssertTrue(!repo.hasUncommitedChanges())
+        XCTAssertTrue(!repo.hasUncommittedChanges())
         XCTAssertEqual(try repo.readFileContents(filePath), "two")
 
         try repo.writeFileContents(filePath, bytes: "three")
-        XCTAssertTrue(repo.hasUncommitedChanges())
+        XCTAssertTrue(repo.hasUncommittedChanges())
         XCTAssertEqual(try repo.readFileContents(filePath), "three")
 
         try repo.checkout(revision: firstCommit)
-        XCTAssertTrue(!repo.hasUncommitedChanges())
+        XCTAssertTrue(!repo.hasUncommittedChanges())
         XCTAssertEqual(try repo.readFileContents(filePath), "one")
         XCTAssertEqual(try fs.readFileContents(filePath), "one")
 
         try repo.checkout(revision: secondCommit)
-        XCTAssertTrue(!repo.hasUncommitedChanges())
+        XCTAssertTrue(!repo.hasUncommittedChanges())
         XCTAssertEqual(try repo.readFileContents(filePath), "two")
 
         XCTAssert(repo.tags.isEmpty)
         try repo.tag(name: "2.0.0")
         XCTAssertEqual(repo.tags, ["2.0.0"])
-        XCTAssertTrue(!repo.hasUncommitedChanges())
+        XCTAssertTrue(!repo.hasUncommittedChanges())
         XCTAssertEqual(try repo.readFileContents(filePath), "two")
         XCTAssertEqual(try fs.readFileContents(filePath), "two")
 
         try repo.checkout(revision: firstCommit)
-        XCTAssertTrue(!repo.hasUncommitedChanges())
+        XCTAssertTrue(!repo.hasUncommittedChanges())
         XCTAssertEqual(try repo.readFileContents(filePath), "one")
 
         try repo.checkout(tag: "2.0.0")
-        XCTAssertTrue(!repo.hasUncommitedChanges())
+        XCTAssertTrue(!repo.hasUncommittedChanges())
         XCTAssertEqual(try repo.readFileContents(filePath), "two")
     }
 


### PR DESCRIPTION
There's a typo in the spelling of `hasUncommitedChanges` (sic). Here's to hoping that this PR doesn't remain long as an uncommitted change.