### PR TITLE
Printing usage on ArgumentParser subcommands

### DIFF
--- a/Tests/UtilityTests/ArgumentParserTests.swift
+++ b/Tests/UtilityTests/ArgumentParserTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 import Basic
 import TestSupport
-import Utility
+@testable import Utility
 
 enum SampleEnum: String {
     case Foo


### PR DESCRIPTION
This PR is about printing the USAGE: line when a user asks for help on a subcommand. 

It started because I wanted to see the usage of a subcommand. Typing `command subcommand --help` printed the subcommand and a list of the available options for it, but didn't give me any indicator of what the values for those options might be unless I talked about them in each options usage. For example, here's the output from a program I'm working on:

```
OVERVIEW: Sorts the Xcode project file to aleviate merge issues.

OPTIONS:
  --sort-xcode-files       Sorts file lists with the Xcode project file to minimise merge issues.
  --sort-xcode-navigator   "by-name" sorts files listed in the Xcode project file by their name."by-name-folders-first" sorts the folders first then the files in aphebatical order.
```

And here's the same output after applying this PR (Note that I assemble the subcommand options as the subcommands usage string:

```
OVERVIEW: Sorts the Xcode project file to aleviate merge issues.

USAGE: Wrench sortproject [--sort-xcode-navigator by-name|by-name-folders-first] [--sort-xcode-files]

OPTIONS:
  --sort-xcode-files       Sorts file lists with the Xcode project file to minimise merge issues.
  --sort-xcode-navigator   "by-name" sorts files listed in the Xcode project file by their name."by-name-folders-first" sorts the folders first then the files in aphabetical order.
```

## Tests

In running the tests I noticed that the tests for the `ArgumentParser` usage were basically two very large tests which actually tested a number of scenarios. So I broke them up into smaller more easily maintained tests.

## Questions:

* Is there any sort of auto formatting done on code for this project? Both Xcode's default formatting and SwiftFormat's default format it slightly differently so at the moment I've just hand formatted as best I could.
