### PR TITLE
clarify target dependency in a package dependency

### DIFF
--- a/Documentation/PackageDescriptionV4.md
+++ b/Documentation/PackageDescriptionV4.md
@@ -242,7 +242,7 @@ The above manifest declares two target, `Foo` and `Bar`. `Bar` is a test target
 which depends on `Foo`. The Package Manager will automatically search for the
 targets inside package in the [predefined search paths](#target-format-reference).
 
-A target dependency can either be another target in the same package or a target
+A target dependency can either be another target in the same package or a product
 in one of its package dependencies. All target dependencies, internal or
 external, must be explicitly declared.
 


### PR DESCRIPTION
target dependency cannot be a target in a package dependency, it can be a product in a package dependency

Consider this example, _packageA_ depends on a target in _packageB_:

_packageB_:
```swift
let package = Package(
    name: "packageBPackageName",
    products: [             
        .library(
            name: "packageBLibrary",
            targets: ["packageBTarget"]),
    ],
```

_packageA_:
```swift
let package = Package(
    name: "packageA",
    dependencies: [
        .package(url: "../packageB", from: "0.0.0"),
    ],
    targets: [
        // Targets are the basic building blocks of a package. A target can define a module or a test suite.                               
        // Targets can depend on other targets in this package, and on products in packages which this package depends on.                 
        .target(
            name: "packageA",
            dependencies: ["packageBLibrary"]),
    ]
)
```

The target dependency specifies _packageBLibrary_, not _packageBTarget_.

Also note the comment on the target dependencies in the generated Package.swift:
_Targets can depend ... on products in packages which this package depends on._
