### PR TITLE
Mute non-json output from dump-package

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -186,9 +186,10 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             describe(graph.rootPackages[0].underlyingPackage, in: options.describeMode, on: stdoutStream)
 
         case .dumpPackage:
-            let graph = try loadPackageGraph()
-            let manifest = graph.rootPackages[0].manifest
-            print(try manifest.jsonString())
+            let workspace = try getActiveWorkspace()
+            let root = try getWorkspaceRoot()
+            let manifests = workspace.loadRootManifests(packages: root.packages, diagnostics: diagnostics)
+            print(try manifests[0].jsonString())
 
         case .completionTool:
             switch options.completionToolMode {


### PR DESCRIPTION

* Load manifest instead of loading package graph

(cherry picked from commit d1625514175be9b7e46830d24c3392334a8b9755)