### PR TITLE
Revert "[WIP] Rename DictionaryLiteral extensions"

### DIFF
--- a/Sources/Basic/CollectionAlgorithms.swift
+++ b/Sources/Basic/CollectionAlgorithms.swift
@@ -29,7 +29,8 @@ extension BidirectionalCollection where Iterator.Element : Comparable {
     }
 }
 
-extension Sequence where Iterator.Element: Hashable {
+public extension Sequence where Iterator.Element: Hashable {
+
     /// Finds duplicates in given sequence of Hashables.
     /// - Returns: duplicated elements in the invoking sequence.
     public func findDuplicates() -> [Iterator.Element] {

--- a/Sources/Basic/DictionaryLiteralExtensions.swift
+++ b/Sources/Basic/DictionaryLiteralExtensions.swift
@@ -10,13 +10,10 @@
 
 // Can't conform a protocol explicitly with certain where clause for now but it'd be resolved by SE-0143.
 // ref: https://github.com/apple/swift-evolution/blob/master/proposals/0143-conditional-conformances.md
-//
-// In the meantime, avoid naming extension methods in a way that will be source breaking when SE-0143 is implemented.
-
 // MARK: CustomStringConvertible
 extension DictionaryLiteral where Key: CustomStringConvertible, Value: CustomStringConvertible {
     /// A string that represents the contents of the dictionary literal.
-    public var _description: String {
+    public var description: String {
         let lastCount = self.count - 1
         var desc = "["
         for (i, item) in self.enumerated() {
@@ -29,8 +26,7 @@ extension DictionaryLiteral where Key: CustomStringConvertible, Value: CustomStr
 
 // MARK: Equatable
 extension DictionaryLiteral where Key: Equatable, Value: Equatable {
-    public func _isEqual(to rhs: DictionaryLiteral) -> Bool {
-        let lhs = self
+    public static func ==(lhs: DictionaryLiteral, rhs: DictionaryLiteral) -> Bool {
         if lhs.count != rhs.count {
             return false
         }

--- a/Sources/Basic/JSON.swift
+++ b/Sources/Basic/JSON.swift
@@ -65,7 +65,7 @@ extension JSON: CustomStringConvertible {
         case .string(let value): return value.debugDescription
         case .array(let values): return values.description
         case .dictionary(let values): return values.description
-        case .orderedDictionary(let values): return values._description
+        case .orderedDictionary(let values): return values.description
         }
     }
 }
@@ -88,7 +88,7 @@ extension JSON: Equatable {
         case (.array, _): return false
         case (.dictionary(let a), .dictionary(let b)): return a == b
         case (.dictionary, _): return false
-        case (.orderedDictionary(let a), .orderedDictionary(let b)): return a._isEqual(to: b)
+        case (.orderedDictionary(let a), .orderedDictionary(let b)): return a == b
         case (.orderedDictionary, _): return false
         }
     }

--- a/Tests/BasicTests/DictionaryLiteralExtensionsTests.swift
+++ b/Tests/BasicTests/DictionaryLiteralExtensionsTests.swift
@@ -14,18 +14,18 @@ import Basic
 class DictionaryLiteralExtensionsTests: XCTestCase {
 
     func testDescription() {
-        XCTAssertEqual(DictionaryLiteral(dictionaryLiteral: ("foo", 1))._description, "[foo: 1]")
-        XCTAssertEqual(DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2))._description, "[foo: 1, bar: 2]")
+        XCTAssertEqual(DictionaryLiteral(dictionaryLiteral: ("foo", 1)).description, "[foo: 1]")
+        XCTAssertEqual(DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2)).description, "[foo: 1, bar: 2]")
     }
 
     func testEquality() {
-        XCTAssertTrue(DictionaryLiteral(dictionaryLiteral: ("foo", 1))._isEqual(to: DictionaryLiteral(dictionaryLiteral: ("foo", 1))))
-        XCTAssertTrue(DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2))._isEqual(to: DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2))))
+        XCTAssertTrue(DictionaryLiteral(dictionaryLiteral: ("foo", 1)) == DictionaryLiteral(dictionaryLiteral: ("foo", 1)))
+        XCTAssertTrue(DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2)) == DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2)))
 
-        XCTAssertFalse(DictionaryLiteral(dictionaryLiteral: ("no-foo", 1), ("bar", 2))._isEqual(to: DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2))))
-        XCTAssertFalse(DictionaryLiteral(dictionaryLiteral: ("foo", 0), ("bar", 2))._isEqual(to: DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2))))
-        XCTAssertFalse(DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2), ("hoge", 3))._isEqual(to: DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2))))
-        XCTAssertFalse(DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2))._isEqual(to: DictionaryLiteral(dictionaryLiteral: ("bar", 2), ("foo", 1))))
+        XCTAssertFalse(DictionaryLiteral(dictionaryLiteral: ("no-foo", 1), ("bar", 2)) == DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2)))
+        XCTAssertFalse(DictionaryLiteral(dictionaryLiteral: ("foo", 0), ("bar", 2)) == DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2)))
+        XCTAssertFalse(DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2), ("hoge", 3)) == DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2)))
+        XCTAssertFalse(DictionaryLiteral(dictionaryLiteral: ("foo", 1), ("bar", 2)) == DictionaryLiteral(dictionaryLiteral: ("bar", 2), ("foo", 1)))
     }
 
     static var allTests = [


### PR DESCRIPTION
Reverts apple/swift-package-manager#1494. We shouldn't need it for implementation of conditional conformance, and it will be a good test that we're not breaking end users' code.