### PR TITLE
[SR-6737] [Commands] [PackageModel] fix noManifest Description Error

### DIFF
--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -63,13 +63,6 @@ private func _handle(_ error: Any) {
         print(error: error)
         parser.printUsage(on: stderrStream)
 
-    case Package.Error.noManifest(let url, let version):
-        var string = "\(url) has no manifest"
-        if let version = version {
-            string += " for version \(version)"
-        }
-        print(error: string)
-
     default:
         print(error: error)
     }

--- a/Sources/PackageModel/Package.swift
+++ b/Sources/PackageModel/Package.swift
@@ -88,7 +88,18 @@ public final class Package {
 
     public enum Error: Swift.Error {
         case noManifest(baseURL: String, version: String?)
-        case noOrigin(String)
+    }
+}
+extension Package.Error: CustomStringConvertible {
+   public var description: String {
+        switch self {
+        case .noManifest(let baseURL, let version):
+            var string = "\(baseURL) has no manifest"
+            if let version = version {
+                string += " for version \(version)"
+            }
+            return string
+        }
     }
 }
 
@@ -111,12 +122,6 @@ extension Package.Error: Equatable {
         switch (lhs, rhs) {
         case let (.noManifest(lhs), .noManifest(rhs)):
             return lhs.baseURL == rhs.baseURL && lhs.version == rhs.version
-        case (.noManifest, _):
-            return false
-        case let (.noOrigin(lhs), .noOrigin(rhs)):
-            return lhs == rhs
-        case (.noOrigin, _):
-            return false
         }
     }
 }

--- a/Tests/PackageLoadingTests/ManifestTests.swift
+++ b/Tests/PackageLoadingTests/ManifestTests.swift
@@ -105,6 +105,8 @@ class ManifestTests: XCTestCase {
         XCTAssertThrows(PackageModel.Package.Error.noManifest(baseURL: "/bar", version: "1.0.0")) {
             _ = try manifestLoader.loadFile(path: AbsolutePath("/non-existent-file"), baseURL: "/bar", version: "1.0.0", fileSystem: InMemoryFileSystem())
         }
+
+        XCTAssertEqual(PackageModel.Package.Error.noManifest(baseURL: "/bar", version: "1.0.0").description,"/bar has no manifest for version 1.0.0")
     }
 
     func testNonexistentBaseURL() {


### PR DESCRIPTION
Solution to [SR-6737](https://bugs.swift.org/browse/SR-6737)
Previously No manifest File error was
```sh
error: noManifest(baseURL: " https://github.com/BVPMOSC/members.git", version: Optional("1.0.0"))
```
now it shows like
```
https://github.com/BVPMOSC/members.git @ 1.0.0: error: https://github.com/BVPMOSC/members.git has no manifest for version 1.0.0
```