### PR TITLE
[RFC][DNM] Allow clang targets to specify a single public header

### DIFF
--- a/Sources/PackageLoading/ModuleMapGenerator.swift
+++ b/Sources/PackageLoading/ModuleMapGenerator.swift
@@ -91,6 +91,17 @@ public struct ModuleMapGenerator {
             return
         }
 
+        if let umbrella = target.umbrellaHeader {
+            let src = target.includeDir.appending(umbrella)
+            let dstDir = wd.appending(component: ClangTarget.defaultPublicHeadersComponent)
+            try fileSystem.createDirectory(dstDir, recursive: true)
+
+            let dst = dstDir.appending(umbrella)
+            try fileSystem.writeFileContents(dst, bytes: fileSystem.readFileContents(src))
+            target.includeDir = dstDir
+            target.umbrellaHeader = nil
+        }
+
         let includeDir = target.includeDir
         // Warn and return if no include directory.
         guard fileSystem.isDirectory(includeDir) else {

--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -142,8 +142,10 @@ public class ClangTarget: Target {
     /// The default public include directory component.
     public static let defaultPublicHeadersComponent = "include"
 
-    /// The path to include directory.
-    public let includeDir: AbsolutePath
+    /// The path to the directory containing the target's public header/s.
+    public var includeDir: AbsolutePath
+
+    public var umbrellaHeader: RelativePath?
 
     /// True if this is a C++ target.
     public let isCXX: Bool
@@ -159,6 +161,7 @@ public class ClangTarget: Target {
         cLanguageStandard: String?,
         cxxLanguageStandard: String?,
         includeDir: AbsolutePath,
+        umbrellaHeader: RelativePath? = nil,
         isTest: Bool = false,
         sources: Sources,
         dependencies: [Target] = [],
@@ -170,6 +173,7 @@ public class ClangTarget: Target {
         self.cLanguageStandard = cLanguageStandard
         self.cxxLanguageStandard = cxxLanguageStandard
         self.includeDir = includeDir
+        self.umbrellaHeader = umbrellaHeader
         super.init(
             name: name,
             type: type,


### PR DESCRIPTION
Wondering what you think about allowing this. There are some popular C libraries who don't separate their public/internal headers at the filesystem level, instead relying on their own build scripts to only copy the appropriate headers (e.g. Oniguruma and Onigmo). We could also support an explicit list of public headers, but that's more work to do in a source-compatible way at the PackageDescription level.

We need to copy the header file to the build's working directory (and set that directory as the include path), or all subsequent targets will warn about the modulemap being "incomplete" 😕. `FileSystem` could use a `copy` method.

Will add tests if feedback is positive.