### PR TITLE
[SR-8137] Add --disable-color to disable color diagnostics

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -42,6 +42,9 @@ public class ToolOptions {
 
     /// Disables manifest caching.
     public var shouldDisableManifestCaching = false
+    
+    /// Disables coloring diagnostics.
+    public var shouldDisableColorDiagnostics = false
 
     /// Path to the compilation destination describing JSON file.
     public var customCompileDestination: AbsolutePath?

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -204,10 +204,13 @@ private final class DiagnosticsEngineHandler {
     /// The default instance.
     static let `default` = DiagnosticsEngineHandler()
 
+    /// Disables diagnostics coloring
+    var shouldDisableColor = false
+    
     private init() {}
 
     func diagnosticsHandler(_ diagnostic: Diagnostic) {
-        print(diagnostic: diagnostic, stdoutStream: stderrStream)
+        print(diagnostic: diagnostic, stdoutStream: stderrStream, disableColor: shouldDisableColor)
     }
 }
 
@@ -351,6 +354,11 @@ public class SwiftTool<Options: ToolOptions> {
             to: { $0.shouldDisableManifestCaching = $1 })
 
         binder.bind(
+            option: parser.add(option: "--disable-color", kind: Bool.self,
+                               usage: "Disable diagnostics coloring."),
+            to: { $0.shouldDisableColorDiagnostics = $1 })
+        
+        binder.bind(
             option: parser.add(option: "--version", kind: Bool.self),
             to: { $0.shouldPrintVersion = $1 })
 
@@ -430,6 +438,9 @@ public class SwiftTool<Options: ToolOptions> {
         if options.chdir != nil {
             diagnostics.emit(data: ChdirDeprecatedDiagnostic())
         }
+        
+        /// Set Disable Color preference to DiagnosticsEngineHandler
+        DiagnosticsEngineHandler.default.shouldDisableColor = options.shouldDisableColorDiagnostics
     }
 
     class func defineArguments(parser: ArgumentParser, binder: ArgumentBinder<Options>) {


### PR DESCRIPTION
Missing tests for `--disable-color` 

My plan for testing was to run a command with `--disable-color` and then compare, but since `stderr` never comes with formatting/color stuff, I cannot do it like that.
Then I thought about generating the output by myself [not using the output from some command], but I have faced some problems,
so, before doing something maybe complicated/non-needed, any idea/advice please?

Besides from testing. What if we apply `--disable-color` to everything? I mean, not just to the InteractiveWriter output, but to any output/diagnostics output generated.