### PR TITLE
[PackageLoading] Diagnose bad executable products

### DIFF
--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -113,4 +113,16 @@ public enum PackageBuilderDiagnostics {
 
         let product: String
     }
+
+    struct InvalidExecutableProductDecl: DiagnosticData {
+        static let id = DiagnosticID(
+            type: InvalidExecutableProductDecl.self,
+            name: "org.swift.diags.pkg-builder.invalid-exec-product",
+            description: {
+                $0 <<< "executable product" <<< { "'" + $0.product + "'" } <<< "should have exactly one executable target"
+            }
+        )
+
+        let product: String
+    }
 }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -882,6 +882,22 @@ public final class PackageBuilder {
                     continue
                 }
             }
+
+            // Do some validation for executable products.
+            switch product.type {
+            case .library, .test:
+                break
+            case .executable:
+                let executableTargets = targets.filter({ $0.type == .executable })
+                if executableTargets.count != 1 {
+                    diagnostics.emit(
+                        data: PackageBuilderDiagnostics.InvalidExecutableProductDecl(product: product.name),
+                        location: PackageLocation.Local(name: manifest.name, packagePath: packagePath)
+                    )
+                    continue
+                }
+            }
+
             append(Product(name: product.name, type: product.type, targets: targets))
         }
 

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -1251,6 +1251,26 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
+    func testBadExecutableProductDecl() {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/foo/foo.swift"
+        )
+
+        let manifest = Manifest.createV4Manifest(
+            name: "MyPackage",
+            products: [
+                ProductDescription(name: "foo", type: .executable, targets: ["foo"]),
+            ],
+            targets: [
+                TargetDescription(name: "foo"),
+            ]
+        )
+        PackageBuilderTester(manifest, in: fs) { result in
+            result.checkModule("foo") { _ in }
+            result.checkDiagnostic("executable product \'foo\' should have exactly one executable target")
+        }
+    }
+
     static var allTests = [
         ("testCInTests", testCInTests),
         ("testDotFilesAreIgnored", testDotFilesAreIgnored),
@@ -1282,6 +1302,7 @@ class PackageBuilderTests: XCTestCase {
         ("testSystemLibraryTarget", testSystemLibraryTarget),
         ("testSystemLibraryTargetDiagnostics", testSystemLibraryTargetDiagnostics),
         ("testLinuxMainSearch", testLinuxMainSearch),
+        ("testBadExecutableProductDecl", testBadExecutableProductDecl),
     ]
 }
 


### PR DESCRIPTION
<rdar://problem/42138100> Incorrect product reference in Package.swift caused failed build on linux, succeeded on macOS