### PR TITLE
[PkgConfig] Print warning message when pkg-config not found

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -534,7 +534,7 @@ public class BuildPlan {
     /// The filesystem to operate on.
     let fileSystem: FileSystem
 
-    /// Diagnostics Engine to emit errors
+    /// Diagnostics Engine to emit diagnostics
     let diagnostics: DiagnosticsEngine
 
     /// Create a build plan with build parameters and a package graph.
@@ -550,7 +550,6 @@ public class BuildPlan {
         self.diagnostics = diagnostics
         self.delegate = delegate
         self.fileSystem = fileSystem
-
 
         // Create build target description for each target which we need to plan.
         var targetMap = [ResolvedTarget: TargetDescription]()

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -534,17 +534,23 @@ public class BuildPlan {
     /// The filesystem to operate on.
     let fileSystem: FileSystem
 
+    /// Diagnostics Engine to emit errors
+    let diagnostics: DiagnosticsEngine
+
     /// Create a build plan with build parameters and a package graph.
     public init(
         buildParameters: BuildParameters,
         graph: PackageGraph,
+        diagnostics: DiagnosticsEngine,
         delegate: BuildPlanDelegate? = nil,
         fileSystem: FileSystem = localFileSystem
     ) throws {
-        self.fileSystem = fileSystem
         self.buildParameters = buildParameters
         self.graph = graph
+        self.diagnostics = diagnostics
         self.delegate = delegate
+        self.fileSystem = fileSystem
+
 
         // Create build target description for each target which we need to plan.
         var targetMap = [ResolvedTarget: TargetDescription]()
@@ -761,7 +767,7 @@ public class BuildPlan {
             return flags
         }
         // Otherwise, get the result and cache it.
-        guard let result = pkgConfigArgs(for: target) else {
+        guard let result = pkgConfigArgs(for: target, diagnostics: diagnostics) else {
             pkgConfigCache[target] = ([], [])
             return pkgConfigCache[target]!
         }

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -57,7 +57,7 @@ public class SwiftBuildTool: SwiftTool<BuildToolOptions> {
             let regenerateManifest = try shouldRegenerateManifest()
             if regenerateManifest {
                 // Create the build plan and build normally.
-                let plan = try BuildPlan(buildParameters: buildParameters(), graph: loadPackageGraph())
+                let plan = try BuildPlan(buildParameters: buildParameters(), graph: loadPackageGraph(), diagnostics: diagnostics)
                 try build(plan: plan, subset: subset)
             } else {
                 // Otherwise, run llbuild directly.

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -167,7 +167,9 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
                 projectName: projectName,
                 xcodeprojPath: xcodeprojPath,
                 graph: graph,
-                options: options.xcodeprojOptions)
+                options: options.xcodeprojOptions,
+                diagnostics: diagnostics)
+
             print("generated:", xcodeprojPath.prettyPath(cwd: originalWorkingDirectory))
 
         case .describe:

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -113,7 +113,7 @@ public class SwiftRunTool: SwiftTool<RunToolOptions> {
                 return
             }
                     
-            let plan = try BuildPlan(buildParameters: self.buildParameters(), graph: loadPackageGraph())
+            let plan = try BuildPlan(buildParameters: self.buildParameters(), graph: loadPackageGraph(), diagnostics: diagnostics)
             let product = try findProduct(in: plan.graph)
 
             if options.shouldBuild {

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -231,7 +231,7 @@ public class SwiftTestTool: SwiftTool<TestToolOptions> {
     ///
     /// - Returns: The path to the test binary.
     private func buildTestsIfNeeded(_ options: TestToolOptions, graph: PackageGraph) throws -> AbsolutePath {
-        let buildPlan = try BuildPlan(buildParameters: self.buildParameters(), graph: graph)
+        let buildPlan = try BuildPlan(buildParameters: self.buildParameters(), graph: graph, diagnostics: diagnostics)
         if options.shouldBuildTests {
             try build(plan: buildPlan, subset: .allIncludingTests)
         }

--- a/Sources/PackageLoading/Target+PkgConfig.swift
+++ b/Sources/PackageLoading/Target+PkgConfig.swift
@@ -58,7 +58,7 @@ public struct PkgConfigResult {
 }
 
 /// Get pkgConfig result for a system library target.
-public func pkgConfigArgs(for target: SystemLibraryTarget, fileSystem: FileSystem = localFileSystem) -> PkgConfigResult? {
+public func pkgConfigArgs(for target: SystemLibraryTarget, diagnostics: DiagnosticsEngine, fileSystem: FileSystem = localFileSystem) -> PkgConfigResult? {
     // If there is no pkg config name defined, we're done.
     guard let pkgConfigName = target.pkgConfig else { return nil }
     // Compute additional search paths for the provider, if any.
@@ -69,6 +69,7 @@ public func pkgConfigArgs(for target: SystemLibraryTarget, fileSystem: FileSyste
         let pkgConfig = try PkgConfig(
             name: pkgConfigName,
             additionalSearchPaths: additionalSearchPaths,
+            diagnostics: diagnostics,
             fileSystem: fileSystem)
         // Run the whitelist checker.
         try whitelist(pcFile: pkgConfigName, flags: (pkgConfig.cFlags, pkgConfig.libs))

--- a/Sources/Utility/PkgConfig.swift
+++ b/Sources/Utility/PkgConfig.swift
@@ -24,12 +24,12 @@ public struct PkgConfigExecutionDiagnostic: DiagnosticData {
         name: "org.swift.diags.pkg-config-execution",
         defaultBehavior: .warning,
         description: {
-            $0 <<< "Failed to retrieve search paths with pkg-config"
+            $0 <<< "failed to retrieve search paths with pkg-config"
         }
     )
 }
 
-struct PCFileFinder {
+private struct PCFileFinder {
     /// DiagnosticsEngine to emit warnings
     let diagnostics: DiagnosticsEngine
 

--- a/Sources/Utility/PkgConfig.swift
+++ b/Sources/Utility/PkgConfig.swift
@@ -18,21 +18,6 @@ public enum PkgConfigError: Swift.Error {
     case nonWhitelistedFlags(String)
 }
 
-extension PkgConfigError: CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case .couldNotFindConfigFile:
-            return "Could not locate .pc file"
-
-        case .parsingError(let issue):
-            return issue
-
-        case .nonWhitelistedFlags(let flags):
-            return flags
-        }
-    }
-}
-
 public struct PkgConfigExecutionDiagnostic: DiagnosticData {
     public static let id = DiagnosticID(
         type: AnyDiagnostic.self,

--- a/Sources/Utility/PkgConfig.swift
+++ b/Sources/Utility/PkgConfig.swift
@@ -24,7 +24,7 @@ public struct PkgConfigExecutionDiagnostic: DiagnosticData {
         name: "org.swift.diags.pkg-config-execution",
         defaultBehavior: .warning,
         description: {
-            $0 <<< "failed to retrieve search paths with pkg-config"
+            $0 <<< "failed to retrieve search paths with pkg-config; maybe pkg-config is not installed"
         }
     )
 }

--- a/Sources/Utility/PkgConfig.swift
+++ b/Sources/Utility/PkgConfig.swift
@@ -29,7 +29,7 @@ public struct PkgConfigExecutionDiagnostic: DiagnosticData {
     )
 }
 
-private struct PCFileFinder {
+struct PCFileFinder {
     /// DiagnosticsEngine to emit warnings
     let diagnostics: DiagnosticsEngine
 

--- a/Sources/Utility/PkgConfig.swift
+++ b/Sources/Utility/PkgConfig.swift
@@ -23,9 +23,13 @@ public enum PkgConfigError: Swift.Error {
 /// This is needed because on Linux machines, the search paths can be different
 /// from the standard locations that we are currently searching.
 private let pkgConfigSearchPaths: [AbsolutePath] = {
-    let searchPaths = try? Process.checkNonZeroExit(
-        args: "pkg-config", "--variable", "pc_path", "pkg-config").chomp()
-    return searchPaths?.split(separator: ":").map({ AbsolutePath(String($0)) }) ?? []
+    if let searchPaths = try? Process.checkNonZeroExit(
+        args: "pkg-config", "--variable", "pc_path", "pkg-config").chomp() {
+        return searchPaths.split(separator: ":").map({ AbsolutePath(String($0)) })
+    } else {
+        stderrStream <<< "Warning: Could not find the program 'pkg-config' on your system"
+        return []
+    }
 }()
 
 /// Information on an individual `pkg-config` supported package.

--- a/Sources/Utility/PkgConfig.swift
+++ b/Sources/Utility/PkgConfig.swift
@@ -34,7 +34,7 @@ struct PCFileFinder {
     let diagnostics: DiagnosticsEngine
 
     /// Cached results of locations `pkg-config` will search for `.pc` files
-    static var pkgConfigPaths: [AbsolutePath]?
+    private static var pkgConfigPaths: [AbsolutePath]?
 
     /// The built-in search path list.
     ///

--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -53,7 +53,8 @@ public func generate(
     projectName: String,
     xcodeprojPath: AbsolutePath,
     graph: PackageGraph,
-    options: XcodeprojOptions
+    options: XcodeprojOptions,
+    diagnostics: DiagnosticsEngine
 ) throws -> Xcode.Project {
     // Note that the output directory might be completely separate from the
     // path of the root package (which is where the sources live).
@@ -74,7 +75,7 @@ public func generate(
     /// Generate the contents of project.xcodeproj (inside the .xcodeproj).
     // FIXME: This could be more efficient by directly writing to a stream
     // instead of first creating a string.
-    let project = try pbxproj(xcodeprojPath: xcodeprojPath, graph: graph, extraDirs: extraDirs, options: options)
+    let project = try pbxproj(xcodeprojPath: xcodeprojPath, graph: graph, extraDirs: extraDirs, options: options, diagnostics: diagnostics)
     try open(xcodeprojPath.appending(component: "project.pbxproj")) { stream in
         // Serialize the project model we created to a plist, and return
         // its string description.

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -33,6 +33,7 @@ public func pbxproj(
         graph: PackageGraph,
         extraDirs: [AbsolutePath],
         options: XcodeprojOptions,
+        diagnostics: DiagnosticsEngine,
         fileSystem: FileSystem = localFileSystem
     ) throws -> Xcode.Project {
     return try xcodeProject(
@@ -40,7 +41,8 @@ public func pbxproj(
         graph: graph,
         extraDirs: extraDirs,
         options: options,
-        fileSystem: fileSystem)
+        fileSystem: fileSystem,
+        diagnostics: diagnostics)
 }
 
 /// A set of c99 target names that are invalid for Xcode Framework targets.
@@ -55,6 +57,7 @@ func xcodeProject(
     extraDirs: [AbsolutePath],
     options: XcodeprojOptions,
     fileSystem: FileSystem,
+    diagnostics: DiagnosticsEngine,
     warningStream: OutputByteStream = stdoutStream
     ) throws -> Xcode.Project {
 
@@ -472,7 +475,7 @@ func xcodeProject(
             switch depModule.underlyingTarget {
               case let systemTarget as SystemLibraryTarget:
                 hdrInclPaths.append("$(SRCROOT)/" + systemTarget.path.relative(to: sourceRootDir).asString)
-                if let pkgArgs = pkgConfigArgs(for: systemTarget) {
+                if let pkgArgs = pkgConfigArgs(for: systemTarget, diagnostics: diagnostics) {
                     targetSettings.common.OTHER_LDFLAGS += pkgArgs.libs
                     targetSettings.common.OTHER_SWIFT_FLAGS += pkgArgs.cFlags
                     targetSettings.common.OTHER_CFLAGS += pkgArgs.cFlags

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -71,7 +71,7 @@ final class BuildPlanTests: XCTestCase {
         let graph = loadMockPackageGraph(["/Pkg": pkg], root: "/Pkg", diagnostics: diagnostics, in: fs)
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
-            graph: graph)
+            graph: graph, diagnostics: diagnostics)
         )
  
         result.checkProductsCount(1)
@@ -140,7 +140,7 @@ final class BuildPlanTests: XCTestCase {
 
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
-            graph: graph,
+            graph: graph, diagnostics: diagnostics,
             fileSystem: fileSystem))
 
         XCTAssertEqual(Set(result.productMap.keys), ["APackageTests"])
@@ -162,7 +162,7 @@ final class BuildPlanTests: XCTestCase {
         )
         let diagnostics = DiagnosticsEngine()
         let graph = loadMockPackageGraph(["/Pkg": Package(name: "Pkg")], root: "/Pkg", diagnostics: diagnostics, in: fs)
-        let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(config: .release), graph: graph))
+        let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(config: .release), graph: graph, diagnostics: diagnostics))
 
         result.checkProductsCount(1)
         result.checkTargetsCount(1)
@@ -205,7 +205,7 @@ final class BuildPlanTests: XCTestCase {
         )
         let diagnostics = DiagnosticsEngine()
         let graph = loadMockPackageGraph(["/Pkg": pkg, "/ExtPkg": Package(name: "ExtPkg")], root: "/Pkg", diagnostics: diagnostics, in: fs)
-        let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(), graph: graph, fileSystem: fs))
+        let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(), graph: graph, diagnostics: diagnostics, fileSystem: fs))
  
         result.checkProductsCount(1)
         result.checkTargetsCount(3)
@@ -271,7 +271,7 @@ final class BuildPlanTests: XCTestCase {
         )
         let diagnostics = DiagnosticsEngine()
         let graph = loadMockPackageGraph4(["/Pkg": pkg], root: "/Pkg", diagnostics: diagnostics, in: fs)
-        let plan = try BuildPlan(buildParameters: mockBuildParameters(), graph: graph, fileSystem: fs)
+        let plan = try BuildPlan(buildParameters: mockBuildParameters(), graph: graph, diagnostics: diagnostics, fileSystem: fs)
         let result = BuildPlanResult(plan: plan)
  
         result.checkProductsCount(1)
@@ -319,7 +319,8 @@ final class BuildPlanTests: XCTestCase {
             ]
         )
         let graph = loadMockPackageGraph(["/Pkg": pkg], root: "/Pkg", in: fs)
-        let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(), graph: graph, fileSystem: fs))
+        let diagnostics = DiagnosticsEngine()
+        let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(), graph: graph, diagnostics: diagnostics, fileSystem: fs))
         result.checkProductsCount(1)
         result.checkTargetsCount(2)
         
@@ -362,7 +363,8 @@ final class BuildPlanTests: XCTestCase {
             "/Pkg/Tests/FooTests/foo.swift"
         )
         let graph = loadMockPackageGraph(["/Pkg": Package(name: "Pkg")], root: "/Pkg", in: fs)
-        let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(), graph: graph, fileSystem: fs))
+        let diagnostics = DiagnosticsEngine()
+        let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(), graph: graph, diagnostics: diagnostics, fileSystem: fs))
         result.checkProductsCount(1)
       #if os(macOS)
         result.checkTargetsCount(2)
@@ -409,7 +411,8 @@ final class BuildPlanTests: XCTestCase {
             ]
         )
         let graph = loadMockPackageGraph(["/Pkg": pkg, "/Clibgit": Package(name: "Clinbgit")], root: "/Pkg", in: fs)
