### PR TITLE
Throwing errors instead of calling fatalError

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -683,8 +683,8 @@ private class GitFileSystemView: FileSystem {
         throw FileSystemError.unsupported
     }
 
-    func removeFileTree(_ path: AbsolutePath) {
-        fatalError("unsupported")
+    func removeFileTree(_ path: AbsolutePath) throws {
+        throw FileSystemError.unsupported
     }
 
     func chmod(_ mode: FileMode, path: AbsolutePath, options: Set<FileMode.Option>) throws {


### PR DESCRIPTION
On `FileSystem` protocol, `removeFileTree` method is throwable.

```swift
    func removeFileTree(_ path: AbsolutePath) throws
```

So I think it is better to throw `FileSystemError.unsupported`. instead of calling `fatalError`