### PR TITLE
OutputByteStream overloads refactoring

### DIFF
--- a/Sources/Basic/OutputByteStream.swift
+++ b/Sources/Basic/OutputByteStream.swift
@@ -236,6 +236,14 @@ precedencegroup StreamingPrecedence {
 
 // MARK: Output Operator Implementations
 
+// FIXME: This override shouldn't be necesary but removing it causes a 30% performance regression. This problem is
+// tracked by the following bug: https://bugs.swift.org/browse/SR-8535
+@discardableResult
+public func <<< (stream: OutputByteStream, value: ArraySlice<UInt8>) -> OutputByteStream {
+    value.write(to: stream)
+    return stream
+}
+
 @discardableResult
 public func <<< (stream: OutputByteStream, value: ByteStreamable) -> OutputByteStream {
     value.write(to: stream)

--- a/Tests/BasicPerformanceTests/OutputByteStreamPerfTests.swift
+++ b/Tests/BasicPerformanceTests/OutputByteStreamPerfTests.swift
@@ -22,6 +22,12 @@ struct ByteSequence: Sequence {
     }
 }
 
+extension ByteSequence: ByteStreamable {
+    func write(to stream: OutputByteStream) {
+        stream.write(sequence: self)
+    }
+}
+
 struct ByteSequenceIterator: IteratorProtocol {
     let bytes16: [UInt8]
     var index: Int

--- a/Tests/BasicTests/OutputByteStreamTests.swift
+++ b/Tests/BasicTests/OutputByteStreamTests.swift
@@ -14,17 +14,17 @@ import Basic
 
 class OutputByteStreamTests: XCTestCase {
     func testBasics() {
-        let stream = BufferedOutputByteStream()
+        var stream = BufferedOutputByteStream()
         
-        stream.write("Hello")
-        stream.write(Character(","))
-        stream.write(Character(" "))
-        stream.write([UInt8]("wor".utf8))
-        stream.write([UInt8]("world".utf8)[3..<5])
+        "Hel".write(to: stream)
+        "Hello".dropFirst(3).write(to: stream)
+        Character(",").write(to: stream)
+        Character(" ").write(to: stream)
+        [UInt8]("wor".utf8).write(to: stream)
+        [UInt8]("world".utf8)[3..<5].write(to: stream)
         
         let streamable: TextOutputStreamable = Character("!")
-        stream.write(streamable)
-
+        streamable.write(to: &stream)
         
         XCTAssertEqual(stream.position, "Hello, world!".utf8.count)
         stream.flush()
@@ -39,10 +39,6 @@ class OutputByteStreamTests: XCTestCase {
         
         XCTAssertEqual(stream.position, "Hello, world!".utf8.count)
         XCTAssertEqual(stream.bytes, "Hello, world!")
-
-        let stream2 = BufferedOutputByteStream()
-        stream2 <<< (0..<5)
-        XCTAssertEqual(stream2.bytes, [0, 1, 2, 3, 4])
     }
     
     func testBufferCorrectness() {


### PR DESCRIPTION
`OutputByteStream` and the `<<<` operator have many overloads that seem to have been created for two main reasons: to resolve performance issues, and to resolve a compiler ambiguity error with types that are both `ByteStreamable` and `TextOutputStreamable`, as can be seen by the following comment note:

```swift
// NOTE: It would be nice to use a protocol here and the adopt it by all the
// things we can efficiently stream out. However, that doesn't work because we
// ultimately need to provide a manual overload sometimes, e.g., TextOutputStreamable, but
// that will then cause ambiguous lookup versus the implementation just using
// the defined protocol.
```

Since now, the performance problems seem to have been resolved and the ambiguity issue can be resolved with an override which targets `ByteStreamable & TextOutputStreamable`. This PR therefore removes the un-necessary overloads and instead makes types which can be efficiently streamed implement the `ByteStreamable` protocol, adding conformances to:

* `Substring`
* `StaticString`
* `Array`
* `ArraySlice`
* `ContiguousArray`
* `UnsafeBufferPointer`
* `UnsafeMutableBufferPointer`
* `UnsafeRawBufferPointer`
* `UnsafeMutableRawBufferPointer`