### PR TITLE
[PackageModel] Rename ManifestVersion enum cases

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -56,7 +56,7 @@ public extension ManifestResourceProvider {
 extension ToolsVersion {
     /// Returns the manifest version for this tools version.
     public var manifestVersion: ManifestVersion {
-        return major == 3 ? .three : .four
+        return major == 3 ? .v3 : .v4
     }
 }
 
@@ -149,7 +149,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         path inputPath: AbsolutePath,
         baseURL: String,
         version: Version?,
-        manifestVersion: ManifestVersion = .three,
+        manifestVersion: ManifestVersion = .v3,
         fileSystem: FileSystem? = nil
     ) throws -> Manifest {
         // If we were given a file system, load via a temporary file.
@@ -191,7 +191,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
         // Load the correct version from JSON.
         switch manifestVersion {
-        case .three:
+        case .v3:
             let pd = try loadPackageDescription(json, baseURL: baseURL)
             manifest = Manifest(
                 path: inputPath,
@@ -201,7 +201,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                 version: version,
                 interpreterFlags: parseResult.interpreterFlags)
 
-        case .four:
+        case .v4:
             let package = try loadPackageDescription4(json, baseURL: baseURL)
             manifest = Manifest(
                 path: inputPath,

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -14,9 +14,9 @@ import PackageDescription4
 import Utility
 
 /// The supported manifest versions.
-public enum ManifestVersion: Int {
-    case three = 3
-    case four
+public enum ManifestVersion: String {
+    case v3 = "3"
+    case v4 = "4"
 }
 
 /**
@@ -84,8 +84,8 @@ public final class Manifest: ObjectIdentifierProtocol, CustomStringConvertible {
     /// The manifest version.
     public var manifestVersion: ManifestVersion {
         switch package {
-        case .v3: return .three
-        case .v4: return .four
+        case .v3: return .v3
+        case .v4: return .v4
         }
     }
 

--- a/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
+++ b/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
@@ -34,7 +34,7 @@ class ManifestLoadingPerfTests: XCTestCasePerf {
         write(trivialManifest) { path in
             measure {
                 for _ in 0..<N {
-                    let manifest = try! self.manifestLoader.load(package: path, baseURL: "/", manifestVersion: .three)
+                    let manifest = try! self.manifestLoader.load(package: path, baseURL: "/", manifestVersion: .v3)
                     XCTAssertEqual(manifest.name, "Trivial")
                 }
             }
@@ -59,7 +59,7 @@ class ManifestLoadingPerfTests: XCTestCasePerf {
         write(manifest) { path in
             measure {
                 for _ in 0..<N {
-                    let manifest = try! self.manifestLoader.load(package: path, baseURL: "/", manifestVersion: .three)
+                    let manifest = try! self.manifestLoader.load(package: path, baseURL: "/", manifestVersion: .v3)
                     XCTAssertEqual(manifest.name, "Foo")
                 }
             }

--- a/Tests/PackageLoadingTests/ManifestTests.swift
+++ b/Tests/PackageLoadingTests/ManifestTests.swift
@@ -56,7 +56,7 @@ class ManifestTests: XCTestCase {
         // Check a trivial manifest.
         loadManifest("trivial-manifest.swift") { manifest in
             XCTAssertEqual(manifest.name, "Trivial")
-            XCTAssertEqual(manifest.manifestVersion, .three)
+            XCTAssertEqual(manifest.manifestVersion, .v3)
             XCTAssertEqual(manifest.package.targets, [])
             XCTAssertEqual(manifest.package.dependencies, [])
         }
@@ -174,7 +174,7 @@ class ManifestTests: XCTestCase {
                     bytes: bogusManifest)
             }
             // Check we can load the repository.
-            let manifest = try manifestLoader.load(package: root, baseURL: root.asString, manifestVersion: .three, fileSystem: fs)
+            let manifest = try manifestLoader.load(package: root, baseURL: root.asString, manifestVersion: .v3, fileSystem: fs)
             XCTAssertEqual(manifest.name, "Trivial")
         }
     }

--- a/Tests/PackageLoadingTests/PD4LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4LoadingTests.swift
@@ -33,7 +33,7 @@ class PackageDescription4LoadingTests: XCTestCase {
         let m = try manifestLoader.load(
             package: AbsolutePath.root,
             baseURL: AbsolutePath.root.asString,
-            manifestVersion: .four,
+            manifestVersion: .v4,
             fileSystem: fs)
         if case .v4 = m.package {} else {
             return XCTFail("Invalid manfiest version")
@@ -63,7 +63,7 @@ class PackageDescription4LoadingTests: XCTestCase {
 
         for version in threeVersions {
             let toolsVersion = ToolsVersion(string: version)!
-            XCTAssertEqual(toolsVersion.manifestVersion, .three)
+            XCTAssertEqual(toolsVersion.manifestVersion, .v3)
         }
 
         let fourVersions = [
@@ -72,7 +72,7 @@ class PackageDescription4LoadingTests: XCTestCase {
 
         for version in fourVersions {
             let toolsVersion = ToolsVersion(string: version)!
-            XCTAssertEqual(toolsVersion.manifestVersion, .four)
+            XCTAssertEqual(toolsVersion.manifestVersion, .v4)
         }
     }
 
@@ -87,7 +87,7 @@ class PackageDescription4LoadingTests: XCTestCase {
 
         loadManifest(stream.bytes) { manifest in
             XCTAssertEqual(manifest.name, "Trivial")
-            XCTAssertEqual(manifest.manifestVersion, .four)
+            XCTAssertEqual(manifest.manifestVersion, .v4)
             XCTAssertEqual(manifest.package.targets, [])
             XCTAssertEqual(manifest.package.dependencies, [])
             let flags = manifest.interpreterFlags.joined(separator: " ")
@@ -385,7 +385,7 @@ class PackageDescription4LoadingTests: XCTestCase {
 
         loadManifest(stream.bytes) { manifest in
             XCTAssertEqual(manifest.name, "Trivial")
-            XCTAssertEqual(manifest.manifestVersion, .four)
+            XCTAssertEqual(manifest.manifestVersion, .v4)
             XCTAssertEqual(manifest.package.targets, [])
             XCTAssertEqual(manifest.package.dependencies, [])
         }


### PR DESCRIPTION
This is better because we need to add a case for 4.2