### PR TITLE
[SR-6368] [Basic] Fixed Log when output is redirected

### DIFF
--- a/Sources/Basic/Process.swift
+++ b/Sources/Basic/Process.swift
@@ -293,6 +293,15 @@ public final class Process: ObjectIdentifierProtocol {
         var outputPipe: [Int32] = [0, 0]
         var stderrPipe: [Int32] = [0, 0]
         if redirectOutput {
+         
+            #if os(macOS)
+                setlinebuf(Darwin.stdout)
+                setlinebuf(Darwin.stderr)
+            #else
+                setlinebuf(Glibc.stdout)
+                setlinebuf(Glibc.stderr)
+            #endif
+            
             // Open the pipes.
             try open(pipe: &outputPipe)
             try open(pipe: &stderrPipe)


### PR DESCRIPTION
solution to [SR-6368](https://bugs.swift.org/browse/SR-6368) as suggested on comment , before,redirecting the logs to a file looks like this
```
Compile Swift Module 'Eraser' (1 sources)
Compile Swift Module 'EternalFlame' (1 sources)
Compile Swift Module 'ldemo' (1 sources)
Linking ./.build/x86_64-apple-macosx10.10/debug/ldemo
Fetching http://github.com/aniket965/Eraser.git
Fetching https://github.com/Aniket965/EternalFlame.git
Cloning https://github.com/Aniket965/EternalFlame.git
Resolving https://github.com/Aniket965/EternalFlame.git at 1.0.2
Cloning http://github.com/aniket965/Eraser.git
Resolving http://github.com/aniket965/Eraser.git at 1.0.1

```


now it is 
```
Fetching https://github.com/Aniket965/EternalFlame.git
Fetching http://github.com/aniket965/Eraser.git
Cloning https://github.com/Aniket965/EternalFlame.git
Resolving https://github.com/Aniket965/EternalFlame.git at 1.0.2
Cloning http://github.com/aniket965/Eraser.git
Resolving http://github.com/aniket965/Eraser.git at 1.0.1
Compile Swift Module 'Eraser' (1 sources)
Compile Swift Module 'EternalFlame' (1 sources)
Compile Swift Module 'ldemo' (1 sources)
Linking ./.build/x86_64-apple-macosx10.10/debug/ldemo

```