### PR TITLE
[SR-7830] describe --type JSON does not output JSON

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -173,7 +173,7 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             print("generated:", xcodeprojPath.prettyPath(cwd: originalWorkingDirectory))
 
         case .describe:
-            let graph = try loadPackageGraph()
+            let graph = try loadPackageGraph(quiet: true)
             describe(graph.rootPackages[0].underlyingPackage, in: options.describeMode, on: stdoutStream)
 
         case .dumpPackage:

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -182,15 +182,19 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             print(try manifest.jsonString())
 
         case .completionTool:
-            switch options.completionToolMode {
-            case .generateBashScript?:
+            guard let completionToolMode = options.completionToolMode else {
+                preconditionFailure("somehow we ended up with an invalid positional argument")
+            }
+
+            switch completionToolMode {
+            case .generateBashScript:
                 bash_template(on: stdoutStream)
-            case .generateZshScript?:
+            case .generateZshScript:
                 zsh_template(on: stdoutStream)
-            case .listDependencies?:
+            case .listDependencies:
                 let graph = try loadPackageGraph()
                 dumpDependenciesOf(rootPackage: graph.rootPackages[0], mode: .flatlist)
-            case .listExecutables?:
+            case .listExecutables:
                 let graph = try loadPackageGraph()
                 let package = graph.rootPackages[0].underlyingPackage
                 let executables = package.targets.filter { $0.type == .executable }
@@ -198,8 +202,6 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
                     stdoutStream <<< "\(executable.name)\n"
                 }
                 stdoutStream.flush()
-            default:
-                preconditionFailure("somehow we ended up with an invalid positional argument")
             }
         case .help:
             parser.printUsage(on: stdoutStream)


### PR DESCRIPTION
When using `swift package describe --type JSON` (or text for that matter), loading the package graph will result in verbose logging of updates/etc via `ToolWorkspaceDelegate`. 

This PR adds a `quiet` option (defaults to `false`, making this purely additive) to `getActiveWorkspace`, `ToolWorkspaceDelegate`, and the other methods leading up to describing the package.