### PR TITLE
Fix a simple compiler warning about CountableRange being deprecated

### DIFF
--- a/Sources/Basic/OrderedSet.swift
+++ b/Sources/Basic/OrderedSet.swift
@@ -13,7 +13,7 @@
 public struct OrderedSet<E: Hashable>: Equatable, Collection {
     public typealias Element = E
     public typealias Index = Int
-    public typealias Indices = CountableRange<Int>
+    public typealias Indices = Range<Int>
 
     private var array: [Element]
     private var set: Set<Element>


### PR DESCRIPTION
Simple deprecation warning fix that kept false signaling me while building. 