### PR TITLE
[Workspace] Resolve correctly with outdated Package.resolved file

### DIFF
--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -394,4 +394,16 @@ public enum WorkspaceDiagnostics {
 
         let manifests: [String]
     }
+
+    public struct OutdatedResolvedFile: DiagnosticData {
+        public static let id = DiagnosticID(
+            type: OutdatedResolvedFile.self,
+            name: "org.swift.diags.workspace.\(OutdatedResolvedFile.self)",
+            defaultBehavior: .error,
+            description: {
+                $0 <<< "the Package.resolved file is most likely severely out-of-date and is preventing correct resolution;"
+                $0 <<< "delete the resolved file and try again"
+            }
+        )
+    }
 }

--- a/Tests/WorkspaceTests/XCTestManifests.swift
+++ b/Tests/WorkspaceTests/XCTestManifests.swift
@@ -75,6 +75,7 @@ extension WorkspaceTests {
         ("testRootAsDependency2", testRootAsDependency2),
         ("testSkipUpdate", testSkipUpdate),
         ("testToolsVersionRootPackages", testToolsVersionRootPackages),
+        ("testTransitiveDependencySwitchWithSameIdentity", testTransitiveDependencySwitchWithSameIdentity),
         ("testUpdate", testUpdate),
     ]
 }


### PR DESCRIPTION
This fixes the issue when we would end up using a dependency URL from an
outdated Package.resolved file for a transitive dependency. Since the
resolver clones the first package identity it encounters, we would not
clone the right thing and then would end up in a broken state in later
stages.

The patch will basically re-run the resolver once we have enough
information to correctly determine the correct path of the trasitive
dependency.

<rdar://problem/44948545>