### PR TITLE
[Xcodeproj] Fix extra directories method

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -377,10 +377,10 @@ public final class PackageBuilder {
     }
 
     /// Predefined source directories, in order of preference.
-    static let predefinedSourceDirectories = ["Sources", "Source", "src", "srcs"]
+    public static let predefinedSourceDirectories = ["Sources", "Source", "src", "srcs"]
 
     /// Predefined test directories, in order of preference.
-    static let predefinedTestDirectories = ["Tests", "Sources", "Source", "src", "srcs"]
+    public static let predefinedTestDirectories = ["Tests", "Sources", "Source", "src", "srcs"]
 
     /// Finds the predefined directories for regular and test targets.
     private func findPredefinedTargetDirectory() -> (targetDir: String, testTargetDir: String) {

--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -180,6 +180,7 @@ func findDirectoryReferences(path: AbsolutePath) throws -> [AbsolutePath] {
         if $0.suffix == ".xcodeproj" { return false }
         if $0.suffix == ".playground" { return false }
         if $0.basename.hasPrefix(".") { return false }
+        if PackageBuilder.predefinedTestDirectories.contains($0.basename) { return false }
         return isDirectory($0)
     })
 }


### PR DESCRIPTION
I think I broke this method when removing PD v3. We need to ignore
predefined directories while creating the Xcode project.

<rdar://problem/42134605> The generated Xcode project has blue folders for Sources and Tests in SwiftPM