### PR TITLE
Create a shim target for llbuild library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -89,6 +89,10 @@ let package = Package(
             /** Source control operations */
             name: "SourceControl",
             dependencies: ["Basic", "Utility"]),
+        .target(
+            /** Shim for llbuild library */
+            name: "SPMLLBuild",
+            dependencies: ["Basic", "Utility"]),
 
         // MARK: Project Model
         
@@ -99,7 +103,7 @@ let package = Package(
         .target(
             /** Package model conventions and loading support */
             name: "PackageLoading",
-            dependencies: ["Basic", "PackageModel", "Utility"]),
+            dependencies: ["Basic", "PackageModel", "Utility", "SPMLLBuild"]),
 
         // MARK: Package Dependency Resolution
         

--- a/Sources/SPMLLBuild/llbuild.swift
+++ b/Sources/SPMLLBuild/llbuild.swift
@@ -1,0 +1,17 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+#if canImport(llbuildSwift)
+@_exported import llbuildSwift
+#elseif canImport(llbuild)
+@_exported import llbuild
+#else
+// This should be a hard error in future.
+#endif

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -1145,6 +1145,9 @@ def main():
                 llbuild_libs_rpath = "$ORIGIN/../lib/swift/pm/llbuild"
             build_flags.extend(["-Xlinker", "-rpath", "-Xlinker", llbuild_libs_rpath])
 
+        if args.llbuild_link_framework:
+            build_flags.extend(["-Xswiftc", "-F%s" % args.llbuild_build_dir])
+
         # Add llbuild link flags.
         build_flags.extend(llbuild_link_args(args))
     


### PR DESCRIPTION
This target is a bridge between llbuild library and rest of the swiftpm
targets. The llbuild module is re-exported by the module.