### PR TITLE
Add 'PseudoTerminal' to 'TestSupport'

### DIFF
--- a/Sources/TestSupport/PseudoTerminal.swift
+++ b/Sources/TestSupport/PseudoTerminal.swift
@@ -11,12 +11,12 @@
 @testable import Basic
 import SPMLibc
 
-final class PseudoTerminal {
+public final class PseudoTerminal {
     let master: Int32
     let slave: Int32
-    var outStream: LocalFileOutputByteStream
+    public var outStream: LocalFileOutputByteStream
     
-    init?(){
+    public init?(){
         var master: Int32 = 0
         var slave: Int32 = 0
         if openpty(&master, &slave, nil, nil, nil) != 0 {
@@ -30,7 +30,7 @@ final class PseudoTerminal {
         self.slave = slave
     }
     
-    func readMaster(maxChars n: Int = 1000) -> String? {
+    public func readMaster(maxChars n: Int = 1000) -> String? {
         var buf: [CChar] = [CChar](repeating: 0, count: n)
         if read(master, &buf, n) <= 0 {
             return nil
@@ -38,7 +38,7 @@ final class PseudoTerminal {
         return String(cString: buf)
     }
     
-    func close() {
+    public func close() {
         _ = SPMLibc.close(slave)
         _ = SPMLibc.close(master)
     }

--- a/Sources/TestSupport/PseudoTerminal.swift
+++ b/Sources/TestSupport/PseudoTerminal.swift
@@ -1,0 +1,45 @@
+/*
+ This source file is part of the Swift.org open source project
+ 
+ Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+ 
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+@testable import Basic
+import SPMLibc
+
+final class PseudoTerminal {
+    let master: Int32
+    let slave: Int32
+    var outStream: LocalFileOutputByteStream
+    
+    init?(){
+        var master: Int32 = 0
+        var slave: Int32 = 0
+        if openpty(&master, &slave, nil, nil, nil) != 0 {
+            return nil
+        }
+        guard let outStream = try? LocalFileOutputByteStream(filePointer: fdopen(slave, "w"), closeOnDeinit: false) else {
+            return nil
+        }
+        self.outStream = outStream
+        self.master = master
+        self.slave = slave
+    }
+    
+    func readMaster(maxChars n: Int = 1000) -> String? {
+        var buf: [CChar] = [CChar](repeating: 0, count: n)
+        if read(master, &buf, n) <= 0 {
+            return nil
+        }
+        return String(cString: buf)
+    }
+    
+    func close() {
+        _ = SPMLibc.close(slave)
+        _ = SPMLibc.close(master)
+    }
+}

--- a/Sources/TestSupport/PseudoTerminal.swift
+++ b/Sources/TestSupport/PseudoTerminal.swift
@@ -38,8 +38,16 @@ public final class PseudoTerminal {
         return String(cString: buf)
     }
     
-    public func close() {
+    public func closeSlave() {
         _ = SPMLibc.close(slave)
+    }
+    
+    public func closeMaster() {
         _ = SPMLibc.close(master)
+    }
+    
+    public func close() {
+        closeSlave()
+        closeMaster()
     }
 }

--- a/Tests/BasicTests/TerminalControllerTests.swift
+++ b/Tests/BasicTests/TerminalControllerTests.swift
@@ -10,40 +10,9 @@
 
 import XCTest
 @testable import Basic
+@testable import TestSupport
 import SPMLibc
 
-final class PseudoTerminal {
-    let master: Int32
-    let slave: Int32
-    var outStream: LocalFileOutputByteStream
-
-    init?(){
-        var master: Int32 = 0
-        var slave: Int32 = 0
-        if openpty(&master, &slave, nil, nil, nil) != 0 {
-            return nil
-        }
-        guard let outStream = try? LocalFileOutputByteStream(filePointer: fdopen(slave, "w"), closeOnDeinit: false) else {
-            return nil
-        }
-        self.outStream = outStream
-        self.master = master
-        self.slave = slave
-    }
-
-    func readMaster(maxChars n: Int = 1000) -> String? {
-        var buf: [CChar] = [CChar](repeating: 0, count: n)
-        if read(master, &buf, n) <= 0 {
-            return nil
-        }
-        return String(cString: buf)
-    }
-
-    func close() {
-        _ = SPMLibc.close(slave)
-        _ = SPMLibc.close(master)
-    }
-}
 
 final class TerminalControllerTests: XCTestCase {
     func testBasic() {

--- a/Tests/BasicTests/TerminalControllerTests.swift
+++ b/Tests/BasicTests/TerminalControllerTests.swift
@@ -9,10 +9,9 @@
 */
 
 import XCTest
-@testable import Basic
-@testable import TestSupport
+import TestSupport
 import SPMLibc
-
+@testable import Basic
 
 final class TerminalControllerTests: XCTestCase {
     func testBasic() {

--- a/Tests/UtilityTests/ProgressBarTests.swift
+++ b/Tests/UtilityTests/ProgressBarTests.swift
@@ -11,8 +11,8 @@
 import XCTest
 import Utility
 import SPMLibc
+import TestSupport
 @testable import Basic
-@testable import TestSupport
 
 typealias Thread = Basic.Thread
 

--- a/Tests/UtilityTests/ProgressBarTests.swift
+++ b/Tests/UtilityTests/ProgressBarTests.swift
@@ -12,45 +12,9 @@ import XCTest
 import Utility
 import SPMLibc
 @testable import Basic
+@testable import TestSupport
 
 typealias Thread = Basic.Thread
-
-// FIXME: Copied from BasicTests, move to TestSupport once available.
-final class PseudoTerminal {
-    let master: Int32
-    let slave: Int32
-    var outStream: LocalFileOutputByteStream
-
-    init?(){
-        var master: Int32 = 0
-        var slave: Int32 = 0
-        if openpty(&master, &slave, nil, nil, nil) != 0 {
-            return nil
-        }
-        guard let outStream = try? LocalFileOutputByteStream(filePointer: fdopen(slave, "w"), closeOnDeinit: false) else {
-            return nil
-        }
-        self.outStream = outStream
-        self.master = master
-        self.slave = slave
-    }
-
-    func readMaster(maxChars n: Int = 1000) -> String? {
-        var buf: [CChar] = [CChar](repeating: 0, count: n)
-        if read(master, &buf, n) <= 0 {
-            return nil
-        }
-        return String(cString: buf)
-    }
-
-    func closeSlave() {
-        _ = SPMLibc.close(slave)
-    }
-
-    func closeMaster() {
-        _ = SPMLibc.close(master)
-    }
-}
 
 final class ProgressBarTests: XCTestCase {
     func testProgressBar() {
@@ -88,10 +52,10 @@ final class ProgressBarTests: XCTestCase {
         }
         thread.start()
         runProgressBar(bar)
-        pty.closeSlave()
         // Make sure to read the complete output before checking it.
+        pty.close()
         thread.join()
-        pty.closeMaster()
+        pty.close()
         XCTAssertTrue(output.chuzzle()?.hasPrefix("\u{1B}[36m\u{1B}[1mTestHeader\u{1B}[0m") ?? false)
     }
 

--- a/Tests/UtilityTests/ProgressBarTests.swift
+++ b/Tests/UtilityTests/ProgressBarTests.swift
@@ -53,9 +53,9 @@ final class ProgressBarTests: XCTestCase {
         thread.start()
         runProgressBar(bar)
         // Make sure to read the complete output before checking it.
-        pty.close()
+        pty.closeSlave()
         thread.join()
-        pty.close()
+        pty.closeMaster()
         XCTAssertTrue(output.chuzzle()?.hasPrefix("\u{1B}[36m\u{1B}[1mTestHeader\u{1B}[0m") ?? false)
     }
 

--- a/Tests/UtilityTests/ProgressBarTests.swift
+++ b/Tests/UtilityTests/ProgressBarTests.swift
@@ -52,8 +52,8 @@ final class ProgressBarTests: XCTestCase {
         }
         thread.start()
         runProgressBar(bar)
-        // Make sure to read the complete output before checking it.
         pty.closeSlave()
+        // Make sure to read the complete output before checking it.
         thread.join()
         pty.closeMaster()
         XCTAssertTrue(output.chuzzle()?.hasPrefix("\u{1B}[36m\u{1B}[1mTestHeader\u{1B}[0m") ?? false)


### PR DESCRIPTION
Add 'PseudoTerminal' to 'TestSupport' so it can be shared across different test targets 
[ @aciidb0mb3r suggestion ]