### PR TITLE
Rename swift_build_path to swiftpm_build_dir to agree with other projects naming schemes

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -749,7 +749,7 @@ private func findPackageRoot() -> AbsolutePath? {
 private func getEnvBuildPath() -> AbsolutePath? {
     // Don't rely on build path from env for SwiftPM's own tests.
     guard POSIX.getenv("IS_SWIFTPM_TEST") == nil else { return nil }
-    guard let env = POSIX.getenv("SWIFT_BUILD_PATH") else { return nil }
+    guard let env = POSIX.getenv("SWIFTPM_BUILD_DIR") else { return nil }
     return AbsolutePath(env, relativeTo: currentWorkingDirectory)
 }
 

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -1051,7 +1051,7 @@ def main():
         build_flags.extend(["--configuration", "release"])
 
     env_cmd = ["env", "SWIFT_EXEC=" + os.path.join(bindir, "swiftc"),
-                      "SWIFT_BUILD_PATH=" + build_path]
+                      "SWIFTPM_BUILD_DIR=" + build_path]
     if args.sysroot:
         env_cmd.append("SYSROOT=" + args.sysroot)
     cmd = env_cmd + [bootstrapped_product] + build_flags
@@ -1066,7 +1066,7 @@ def main():
         error("build failed with exit status %d" % (result,))
 
     swift_package_path = os.path.join(target_path, conf, "swift-package")
-    swift_build_path = os.path.join(target_path, conf, "swift-build")
+    swiftpm_build_dir = os.path.join(target_path, conf, "swift-build")
     swift_test_path = os.path.join(target_path, conf, "swift-test")
     swift_run_path = os.path.join(target_path, conf, "swift-run")
     swiftpm_xctest_helper_path = os.path.join(
@@ -1113,7 +1113,7 @@ def main():
                                          "lib/swift/macosx"))
 
             # Install the main executables.
-            for product_path in [swift_package_path, swift_build_path,
+            for product_path in [swift_package_path, swiftpm_build_dir,
                                  swift_test_path, swift_run_path]:
                 installBinary(product_path, bin_install_path, args.swiftc_path)
 


### PR DESCRIPTION
https://gitHub.com/apple/swift regularly uses `SWIFT_BUILD_DIR` to refer to, e.g., `.../build/Ninja-ReleaseAsserts/swift-linux-x86_64/` and thus the variable was introduced to swiftpm. Thus `swift_build_path` in swiftpm is being renamed to `swiftpm_build_dir` to differentiate between the two variables more clearly.