### PR TITLE
SR-6277 "WIP" Mute non-JSON output from "dump-package"

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -31,6 +31,9 @@ public class ToolOptions {
     /// Enable prefetching in resolver which will kick off parallel git cloning.
     public var shouldEnableResolverPrefetching = true
 
+    /// Mute the output of tool operations.
+    public var shouldMuteOutput = true
+
     /// If print version option was passed.
     public var shouldPrintVersion: Bool = false
 

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -175,6 +175,8 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             describe(graph.rootPackages[0].underlyingPackage, in: options.describeMode, on: stdoutStream)
 
         case .dumpPackage:
+            options.shouldMuteOutput = !options.dumpPackageOptions.includeToolOutput
+
             let graph = try loadPackageGraph()
             let manifest = graph.rootPackages[0].manifest
             print(try manifest.jsonString())
@@ -212,7 +214,10 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             option: describeParser.add(option: "--type", kind: DescribeMode.self, usage: "json|text"),
             to: { $0.describeMode = $1 })
 
-        _ = parser.add(subparser: PackageMode.dumpPackage.rawValue, overview: "Print parsed Package.swift as JSON")
+        let dumpParser = parser.add(subparser: PackageMode.dumpPackage.rawValue, overview: "Print parsed Package.swift as JSON")
+        binder.bind(
+            option: dumpParser.add(option: "--include-tool-output", kind: Bool.self, usage: "Show package manager output"),
+            to: { $0.dumpPackageOptions.includeToolOutput = $1 })
 
         let editParser = parser.add(subparser: PackageMode.edit.rawValue, overview: "Put a package in editable mode")
         binder.bind(
@@ -370,6 +375,12 @@ public class PackageToolOptions: ToolOptions {
 
     var inputPath: AbsolutePath?
     var showDepsMode: ShowDependenciesMode = .text
+
+	struct DumpPackageOptions {
+		var includeToolOutput = false
+	}
+
+	var dumpPackageOptions = DumpPackageOptions()
 
     struct EditOptions {
         var packageName: String?


### PR DESCRIPTION
Submitting PR for feedback on this solution, in advance of writing unit tests.

This PR changes tool progress output to be muted by default.

It also introduces a new dump-package option: ` --include-tool-output` to override this default and show dependency resolution and fetch progress as before.

Diagnostics that contain an error are still printed to the console.

I would appreciate feedback on this solution as a new contributor to this codebase, not entirely familiar with its broader structure, and with expectations regarding tool output handling.