### PR TITLE
Emit a script allow self-hosting SwiftPM after bootstrap

### DIFF
--- a/Documentation/Development.md
+++ b/Documentation/Development.md
@@ -76,22 +76,22 @@ using a [snapshot](https://swift.org/download/#releases) from swift.org.
 
 ## Self-hosting
 
-It is possible to build the Package Manager with itself. This is useful when you
-want to rebuild just the sources or run a single test. Make sure you run the
-bootstrap script first.
+It is possible to build SwiftPM with itself using a special script that is
+emitted during bootstrapping. This is useful when you want to rebuild just the
+sources or run a single test. Make sure you run the bootstrap script first.
 
 ```sh
 $ cd swiftpm
 
 # Rebuild just the sources.
-$ .build/x86_64-apple-macosx10.10/debug/swift-build
+$ .build/x86_64-apple-macosx10.10/debug/spm build
 
 # Run a single test.
-$ .build/x86_64-apple-macosx10.10/debug/swift-test --filter BasicTests.GraphAlgorithmsTests/testCycleDetection
+$ .build/x86_64-apple-macosx10.10/debug/spm test --filter BasicTests.GraphAlgorithmsTests/testCycleDetection
 ```
 
-Note: If you make any changes to `PackageDescription` or `PackageDescription4`
-target, you **will** need to rebuild using the bootstrap script.
+Note: If you make any changes to `PackageDescription` runtime-related targets,
+you **will** need to rebuild using the bootstrap script.
 
 ## Developing using Xcode
 

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -39,6 +39,7 @@ import os
 import pipes
 import platform
 import re
+import stat
 import shlex
 import shutil
 import subprocess
@@ -857,6 +858,46 @@ def llbuild_link_args(args):
     build_flags.extend(["-Xlinker", "-rpath", "-Xlinker", llbuild_libdir])
     return build_flags
 
+def write_self_hosting_script(path, args):
+    # Construct the build flags.
+    swiftpm_flags = []
+    for import_path in llbuild_import_paths(args):
+        swiftpm_flags.extend(["-Xswiftc", "-I%s" % import_path])
+    if args.llbuild_link_framework:
+        swiftpm_flags.extend(["-Xswiftc", "-F%s" % args.llbuild_build_dir])
+    swiftpm_flags.extend(llbuild_link_args(args))
+
+    # Construct the string from the build flags.
+    swiftpm_flags_str = ' '.join(('"%s"' % flag) for flag in swiftpm_flags)
+
+    script_contents = """#!/usr/bin/env bash
+
+# Helper script for self-hosting SwiftPM tools.
+ 
+set -e
+
+if [ ! -z "$SPM_VERBOSE" ]; then
+    set -x
+fi
+
+if [ -z "$1" ]; then
+    echo "provide the executable name: build|test|package|run" && exit 1
+fi
+
+__dir="$(cd "$(dirname "${{BASH_SOURCE[0]}}")" && pwd)"
+
+SPM_FLAGS=({options})
+
+exec ${{__dir}}/swift-$1 ${{SPM_FLAGS[@]}} "${{@:2}}" """.format(options=swiftpm_flags_str)
+
+    script_path = os.path.join(path, "spm")
+    with open(script_path, "w") as f:
+        print(script_contents, file=f)
+
+    st = os.stat(script_path)
+    os.chmod(script_path, st.st_mode | stat.S_IEXEC)
+
+
 def main():
     parser = argparse.ArgumentParser(
         usage="%(prog)s [options] [clean|all|test|install]",
@@ -1193,6 +1234,9 @@ def main():
     result = subprocess.call(cmd, cwd=g_project_root)
     if result != 0:
         error("build failed with exit status %d" % (result,))
+
+    # Write the script to allow self-hosting for development.
+    write_self_hosting_script(os.path.join(target_path, conf), args)
 
     swift_package_path = os.path.join(target_path, conf, "swift-package")
     swiftpm_build_dir = os.path.join(target_path, conf, "swift-build")


### PR DESCRIPTION
<rdar://problem/42350010> Emit a script allow self-hosting SwiftPM after bootstrap

SwiftPM allowed using the built/inferior swift-{build, package, run, test} to
iterate on the package manager codebase. This is going to break now because we
adopted llbuild as a link time dependency. To resolve this, the bootstrap
script will emit a script that will call the swiftpm tool with the additional
flags that are required to allow self-hosting. This can be removed once we have
actual support for build settings.