### PR TITLE
[SR-8138] add --num-workers option to limit the parallelism of `swift test --parallel`

### DIFF
--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -57,6 +57,8 @@ final class TestToolTests: XCTestCase {
     }
     
     func testNumWorkersParallelRequeriment() throws {
+        // Running swift-test fixtures on linux is not yet possible.
+        #if os(macOS)
         fixture(name: "Miscellaneous/EchoExecutable") { path in
             do {
                 _ = try execute(["--num-workers", "1"])
@@ -65,16 +67,19 @@ final class TestToolTests: XCTestCase {
                 XCTAssertEqual(stderr, "error: --num-workers must be used with --parallel\nerror: fatalError\n")
             }
         }
+        #endif
     }
     
     func testNumWorkersValue() throws {
+        #if os(macOS)
         fixture(name: "Miscellaneous/EchoExecutable") { path in
             do {
-                _ = try execute(["--parallel --num-workers", "0"])
+                _ = try execute(["--parallel", "--num-workers", "0"])
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
                 // FIXME: remove "error: fatalError\n" when https://bugs.swift.org/browse/SR-8338 gets fixed
                 XCTAssertEqual(stderr, "error: '--num-workers' must be greater than zero\nerror: fatalError\n")
             }
         }
+        #endif
     }
 }

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -55,4 +55,26 @@ final class TestToolTests: XCTestCase {
         }
       #endif
     }
+    
+    func testNumWorkersParallelRequeriment() throws {
+        fixture(name: "Miscellaneous/EchoExecutable") { path in
+            do {
+                _ = try execute(["--num-workers", "1"])
+            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
+                // FIXME: remove "error: fatalError\n" when https://bugs.swift.org/browse/SR-8338 gets fixed
+                XCTAssertEqual(stderr, "error: --num-workers must be used with --parallel\nerror: fatalError\n")
+            }
+        }
+    }
+    
+    func testNumWorkersValue() throws {
+        fixture(name: "Miscellaneous/EchoExecutable") { path in
+            do {
+                _ = try execute(["--parallel --num-workers", "0"])
+            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
+                // FIXME: remove "error: fatalError\n" when https://bugs.swift.org/browse/SR-8338 gets fixed
+                XCTAssertEqual(stderr, "error: '--num-workers' must be greater than zero\nerror: fatalError\n")
+            }
+        }
+    }
 }

--- a/Tests/CommandsTests/XCTestManifests.swift
+++ b/Tests/CommandsTests/XCTestManifests.swift
@@ -52,6 +52,8 @@ extension RunToolTests {
 
 extension TestToolTests {
     static let __allTests = [
+        ("testNumWorkersParallelRequeriment", testNumWorkersParallelRequeriment),
+        ("testNumWorkersValue", testNumWorkersValue),
         ("testSanitizeThread", testSanitizeThread),
         ("testSeeAlso", testSeeAlso),
         ("testUsage", testUsage),


### PR DESCRIPTION
This adds --num-workers option to specify how many workers we want in the test.

Example: `swift test --num-workers 4`