### PR TITLE
[Workspace] Add deprecation warning for v3 manifests

### DIFF
--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -343,4 +343,18 @@ public enum WorkspaceDiagnostics {
             self.duration = duration
         }
     }
+
+    public struct PD3DeprecatedDiagnostic: DiagnosticData {
+        public static let id = DiagnosticID(
+            type: PD3DeprecatedDiagnostic.self,
+            name: "org.swift.diags.workspace.\(PD3DeprecatedDiagnostic.self)",
+            defaultBehavior: .warning,
+            description: {
+                $0 <<< "PackageDescription API v3 is deprecated and will be removed in the future;"
+                $0 <<< "used by package(s):" <<< { $0.manifests.joined(separator: ", ") }
+            }
+        )
+
+        let manifests: [String]
+    }
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -543,11 +543,20 @@ extension Workspace {
 
         // Perform dependency resolution, if required.
         let manifests = self._resolve(root: root, diagnostics: diagnostics)
+        let externalManifests = manifests.allManifests()
+
+        // Emit deprecation warning for v3 manifests.
+        let v3Manifests = (manifests.root.manifests + externalManifests).filter({ $0.manifestVersion == .v3 })
+        if !v3Manifests.isEmpty {
+            let warning = WorkspaceDiagnostics.PD3DeprecatedDiagnostic(
+                manifests: v3Manifests.map({ $0.name }))
+            diagnostics.emit(data: warning)
+        }
 
         // Load the graph.
         return PackageGraphLoader().load(
             root: manifests.root,
-            externalManifests: manifests.allManifests(),
+            externalManifests: externalManifests,
             diagnostics: diagnostics,
             fileSystem: fileSystem,
             shouldCreateMultipleTestProducts: createMultipleTestProducts

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -83,7 +83,8 @@ final class PackageToolTests: XCTestCase {
 
     func testDescribe() throws {
         fixture(name: "CFamilyTargets/SwiftCMixed") { prefix in
-            let output = try execute(["describe", "--type=json"], packagePath: prefix)
+            let result = try SwiftPMProduct.SwiftPackage.executeProcess(["describe", "--type=json"], packagePath: prefix)
+            let output = try result.utf8Output()
             let json = try JSON(bytes: ByteString(encodingAsUTF8: output))
 
             XCTAssertEqual(json["name"]?.string, "SwiftCMixed")
@@ -126,19 +127,17 @@ final class PackageToolTests: XCTestCase {
     func testShowDependencies() throws {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
             let packageRoot = prefix.appending(component: "app")
-            let textOutput = try execute(["show-dependencies", "--format=text"], packagePath: packageRoot)
+            let textOutput = try SwiftPMProduct.SwiftPackage.executeProcess(["show-dependencies", "--format=text"], packagePath: packageRoot).utf8Output()
             XCTAssert(textOutput.contains("FisherYates@1.2.3"))
 
-            // FIXME: We have to fetch first otherwise the fetching output is mingled with the JSON data.
-            let jsonOutput = try execute(["show-dependencies", "--format=json"], packagePath: packageRoot)
-            print("output = \(jsonOutput)")
+            let jsonOutput = try SwiftPMProduct.SwiftPackage.executeProcess(["show-dependencies", "--format=json"], packagePath: packageRoot).utf8Output()
             let json = try JSON(bytes: ByteString(encodingAsUTF8: jsonOutput))
             guard case let .dictionary(contents) = json else { XCTFail("unexpected result"); return }
             guard case let .string(name)? = contents["name"] else { XCTFail("unexpected result"); return }
             XCTAssertEqual(name, "Dealer")
             guard case let .string(path)? = contents["path"] else { XCTFail("unexpected result"); return }
             XCTAssertEqual(resolveSymlinks(AbsolutePath(path)), resolveSymlinks(packageRoot))
-        }
+        } 
     }
 
     func testInitEmpty() throws {

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -34,6 +34,7 @@ class MiscellaneousTestCase: XCTestCase {
             let output = try executeSwiftBuild(prefix.appending(component: "Bar"))
             XCTAssertTrue(output.contains("Resolving"))
             XCTAssertTrue(output.contains("at 1.2.3"))
+            XCTAssertTrue(output.contains("warning: PackageDescription API v3 is deprecated and will be removed in the future; used by package(s): Bar, Foo"))
         }
     }
 


### PR DESCRIPTION
<rdar://problem/41792011> Emit deprecation notice if there is a v3 manifest in a package graph

Emits a deprecation warning if there are v3 manifests in a
package graph.

(cherry picked from commit c9220990855f90671a974c85c5feeda6fc722591)