### PR TITLE
[SR-7592] and other memory leaks fixes

### DIFF
--- a/Sources/Basic/FileSystem.swift
+++ b/Sources/Basic/FileSystem.swift
@@ -348,6 +348,7 @@ private class LocalFileSystem: FileSystem {
         guard let setMode = setmode(mode.cliArgument) else {
             throw FileSystemError(errno: errno)
         }
+        defer { setMode.deallocate() }
 
         let recursive = options.contains(.recursive)
         // If we're in recursive mode, do physical walk otherwise logical.
@@ -358,6 +359,7 @@ private class LocalFileSystem: FileSystem {
         guard let ftsp = fts_open(paths.cArray, ftsOptions, nil) else {
             throw FileSystemError(errno: errno)
         }
+        defer { fts_close(ftsp) }
 
         // Start traversing.
         while let p = fts_read(ftsp) {

--- a/Sources/Basic/Process.swift
+++ b/Sources/Basic/Process.swift
@@ -326,8 +326,10 @@ public final class Process: ObjectIdentifierProtocol {
             try close(fd: &outputPipe[1])
 
             // Create a thread and start reading the output on it.
-            var thread = Thread { [unowned self] in
-                self.stdout.result = self.readOutput(onFD: outputPipe[0])
+            var thread = Thread { [weak self] in
+                if let readResult = self?.readOutput(onFD: outputPipe[0]) {
+                    self?.stdout.result = readResult
+                }
             }
             thread.start()
             self.stdout.thread = thread
@@ -336,8 +338,10 @@ public final class Process: ObjectIdentifierProtocol {
             try close(fd: &stderrPipe[1])
 
             // Create a thread and start reading the stderr output on it.
-            thread = Thread { [unowned self] in
-                self.stderr.result = self.readOutput(onFD: stderrPipe[0])
+            thread = Thread { [weak self] in
+                if let readResult = self?.readOutput(onFD: stderrPipe[0]) {
+                    self?.stderr.result = readResult
+                }
             }
             thread.start()
             self.stderr.thread = thread

--- a/Sources/Basic/Process.swift
+++ b/Sources/Basic/Process.swift
@@ -240,6 +240,7 @@ public final class Process: ObjectIdentifierProtocol {
         var attributes = posix_spawnattr_t()
       #endif
         posix_spawnattr_init(&attributes)
+        defer { posix_spawnattr_destroy(&attributes) }
 
         // Unmask all signals.
         var noSignals = sigset_t()
@@ -283,6 +284,7 @@ public final class Process: ObjectIdentifierProtocol {
         var fileActions = posix_spawn_file_actions_t()
       #endif
         posix_spawn_file_actions_init(&fileActions)
+        defer { posix_spawn_file_actions_destroy(&fileActions) }
 
         // Workaround for https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=89e435f3559c53084498e9baad22172b64429362
         let devNull = strdup("/dev/null")
@@ -319,15 +321,12 @@ public final class Process: ObjectIdentifierProtocol {
             throw SystemError.posix_spawn(rv, arguments)
         }
 
-        posix_spawn_file_actions_destroy(&fileActions)
-        posix_spawnattr_destroy(&attributes)
-
         if redirectOutput {
             // Close the write end of the output pipe.
             try close(fd: &outputPipe[1])
 
             // Create a thread and start reading the output on it.
-            var thread = Thread {
+            var thread = Thread { [unowned self] in
                 self.stdout.result = self.readOutput(onFD: outputPipe[0])
             }
             thread.start()
@@ -337,7 +336,7 @@ public final class Process: ObjectIdentifierProtocol {
             try close(fd: &stderrPipe[1])
 
             // Create a thread and start reading the stderr output on it.
-            thread = Thread {
+            thread = Thread { [unowned self] in
                 self.stderr.result = self.readOutput(onFD: stderrPipe[0])
             }
             thread.start()

--- a/Sources/Utility/Platform.swift
+++ b/Sources/Utility/Platform.swift
@@ -60,6 +60,7 @@ public enum Platform {
     private static func getConfstr(_ name: Int32) -> AbsolutePath? {
         let len = confstr(name, nil, 0)
         let tmp = UnsafeMutableBufferPointer(start: UnsafeMutablePointer<Int8>.allocate(capacity: len), count:len)
+        defer { tmp.deallocate() }
         guard confstr(name, tmp.baseAddress, len) == len else { return nil }
         let value = String(cString: tmp.baseAddress!)
         guard value.hasSuffix(AbsolutePath.root.asString) else { return nil }


### PR DESCRIPTION
Fixed memory leaks reported in [SR-7592](https://bugs.swift.org/browse/SR-7592) and other memory leaks reported by Instruments. This also moves `posix_spawn*_destroy()` calls to be defered with their `posix_spawn*_init()` calls to prevent memory leaks when exiting scope early.