### PR TITLE
[Commands] Store path to clang compiler after lookup

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -506,7 +506,7 @@ public class SwiftTool<Options: ToolOptions> {
     func redirectStdoutToStderr() {
         self.shouldRedirectStdoutToStderr = true
         self.stdoutStream = Basic.stderrStream
-        DiagnosticsEngineHandler.default.stdoutStream = Basic.stdoutStream
+        DiagnosticsEngineHandler.default.stdoutStream = Basic.stderrStream
     }
 
     /// Resolve the dependencies.

--- a/Sources/Commands/UserToolchain.swift
+++ b/Sources/Commands/UserToolchain.swift
@@ -30,13 +30,16 @@ private struct UserManifestResources: ManifestResourceProvider {
 }
 
 // FIXME: This is messy and needs a redesign.
-public struct UserToolchain: Toolchain {
+public final class UserToolchain: Toolchain {
 
     /// The manifest resource provider.
     public let manifestResources: ManifestResourceProvider
 
     /// Path of the `swiftc` compiler.
     public let swiftCompiler: AbsolutePath
+
+    /// Storage for clang compiler path.
+    private var _clangCompiler: AbsolutePath?
 
     public let extraCCFlags: [String]
 
@@ -128,6 +131,10 @@ public struct UserToolchain: Toolchain {
 
     public func getClangCompiler() throws -> AbsolutePath {
 
+        if let clangCompiler = _clangCompiler {
+            return clangCompiler
+        }
+
         let clangCompiler: AbsolutePath
 
         // Find the Clang compiler, looking first in the environment.
@@ -146,6 +153,7 @@ public struct UserToolchain: Toolchain {
         guard localFileSystem.isExecutableFile(clangCompiler) else {
             throw Error.invalidToolchain(problem: "could not find `clang` at expected path \(clangCompiler.asString)")
         }
+        _clangCompiler = clangCompiler
         return clangCompiler
     }
 


### PR DESCRIPTION
<rdar://problem/42590491> SwiftPM shouldn't lookup clang on every getClangCompiler() invocation