### PR TITLE
[PackageGraph] Use OrderedDictionary to store assignments

### DIFF
--- a/Sources/Basic/OrderedDictionary.swift
+++ b/Sources/Basic/OrderedDictionary.swift
@@ -1,0 +1,114 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2018 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// A generic collection to store key-value pairs in the order they were inserted in.
+///
+/// This is modelled after the stdlib's Dictionary.
+public struct OrderedDictionary<Key: Hashable, Value> {
+
+    /// The element type of a dictionary: a tuple containing an individual
+    /// key-value pair.
+    public typealias Element = (key: Key, value: Value)
+
+    /// The underlying storage for the OrderedDictionary.
+    fileprivate var array: [Key]
+    fileprivate var dict: [Key: Value]
+
+    /// Create an empty OrderedDictionary object.
+    public init() {
+        self.array = []
+        self.dict = [:]
+    }
+
+    /// Accesses the value associated with the given key for reading and writing.
+    ///
+    /// This *key-based* subscript returns the value for the given key if the key
+    /// is found in the dictionary, or `nil` if the key is not found.
+    public subscript(key: Key) -> Value? {
+        get {
+            return dict[key]
+        }
+        set {
+            if let newValue = newValue {
+                updateValue(newValue, forKey: key)
+            } else {
+                removeValue(forKey: key)
+            }
+        }
+    }
+
+    /// Updates the value stored in the dictionary for the given key, or adds a
+    /// new key-value pair if the key does not exist.
+    ///
+    /// Use this method instead of key-based subscripting when you need to know
+    /// whether the new value supplants the value of an existing key. If the
+    /// value of an existing key is updated, `updateValue(_:forKey:)` returns
+    /// the original value.
+    @discardableResult
+    public mutating func updateValue(_ value: Value, forKey key: Key) -> Value? {
+        // If there is already a value for this key, replace and return the old value.
+        if let oldValue = dict[key] {
+            dict[key] = value
+            return oldValue
+        }
+
+        // Otherwise, create a new entry.
+        dict[key] = value
+        array.append(key)
+        return nil
+    }
+
+    /// Removes the given key and its associated value from the dictionary.
+    ///
+    /// If the key is found in the dictionary, this method returns the key's
+    /// associated value.
+    @discardableResult
+    public mutating func removeValue(forKey key: Key) -> Value? {
+        guard let value = dict[key] else {
+            return nil
+        }
+        dict[key] = nil
+        array.remove(at: array.index(of: key)!)
+        return value
+    }
+}
+
+extension OrderedDictionary: ExpressibleByDictionaryLiteral {
+    public init(dictionaryLiteral elements: (Key, Value)...) {
+        self.init()
+        for element in elements {
+            updateValue(element.1, forKey: element.0)
+        }
+    } 
+}
+
+extension OrderedDictionary: CustomStringConvertible {
+    public var description: String {
+        var string = "["
+        for (idx, key) in array.enumerated() {
+            string += "\(key): \(dict[key]!)"
+            if idx != array.count - 1 {
+                string += ", "
+            }
+        }
+        string += "]"
+        return string
+    }
+}
+
+extension OrderedDictionary: RandomAccessCollection {
+    public var startIndex: Int { return array.startIndex }
+    public var endIndex: Int { return array.endIndex }
+    public subscript(index: Int) -> Element {
+        let key = array[index]
+        let value = dict[key]!
+        return (key, value)
+    }
+}

