### PR TITLE
[Workspace] Use PackageRef to compute missing packages

### DIFF
--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -958,7 +958,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Check that we can compute missing dependencies.
         workspace.loadDependencyManifests(roots: ["Root1", "Root2"]) { (manifests, diagnostics) in
-            XCTAssertEqual(manifests.missingPackageIdentities().map{$0}.sorted(), ["bar", "foo"])
+            XCTAssertEqual(manifests.missingPackageURLs().map{$0.path}.sorted(), ["/tmp/ws/pkgs/Bar", "/tmp/ws/pkgs/Foo"])
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -972,7 +972,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Check that we compute the correct missing dependencies.
         workspace.loadDependencyManifests(roots: ["Root1", "Root2"]) { (manifests, diagnostics) in
-            XCTAssertEqual(manifests.missingPackageIdentities().map{$0}.sorted(), ["bar"])
+            XCTAssertEqual(manifests.missingPackageURLs().map{$0.path}.sorted(), ["/tmp/ws/pkgs/Bar"])
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -986,7 +986,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Check that we compute the correct missing dependencies.
         workspace.loadDependencyManifests(roots: ["Root1", "Root2"]) { (manifests, diagnostics) in
-            XCTAssertEqual(manifests.missingPackageIdentities().map{$0}.sorted(), [])
+            XCTAssertEqual(manifests.missingPackageURLs().map{$0.path}.sorted(), [])
             XCTAssertNoDiagnostics(diagnostics)
         }
     }


### PR DESCRIPTION
This switches the method from providing a set of missing identities to
provide a set of missing package references. This should eventually help
in resolving the issue where we don't re-resolve when a package url is
changed without affecting the identity.