### PR TITLE
Revert "[Commands] Use library based llbuild by default"

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -50,7 +50,7 @@ public class ToolOptions {
     public var shouldLinkStaticSwiftStdlib = false
     
     /// If should enable building with llbuild library.
-    public var shouldEnableLLBuildLibrary = true
+    public var shouldEnableLLBuildLibrary = false
 
     /// Skip updating dependencies from their remote during a resolution.
     public var skipDependencyUpdate = false


### PR DESCRIPTION
Reverts apple/swift-package-manager#1738

This is causing build failure in the integration repo https://ci.swift.org/job/oss-swift-package-osx/2031