### PR TITLE
[Basic] Fix the SHA256 padding function

### DIFF
--- a/Sources/Basic/SHA256.swift
+++ b/Sources/Basic/SHA256.swift
@@ -174,7 +174,7 @@ public final class SHA256 {
         //
         // inputBitLength + 1 + bitsToAppend ≡ 448 mod 512
         let mod = inputBitLength % 512
-        let bitsToAppend = mod == 448 ? 512 : 448 - mod - 1
+        let bitsToAppend = mod < 448 ? 448 - 1 - mod : 512 + 448 - mod - 1
 
         // We already appended first 7 bits with 0x80 above.
         input += [UInt8](repeating: 0, count: (bitsToAppend - 7) / 8)

--- a/Tests/BasicTests/SHA256Tests.swift
+++ b/Tests/BasicTests/SHA256Tests.swift
@@ -37,7 +37,14 @@ class SHA256Tests: XCTestCase {
         XCTAssertEqual(SHA256(stream.bytes).digestString(), "23d00697ba26b4140869bab958431251e7e41982794d41b605b6a1d5dee56abf")
     }
 
+    func testLargeData() {
+        let data: [UInt8] = (0..<1788).map { _ in 0x03 }
+        let digest = SHA256(data).digestString()
+        XCTAssertEqual(digest, "907422e2f24d749d0add2b504ccae8ad1aa392477591905880fb2dc494e33d63")
+    }
+
     static var allTests = [
         ("testBasics", testBasics),
+        ("testLargeData", testLargeData),
     ]
 }


### PR DESCRIPTION
The padding function wasn't written correctly to handle cases when mod
of input length was greater than 448.