### PR TITLE
[Basic] Fix build warnings

### DIFF
--- a/Sources/Basic/OrderedSet.swift
+++ b/Sources/Basic/OrderedSet.swift
@@ -13,7 +13,7 @@
 public struct OrderedSet<E: Hashable>: Equatable, Collection {
     public typealias Element = E
     public typealias Index = Int
-    public typealias Indices = CountableRange<Int>
+    public typealias Indices = Range<Int>
 
     private var array: [Element]
     private var set: Set<Element>


### PR DESCRIPTION
Tried building SPM with 25th Feb snapshot, got the following warnings in `OrderedSet`:
```
Use Range instead of CountableRange
```

Looks like this usage is deprecated: https://github.com/apple/swift/blob/swift-DEVELOPMENT-SNAPSHOT-2018-02-25-a/stdlib/public/core/Range.swift#L280