### PR TITLE
Improve handling of "extra" files

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -373,9 +373,13 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             generateXcodeParser.add(
                 option: "--watch", kind: Bool.self,
                 usage: "Watch for changes to the Package manifest to regenerate the Xcode project"),
+            generateXcodeParser.add(
+                option: "--skip-extra-files", kind: Bool.self,
+                usage: "Do not add file references for extra files to the generated Xcode project"),
             to: {
                 $0.xcodeprojOptions.useLegacySchemeGenerator = $1 ?? false
                 $0.xcodeprojOptions.enableAutogeneration = $2 ?? false
+                $0.xcodeprojOptions.addExtraFiles = !($3 ?? false)
             })
 
         let completionToolParser = parser.add(

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -319,17 +319,6 @@ func xcodeProject(
     // Create a `Tests` group for the source targets in the root package.
     createSourceGroup(named: "Tests", for: testModules, in: project.mainGroup)
 
-    // Add "blue folders" for any other directories at the top level (note that
-    // they are not guaranteed to be direct children of the root directory).
-    for extraDir in extraDirs {
-        project.mainGroup.addFileReference(path: extraDir.relative(to: sourceRootDir).asString, pathBase: .projectDir)
-    }
-
-    for extraFile in extraFiles {
-        let groupOfFile = srcPathsToGroups[extraFile.parentDirectory]
-        groupOfFile?.addFileReference(path: extraFile.basename)
-    }
-
     // Determine the set of targets to generate in the project by excluding
     // any system targets.
     let targets = graph.reachableTargets.filter({ $0.type != .systemModule })
@@ -371,6 +360,17 @@ func xcodeProject(
     // Add a `Products` group, to which we'll add references to the outputs of
     // the various targets; these references will be added to the link phases.
     let productsGroup = project.mainGroup.addGroup(path: "", pathBase: .buildDir, name: "Products")
+
+    // Add "blue folders" for any other directories at the top level (note that
+    // they are not guaranteed to be direct children of the root directory).
+    for extraDir in extraDirs {
+        project.mainGroup.addFileReference(path: extraDir.relative(to: sourceRootDir).asString, pathBase: .projectDir)
+    }
+
+    for extraFile in extraFiles {
+        let groupOfFile = srcPathsToGroups[extraFile.parentDirectory]
+        groupOfFile?.addFileReference(path: extraFile.basename)
+    }
 
     // Set the newly created `Products` group as the official products group of
     // the project.

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -231,6 +231,9 @@ class GenerateXcodeprojTests: XCTestCase {
             let project = try Xcodeproj.generate(projectName: projectName, xcodeprojPath: outpath, graph: graph, options: XcodeprojOptions(), diagnostics: diagnostics)
 
             XCTAssertTrue(project.mainGroup.subitems.contains { $0.path == "a.txt" })
+
+            let projectWithoutExtraFiles = try Xcodeproj.generate(projectName: projectName, xcodeprojPath: outpath, graph: graph, options: XcodeprojOptions(addExtraFiles: false), diagnostics: diagnostics)
+            XCTAssertFalse(projectWithoutExtraFiles.mainGroup.subitems.contains { $0.path == "a.txt" })
         }
     }
 


### PR DESCRIPTION
In #1507, we started adding "extra" files to the generated Xcode
project. This makes some enhancements to that feature:

- Introduce a new CLI flag `--skip-extra-files` to go back to the pre-4.2 behaviour (best behaviour) of not including these files at all
- Do not add a file reference for "Package.resolved" since this shouldn't be edited by hand and most people also never have to read it
- Move the "extra" file references after the products group. This may be debatable, but I think it is more clean to have all file references related to the package manifest grouped together at the top instead of having these interspersed throughout the main group