### PR TITLE
WIP Specific include paths

### DIFF
--- a/Sources/Build/ToolProtocol.swift
+++ b/Sources/Build/ToolProtocol.swift
@@ -127,8 +127,9 @@ struct SwiftCompilerTool: ToolProtocol {
             <<< Format.asJSON(inputs) <<< "\n"
         stream <<< "    outputs: "
             <<< Format.asJSON(outputs) <<< "\n"
-        stream <<< "    import-paths: "
-            <<< Format.asJSON([target.buildParameters.buildPath.asString]) <<< "\n"
+        // XXX see BuildPlan.swift:927
+        // stream <<< "    import-paths:"
+        //     <<< Format.asJSON([]) <<< "\n"
         stream <<< "    temps-path: "
             <<< Format.asJSON(target.tempsPath.asString) <<< "\n"
         stream <<< "    objects: "


### PR DESCRIPTION
This is a partially working proof of concept. It doesn't yet properly
handle clang modules and a few other corner cases. Tests and a bunch of cleanup is notably missing. This is able to compile a simple-ish project with external dependencies but doesn't yet work to bootstrap spm itself.

This is more about highlighting the various tradeoffs and triggering
some discussion. I want to validate that this is the correct approach first. The empty import-paths in the llbuild file in particular seems unfortunate.