### PR TITLE
Revert "[SR-6978] Implement support for simultaneous vX.X.X and X.X.X…

### DIFF
--- a/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
@@ -362,17 +362,7 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
         // Compute the map of known versions.
         //
         // FIXME: Move this utility to a more stable location.
-        let knownVersionsWithDuplicates = Git.convertTagsToVersionMap(repository.tags)
-        
-        let knownVersions = knownVersionsWithDuplicates.mapValues({ tags -> String in
-            if tags.count == 2 {
-                // FIXME: Warn if the two tags point to different git references.
-                return tags.first(where: { !$0.hasPrefix("v") })!
-            }
-            assert(tags.count == 1, "Unexpected number of tags")
-            return tags[0]
-        })
-        
+        let knownVersions = Git.convertTagsToVersionMap(repository.tags)
         self.knownVersions = knownVersions
         self.reversedVersions = [Version](knownVersions.keys).sorted().reversed()
         super.init(

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -327,52 +327,11 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             XCTAssertEqual(v, [])
         }
     }
-    
-    func testSimultaneousVersions() throws {
-        let fs = InMemoryFileSystem()
-        
-        let repoPath = AbsolutePath.root.appending(component: "some-repo")
-        let filePath = repoPath.appending(component: "Package.swift")
-        
-        let specifier = RepositorySpecifier(url: repoPath.asString)
-        let repo = InMemoryGitRepository(path: repoPath, fs: fs)
-        try repo.createDirectory(repoPath, recursive: true)
-        try repo.writeFileContents(filePath, bytes: ByteString(encodingAsUTF8: "// swift-tools-version:\(ToolsVersion.currentToolsVersion)\n"))
-        repo.commit()
-        try repo.tag(name: "v1.0.0")
-        try repo.tag(name: "1.0.0")
-        try repo.tag(name: "1.0.1")
-        try repo.tag(name: "1.0.2")
-        try repo.tag(name: "v1.0.2")
-        try repo.tag(name: "1.0.4")
-        try repo.tag(name: "v2.0.1")
-        try repo.tag(name: "2.0.1")
-        
-        let inMemRepoProvider = InMemoryGitRepositoryProvider()
-        inMemRepoProvider.add(specifier: specifier, repository: repo)
-        
-        let p = AbsolutePath.root.appending(component: "repoManager")
-        try fs.createDirectory(p, recursive: true)
-        let repositoryManager = RepositoryManager(
-            path: p,
-            provider: inMemRepoProvider,
-            delegate: MockResolverDelegate(),
-            fileSystem: fs)
-        
-        let provider = RepositoryPackageContainerProvider(
-            repositoryManager: repositoryManager,
-            manifestLoader: MockManifestLoader(manifests: [:]))
-        let ref = PackageReference(identity: "foo", path: repoPath.asString)
-        let container = try await { provider.getContainer(for: ref, completion: $0) }
-        let v = container.versions(filter: { _ in true }).map{$0}
-        XCTAssertEqual(v, ["2.0.1", "1.0.4", "1.0.2", "1.0.1", "1.0.0"])
-    }
 
     static var allTests = [
         ("testPackageReference", testPackageReference),
         ("testBasics", testBasics),
         ("testVersions", testVersions),
         ("testVprefixVersions", testVprefixVersions),
-        ("testSimultaneousVersions", testSimultaneousVersions)
     ]
 }


### PR DESCRIPTION
… style tags (#1503)"

This reverts commit a0087c7bc47a20d059c54e81a196c4e3492396e1.

Reverting this commit because it is causing resolution error in some of
the community packages. We need to understand the bug and write a test
that would have caught this issue. To reproduce, clone the community
package Moya @ 4b3ff7e and run swift-build.