### PR TITLE
Fix redundant access-level modifiers.

### DIFF
--- a/Sources/Basic/CollectionAlgorithms.swift
+++ b/Sources/Basic/CollectionAlgorithms.swift
@@ -29,7 +29,7 @@ extension BidirectionalCollection where Iterator.Element : Comparable {
     }
 }
 
-public extension Sequence where Iterator.Element: Hashable {
+extension Sequence where Iterator.Element: Hashable {
 
     /// Finds duplicates in given sequence of Hashables.
     /// - Returns: duplicated elements in the invoking sequence.

--- a/Sources/Basic/StringConversions.swift
+++ b/Sources/Basic/StringConversions.swift
@@ -35,7 +35,7 @@ private func inShellWhitelist(_ codeUnit: UInt8) -> Bool {
     }
 }
 
-public extension String {
+extension String {
 
     /// Creates a shell escaped string. If the string does not need escaping, returns the original string.
     /// Otherwise escapes using single quotes. For example:

--- a/Sources/Commands/Destination.swift
+++ b/Sources/Commands/Destination.swift
@@ -160,7 +160,7 @@ public struct Destination {
   #endif
 }
 
-public extension Destination {
+extension Destination {
 
     /// Load a Destination description from a JSON representation from disk.
     public init(fromFile path: AbsolutePath, fileSystem: FileSystem = localFileSystem) throws {

--- a/Sources/Workspace/ToolsVersionWriter.swift
+++ b/Sources/Workspace/ToolsVersionWriter.swift
@@ -39,7 +39,7 @@ public func writeToolsVersion(at path: AbsolutePath, version: ToolsVersion, fs: 
     try fs.writeFileContents(file, bytes: stream.bytes)
 }
 
-public extension ToolsVersion {
+extension ToolsVersion {
 
     /// Returns the tools version with zeroed patch number.
     public var zeroedPatch: ToolsVersion {


### PR DESCRIPTION
This patch aims to make `swiftpm` adapted to [this PR](https://github.com/apple/swift/pull/18623), which produces warnings for redundant access-level modifiers.

@aciidb0mb3r Hi Ankit, would you help take a look at this, please?