### PR TITLE
[PackageLoading] Print warnings when loading manifests

### DIFF
--- a/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
@@ -186,7 +186,7 @@ public class LocalPackageContainer: BasePackageContainer, CustomStringConvertibl
 
         // Load the manifest.
         _manifest = try manifestLoader.load(
-            packagePath: AbsolutePath(identifier.path),
+            package: AbsolutePath(identifier.path),
             baseURL: identifier.path,
             version: nil,
             manifestVersion: toolsVersion.manifestVersion,

--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -139,3 +139,16 @@ public enum PackageBuilderDiagnostics {
         let path: String
     }
 }
+
+public struct ManifestLoadingDiagnostic: DiagnosticData {
+    public static let id = DiagnosticID(
+        type: ManifestLoadingDiagnostic.self,
+        name: "org.swift.diags.pkg-loading.manifest-output",
+        defaultBehavior: .warning,
+        description: {
+            $0 <<< { $0.output }
+        }
+    )
+
+    public let output: String
+}

--- a/Sources/TestSupport/MockManifestLoader.swift
+++ b/Sources/TestSupport/MockManifestLoader.swift
@@ -56,7 +56,8 @@ public final class MockManifestLoader: ManifestLoaderProtocol {
         baseURL: String,
         version: Version?,
         manifestVersion: ManifestVersion,
-        fileSystem: FileSystem?
+        fileSystem: FileSystem?,
+        diagnostics: DiagnosticsEngine?
     ) throws -> PackageModel.Manifest {
         let key = Key(url: PackageReference.computeIdentity(packageURL: baseURL), version: version)
         if let result = manifests[key] {

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -987,7 +987,8 @@ extension Workspace {
                 package: packagePath,
                 baseURL: url,
                 version: version,
-                manifestVersion: toolsVersion.manifestVersion
+                manifestVersion: toolsVersion.manifestVersion,
+                diagnostics: diagnostics
             )
         })
     }


### PR DESCRIPTION
We were supressing the warnings while loading the manifests because we
considered any type of output from the compiler as a sign of error. This
changes the error state to depend on the exit code. The warnings will be
printed when loading a resolved package graph and not during dependency
resolution. This makes sense because the manifest we look at during
dependency resolution might not be used in the final resolved graph.

<rdar://problem/41180566> SwiftPM should not suppress compiler warnings in the manifest file