### PR TITLE
[SR-4793] Add check that target path is not referenced by absolute path

### DIFF
--- a/Tests/PackageLoadingTests/PackageBuilderV4Tests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderV4Tests.swift
@@ -602,6 +602,37 @@ class PackageBuilderV4Tests: XCTestCase {
                 result.checkDiagnostic("target 'Foo' in package 'Foo' is outside the package root")
             }
         }
+        do {
+            let fs = InMemoryFileSystem(emptyFiles:
+                "/pkg/Sources/Foo/Foo.c",
+                "/foo/Bar.c")
+
+            let package = Package(
+                name: "Foo",
+                targets: [
+                    .target(name: "Foo", path: "/foo"),
+                    ])
+
+            PackageBuilderTester(package, path: AbsolutePath("/pkg"), in: fs) { result in
+                result.checkDiagnostic("target path \'/foo\' is not supported; it should be relative to package root")
+            }
+        }
+
+        do {
+            let fs = InMemoryFileSystem(emptyFiles:
+                "/pkg/Sources/Foo/Foo.c",
+                "/foo/Bar.c")
+
+            let package = Package(
+                name: "Foo",
+                targets: [
+                    .target(name: "Foo", path: "~/foo"),
+                    ])
+
+            PackageBuilderTester(package, path: AbsolutePath("/pkg"), in: fs) { result in
+                result.checkDiagnostic("target path \'~/foo\' is not supported; it should be relative to package root")
+            }
+        }
     }
 
     func testExecutableAsADep() {


### PR DESCRIPTION
Referencing `target path` with `AbsolutePath` is error prone and should be avoided. 