### PR TITLE
[bootstrap] Fix swiftpm version when building on CI

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -113,7 +113,7 @@ def write_file_if_changed(path, data):
 def get_current_sha(project_root):
     try:
         return subprocess.check_output(
-            ["git", "rev-parse", "--short", "HEAD"], universal_newlines=True).strip()
+            ["git", "-C", project_root, "rev-parse", "--short", "HEAD"], universal_newlines=True).strip()
     except:
         return None
 


### PR DESCRIPTION
<rdar://problem/43234168> git hash is absent from swiftpm version in toolchains created by Swift CI