### PR TITLE
Add support for Swift REPL

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -501,13 +501,18 @@ public class SwiftTool<Options: ToolOptions> {
 
     /// Fetch and load the complete package graph.
     @discardableResult
-    func loadPackageGraph() throws -> PackageGraph {
+    func loadPackageGraph(
+        createREPLProduct: Bool = false
+    ) throws -> PackageGraph {
         do {
             let workspace = try getActiveWorkspace()
 
             // Fetch and load the package graph.
             let graph = try workspace.loadPackageGraph(
-                root: getWorkspaceRoot(), diagnostics: diagnostics)
+                root: getWorkspaceRoot(),
+                createREPLProduct: createREPLProduct,
+                diagnostics: diagnostics
+            )
 
             // Throw if there were errors when loading the graph.
             // The actual errors will be printed before exiting.

--- a/Sources/PackageGraph/PackageGraphLoader.swift
+++ b/Sources/PackageGraph/PackageGraphLoader.swift
@@ -76,7 +76,8 @@ public struct PackageGraphLoader {
         externalManifests: [Manifest],
         diagnostics: DiagnosticsEngine,
         fileSystem: FileSystem = localFileSystem,
-        shouldCreateMultipleTestProducts: Bool = false
+        shouldCreateMultipleTestProducts: Bool = false,
+        createREPLProduct: Bool = false
     ) -> PackageGraph {
 
         // Create a map of the manifests, keyed by their identity.
@@ -131,7 +132,8 @@ public struct PackageGraphLoader {
                 fileSystem: fileSystem,
                 diagnostics: diagnostics,
                 isRootPackage: isRootPackage,
-                shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts
+                shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts,
+                createREPLProduct: isRootPackage ? createREPLProduct : false
             )
 
             diagnostics.wrap(with: PackageLocation.Local(name: manifest.name, packagePath: packagePath), {

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -195,6 +195,9 @@ public final class PackageBuilder {
     /// If set to true, one test product will be created for each test target.
     private let shouldCreateMultipleTestProducts: Bool
 
+    /// Create the special REPL product for this package.
+    private let createREPLProduct: Bool
+
     /// Create a builder for the given manifest and package `path`.
     ///
     /// - Parameters:
@@ -211,7 +214,8 @@ public final class PackageBuilder {
         fileSystem: FileSystem = localFileSystem,
         diagnostics: DiagnosticsEngine,
         isRootPackage: Bool,
-        shouldCreateMultipleTestProducts: Bool = false
+        shouldCreateMultipleTestProducts: Bool = false,
+        createREPLProduct: Bool = false
     ) {
         self.isRootPackage = isRootPackage
         self.manifest = manifest
@@ -219,6 +223,7 @@ public final class PackageBuilder {
         self.fileSystem = fileSystem
         self.diagnostics = diagnostics
         self.shouldCreateMultipleTestProducts = shouldCreateMultipleTestProducts
+        self.createREPLProduct = createREPLProduct
     }
 
     /// Build a new package following the conventions.
@@ -914,6 +919,16 @@ public final class PackageBuilder {
             }
 
             append(Product(name: product.name, type: product.type, targets: targets))
+        }
+
+        // Create a special REPL product that contains all the library targets.
+        if createREPLProduct {
+            let replProduct = Product(
+                name: manifest.name + Product.replProductSuffix,
+                type: .library(.dynamic),
+                targets: targets.filter({ $0.type == .library })
+            )
+            append(replProduct)
         }
 
         return products.map({ $0.item })

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -71,6 +71,9 @@ public class Product {
     /// The path to linux main file.
     public let linuxMain: AbsolutePath?
 
+    /// The suffix for REPL product name.
+    public static let replProductSuffix: String = "__REPL"
+
     public init(name: String, type: ProductType, targets: [Target], linuxMain: AbsolutePath? = nil) {
         precondition(!targets.isEmpty)
         if type == .executable {

--- a/Sources/TestSupport/misc.swift
+++ b/Sources/TestSupport/misc.swift
@@ -201,7 +201,8 @@ public func loadPackageGraph(
     roots: [String],
     fs: FileSystem,
     diagnostics: DiagnosticsEngine = DiagnosticsEngine(),
-    manifests: [Manifest]
+    manifests: [Manifest],
+    createREPLProduct: Bool = false
 ) -> PackageGraph {
     let input = PackageGraphRootInput(packages: roots.map({ AbsolutePath($0) }))
     let rootManifests = manifests.filter({ roots.contains($0.path.parentDirectory.asString) })
@@ -212,18 +213,23 @@ public func loadPackageGraph(
         root: graphRoot,
         externalManifests: externalManifests,
         diagnostics: diagnostics,
-        fileSystem: fs)
+        fileSystem: fs,
+        createREPLProduct: createREPLProduct
+    )
 }
 
 public func loadPackageGraph(
     root: String,
     fs: FileSystem,
     diagnostics: DiagnosticsEngine = DiagnosticsEngine(),
-    manifests: [Manifest]
+    manifests: [Manifest],
+    createREPLProduct: Bool = false
 ) -> PackageGraph {
     return loadPackageGraph(
         roots: [root], fs: fs,
-        diagnostics: diagnostics, manifests: manifests)
+        diagnostics: diagnostics, manifests: manifests,
+        createREPLProduct: createREPLProduct
+    )
 }
 
 /// Temporary override environment variables

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -556,6 +556,7 @@ extension Workspace {
     public func loadPackageGraph(
         root: PackageGraphRootInput,
         createMultipleTestProducts: Bool = false,
+        createREPLProduct: Bool = false,
         diagnostics: DiagnosticsEngine
     ) -> PackageGraph {
 
@@ -569,7 +570,8 @@ extension Workspace {
             externalManifests: externalManifests,
             diagnostics: diagnostics,
             fileSystem: fileSystem,
-            shouldCreateMultipleTestProducts: createMultipleTestProducts
+            shouldCreateMultipleTestProducts: createMultipleTestProducts,
+            createREPLProduct: createREPLProduct
         )
     }
 

--- a/Tests/BuildTests/XCTestManifests.swift
+++ b/Tests/BuildTests/XCTestManifests.swift
@@ -19,6 +19,7 @@ extension BuildPlanTests {
         ("testNonReachableProductsAndTargets", testNonReachableProductsAndTargets),
         ("testPkgConfigGenericDiagnostic", testPkgConfigGenericDiagnostic),
         ("testPkgConfigHintDiagnostic", testPkgConfigHintDiagnostic),
+        ("testREPLArguments", testREPLArguments),
         ("testSwiftCMixed", testSwiftCMixed),
         ("testSystemPackageBuildPlan", testSystemPackageBuildPlan),
         ("testTestModule", testTestModule),


### PR DESCRIPTION
This adds a --repl option to `swift run` which will build the package
and launch the Swift REPL. All reachable library modules will be
accessible in the REPL. It works by generating a special dylib product
that contains all of the library targets of the root package.

https://bugs.swift.org/browse/SR-1573