### PR TITLE
Add RelativePath validating init

### DIFF
--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -252,6 +252,16 @@ public struct RelativePath: Hashable {
         _impl = PathImpl(string: normalize(relative: string))
     }
 
+    /// Convenience initializer that verifies that the path is relative.
+    public init(validating path: String) throws {
+        switch path.first {
+        case "/", "~":
+            throw PathValidationError.invalidRelativePath(path)
+        default:
+            self.init(path)
+        }
+    }
+
     /// Directory component.  For a relative path without any path separators,
     /// this is the `.` string instead of the empty string.
     public var dirname: String {
@@ -455,15 +465,18 @@ extension PathImpl {
 public enum PathValidationError: Error {
     case startsWithTilde(String)
     case invalidAbsolutePath(String)
+    case invalidRelativePath(String)
 }
 
 extension PathValidationError: CustomStringConvertible {
     public var description: String {
         switch self {
         case .startsWithTilde(let path):
-            return "invalid absolute path '\(path)'; absolute path must begin with /"
+            return "invalid absolute path '\(path)'; absolute path must begin with '/'"
         case .invalidAbsolutePath(let path):
             return "invalid absolute path '\(path)'"
+        case .invalidRelativePath(let path):
+            return "invalid relative path '\(path)'; relative path should not begin with '/' or '~'"
         }
     }
 }

--- a/Tests/BasicTests/PathTests.swift
+++ b/Tests/BasicTests/PathTests.swift
@@ -276,11 +276,23 @@ class PathTests: XCTestCase {
         XCTAssertNoThrow(try AbsolutePath(validating: "/a/b/c/d"))
 
         XCTAssertThrowsError(try AbsolutePath(validating: "~/a/b/d")) { error in
-            XCTAssertEqual("\(error)", "invalid absolute path '~/a/b/d'; absolute path must begin with /")
+            XCTAssertEqual("\(error)", "invalid absolute path '~/a/b/d'; absolute path must begin with '/'")
         }
 
         XCTAssertThrowsError(try AbsolutePath(validating: "a/b/d")) { error in
             XCTAssertEqual("\(error)", "invalid absolute path 'a/b/d'")
+        }
+    }
+
+    func testRelativePathValidation() {
+        XCTAssertNoThrow(try RelativePath(validating: "a/b/c/d"))
+
+        XCTAssertThrowsError(try RelativePath(validating: "/a/b/d")) { error in
+            XCTAssertEqual("\(error)", "invalid relative path '/a/b/d'; relative path should not begin with '/' or '~'")
+        }
+
+        XCTAssertThrowsError(try RelativePath(validating: "~/a/b/d")) { error in
+            XCTAssertEqual("\(error)", "invalid relative path '~/a/b/d'; relative path should not begin with '/' or '~'")
         }
     }
 


### PR DESCRIPTION
Validating RelativePath checks first symbols not to be "/" or "~" and throws `PathValidationError.invalidRelativePath` otherwise 