### PR TITLE
link directly to snapshots section of swift.org

### DIFF
--- a/Documentation/Development.md
+++ b/Documentation/Development.md
@@ -29,7 +29,7 @@ using a [snapshot](https://swift.org/download/#releases) from swift.org.
 ## Using trunk snapshot
 
 
-1. [Download](https://swift.org/download/#releases) and install latest Trunk Development snapshot.
+1. [Download](https://swift.org/download/#snapshots) and install latest Trunk Development snapshot.
 2. Run the following command depending on your platform.
 
 


### PR DESCRIPTION
Hey folks, another small PR here. The link currently goes to the releases page of swift.org rather than the snapshots page that is being referred to.