### PR TITLE
[PackageLoading] Don't escape root package when searching for LinuxMain

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -937,8 +937,18 @@ public final class PackageBuilder {
 
         // Look for linux main file adjacent to each test target root, iterating upto package root.
         for target in testTargets {
+
+            // Form the initial search path.
+            //
+            // If the target root's parent directory is inside the package, start
+            // search there. Otherwise, we start search from the target root.
             var searchPath = target.sources.root.parentDirectory
+            if !searchPath.contains(packagePath) {
+                searchPath = target.sources.root
+            }
+
             while true {
+                assert(searchPath.contains(packagePath), "search path \(searchPath) is outside the package \(packagePath)")
                 // If we have already searched this path, skip.
                 if !pathsSearched.contains(searchPath) {
                     let linuxMain = searchPath.appending(component: SwiftTarget.linuxMainBasename)

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -1253,8 +1253,8 @@ final class PackageBuilderTester {
             XCTAssertEqual(product.targets.map{$0.name}.sorted(), targets.sorted(), file: file, line: line)
         }
 
-        func check(linuxMainPath: String, file: StaticString = #file, line: UInt = #line) {
-            XCTAssertEqual(product.linuxMain, AbsolutePath(linuxMainPath), file: file, line: line)
+        func check(linuxMainPath: String?, file: StaticString = #file, line: UInt = #line) {
+            XCTAssertEqual(product.linuxMain, linuxMainPath.map({ AbsolutePath($0) }), file: file, line: line)
         }
     }
 

--- a/Tests/PackageLoadingTests/PackageBuilderV4Tests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderV4Tests.swift
@@ -110,6 +110,38 @@ class PackageBuilderV4Tests: XCTestCase {
         }
     }
 
+    func testLinuxMainSearch() {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/pkg/foo.swift",
+            "/pkg/footests.swift"
+        )
+
+        let package = Package(
+            name: "pkg",
+            targets: [
+                .target(
+                    name: "exe",
+                    path: "./",
+                    sources: ["foo.swift"]
+                ),
+                .testTarget(
+                    name: "tests",
+                    path: "./",
+                    sources: ["footests.swift"]
+                ),
+            ]
+        )
+        PackageBuilderTester(package, path: AbsolutePath("/pkg"), in: fs) { result in
+            result.checkModule("exe") { _ in }
+            result.checkModule("tests") { _ in }
+
+            result.checkProduct("pkgPackageTests") { productResult in
+                productResult.check(type: .test, targets: ["tests"])
+                productResult.check(linuxMainPath: nil)
+            }
+        }
+    }
+
     func testLinuxMainError() {
         let fs = InMemoryFileSystem(emptyFiles:
             "/LinuxMain.swift",
@@ -1004,5 +1036,6 @@ class PackageBuilderV4Tests: XCTestCase {
         ("testSystemPackageDeclaresTargetsDiagnostic", testSystemPackageDeclaresTargetsDiagnostic),
         ("testSystemLibraryTarget", testSystemLibraryTarget),
         ("testSystemLibraryTargetDiagnostics", testSystemLibraryTargetDiagnostics),
+        ("testLinuxMainSearch", testLinuxMainSearch),
     ]
 }


### PR DESCRIPTION
There was an edge case where which lead swiftpm to escape the root package while searching for LinuxMain.

<rdar://problem/41444373> [SR-8072]: 4.2 dev hangs on `swift build` on mac and linux