### PR TITLE
Thread-safe Output Byte Stream

### DIFF
--- a/Sources/Basic/OutputByteStream.swift
+++ b/Sources/Basic/OutputByteStream.swift
@@ -23,14 +23,14 @@ public protocol ByteStreamable {
 
 /// An output byte stream.
 ///
-/// This class is designed to be able to support efficient streaming to
+/// This protocol is designed to be able to support efficient streaming to
 /// different output destinations, e.g., a file or an in memory buffer. This is
 /// loosely modeled on LLVM's llvm::raw_ostream class.
 ///
 /// The stream is generally used in conjunction with the custom streaming
 /// operator '<<<'. For example:
 ///
-///   let stream = OutputByteStream()
+///   let stream = BufferedOutputByteStream()
 ///   stream <<< "Hello, world!"
 ///
 /// would write the UTF8 encoding of "Hello, world!" to the stream.
@@ -43,7 +43,93 @@ public protocol ByteStreamable {
 ///
 /// would write each item in the list to the stream, separating them with a
 /// space.
-public class OutputByteStream: TextOutputStream {
+public protocol OutputByteStream: class, TextOutputStream {
+    /// The current offset within the output stream.
+    var position: Int { get }
+
+    /// Write an individual byte to the buffer.
+    func write(_ byte: UInt8)
+
+    /// Write a collection of bytes to the buffer.
+    func write<C: Collection>(_ bytes: C) where C.Element == UInt8
+
+    /// Flush the stream's buffer.
+    func flush()
+}
+
+extension OutputByteStream {
+    /// Write a sequence of bytes to the buffer.
+    public func write<S: Sequence>(sequence: S) where S.Iterator.Element == UInt8 {
+        // Iterate the sequence and append byte by byte since sequence's append
+        // is not performant anyway.
+        for byte in sequence {
+            write(byte)
+        }
+    }
+
+    /// Write a string to the buffer (as UTF8).
+    public func write(_ string: String) {
+        // FIXME(performance): Use `string.utf8._copyContents(initializing:)`.
+        write(string.utf8)
+    }
+
+    /// Write a string (as UTF8) to the buffer, with escaping appropriate for
+    /// embedding within a JSON document.
+    ///
+    /// NOTE: This writes the literal data applying JSON string escaping, but
+    /// does not write any other characters (like the quotes that would surround
+    /// a JSON string).
+    public func writeJSONEscaped(_ string: String) {
+        // See RFC7159 for reference: https://tools.ietf.org/html/rfc7159
+        for character in string.utf8 {
+            // Handle string escapes; we use constants here to directly match the RFC.
+            switch character {
+            // Literal characters.
+            case 0x20...0x21, 0x23...0x5B, 0x5D...0xFF:
+                write(character)
+
+            // Single-character escaped characters.
+            case 0x22: // '"'
+                write(0x5C) // '\'
+                write(0x22) // '"'
+            case 0x5C: // '\\'
+                write(0x5C) // '\'
+                write(0x5C) // '\'
+            case 0x08: // '\b'
+                write(0x5C) // '\'
+                write(0x62) // 'b'
+            case 0x0C: // '\f'
+                write(0x5C) // '\'
+                write(0x66) // 'b'
+            case 0x0A: // '\n'
+                write(0x5C) // '\'
+                write(0x6E) // 'n'
+            case 0x0D: // '\r'
+                write(0x5C) // '\'
+                write(0x72) // 'r'
+            case 0x09: // '\t'
+                write(0x5C) // '\'
+                write(0x74) // 't'
+
+            // Multi-character escaped characters.
+            default:
+                write(0x5C) // '\'
+                write(0x75) // 'u'
+                write(hexdigit(0))
+                write(hexdigit(0))
+                write(hexdigit(character >> 4))
+                write(hexdigit(character & 0xF))
+            }
+        }
+    }
+}
+
+/// The `OutputByteStream` base class.
+///
+/// This class provides a base and efficient implementation of the `OutputByteStream`
+/// protocol. It can not be used as is-as subclasses as several functions need to be
+/// implemented in subclasses.
+public class _OutputByteStreamBase: OutputByteStream {
     /// The data buffer.
     /// Note: Minimum Buffer size should be one.
     private var buffer: [UInt8]
@@ -52,20 +138,18 @@ public class OutputByteStream: TextOutputStream {
     private static let bufferSize = 1024
 
     /// Queue to protect mutating operation.
-    private let queue = DispatchQueue(label: "org.swift.swiftpm.basic.stream")
+    fileprivate let queue = DispatchQueue(label: "org.swift.swiftpm.basic.stream")
 
     init() {
         self.buffer = []
-        self.buffer.reserveCapacity(OutputByteStream.bufferSize)
+        self.buffer.reserveCapacity(_OutputByteStreamBase.bufferSize)
     }
 
     // MARK: Data Access API
 
     /// The current offset within the output stream.
     public final var position: Int {
-        return queue.sync {
-            return buffer.count
-        }
+        return buffer.count
     }
 
     /// Currently available buffer size.
@@ -81,11 +165,9 @@ public class OutputByteStream: TextOutputStream {
     // MARK: Data Output API
 
     public final func flush() {
-        queue.sync {
-            writeImpl(buffer)
-            clearBuffer()
-            flushImpl()
-        }
+        writeImpl(buffer)
+        clearBuffer()
+        flushImpl()
     }
 
     func flushImpl() {
@@ -98,11 +180,6 @@ public class OutputByteStream: TextOutputStream {
 
     /// Write an individual byte to the buffer.
     public final func write(_ byte: UInt8) {
-        queue.sync {
-            writeUnsafe(byte)
-        }
-    }
-    private final func writeUnsafe(_ byte: UInt8) {
         // If buffer is full, write and clear it.
         if availableBufferSize == 0 {
             writeImpl(buffer)
@@ -115,114 +192,96 @@ public class OutputByteStream: TextOutputStream {
     }
 
     /// Write a collection of bytes to the buffer.
-    public final func write<C: Collection>(_ bytes: C)
-        where C.Element == UInt8 {
-        queue.sync {
-            // This is based on LLVM's raw_ostream.
-            let availableBufferSize = self.availableBufferSize
-            let byteCount = Int(bytes.count)
+    public final func write<C: Collection>(_ bytes: C) where C.Element == UInt8 {
+        // This is based on LLVM's raw_ostream.
+        let availableBufferSize = self.availableBufferSize
+        let byteCount = Int(bytes.count)
 
-            // If we have to insert more than the available space in buffer.
-            if byteCount > availableBufferSize {
-                // If buffer is empty, start writing and keep the last chunk in buffer.
-                if buffer.isEmpty {
-                    let bytesToWrite = byteCount - (byteCount % availableBufferSize)
-                    let writeUptoIndex = bytes.index(bytes.startIndex, offsetBy: numericCast(bytesToWrite))
-                    writeImpl(bytes.prefix(upTo: writeUptoIndex))
+        // If we have to insert more than the available space in buffer.
+        if byteCount > availableBufferSize {
+            // If buffer is empty, start writing and keep the last chunk in buffer.
+            if buffer.isEmpty {
+                let bytesToWrite = byteCount - (byteCount % availableBufferSize)
+                let writeUptoIndex = bytes.index(bytes.startIndex, offsetBy: numericCast(bytesToWrite))
+                writeImpl(bytes.prefix(upTo: writeUptoIndex))
 
-                    // If remaining bytes is more than buffer size write everything.
-                    let bytesRemaining = byteCount - bytesToWrite
-                    if bytesRemaining > availableBufferSize {
-                        writeImpl(bytes.suffix(from: writeUptoIndex))
-                        return
-                    }
-                    // Otherwise keep remaining in buffer.
-                    buffer += bytes.suffix(from: writeUptoIndex)
+                // If remaining bytes is more than buffer size write everything.
+                let bytesRemaining = byteCount - bytesToWrite
+                if bytesRemaining > availableBufferSize {
+                    writeImpl(bytes.suffix(from: writeUptoIndex))
                     return
                 }
-
-                let writeUptoIndex = bytes.index(bytes.startIndex, offsetBy: numericCast(availableBufferSize))
-                // Append whatever we can accommodate.
-                buffer += bytes.prefix(upTo: writeUptoIndex)
-
-                writeImpl(buffer)
-                clearBuffer()
-
-                // FIXME: We should start again with remaining chunk but this doesn't work. Write everything for now.
-                //write(collection: bytes.suffix(from: writeUptoIndex))
-                writeImpl(bytes.suffix(from: writeUptoIndex))
+                // Otherwise keep remaining in buffer.
+                buffer += bytes.suffix(from: writeUptoIndex)
                 return
             }
-            buffer += bytes
+
+            let writeUptoIndex = bytes.index(bytes.startIndex, offsetBy: numericCast(availableBufferSize))
+            // Append whatever we can accommodate.
+            buffer += bytes.prefix(upTo: writeUptoIndex)
+
+            writeImpl(buffer)
+            clearBuffer()
+
+            // FIXME: We should start again with remaining chunk but this doesn't work. Write everything for now.
+            //write(collection: bytes.suffix(from: writeUptoIndex))
+            writeImpl(bytes.suffix(from: writeUptoIndex))
+            return
+        }
+        buffer += bytes
+    }
+}
+
+/// The thread-safe wrapper around output byte streams.
+///
+/// This class wraps any `OutputByteStream` conforming type to provide a type-safe
+/// access to its operations. If the provided stream inherits from `_OutputByteStreamBase`,
+/// it will also ensure it is type-safe will all other `ThreadSafeOutputByteStream` instances
+/// around the same stream.
+public final class ThreadSafeOutputByteStream: OutputByteStream {
+    private static let defaultQueue = DispatchQueue(label: "org.swift.swiftpm.basic.thread-safe-output-byte-stream")
+    public let stream: OutputByteStream
+    private let queue: DispatchQueue
+
+    public var position: Int {
+        return queue.sync {
+            stream.position
         }
     }
 
-    /// Write a sequence of bytes to the buffer.
-    public final func write<S: Sequence>(sequence: S) where S.Iterator.Element == UInt8 {
+    public init(_ stream: OutputByteStream) {
+        self.stream = stream
+        self.queue = (stream as? _OutputByteStreamBase)?.queue ?? ThreadSafeOutputByteStream.defaultQueue
+    }
+
+    public func write(_ byte: UInt8) {
         queue.sync {
-            // Iterate the sequence and append byte by byte since sequence's append
-            // is not performant anyway.
-            for byte in sequence {
-                writeUnsafe(byte)
-            }
+            stream.write(byte)
         }
     }
 
-    /// Write a string to the buffer (as UTF8).
-    public final func write(_ string: String) {
-        // FIXME(performance): Use `string.utf8._copyContents(initializing:)`.
-        write(string.utf8)
+    public func write<C: Collection>(_ bytes: C) where C.Element == UInt8 {
+        queue.sync {
+            stream.write(bytes)
+        }
+
     }
 
-    /// Write a string (as UTF8) to the buffer, with escaping appropriate for
-    /// embedding within a JSON document.
-    ///
-    /// NOTE: This writes the literal data applying JSON string escaping, but
-    /// does not write any other characters (like the quotes that would surround
-    /// a JSON string).
-    public final func writeJSONEscaped(_ string: String) {
+    public func flush() {
         queue.sync {
-            // See RFC7159 for reference: https://tools.ietf.org/html/rfc7159
-            for character in string.utf8 {
-                // Handle string escapes; we use constants here to directly match the RFC.
-                switch character {
-                    // Literal characters.
-                case 0x20...0x21, 0x23...0x5B, 0x5D...0xFF:
-                    writeUnsafe(character)
+            stream.flush()
+        }
+    }
 
-                    // Single-character escaped characters.
-                    case 0x22: // '"'
-                    writeUnsafe(0x5C) // '\'
-                    writeUnsafe(0x22) // '"'
-                    case 0x5C: // '\\'
-                    writeUnsafe(0x5C) // '\'
-                    writeUnsafe(0x5C) // '\'
-                    case 0x08: // '\b'
-                    writeUnsafe(0x5C) // '\'
-                    writeUnsafe(0x62) // 'b'
-                    case 0x0C: // '\f'
-                    writeUnsafe(0x5C) // '\'
-                    writeUnsafe(0x66) // 'b'
-                    case 0x0A: // '\n'
-                    writeUnsafe(0x5C) // '\'
-                    writeUnsafe(0x6E) // 'n'
-                    case 0x0D: // '\r'
-                    writeUnsafe(0x5C) // '\'
-                    writeUnsafe(0x72) // 'r'
-                    case 0x09: // '\t'
-                    writeUnsafe(0x5C) // '\'
-                    writeUnsafe(0x74) // 't'
+    public func write<S: Sequence>(sequence: S) where S.Iterator.Element == UInt8 {
+        queue.sync {
+            stream.write(sequence: sequence)
+        }
+    }
 
-                    // Multi-character escaped characters.
-                default:
-                    writeUnsafe(0x5C) // '\'
-                    writeUnsafe(0x75) // 'u'
-                    writeUnsafe(hexdigit(0))
-                    writeUnsafe(hexdigit(0))
-                    writeUnsafe(hexdigit(character >> 4))
-                    writeUnsafe(hexdigit(character & 0xF))
-                }
-            }
+    public func writeJSONEscaped(_ string: String) {
+        queue.sync {
+            stream.writeJSONEscaped(string)
         }
     }
 }
@@ -247,20 +306,6 @@ public func <<< (stream: OutputByteStream, value: ArraySlice<UInt8>) -> OutputBy
 @discardableResult
 public func <<< (stream: OutputByteStream, value: ByteStreamable) -> OutputByteStream {
     value.write(to: stream)
-    return stream
-}
-
-@discardableResult
-public func <<< (stream: OutputByteStream, value: TextOutputStreamable) -> OutputByteStream {
-    // Get a mutable reference.
-    var mutableStream = stream
-    value.write(to: &mutableStream)
-    return mutableStream
-}
-
-@discardableResult
-public func <<< (stream: OutputByteStream, value: ByteStreamable & TextOutputStreamable) -> OutputByteStream {
-    (value as ByteStreamable).write(to: stream)
     return stream
 }
 
@@ -490,7 +535,7 @@ public struct Format {
 }
 
 /// Inmemory implementation of OutputByteStream.
-public final class BufferedOutputByteStream: OutputByteStream {
+public final class BufferedOutputByteStream: _OutputByteStreamBase {
 
     /// Contents of the stream.
     // FIXME: For inmemory implementation we should be share this buffer with OutputByteStream.
@@ -519,7 +564,7 @@ public final class BufferedOutputByteStream: OutputByteStream {
 }
 
 /// Represents a stream which is backed to a file. Not for instantiating.
-public class FileOutputByteStream: OutputByteStream {
+public class FileOutputByteStream: _OutputByteStreamBase {
 
     /// Closes the file flushing any buffered data.
     public final func close() throws {
@@ -612,11 +657,11 @@ public final class LocalFileOutputByteStream: FileOutputByteStream {
 }
 
 /// Public stdout stream instance.
-public var stdoutStream: FileOutputByteStream = try! LocalFileOutputByteStream(
+public var stdoutStream: ThreadSafeOutputByteStream = try! ThreadSafeOutputByteStream(LocalFileOutputByteStream(
     filePointer: SPMLibc.stdout,
-    closeOnDeinit: false)
+    closeOnDeinit: false))
 
 /// Public stderr stream instance.
-public var stderrStream: FileOutputByteStream = try! LocalFileOutputByteStream(
+public var stderrStream: ThreadSafeOutputByteStream = try! ThreadSafeOutputByteStream(LocalFileOutputByteStream(
     filePointer: SPMLibc.stderr,
-    closeOnDeinit: false)
+    closeOnDeinit: false))

--- a/Sources/Basic/TerminalController.swift
+++ b/Sources/Basic/TerminalController.swift
@@ -56,7 +56,7 @@ public final class TerminalController {
     }
 
     /// Pointer to output stream to operate on.
-    private var stream: LocalFileOutputByteStream
+    private var stream: OutputByteStream
 
     /// Width of the terminal.
     public let width: Int
@@ -71,11 +71,14 @@ public final class TerminalController {
     private let boldString = "\u{001B}[1m"
 
     /// Constructs the instance if the stream is a tty.
-    public init?(stream: LocalFileOutputByteStream) {
-        // Make sure this file stream is tty.
-        guard TerminalController.isTTY(stream) else {
+    public init?(stream: OutputByteStream) {
+        let realStream = (stream as? ThreadSafeOutputByteStream)?.stream ?? stream
+
+        // Make sure it is a file stream and it is tty.
+        guard let fileStream = realStream as? LocalFileOutputByteStream, TerminalController.isTTY(fileStream) else {
             return nil
         }
+
         width = TerminalController.terminalWidth() ?? 80 // Assume default if we are not able to determine.
         self.stream = stream
     }

--- a/Sources/Build/BuildDelegate.swift
+++ b/Sources/Build/BuildDelegate.swift
@@ -172,13 +172,15 @@ extension SPMLLBuild.Diagnostic: DiagnosticDataConvertible {
 private let newLineByte: UInt8 = 10
 public final class BuildDelegate: BuildSystemDelegate {
     private let diagnostics: DiagnosticsEngine
-    public var outputStream: OutputByteStream
+    public var outputStream: ThreadSafeOutputByteStream
     public var isVerbose: Bool = false
     public var onCommmandFailure: (() -> Void)?
 
     public init(diagnostics: DiagnosticsEngine, outputStream: OutputByteStream = stdoutStream) {
         self.diagnostics = diagnostics
-        self.outputStream = outputStream
+        // FIXME: Implement a class convenience initializer that does this once they are supported
+        // https://forums.swift.org/t/allow-self-x-in-class-convenience-initializers/15924
+        self.outputStream = outputStream as? ThreadSafeOutputByteStream ?? ThreadSafeOutputByteStream(outputStream)
     }
 
     public var fs: SPMLLBuild.FileSystem? {

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -80,7 +80,7 @@ public struct BuildParameters {
 
     /// Checks if stdout stream is tty.
     fileprivate let isTTY: Bool = {
-        guard let stream = stdoutStream as? LocalFileOutputByteStream else {
+        guard let stream = stdoutStream.stream as? LocalFileOutputByteStream else {
             return false
         }
         return TerminalController.isTTY(stream)

--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -125,7 +125,7 @@ private final class InteractiveWriter {
 
     /// Create an instance with the given stream.
     init(stream: OutputByteStream) {
-        self.term = (stream as? LocalFileOutputByteStream).flatMap(TerminalController.init(stream:))
+        self.term = TerminalController(stream: stream)
         self.stream = stream
     }
 

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -82,10 +82,12 @@ struct TargetNotFoundDiagnostic: DiagnosticData {
 private class ToolWorkspaceDelegate: WorkspaceDelegate {
 
     /// The stream to use for reporting progress.
-    private let stdoutStream: OutputByteStream
+    private let stdoutStream: ThreadSafeOutputByteStream
 
     init(_ stdoutStream: OutputByteStream) {
-        self.stdoutStream = stdoutStream
+        // FIXME: Implement a class convenience initializer that does this once they are supported
+        // https://forums.swift.org/t/allow-self-x-in-class-convenience-initializers/15924
+        self.stdoutStream = stdoutStream as? ThreadSafeOutputByteStream ?? ThreadSafeOutputByteStream(stdoutStream)
     }
 
     func packageGraphWillLoad(

--- a/Sources/Utility/ProgressBar.swift
+++ b/Sources/Utility/ProgressBar.swift
@@ -141,17 +141,13 @@ public final class ProgressBar: ProgressBarProtocol {
 
 /// Creates colored or simple progress bar based on the provided output stream.
 public func createProgressBar(forStream stream: OutputByteStream, header: String) -> ProgressBarProtocol {
-    guard let stdStream = stream as? LocalFileOutputByteStream else {
-        return SimpleProgressBar(stream: stream, header: header)
-    }
-
     // If we have a terminal, use animated progress bar.
-    if let term = TerminalController(stream: stdStream) {
+    if let term = TerminalController(stream: stream) {
         return ProgressBar(term: term, header: header)
     }
 
     // If the terminal is dumb, use single line progress bar.
-    if TerminalController.terminalType(stdStream) == .dumb {
+    if let fileStream = stream as? LocalFileOutputByteStream, TerminalController.terminalType(fileStream) == .dumb {
         return SingleLineProgressBar(stream: stream, header: header)
     }
 

--- a/Tests/BasicTests/OutputByteStreamTests.swift
+++ b/Tests/BasicTests/OutputByteStreamTests.swift
@@ -34,11 +34,10 @@ class OutputByteStreamTests: XCTestCase {
     func testStreamOperator() {
         let stream = BufferedOutputByteStream()
 
-        let streamable: TextOutputStreamable = Character("!")
-        stream <<< "Hello" <<< Character(",") <<< Character(" ") <<< [UInt8]("wor".utf8) <<< [UInt8]("world".utf8)[3..<5] <<< streamable
+        stream <<< "Hello" <<< Character(",") <<< Character(" ") <<< [UInt8]("wor".utf8) <<< [UInt8]("world".utf8)[3..<5]
         
-        XCTAssertEqual(stream.position, "Hello, world!".utf8.count)
-        XCTAssertEqual(stream.bytes, "Hello, world!")
+        XCTAssertEqual(stream.position, "Hello, world".utf8.count)
+        XCTAssertEqual(stream.bytes, "Hello, world")
     }
     
     func testBufferCorrectness() {
@@ -176,17 +175,18 @@ class OutputByteStreamTests: XCTestCase {
         var threads = [Thread]()
 
         let stream = BufferedOutputByteStream()
+        let threadSafeStream = ThreadSafeOutputByteStream(stream)
 
         let t1 = Thread {
             for _ in 0..<1000 {
-                stream <<< "Hello"
+                threadSafeStream <<< "Hello"
             }
         }
         threads.append(t1)
 
         let t2 = Thread {
             for _ in 0..<1000 {
-                stream.write("Hello")
+                threadSafeStream.write("Hello")
             }
         }
         threads.append(t2)


### PR DESCRIPTION
To support Thread-safe around any OutputByteStream, and after a design discussion with @aciidb0mb3r, I implemented the following solution:

- renamed `OutputByteSteam` into `OutputByteStreamBase`
- introduced a new `OutputByteStream` protocol that `OutputByteStreamBase` conforms to
- removed thread-safety from `OutputByteStream`
- introduced a new `ThreadSafeOutputByteStream` class that wraps any `OutputByteStream` around a queue
- removed the `<<<` override for `TextOutputStreamable` as its generic signature doesn't play well with the `OutputByteStream` protocol (a protocol can't *yet* conform to itself).