### PR TITLE
[Commands] Use library based llbuild by default

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -50,7 +50,7 @@ public class ToolOptions {
     public var shouldLinkStaticSwiftStdlib = false
     
     /// If should enable building with llbuild library.
-    public var shouldEnableLLBuildLibrary = false
+    public var shouldEnableLLBuildLibrary = true
 
     /// Skip updating dependencies from their remote during a resolution.
     public var skipDependencyUpdate = false


### PR DESCRIPTION
The implementation seems to work fine with several community packages and should now pass integration tests.