### PR TITLE
Trivial typo in a source comment

### DIFF
--- a/Sources/Basic/CacheableSequence.swift
+++ b/Sources/Basic/CacheableSequence.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-/// Wrapper for caching an arbitrary sequnce.
+/// Wrapper for caching an arbitrary sequence.
 public final class CacheableSequence<T: Sequence>: Sequence {
     public typealias Element = T.Element
     public typealias Iterator = CacheableSequenceIterator<T>


### PR DESCRIPTION
Accidentally spotted a missing "e" in "sequence" (I made the same typo in a search ;-)
If I could only be as sure that "ExprSequnceContext" in the compiler source is a typo as well... ;-)