### PR TITLE
[bootstrap] Emit debug info when compiling a debug stage1 swiftpm.

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -215,7 +215,7 @@ class Target(object):
         if self.release:
             other_args.append("-O")
         else:
-            other_args.append("-Onone")
+            other_args.extend(["-Onone", "-g"])
         other_args.extend(['-j%d' % g_num_cpus] + self.swiftflags)
         if platform.system() == 'Darwin':
             other_args.extend(["-target", "x86_64-apple-macosx10.10"])


### PR DESCRIPTION
While debugging a crash in the stage 1 bootstrap swiftpm, I noticed that the stage 1 bootstrap is not compiled with debug info even when it is compiled in debug mode. This PR adds such support.