### PR TITLE
[SR-8108] CHANGELOG for Swift 4.1 and 4.2 from commit logs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,41 +22,39 @@ Swift 4.2
   path on the local filesystem which hosts a package. This will enable interconnected
   projects to be edited in parallel.
 
-* The `generate-xcodeproj` has a new `--watch` option to automatically regenerate the
-  Xcode project if changes are detected. This uses the
-  [`watchman`](https://facebook.github.io/watchman/docs/install.html) tool to detect
-  filesystem changes.
+* [#1604](https://github.com/apple/swift-package-manager/pull/1604)
+
+  The `generate-xcodeproj` has a new `--watch` option to automatically regenerate the Xcode project
+  if changes are detected. This uses the
+  [`watchman`](https://facebook.github.io/watchman/docs/install.html) tool to detect filesystem
+  changes.
 
 * Scheme generation has been improved:
   * One scheme containing all regular and test targets of the root package.
   * One scheme per executable target containing the test targets whose dependencies
     intersect with the dependencies of the exectuable target.
 
-* Packages which mix versions of the form `vX.X.X` with `Y.Y.Y` will now be parsed and
+* [SR-6978](https://bugs.swift.org/browse/SR-6978)
+  Packages which mix versions of the form `vX.X.X` with `Y.Y.Y` will now be parsed and
   ordered numerically.
 
-* Local `Package` declarations can no longer specify an absolute path, and must instead
+* [SR-4793](https://bugs.swift.org/browse/SR-4793)
+  Local `Package` declarations can no longer specify an absolute path, and must instead
   be relative definitions.
 
-* `swift test` now has rudimentary support for exporting xUnit-formatted xml output.
-
-* The package manager now supports `ppc64le`, `arm`, `arm64`, and `aarch64` machines.
-
-* A simpler progress bar is now generated for "dumb" terminals
+* [#1489](https://github.com/apple/swift-package-manager/pull/1489)
+  A simpler progress bar is now generated for "dumb" terminals.
 
 Swift 4.1
 ---------
 
-* Support has been added to automatically generate the `LinuxMain` files for testing on
-  Linux systems. On a macOS system, run `swift test --generate-linuxmain`
+* [#1485](https://github.com/apple/swift-package-manager/pull/1485)
+  Support has been added to automatically generate the `LinuxMain` files for testing on
+  Linux systems. On a macOS system, run `swift test --generate-linuxmain`.
 
-* Experimental support for `llbuild` manifest caching may be enabled with
-  `--enable-build-manifest-caching`
-
-* Generating an Xcode project now sets the default configuration to `Release`.
-
-* `Package` manifests that include multiple products with the same name will now throw an
-  error
+* [SR-5918](https://bugs.swift.org/browse/SR-5918)
+  `Package` manifests that include multiple products with the same name will now throw an
+  error.
 
 
 Swift 4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,35 +6,57 @@ Swift 4.2
 
 * [SE-209](https://github.com/apple/swift-evolution/blob/master/proposals/0209-package-manager-swift-lang-version-update.md)
 
-    The `swiftLanguageVersions` property no long takes its Swift language versions via
-    a freeform Integer array; instead it should be passed as a new `SwiftVersion` enum
-    array.
+  The `swiftLanguageVersions` property no long takes its Swift language versions via
+  a freeform Integer array; instead it should be passed as a new `SwiftVersion` enum
+  array.
 
 * [SE-208](https://github.com/apple/swift-evolution/blob/master/proposals/0208-package-manager-system-library-targets.md)
 
-    The `Package` manifest now accepts a new type of target, `systemLibrary`. This
-    deprecates "system-module packages" which are now to be included in the packages
-    that require system-installed dependencies.
+  The `Package` manifest now accepts a new type of target, `systemLibrary`. This
+  deprecates "system-module packages" which are now to be included in the packages
+  that require system-installed dependencies.
 
 * [SE-201](https://github.com/apple/swift-evolution/blob/master/proposals/0201-package-manager-local-dependencies.md)
 
-    Packages can now specify a dependency as `package(path: String)` to point to a
-    path on the local filesystem which hosts a package. This will enable interconnected
-    projects to be edited in parallel.
+  Packages can now specify a dependency as `package(path: String)` to point to a
+  path on the local filesystem which hosts a package. This will enable interconnected
+  projects to be edited in parallel.
 
 * The `generate-xcodeproj` has a new `--watch` option to automatically regenerate the
-    Xcode project if changes are detected. This uses the
-    [`watchman`](https://facebook.github.io/watchman/docs/install.html) tool to detect
-    filesystem changes.
+  Xcode project if changes are detected. This uses the
+  [`watchman`](https://facebook.github.io/watchman/docs/install.html) tool to detect
+  filesystem changes.
 
 * Scheme generation has been improved:
   * One scheme containing all regular and test targets of the root package.
   * One scheme per executable target containing the test targets whose dependencies
     intersect with the dependencies of the exectuable target.
 
+* Packages which mix versions of the form `vX.X.X` with `Y.Y.Y` will now be parsed and
+  ordered numerically.
+
+* Local `Package` declarations can no longer specify an absolute path, and must instead
+  be relative definitions.
+
+* `swift test` now has rudimentary support for exporting xUnit-formatted xml output.
+
+* The package manager now supports `ppc64le`, `arm`, `arm64`, and `aarch64` machines.
+
+* A simpler progress bar is now generated for "dumb" terminals
 
 Swift 4.1
 ---------
+
+* Support has been added to automatically generate the `LinuxMain` files for testing on
+  Linux systems. On a macOS system, run `swift test --generate-linuxmain`
+
+* Experimental support for `llbuild` manifest caching may be enabled with
+  `--enable-build-manifest-caching`
+
+* Generating an Xcode project now sets the default configuration to `Release`.
+
+* `Package` manifests that include multiple products with the same name will now throw an
+  error
 
 
 Swift 4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,6 @@ Swift 4.2
   Packages which mix versions of the form `vX.X.X` with `Y.Y.Y` will now be parsed and
   ordered numerically.
 
-* [SR-4793](https://bugs.swift.org/browse/SR-4793)
-  Local `Package` declarations can no longer specify an absolute path, and must instead
-  be relative definitions.
-
 * [#1489](https://github.com/apple/swift-package-manager/pull/1489)
   A simpler progress bar is now generated for "dumb" terminals.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Swift 4.2
 
 * [SE-209](https://github.com/apple/swift-evolution/blob/master/proposals/0209-package-manager-swift-lang-version-update.md)
 
-  The `swiftLanguageVersions` property no long takes its Swift language versions via
+  The `swiftLanguageVersions` property no longer takes its Swift language versions via
   a freeform Integer array; instead it should be passed as a new `SwiftVersion` enum
   array.
 


### PR DESCRIPTION
## Swift 4.1

* #1485 `LinuxMain` generation
* #1435 `llbuild` manifest caching
* #1416 Xcode default config
* #1411 multiple products, same name error

* I wasn't sure about Docker 🐳 support (#1372) since it isn't necessarily end-user related, but might be cool to call out.

## Swift 4.2

* #1524 Mix versions
* #1566 No absolute path
* #1575  xUnit output (Do we actually want this since it's not in the help output? 🤔 )
* #1482, #1546, #1587 `ppc64le`, `arm`, `arm64`, and `aarch64` support.
* #1489 Simple Progress Bar

* What about #1543, did that get attempted again somewhere?
* I didn't quite grok #1518, should we mention that?