### PR TITLE
Allow to create child processes in the same process group

### DIFF
--- a/Sources/Basic/Process.swift
+++ b/Sources/Basic/Process.swift
@@ -166,7 +166,7 @@ public final class Process: ObjectIdentifierProtocol {
         label: "org.swift.swiftpm.process.findExecutable")
     
     /// Indicates if a new progress group is created for the child process.
-    private let startsNewProcessGroup: Bool
+    private let startNewProcessGroup: Bool
 
     /// Cache of validated executables.
     ///
@@ -183,20 +183,20 @@ public final class Process: ObjectIdentifierProtocol {
     ///   - redirectOutput: Redirect and store stdout/stderr output (of subprocess) in the process result, instead of
     ///     printing on the standard streams. Default value is true.
     ///   - verbose: If true, launch() will print the arguments of the subprocess before launching it.
-    ///   - startsNewProcessGroup: If true, a new progress group is created for the child making it
+    ///   - startNewProcessGroup: If true, a new progress group is created for the child making it
     ///     continue running even if the parent is killed or interrupted. Default value is true.
     public init(
         arguments: [String],
         environment: [String: String] = env,
         redirectOutput: Bool = true,
         verbose: Bool = Process.verbose,
-        startsNewProcessGroup: Bool = true
+        startNewProcessGroup: Bool = true
     ) {
         self.arguments = arguments
         self.environment = environment
         self.redirectOutput = redirectOutput
         self.verbose = verbose
-        self.startsNewProcessGroup = startsNewProcessGroup
+        self.startNewProcessGroup = startNewProcessGroup
     }
 
     /// Returns the path of the the given program if found in the search paths.
@@ -277,7 +277,7 @@ public final class Process: ObjectIdentifierProtocol {
 
         // Set the attribute flags.
         var flags = POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETSIGDEF
-        if startsNewProcessGroup {
+        if startNewProcessGroup {
             // Establish a separate process group.
             flags |= POSIX_SPAWN_SETPGROUP
             posix_spawnattr_setpgroup(&attributes, 0)

--- a/Sources/Basic/Process.swift
+++ b/Sources/Basic/Process.swift
@@ -164,6 +164,9 @@ public final class Process: ObjectIdentifierProtocol {
     /// Queue to protect reading/writing on map of validated executables.
     private static let executablesQueue = DispatchQueue(
         label: "org.swift.swiftpm.process.findExecutable")
+    
+    /// Indicates if a new progress group is created for the child process.
+    private let startsNewProcessGroup: Bool
 
     /// Cache of validated executables.
     ///
@@ -180,16 +183,20 @@ public final class Process: ObjectIdentifierProtocol {
     ///   - redirectOutput: Redirect and store stdout/stderr output (of subprocess) in the process result, instead of
     ///     printing on the standard streams. Default value is true.
     ///   - verbose: If true, launch() will print the arguments of the subprocess before launching it.
+    ///   - startsNewProcessGroup: If true, a new progress group is created for the child making it
+    ///     continue running even if the parent is killed or interrupted. Default value is true.
     public init(
         arguments: [String],
         environment: [String: String] = env,
         redirectOutput: Bool = true,
-        verbose: Bool = Process.verbose
+        verbose: Bool = Process.verbose,
+        startsNewProcessGroup: Bool = true
     ) {
         self.arguments = arguments
         self.environment = environment
         self.redirectOutput = redirectOutput
         self.verbose = verbose
+        self.startsNewProcessGroup = startsNewProcessGroup
     }
 
     /// Returns the path of the the given program if found in the search paths.
@@ -268,12 +275,13 @@ public final class Process: ObjectIdentifierProtocol {
         posix_spawnattr_setsigdefault(&attributes, &mostSignals)
       #endif
 
-        // Establish a separate process group.
-        posix_spawnattr_setpgroup(&attributes, 0)
-
         // Set the attribute flags.
         var flags = POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETSIGDEF
-        flags |= POSIX_SPAWN_SETPGROUP
+        if startsNewProcessGroup {
+            // Establish a separate process group.
+            flags |= POSIX_SPAWN_SETPGROUP
+            posix_spawnattr_setpgroup(&attributes, 0)
+        }
 
         posix_spawnattr_setflags(&attributes, Int16(flags))
 


### PR DESCRIPTION
Sometimes there is a need to create child processes and ensure they will die together with their parent. By default, both `NSTask` and `SPM.Process` 'detach' the new subprocess from the current process' group. By adding a new flag `startsNewProcessGroup: Bool` we allow child process to inherit the process group from its parent.

Similar effect can be achieved on `NSTask` by calling `-[NSConcreteTask setStartsNewProcessGroup:]` private API. 