### PR TITLE
[Build] Pass object files via a file to Swift compiler

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -420,6 +420,16 @@ public final class ProductBuildDescription {
     /// Any additional flags to be added. These flags are expected to be computed during build planning.
     fileprivate var additionalFlags: [String] = []
 
+    /// Path to the temporary directory for this product.
+    var tempsPath: AbsolutePath {
+        return buildParameters.buildPath.appending(component: product.name + ".product")
+    }
+
+    /// Path to the link filelist file.
+    var linkFileListPath: AbsolutePath {
+        return tempsPath.appending(component: "Objects.LinkFileList")
+    }
+
     /// Create a build description for a product.
     init(product: ResolvedProduct, buildParameters: BuildParameters) {
         assert(product.type != .library(.automatic), "Automatic type libraries should not be described.")
@@ -482,12 +492,24 @@ public final class ProductBuildDescription {
         // adjacent to the product. This happens by default on macOS.
         args += ["-Xlinker", "-rpath=$ORIGIN"]
       #endif
-        args += objects.map({ $0.asString })
+        args += ["@" + linkFileListPath.asString]
 
         // User arguments (from -Xlinker and -Xswiftc) should follow generated arguments to allow user overrides
         args += buildParameters.linkerFlags
         args += stripInvalidArguments(buildParameters.swiftCompilerFlags)
         return args
+    }
+
+    /// Writes link filelist to the filesystem.
+    func writeLinkFilelist(_ fs: FileSystem) throws {
+        let stream = BufferedOutputByteStream()
+
+        for object in objects {
+            stream <<< object.asString <<< "\n"
+        }
+
+        try fs.createDirectory(linkFileListPath.parentDirectory, recursive: true)
+        try fs.writeFileContents(linkFileListPath, bytes: stream.bytes)
     }
 }
 
@@ -612,7 +634,7 @@ public class BuildPlan {
 
         // Plan products.
         for buildProduct in buildProducts {
-            plan(buildProduct)
+            try plan(buildProduct)
         }
         // FIXME: We need to find out if any product has a target on which it depends 
         // both static and dynamically and then issue a suitable diagnostic or auto
@@ -620,7 +642,7 @@ public class BuildPlan {
     }
 
     /// Plan a product.
-    private func plan(_ buildProduct: ProductBuildDescription) {
+    private func plan(_ buildProduct: ProductBuildDescription) throws {
         // Compute the product's dependency.
         let dependencies = computeDependencies(of: buildProduct.product)
         // Add flags for system targets.
@@ -643,6 +665,12 @@ public class BuildPlan {
 
         buildProduct.dylibs = dependencies.dylibs.map({ productMap[$0]! })
         buildProduct.objects += dependencies.staticTargets.flatMap({ targetMap[$0]!.objects })
+
+        // Write the link filelist file.
+        //
+        // FIXME: We should write this as a custom llbuild task once we adopt it
+        // as a library.
+        try buildProduct.writeLinkFilelist(fileSystem)
     }
 
     /// Computes the dependencies of a product.

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -71,7 +71,7 @@ final class BuildPlanTests: XCTestCase {
         let graph = loadMockPackageGraph(["/Pkg": pkg], root: "/Pkg", diagnostics: diagnostics, in: fs)
         let result = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(shouldLinkStaticSwiftStdlib: true),
-            graph: graph, diagnostics: diagnostics)
+            graph: graph, diagnostics: diagnostics, fileSystem: fs)
         )
  
         result.checkProductsCount(1)
@@ -88,8 +88,7 @@ final class BuildPlanTests: XCTestCase {
             "/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug",
             "-o", "/path/to/build/debug/exe", "-module-name", "exe",
             "-static-stdlib", "-emit-executable",
-            "/path/to/build/debug/exe.build/main.swift.o",
-            "/path/to/build/debug/lib.build/lib.swift.o",
+            "@/path/to/build/debug/exe.product/Objects.LinkFileList",
         ]
       #else
         let linkArguments = [
@@ -97,8 +96,7 @@ final class BuildPlanTests: XCTestCase {
             "-o", "/path/to/build/debug/exe", "-module-name", "exe",
             "-emit-executable",
             "-Xlinker", "-rpath=$ORIGIN",
-            "/path/to/build/debug/exe.build/main.swift.o",
-            "/path/to/build/debug/lib.build/lib.swift.o",
+            "@/path/to/build/debug/exe.product/Objects.LinkFileList",
         ]
       #endif
 
@@ -162,7 +160,7 @@ final class BuildPlanTests: XCTestCase {
         )
         let diagnostics = DiagnosticsEngine()
         let graph = loadMockPackageGraph(["/Pkg": Package(name: "Pkg")], root: "/Pkg", diagnostics: diagnostics, in: fs)
-        let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(config: .release), graph: graph, diagnostics: diagnostics))
+        let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(config: .release), graph: graph, diagnostics: diagnostics, fileSystem: fs))
 
         result.checkProductsCount(1)
         result.checkTargetsCount(1)