-        let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(), graph: graph, fileSystem: fs))
+        let diagnostics = DiagnosticsEngine()
+        let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(), graph: graph, diagnostics: diagnostics, fileSystem: fs))
         result.checkProductsCount(1)
         result.checkTargetsCount(1)
 
@@ -444,7 +447,8 @@ final class BuildPlanTests: XCTestCase {
             ]
         )
         let graph = loadMockPackageGraph(["/Pkg": pkg], root: "/Pkg", in: fs)
-        let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(), graph: graph, fileSystem: fs))
+        let diagnostics = DiagnosticsEngine()
+        let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(), graph: graph, diagnostics: diagnostics, fileSystem: fs))
         result.checkProductsCount(1)
         result.checkTargetsCount(2)
         let linkArgs = try result.buildProduct(for: "exe").linkArguments()
@@ -482,7 +486,8 @@ final class BuildPlanTests: XCTestCase {
                 swiftLanguageVersions: [2, ToolsVersion.currentToolsVersion.major]),
         ], root: "/Foo", in: fs)
 
-        let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(), graph: g, fileSystem: fs))
+        let diagnostics = DiagnosticsEngine()
+        let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(), graph: g, diagnostics: diagnostics, fileSystem: fs))
         result.checkProductsCount(2)
         result.checkTargetsCount(2)
 
