### PR TITLE
[SR-7834] Specify which packages contain the duplicate target

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -29,8 +29,8 @@ public enum ModuleError: Swift.Error {
         case modulemapInSources(String)
     }
 
-    /// Indicates two targets with the same name.
-    case duplicateModule(String)
+    /// Indicates two targets with the same name and their corresponding packages.
+    case duplicateModule(String, [String])
 
     /// One or more referenced targets could not be found.
     case modulesNotFound([String])
@@ -66,8 +66,9 @@ public enum ModuleError: Swift.Error {
 extension ModuleError: CustomStringConvertible {
     public var description: String {
         switch self {
-        case .duplicateModule(let name):
-            return "multiple targets named '\(name)'"
+        case .duplicateModule(let name, let packages):
+            let packages = packages.joined(separator: ", ")
+            return "multiple targets named '\(name)' in: \(packages)"
         case .modulesNotFound(let targets):
             let targets = targets.joined(separator: ", ")
             return "could not find source files for target(s): \(targets); use the 'path' property in the Swift 4 manifest to set a custom target path"


### PR DESCRIPTION
Change the error message from:

```
jmsmith@SFO-M-JSMITH01 ~/w/B/T/CombinedPackage (master)>
../../apple/swift-package-manager/.build/x86_64-apple-macosx10.10/debug/swift-build
'FirstPackage' /Users/jmsmith/workspace/Baseline/TwoTargets/CombinedPackage/.build/checkouts/FirstPackage--6769754764505680219: error: multiple targets named 'FirstTarget'
```

to:

```
jmsmith@SFO-M-JSMITH01 ~/w/B/T/CombinedPackage (master) [1]>
../../apple/swift-package-manager/.build/x86_64-apple-macosx10.10/debug/swift-build
'FirstPackage' /Users/jmsmith/workspace/Baseline/TwoTargets/CombinedPackage/.build/checkouts/FirstPackage--6769754764505680219: error: multiple targets named 'FirstTarget' in: ["SecondPackage", "FirstPackage"]
```