### PR TITLE
[PackageLoading] Initialize build engine lazily

### DIFF
--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -94,7 +94,7 @@ class DependencyResolverPerfTests: XCTestCasePerf {
                 delegate: GitRepositoryResolutionHelper.DummyRepositoryManagerDelegate()
             )
 
-            let containerProvider = try RepositoryPackageContainerProvider(
+            let containerProvider = RepositoryPackageContainerProvider(
                 repositoryManager: repositoryManager, manifestLoader: ManifestLoader(resources: Resources.default, isManifestCachingEnabled: false, cacheDir: path))
 
             let resolver = DependencyResolver(containerProvider, GitRepositoryResolutionHelper.DummyResolverDelegate())

--- a/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
+++ b/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
@@ -15,7 +15,7 @@ import TestSupport
 import PackageLoading
 
 class ManifestLoadingPerfTests: XCTestCasePerf {
-    let manifestLoader = try! ManifestLoader(resources: Resources.default, isManifestCachingEnabled: false)
+    let manifestLoader = ManifestLoader(resources: Resources.default, isManifestCachingEnabled: false)
 
     func write(_ bytes: ByteString, body: (AbsolutePath) -> ()) {
         mktmpdir { path in

--- a/Tests/PackageLoadingTests/PD4LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4LoadingTests.swift
@@ -19,7 +19,7 @@ import TestSupport
 import PackageLoading
 
 class PackageDescription4LoadingTests: XCTestCase {
-    let manifestLoader = try! ManifestLoader(resources: Resources.default, isManifestCachingEnabled: false)
+    let manifestLoader = ManifestLoader(resources: Resources.default, isManifestCachingEnabled: false)
 
     private func loadManifestThrowing(
         _ contents: ByteString,

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -18,7 +18,7 @@ import PackageLoading
 
 // FIXME: We should share the infra with other loading tests.
 class PackageDescription4_2LoadingTests: XCTestCase {
-    let manifestLoader = try! ManifestLoader(resources: Resources.default, isManifestCachingEnabled: false)
+    let manifestLoader = ManifestLoader(resources: Resources.default, isManifestCachingEnabled: false)
 
     private func loadManifestThrowing(
         _ contents: ByteString,
@@ -329,7 +329,7 @@ class PackageDescription4_2LoadingTests: XCTestCase {
             }
 
             let delegate = ManifestTestDelegate()
-            let manifestLoader = try! ManifestLoader(
+            let manifestLoader = ManifestLoader(
                 resources: Resources.default, cacheDir: path, delegate: delegate)
 
             func check(loader: ManifestLoader, expectCached: Bool) {
@@ -372,7 +372,7 @@ class PackageDescription4_2LoadingTests: XCTestCase {
                 check(loader: manifestLoader, expectCached: true)
             }
 
-            let noCacheLoader = try! ManifestLoader(
+            let noCacheLoader = ManifestLoader(
                 resources: Resources.default, isManifestCachingEnabled: false, delegate: delegate)
             for _ in 0..<2 {
                 check(loader: noCacheLoader, expectCached: false)

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -121,7 +121,7 @@ final class WorkspaceTests: XCTestCase {
                 """
             }
 
-            let manifestLoader = try ManifestLoader(
+            let manifestLoader = ManifestLoader(
                 resources: Resources.default, isManifestCachingEnabled: false)
 
             let sandbox = path.appending(component: "ws")


### PR DESCRIPTION
<rdar://problem/42399854> swift-package crash on clean

This avoids creating the build engine when its not really needed.