### PR TITLE
add generic params to DictionaryLiteral<Key,Value>

### DIFF
--- a/Sources/Basic/DictionaryLiteralExtensions.swift
+++ b/Sources/Basic/DictionaryLiteralExtensions.swift
@@ -26,7 +26,7 @@ extension DictionaryLiteral where Key: CustomStringConvertible, Value: CustomStr
 
 // MARK: Equatable
 extension DictionaryLiteral where Key: Equatable, Value: Equatable {
-    public static func ==(lhs: DictionaryLiteral, rhs: DictionaryLiteral) -> Bool {
+    public static func ==(lhs: DictionaryLiteral<Key,Value>, rhs: DictionaryLiteral<Key,Value>) -> Bool {
         if lhs.count != rhs.count {
             return false
         }


### PR DESCRIPTION
Currently there seems to be a limitations on typealias where they need their generics parameters declared.

Related:
https://github.com/apple/swift/pull/16577

