### PR TITLE
[bootstrap] Remove an useless check

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -829,9 +829,6 @@ def installBinary(binary_path, install_path, swiftc_path, add_rpaths=[], delete_
         # Add additional RPATHs, if requested.
         for rpath in add_rpaths:
             add_rpath(rpath, installed_path)
-    else:
-        if add_rpath:
-            error("unable to add RPATHs on this platform")
 
 
 def llbuild_import_paths(args):


### PR DESCRIPTION
This check was checking the method instead of the variable due to the
recent changes. Removing it as its not really required.