### PR TITLE
[Docs] Update list of pre-defined paths in the documentation

### DIFF
--- a/Documentation/PackageDescriptionV4.md
+++ b/Documentation/PackageDescriptionV4.md
@@ -19,7 +19,7 @@ All targets should be declared in the `Package.swift` manifest file.  Unless the
 relative path of the target is declared, the Package Manager will look for
 a directory matching the name of the target in these places:
 
-Regular targets: Sources, Source, src, srcs.
+Regular targets: Sources, Source, src, srcs.  
 Test targets: Tests, Sources, Source, src, srcs.
 
 ## Package Manifest File Format Reference

--- a/Documentation/PackageDescriptionV4.md
+++ b/Documentation/PackageDescriptionV4.md
@@ -19,8 +19,8 @@ All targets should be declared in the `Package.swift` manifest file.  Unless the
 relative path of the target is declared, the Package Manager will look for
 a directory matching the name of the target in these places:
 
-Regular targets: package root, Sources, Source, src, srcs.  
-Test targets: Tests, package root, Sources, Source, src, srcs.
+Regular targets: Sources, Source, src, srcs.
+Test targets: Tests, Sources, Source, src, srcs.
 
 ## Package Manifest File Format Reference
 


### PR DESCRIPTION
It was decided to not include root directory to the list of pre-defined paths in the [discussion](https://github.com/apple/swift-package-manager/pull/1499). So I updated the documentation to reflect this fact.