### PR TITLE
[WorkspaceTests] Disable a test on linux

### DIFF
--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -400,6 +400,9 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testCanResolveWithIncompatiblePins() throws {
+        // Disabled on linux due to an issue in stdlib:
+        // <rdar://problem/38647101> Intermittent lit test failure. SwiftPMPackageTests. HashedCollections.swift, line 6567
+      #if os(macOS)
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
@@ -489,6 +492,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertMatch(workspace.delegate.events, [.equal("updating repo: /tmp/ws/pkgs/AA")])
             XCTAssertEqual(workspace.delegate.events.filter({ $0.hasPrefix("updating repo") }).count, 2)
         }
+      #endif
     }
 
     func testResolverCanHaveError() throws {


### PR DESCRIPTION
Disabling this test because it intermittently fails on linux. This is
tracked by <rdar://problem/38647101> Intermittent lit test failure. SwiftPMPackageTests. HashedCollections.swift, line 6567