### PR TITLE
[Workspace] Improve pinAll logic

### DIFF
--- a/Tests/WorkspaceTests/XCTestManifests.swift
+++ b/Tests/WorkspaceTests/XCTestManifests.swift
@@ -64,6 +64,7 @@ extension WorkspaceTests {
         ("testMultipleRootPackages", testMultipleRootPackages),
         ("testResolutionFailureWithEditedDependency", testResolutionFailureWithEditedDependency),
         ("testResolve", testResolve),
+        ("testResolvedFileUpdate", testResolvedFileUpdate),
         ("testResolverCanHaveError", testResolverCanHaveError),
         ("testRevisionVersionSwitch", testRevisionVersionSwitch),
         ("testRootAsDependency1", testRootAsDependency1),


### PR DESCRIPTION
This correctly computes the pinning logic when there are managed
dependencies which are not required in the package graph.