### PR TITLE
[SR-7612] Add host target triple for arm64/aarch64 machines.

### DIFF
--- a/Sources/Build/Triple.swift
+++ b/Sources/Build/Triple.swift
@@ -32,9 +32,10 @@ public struct Triple {
 
     public enum Arch: String {
         case x86_64
-        case armv7
+        case ppc64le
         case s390x
-        case powerpc64le
+        case aarch64
+        case armv7
         case arm
     }
 
@@ -106,20 +107,26 @@ public struct Triple {
     }
 
     public static let macOS = try! Triple("x86_64-apple-macosx10.10")
-    public static let linux = try! Triple("x86_64-unknown-linux")
+    public static let x86Linux = try! Triple("x86_64-unknown-linux")
     public static let ppc64leLinux = try! Triple("powerpc64le-unknown-linux")
-    public static let armLinux = try! Triple("arm-linux-gnueabihf")
+    public static let s390xLinux = try! Triple("s390x-unknown-linux")
+    public static let arm64Linux = try! Triple("aarch64-unknown-linux")
+    public static let armLinux = try! Triple("armv7-unknown-linux-gnueabihf")
     public static let android = try! Triple("armv7-unknown-linux-androideabi")
 
   #if os(macOS)
     public static let hostTriple: Triple = .macOS
-  #elseif os(Linux) && arch(s390x)
-    public static let hostTriple: Triple = try! Triple("s390x-unknown-linux")
-  #elseif os(Linux) && arch(powerpc64le)
-    public static let hostTriple: Triple = .ppc64leLinux
-  #elseif os(Linux) && arch(arm)
-    public static let hostTriple: Triple = .armLinux
-  #else
-    public static let hostTriple: Triple = .linux
+  #elseif os(Linux)
+    #if arch(x86_64)
+      public static let hostTriple: Triple = .x86Linux
+    #elseif arch(powerpc64le)
+      public static let hostTriple: Triple = .ppc64leLinux
+    #elseif arch(s390x)
+      public static let hostTriple: Triple = .s390xLinux
+    #elseif arch(arm64)
+      public static let hostTriple: Triple = .arm64Linux
+    #elseif arch(arm)
+      public static let hostTriple: Triple = .armLinux    
+    #endif
   #endif
 }

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -895,14 +895,21 @@ def main():
     # Compute the build paths.
     if platform.system() == 'Darwin':
         build_target = "x86_64-apple-macosx10.10"
-    elif platform.processor() == 's390x':
-        build_target = "s390x-unknown-linux"
-    elif platform.system() == 'Linux' and platform.machine() == 'ppc64le':
-        build_target = 'powerpc64le-unknown-linux'
-    elif platform.system() == 'Linux' and platform.machine() == 'arm':
-        build_target = 'arm-linux-gnueabihf'
+    elif platform.system() == 'Linux':              
+        if platform.machine() == 'x86_64':
+            build_target = "x86_64-unknown-linux"
+        elif platform.machine() == 's390x':
+            build_target = "s390x-unknown-linux"
+        elif platform.machine() == 'ppc64le':
+            build_target = 'powerpc64le-unknown-linux'
+        elif platform.machine().startswith("armv7"):
+            build_target = 'armv7-unknown-linux-gnueabihf'
+        elif platform.machine() == 'aarch64':
+            build_target = 'aarch64-unknown-linux'
+        else:
+            raise SystemExit("ERROR: unsupported machine:",platform.machine())
     else:
-        build_target = 'x86_64-unknown-linux'
+        raise SystemExit("ERROR: unsupported system:",platform.system())
 
     build_path = os.path.join(g_project_root, args.build_path)
     sandbox_path = os.path.join(build_path, ".bootstrap")


### PR DESCRIPTION
Added host target triple for arm64/aarch64.
Fixed incorrect armv7 triple.
Refactored bootstrap "compute the build paths"
Refactored Triple.swift "os and machine" dif's

New OS's and processor/machine types are currently being added in an addhoc manner. Refactoring the Utilities/bootstrap and Triple.swift addresses [[SR-7612]](https://bugs.swift.org/browse/SR-7612). While this solution is still hardcoded it provides conformity between machines and a consistent naming type for triples. 
i.e [machine][OS] - x86Linux, arm64Linux.
This will provide an easy path for adding new machines and OS's in the future.