### PR TITLE
SR-7154: swiftpm tests fail if --debug-foundation option is used.

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -816,6 +816,9 @@ def main():
     parser.add_argument("--swiftc", dest="swiftc_path",
                         help="path to the swift compiler [%(default)s]",
                         metavar="PATH")
+    parser.add_argument("--swift-lib-dir", dest="swift_lib_dir",
+                        help="path to the swift built library directory",
+                        metavar="PATH")
     parser.add_argument("--sbt", dest="sbt_path",
                         help="path to the 'swift-build-tool' tool "
                              "[%(default)s]",
@@ -1052,6 +1055,9 @@ def main():
 
     env_cmd = ["env", "SWIFT_EXEC=" + os.path.join(bindir, "swiftc"),
                       "SWIFTPM_BUILD_DIR=" + build_path]
+
+    if args.swift_lib_dir:
+        env_cmd.append("LD_LIBRARY_PATH=" + args.swift_lib_dir)
     if args.sysroot:
         env_cmd.append("SYSROOT=" + args.sysroot)
     cmd = env_cmd + [bootstrapped_product] + build_flags


### PR DESCRIPTION
- Add a --swift-lib-dir so that tests can find libswiftSwiftOnone.so
  which is required by libFoundation.so

- The path to the libraries in the swift build directory are passed
  to the test programs via the environment using LD_LIBRARY_PATH.

When testing using `./utils/build-script -R -T --llbuild --swiftpm --xctest --debug-foundation -- --reconfigure --lit-args=-v` to build a debug version of Foundation, the `libFoundation.so` in the Foundation build directory is linked to `libswiftSwiftOnone.so` in the swift build directory. However `libFoundation.so` cannot find `libswiftSwiftOnone.so`  in its default `RUNPATH`. This adds an `LD_LIBRARY_PATH` to the environment so that `libswiftSwiftOnone.so` can be found ok.

This PR works in conjunction with https://github.com/apple/swift/pull/15498 for swift's main build script so it can pass the directory. 