### PR TITLE
Deprecate stand-alone currentWorkingDirectory

### DIFF
--- a/Sources/Basic/Process.swift
+++ b/Sources/Basic/Process.swift
@@ -204,7 +204,7 @@ public final class Process: ObjectIdentifierProtocol {
             // FIXME: This can be cached.
             let envSearchPaths = getEnvSearchPaths(
                 pathString: getenv("PATH"),
-                currentWorkingDirectory: currentWorkingDirectory
+                currentWorkingDirectory: localFileSystem.currentWorkingDirectory
             )
             // Lookup the executable.
             let value = lookupExecutablePath(

--- a/Sources/Commands/Destination.swift
+++ b/Sources/Commands/Destination.swift
@@ -59,7 +59,7 @@ public struct Destination {
     ///
     /// - Parameter originalWorkingDirectory: The working directory when the program was launched.
     private static func hostBinDir(
-        originalWorkingDirectory: AbsolutePath = currentWorkingDirectory
+        originalWorkingDirectory: AbsolutePath? = localFileSystem.currentWorkingDirectory
     ) -> AbsolutePath {
       #if Xcode
         // For Xcode, set bin directory to the build directory containing the fake
@@ -74,15 +74,17 @@ public struct Destination {
         return AbsolutePath(#file).parentDirectory
             .parentDirectory.parentDirectory.appending(components: ".build", hostTargetTriple, "debug")
       #else
-        return AbsolutePath(
-            CommandLine.arguments[0], relativeTo: originalWorkingDirectory).parentDirectory
+        guard let cwd = originalWorkingDirectory else {
+            return try! AbsolutePath(validating: CommandLine.arguments[0]).parentDirectory
+        }
+        return AbsolutePath(CommandLine.arguments[0], relativeTo: cwd).parentDirectory
       #endif
     }
 
     /// The destination describing the host OS.
     public static func hostDestination(
         _ binDir: AbsolutePath? = nil,
-        originalWorkingDirectory: AbsolutePath = currentWorkingDirectory
+        originalWorkingDirectory: AbsolutePath? = localFileSystem.currentWorkingDirectory
     ) throws -> Destination {
         // Select the correct binDir.
         let binDir = binDir ?? Destination.hostBinDir(

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -47,7 +47,7 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             print(Versioning.currentVersion.completeDisplayString)
 
         case .initPackage:
-            let initPackage = try InitPackage(destinationPath: currentWorkingDirectory, packageType: options.initMode)
+            let initPackage = try InitPackage(destinationPath: localFileSystem.currentWorkingDirectory!, packageType: options.initMode)
             initPackage.progressReporter = { message in
                 print(message)
             }

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -292,7 +292,7 @@ public class SwiftTestTool: SwiftTool<TestToolOptions> {
     private static func xctestHelperPath() -> AbsolutePath {
         let xctestHelperBin = "swiftpm-xctest-helper"
         let binDirectory = AbsolutePath(CommandLine.arguments.first!,
-            relativeTo: currentWorkingDirectory).parentDirectory
+            relativeTo: localFileSystem.currentWorkingDirectory!).parentDirectory
         // XCTestHelper tool is installed in libexec.
         let maybePath = binDirectory.parentDirectory.appending(components: "libexec", "swift", "pm", xctestHelperBin)
         if isFile(maybePath) {

--- a/Sources/Commands/UserToolchain.swift
+++ b/Sources/Commands/UserToolchain.swift
@@ -127,7 +127,7 @@ public struct UserToolchain: Toolchain {
 
         // Get the search paths from PATH.
         let envSearchPaths = getEnvSearchPaths(
-            pathString: getenv("PATH"), currentWorkingDirectory: currentWorkingDirectory)
+            pathString: getenv("PATH"), currentWorkingDirectory: localFileSystem.currentWorkingDirectory)
 
         func lookup(fromEnv: String) -> AbsolutePath? {
             return lookupExecutablePath(

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -602,6 +602,10 @@ private class GitFileSystemView: FileSystem {
         return false
     }
 
+    public var currentWorkingDirectory: AbsolutePath? {
+        return AbsolutePath("/")
+    }
+
     func getDirectoryContents(_ path: AbsolutePath) throws -> [String] {
         guard let entry = try getEntry(path) else {
             throw FileSystemError.noEntry

--- a/Sources/SourceControl/InMemoryGitRepository.swift
+++ b/Sources/SourceControl/InMemoryGitRepository.swift
@@ -203,6 +203,10 @@ extension InMemoryGitRepository: FileSystem {
         return head.fileSystem.isExecutableFile(path)
     }
 
+    public var currentWorkingDirectory: AbsolutePath? {
+        return AbsolutePath("/")
+    }
+
     public func getDirectoryContents(_ path: AbsolutePath) throws -> [String] {
         return try head.fileSystem.getDirectoryContents(path)
     }

--- a/Sources/Utility/ArgumentParser.swift
+++ b/Sources/Utility/ArgumentParser.swift
@@ -197,7 +197,11 @@ public struct PathArgument: ArgumentKind {
 
     public init(argument: String) throws {
         // FIXME: This should check for invalid paths.
-        path = AbsolutePath(argument, relativeTo: currentWorkingDirectory)
+        if let cwd = localFileSystem.currentWorkingDirectory {
+            path = AbsolutePath(argument, relativeTo: cwd)
+        } else {
+            path = try AbsolutePath(validating: argument)
+        }
     }
 
     public static var completion: ShellCompletion = .filename

--- a/Tests/BasicTests/PathShimTests.swift
+++ b/Tests/BasicTests/PathShimTests.swift
@@ -93,7 +93,7 @@ class PathShimTests : XCTestCase {
     
     func testCurrentWorkingDirectory() {
         // Test against what POSIX returns, at least for now.
-        let cwd = currentWorkingDirectory;
+        let cwd = localFileSystem.currentWorkingDirectory!
         XCTAssertEqual(cwd, AbsolutePath(getcwd()))
     }
     

--- a/Tests/UtilityTests/ArgumentParserTests.swift
+++ b/Tests/UtilityTests/ArgumentParserTests.swift
@@ -464,21 +464,21 @@ class ArgumentParserTests: XCTestCase {
         // Test that relative path is resolved.
         do {
             let actual = try! SwiftPMProduct.TestSupportExecutable.execute(["pathArgumentTest", "some/path"]).chomp()
-            let expected = currentWorkingDirectory.appending(RelativePath("some/path")).asString
+            let expected = localFileSystem.currentWorkingDirectory!.appending(RelativePath("some/path")).asString
             XCTAssertEqual(actual, expected)
         }
 
         // Test that relative path starting with ./ is resolved.
         do {
             let actual = try! SwiftPMProduct.TestSupportExecutable.execute(["pathArgumentTest", "./some/path"]).chomp()
-            let expected = currentWorkingDirectory.appending(RelativePath("./some/path")).asString
+            let expected = localFileSystem.currentWorkingDirectory!.appending(RelativePath("./some/path")).asString
             XCTAssertEqual(actual, expected)
         }
 
         // Test that relative path starting with ../ is resolved.
         do {
             let actual = try! SwiftPMProduct.TestSupportExecutable.execute(["pathArgumentTest", "../other/path"]).chomp()
-            let expected = currentWorkingDirectory.appending(RelativePath("../other/path")).asString
+            let expected = localFileSystem.currentWorkingDirectory!.appending(RelativePath("../other/path")).asString
             XCTAssertEqual(actual, expected)
         }
 


### PR DESCRIPTION

## Rationale

When a directory gets removed from under the running SwiftPM-based application, an irrecoverable error is generated. We'd like to be able to catch the error earlier.

## Changes

 * deprecated stand-alone `currentWorkingDirectory`
 * introduced per-`FileSystem` `currentWorkingDirectory` which returns an *optional* `AbsolutePath` result.
 * made a bunch of changes throughout the code which made sense. In some cases an explicit unwrapping is added, in some other a semantically reasonable behavior is codified.
