### PR TITLE
Fix SR-7830: move output from `loadPackageGraph()` to stderr for 'describe' subcommand

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -182,7 +182,7 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             }
 
         case .describe:
-            let graph = try loadPackageGraph()
+            let graph = try loadPackageGraph(outputTo: stderrStream)
             describe(graph.rootPackages[0].underlyingPackage, in: options.describeMode, on: stdoutStream)
 
         case .dumpPackage:


### PR DESCRIPTION
This fix passes all tests in the test suite on both MacOS and Ubuntu. The test suite does not, however, sufficiently exercise the changes. I have, of course, manually confirmed that it works. Ironically, writing an effective test for these changes is substantially more difficult than making the changes themselves.

I expect to submit a PR with a new or updated test separately in the next few days.