### PR TITLE
Lifted the validation API

### DIFF
--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -98,6 +98,18 @@ public struct AbsolutePath {
         self.init(absPath, RelativePath(relStr))
     }
 
+    /// Convenience initializer that verifies that the path is absolute.
+    public init(validating path: String) throws {
+        switch path.first {
+        case "/":
+            self.init(path)
+        case "~":
+            throw PathValidationError.startsWithTilde(path)
+        default:
+            throw PathValidationError.invalidAbsolutePath(path)
+        }
+    }
+
     /// Directory component.  An absolute path always has a non-empty directory
     /// component (the directory component of the root path is the root itself).
     public var dirname: String {
@@ -503,17 +515,6 @@ extension AbsolutePath {
         return self.components.starts(with: other.components)
     }
 
-    /// Checks the path and throws a `PathValidationError` if the path is invalid.
-    public static func validate(pathString path: String) throws {
-        switch path.first {
-        case "/":
-            return
-        case "~":
-            throw PathValidationError.startsWithTilde(path)
-        default:
-            throw PathValidationError.invalidAbsolutePath(path)
-        }
-    }
 }
 
 // FIXME: We should consider whether to merge the two `normalize()` functions.

--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -143,7 +143,7 @@ extension ManagedDependency.State: JSONMappable, JSONSerializable {
             self = try .checkout(json.get("checkoutState"))
         case "edited":
             let path: String? = json.get("path")
-            self = .edited(path.map(AbsolutePath.init))
+            self = .edited(path.map({AbsolutePath($0)}))
         default:
             throw JSON.MapError.custom(key: nil, message: "Invalid state \(name)")
         }

--- a/Tests/BasicTests/PathTests.swift
+++ b/Tests/BasicTests/PathTests.swift
@@ -273,13 +273,13 @@ class PathTests: XCTestCase {
     }
     
     func testAbsolutePathValidation() {
-        XCTAssertNoThrow(try AbsolutePath.validate(pathString: "/a/b/c/d"))
+        XCTAssertNoThrow(try AbsolutePath(validating: "/a/b/c/d"))
 
-        XCTAssertThrowsError(try AbsolutePath.validate(pathString: "~/a/b/d")) { error in
+        XCTAssertThrowsError(try AbsolutePath(validating: "~/a/b/d")) { error in
             XCTAssertEqual("\(error)", "invalid absolute path '~/a/b/d'; absolute path must begin with /")
         }
 
-        XCTAssertThrowsError(try AbsolutePath.validate(pathString: "a/b/d")) { error in
+        XCTAssertThrowsError(try AbsolutePath(validating: "a/b/d")) { error in
             XCTAssertEqual("\(error)", "invalid absolute path 'a/b/d'")
         }
     }

--- a/Tests/BasicTests/miscTests.swift
+++ b/Tests/BasicTests/miscTests.swift
@@ -50,7 +50,7 @@ class miscTests: XCTestCase {
     func testEnvSearchPaths() throws {
         let cwd = AbsolutePath("/dummy")
         let paths = getEnvSearchPaths(pathString: "something:.:abc/../.build/debug:/usr/bin:/bin/", currentWorkingDirectory: cwd)
-        XCTAssertEqual(paths, ["/dummy/something", "/dummy", "/dummy/.build/debug", "/usr/bin", "/bin"].map(AbsolutePath.init))
+        XCTAssertEqual(paths, ["/dummy/something", "/dummy", "/dummy/.build/debug", "/usr/bin", "/bin"].map({AbsolutePath($0)}))
     }
     
     func testEmptyEnvSearchPaths() throws {


### PR DESCRIPTION
Based on a comment of https://github.com/apple/swift-package-manager/pull/1536 elevated the validate API to the init() level.