### PR TITLE
[Xcodeproj] Use Xcode's modulemap generation when umbrella header is …

### DIFF
--- a/Sources/Xcodeproj/XcodeProjectModel.swift
+++ b/Sources/Xcodeproj/XcodeProjectModel.swift
@@ -302,6 +302,13 @@ public struct Xcode {
         init(fileRef: FileReference) {
             self.fileRef = fileRef
         }
+
+        var settings = Settings()
+
+        /// A set of file settings.
+        public struct Settings {
+            var ATTRIBUTES: [String]?
+        }
     }
 
     /// A table of build settings, which for the sake of simplicity consists
@@ -336,6 +343,7 @@ public struct Xcode {
             // they are all either strings or arrays of strings, because even
             // a boolean may be a macro reference expression.
             var CLANG_CXX_LANGUAGE_STANDARD: String?
+            var CLANG_ENABLE_MODULES: String?
             var CLANG_ENABLE_OBJC_ARC: String?
             var COMBINE_HIDPI_IMAGES: String?
             var COPY_PHASE_STRIP: String?
@@ -375,8 +383,50 @@ public struct Xcode {
             var USE_HEADERMAP: String?
             var LD: String?
 
-            init(CLANG_CXX_LANGUAGE_STANDARD: String? = nil, CLANG_ENABLE_OBJC_ARC: String? = nil, COMBINE_HIDPI_IMAGES: String? = nil, COPY_PHASE_STRIP: String? = nil, DEBUG_INFORMATION_FORMAT: String? = nil, DEFINES_MODULE: String? = nil, DYLIB_INSTALL_NAME_BASE: String? = nil, EMBEDDED_CONTENT_CONTAINS_SWIFT: String? = nil, ENABLE_NS_ASSERTIONS: String? = nil, ENABLE_TESTABILITY: String? = nil, FRAMEWORK_SEARCH_PATHS: [String]? = nil, GCC_C_LANGUAGE_STANDARD: String? = nil, GCC_OPTIMIZATION_LEVEL: String? = nil, GCC_PREPROCESSOR_DEFINITIONS: [String]? = nil, HEADER_SEARCH_PATHS: [String]? = nil, INFOPLIST_FILE: String? = nil, LD_RUNPATH_SEARCH_PATHS: [String]? = nil, LIBRARY_SEARCH_PATHS: [String]? = nil, MACOSX_DEPLOYMENT_TARGET: String? = nil, MODULEMAP_FILE: String? = nil, ONLY_ACTIVE_ARCH: String? = nil, OTHER_CFLAGS: [String]? = nil, OTHER_LDFLAGS: [String]? = nil, OTHER_SWIFT_FLAGS: [String]? = nil, PRODUCT_BUNDLE_IDENTIFIER: String? = nil, PRODUCT_MODULE_NAME: String? = nil, PRODUCT_NAME: String? = nil, PROJECT_NAME: String? = nil, SDKROOT: String? = nil, SKIP_INSTALL: String? = nil, SUPPORTED_PLATFORMS: [String]? = nil, SWIFT_ACTIVE_COMPILATION_CONDITIONS: [String]? = nil, SWIFT_FORCE_STATIC_LINK_STDLIB: String? = nil, SWIFT_FORCE_DYNAMIC_LINK_STDLIB: String? = nil, SWIFT_OPTIMIZATION_LEVEL: String? = nil, SWIFT_VERSION: String? = nil, TARGET_NAME: String? = nil, USE_HEADERMAP: String? = nil, LD: String? = nil) {
+            init(
+                CLANG_CXX_LANGUAGE_STANDARD: String? = nil,
+                CLANG_ENABLE_MODULES: String? = nil,
+                CLANG_ENABLE_OBJC_ARC: String? = nil,
+                COMBINE_HIDPI_IMAGES: String? = nil,
+                COPY_PHASE_STRIP: String? = nil,
+                DEBUG_INFORMATION_FORMAT: String? = nil,
+                DEFINES_MODULE: String? = nil,
+                DYLIB_INSTALL_NAME_BASE: String? = nil,
+                EMBEDDED_CONTENT_CONTAINS_SWIFT: String? = nil,
+                ENABLE_NS_ASSERTIONS: String? = nil,
+                ENABLE_TESTABILITY: String? = nil,
+                FRAMEWORK_SEARCH_PATHS: [String]? = nil,
+                GCC_C_LANGUAGE_STANDARD: String? = nil,
+                GCC_OPTIMIZATION_LEVEL: String? = nil,
+                GCC_PREPROCESSOR_DEFINITIONS: [String]? = nil,
+                HEADER_SEARCH_PATHS: [String]? = nil,
+                INFOPLIST_FILE: String? = nil,
+                LD_RUNPATH_SEARCH_PATHS: [String]? = nil,
+                LIBRARY_SEARCH_PATHS: [String]? = nil,
+                MACOSX_DEPLOYMENT_TARGET: String? = nil,
+                MODULEMAP_FILE: String? = nil,
+                ONLY_ACTIVE_ARCH: String? = nil,
+                OTHER_CFLAGS: [String]? = nil,
+                OTHER_LDFLAGS: [String]? = nil,
+                OTHER_SWIFT_FLAGS: [String]? = nil,
+                PRODUCT_BUNDLE_IDENTIFIER: String? = nil,
+                PRODUCT_MODULE_NAME: String? = nil,
+                PRODUCT_NAME: String? = nil,
+                PROJECT_NAME: String? = nil,
+                SDKROOT: String? = nil,
+                SKIP_INSTALL: String? = nil,
+                SUPPORTED_PLATFORMS: [String]? = nil,
+                SWIFT_ACTIVE_COMPILATION_CONDITIONS: [String]? = nil,
+                SWIFT_FORCE_STATIC_LINK_STDLIB: String? = nil,
+                SWIFT_FORCE_DYNAMIC_LINK_STDLIB: String? = nil,
+                SWIFT_OPTIMIZATION_LEVEL: String? = nil,
+                SWIFT_VERSION: String? = nil,
+                TARGET_NAME: String? = nil,
+                USE_HEADERMAP: String? = nil,
+                LD: String? = nil
+            ) {
                 self.CLANG_CXX_LANGUAGE_STANDARD = CLANG_CXX_LANGUAGE_STANDARD
+                self.CLANG_ENABLE_MODULES = CLANG_ENABLE_MODULES
                 self.CLANG_ENABLE_OBJC_ARC = CLANG_CXX_LANGUAGE_STANDARD
                 self.COMBINE_HIDPI_IMAGES = COMBINE_HIDPI_IMAGES
                 self.COPY_PHASE_STRIP = COPY_PHASE_STRIP

--- a/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
+++ b/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
@@ -286,6 +286,12 @@ extension Xcode.BuildFile: PropertyListSerializable {
         if let fileRef = fileRef {
             dict["fileRef"] = .identifier(serializer.id(of: fileRef))
         }
+
+        let settingsDict = settings.asPropertyList()
+        if !settingsDict.isEmpty {
+            dict["settings"] = settingsDict
+        }
+
         return dict
     }
 }
@@ -359,8 +365,11 @@ extension Xcode.BuildSettingsTable: PropertyListSerializable {
     }
 }
 
-extension Xcode.BuildSettingsTable.BuildSettings {
+protocol PropertyListDictionaryConvertible {
+    func asPropertyList() -> PropertyList
+}
 
+extension PropertyListDictionaryConvertible {
     /// Returns a property list representation of the build settings, in which
     /// every struct field is represented as a dictionary entry.  Fields of
     /// type `String` are represented as `PropertyList.string` values; fields
@@ -409,6 +418,9 @@ extension Xcode.BuildSettingsTable.BuildSettings {
         return .dictionary(dict)
     }
 }
+
+extension Xcode.BuildFile.Settings: PropertyListDictionaryConvertible {}
+extension Xcode.BuildSettingsTable.BuildSettings: PropertyListDictionaryConvertible {}
 
 /// Private helper function that combines a base property list and an overlay
 /// property list, respecting the semantics of `$(inherited)` as we go.
@@ -566,3 +578,13 @@ extension PropertyListSerializable {
     }
 }
 
+extension PropertyList {
+    var isEmpty: Bool {
+        switch self {
+        case let .identifier(string): return string.isEmpty
+        case let .string(string): return string.isEmpty
+        case let .array(array): return array.isEmpty
+        case let .dictionary(dictionary): return dictionary.isEmpty
+        }
+    }
+}

--- a/Tests/XcodeprojTests/XcodeProjectModelSerializationTests.swift
+++ b/Tests/XcodeprojTests/XcodeProjectModelSerializationTests.swift
@@ -141,9 +141,47 @@ class XcodeProjectModelSerializationTests: XCTestCase {
         }
         XCTAssertEqual(activeCompilationConditions, activeCompilationConditionsValues)
     }
+
+    func testBuildFileSettingsSerialization() {
+
+        // Create build file settings.
+        var buildFileSettings = Xcode.BuildFile.Settings()
+
+        let attributeValues = ["Public"]
+        buildFileSettings.ATTRIBUTES = attributeValues
+
+        // Serialize it to a property list.
+        let plist = buildFileSettings.asPropertyList()
+
+        // Assert things about plist
+        guard case let .dictionary(buildFileSettingsDict) = plist else {
+            XCTFail("build file settings plist must be a dictionary")
+            return
+        }
+
+        guard let attributesPlist = buildFileSettingsDict["ATTRIBUTES"] else {
+            XCTFail("build file settings plist must contain ATTRIBUTES")
+            return
+        }
+
+        guard case let .array(attributePlists) = attributesPlist else {
+            XCTFail("attributes plist must be an array")
+            return
+        }
+
+        let attributes = attributePlists.compactMap { attributePlist -> String? in
+            guard case let .string(attribute) = attributePlist else {
+                XCTFail("attribute plist must be a string")
+                return nil
+            }
+            return attribute
+        }
+        XCTAssertEqual(attributes, attributeValues)
+    }
     
     static var allTests = [
         ("testBasicProjectSerialization", testBasicProjectSerialization),
         ("testBuildSettingsSerialization", testBuildSettingsSerialization),
+        ("testBuildFileSettingsSerialization", testBuildFileSettingsSerialization),
     ]
 }


### PR DESCRIPTION
…present

This makes the C language frameworks actual frameworks when umbrealla
header is present in the target. It should be possible to embed these
targets in other Xcode projects using subprojects or workspaces.

This is based on @norio-nomura original PR https://github.com/apple/swift-package-manager/pull/1406