### PR TITLE
Support runtime checks for erroneous behavior

### DIFF
--- a/Fixtures/Miscellaneous/SanitizersTest/Package.swift
+++ b/Fixtures/Miscellaneous/SanitizersTest/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:4.0
+
+import PackageDescription
+
+let package = Package(
+    name: "SanitizersTest",
+    products: [
+    ],
+    dependencies: [ ],
+    targets: [
+        .target(name: "executable", dependencies: ["BadCode"]),
+        .target(name: "BadCode", dependencies: ["CLib"]),
+        .target(name: "CLib", dependencies: []),
+        .testTarget(name: "BadCodeTests", dependencies: ["BadCode"]),
+    ]
+)

--- a/Fixtures/Miscellaneous/SanitizersTest/README.md
+++ b/Fixtures/Miscellaneous/SanitizersTest/README.md
@@ -1,0 +1,3 @@
+# SanitizersTest
+
+Help to determine whether --sanitizer=thread works.

--- a/Fixtures/Miscellaneous/SanitizersTest/Sources/BadCode/BadCode.swift
+++ b/Fixtures/Miscellaneous/SanitizersTest/Sources/BadCode/BadCode.swift
@@ -1,0 +1,71 @@
+import CLib
+
+// This code properly crashes with just
+//
+//  swiftc -sanitize=thread
+//
+public func badSwift() -> Int32 {
+    var nonatomic: Int32 = 0
+
+    let pt = spawn { nonatomic += 1 }
+
+    nonatomic += 1
+
+    join(pt)
+
+    return nonatomic
+}
+
+// This code only properly crashes with
+//
+//  swiftc -sanitize=thread -Xcc -fsanitize=thread
+//
+public func badSwiftWithBadC() -> Int32 {
+    var nonatomic: Int32 = 0
+
+    incrementInThread(&nonatomic)
+
+    nonatomic += 1
+
+    joinThread()
+
+    return nonatomic
+}
+
+private func spawn(_ callback: @escaping () -> ()) -> pthread_t {
+#if os(Linux)
+    var pt: pthread_t = pthread_t()
+#else
+    var pt: pthread_t? = nil
+#endif
+
+    let box = BoxedCallback(callback)
+
+    let res = pthread_create(&pt, nil, { p in
+        let box = Unmanaged<BoxedCallback>.fromOpaque((p as UnsafeMutableRawPointer?)!.assumingMemoryBound(to: BoxedCallback.self)).takeRetainedValue()
+
+        box.value()
+
+        return nil
+    }, Unmanaged.passRetained(box).toOpaque())
+
+    precondition(res == 0, "Unable to create thread")
+
+#if os(Linux)
+    return pt
+#else
+    return pt!
+#endif
+}
+
+private func join(_ pt: pthread_t) {
+    pthread_join(pt, nil)
+}
+
+final class Box<T> {
+    let value: T
+    init(_ value: T) {
+        self.value = value
+    }
+}
+typealias BoxedCallback = Box<()->()>

--- a/Fixtures/Miscellaneous/SanitizersTest/Sources/CLib/CLib.c
+++ b/Fixtures/Miscellaneous/SanitizersTest/Sources/CLib/CLib.c
@@ -1,0 +1,19 @@
+#include <pthread.h>
+#include <assert.h>
+
+static void *increment(void *intp) {
+    int *i = intp;
+    *i = *i + 1;
+    return 0;
+}
+
+static pthread_t t;
+
+void incrementInThread(int *ptr) {
+    int r = pthread_create(&t, 0, increment, ptr);
+    assert(r == 0);
+}
+
+void joinThread() {
+    pthread_join(t, 0);
+}

--- a/Fixtures/Miscellaneous/SanitizersTest/Sources/CLib/include/CLib.h
+++ b/Fixtures/Miscellaneous/SanitizersTest/Sources/CLib/include/CLib.h
@@ -1,0 +1,4 @@
+#include <pthread.h>
+
+void incrementInThread(int *);
+void joinThread();

--- a/Fixtures/Miscellaneous/SanitizersTest/Sources/executable/main.swift
+++ b/Fixtures/Miscellaneous/SanitizersTest/Sources/executable/main.swift
@@ -1,0 +1,5 @@
+import BadCode
+
+let value = badSwiftWithBadC()
+print("Unexpected flawless execution of unsafe code: \(value)")
+precondition(value == 2, "Unexpected value \(value), expected 2")

