### PR TITLE
[PackageGraph] Filter unversioned pins before running the debug algo

### DIFF
--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -1332,7 +1332,7 @@ private struct ResolverDebugger<
     /// This algorithm can be exponential, so we abort after the predefined time limit.
     func debug(
         dependencies inputDependencies: [Constraint],
-        pins: [Constraint]
+        pins inputPins: [Constraint]
     ) throws -> (dependencies: [Constraint], pins: [Constraint]) {
 
         // Form the dependencies array.
@@ -1353,10 +1353,12 @@ private struct ResolverDebugger<
             }
         }
 
-        // Remove the unversioned constraints which may be added as result of the above loop.
-        dependencies = dependencies.filter({ dep in
-            return !inputDependencies.contains(where: { $0.identifier == dep.identifier && $0.requirement == .unversioned })
-        })
+        // Form a set of all unversioned dependencies.
+        let unversionedDependencies = Set(inputDependencies.filter({ $0.requirement == .unversioned }).map({ $0.identifier }))
+
+        // Remove the unversioned constraints from dependencies and pins.
+        dependencies = dependencies.filter({ !unversionedDependencies.contains($0.identifier) })
+        let pins = inputPins.filter({ !unversionedDependencies.contains($0.identifier) })
 
         // Put the resolver in incomplete mode to avoid cloning new repositories.
         resolver.isInIncompleteMode = true

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -1682,12 +1682,15 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkManagedDependencies { result in
             result.check(dependency: "foo", at: .edited(nil))
         }
+        workspace.checkResolved() { result in
+            result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
+        }
 
         // Try resolving a bad graph.
         let deps: [TestWorkspace.PackageDependency] = [
             .init(name: "Bar", requirement: .exact("1.1.0")),
         ]
-        workspace.checkUpdate(roots: ["Root"], deps: deps) { diagnostics in
+        workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(diagnostic: .contains("/tmp/ws/pkgs/Bar @ 1.1.0"), behavior: .error)
             }


### PR DESCRIPTION
<rdar://problem/39616386> Crash under BasePackageContainer.versions(filter:)
https://bugs.swift.org/browse/SR-8177

(cherry picked from commit be4bc8c444454443e94f8d6f6c88fbb65e1db85a)