### PR TITLE
Allow optionArguments to be required.

### DIFF
--- a/Sources/Utility/ArgumentParser.swift
+++ b/Sources/Utility/ArgumentParser.swift
@@ -441,7 +441,8 @@ final class AnyArgument: ArgumentProtocol, CustomStringConvertible {
 
     let usage: String?
 
-    let wasParsed: Bool = false
+    private let wasParsedClosure: () -> Bool
+    var wasParsed: Bool { return wasParsedClosure() }
 
     let completion: ShellCompletion
 
@@ -463,6 +464,7 @@ final class AnyArgument: ArgumentProtocol, CustomStringConvertible {
         self.usage = argument.usage
         self.completion = argument.completion
         self.parseClosure = argument.parse(_:with:)
+        self.wasParsedClosure = { argument.wasParsed }
         isArray = false
     }
 
@@ -476,6 +478,7 @@ final class AnyArgument: ArgumentProtocol, CustomStringConvertible {
         self.usage = argument.usage
         self.completion = argument.completion
         self.parseClosure = argument.parse(_:with:)
+        self.wasParsedClosure = { argument.wasParsed }
         isArray = true
     }
 


### PR DESCRIPTION
This PR came about because I wanted to have two arguments on a command. Both had an array of values and the first was optional where as the second was required. For example

```
command --optional-arg v1 v2 v3 --required-arg v4 v5 v6
``` 

However the `ArgumentParser` insists that all option arguments are optional and the problem could not be solved with positionals.

The changes in this PR allow an optional `optional` argument to be passed when adding an `OptionArgument` like this:

```
arg = argumentParser.add(option: "--required-arg",
                         kind: String.self,
                         usage: "At least one or more things.",
                         optional: false)
```

Telling the parser (like positionals) that this option must be present.