### PR TITLE
[Workspace] Improve isResolutionRequired check

### DIFF
--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -404,7 +404,7 @@ public struct PackageContainerConstraintSet<C: PackageContainer>: Collection, Ha
     }
 
     /// Get the version set specifier associated with the given package `identifier`.
-    subscript(identifier: Identifier) -> Requirement {
+    public subscript(identifier: Identifier) -> Requirement {
         return constraints[identifier] ?? .versionSet(.any)
     }
 
@@ -433,13 +433,16 @@ public struct PackageContainerConstraintSet<C: PackageContainer>: Collection, Ha
             var result = self
             result.constraints[identifier] = .versionSet(intersection)
             return result
+
         case (.unversioned, .unversioned):
             return self
+
         case (.unversioned, _):
             // Unversioned requirements always *wins*.
             var result = self
             result.constraints[identifier] = requirement
             return result
+
         case (_, .unversioned):
             // Unversioned requirements always *wins*.
             return self
@@ -451,14 +454,18 @@ public struct PackageContainerConstraintSet<C: PackageContainer>: Collection, Ha
             if lhs == rhs { return self }
             return nil
 
-        case (.revision, _):
-            // The revision requirement *wins*.
+        // We can merge the revision requiement if it currently does not have a requirement.
+        case (.revision, .versionSet(.any)):
             var result = self
             result.constraints[identifier] = requirement
             return result
 
+        // Otherwise, we can't merge the revision requirement.
+        case (.revision, _):
+            return nil
+
+        // Exisiting revision requirements always *wins*.
         case (_, .revision):
-            // The revision requirement *wins*.
             return self
         }
     }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1127,15 +1127,18 @@ extension Workspace {
             constraintSet = mergedSet
         }
 
-        // Compute the pins which are valid w.r.t dependencies.
-        let validPins: [RepositoryPackageConstraint]
-        validPins = pinConstraints.compactMap { pin in
+        // Merge all the pin constraints.
+        for pin in pinConstraints {
             if let mergedSet = constraintSet.merging(pin) {
                 constraintSet = mergedSet
-                return pin
             }
-            return nil
         }
+
+        // Compute the valid pins, i.e., the pins which are still valid in the
+        // final merged set.
+        let validPins = pinConstraints.filter({
+            $0.requirement == constraintSet[$0.identifier]
+        })
 
         // If there are pins which are not valid anymore, we need to resolve.
         if pinConstraints.count != validPins.count {

--- a/Tests/PackageGraphTests/DependencyResolverTests.swift
+++ b/Tests/PackageGraphTests/DependencyResolverTests.swift
@@ -408,12 +408,22 @@ class DependencyResolverTests: XCTestCase {
             ]),
         ])
 
+        // It is illegal for a revision constraint to appear after a versioned constraint.
+        do {
+            let resolver = MockDependencyResolver(provider, MockResolverDelegate())
+            XCTAssertThrows(DependencyResolverError.unsatisfiable) {
+                _ = try resolver.resolve(constraints: [
+                    MockPackageConstraint(container: "C", versionRequirement: v1Range),
+                    MockPackageConstraint(container: "C", requirement: .revision(develop)),
+                ])
+            }
+        }
+
         // Having a revision dependency at root should resolve.
         do {
             let resolver = MockDependencyResolver(provider, MockResolverDelegate())
             let result = try resolver.resolve(constraints: [
-                // With version and revision constraints, revision should win.
-                MockPackageConstraint(container: "C", versionRequirement: v1Range),
+                // With version and revision constraints, revision should win if it appears first.
                 MockPackageConstraint(container: "C", requirement: .revision(develop)),
                 MockPackageConstraint(container: "C", versionRequirement: v1Range),
             ])


### PR DESCRIPTION
The previous logic wasn't able to detect when a dependency was switched
between version and revision.

<rdar://problem/40628265> Switching a dependency from .revision to .exact doesn't rerun dependency resolution