--- a/Fixtures/Miscellaneous/SanitizersTest/Tests/BadCodeTests/BadCodeTests.swift
+++ b/Fixtures/Miscellaneous/SanitizersTest/Tests/BadCodeTests/BadCodeTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+import BadCode
+
+class BadCodeTests: XCTestCase {
+
+    func testExecuteBadSwift() {
+        badSwift()
+        XCTAssertEqual("ok", "ok")
+    }
+
+    func testExecuteBadSwiftWithBadC() {
+        badSwiftWithBadC()
+        XCTAssertEqual("ok", "ok")
+    }
+
+
+    static var allTests = [
+        ("testExecuteBadSwift", testExecuteBadSwift),
+        ("testExecuteBadSwiftWithBadC", testExecuteBadSwiftWithBadC),
+    ]
+}

--- a/Fixtures/Miscellaneous/SanitizersTest/Tests/LinuxMain.swift
+++ b/Fixtures/Miscellaneous/SanitizersTest/Tests/LinuxMain.swift
@@ -1,0 +1,6 @@
+import XCTest
+@testable import BadCodeTests
+
+XCTMain([
+    testCase(BadCodeTests.allTests),
+])

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -72,6 +72,9 @@ public struct BuildParameters {
     /// If should link the Swift stdlib statically.
     public let shouldLinkStaticSwiftStdlib: Bool
 
+    /// Which compiler sanitizers should be enabled
+    public let sanitizers: EnabledSanitizers
+
     /// If should enable llbuild manifest caching.
     public let shouldEnableManifestCaching: Bool
 
@@ -99,7 +102,8 @@ public struct BuildParameters {
         flags: BuildFlags,
         toolsVersion: ToolsVersion = ToolsVersion.currentToolsVersion,
         shouldLinkStaticSwiftStdlib: Bool = false,
-        shouldEnableManifestCaching: Bool = false
+        shouldEnableManifestCaching: Bool = false,
+        sanitizers: EnabledSanitizers = EnabledSanitizers()
     ) {
         self.dataPath = dataPath
         self.configuration = configuration
@@ -109,6 +113,7 @@ public struct BuildParameters {
         self.toolsVersion = toolsVersion
         self.shouldLinkStaticSwiftStdlib = shouldLinkStaticSwiftStdlib
         self.shouldEnableManifestCaching = shouldEnableManifestCaching
+        self.sanitizers = sanitizers
     }
 }
 
@@ -210,6 +215,7 @@ public final class ClangTargetDescription {
         args += ["-I", clangTarget.includeDir.asString]
         args += additionalFlags
         args += moduleCacheArgs
+        args += buildParameters.sanitizers.compileCFlags()
 
         // User arguments (from -Xcc and -Xcxx below) should follow generated arguments to allow user overrides
         args += buildParameters.flags.cCompilerFlags
@@ -323,6 +329,7 @@ public final class SwiftTargetDescription {
         args += activeCompilationConditions
         args += additionalFlags
         args += moduleCacheArgs
+        args += buildParameters.sanitizers.compileSwiftFlags()
 
         // Add arguments to colorize output if stdout is tty
         if buildParameters.isTTY {
@@ -435,6 +442,7 @@ public final class ProductBuildDescription {
         var args = [buildParameters.toolchain.swiftCompiler.asString]
         args += buildParameters.toolchain.extraSwiftCFlags
         args += additionalFlags
+        args += buildParameters.sanitizers.linkSwiftFlags()
 
         if buildParameters.configuration == .debug {
             args += ["-g"]

--- a/Sources/Build/Sanitizers.swift
+++ b/Sources/Build/Sanitizers.swift
@@ -1,0 +1,114 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2018 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+import Basic
+import Utility
+
+/// A set of enabled runtime sanitizers.
+public struct EnabledSanitizers {
+    public enum Sanitizer: String {
+        case address
+        case thread
+    }
+
+    /// A set of enabled sanitizers.
+    private let sanitizers: Set<Sanitizer>
+
+    /// OS identification
+    private let triple: Triple
+
+    /// Runtime verbosity level
+    private let verbose: Bool
+
+    public init(from list: [Sanitizer] = [], triple: Triple = Triple.hostTriple, verbose: Bool = false) {
+        self.sanitizers = Set(list)
+        self.triple = triple
+        self.verbose = verbose
+    }
+
+    /// Return an established short name for a sanitizer, e.g. "asan".
+    private func shortname(_ sanitizer: Sanitizer) -> String {
+        switch sanitizer {
+        case .address: return "asan"
+        case .thread: return "tsan"
+        }
+    }
+
+    /// Return a dictionary with the sanitizer-specific list of additional
+    /// environment variables that have to be injected during runtime.
+    public func addRuntimeEnvironment(baseEnvironment: [String: String], toolchain: Toolchain) -> [String: String] {
+      #if os(macOS)
+        return macosAddRuntimeEnvironment(baseEnvironment: baseEnvironment, toolchain: toolchain)
+      #else
+        return [:]
+      #endif
+    }
+
+    private func macosAddRuntimeEnvironment(baseEnvironment: [String: String], toolchain: Toolchain) -> [String: String] {
+        var env: [String: String] = [:]
+        var insertLibs: [String] = []
+
+        if let existingLibs = baseEnvironment["DYLD_INSERT_LIBRARIES"] {
+            if existingLibs.count != 0 {
+                insertLibs = [existingLibs]
+            }
+        }
+
+        for sanitizer in sanitizers {
+            let libPath = sanitizerLibrary(clangPath: toolchain.clangCompiler, for: sanitizer)
+            insertLibs.append(libPath.asString)
+        }
+
+        env["DYLD_INSERT_LIBRARIES"] = insertLibs.joined(separator: ":")
+
+        if verbose {
+            env["DYLD_PRINT_LIBRARIES"] = "1"
+        }
+
+        return env
+    }
+
+    /// Sanitization flags for the C family compiler (C/C++)
+    public func compileCFlags() -> [String] {
+        return sanitizers.map({ "-fsanitize=\($0.rawValue)" })
+    }
+
+    /// Sanitization flags for the Swift compiler.
+    public func compileSwiftFlags() -> [String] {
+        return sanitizers.map({ "-sanitize=\($0.rawValue)" })
+    }
+
+    /// Sanitization flags for the Swift linker and compiler are the same so far.
+    public func linkSwiftFlags() -> [String] {
+        return compileSwiftFlags()
+    }
+
+    /// The sanitizer library is part of clang, but it is possible
+    /// to fetch a proper version of it by going through the `swift` symlink.
+    private func sanitizerLibrary(clangPath clang: AbsolutePath, for sanitizer: Sanitizer) -> AbsolutePath {
+        return clang.appending(RelativePath("../../lib/swift/clang/lib/\(osName())/libclang_rt.\(shortname(sanitizer))_osx_dynamic.dylib"))
+    }
+
+    /// Operating system short name for the filesystem path.
+    private func osName() -> String {
+        switch triple.os {
+        case .darwin, .macOS: return "darwin"
+        case .linux: return "linux"
+        }
+    }
+
+}
+
+// StringEnumArgument conformance to help with command line parsing
+extension EnabledSanitizers.Sanitizer: StringEnumArgument {
+    public static let completion: ShellCompletion = .values([
+        (address.rawValue, "enable Address sanitizer"),
+        (thread.rawValue, "enable Thread sanitizer"),
+    ])
+}

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -52,5 +52,8 @@ public class ToolOptions {
     /// Skip updating dependencies from their remote during a resolution.
     public var skipDependencyUpdate = false
 
+    /// Which compile-time sanitizers should be enabled.
+    public var sanitizers = EnabledSanitizers()
+
     public required init() {}
 }

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -269,6 +269,10 @@ public class SwiftTool<Options: ToolOptions> {
                 usage: "Change working directory before any other operation"),
             to: { $0.packagePath = $1.path })
 
+        binder.bindArray(
+            option: parser.add(option: "--sanitize", kind: [EnabledSanitizers.Sanitizer].self, strategy: .oneByOne, usage: "Turn on runtime checks for erroneous behavior"),
+            to: { $0.sanitizers = EnabledSanitizers(from: $1) })
+
         binder.bind(
             option: parser.add(option: "--disable-prefetching", kind: Bool.self, usage: ""),
             to: { $0.shouldEnableResolverPrefetching = !$1 })
@@ -632,7 +636,8 @@ public class SwiftTool<Options: ToolOptions> {
                 destinationTriple: triple,
                 flags: options.buildFlags,
                 shouldLinkStaticSwiftStdlib: options.shouldLinkStaticSwiftStdlib,
-                shouldEnableManifestCaching: options.shouldEnableManifestCaching
+                shouldEnableManifestCaching: options.shouldEnableManifestCaching,
+                sanitizers: options.sanitizers
             )
         })
     }()

--- a/Sources/TestSupport/XCTAssertHelpers.swift
+++ b/Sources/TestSupport/XCTAssertHelpers.swift
@@ -128,6 +128,25 @@ public func XCTAssertThrows<T: Swift.Error>(
     }
 }
 
+public func XCTAssertThrows<T: Swift.Error, Ignore>(
+    _ expression: @autoclosure () throws -> Ignore,
+    file: StaticString = #file,
+    line: UInt = #line,
+    _ recognize: (T) -> Bool
+) {
+    do {
+        _ = try expression()
+        XCTFail("body completed successfully", file: file, line: line)
+    } catch let error as T {
+        guard recognize(error) else {
+            XCTFail("unrecognized error thrown \(error)", file: file, line: line)
+            return
+        }
+    } catch {
+        XCTFail("unexpected error thrown", file: file, line: line)
+    }
+}
+
 public func XCTNonNil<T>( 
    _ optional: T?,
    file: StaticString = #file,

--- a/Tests/BasicTests/ResultTests.swift
+++ b/Tests/BasicTests/ResultTests.swift
@@ -151,8 +151,8 @@ class ResultTests: XCTestCase {
             let second = try throwing(false)
             return value + second
         }
-        XCTAssertThrowsAny(DummyError.somethingWentWrong) {
-            _ = try failure1.dematerialize()
+        XCTAssertThrows(try failure1.dematerialize()) {
+            $0 == DummyError.somethingWentWrong
         }
 
         // We have a value, but our closure throws.
@@ -160,8 +160,8 @@ class ResultTests: XCTestCase {
             let second = try throwing(true)
             return value + second
         }
-        XCTAssertThrowsAny(DummyError.somethingWentWrong) {
-            _ = try failure2.dematerialize()
+        XCTAssertThrows(try failure2.dematerialize()) {
+            $0 == DummyError.somethingWentWrong
         }
     }
 
@@ -196,15 +196,4 @@ class ResultTests: XCTestCase {
         ("testMapAny", testMapAny),
         ("testFlatMap", testFlatMap)
     ]
-}
-
-public func XCTAssertThrowsAny<T: Swift.Error>(_ expectedError: T, file: StaticString = #file, line: UInt = #line, _ body: () throws -> ()) where T: Equatable {
-    do {
-        try body()
-        XCTFail("body completed successfully", file: file, line: line)
-    } catch let error as AnyError {
-        XCTAssertEqual(error.underlyingError as? T, expectedError, file: file, line: line)
-    } catch {
-        XCTFail("unexpected error thrown", file: file, line: line)
-    }
 }

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -11,13 +11,14 @@
 import XCTest
 
 import TestSupport
+import Basic
 import Commands
 
 final class TestToolTests: XCTestCase {
-    private func execute(_ args: [String]) throws -> String {
-        return try SwiftPMProduct.SwiftTest.execute(args, printIfError: true)
+    private func execute(_ args: [String], packagePath: AbsolutePath? = nil, printIfError: Bool = true) throws -> String {
+        return try SwiftPMProduct.SwiftTest.execute(args, packagePath: packagePath, printIfError: printIfError)
     }
-    
+
     func testUsage() throws {
         XCTAssert(try execute(["--help"]).contains("USAGE: swift test"))
     }
@@ -30,8 +31,27 @@ final class TestToolTests: XCTestCase {
         XCTAssert(try execute(["--version"]).contains("Swift Package Manager"))
     }
 
+    // Verifies that sanitization works
+    func testSanitizeThread() throws {
+        #if os(macOS)
+        fixture(name: "Miscellaneous/SanitizersTest") { path in
+            let cmdline = ["--sanitize=thread"]
+            XCTAssertThrows(try execute(cmdline, packagePath: path, printIfError: false)) { (error: SwiftPMProductError) -> Bool in
+                switch error {
+                case .executionFailure(_, _, let stderr):
+                    return stderr.range(of: "ThreadSanitizer:") != nil
+                        && stderr.range(of: "access race") != nil
+                default:
+                    return false
+                }
+            }
+        }
+        #endif
+    }
+
     static var allTests = [
         ("testUsage", testUsage),
         ("testVersion", testVersion),
+        ("testSanitizeThread", testSanitizeThread),
     ]
 }


### PR DESCRIPTION
Added `--sanitize=address` and `--sanitize=thread` to be in line with swiftc/clang approach to sanitizer selection.

 * It does not seem to make sense to support other sanitizers, since only these two are reasonably supported by swiftc.
 * The Test infrastructure intentionally use the hostTriple, not a destinationTriple, because the tests are run locally.
 * The `.../swift/lib/clang` is a symlink to the most appropriate version of clang's libraries. An alternative would be to parse `clang -print-file-name=lib`.
 * The access to clang-based libraries is through `clang` executable path, not a `swift` path. This is intentional. In addition to the fact that the libraries clang's, going through the `swift` path wouldn't properly bootstrap during swift-package-manager development.
 * Linux doesn't need support for runtime, since sanitizers are added statically. Therefore, the `runtimeEnvironment()` for Linux is no-op.
 * The sanitizer is detectable during compile time in Swift via `#if SANITIZE_THREAD` and `#if SANITIZE_ADDRESS`, and in C/C++ through the usual [__has_feature()](https://clang.llvm.org/docs/ThreadSanitizer.html#has-feature-thread-sanitizer).

### Notes
 * In `clang-6.0` (at least) the `-fsanitize=address` is incompatible with `-fsanitize=thread`, so enabling both sanitizers would not work.