### PR TITLE
Update Development.md to include a tip about installing the xcode beta

### DIFF
--- a/Documentation/Development.md
+++ b/Documentation/Development.md
@@ -77,6 +77,8 @@ using a [snapshot](https://swift.org/download/#releases) from swift.org.
 	$ Utilities/bootstrap test --test-parallel
 	```
 	Use this command to run the tests. All tests must pass before a patch can be accepted.
+
+	If you encounter issues building or testing the Swift Package Manager project, try installing the latest version of the Xcode beta if applicable.
 	
 
 ## Self-hosting


### PR DESCRIPTION
Hey folks, I had issues when trying to build and test SwiftPM on my local machine. Building worked fine (probably due to me not installing the latest Trunk Development snapshot), but I encountered issues when it came to testing. The error was `invalid value '4.2' in '-swift-version 4.2'`.

This was solved by using the latest version of the Xcode beta. What do you think of adding this small tagline to provide a bit of support in this scenario? 