### PR TITLE
Add completions directly to bash

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -724,6 +724,15 @@ echo -e "source ~/.swift-package-complete.bash\n" >> ~/.bash_profile
 source ~/.swift-package-complete.bash
 ```
 
+Alternatively, add the following commands to your `~/.bash_profile` file to directly load completions:
+
+```bash
+# Source Swift completion
+if [ -n "`which swift`" ]; then
+	eval "`swift package completion-tool generate-bash-script`"
+fi
+```
+
 ### ZSH
 
 Use the following commands to install the ZSH completions to `~/.zsh/_swift`. You can chose a different folder, but the filename should be `_swift`. This will also add `~/.zsh` to your `$fpath` using your `~/.zshrc` file.


### PR DESCRIPTION
Completions can be loaded directly instead of using a second file.
This also has the advantage of updating automatically when completions change
with updates.