### PR TITLE
[PackageLoading] Make sure JSON-encoded rule keys are stable

### DIFF
--- a/Sources/SPMLLBuild/llbuild.swift
+++ b/Sources/SPMLLBuild/llbuild.swift
@@ -197,6 +197,14 @@ private func fromBytes<T: Decodable>(_ bytes: [UInt8]) throws -> T {
 }
 
 private func toBytes<T: Encodable>(_ value: T) throws -> [UInt8] {
-    let encoded = try JSONEncoder().encode(value)
+    let encoder = JSONEncoder()
+    #if os(macOS)
+      if #available(OSX 10.13, *) {
+          encoder.outputFormatting = [.sortedKeys]
+      }
+    #else
+      encoder.outputFormatting = [.sortedKeys]
+    #endif
+    let encoded = try encoder.encode(value)
     return [UInt8](encoded)
 }


### PR DESCRIPTION
JSONEncoder does not guarantee stable element ordering unless we specifically ask for the keys to be sorted.

This gets especially important as we plan to enable per-instance hash seeding for Dictionary, which breaks llbuild's rule keys on Linux without this change.