### PR TITLE
Fix cross-compile toolchain

### DIFF
--- a/Utilities/build_ubuntu_cross_compilation_toolchain
+++ b/Utilities/build_ubuntu_cross_compilation_toolchain
@@ -68,7 +68,7 @@ function fix_glibc_modulemap() {
     rm -rf "$inc_dir"
     mkdir "$inc_dir"
     cat "$tmp" | while IFS='' read line; do
-        if [[ "$line" =~ ^(\ *header\ )\"\/\/\/usr\/include\/(x86_64-linux-gnu\/)?([^\"]+)\" ]]; then
+        if [[ "$line" =~ ^(\ *header\ )\"\/+usr\/include\/(x86_64-linux-gnu\/)?([^\"]+)\" ]]; then
             local orig_inc
             local rel_repl_inc
             local repl_inc


### PR DESCRIPTION
The cross-compile toolchain was built assuming that the includes were prepended with a triple slash. The changes introduced in the Swift project at e06c52584 modified this so that the triple slash is no longer generated.