### PR TITLE
[Build] Diagnose graphs that have no buildable targets

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -534,9 +534,21 @@ public protocol BuildPlanDelegate: class {
 /// A build plan for a package graph.
 public class BuildPlan {
 
-    public enum Error: Swift.Error {
+    public enum Error: Swift.Error, CustomStringConvertible, Equatable {
         /// The linux main file is missing.
         case missingLinuxMain
+
+        /// There is no buildable target in the graph.
+        case noBuildableTarget
+
+        public var description: String {
+            switch self {
+            case .missingLinuxMain:
+                return "missing LinuxMain.swift file"
+            case .noBuildableTarget:
+                return "the package does not contain a buildable target"
+            }
+        }
     }
 
     /// The build parameters.
@@ -600,6 +612,11 @@ public class BuildPlan {
              default:
                  fatalError("unhandled \(target.underlyingTarget)")
              }
+        }
+
+        /// Ensure we have at least one buildable target.
+        guard !targetMap.isEmpty else {
+            throw Error.noBuildableTarget
         }
 
         if buildParameters.triple.isLinux() {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -801,6 +801,30 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(Set(result.productMap.keys), ["aexec", "BLibrary", "bexec", "cexec"])
         XCTAssertEqual(Set(result.targetMap.keys), ["ATarget", "BTarget1", "BTarget2", "CTarget"])
     }
+
+    func testSystemPackageBuildPlan() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Pkg/module.modulemap"
+        )
+
+        let diagnostics = DiagnosticsEngine()
+        let graph = loadPackageGraph(root: "/Pkg", fs: fs, diagnostics: diagnostics,
+            manifests: [
+                Manifest.createV4Manifest(
+                    name: "Pkg",
+                    path: "/Pkg",
+                    url: "/Pkg"
+                ),
+            ]
+        )
+        XCTAssertNoDiagnostics(diagnostics)
+
+        XCTAssertThrows(BuildPlan.Error.noBuildableTarget) {
+            _ = try BuildPlan(
+                buildParameters: mockBuildParameters(),
+                graph: graph, diagnostics: diagnostics, fileSystem: fs)
+        }
+    }
 }
 
 // MARK:- Test Helpers

--- a/Tests/BuildTests/XCTestManifests.swift
+++ b/Tests/BuildTests/XCTestManifests.swift
@@ -15,6 +15,7 @@ extension BuildPlanTests {
         ("testExecAsDependency", testExecAsDependency),
         ("testNonReachableProductsAndTargets", testNonReachableProductsAndTargets),
         ("testSwiftCMixed", testSwiftCMixed),
+        ("testSystemPackageBuildPlan", testSystemPackageBuildPlan),
         ("testTestModule", testTestModule),
     ]
 }


### PR DESCRIPTION
<rdar://problem/33057869> [SR-5383]: Display appropriate message when trying to build system module packages