### PR TITLE
[Commands] Move generated __allTests entries under #if

### DIFF
--- a/Sources/Commands/GenerateLinuxMain.swift
+++ b/Sources/Commands/GenerateLinuxMain.swift
@@ -57,6 +57,7 @@ final class LinuxMainGenerator {
             let testManifest = target.sources.root.appending(component: "XCTestManifests.swift")
             let stream = try LocalFileOutputByteStream(testManifest)
 
+            stream <<< "#if !os(macOS)" <<< "\n"
             stream <<< "import XCTest" <<< "\n"
             for klass in module.classes.lazy.sorted(by: { $0.name < $1.name }) {
                 stream <<< "\n"
@@ -72,7 +73,6 @@ final class LinuxMainGenerator {
             stream <<<
             """
 
-            #if !os(macOS)
             public func __allTests() -> [XCTestCaseEntry] {
                 return [
 

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -401,6 +401,7 @@ class MiscellaneousTestCase: XCTestCase {
             // Check test manifest.
             let testManifest = prefix.appending(components: "Tests", "ParallelTestsPkgTests", "XCTestManifests.swift")
             XCTAssertEqual(try fs.readFileContents(testManifest), """
+                #if !os(macOS)
                 import XCTest
 
                 extension ParallelTestsFailureTests {
@@ -416,7 +417,6 @@ class MiscellaneousTestCase: XCTestCase {
                     ]
                 }
                 
-                #if !os(macOS)
                 public func __allTests() -> [XCTestCaseEntry] {
                     return [
                         testCase(ParallelTestsFailureTests.__allTests),


### PR DESCRIPTION
<rdar://problem/40489163> [SR-7754]: Generating LinuxMain breaks when renaming a test

This prevents the generated entries to be considered as source code on
macOS as that can lead to compilation errors when a test is renamed or
removed.