### PR TITLE
[Workspace] Don't generate Package.resolved when there are zero pins

### DIFF
--- a/Sources/Workspace/PinsStore.swift
+++ b/Sources/Workspace/PinsStore.swift
@@ -146,6 +146,14 @@ public final class PinsStore {
 extension PinsStore: SimplePersistanceProtocol {
 
     public func saveState() throws {
+        if pinsMap.isEmpty {
+            // Remove the pins file if there are zero pins to save.
+            //
+            // This can happen if all dependencies are path-based or edited
+            // dependencies.
+            return try fileSystem.removeFileTree(pinsFile)
+        }
+
         try self.persistence.saveState(self)
     }
 

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -134,4 +134,26 @@ final class PinsStoreTests: XCTestCase {
         let store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
         XCTAssertEqual(store.pinsMap.keys.map{$0}.sorted(), ["clang_c", "commandant"])
     }
+
+    func testEmptyPins() throws {
+        let fs = InMemoryFileSystem()
+        let pinsFile = AbsolutePath("/pinsfile.txt")
+        let store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
+
+        try store.saveState()
+        XCTAssertFalse(fs.exists(pinsFile))
+
+        let fooRef = PackageReference(identity: "foo", path: "/foo")
+        let revision = Revision(identifier: "81513c8fd220cf1ed1452b98060cd80d3725c5b7")
+        store.pin(packageRef: fooRef, state: CheckoutState(revision: revision, version: v1))
+
+        XCTAssert(!fs.exists(pinsFile))
+
+        try store.saveState()
+        XCTAssert(fs.exists(pinsFile))
+
+        store.unpinAll()
+        try store.saveState()
+        XCTAssertFalse(fs.exists(pinsFile))
+    }
 }

--- a/Tests/WorkspaceTests/XCTestManifests.swift
+++ b/Tests/WorkspaceTests/XCTestManifests.swift
@@ -21,6 +21,7 @@ extension PinsStoreTests {
     // to regenerate.
     static let __allTests__PinsStoreTests = [
         ("testBasics", testBasics),
+        ("testEmptyPins", testEmptyPins),
         ("testLoadingSchema1", testLoadingSchema1),
     ]
 }


### PR DESCRIPTION
<rdar://problem/44761993> SwiftPM shouldn't write a Package.resolved with zero objects