### PR TITLE
[Basic] Add `AbsolutePath` validate(pathString:) method

### DIFF
--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -433,6 +433,23 @@ struct PathImpl {
     }
 }
 
+/// Describes the way in which a path is invalid.
+public enum PathValidationError: Error {
+    case startsWithTilda(String)
+    case invalidAbsolutePath(String)
+}
+
+extension PathValidationError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .startsWithTilda(let path):
+            return "invalid absolute path '\(path)'; absolute path must begin with /"
+        case .invalidAbsolutePath(let path):
+            return "invalid absolute path '\(path)'"
+        }
+    }
+}
+
 extension AbsolutePath {
     /// Returns a relative path that, when concatenated to `base`, yields the
     /// callee path itself.  If `base` is not an ancestor of the callee, the
@@ -484,6 +501,18 @@ extension AbsolutePath {
     /// in any way.
     public func contains(_ other: AbsolutePath) -> Bool {
         return self.components.starts(with: other.components)
+    }
+
+    /// Checks the path and throws a `PathValidationError` if the path is invalid.
+    public static func validate(pathString path: String) throws {
+        switch path.first {
+        case "/":
+            return
+        case "~":
+            throw PathValidationError.startsWithTilda(path)
+        default:
+            throw PathValidationError.invalidAbsolutePath(path)
+        }
     }
 }
 

--- a/Tests/BasicTests/PathTests.swift
+++ b/Tests/BasicTests/PathTests.swift
@@ -272,6 +272,18 @@ class PathTests: XCTestCase {
         XCTAssertFalse(AbsolutePath("/foo/bar").contains(AbsolutePath("/bar")))
     }
     
+    func testAbsolutePathValidation() {
+        XCTAssertNoThrow(try AbsolutePath.validate(pathString: "/a/b/c/d"))
+
+        XCTAssertThrowsError(try AbsolutePath.validate(pathString: "~/a/b/d")) { error in
+            XCTAssertEqual("\(error)", "invalid absolute path '~/a/b/d'; absolute path must begin with /")
+        }
+
+        XCTAssertThrowsError(try AbsolutePath.validate(pathString: "a/b/d")) { error in
+            XCTAssertEqual("\(error)", "invalid absolute path 'a/b/d'")
+        }
+    }
+
     // FIXME: We also need tests for join() operations.
     
     // FIXME: We also need tests for dirname, basename, suffix, etc.
@@ -296,5 +308,6 @@ class PathTests: XCTestCase {
         ("testPathComponents",                testPathComponents),
         ("testRelativePathFromAbsolutePaths", testRelativePathFromAbsolutePaths),
         ("testComparison",                    testComparison),
+        ("testAbsolutePathValidation",        testAbsolutePathValidation),
     ]
 }


### PR DESCRIPTION
Add static method to validate AbsolutePath throwing PathValidationError