### PR TITLE
Add an option to not delete TemporaryFile on dealloc

### DIFF
--- a/Sources/Basic/TemporaryFile.swift
+++ b/Sources/Basic/TemporaryFile.swift
@@ -74,6 +74,9 @@ public final class TemporaryFile {
 
     /// FileHandle of the temporary file, can be used to read/write data.
     public let fileHandle: FileHandle
+    
+    /// Whether the file should be deleted on dealloc.
+    public let deleteOnClose: Bool
 
     /// Creates an instance of Temporary file. The temporary file will live on disk until the instance
     /// goes out of scope.
@@ -84,11 +87,13 @@ public final class TemporaryFile {
     ///            set, dir will be set to `/tmp/`.
     ///     - prefix: The prefix to the temporary file name.
     ///     - suffix: The suffix to the temporary file name.
+    ///     - deleteOnClose: Whether the file should get deleted when the instance is deallocated.
     ///
     /// - Throws: TempFileError
-    public init(dir: AbsolutePath? = nil, prefix: String = "TemporaryFile", suffix: String = "") throws {
+    public init(dir: AbsolutePath? = nil, prefix: String = "TemporaryFile", suffix: String = "", deleteOnClose: Bool = true) throws {
         self.suffix = suffix
         self.prefix = prefix
+        self.deleteOnClose = deleteOnClose
         // Determine in which directory to create the temporary file.
         self.dir = determineTempDirectory(dir)
         // Construct path to the temporary file.
@@ -109,7 +114,9 @@ public final class TemporaryFile {
 
     /// Remove the temporary file before deallocating.
     deinit {
-        unlink(path.asString)
+        if deleteOnClose {
+            unlink(path.asString)
+        }
     }
 }
 

--- a/Tests/BasicTests/TemporaryFileTests.swift
+++ b/Tests/BasicTests/TemporaryFileTests.swift
@@ -70,6 +70,8 @@ class TemporaryFileTests: XCTestCase {
         }
         // File should not be deleted.
         XCTAssertTrue(isFile(filePath))
+        // Delete the file now
+        try localFileSystem.removeFileTree(filePath)
     }
 
     func testCanCreateUniqueTempFiles() throws {

--- a/Tests/BasicTests/TemporaryFileTests.swift
+++ b/Tests/BasicTests/TemporaryFileTests.swift
@@ -44,6 +44,33 @@ class TemporaryFileTests: XCTestCase {
         // File should be deleted now.
         XCTAssertFalse(isFile(filePath))
     }
+    
+    func testNoCleanupTemporaryFile() throws {
+        let filePath: AbsolutePath
+        do {
+            let file = try TemporaryFile(deleteOnClose: false)
+            
+            // Check if file is created.
+            XCTAssertTrue(isFile(file.path))
+            
+            // Try writing some data to the file.
+            let stream = BufferedOutputByteStream()
+            stream <<< "foo"
+            stream <<< "bar"
+            stream <<< "baz"
+            try fputs(stream.bytes.contents, file.fileHandle)
+            
+            // Go to the beginning of the file.
+            file.fileHandle.seek(toFileOffset: 0)
+            // Read the contents.
+            let contents = try? file.fileHandle.readFileContents()
+            XCTAssertEqual(contents, "foobarbaz")
+            
+            filePath = file.path
+        }
+        // File should not be deleted.
+        XCTAssertTrue(isFile(filePath))
+    }
 
     func testCanCreateUniqueTempFiles() throws {
         let filePathOne: AbsolutePath
@@ -133,6 +160,7 @@ class TemporaryFileTests: XCTestCase {
     static var allTests = [
         ("testBasicReadWrite", testBasicReadWrite),
         ("testCanCreateUniqueTempFiles", testCanCreateUniqueTempFiles),
+        ("testNoCleanupTemporaryFile", testNoCleanupTemporaryFile),
         ("testBasicTemporaryDirectory", testBasicTemporaryDirectory),
         ("testCanCreateUniqueTempDirectories", testCanCreateUniqueTempDirectories),
         ("testLeaks", testLeaks),


### PR DESCRIPTION
It's sometimes useful to create a temp file but keep it around for a little bit longer, instead of automatically deleting it on dealloc. `TemporaryDirectory` already has a similar option.