### PR TITLE
[SR-8459] fix --generate-linuxmain when testing subclasses

### DIFF
--- a/Sources/Commands/GenerateLinuxMain.swift
+++ b/Sources/Commands/GenerateLinuxMain.swift
@@ -62,7 +62,7 @@ final class LinuxMainGenerator {
             for klass in module.classes.lazy.sorted(by: { $0.name < $1.name }) {
                 stream <<< "\n"
                 stream <<< "extension " <<< klass.name <<< " {" <<< "\n"
-                stream <<< indent(4) <<< "static let __allTests = [" <<< "\n"
+                stream <<< indent(4) <<< "static let __\(klass.name) = [" <<< "\n"
                 for method in klass.methods {
                     stream <<< indent(8) <<< "(\"\(method)\", \(method))," <<< "\n"
                 }
@@ -79,7 +79,7 @@ final class LinuxMainGenerator {
             """
 
             for klass in module.classes {
-                stream <<< indent(8) <<< "testCase(" <<< klass.name <<< ".__allTests)," <<< "\n"
+                stream <<< indent(8) <<< "testCase(" <<< klass.name <<< ".__\(klass.name))," <<< "\n"
             }
 
             stream <<< """

--- a/Sources/Commands/GenerateLinuxMain.swift
+++ b/Sources/Commands/GenerateLinuxMain.swift
@@ -62,7 +62,7 @@ final class LinuxMainGenerator {
             for klass in module.classes.lazy.sorted(by: { $0.name < $1.name }) {
                 stream <<< "\n"
                 stream <<< "extension " <<< klass.name <<< " {" <<< "\n"
-                stream <<< indent(4) <<< "static let __\(klass.name) = [" <<< "\n"
+                stream <<< indent(4) <<< "static let __allTests__\(klass.name) = [" <<< "\n"
                 for method in klass.methods {
                     stream <<< indent(8) <<< "(\"\(method)\", \(method))," <<< "\n"
                 }
@@ -79,7 +79,7 @@ final class LinuxMainGenerator {
             """
 
             for klass in module.classes {
-                stream <<< indent(8) <<< "testCase(" <<< klass.name <<< ".__\(klass.name))," <<< "\n"
+                stream <<< indent(8) <<< "testCase(" <<< klass.name <<< ".__allTests__\(klass.name))," <<< "\n"
             }
 
             stream <<< """

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -405,13 +405,13 @@ class MiscellaneousTestCase: XCTestCase {
                 import XCTest
 
                 extension ParallelTestsFailureTests {
-                    static let __ParallelTestsFailureTests = [
+                    static let __allTests__ParallelTestsFailureTests = [
                         ("testSureFailure", testSureFailure),
                     ]
                 }
                 
                 extension ParallelTestsTests {
-                    static let __ParallelTestsTests = [
+                    static let __allTests__ParallelTestsTests = [
                         ("testExample1", testExample1),
                         ("testExample2", testExample2),
                     ]
@@ -419,8 +419,8 @@ class MiscellaneousTestCase: XCTestCase {
                 
                 public func __allTests() -> [XCTestCaseEntry] {
                     return [
-                        testCase(ParallelTestsFailureTests.__ParallelTestsFailureTests),
-                        testCase(ParallelTestsTests.__ParallelTestsTests),
+                        testCase(ParallelTestsFailureTests.__allTests__ParallelTestsFailureTests),
+                        testCase(ParallelTestsTests.__allTests__ParallelTestsTests),
                     ]
                 }
                 #endif

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -405,13 +405,13 @@ class MiscellaneousTestCase: XCTestCase {
                 import XCTest
 
                 extension ParallelTestsFailureTests {
-                    static let __allTests = [
+                    static let __ParallelTestsFailureTests = [
                         ("testSureFailure", testSureFailure),
                     ]
                 }
                 
                 extension ParallelTestsTests {
-                    static let __allTests = [
+                    static let __ParallelTestsTests = [
                         ("testExample1", testExample1),
                         ("testExample2", testExample2),
                     ]
@@ -419,8 +419,8 @@ class MiscellaneousTestCase: XCTestCase {
                 
                 public func __allTests() -> [XCTestCaseEntry] {
                     return [
-                        testCase(ParallelTestsFailureTests.__allTests),
-                        testCase(ParallelTestsTests.__allTests),
+                        testCase(ParallelTestsFailureTests.__ParallelTestsFailureTests),
+                        testCase(ParallelTestsTests.__ParallelTestsTests),
                     ]
                 }
                 #endif


### PR DESCRIPTION
- Replaced `__allTests` by `__<className>` 
- Updated the tests to fit this new naming method

Bug report by @aciidb0mb3r : https://bugs.swift.org/browse/SR-8459