### PR TITLE
Fix value of TEST_NAME variable in generated Xcode projects. 

### DIFF
--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -426,7 +426,7 @@ func xcodeProject(
         // .xcconfig, if we have one.  This lets it override project settings.
         targetSettings.xcconfigFileRef = xcconfigOverridesFileRef
 
-        targetSettings.common.TARGET_NAME = target.name
+        targetSettings.common.TARGET_NAME = target.c99name
 
         let infoPlistFilePath = xcodeprojPath.appending(component: target.infoPlistFileName)
         targetSettings.common.INFOPLIST_FILE = infoPlistFilePath.relative(to: sourceRootDir).asString


### PR DESCRIPTION
This is a follow-up task to SR-8139 which addreses issues package names that contain dashes but
will apply to a variety of target names that are not c99 compliant.