### PR TITLE
 [SR-6978] Implement support for simultaneous vX.X.X and X.X.X style tags with fix for prerelease tags

### DIFF
--- a/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
@@ -365,22 +365,24 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
         let knownVersionsWithDuplicates = Git.convertTagsToVersionMap(repository.tags)
         
         let knownVersions = knownVersionsWithDuplicates.mapValues { (tags) -> String in
-            switch tags {
-            case (normal: .some, vPrefixed: .none):
-                return tags.normal!
-            case (normal: .none, vPrefixed: .some):
-                return tags.vPrefixed!
-            case (normal: .some, vPrefixed: .some):
-                let normalRevision = try! repository.resolveRevision(tag: tags.normal!)
-                let vPrefixedRevision = try! repository.resolveRevision(tag: tags.vPrefixed!)
-                if normalRevision != vPrefixedRevision {
-                    // Warn if the duplicate tags point to different revisions.
-                    print("Warning: tags \(tags.normal!) and \(tags.vPrefixed!) point to different revisions. Defaulting to \(tags.normal!)")
-                }
-                return tags.normal!
-            case (.none, .none):
-                return ""
+            if tags.count == 1 {
+                return tags[0]
             }
+            else if tags.count == 2 {
+                do {
+                    let normalRevision = try repository.resolveRevision(tag: tags[0])
+                    let vPrefixedRevision = try repository.resolveRevision(tag: tags[1])
+                    
+                    if normalRevision != vPrefixedRevision {
+                        // FIXME: Warn that the duplicate tags point to different revisions.
+                    }
+                }
+                catch {
+                    return tags[0]
+                }
+                return tags[0]
+            }
+            return tags[0]
         }
 
         self.knownVersions = knownVersions

--- a/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
@@ -364,14 +364,14 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
         // FIXME: Move this utility to a more stable location.
         let knownVersionsWithDuplicates = Git.convertTagsToVersionMap(repository.tags)
         
-        let knownVersions = knownVersionsWithDuplicates.mapValues { tags -> String in
+        let knownVersions = knownVersionsWithDuplicates.mapValues({ tags -> String in
             if tags.count == 2 {
                 // FIXME: Warn if the two tags point to different git references.
                 return tags.first(where: { !$0.hasPrefix("v") })!
             }
             assert(tags.count == 1, "Unexpected number of tags")
             return tags[0]
-        }
+        })
         
         self.knownVersions = knownVersions
         self.reversedVersions = [Version](knownVersions.keys).sorted().reversed()

--- a/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
@@ -362,7 +362,6 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
         // Compute the map of known versions.
         //
         // FIXME: Move this utility to a more stable location.
-        
         let knownVersionsWithDuplicates = Git.convertTagsToVersionMap(repository.tags)
         
         let knownVersions = knownVersionsWithDuplicates.mapValues { (tags) -> String in
@@ -375,7 +374,7 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
                 let normalRevision = try! repository.resolveRevision(tag: tags.normal!)
                 let vPrefixedRevision = try! repository.resolveRevision(tag: tags.vPrefixed!)
                 if normalRevision != vPrefixedRevision {
-                    //WARN
+                    // Warn if the duplicate tags point to different revisions.
                     print("Warning: tags \(tags.normal!) and \(tags.vPrefixed!) point to different revisions. Defaulting to \(tags.normal!)")
                 }
                 return tags.normal!

--- a/Sources/Utility/Git.swift
+++ b/Sources/Utility/Git.swift
@@ -27,7 +27,7 @@ public class Git {
         // First, check if we need to restrict the tag set to version-specific tags.
         var knownVersions: [Version: [String]] = [:]
         for versionSpecificKey in Versioning.currentVersionSpecificKeys {
-            for tag in tags {
+            for tag in tags where tag.hasSuffix(versionSpecificKey) {
                 let specifier = String(tag.dropLast(versionSpecificKey.count))
                 if let version = Version(string: specifier) ?? Version.vprefix(specifier) {
                     knownVersions[version, default: []].append(tag)

--- a/Sources/Utility/Git.swift
+++ b/Sources/Utility/Git.swift
@@ -29,23 +29,13 @@ public class Git {
         // First, check if we need to restrict the tag set to version-specific tags.
         var knownVersions: [Version: [String]] = [:]
         for versionSpecificKey in Versioning.currentVersionSpecificKeys {
-            for tag in tags where tag.hasSuffix(versionSpecificKey) {
+            for tag in tags {
                 let specifier = String(tag.dropLast(versionSpecificKey.count))
-                if let version = Version(string: specifier) {
-                    knownVersions[version] = [tag]
+                if let version = Version(string: specifier) ?? Version.vprefix(specifier) {
+                    knownVersions[version, default: []].append(tag)
                 }
             }
-            for tag in tags where tag.hasSuffix(versionSpecificKey) {
-                let specifier = String(tag.dropLast(versionSpecificKey.count))
-                if let version = Version.vprefix(specifier) {
-                    if knownVersions[version] != nil {
-                        knownVersions[version]?.append(tag)
-                    }
-                    else {
-                        knownVersions[version] = [tag]
-                    }
-                }
-            }
+
             // If we found tags at this version-specific key, we are done.
             if !knownVersions.isEmpty {
                 return knownVersions
@@ -54,18 +44,8 @@ public class Git {
 
         // Otherwise, look for normal and 'v'-prefixed tags.
         for tag in tags {
-            if let version = Version(string: tag) {
-                knownVersions[version] = [tag]
-            }
-        }
-        for tag in tags {
-            if let version = Version.vprefix(tag) {
-                if knownVersions[version] != nil {
-                    knownVersions[version]?.append(tag)
-                }
-                else {
-                    knownVersions[version] = [tag]
-                }
+            if let version = Version(string: tag) ?? Version.vprefix(tag) {
+                knownVersions[version, default: []].append(tag)
             }
         }
         return knownVersions

--- a/Sources/Utility/Git.swift
+++ b/Sources/Utility/Git.swift
@@ -23,8 +23,6 @@ extension Version {
 
 public class Git {
     /// Compute the version -> tags mapping from a list of input `tags`.
-    /// The returned array has a minimum of one element and a maximum of two.
-    /// The X.X.X tag will always precede the vX.X.X tag in case of duplicates.
     public static func convertTagsToVersionMap(_ tags: [String]) -> [Version: [String]] {
         // First, check if we need to restrict the tag set to version-specific tags.
         var knownVersions: [Version: [String]] = [:]

--- a/Sources/Utility/Git.swift
+++ b/Sources/Utility/Git.swift
@@ -22,15 +22,18 @@ extension Version {
 }
 
 public class Git {
-    /// Compute the version -> tag mapping from a list of input `tags`.
-    public static func convertTagsToVersionMap(_ tags: [String]) -> [Version: String] {
+    /// Compute the version -> tags mapping from a list of input `tags`.
+    public static func convertTagsToVersionMap(_ tags: [String]) -> [Version: (normal: String?, vPrefixed: String?)] {
         // First, check if we need to restrict the tag set to version-specific tags.
-        var knownVersions: [Version: String] = [:]
+        var knownVersions: [Version: (normal: String?, vPrefixed: String?)] = [:]
         for versionSpecificKey in Versioning.currentVersionSpecificKeys {
             for tag in tags where tag.hasSuffix(versionSpecificKey) {
                 let specifier = String(tag.dropLast(versionSpecificKey.count))
-                if let version = Version(string: specifier) ?? Version.vprefix(specifier) {
-                    knownVersions[version] = tag
+                if let version = Version(string: specifier) {
+                    (knownVersions[version]?.normal = tag) ?? (knownVersions[version] = (normal: tag, vPrefixed: nil))
+                }
+                else if let version = Version.vprefix(specifier) {
+                    (knownVersions[version]?.vPrefixed = tag) ?? (knownVersions[version] = (normal: nil, vPrefixed: tag))
                 }
             }
 
@@ -40,21 +43,13 @@ public class Git {
             }
         }
 
-        // Otherwise, look for normal tags.
+        // Otherwise, look for normal and 'v'-prefixed tags.
         for tag in tags {
             if let version = Version(string: tag) {
-                knownVersions[version] = tag
+                (knownVersions[version]?.normal = tag) ?? (knownVersions[version] = (normal: tag, vPrefixed: nil))
             }
-        }
-
-        // If we didn't find any versions, look for 'v'-prefixed ones.
-        //
-        // FIXME: We should match both styles simultaneously.
-        if knownVersions.isEmpty {
-            for tag in tags {
-                if let version = Version.vprefix(tag) {
-                    knownVersions[version] = tag
-                }
+            else if let version = Version.vprefix(tag) {
+                (knownVersions[version]?.vPrefixed = tag) ?? (knownVersions[version] = (normal: nil, vPrefixed: tag))
             }
         }
         return knownVersions

--- a/Sources/Utility/Git.swift
+++ b/Sources/Utility/Git.swift
@@ -15,8 +15,7 @@ extension Version {
     init?(tag: String) {
         if tag.first == "v" {
             self.init(string: String(tag.dropFirst()))
-        }
-        else {
+        } else {
             self.init(string: tag)
         }
     }
@@ -46,8 +45,7 @@ public class Git {
         }
         if !versionSpecificKnownVersions.isEmpty {
             return versionSpecificKnownVersions
-        }
-        else {
+        } else {
             return knownVersions
         }
     }

--- a/Sources/Utility/Git.swift
+++ b/Sources/Utility/Git.swift
@@ -43,6 +43,9 @@ public class Git {
                 knownVersions[version, default: []].append(tag)
             }
         }
+        // Check if any version specific tags were found.
+        // If true, then return the version specific tags,
+        // or else return the version independent tags.
         if !versionSpecificKnownVersions.isEmpty {
             return versionSpecificKnownVersions
         } else {

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -235,9 +235,9 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         try repo.writeFileContents(filePath, bytes: ByteString(encodingAsUTF8: "// swift-tools-version:\(ToolsVersion.currentToolsVersion)\n"))
         repo.commit()
         try repo.tag(name: "v1.0.0")
-        try repo.tag(name: "v1.0.1")
+        try repo.tag(name: "1.0.1")
         try repo.tag(name: "v1.0.2")
-        try repo.tag(name: "v1.0.3")
+        try repo.tag(name: "1.0.3")
         try repo.tag(name: "v2.0.3")
 
         let inMemRepoProvider = InMemoryGitRepositoryProvider()

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -328,6 +328,45 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         }
     }
     
+    func testPrereleaseVersions() throws {
+        let fs = InMemoryFileSystem()
+        
+        let repoPath = AbsolutePath.root.appending(component: "some-repo")
+        let filePath = repoPath.appending(component: "Package.swift")
+        
+        let specifier = RepositorySpecifier(url: repoPath.asString)
+        let repo = InMemoryGitRepository(path: repoPath, fs: fs)
+        try repo.createDirectory(repoPath, recursive: true)
+        try repo.writeFileContents(filePath, bytes: ByteString(encodingAsUTF8: "// swift-tools-version:\(ToolsVersion.currentToolsVersion)\n"))
+        repo.commit()
+        try repo.tag(name: "1.0.0-alpha.1")
+        try repo.tag(name: "1.0.0-beta.1")
+        try repo.tag(name: "1.0.0")
+        try repo.tag(name: "1.0.1")
+        try repo.tag(name: "1.0.2-dev")
+        try repo.tag(name: "1.0.2-dev.2")
+        try repo.tag(name: "1.0.4-alpha")
+        
+        let inMemRepoProvider = InMemoryGitRepositoryProvider()
+        inMemRepoProvider.add(specifier: specifier, repository: repo)
+        
+        let p = AbsolutePath.root.appending(component: "repoManager")
+        try fs.createDirectory(p, recursive: true)
+        let repositoryManager = RepositoryManager(
+            path: p,
+            provider: inMemRepoProvider,
+            delegate: MockResolverDelegate(),
+            fileSystem: fs)
+        
+        let provider = RepositoryPackageContainerProvider(
+            repositoryManager: repositoryManager,
+            manifestLoader: MockManifestLoader(manifests: [:]))
+        let ref = PackageReference(identity: "foo", path: repoPath.asString)
+        let container = try await { provider.getContainer(for: ref, completion: $0) }
+        let v = container.versions(filter: { _ in true }).map{$0}
+        XCTAssertEqual(v, ["1.0.4-alpha", "1.0.2-dev.2", "1.0.2-dev", "1.0.1", "1.0.0", "1.0.0-beta.1", "1.0.0-alpha.1"])
+    }
+    
     func testSimultaneousVersions() throws {
         let fs = InMemoryFileSystem()
         
@@ -373,6 +412,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         ("testBasics", testBasics),
         ("testVersions", testVersions),
         ("testVprefixVersions", testVprefixVersions),
+        ("testPrereleaseVersions", testPrereleaseVersions),
         ("testSimultaneousVersions", testSimultaneousVersions)
     ]
 }

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -235,9 +235,9 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         try repo.writeFileContents(filePath, bytes: ByteString(encodingAsUTF8: "// swift-tools-version:\(ToolsVersion.currentToolsVersion)\n"))
         repo.commit()
         try repo.tag(name: "v1.0.0")
-        try repo.tag(name: "1.0.1")
+        try repo.tag(name: "v1.0.1")
         try repo.tag(name: "v1.0.2")
-        try repo.tag(name: "1.0.3")
+        try repo.tag(name: "v1.0.3")
         try repo.tag(name: "v2.0.3")
 
         let inMemRepoProvider = InMemoryGitRepositoryProvider()
@@ -327,11 +327,52 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             XCTAssertEqual(v, [])
         }
     }
+    
+    func testSimultaneousVersions() throws {
+        let fs = InMemoryFileSystem()
+        
+        let repoPath = AbsolutePath.root.appending(component: "some-repo")
+        let filePath = repoPath.appending(component: "Package.swift")
+        
+        let specifier = RepositorySpecifier(url: repoPath.asString)
+        let repo = InMemoryGitRepository(path: repoPath, fs: fs)
+        try repo.createDirectory(repoPath, recursive: true)
+        try repo.writeFileContents(filePath, bytes: ByteString(encodingAsUTF8: "// swift-tools-version:\(ToolsVersion.currentToolsVersion)\n"))
+        repo.commit()
+        try repo.tag(name: "v1.0.0")
+        try repo.tag(name: "1.0.0")
+        try repo.tag(name: "1.0.1")
+        try repo.tag(name: "1.0.2")
+        try repo.tag(name: "v1.0.2")
+        try repo.tag(name: "1.0.4")
+        try repo.tag(name: "v2.0.1")
+        try repo.tag(name: "2.0.1")
+        
+        let inMemRepoProvider = InMemoryGitRepositoryProvider()
+        inMemRepoProvider.add(specifier: specifier, repository: repo)
+        
+        let p = AbsolutePath.root.appending(component: "repoManager")
+        try fs.createDirectory(p, recursive: true)
+        let repositoryManager = RepositoryManager(
+            path: p,
+            provider: inMemRepoProvider,
+            delegate: MockResolverDelegate(),
+            fileSystem: fs)
+        
+        let provider = RepositoryPackageContainerProvider(
+            repositoryManager: repositoryManager,
+            manifestLoader: MockManifestLoader(manifests: [:]))
+        let ref = PackageReference(identity: "foo", path: repoPath.asString)
+        let container = try await { provider.getContainer(for: ref, completion: $0) }
+        let v = container.versions(filter: { _ in true }).map{$0}
+        XCTAssertEqual(v, ["2.0.1", "1.0.4", "1.0.2", "1.0.1", "1.0.0"])
+    }
 
     static var allTests = [
         ("testPackageReference", testPackageReference),
         ("testBasics", testBasics),
         ("testVersions", testVersions),
         ("testVprefixVersions", testVprefixVersions),
+        ("testSimultaneousVersions", testSimultaneousVersions)
     ]
 }

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -381,11 +381,9 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         try repo.tag(name: "v1.0.0")
         try repo.tag(name: "1.0.0")
         try repo.tag(name: "1.0.1")
-        try repo.tag(name: "1.0.2")
         try repo.tag(name: "v1.0.2")
         try repo.tag(name: "1.0.4")
         try repo.tag(name: "v2.0.1")
-        try repo.tag(name: "2.0.1")
         
         let inMemRepoProvider = InMemoryGitRepositoryProvider()
         inMemRepoProvider.add(specifier: specifier, repository: repo)


### PR DESCRIPTION
This implements support for simultaneous vX.X.X and X.X.X style tags and fixes a bug that was discovered in the original PR for this bug where prerelease tags were handled incorrectly. An additional test case was made to test for prerelease tags.