### PR TITLE
Remove PackageDescription4 from libSwiftPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,6 @@ let package = Package(
                 "Utility",
                 "SourceControl",
                 "SPMLLBuild",
-                "PackageDescription4",
                 "PackageModel",
                 "PackageLoading",
                 "PackageGraph",


### PR DESCRIPTION
The runtimes are separated from libSwiftPM so there is no need to
include it in the libSwiftPM product.