### PR TITLE
Add host target triple for RaspberryPi arm-linux-gnueabihf

### DIFF
--- a/Sources/Build/Triple.swift
+++ b/Sources/Build/Triple.swift
@@ -35,6 +35,7 @@ public struct Triple {
         case armv7
         case s390x
         case powerpc64le
+        case arm
     }
 
     public enum Vendor: String {
@@ -107,6 +108,7 @@ public struct Triple {
     public static let macOS = try! Triple("x86_64-apple-macosx10.10")
     public static let linux = try! Triple("x86_64-unknown-linux")
     public static let ppc64leLinux = try! Triple("powerpc64le-unknown-linux")
+    public static let armLinux = try! Triple("arm-linux-gnueabihf")
     public static let android = try! Triple("armv7-unknown-linux-androideabi")
 
   #if os(macOS)
@@ -115,6 +117,8 @@ public struct Triple {
     public static let hostTriple: Triple = try! Triple("s390x-unknown-linux")
   #elseif os(Linux) && arch(powerpc64le)
     public static let hostTriple: Triple = .ppc64leLinux
+  #elseif os(Linux) && arch(arm)
+    public static let hostTriple: Triple = .armLinux
   #else
     public static let hostTriple: Triple = .linux
   #endif

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -897,6 +897,8 @@ def main():
         build_target = "s390x-unknown-linux"
     elif platform.system() == 'Linux' and platform.machine() == 'ppc64le':
         build_target = 'powerpc64le-unknown-linux'
+    elif platform.system() == 'Linux' and platform.machine() == 'arm':
+        build_target = 'arm-linux-gnueabihf'
     else:
         build_target = 'x86_64-unknown-linux'
 


### PR DESCRIPTION
My [RaspberryPi cross compiler toolchain instructions](https://github.com/AlwaysRightInstitute/swift-mac2arm-x-compile-toolchain/tree/swift-4.1-release) break in SPM 4.1 because it hardcodes(!) the architecture. The proper fix would be to remove all this hardcoding, but meanwhile, this adds the specific target triple, similar to what people do for S/390 and PPC.