### PR TITLE
[SR-7375] Remove default static-swift-stdlib option

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -303,9 +303,9 @@ public class SwiftTool<Options: ToolOptions> {
 
         binder.bind(
             option: parser.add(option: "--no-static-swift-stdlib", kind: Bool.self,
-                               usage: "Do not link Swift stdlib statically [default]"),
+                usage: "Do not link Swift stdlib statically [default]"),
             to: { $0.shouldLinkStaticSwiftStdlib = !$1 })
-        
+
         binder.bind(
             option: parser.add(option: "--static-swift-stdlib", kind: Bool.self,
                 usage: "Link Swift stdlib statically"),

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -302,11 +302,6 @@ public class SwiftTool<Options: ToolOptions> {
             to: { $0.verbosity = $1 ? 1 : 0 })
 
         binder.bind(
-            option: parser.add(option: "--no-static-swift-stdlib", kind: Bool.self,
-                usage: "Do not link Swift stdlib statically"),
-            to: { $0.shouldLinkStaticSwiftStdlib = !$1 })
-
-        binder.bind(
             option: parser.add(option: "--static-swift-stdlib", kind: Bool.self,
                 usage: "Link Swift stdlib statically"),
             to: { $0.shouldLinkStaticSwiftStdlib = $1 })

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -302,6 +302,11 @@ public class SwiftTool<Options: ToolOptions> {
             to: { $0.verbosity = $1 ? 1 : 0 })
 
         binder.bind(
+            option: parser.add(option: "--no-static-swift-stdlib", kind: Bool.self,
+                               usage: "Do not link Swift stdlib statically [default]"),
+            to: { $0.shouldLinkStaticSwiftStdlib = !$1 })
+        
+        binder.bind(
             option: parser.add(option: "--static-swift-stdlib", kind: Bool.self,
                 usage: "Link Swift stdlib statically"),
             to: { $0.shouldLinkStaticSwiftStdlib = $1 })


### PR DESCRIPTION
[SR-7375](https://bugs.swift.org/browse/SR-7375?jql=project%20%3D%20SR%20AND%20component%20%3D%20%22Package%20Manager%22)
This removes the default `static-swift-stdlib` command line option since it does nothing.
It may break scripts that rely on this command - an alternative may just be to hide it from `--help`?