### PR TITLE
[PackageGraph] Remove a unnecessary assertion

### DIFF
--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -122,7 +122,6 @@ extension PackageDependencyDescription.Requirement {
             return .versionSet(.range(range))
 
         case .revision(let identifier):
-            assert(identifier.count == 40)
             assert(Git.checkRefFormat(ref: identifier))
 
             return .revision(identifier)


### PR DESCRIPTION
<rdar://problem/40617721> [SR-7796]: Assertion failed: : file /Users/buildnode/jenkins/workspace/oss-swift-4.2-package-osx/swiftpm/Sources/PackageGraph/PackageGraphRoot.swift, line 124

I was overly strict and added an assertion to check that revision
dependencies have git hash length of 40. I don't think that check is
actually needed because we do validate the git ref.