### PR TITLE
[Workspace] Make `dependencyMap` private

### DIFF
--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -208,7 +208,7 @@ public final class ManagedDependencies: SimplePersistanceProtocol {
     /// The current state of managed dependencies.
     ///
     /// Key -> package URL.
-    var dependencyMap: [String: ManagedDependency]
+    private var dependencyMap: [String: ManagedDependency]
 
     /// Path to the state file.
     let statePath: AbsolutePath


### PR DESCRIPTION
I made it internal by mistake in the previous commit.