### PR TITLE
[Commands] Skip test cases with no tests

### DIFF
--- a/Sources/Commands/GenerateLinuxMain.swift
+++ b/Sources/Commands/GenerateLinuxMain.swift
@@ -165,7 +165,12 @@ private final class ModulesBuilder {
         for testCase in cases {
             let (module, theKlass) = testCase.name.split(around: ".")
             guard let klass = theKlass else {
-                fatalError("Unsupported test case name \(testCase.name)")
+                // This should only happen if there are no tests in the test case.
+                if testCase.tests.isEmpty {
+                    print("warning: \(testCase.name) does not contain any tests")
+                    continue
+                }
+                fatalError("unreachable \(testCase.name)")
             }
             for method in testCase.tests {
                 add(module, klass, method)


### PR DESCRIPTION
This prevents a crash when a test class doesn't contain any test
methods.

<rdar://problem/42554220> swift test --generate-linuxmain can't handle tests with underscores in the name