### PR TITLE
[PackageGraph] Fix crash when there is a cycle in root package

### DIFF
--- a/Sources/PackageGraph/PackageGraphLoader.swift
+++ b/Sources/PackageGraph/PackageGraphLoader.swift
@@ -107,7 +107,8 @@ public struct PackageGraphLoader {
         // Detect cycles in manifest dependencies.
         if let cycle = findCycle(inputManifests, successors: successors) {
             diagnostics.emit(PackageGraphError.cycleDetected(cycle))
-            allManifests = inputManifests
+            // Break the cycle so we can build a partial package graph.
+            allManifests = inputManifests.filter({ $0 != cycle.cycle[0] })
         } else {
             // Sort all manifests toplogically.
             allManifests = try! topologicalSort(inputManifests, successors: successors)

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -169,6 +169,32 @@ class PackageGraphTests: XCTestCase {
         XCTAssertEqual(diagnostics.diagnostics[0].localizedDescription, "cyclic dependency declaration found: Foo -> Bar -> Baz -> Bar")
     }
 
+    func testCycle2() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Foo/Sources/Foo/source.swift",
+            "/Bar/Sources/Bar/source.swift",
+            "/Baz/Sources/Baz/source.swift"
+        )
+
+        let diagnostics = DiagnosticsEngine()
+        _ = loadPackageGraph(root: "/Foo", fs: fs, diagnostics: diagnostics,
+            manifests: [
+                Manifest.createV4Manifest(
+                    name: "Foo",
+                    path: "/Foo",
+                    url: "/Foo",
+                    dependencies: [
+                        PackageDependencyDescription(url: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
+                    ],
+                    targets: [
+                        TargetDescription(name: "Foo"),
+                    ]),
+            ]
+        )
+
+        XCTAssertEqual(diagnostics.diagnostics[0].localizedDescription, "cyclic dependency declaration found: Foo -> Foo")
+    }
+
     // Make sure there is no error when we reference Test targets in a package and then
     // use it as a dependency to another package. SR-2353
     func testTestTargetDeclInExternalPackage() throws {

--- a/Tests/PackageGraphTests/XCTestManifests.swift
+++ b/Tests/PackageGraphTests/XCTestManifests.swift
@@ -23,6 +23,7 @@ extension DependencyResolverTests {
 extension PackageGraphTests {
     static let __allTests = [
         ("testBasic", testBasic),
+        ("testCycle2", testCycle2),
         ("testCycle", testCycle),
         ("testDuplicateInterPackageTargetNames", testDuplicateInterPackageTargetNames),
         ("testDuplicateModules", testDuplicateModules),


### PR DESCRIPTION
<rdar://problem/39954169> [SR-7597]: Running 'swift build' crashes with segmentation fault when dependency name equals project's name