@@ -545,7 +550,7 @@ final class BuildPlanTests: XCTestCase {
 
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
-            graph: graph, fileSystem: fs)
+            graph: graph, diagnostics: diagnostics, fileSystem: fs)
         )
 
         result.checkProductsCount(2)
@@ -596,7 +601,7 @@ final class BuildPlanTests: XCTestCase {
 
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
-            graph: graph,
+            graph: graph, diagnostics: diagnostics,
             fileSystem: fs)
         )
 
@@ -681,7 +686,7 @@ final class BuildPlanTests: XCTestCase {
 
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
-            graph: graph,
+            graph: graph, diagnostics: diagnostics,
             fileSystem: fileSystem))
 
         XCTAssertEqual(Set(result.productMap.keys), ["aexec", "BLibrary", "bexec", "cexec"])

--- a/Tests/UtilityTests/PkgConfigParserTests.swift
+++ b/Tests/UtilityTests/PkgConfigParserTests.swift
@@ -63,20 +63,20 @@ final class PkgConfigParserTests: XCTestCase {
     
     /// Test custom search path get higher priority for locating pc files.
     func testCustomPcFileSearchPath() throws {
-
+        let diagnostics = DiagnosticsEngine()
 
         let fs = InMemoryFileSystem(emptyFiles:
             "/usr/lib/pkgconfig/foo.pc",
             "/usr/local/opt/foo/lib/pkgconfig/foo.pc",
             "/custom/foo.pc")
-        XCTAssertEqual("/custom/foo.pc", try PkgConfig.locatePCFile(name: "foo", customSearchPaths: [AbsolutePath("/custom")], fileSystem: fs).asString)
-        XCTAssertEqual("/custom/foo.pc", try PkgConfig(name: "foo", additionalSearchPaths: [AbsolutePath("/custom")], fileSystem: fs).pcFile.asString)
-        XCTAssertEqual("/usr/lib/pkgconfig/foo.pc", try PkgConfig.locatePCFile(name: "foo", customSearchPaths: [], fileSystem: fs).asString)
+        XCTAssertEqual("/custom/foo.pc", try PkgConfig.locatePCFile(name: "foo", customSearchPaths: [AbsolutePath("/custom")], fileSystem: fs, diagnostics: diagnostics).asString)
+        XCTAssertEqual("/custom/foo.pc", try PkgConfig(name: "foo", additionalSearchPaths: [AbsolutePath("/custom")], diagnostics: diagnostics, fileSystem: fs).pcFile.asString)
+        XCTAssertEqual("/usr/lib/pkgconfig/foo.pc", try PkgConfig.locatePCFile(name: "foo", customSearchPaths: [], fileSystem: fs, diagnostics: diagnostics).asString)
         try withCustomEnv(["PKG_CONFIG_PATH": "/usr/local/opt/foo/lib/pkgconfig"]) {
-            XCTAssertEqual("/usr/local/opt/foo/lib/pkgconfig/foo.pc", try PkgConfig(name: "foo", fileSystem: fs).pcFile.asString)
+            XCTAssertEqual("/usr/local/opt/foo/lib/pkgconfig/foo.pc", try PkgConfig(name: "foo", diagnostics: diagnostics, fileSystem: fs).pcFile.asString)
         }
         try withCustomEnv(["PKG_CONFIG_PATH": "/usr/local/opt/foo/lib/pkgconfig:/usr/lib/pkgconfig"]) {
-            XCTAssertEqual("/usr/local/opt/foo/lib/pkgconfig/foo.pc", try PkgConfig(name: "foo", fileSystem: fs).pcFile.asString)
+            XCTAssertEqual("/usr/local/opt/foo/lib/pkgconfig/foo.pc", try PkgConfig(name: "foo", diagnostics: diagnostics, fileSystem: fs).pcFile.asString)
         }
     }
 

--- a/Tests/UtilityTests/PkgConfigParserTests.swift
+++ b/Tests/UtilityTests/PkgConfigParserTests.swift
@@ -69,9 +69,9 @@ final class PkgConfigParserTests: XCTestCase {
             "/usr/lib/pkgconfig/foo.pc",
             "/usr/local/opt/foo/lib/pkgconfig/foo.pc",
             "/custom/foo.pc")
-        XCTAssertEqual("/custom/foo.pc", try PkgConfig.locatePCFile(name: "foo", customSearchPaths: [AbsolutePath("/custom")], fileSystem: fs, diagnostics: diagnostics).asString)
+        XCTAssertEqual("/custom/foo.pc", try PCFileFinder(diagnostics: diagnostics).locatePCFile(name: "foo", customSearchPaths: [AbsolutePath("/custom")], fileSystem: fs).asString)
         XCTAssertEqual("/custom/foo.pc", try PkgConfig(name: "foo", additionalSearchPaths: [AbsolutePath("/custom")], diagnostics: diagnostics, fileSystem: fs).pcFile.asString)
-        XCTAssertEqual("/usr/lib/pkgconfig/foo.pc", try PkgConfig.locatePCFile(name: "foo", customSearchPaths: [], fileSystem: fs, diagnostics: diagnostics).asString)
+        XCTAssertEqual("/usr/lib/pkgconfig/foo.pc", try PCFileFinder(diagnostics: diagnostics).locatePCFile(name: "foo", customSearchPaths: [], fileSystem: fs).asString)
         try withCustomEnv(["PKG_CONFIG_PATH": "/usr/local/opt/foo/lib/pkgconfig"]) {
             XCTAssertEqual("/usr/local/opt/foo/lib/pkgconfig/foo.pc", try PkgConfig(name: "foo", diagnostics: diagnostics, fileSystem: fs).pcFile.asString)
         }

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -37,7 +37,7 @@ class GenerateXcodeprojTests: XCTestCase {
 
             let projectName = "DummyProjectName"
             let outpath = Xcodeproj.buildXcodeprojPath(outputDir: dstdir, projectName: projectName)
-            try Xcodeproj.generate(projectName: projectName, xcodeprojPath: outpath, graph: graph, options: XcodeprojOptions())
+            try Xcodeproj.generate(projectName: projectName, xcodeprojPath: outpath, graph: graph, options: XcodeprojOptions(), diagnostics: diagnostics)
 
             XCTAssertDirectoryExists(outpath)
             XCTAssertEqual(outpath, dstdir.appending(component: projectName + ".xcodeproj"))
@@ -76,7 +76,7 @@ class GenerateXcodeprojTests: XCTestCase {
         let options = XcodeprojOptions(xcconfigOverrides: AbsolutePath("/doesntexist"))
         do {
             _ = try xcodeProject(xcodeprojPath: AbsolutePath.root.appending(component: "xcodeproj"),
-                                 graph: graph, extraDirs: [], options: options, fileSystem: fileSystem)
+                                 graph: graph, extraDirs: [], options: options, fileSystem: fileSystem, diagnostics: diagnostics)
             XCTFail("Project generation should have failed")
         } catch ProjectGenerationError.xcconfigOverrideNotFound(let path) {
             XCTAssertEqual(options.xcconfigOverrides, path)
@@ -94,7 +94,7 @@ class GenerateXcodeprojTests: XCTestCase {
         XCTAssertFalse(diagnostics.hasErrors)
 
         _ = try xcodeProject(xcodeprojPath: AbsolutePath.root.appending(component: "xcodeproj"),
-                             graph: graph, extraDirs: [], options: XcodeprojOptions(), fileSystem: fileSystem,
+                             graph: graph, extraDirs: [], options: XcodeprojOptions(), fileSystem: fileSystem, diagnostics: diagnostics,
                              warningStream: warningStream)
 
         let warnings = warningStream.bytes.asReadableString

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -39,7 +39,7 @@ class PackageGraphTests: XCTestCase {
 
         let options = XcodeprojOptions(xcconfigOverrides: AbsolutePath("/Overrides.xcconfig"))
         
-        let project = try xcodeProject(xcodeprojPath: AbsolutePath.root.appending(component: "xcodeproj"), graph: g, extraDirs: [], options: options, fileSystem: fs)
+        let project = try xcodeProject(xcodeprojPath: AbsolutePath.root.appending(component: "xcodeproj"), graph: g, extraDirs: [], options: options, fileSystem: fs, diagnostics: diagnostics)
 
         XcodeProjectTester(project) { result in
             result.check(projectDir: "Bar")
@@ -149,7 +149,7 @@ class PackageGraphTests: XCTestCase {
                 products: [.library(name: "Bar", type: .dynamic, targets: ["Foo"])],
                 targets: [.target(name: "Foo")]),
         ], root: "/Foo", diagnostics: diagnostics, in: fs)
-        let project = try xcodeProject(xcodeprojPath: AbsolutePath("/Foo/build").appending(component: "xcodeproj"), graph: g, extraDirs: [], options: XcodeprojOptions(), fileSystem: fs)
+        let project = try xcodeProject(xcodeprojPath: AbsolutePath("/Foo/build").appending(component: "xcodeproj"), graph: g, extraDirs: [], options: XcodeprojOptions(), fileSystem: fs, diagnostics: diagnostics)
         XcodeProjectTester(project) { result in
             result.check(target: "Foo") { targetResult in
                 targetResult.check(productType: .framework)
@@ -175,7 +175,7 @@ class PackageGraphTests: XCTestCase {
       let g = loadMockPackageGraph([
           "/Bar": Package(name: "Bar", targets: [Target(name: "swift", dependencies: ["Sea", "Sea2"])]),
       ], root: "/Bar", diagnostics: diagnostics, in: fs)
-      let project = try xcodeProject(xcodeprojPath: AbsolutePath("/Bar/build").appending(component: "xcodeproj"), graph: g, extraDirs: [], options: XcodeprojOptions(), fileSystem: fs)
+        let project = try xcodeProject(xcodeprojPath: AbsolutePath("/Bar/build").appending(component: "xcodeproj"), graph: g, extraDirs: [], options: XcodeprojOptions(), fileSystem: fs, diagnostics: diagnostics)
 
       XcodeProjectTester(project) { result in
           result.check(target: "swift") { targetResult in
@@ -209,7 +209,7 @@ class PackageGraphTests: XCTestCase {
             "/Pkg": Package(name: "Pkg", targets: [Target(name: "LibraryTests", dependencies: ["Library", "HelperTool"])]),
             ], root: "/Pkg", diagnostics: diagnostics, in: fs)
         
-        let project = try xcodeProject(xcodeprojPath: AbsolutePath.root.appending(component: "xcodeproj"), graph: g, extraDirs: [], options: XcodeprojOptions(), fileSystem: fs)
+        let project = try xcodeProject(xcodeprojPath: AbsolutePath.root.appending(component: "xcodeproj"), graph: g, extraDirs: [], options: XcodeprojOptions(), fileSystem: fs, diagnostics: diagnostics)
         
         XcodeProjectTester(project) { result in
             result.check(projectDir: "Pkg")


### PR DESCRIPTION
When users require system packages, they will typically want to use `pkg-config`
to help identify the location of libraries on the system to link to. We will
now print a warning to let users know they should install this tool if they
are running into link errors.