### PR TITLE
[Experimental][Build] Add support for building gyb files

### DIFF
--- a/Sources/Build/ToolProtocol.swift
+++ b/Sources/Build/ToolProtocol.swift
@@ -136,7 +136,7 @@ struct SwiftCompilerTool: ToolProtocol {
         stream <<< "    other-args: "
             <<< Format.asJSON(target.compileArguments()) <<< "\n"
         stream <<< "    sources: "
-            <<< Format.asJSON(target.target.sources.paths.map({ $0.asString })) <<< "\n"
+            <<< Format.asJSON(target.swiftSources.map({ $0.asString })) <<< "\n"
         stream <<< "    is-library: "
             <<< Format.asJSON(target.target.type == .library || target.target.type == .test) <<< "\n"
         stream <<< "    enable-whole-module-optimization: "

--- a/Sources/Build/Toolchain.swift
+++ b/Sources/Build/Toolchain.swift
@@ -18,6 +18,9 @@ public protocol Toolchain {
     /// Path of the `clang` compiler.
     var clangCompiler: AbsolutePath { get }
 
+    /// Path of the `gyb` compiler.
+    var gybCompiler: AbsolutePath? { get }
+
     /// Additional flags to be passed to the C compiler.
     var extraCCFlags: [String] { get }
 
@@ -29,4 +32,10 @@ public protocol Toolchain {
 
     /// The dynamic library extension, for e.g. dylib, so.
     var dynamicLibraryExtension: String { get }
+}
+
+extension Toolchain {
+    var gybCompiler: AbsolutePath? {
+        return nil
+    }
 }

--- a/Sources/Commands/UserToolchain.swift
+++ b/Sources/Commands/UserToolchain.swift
@@ -40,6 +40,11 @@ public struct UserToolchain: Toolchain {
     /// Path of the `clang` compiler.
     public let clangCompiler: AbsolutePath
 
+    public var gybCompiler: AbsolutePath? {
+        // FIXME: We can only find gyb compiler via this enviornment variable currently.
+        return Process.env["GYB"].flatMap(AbsolutePath.init)
+    }
+
     public let extraCCFlags: [String]
 
     public let extraSwiftCFlags: [String]

--- a/Sources/PackageModel/Sources.swift
+++ b/Sources/PackageModel/Sources.swift
@@ -41,6 +41,7 @@ public struct Sources {
 public enum SupportedLanguageExtension: String {
     /// Swift
     case swift
+    case swiftgyb = "gyb"
     /// C
     case c
     /// Objective C
@@ -54,7 +55,7 @@ public enum SupportedLanguageExtension: String {
 
     /// Returns a set of valid swift extensions.
     public static var swiftExtensions: Set<String> = {
-        SupportedLanguageExtension.stringSet(swift)
+        SupportedLanguageExtension.stringSet(swift, swiftgyb)
     }()
 
     /// Returns a set of valid c extensions.

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -670,6 +670,9 @@ private extension SupportedLanguageExtension {
             return "sourcecode.cpp.objcpp"
         case .swift:
             return "sourcecode.swift"
+        case .swiftgyb:
+            // FIXME: This needs to be handled.
+            fatalError("Unsupported")
         }
     }
 }


### PR DESCRIPTION
This will generate commands to build gyb files if they're present in a
Swift target. Currently, there are no customization available and
the gyb compiler will be looked up in the environment variable "GYB".

I tested this patch with `SwiftSyntax` on macOS, using this manifest file:

```swift
// swift-tools-version:4.0

import PackageDescription

let package = Package(
    name: "SwiftSyntax",
    products: [
        .library(name: "libSwiftSyntax", type: .dynamic, targets: ["SwiftSyntax"]),
    ],
    targets: [
        .target(
            name: "SwiftSyntax", path: ".")
    ]
)
```