### PR TITLE
Support tilde expansion for local dependencies on DescriptionV4_2

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -217,7 +217,11 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
         // Load the manifest from JSON.
         let json = try JSON(string: jsonString)
-        let manifestBuilder = try ManifestBuilder(v4: json, baseURL: baseURL)
+        let manifestBuilder = try ManifestBuilder(
+            v4: json,
+            baseURL: baseURL,
+            fileSystem: fileSystem ?? localFileSystem
+        )
 
         // Throw if we encountered any runtime errors.
         guard manifestBuilder.errors.isEmpty else {

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -671,6 +671,10 @@ private class GitFileSystemView: FileSystem {
 
     // MARK: Unsupported methods.
 
+    public var homeDirectory: AbsolutePath {
+        fatalError("unsupported")
+    }
+
     func createDirectory(_ path: AbsolutePath) throws {
         throw FileSystemError.unsupported
     }

--- a/Sources/SourceControl/InMemoryGitRepository.swift
+++ b/Sources/SourceControl/InMemoryGitRepository.swift
@@ -207,6 +207,10 @@ extension InMemoryGitRepository: FileSystem {
         return AbsolutePath("/")
     }
 
+    public var homeDirectory: AbsolutePath {
+        fatalError("Unsupported")
+    }
+
     public func getDirectoryContents(_ path: AbsolutePath) throws -> [String] {
         return try head.fileSystem.getDirectoryContents(path)
     }

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -179,6 +179,10 @@ class PackageDescription4_2LoadingTests: XCTestCase {
                    .package(url: "/foo7", .branch("master")),
                    .package(url: "/foo8", .upToNextMinor(from: "1.3.4")),
                    .package(url: "/foo9", .upToNextMajor(from: "1.3.4")),
+                   .package(path: "~/path/to/foo10"),
+                   .package(path: "~foo11"),
+                   .package(path: "~/path/to/~/foo12"),
+                   .package(path: "~"),
                ]
             )
             """
@@ -198,6 +202,19 @@ class PackageDescription4_2LoadingTests: XCTestCase {
             XCTAssertEqual(deps["/foo7"], PackageDependencyDescription(url: "/foo7", requirement: .branch("master")))
             XCTAssertEqual(deps["/foo8"], PackageDependencyDescription(url: "/foo8", requirement: .upToNextMinor(from: "1.3.4")))
             XCTAssertEqual(deps["/foo9"], PackageDependencyDescription(url: "/foo9", requirement: .upToNextMajor(from: "1.3.4")))
+
+            let homeDir = "/home/user"
+            XCTAssertEqual(deps["\(homeDir)/path/to/foo10"]?.url, "\(homeDir)/path/to/foo10")
+            XCTAssertEqual(deps["\(homeDir)/path/to/foo10"]?.requirement, .localPackage)
+
+            XCTAssertEqual(deps["/~foo11"]?.url, "/~foo11")
+            XCTAssertEqual(deps["/~foo11"]?.requirement, .localPackage)
+
+            XCTAssertEqual(deps["\(homeDir)/path/to/~/foo12"]?.url, "\(homeDir)/path/to/~/foo12")
+            XCTAssertEqual(deps["\(homeDir)/path/to/~/foo12"]?.requirement, .localPackage)
+
+            XCTAssertEqual(deps["/~"]?.url, "/~")
+            XCTAssertEqual(deps["/~"]?.requirement, .localPackage)
         }
     }
 


### PR DESCRIPTION
## Problem

According to [the documentation](https://github.com/apple/swift-package-manager/blob/master/Documentation/PackageDescriptionV4_2.md#local-dependencies), local dependencies are available on SPM DescriptionV4_2.

However, we can't declare paths which start with `~`.

```swift
// swift-tools-version:4.2
// The swift-tools-version declares the minimum version of Swift required to build this package.

import PackageDescription

let package = Package(
    name: "myexecutable",
    dependencies: [
        // Dependencies declare other packages that this package depends on.
        .package(path: "~/work/MyPackage"),
    ],
    targets: [
        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
        .target(
            name: "myexecutable",
            dependencies: ["MyPackage"]),
    ]
)
```

```console
$ swift build --disable-package-manifest-caching
error: /Users/giginet/work/myexecutable/~/work/MyPackage has no manifest
'myexecutable' /Users/giginet/work/myexecutable: error: product dependency 'MyPackage' not found
```

We want SPM to expand `~` as a home directory.

## Description

This PR make Package Description v4.2 to support tilde expansion.