### PR TITLE
Introduce PackageGraphSnapshot tool

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -179,6 +179,14 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             let manifest = graph.rootPackages[0].manifest
             print(try manifest.jsonString())
 
+        case .snapshotPackageGraph:
+            let workspace = try getActiveWorkspace()
+            let tool = PackageGraphSnapshotTool(workspace: workspace)
+            try tool.createGraphSnapshot(
+                root: getWorkspaceRoot(),
+                diagnostics: diagnostics
+            )
+
         case .completionTool:
             switch options.completionToolMode {
             case .generateBashScript?:
@@ -213,6 +221,8 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             to: { $0.describeMode = $1 })
 
         _ = parser.add(subparser: PackageMode.dumpPackage.rawValue, overview: "Print parsed Package.swift as JSON")
+
+        _ = parser.add(subparser: PackageMode.snapshotPackageGraph.rawValue, overview: "Snapshot the package graph")
 
         let editParser = parser.add(subparser: PackageMode.edit.rawValue, overview: "Put a package in editable mode")
         binder.bind(
@@ -412,6 +422,7 @@ public enum PackageMode: String, StringEnumArgument {
     case clean
     case describe
     case dumpPackage = "dump-package"
+    case snapshotPackageGraph = "snapshot-graph"
     case edit
     case fetch
     case generateXcodeproj = "generate-xcodeproj"

--- a/Sources/PackageGraph/Codable.swift
+++ b/Sources/PackageGraph/Codable.swift
@@ -1,0 +1,98 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Utility
+
+extension VersionSetSpecifier: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case any
+        case empty
+        case range
+        case exact
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .any:
+            try container.encodeNil(forKey: .any)
+        case .empty:
+            try container.encodeNil(forKey: .empty)
+        case let .range(a1):
+            var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .range)
+            try unkeyedContainer.encode(a1)
+        case let .exact(a1):
+            var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .exact)
+            try unkeyedContainer.encode(a1)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        guard let key = values.allKeys.first(where: values.contains) else {
+            throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Did not find a matching key"))
+        }
+        switch key {
+        case .any:
+            self = .any
+        case .empty:
+            self = .empty
+        case .range:
+            var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
+            let a1 = try unkeyedValues.decode(Range<Version>.self)
+            self = .range(a1)
+        case .exact:
+            var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
+            let a1 = try unkeyedValues.decode(Version.self)
+            self = .exact(a1)
+        }
+    }
+}
+
+extension PackageContainerConstraint.Requirement: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case versionSet
+        case revision
+        case unversioned
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .versionSet(a1):
+            var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .versionSet)
+            try unkeyedContainer.encode(a1)
+        case let .revision(a1):
+            var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .revision)
+            try unkeyedContainer.encode(a1)
+        case .unversioned:
+            try container.encodeNil(forKey: .unversioned)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        guard let key = values.allKeys.first(where: values.contains) else {
+            throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Did not find a matching key"))
+        }
+        switch key {
+        case .versionSet:
+            var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
+            let a1 = try unkeyedValues.decode(VersionSetSpecifier.self)
+            self = .versionSet(a1)
+        case .revision:
+            var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
+            let a1 = try unkeyedValues.decode(String.self)
+            self = .revision(a1)
+        case .unversioned:
+            self = .unversioned
+        }
+    }
+}

