### PR TITLE
Link back to full docs.

### DIFF
--- a/Documentation/PackageDescriptionV4_2.md
+++ b/Documentation/PackageDescriptionV4_2.md
@@ -14,7 +14,7 @@
 
 ---
 
-The PackageDescription 4.2 contains one breaking and two additive changes.
+The PackageDescription 4.2 contains one breaking and two additive changes to [PackageDescription API Version 4](PackageDescriptionV4.md).
 
 ## Swift Language Version
 


### PR DESCRIPTION
Search results and my desire to use the latest version made me think that I could find everything I needed to use in the 4.2 documentation.

Come to find out most it and the specs are in PackageDescriptionV4.md with 4.2 documentation being a supplement. 

Thinking a link near the top might help call this out. Or some copy mentioning that this is a modification to the full set of docs.