### PR TITLE
[Workspace] Use topological sort when creating DependencyManifests

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -914,7 +914,7 @@ extension Workspace {
         var loadedManifests = [String: Manifest]()
 
         // Compute the transitive closure of available dependencies.
-        let dependencies = transitiveClosure(inputManifests.map({ KeyedPair($0, key: $0.name) })) { node in
+        let allManifests = try! topologicalSort(inputManifests.map({ KeyedPair($0, key: $0.name) })) { node in
             return node.item.dependencies.compactMap({ dependency in
                 let ref = dependency.createPackageRef()
                 let manifest = loadedManifests[ref.identity] ?? loadManifest(for: ref, diagnostics: diagnostics)
@@ -923,10 +923,9 @@ extension Workspace {
             })
         }
 
-        // It is possible that some root dependency is also present as a regular dependency, so we
-        // form a unique set of all dependency manifests.
-        let allManifests = Set(rootDependencyManifests.map({ KeyedPair($0, key: $0.name) }) + dependencies).map({ $0.item })
-        let deps: [(Manifest, ManagedDependency)] = allManifests.map({
+        let allDependencyManifests = allManifests.map({ $0.item }).filter({ !root.manifests.contains($0) })
+
+        let deps: [(Manifest, ManagedDependency)] = allDependencyManifests.map({
             // FIXME: We should use package name directly once this radar is fixed:
             // <rdar://problem/33693433> Ensure that identity and package name
             // are the same once we have an API to specify identity in the

--- a/Tests/WorkspaceTests/XCTestManifests.swift
+++ b/Tests/WorkspaceTests/XCTestManifests.swift
@@ -48,6 +48,7 @@ extension WorkspaceTests {
         ("testCleanAndReset", testCleanAndReset),
         ("testDeletedCheckoutDirectory", testDeletedCheckoutDirectory),
         ("testDependencyManifestLoading", testDependencyManifestLoading),
+        ("testDependencyManifestsOrder", testDependencyManifestsOrder),
         ("testDependencyResolutionWithEdit", testDependencyResolutionWithEdit),
         ("testEditDependency", testEditDependency),
         ("testGraphData", testGraphData),


### PR DESCRIPTION
<rdar://problem/43700179> isResolutionRequired is non-deterministic when a graph contains both revision and version based dependency requirements