### PR TITLE
[Commands] Remove build manifest caching

### DIFF
--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -53,16 +53,9 @@ public class SwiftBuildTool: SwiftTool<BuildToolOptions> {
 
             guard let subset = options.buildSubset(diagnostics: diagnostics) else { return }
           
-            // Check if we need to generate the llbuild manifest.
-            let regenerateManifest = try shouldRegenerateManifest()
-            if regenerateManifest {
-                // Create the build plan and build normally.
-                let plan = try BuildPlan(buildParameters: buildParameters(), graph: loadPackageGraph(), diagnostics: diagnostics)
-                try build(plan: plan, subset: subset)
-            } else {
-                // Otherwise, run llbuild directly.
-                try build(parameters: buildParameters(), subset: subset)
-            }
+           // Create the build plan and build.
+           let plan = try BuildPlan(buildParameters: buildParameters(), graph: loadPackageGraph(), diagnostics: diagnostics)
+           try build(plan: plan, subset: subset)
 
         case .binPath:
             try print(buildParameters().buildPath.asString)

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -177,30 +177,4 @@ final class BuildToolTests: XCTestCase {
             }
         }
     }
-
-    func testLLBuildManifestCachingBasics() {
-        fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { path in
-            let fs = localFileSystem
-
-            // First run should produce output.
-            var output = try execute(["--enable-build-manifest-caching"], packagePath: path)
-            XCTAssert(!output.isEmpty, output)
-
-            // Null builds.
-            output = try execute(["--enable-build-manifest-caching"], packagePath: path)
-            XCTAssert(output.isEmpty, output)
-
-            output = try execute(["--enable-build-manifest-caching"], packagePath: path)
-            XCTAssert(output.isEmpty, output)
-
-            // Adding a new file should reset the token.
-            try fs.writeFileContents(path.appending(components: "Sources", "ExecutableNew", "bar.swift"), bytes: "")
-            output = try execute(["--enable-build-manifest-caching"], packagePath: path)
-            XCTAssert(!output.isEmpty, output)
-
-            // This should be another null build.
-            output = try execute(["--enable-build-manifest-caching"], packagePath: path)
-            XCTAssert(output.isEmpty, output)
-        }
-    }
 }

--- a/Tests/CommandsTests/XCTestManifests.swift
+++ b/Tests/CommandsTests/XCTestManifests.swift
@@ -4,7 +4,6 @@ import XCTest
 extension BuildToolTests {
     static let __allTests = [
         ("testBinPathAndSymlink", testBinPathAndSymlink),
-        ("testLLBuildManifestCachingBasics", testLLBuildManifestCachingBasics),
         ("testNonReachableProductsAndTargetsFunctional", testNonReachableProductsAndTargetsFunctional),
         ("testProductAndTarget", testProductAndTarget),
         ("testSeeAlso", testSeeAlso),


### PR DESCRIPTION
<rdar://problem/42583418> Remove build manifest caching

The build manifest caching provides a preformance win but creating build
plan is now faster (than build manifest caching) because of package
manifest caching. The difference is about 100ms and we can bring the
time down by optimizing the tools lookup. However, this feature is not
critical anymore because the performance is decent with package manifest
caching. We can add it back in the future when required.
￼