### PR TITLE
[Build] Emit BuildPlan diagnostics to DiagnosticsEngine

### DIFF
--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -30,6 +30,17 @@ struct SpecifierDeprecatedDiagnostic: DiagnosticData {
     )
 }
 
+struct LinuxTestDiscoveryDiagnostic: DiagnosticData {
+    static let id = DiagnosticID(
+        type: LinuxTestDiscoveryDiagnostic.self,
+        name: "org.swift.diags.linux-test-discovery",
+        defaultBehavior: .warning,
+        description: {
+            $0 <<< "can't discover tests on Linux; please use this option on macOS instead"
+        }
+    )
+}
+
 /// Diagnostic data for zero --filter matches.
 struct NoMatchingTestsWarning: DiagnosticData {
     static let id = DiagnosticID(
@@ -185,7 +196,7 @@ public class SwiftTestTool: SwiftTool<TestToolOptions> {
 
         case .generateLinuxMain:
           #if os(Linux)
-            warning(message: "can't discover new tests on Linux; please use this option on macOS instead")
+            diagnostics.emit(data: LinuxTestDiscoveryDiagnostic())
           #endif
             let graph = try loadPackageGraph()
             let testPath = try buildTestsIfNeeded(options, graph: graph)

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -572,11 +572,6 @@ public class SwiftTool<Options: ToolOptions> {
     
     /// Build a subset of products and targets using swift-build-tool.
     func build(plan: BuildPlan, subset: BuildSubset) throws {
-        guard !plan.graph.rootPackages[0].targets.isEmpty else {
-            warning(message: "no targets to build in package")
-            return
-        }
-
         guard let llbuildTargetName = subset.llbuildTargetName(for: plan.graph, diagnostics: diagnostics) else {
             return
         }
@@ -736,13 +731,6 @@ enum BuildSubset {
 
     /// Represents a specific target.
     case target(String)
-}
-
-extension SwiftTool: BuildPlanDelegate {
-    public func warning(message: String) {
-        // FIXME: Coloring would be nice.
-        print("warning: " + message)
-    }
 }
 
 extension BuildSubset {

--- a/Tests/BuildTests/XCTestManifests.swift
+++ b/Tests/BuildTests/XCTestManifests.swift
@@ -14,6 +14,7 @@ extension BuildPlanTests {
         ("testDynamicProducts", testDynamicProducts),
         ("testExecAsDependency", testExecAsDependency),
         ("testNonReachableProductsAndTargets", testNonReachableProductsAndTargets),
+        ("testPkgConfigError", testPkgConfigError),
         ("testSwiftCMixed", testSwiftCMixed),
         ("testSystemPackageBuildPlan", testSystemPackageBuildPlan),
         ("testTestModule", testTestModule),


### PR DESCRIPTION
<rdar://problem/41342798> SwiftPM is not warning about non whitelisted flags
<rdar://problem/40260898> [SR-7690]: SwiftPM does not print any warnings which is must be emitted at all during `build plan` including message about pkg-config provider hinting feature