@@ -174,14 +172,14 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
             "/fake/path/to/swiftc", "-L", "/path/to/build/release",
             "-o", "/path/to/build/release/exe", "-module-name", "exe", "-emit-executable",
-            "/path/to/build/release/exe.build/main.swift.o"
+            "@/path/to/build/release/exe.product/Objects.LinkFileList",
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
             "/fake/path/to/swiftc", "-L", "/path/to/build/release",
             "-o", "/path/to/build/release/exe", "-module-name", "exe", "-emit-executable",
             "-Xlinker", "-rpath=$ORIGIN",
-            "/path/to/build/release/exe.build/main.swift.o"
+            "@/path/to/build/release/exe.product/Objects.LinkFileList",
         ])
       #endif
     }
@@ -237,20 +235,24 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
             "/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug",
             "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable", 
-            "/path/to/build/debug/exe.build/main.c.o",
-            "/path/to/build/debug/extlib.build/extlib.c.o",
-            "/path/to/build/debug/lib.build/lib.c.o",
+            "@/path/to/build/debug/exe.product/Objects.LinkFileList",
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
             "/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug",
             "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable", 
             "-Xlinker", "-rpath=$ORIGIN",
-            "/path/to/build/debug/exe.build/main.c.o",
-            "/path/to/build/debug/extlib.build/extlib.c.o",
-            "/path/to/build/debug/lib.build/lib.c.o",
+            "@/path/to/build/debug/exe.product/Objects.LinkFileList",
         ])
       #endif
+
+      let linkedFileList = try fs.readFileContents(AbsolutePath("/path/to/build/debug/exe.product/Objects.LinkFileList"))
+      XCTAssertEqual(linkedFileList, """
+          /path/to/build/debug/exe.build/main.c.o
+          /path/to/build/debug/extlib.build/extlib.c.o
+          /path/to/build/debug/lib.build/lib.c.o
+
+          """)
     }
 
     func testCLanguageStandard() throws {
@@ -281,18 +283,14 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
             "/fake/path/to/swiftc", "-lc++", "-g", "-L", "/path/to/build/debug", "-o",
             "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable",
-            "/path/to/build/debug/exe.build/main.cpp.o",
-            "/path/to/build/debug/lib.build/lib.c.o",
-            "/path/to/build/debug/lib.build/libx.cpp.o"
+            "@/path/to/build/debug/exe.product/Objects.LinkFileList",
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
             "/fake/path/to/swiftc", "-lstdc++", "-g", "-L", "/path/to/build/debug", "-o",
             "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable",
             "-Xlinker", "-rpath=$ORIGIN",
-            "/path/to/build/debug/exe.build/main.cpp.o",
-            "/path/to/build/debug/lib.build/lib.c.o",
-            "/path/to/build/debug/lib.build/libx.cpp.o"
+            "@/path/to/build/debug/exe.product/Objects.LinkFileList",
         ])
       #endif
 
@@ -342,16 +340,14 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
             "/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug",
             "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable",
-            "/path/to/build/debug/exe.build/main.swift.o",
-            "/path/to/build/debug/lib.build/lib.c.o",
+            "@/path/to/build/debug/exe.product/Objects.LinkFileList",
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
             "/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug",
             "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable",
             "-Xlinker", "-rpath=$ORIGIN",
-            "/path/to/build/debug/exe.build/main.swift.o",
-            "/path/to/build/debug/lib.build/lib.c.o",
+            "@/path/to/build/debug/exe.product/Objects.LinkFileList",
         ])
       #endif
     }
@@ -384,17 +380,14 @@ final class BuildPlanTests: XCTestCase {
             "/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug", "-o",
             "/path/to/build/debug/PkgPackageTests.xctest/Contents/MacOS/PkgPackageTests", "-module-name",
             "PkgPackageTests", "-Xlinker", "-bundle",
-            "/path/to/build/debug/Foo.build/foo.swift.o",
-            "/path/to/build/debug/FooTests.build/foo.swift.o",
+            "@/path/to/build/debug/PkgPackageTests.product/Objects.LinkFileList",
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "PkgPackageTests").linkArguments(), [
             "/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug", "-o",
             "/path/to/build/debug/PkgPackageTests.xctest", "-module-name", "PkgPackageTests", "-emit-executable",
             "-Xlinker", "-rpath=$ORIGIN",
-            "/path/to/build/debug/Foo.build/foo.swift.o",
-            "/path/to/build/debug/FooTests.build/foo.swift.o",
-            "/path/to/build/debug/PkgPackageTests.build/LinuxMain.swift.o",
+            "@/path/to/build/debug/PkgPackageTests.product/Objects.LinkFileList",
         ])
       #endif
     }
@@ -422,14 +415,14 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
             "/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug",
             "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable",
-            "/path/to/build/debug/exe.build/main.swift.o"
+            "@/path/to/build/debug/exe.product/Objects.LinkFileList",
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
             "/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug",
             "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable",
             "-Xlinker", "-rpath=$ORIGIN",
