### PR TITLE
[bootstrap] Forward swift compiler path when building llbuild

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -911,7 +911,7 @@ def build_llbuild(args):
     # FIXME: Is this check enough?
     if not os.path.isfile(os.path.join(llbuild_build_dir, "CMakeCache.txt")):
         mkdir_p(llbuild_build_dir)
-        cmd = ["cmake", "-G", "Ninja", "-DCMAKE_BUILD_TYPE:=Debug", "-DCMAKE_C_COMPILER:=clang", "-DCMAKE_CXX_COMPILER:=clang++", "-DLLBUILD_SUPPORT_BINDINGS:=Swift", llbuild_source_dir]
+        cmd = ["cmake", "-G", "Ninja", "-DCMAKE_BUILD_TYPE:=Debug", "-DCMAKE_C_COMPILER:=clang", "-DCMAKE_CXX_COMPILER:=clang++", "-DLLBUILD_SUPPORT_BINDINGS:=Swift", "-DSWIFTC_EXECUTABLE:=%s" % (args.swiftc_path), llbuild_source_dir]
         subprocess.check_call(cmd, cwd=llbuild_build_dir)
 
     # Build.


### PR DESCRIPTION
<rdar://problem/44583560> Swiftpm needs to forward --swiftc to llbuild