### PR TITLE
Improve diagnostic for missing source files

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -70,7 +70,7 @@ extension ModuleError: CustomStringConvertible {
             return "multiple targets named '\(name)'"
         case .modulesNotFound(let targets):
             let targets = targets.joined(separator: ", ")
-            return "could not find target(s): \(targets); use the 'path' property in the Swift 4 manifest to set a custom target path"
+            return "could not find source files for target(s): \(targets); use the 'path' property in the Swift 4 manifest to set a custom target path"
         case .invalidLayout(let type):
             return "package has unsupported layout; \(type)"
         case .invalidManifestConfig(let package, let message):

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -184,7 +184,7 @@ final class ModuleMapResult {
         if diagnostics.contains(str) {
             diagnostics.remove(str)
         } else {
-            XCTFail("no error: \(str) or is already checked", file: file, line: line)
+            XCTFail("no error: \"\(str)\" or is already checked", file: file, line: line)
         }
     }
 

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -606,7 +606,7 @@ class PackageBuilderTests: XCTestCase {
             ])
 
         PackageBuilderTester(package, in: fs) { result in
-            result.checkDiagnostic("could not find target(s): Bam; use the 'path' property in the Swift 4 manifest to set a custom target path")
+            result.checkDiagnostic("could not find source files for target(s): Bam; use the 'path' property in the Swift 4 manifest to set a custom target path")
         }
     }
 
@@ -673,13 +673,13 @@ class PackageBuilderTests: XCTestCase {
             "/Foo.swift")
         var package = PackageDescription.Package(name: "pkg", targets: [.init(name: "Random")])
         PackageBuilderTester(package, in: fs) { result in
-            result.checkDiagnostic("could not find target(s): Random; use the 'path' property in the Swift 4 manifest to set a custom target path")
+            result.checkDiagnostic("could not find source files for target(s): Random; use the 'path' property in the Swift 4 manifest to set a custom target path")
         }
 
         // Reference an invalid dependency.
         package = PackageDescription.Package(name: "pkg", targets: [.init(name: "pkg", dependencies: ["Foo"])])
         PackageBuilderTester(package, in: fs) { result in
-            result.checkDiagnostic("could not find target(s): Foo; use the 'path' property in the Swift 4 manifest to set a custom target path")
+            result.checkDiagnostic("could not find source files for target(s): Foo; use the 'path' property in the Swift 4 manifest to set a custom target path")
         }
 
         // Reference self in dependencies.
@@ -1197,7 +1197,7 @@ final class PackageBuilderTester {
         if uncheckedDiagnostics.contains(str) {
             uncheckedDiagnostics.remove(str)
         } else {
-            XCTFail("\(result) did not have error: \(str) or is already checked", file: file, line: line)
+            XCTFail("\(result) did not have error: \"\(str)\" or is already checked", file: file, line: line)
         }
     }
 

--- a/Tests/PackageLoadingTests/PackageBuilderV4Tests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderV4Tests.swift
@@ -482,7 +482,7 @@ class PackageBuilderV4Tests: XCTestCase {
                 "/Foo.swift")
             let package = Package(name: "pkg", targets: [.target(name: "Random")])
             PackageBuilderTester(package, in: fs) { result in
-                result.checkDiagnostic("could not find target(s): Random; use the 'path' property in the Swift 4 manifest to set a custom target path")
+                result.checkDiagnostic("could not find source files for target(s): Random; use the 'path' property in the Swift 4 manifest to set a custom target path")
             }
         }
 
@@ -496,7 +496,7 @@ class PackageBuilderV4Tests: XCTestCase {
                     .target(name: "pkg", dependencies: [.target(name: "Foo")]),
                 ])
             PackageBuilderTester(package, in: fs) { result in
-                result.checkDiagnostic("could not find target(s): Foo; use the 'path' property in the Swift 4 manifest to set a custom target path")
+                result.checkDiagnostic("could not find source files for target(s): Foo; use the 'path' property in the Swift 4 manifest to set a custom target path")
             }
         }
 
@@ -516,7 +516,7 @@ class PackageBuilderV4Tests: XCTestCase {
             // Reference invalid target.
             let package = Package(name: "pkg", targets: [.target(name: "foo")])
             PackageBuilderTester(package, in: fs) { result in
-                result.checkDiagnostic("could not find target(s): foo; use the 'path' property in the Swift 4 manifest to set a custom target path")
+                result.checkDiagnostic("could not find source files for target(s): foo; use the 'path' property in the Swift 4 manifest to set a custom target path")
             }
         }
 
@@ -732,7 +732,7 @@ class PackageBuilderV4Tests: XCTestCase {
             )
 
             PackageBuilderTester(package, in: fs) { result in
-                result.checkDiagnostic("could not find target(s): Bar; use the 'path' property in the Swift 4 manifest to set a custom target path")
+                result.checkDiagnostic("could not find source files for target(s): Bar; use the 'path' property in the Swift 4 manifest to set a custom target path")
             }
         }
 
@@ -752,7 +752,7 @@ class PackageBuilderV4Tests: XCTestCase {
             )
 
             PackageBuilderTester(package, in: fs) { result in
-                result.checkDiagnostic("could not find target(s): BarTests; use the 'path' property in the Swift 4 manifest to set a custom target path")
+                result.checkDiagnostic("could not find source files for target(s): BarTests; use the 'path' property in the Swift 4 manifest to set a custom target path")
             }
 
             // We should be able to fix this by using custom paths.


### PR DESCRIPTION
I found the "could not find target(s)" diagnostic a bit misleading. This changes it to "could not find source files for target(s)" which seems more clear to me.