### PR TITLE
[Commands] Don't print fatalError diagnostic

### DIFF
--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -22,9 +22,6 @@ enum Error: Swift.Error {
 
     /// The root manifest was not found.
     case rootManifestFileNotFound
-
-    /// There were fatal diagnostics during the operation.
-    case hasFatalDiagnostics
 }
 
 extension Error: CustomStringConvertible {
@@ -34,8 +31,6 @@ extension Error: CustomStringConvertible {
             return problem
         case .rootManifestFileNotFound:
             return "root manifest not found"
-        case .hasFatalDiagnostics:
-            return ""
         }
     }
 }
@@ -56,7 +51,7 @@ public func handle(error: Any) {
 private func _handle(_ error: Any) {
 
     switch error {
-    case Error.hasFatalDiagnostics:
+    case Diagnostics.fatalError:
         break
 
     case ArgumentParserError.expectedArguments(let parser, _):

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -470,7 +470,7 @@ public class SwiftTool<Options: ToolOptions> {
             // Call the implementation.
             try runImpl()
             if diagnostics.hasErrors {
-                throw Error.hasFatalDiagnostics
+                throw Diagnostics.fatalError
             }
         } catch {
             // Set execution status to failure in case of errors.
@@ -508,7 +508,7 @@ public class SwiftTool<Options: ToolOptions> {
         // Throw if there were errors when loading the graph.
         // The actual errors will be printed before exiting.
         guard !diagnostics.hasErrors else {
-            throw Error.hasFatalDiagnostics
+            throw Diagnostics.fatalError
         }
     }
 
@@ -526,7 +526,7 @@ public class SwiftTool<Options: ToolOptions> {
             // The actual errors will be printed before exiting.
             guard !diagnostics.hasErrors else {
                 try buildManifestRegenerationToken().set(valid: false)
-                throw Error.hasFatalDiagnostics
+                throw Diagnostics.fatalError
             }
             try buildManifestRegenerationToken().set(valid: true)
             return graph

--- a/Sources/Commands/WatchmanHelper.swift
+++ b/Sources/Commands/WatchmanHelper.swift
@@ -98,6 +98,6 @@ final class WatchmanHelper {
             return toolPath
         }
         diagnostics.emit(data: WatchmanMissingDiagnostic())
-        throw Error.hasFatalDiagnostics
+        throw Diagnostics.fatalError
     }
 }

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -63,8 +63,7 @@ final class TestToolTests: XCTestCase {
             do {
                 _ = try execute(["--num-workers", "1"])
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                // FIXME: remove "error: fatalError\n" when https://bugs.swift.org/browse/SR-8338 gets fixed
-                XCTAssertEqual(stderr, "error: --num-workers must be used with --parallel\nerror: fatalError\n")
+                XCTAssertEqual(stderr, "error: --num-workers must be used with --parallel\n")
             }
         }
         #endif
@@ -76,8 +75,7 @@ final class TestToolTests: XCTestCase {
             do {
                 _ = try execute(["--parallel", "--num-workers", "0"])
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                // FIXME: remove "error: fatalError\n" when https://bugs.swift.org/browse/SR-8338 gets fixed
-                XCTAssertEqual(stderr, "error: '--num-workers' must be greater than zero\nerror: fatalError\n")
+                XCTAssertEqual(stderr, "error: '--num-workers' must be greater than zero\n")
             }
         }
         #endif


### PR DESCRIPTION
The Diagnostics.fatalError error is used to abort the execution. The
actual diagnostics are expected to be present in the DiagnosticsEngine.

<rdar://problem/42511641> [SR-8338]: 'Diagnostics.fatalError' should not print out to console