### PR TITLE
[SR-7828] Add name-based fixits to product dependencies name

### DIFF
--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -499,8 +499,9 @@ class PackageGraphTests: XCTestCase {
         DiagnosticsEngineTester(diagnostics) { result in
             result.check(diagnostic: "target 'Bar' in package 'Bar' contains no valid source files", behavior: .warning)
             result.check(diagnostic: "target 'Bar' referenced in product 'Bar' could not be found", behavior: .error, location: "'Bar' /Bar")
-            result.check(diagnostic: "product dependency 'Bar' not found", behavior: .error, location: "'Foo' /Foo")
+            result.check(diagnostic: "product dependency 'Bar' not found, did you mean: '' ?", behavior: .error, location: "'Foo' /Foo")
 
+            
         }
     }
 


### PR DESCRIPTION
Added "did you mean ___ ?" when a product dependency cannot be found.

Please check my implementation with map and reduce, I am not sure if that is perfectly correct (in terms of readability, guidelines, etc).