--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -178,7 +178,7 @@ public enum VersionSetSpecifier: Hashable, CustomStringConvertible {
 ///
 /// This identifier is used to abstractly refer to another container when
 /// encoding dependencies across packages.
-public protocol PackageContainerIdentifier: Hashable { }
+public protocol PackageContainerIdentifier: Hashable, Codable { }
 
 /// A type-erased package container identifier.
 public struct AnyPackageContainerIdentifier: PackageContainerIdentifier {
@@ -197,6 +197,14 @@ public struct AnyPackageContainerIdentifier: PackageContainerIdentifier {
 
     public static func == (lhs: AnyPackageContainerIdentifier, rhs: AnyPackageContainerIdentifier) -> Bool {
         return lhs.identifier == rhs.identifier
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        fatalError()
+    }
+
+    public init(from decoder: Decoder) throws {
+        fatalError()
     }
 }
 
@@ -281,7 +289,7 @@ public protocol PackageContainerProvider {
 }
 
 /// An individual constraint onto a container.
-public struct PackageContainerConstraint<T: PackageContainerIdentifier>: CustomStringConvertible, Equatable {
+public struct PackageContainerConstraint<T: PackageContainerIdentifier>: CustomStringConvertible, Equatable, Codable {
     public typealias Identifier = T
 
     /// The requirement of this constraint.

--- a/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
@@ -102,7 +102,7 @@ enum RepositoryPackageResolutionError: Swift.Error {
 /// A package reference.
 ///
 /// This represents a reference to a package containing its identity and location.
-public struct PackageReference: PackageContainerIdentifier, JSONMappable, JSONSerializable {
+public struct PackageReference: PackageContainerIdentifier, JSONMappable, JSONSerializable, Codable {
 
     /// Compute identity of a package given its URL.
     public static func computeIdentity(packageURL: String) -> String {

--- a/Sources/TestSupport/MockDependencyResolver.swift
+++ b/Sources/TestSupport/MockDependencyResolver.swift
@@ -18,8 +18,6 @@ import struct Utility.Version
 
 public typealias MockDependencyResolver = DependencyResolver<MockPackagesProvider, MockResolverDelegate>
 
-extension String: PackageContainerIdentifier { }
-
 public typealias MockPackageConstraint = PackageContainerConstraint<String>
 
 extension VersionSetSpecifier {

--- a/Sources/Utility/Range.swift
+++ b/Sources/Utility/Range.swift
@@ -1,0 +1,29 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+extension Range: Codable where Bound: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case lowerBound
+        case upperBound
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(upperBound, forKey: .upperBound)
+        try container.encode(lowerBound, forKey: .lowerBound)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        let lowerBound = try values.decode(Bound.self, forKey: .lowerBound)
+        let upperBound = try values.decode(Bound.self, forKey: .upperBound)
+        self = lowerBound..<upperBound
+    }
+}

--- a/Sources/Utility/Version.swift
+++ b/Sources/Utility/Version.swift
@@ -11,7 +11,7 @@
 import Basic
 
 /// A struct representing a semver version.
-public struct Version {
+public struct Version: Codable {
 
     /// The major version.
     public let major: Int

--- a/Sources/Workspace/PackageGraphSnapshot.swift
+++ b/Sources/Workspace/PackageGraphSnapshot.swift
@@ -1,0 +1,174 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Basic
+import Utility
+import Foundation
+import PackageGraph
+
+final public class PackageGraphSnapshotTool {
+
+    let workspace: Workspace
+
+    public init(workspace: Workspace) {
+        self.workspace = workspace
+    }
+
+    public func createGraphSnapshot(
+        root: PackageGraphRootInput,
+        diagnostics: DiagnosticsEngine
+    ) throws {
+        let rootManifests = workspace.loadRootManifests(packages: root.packages, diagnostics: diagnostics) 
+        let graphRoot = PackageGraphRoot(input: root, manifests: rootManifests)
+
+        try PackageGraphSnapshotBuilder(containerProvider: workspace.containerProvider)
+            .build(inputConstraints: graphRoot.constraints)
+    }
+}
+
+// MARK: - Models
+
+extension String: PackageContainerIdentifier { }
+
+final class PackageContainerSnapshot: Codable {
+    let identifier: PackageReference
+    let depsByVersion: [String: [RepositoryPackageConstraint]]
+
+    init(identifier: PackageReference, depsByVersion: [String: [RepositoryPackageConstraint]]) {
+        self.identifier = identifier
+        self.depsByVersion = depsByVersion
+    }
+}
+
+struct PackageGraphSnapshot: Codable {
+    public let constraints: [RepositoryPackageConstraint]
+    public let containers: [PackageContainerSnapshot]
+}
+
+// MARK: - Builders
+
+final class PackageContainerSnapshotBuilder {
+    let identifier: PackageReference
+    var depsByVersion: [String: [RepositoryPackageConstraint]]
+
+    init(identifier: PackageReference) {
+        self.identifier = identifier
+        self.depsByVersion = [:]
+    }
+
+    func add(constraints: [RepositoryPackageConstraint], forKey key: String) {
+        depsByVersion[key] = constraints
+    }
+
+    func build() -> PackageContainerSnapshot {
+        return PackageContainerSnapshot(identifier: identifier, depsByVersion: depsByVersion)
+    }
+}
+
+private final class PackageGraphSnapshotBuilder {
+    let containerProvider: RepositoryPackageContainerProvider
+
+    private let operationQueue = OperationQueue()
+    private let queue = DispatchQueue(label: "org.swift.swiftpm.something-2")
+    private var packageContainerBuilders: [PackageReference: PackageContainerSnapshotBuilder] = [:]
+    private let progressBar: LaneBasedProgressBarProtocol
+
+    init(containerProvider: RepositoryPackageContainerProvider) {
+        self.containerProvider = containerProvider
+        operationQueue.name = "org.swift.swiftpm.something"
+
+        let lanes = ProcessInfo.processInfo.activeProcessorCount
+        progressBar = createLaneBasedProgressBar(forStream: stdoutStream, numLanes: lanes)
+        operationQueue.maxConcurrentOperationCount = lanes
+    }
+
+    func build(constraint: RepositoryPackageConstraint) {
+        let identifier = constraint.identifier
+
+        // We only care about the first constraint that we encounter.
+        let builder: PackageContainerSnapshotBuilder? = queue.sync(execute: {
+            if !self.packageContainerBuilders.keys.contains(identifier) {
+                let containerBuilder = PackageContainerSnapshotBuilder(identifier: identifier)
+                packageContainerBuilders[identifier] = containerBuilder
+                return containerBuilder
+            }
+            return nil
+        })
+
+        guard let containerBuilder = builder else { return }
+
+        let theContainer = try? await { containerProvider.getContainer(for: identifier, skipUpdate: true, completion: $0) }
+        guard let container = theContainer else {
+            return
+        }
+
+        let progressBarLane = progressBar.createLane(name: "Processing \(identifier.path)")
+
+        switch constraint.requirement {
+        case .versionSet(let versionSet):
+            let validVersions = container.versions(filter: versionSet.contains)
+
+            for version in validVersions {
+                progressBarLane.update(text: version.description)
+
+                if let dependencies = try? container.getDependencies(at: version) {
+                    containerBuilder.add(constraints: dependencies, forKey: version.description)
+                    enqueue(constraints: dependencies)
+                }
+            }
+
+        case .revision(let revision):
+            progressBarLane.update(text: revision)
+
+            if let dependencies = try? container.getDependencies(at: revision) {
+                containerBuilder.add(constraints: dependencies, forKey: revision)
+                enqueue(constraints: dependencies)
+            }
+
+        case .unversioned:
+            progressBarLane.update(text: "Unversioned")
+
+            if let dependencies = try? container.getUnversionedDependencies() {
+                containerBuilder.add(constraints: dependencies, forKey: "___spm_unversioned")
+                enqueue(constraints: dependencies)
+            }
+        }
+
+        progressBarLane.complete()
+    }
+
+    func enqueue(constraints: [RepositoryPackageConstraint]) {
+        for constraint in constraints {
+            operationQueue.addOperation({
+                self.build(constraint: constraint)
+            })
+        }
+    }
+
+    func build(inputConstraints: [RepositoryPackageConstraint]) throws {
+        // Enqueue the input constraints.
+        enqueue(constraints: inputConstraints)
+
+        // Wait for all operations to finish.
+        operationQueue.waitUntilAllOperationsAreFinished()
+        progressBar.complete(text: "Done!")
+
+        // Build all the containers.
+        let snapshot = PackageGraphSnapshot(
+            constraints: inputConstraints,
+            containers: packageContainerBuilders.values.map({ $0.build() })
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        let d = try encoder.encode(snapshot)
+        print(String(data: d, encoding: .utf8)!)
+    }
+}

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -251,7 +251,7 @@ public class Workspace {
     fileprivate let repositoryManager: RepositoryManager
 
     /// The package container provider.
-    fileprivate let containerProvider: RepositoryPackageContainerProvider
+    let containerProvider: RepositoryPackageContainerProvider
 
     /// Enable prefetching containers in resolver.
     fileprivate let isResolverPrefetchingEnabled: Bool


### PR DESCRIPTION
This introduces a tool to create JSON representation of a package graph, even if it is unresolvable. The purpose of this tools is to help SwiftPM developers reproduce bugs, improve performance and diagnostics of the dependency resolver.

The tool also emits a cool progress animation!
![ezgif-5-d127251c60](https://user-images.githubusercontent.com/4136295/37259113-a02f6856-253f-11e8-8f13-dd987c977dcf.gif)

--

TODO:
- [ ] Cleanup
- [ ] Tests