### PR TITLE
[Workspace] Key managed dependencies by the URL

### DIFF
--- a/Sources/TestSupport/MockManifestLoader.swift
+++ b/Sources/TestSupport/MockManifestLoader.swift
@@ -35,13 +35,8 @@ public final class MockManifestLoader: ManifestLoaderProtocol {
         public let version: Version?
 
         public init(url: String, version: Version? = nil) {
-            self.url = PackageReference.computeIdentity(packageURL: url)
+            self.url = url
             self.version = version
-        }
-
-        //FIXME: Remove in 4.2
-        public var hashValue: Int {
-            return url.hashValue ^ (version?.hashValue ?? 0)
         }
     }
 
@@ -59,7 +54,7 @@ public final class MockManifestLoader: ManifestLoaderProtocol {
         fileSystem: FileSystem?,
         diagnostics: DiagnosticsEngine?
     ) throws -> PackageModel.Manifest {
-        let key = Key(url: PackageReference.computeIdentity(packageURL: baseURL), version: version)
+        let key = Key(url: baseURL, version: version)
         if let result = manifests[key] {
             return result
         }

--- a/Sources/TestSupport/TestWorkspace.swift
+++ b/Sources/TestSupport/TestWorkspace.swift
@@ -71,9 +71,10 @@ public final class TestWorkspace {
         var manifests: [MockManifestLoader.Key: Manifest] = [:]
 
         func create(package: TestPackage, basePath: AbsolutePath, isRoot: Bool) throws {
-            let packagePath = basePath.appending(component: package.path ?? package.name)
+            let packagePath = basePath.appending(RelativePath(package.path ?? package.name))
+
             let sourcesDir = packagePath.appending(component: "Sources")
-            let url = (isRoot ? packagePath : packagesDir.appending(component: package.path ?? package.name)).asString
+            let url = (isRoot ? packagePath : packagesDir.appending(RelativePath(package.path ?? package.name))).asString
             let specifier = RepositorySpecifier(url: url)
             
             // Create targets on disk.
@@ -161,7 +162,7 @@ public final class TestWorkspace {
 
         fileprivate func convert(_ packagesDir: AbsolutePath) -> PackageGraphRootInput.PackageDependency {
             return PackageGraphRootInput.PackageDependency(
-                url: packagesDir.appending(component: name).asString,
+                url: packagesDir.appending(RelativePath(name)).asString,
                 requirement: requirement,
                 location: name
             )
@@ -294,7 +295,8 @@ public final class TestWorkspace {
         }
 
         public func check(notPresent name: String, file: StaticString = #file, line: UInt = #line) {
-            XCTAssert(managedDependencies[forIdentity: name] == nil, "Unexpectedly found \(name) in managed dependencies", file: file, line: line)
+            let dependency = try? managedDependencies.dependency(forNameOrIdentity: name)
+            XCTAssert(dependency == nil, "Unexpectedly found \(name) in managed dependencies", file: file, line: line)
         }
 
         public func checkEmpty(file: StaticString = #file, line: UInt = #line) {
@@ -302,7 +304,7 @@ public final class TestWorkspace {
         }
 
         public func check(dependency name: String, at state: State, file: StaticString = #file, line: UInt = #line) {
-            guard let dependency = managedDependencies[forIdentity: name] else {
+            guard let dependency = try? managedDependencies.dependency(forNameOrIdentity: name) else {
                 XCTFail("\(name) does not exists", file: file, line: line)
                 return
             }
@@ -318,7 +320,7 @@ public final class TestWorkspace {
                 }
             case .edited(let path):
                 if dependency.state != .edited(path) {
-                    XCTFail("Expected edited dependency", file: file, line: line)
+                    XCTFail("Expected edited dependency; found '\(dependency.state)' instead", file: file, line: line)
                 }
             case .local:
                 if dependency.state != .local {
@@ -445,7 +447,7 @@ public struct TestDependency {
     }
 
     public func convert(baseURL: AbsolutePath) -> PackageDependencyDescription {
-        return PackageDependencyDescription(url: baseURL.appending(component: name).asString, requirement: requirement)
+        return PackageDependencyDescription(url: baseURL.appending(RelativePath(name)).asString, requirement: requirement)
     }
 }
 

--- a/Tests/WorkspaceTests/XCTestManifests.swift
+++ b/Tests/WorkspaceTests/XCTestManifests.swift
@@ -50,6 +50,7 @@ extension WorkspaceTests {
         ("testDependencyManifestLoading", testDependencyManifestLoading),
         ("testDependencyManifestsOrder", testDependencyManifestsOrder),
         ("testDependencyResolutionWithEdit", testDependencyResolutionWithEdit),
+        ("testDependencySwitchWithSameIdentity", testDependencySwitchWithSameIdentity),
         ("testEditDependency", testEditDependency),
         ("testGraphData", testGraphData),
         ("testGraphRootDependencies", testGraphRootDependencies),


### PR DESCRIPTION
Instead of identity, this will key managed dependencies by the package
URLs. This will help us to distingush between forks and also resolves
this bug:

<rdar://problem/34302690> Detect changes in dependency URLs when the package identity remains same