### PR TITLE
Add an additional newline after progress bar

### DIFF
--- a/Sources/Utility/ProgressBar.swift
+++ b/Sources/Utility/ProgressBar.swift
@@ -129,6 +129,7 @@ public final class ProgressBar: ProgressBarProtocol {
 
     public func complete(success: Bool) {
         term.endLine()
+        term.endLine()
     }
 }
 


### PR DESCRIPTION
This fixes a small output glitch of parallel testing.