### PR TITLE
Fix progress bar if output exceeds terminal width

### DIFF
--- a/Sources/Utility/ProgressBar.swift
+++ b/Sources/Utility/ProgressBar.swift
@@ -122,7 +122,13 @@ public final class ProgressBar: ProgressBarProtocol {
         term.endLine()
 
         term.clearLine()
-        term.write(text)
+        if text.utf8.count > term.width {
+            let prefix = "…"
+            term.write(prefix)
+            term.write(String(text.suffix(term.width - prefix.utf8.count)))
+        } else {
+            term.write(text)
+        }
 
         term.moveCursor(up: 1)
     }


### PR DESCRIPTION
This currently messes up the progress bar, this change makes it so that long output gets head truncated with ellipsis.