### PR TITLE
[PackageGraph] Fix hashing for PackageContainerConstraintSet

### DIFF
--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -469,7 +469,7 @@ public struct PackageContainerConstraintSet<C: PackageContainer>: Collection, Ha
     public var hashValue: Int {
         var result = 0
         for c in self.constraints {
-            result = result &* 31 ^ c.key.hashValue &* 0x62F ^ c.value.hashValue
+            result ^= c.key.hashValue &* 0x62F ^ c.value.hashValue
         }
         return result
     }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -400,9 +400,6 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testCanResolveWithIncompatiblePins() throws {
-        // Disabled due to a crash in stdlib:
-        // <rdar://problem/38647101> Intermittent lit test failure. SwiftPMPackageTests. HashedCollections.swift, line 6567
-      #if false
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
@@ -492,7 +489,6 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertMatch(workspace.delegate.events, [.equal("updating repo: /tmp/ws/pkgs/AA")])
             XCTAssertEqual(workspace.delegate.events.filter({ $0.hasPrefix("updating repo") }).count, 2)
         }
-      #endif
     }
 
     func testResolverCanHaveError() throws {


### PR DESCRIPTION
The ordering of its elements is not an essential part of a Dictionary;
two dictionaries with the same elements compare equal even if they're in
a different order. We must also produce hash values independent of element
ordering, or we will run afool of Hashable requirements.

Re-enable the test that was failing nondeterministically in previous commits.

rdar://problem/38647101