-            "/path/to/build/debug/exe.build/main.swift.o"
+            "@/path/to/build/debug/exe.product/Objects.LinkFileList",
         ])
       #endif
     }
@@ -498,21 +491,21 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(fooLinkArgs, [
             "/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug",
             "-o", "/path/to/build/debug/Foo", "-module-name", "Foo", "-lBar", "-emit-executable",
-            "/path/to/build/debug/Foo.build/main.swift.o"
+            "@/path/to/build/debug/Foo.product/Objects.LinkFileList",
         ])
 
         XCTAssertEqual(barLinkArgs, [
             "/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug", "-o",
             "/path/to/build/debug/libBar.dylib",
             "-module-name", "Bar", "-emit-library",
-            "/path/to/build/debug/Bar.build/source.swift.o"
+            "@/path/to/build/debug/Bar.product/Objects.LinkFileList",
         ])
       #else
         XCTAssertEqual(fooLinkArgs, [
             "/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug",
             "-o", "/path/to/build/debug/Foo", "-module-name", "Foo", "-lBar", "-emit-executable",
             "-Xlinker", "-rpath=$ORIGIN",
-            "/path/to/build/debug/Foo.build/main.swift.o"
+            "@/path/to/build/debug/Foo.product/Objects.LinkFileList",
         ])
 
         XCTAssertEqual(barLinkArgs, [
@@ -520,7 +513,7 @@ final class BuildPlanTests: XCTestCase {
             "/path/to/build/debug/libBar.so",
             "-module-name", "Bar", "-emit-library",
             "-Xlinker", "-rpath=$ORIGIN",
-            "/path/to/build/debug/Bar.build/source.swift.o"
+            "@/path/to/build/debug/Bar.product/Objects.LinkFileList",
         ])
       #endif
 
@@ -567,10 +560,15 @@ final class BuildPlanTests: XCTestCase {
                 "/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug",
                 "-o", "/path/to/build/debug/liblib.dylib", "-module-name", "lib",
                 "-emit-library",
-                "/path/to/build/debug/lib.build/lib.swift.o",
+                "@/path/to/build/debug/lib.product/Objects.LinkFileList",
             ]
         #else
-            let linkArguments = ["/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/liblib.so", "-module-name", "lib", "-emit-library", "-Xlinker", "-rpath=$ORIGIN", "/path/to/build/debug/lib.build/lib.swift.o"]
+            let linkArguments = [
+                "/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug",
+                "-o", "/path/to/build/debug/liblib.so", "-module-name", "lib",
+                "-emit-library", "-Xlinker", "-rpath=$ORIGIN",
+                "@/path/to/build/debug/lib.product/Objects.LinkFileList",
+            ]
         #endif
 
         XCTAssertEqual(try result.buildProduct(for: "lib").linkArguments(), linkArguments)
@@ -627,11 +625,11 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(lib.moduleMap, AbsolutePath("/path/to/build/debug/lib.build/module.modulemap"))
 
     #if os(macOS)
-        XCTAssertEqual(try result.buildProduct(for: "lib").linkArguments(), ["/fake/path/to/swiftc", "-lc++", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/liblib.dylib", "-module-name", "lib", "-emit-library", "/path/to/build/debug/lib.build/lib.cpp.o"])
-        XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), ["/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable", "/path/to/build/debug/exe.build/main.c.o"])
+        XCTAssertEqual(try result.buildProduct(for: "lib").linkArguments(), ["/fake/path/to/swiftc", "-lc++", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/liblib.dylib", "-module-name", "lib", "-emit-library", "@/path/to/build/debug/lib.product/Objects.LinkFileList"])
+        XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), ["/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable", "@/path/to/build/debug/exe.product/Objects.LinkFileList"])
     #else
-        XCTAssertEqual(try result.buildProduct(for: "lib").linkArguments(), ["/fake/path/to/swiftc", "-lstdc++", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/liblib.so", "-module-name", "lib", "-emit-library", "-Xlinker", "-rpath=$ORIGIN", "/path/to/build/debug/lib.build/lib.cpp.o"])
-        XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), ["/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable", "-Xlinker", "-rpath=$ORIGIN", "/path/to/build/debug/exe.build/main.c.o"])
+        XCTAssertEqual(try result.buildProduct(for: "lib").linkArguments(), ["/fake/path/to/swiftc", "-lstdc++", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/liblib.so", "-module-name", "lib", "-emit-library", "-Xlinker", "-rpath=$ORIGIN", "@/path/to/build/debug/lib.product/Objects.LinkFileList"])
+        XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), ["/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable", "-Xlinker", "-rpath=$ORIGIN", "@/path/to/build/debug/exe.product/Objects.LinkFileList"])
     #endif
     }
 


### PR DESCRIPTION
This is required for packages with large number of dependencies which
may cause the command line invocation to surpass the arg max limit.

<rdar://problem/38803919> Unable to compile the code via terminal using swift test