### PR TITLE
[Xcodeproj] Add SWIFT_PACKAGE define in debug config

### DIFF
--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -165,7 +165,7 @@ func xcodeProject(
     projectSettings.debug.GCC_PREPROCESSOR_DEFINITIONS = ["DEBUG=1", "$(inherited)"]
     projectSettings.debug.ONLY_ACTIVE_ARCH = "YES"
     projectSettings.debug.SWIFT_OPTIMIZATION_LEVEL = "-Onone"
-    projectSettings.debug.SWIFT_ACTIVE_COMPILATION_CONDITIONS += ["DEBUG"]
+    projectSettings.debug.SWIFT_ACTIVE_COMPILATION_CONDITIONS += ["SWIFT_PACKAGE", "DEBUG"]
 
     // Add some release-specific settings.
     projectSettings.release.COPY_PHASE_STRIP = "YES"

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -76,6 +76,8 @@ class PackageGraphTests: XCTestCase {
             XCTAssertEqual(project.buildSettings.common.CLANG_ENABLE_OBJC_ARC, "YES")
             XCTAssertEqual(project.buildSettings.release.SWIFT_OPTIMIZATION_LEVEL, "-Owholemodule")
             XCTAssertEqual(project.buildSettings.debug.SWIFT_OPTIMIZATION_LEVEL, "-Onone")
+            XCTAssertEqual(project.buildSettings.debug.SWIFT_ACTIVE_COMPILATION_CONDITIONS!, ["SWIFT_PACKAGE", "DEBUG"])
+            XCTAssertEqual(project.buildSettings.common.SWIFT_ACTIVE_COMPILATION_CONDITIONS!, ["SWIFT_PACKAGE"])
 
             result.check(target: "Foo") { targetResult in
                 targetResult.check(productType: .framework)


### PR DESCRIPTION
This was a regression caused when the DEBUG define was added as debug
settings overrides the common settings

<rdar://problem/41168212> [SR-7965]: Xcode Project generated by SwiftPM 4.2 can't build when package depends on Yams