--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -534,7 +534,7 @@ struct VersionAssignmentSet<C: PackageContainer>: Equatable, Sequence {
     //
     // FIXME: Does it really make sense to key on the identifier here. Should we
     // require referential equality of containers and use that to simplify?
-    fileprivate var assignments: [Identifier: (container: Container, binding: BoundVersion)]
+    fileprivate var assignments: OrderedDictionary<Identifier, (container: Container, binding: BoundVersion)>
 
     /// Create an empty assignment.
     init() {
@@ -681,7 +681,7 @@ struct VersionAssignmentSet<C: PackageContainer>: Equatable, Sequence {
     /// Check if the assignment is valid and complete.
     func checkIfValidAndComplete() -> Bool {
         // Validity should hold trivially, because it is an invariant of the collection.
-        for assignment in assignments.values {
+        for (_, assignment) in assignments {
             if !isValid(binding: assignment.binding, for: assignment.container) {
                 return false
             }
@@ -709,9 +709,9 @@ struct VersionAssignmentSet<C: PackageContainer>: Equatable, Sequence {
     typealias Iterator = AnyIterator<(Container, BoundVersion)>
 
     func makeIterator() -> Iterator {
-        var it = assignments.values.makeIterator()
+        var it = assignments.makeIterator()
         return AnyIterator {
-            if let next = it.next() {
+            if let (_, next) = it.next() {
                 return (next.container, next.binding)
             } else {
                 return nil

--- a/Tests/BasicTests/OrderedDictionaryTests.swift
+++ b/Tests/BasicTests/OrderedDictionaryTests.swift
@@ -1,0 +1,33 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2018 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+import Basic
+
+class OrderedDictionaryTests: XCTestCase {
+    func testBasics() {
+        var dict: OrderedDictionary = ["a": "aa", "b": "bb", "c": "cc", "d": "dd"]
+        XCTAssertEqual(dict.description, "[a: aa, b: bb, c: cc, d: dd]")
+
+        dict["a"] = "aaa"
+        XCTAssertEqual(dict.description, "[a: aaa, b: bb, c: cc, d: dd]")
+
+        dict["e"] = "ee"
+        XCTAssertEqual(dict.description, "[a: aaa, b: bb, c: cc, d: dd, e: ee]")
+
+        dict["b"] = nil
+        XCTAssertEqual(dict.description, "[a: aaa, c: cc, d: dd, e: ee]")
+    }
+
+    static var allTests = [
+        ("testBasics", testBasics),
+    ]
+}

--- a/Tests/BasicTests/XCTestManifests.swift
+++ b/Tests/BasicTests/XCTestManifests.swift
@@ -34,6 +34,7 @@ public func allTests() -> [XCTestCaseEntry] {
         testCase(LockTests.allTests),
         testCase(miscTests.allTests),
         testCase(ObjectIdentifierProtocolTests.allTests),
+        testCase(OrderedDictionaryTests.allTests),
         testCase(OrderedSetTests.allTests),
         testCase(OutputByteStreamTests.allTests),
         testCase(POSIXTests.allTests),

--- a/Tests/PackageGraphTests/DependencyResolverTests.swift
+++ b/Tests/PackageGraphTests/DependencyResolverTests.swift
@@ -484,6 +484,45 @@ class DependencyResolverTests: XCTestCase {
         }
     }
 
+    func testRevisionConstraint2() throws {
+        // Test that requiring revision constraint for a dependency that is
+        // required via version transitively resolves correctly.
+
+        let develop = "develop"
+
+        let provider = MockPackagesProvider(containers: [
+            MockPackageContainer(name: "A", dependencies: [
+                develop: [
+                    (container: "B", requirement: .versionSet(v1Range)),
+                ],
+            ]),
+
+            MockPackageContainer(name: "B", dependencies: [
+                "1.1.0": [],
+                develop: [],
+            ]),
+
+            MockPackageContainer(name: "C", dependencies: [
+                develop: [
+                    (container: "A", requirement: .revision(develop)),
+                    (container: "B", requirement: .revision(develop)),
+                ],
+            ]),
+        ])
+
+        do {
+            let resolver = MockDependencyResolver(provider, MockResolverDelegate())
+            let result = try resolver.resolve(constraints: [
+                MockPackageConstraint(container: "C", requirement: .revision(develop)),
+            ])
+            XCTAssertEqual(result, [
+                "A": .revision(develop),
+                "B": .revision(develop),
+                "C": .revision(develop),
+            ])
+        }
+    }
+
     func testUnversionedConstraint() throws {
         let provider = MockPackagesProvider(containers: [
             MockPackageContainer(name: "A", dependenciesByVersion: [v1: [], v1_1: []]),
@@ -767,6 +806,7 @@ class DependencyResolverTests: XCTestCase {
         ("testResolveSubtree", testResolveSubtree),
         ("testResolve", testResolve),
         ("testRevisionConstraint", testRevisionConstraint),
+        ("testRevisionConstraint2", testRevisionConstraint2),
         ("testCompleteness", testCompleteness),
         ("testLazyResolve", testLazyResolve),
         ("testExactConstraint", testExactConstraint),


### PR DESCRIPTION
The assignments were stored in a regular dictionary which caused
non-deterministic crashes when a package graph contained dependencies
that were required via a revison and version in different subtrees.
Since the order in which the constrained appear matters, the assignment
also needs to be stored in order.

Cherry-picked from 1c482a5

<rdar://problem/43699736>