### PR TITLE
[WIP][SR-7832] Default executable SwiftPM package should have tests

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -139,7 +139,7 @@ public final class InitPackage {
                                 dependencies: []),
                             .testTarget(
                                 name: "\(pkgname)Tests",
-                            	dependencies: []),
+                                dependencies: []),
                         ]
 
                     """

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -166,7 +166,9 @@ final class PackageToolTests: XCTestCase {
 
             XCTAssertTrue(fs.exists(manifest))
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "Foo")), ["main.swift"])
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Tests")), [])
+            XCTAssertEqual(
+                try fs.getDirectoryContents(path.appending(component: "Tests")).sorted(),
+                ["FooTests", "LinuxMain.swift"])
         }
     }
 

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -75,7 +75,9 @@ class InitTests: XCTestCase {
             XCTAssertTrue(readmeContents.hasPrefix("# Foo\n"))
 
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "Foo")), ["main.swift"])
-            XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Tests")), [])
+            XCTAssertEqual(
+                try fs.getDirectoryContents(path.appending(component: "Tests")).sorted(),
+                ["FooTests", "LinuxMain.swift"])
             
             // Try building it
             XCTAssertBuilds(path)


### PR DESCRIPTION
This PR modifies the default executable package type to include tests ([SR-7832](https://bugs.swift.org/browse/SR-7832)). 

I started working on this task with the assistance of @hartbit during try!Swift San Jose and this is my first attempt to contribute. I would like to request feedback in the overall structure and further changes that should be performed. I tested Linux using docker-utils on macOS but I would appreciate feedback on the correctness of finding the path of the executable in that case.