### PR TITLE
Prefix public stdlib extensions with spm_

### DIFF
--- a/Sources/Basic/CollectionAlgorithms.swift
+++ b/Sources/Basic/CollectionAlgorithms.swift
@@ -16,7 +16,7 @@ extension BidirectionalCollection where Iterator.Element : Comparable {
     //
     // FIXME: This probably shouldn't take the `from` parameter, the pattern in
     // the standard library is to use slices for that.
-    public func rindex(of element: Iterator.Element, from start: Index? = nil) -> Index? {
+    public func spm_rindex(of element: Iterator.Element, from start: Index? = nil) -> Index? {
         let firstIdx = start ?? startIndex
         var i = endIndex
         while i > firstIdx {
@@ -33,7 +33,7 @@ extension Sequence where Iterator.Element: Hashable {
 
     /// Finds duplicates in given sequence of Hashables.
     /// - Returns: duplicated elements in the invoking sequence.
-    public func findDuplicates() -> [Iterator.Element] {
+    public func spm_findDuplicates() -> [Iterator.Element] {
         var unique: Set<Iterator.Element> = []
         return filter {
             !unique.insert($0).inserted
@@ -44,7 +44,7 @@ extension Sequence where Iterator.Element: Hashable {
 extension Collection where Element: Hashable {
 
     /// Finds duplicates in given collection of Hashables.
-    public func findDuplicateElements() -> [[Element]] {
+    public func spm_findDuplicateElements() -> [[Element]] {
         var table: [Element: [Element]] = [:]
         for element in self {
             table[element, default: []].append(element)
@@ -54,7 +54,7 @@ extension Collection where Element: Hashable {
 }
 
 extension Sequence {
-    public func findDuplicateElements<Key: Hashable>(
+    public func spm_findDuplicateElements<Key: Hashable>(
         by keyPath: KeyPath<Self.Element, Key>
     ) -> [[Element]] {
         return Dictionary(grouping: self, by: { $0[keyPath: keyPath] })

--- a/Sources/Basic/CollectionExtensions.swift
+++ b/Sources/Basic/CollectionExtensions.swift
@@ -10,14 +10,14 @@
 
 extension Collection {
     /// Returns the only element of the collection or nil.
-    public var only: Element? {
+    public var spm_only: Element? {
         return count == 1 ? self[startIndex] : nil
     }
 
     /// Prints the element of array to standard output stream.
     ///
     /// This method should be used for debugging only.
-    public func dump() {
+    public func spm_dump() {
         for element in self {
             print(element)
         }

--- a/Sources/Basic/DictionaryExtensions.swift
+++ b/Sources/Basic/DictionaryExtensions.swift
@@ -27,7 +27,7 @@ extension Dictionary {
 
     /// Returns a new dictionary containing the keys of this dictionary with the
     /// values transformed by the given closure, if transformed is not nil.
-    public func flatMapValues<T>(_ transform: (Value) throws -> T?) rethrows -> [Key: T] {
+    public func spm_flatMapValues<T>(_ transform: (Value) throws -> T?) rethrows -> [Key: T] {
         var transformed: [Key: T] = [:]
         for (key, value) in self {
             if let value = try transform(value) {
@@ -40,7 +40,7 @@ extension Dictionary {
 
 extension Array {
     /// Create a dictionary with given sequence of elements.
-    public func createDictionary<Key: Hashable, Value>(
+    public func spm_createDictionary<Key: Hashable, Value>(
         _ uniqueKeysWithValues: (Element) -> (Key, Value)
     ) -> [Key: Value] {
         return Dictionary(uniqueKeysWithValues: self.map(uniqueKeysWithValues))

--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -143,7 +143,7 @@ public struct AbsolutePath: Hashable {
 
     /// True if the path is the root directory.
     public var isRoot: Bool {
-        return _impl.string.only == "/"
+        return _impl.string.spm_only == "/"
     }
 
     /// Returns the absolute path with the relative path applied.
@@ -375,7 +375,7 @@ struct PathImpl: Hashable {
         // FIXME: This method seems too complicated; it should be simplified,
         //        if possible, and certainly optimized (using UTF8View).
         // Find the last path separator.
-        guard let idx = string.rindex(of: "/") else {
+        guard let idx = string.spm_rindex(of: "/") else {
             // No path separators, so the directory name is `.`.
             return "."
         }
@@ -393,13 +393,13 @@ struct PathImpl: Hashable {
         // FIXME: This method seems too complicated; it should be simplified,
         //        if possible, and certainly optimized (using UTF8View).
         // Check for a special case of the root directory.
-        if string.only == "/" {
+        if string.spm_only == "/" {
             // Root directory, so the basename is a single path separator (the
             // root directory is special in this regard).
             return "/"
         }
         // Find the last path separator.
-        guard let idx = string.rindex(of: "/") else {
+        guard let idx = string.spm_rindex(of: "/") else {
             // No path separators, so the basename is the whole string.
             return string
         }
@@ -421,14 +421,14 @@ struct PathImpl: Hashable {
         // FIXME: This method seems too complicated; it should be simplified,
         //        if possible, and certainly optimized (using UTF8View).
         // Find the last path separator, if any.
-        let sIdx = string.rindex(of: "/")
+        let sIdx = string.spm_rindex(of: "/")
         // Find the start of the basename.
         let bIdx = (sIdx != nil) ? string.index(after: sIdx!) : string.startIndex
         // Find the last `.` (if any), starting from the second character of
         // the basename (a leading `.` does not make the whole path component
         // a suffix).
         let fIdx = string.index(bIdx, offsetBy: 1, limitedBy: string.endIndex)
-        if let idx = string.rindex(of: ".", from: fIdx) {
+        if let idx = string.spm_rindex(of: ".", from: fIdx) {
             // Unless it's just a `.` at the end, we have found a suffix.
             if string.distance(from: idx, to: string.endIndex) > 1 {
                 let fromIndex = withDot ? idx : string.index(idx, offsetBy: 1)

--- a/Sources/Basic/Process.swift
+++ b/Sources/Basic/Process.swift
@@ -275,7 +275,7 @@ public final class Process: ObjectIdentifierProtocol {
 
         // Print the arguments if we are verbose.
         if self.verbose {
-            stdoutStream <<< arguments.map({ $0.shellEscaped() }).joined(separator: " ") <<< "\n"
+            stdoutStream <<< arguments.map({ $0.spm_shellEscaped() }).joined(separator: " ") <<< "\n"
             stdoutStream.flush()
         }
 
@@ -606,7 +606,7 @@ extension ProcessResult.Error: CustomStringConvertible {
             if args.first == "sandbox-exec", args.count > 3 {
                 args = args.suffix(from: 3).map({$0})
             }
-            stream <<< args.map({ $0.shellEscaped() }).joined(separator: " ")
+            stream <<< args.map({ $0.spm_shellEscaped() }).joined(separator: " ")
 
             // Include the output, if present.
             if let output = try? result.utf8Output() + result.utf8stderrOutput() {

--- a/Sources/Basic/StringConversions.swift
+++ b/Sources/Basic/StringConversions.swift
@@ -42,7 +42,7 @@ extension String {
     /// hello -> hello, hello$world -> 'hello$world', input A -> 'input A'
     ///
     /// - Returns: Shell escaped string.
-    public func shellEscaped() -> String {
+    public func spm_shellEscaped() -> String {
 
         // If all the characters in the string are in whitelist then no need to escape.
         guard let pos = utf8.index(where: { !inShellWhitelist($0) }) else {
@@ -71,8 +71,8 @@ extension String {
     }
 
     /// Shell escapes the current string. This method is mutating version of shellEscaped().
-    public mutating func shellEscape() {
-        self = shellEscaped()
+    public mutating func spm_shellEscape() {
+        self = spm_shellEscaped()
     }
 }
 
@@ -88,7 +88,7 @@ public enum LocalizedJoinType: String {
 //FIXME: Migrate to DiagnosticFragmentBuilder
 public extension Array where Element == String {
     /// Returns a localized list of terms representing a conjunction or disjunction.
-    func localizedJoin(type: LocalizedJoinType) -> String {
+    func spm_localizedJoin(type: LocalizedJoinType) -> String {
         var result = ""
         
         for (i, item) in enumerated() {
@@ -110,12 +110,5 @@ public extension Array where Element == String {
         }
 
         return result
-    }
-}
-
-extension Substring {
-    /// Creates and returns the String object.
-    public var str: String {
-        return String(self)
     }
 }

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -498,7 +498,7 @@ public final class ProductBuildDescription {
         }
         args += ["-L", buildParameters.buildPath.asString]
         args += ["-o", binary.asString]
-        args += ["-module-name", product.name.mangledToC99ExtendedIdentifier()]
+        args += ["-module-name", product.name.spm_mangledToC99ExtendedIdentifier()]
         args += dylibs.map({ "-l" + $0.product.name })
 
         // Add arguements needed for code coverage if it is enabled.
@@ -550,7 +550,7 @@ public final class ProductBuildDescription {
         let stream = BufferedOutputByteStream()
 
         for object in objects {
-            stream <<< object.asString.shellEscaped() <<< "\n"
+            stream <<< object.asString.spm_shellEscaped() <<< "\n"
         }
 
         try fs.createDirectory(linkFileListPath.parentDirectory, recursive: true)

--- a/Sources/Build/ToolProtocol.swift
+++ b/Sources/Build/ToolProtocol.swift
@@ -53,7 +53,7 @@ struct ShellTool: ToolProtocol {
 
         // If one argument is specified we assume pre-escaped and have llbuild
         // execute it passed through to the shell.
-        if let arg = self.args.only {
+        if let arg = self.args.spm_only {
             stream <<< "    args: " <<< Format.asJSON(arg) <<< "\n"
         } else {
             stream <<< "    args: " <<< Format.asJSON(args) <<< "\n"

--- a/Sources/Commands/GenerateLinuxMain.swift
+++ b/Sources/Commands/GenerateLinuxMain.swift
@@ -166,7 +166,7 @@ private final class ModulesBuilder {
 
     func add(_ cases: [TestSuite.TestCase]) {
         for testCase in cases {
-            let (module, theKlass) = testCase.name.split(around: ".")
+            let (module, theKlass) = testCase.name.spm_split(around: ".")
             guard let klass = theKlass else {
                 // Ignore the classes that have zero tests.
                 if testCase.tests.isEmpty {

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -21,7 +21,7 @@ struct MutuallyExclusiveArgumentsDiagnostic: DiagnosticData {
         name: "org.swift.diags.mutually-exclusive-arguments",
         defaultBehavior: .error,
         description: {
-            $0 <<< { $0.arguments.map({ "'\($0)'" }).localizedJoin(type: .conjunction) }
+            $0 <<< { $0.arguments.map({ "'\($0)'" }).spm_localizedJoin(type: .conjunction) }
             $0 <<< "are mutually exclusive"
         }
     )
@@ -89,9 +89,9 @@ public class SwiftBuildTool: SwiftTool<BuildToolOptions> {
 
     private func checkClangVersion() {
         // We only care about this on Ubuntu 14.04
-        guard let uname = try? Process.checkNonZeroExit(args: "lsb_release", "-r").chomp(),
+        guard let uname = try? Process.checkNonZeroExit(args: "lsb_release", "-r").spm_chomp(),
               uname.hasSuffix("14.04"),
-              let clangVersionOutput = try? Process.checkNonZeroExit(args: "clang", "--version").chomp(),
+              let clangVersionOutput = try? Process.checkNonZeroExit(args: "clang", "--version").spm_chomp(),
               let clang = getClangVersion(versionOutput: clangVersionOutput) else {
             return
         }

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -529,7 +529,7 @@ final class TestRunner {
             let process = Process(arguments: try args(), environment: env, outputRedirection: .collect, verbose: false)
             try process.launch()
             let result = try process.waitUntilExit()
-            output = try (result.utf8Output() + result.utf8stderrOutput()).chuzzle() ?? ""
+            output = try (result.utf8Output() + result.utf8stderrOutput()).spm_chuzzle() ?? ""
             switch result.exitStatus {
             case .terminated(code: 0):
                 success = true

--- a/Sources/Commands/WatchmanHelper.swift
+++ b/Sources/Commands/WatchmanHelper.swift
@@ -82,7 +82,7 @@ final class WatchmanHelper {
         var args = [String]()
         args += ["--settle", "2"]
         args += ["-p", "Package.swift", "Package.resolved"]
-        args += ["--run", scriptPath.asString.shellEscaped()]
+        args += ["--run", scriptPath.asString.spm_shellEscaped()]
 
         // Find and execute watchman.
         let watchmanMakeToolPath = try self.watchmanMakeToolPath()

--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -1230,7 +1230,7 @@ public class DependencyResolver<
     /// The active set of managed containers.
     public var containers: [Identifier: Container] {
         return fetchCondition.whileLocked({
-            _fetchedContainers.flatMapValues({
+            _fetchedContainers.spm_flatMapValues({
                 try? $0.dematerialize()
             })
         })

--- a/Sources/PackageGraph/PackageGraphLoader.swift
+++ b/Sources/PackageGraph/PackageGraphLoader.swift
@@ -225,7 +225,7 @@ private func createResolvedPackages(
     })
 
     // Create a map of package builders keyed by the package identity.
-    let packageMap: [String: ResolvedPackageBuilder] = packageBuilders.createDictionary({
+    let packageMap: [String: ResolvedPackageBuilder] = packageBuilders.spm_createDictionary({
         // FIXME: This shouldn't be needed once <rdar://problem/33693433> is fixed.
         let identity = rootManifestSet.contains($0.package.manifest) ? $0.package.name.lowercased() : PackageReference.computeIdentity(packageURL: $0.package.manifest.url)
         return (identity, $0)
@@ -246,7 +246,7 @@ private func createResolvedPackages(
         packageBuilder.targets = targetBuilders
 
         // Establish dependencies between the targets. A target can only depend on another target present in the same package.
-        let targetMap = targetBuilders.createDictionary({ ($0.target, $0) })
+        let targetMap = targetBuilders.spm_createDictionary({ ($0.target, $0) })
         for targetBuilder in targetBuilders {
             targetBuilder.dependencies += targetBuilder.target.dependencies.map({ targetMap[$0]! })
         }
@@ -261,7 +261,7 @@ private func createResolvedPackages(
     let duplicateProducts = packageBuilders
         .flatMap({ $0.products })
         .map({ $0.product })
-        .findDuplicateElements(by: \.name)
+        .spm_findDuplicateElements(by: \.name)
         .map({ $0[0].name })
 
     // Emit diagnostics for duplicate products.
@@ -306,7 +306,7 @@ private func createResolvedPackages(
         let productDependencies = packageBuilder.dependencies
             .flatMap({ $0.products })
             .filter({ $0.product.type != .test })
-        let productDependencyMap = productDependencies.createDictionary({ ($0.product.name, $0) })
+        let productDependencyMap = productDependencies.spm_createDictionary({ ($0.product.name, $0) })
 
         // Establish dependencies in each target.
         for targetBuilder in packageBuilder.targets {

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -251,7 +251,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
     /// Validate the provided manifest.
     private func validate(_ manifest: Manifest) throws {
-        let duplicateDecls = manifest.dependencies.map({ KeyedPair($0, key: PackageReference.computeIdentity(packageURL: $0.url)) }).findDuplicateElements()
+        let duplicateDecls = manifest.dependencies.map({ KeyedPair($0, key: PackageReference.computeIdentity(packageURL: $0.url)) }).spm_findDuplicateElements()
         if !duplicateDecls.isEmpty {
             throw ManifestParseError.duplicateDependencyDecl(duplicateDecls.map({ $0.map({ $0.item }) }))
         }
@@ -330,7 +330,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
         // Run the command.
         let result = try Process.popen(arguments: cmd)
-        let output = try (result.utf8Output() + result.utf8stderrOutput()).chuzzle()
+        let output = try (result.utf8Output() + result.utf8stderrOutput()).spm_chuzzle()
 
         // Throw an error if there was a non-zero exit or emit the output
         // produced by the process. A process output will usually mean there
@@ -358,7 +358,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
       #if os(macOS)
         let foundPath = try? Process.checkNonZeroExit(
             args: "xcrun", "--sdk", "macosx", "--show-sdk-path")
-        guard let sdkRoot = foundPath?.chomp(), !sdkRoot.isEmpty else {
+        guard let sdkRoot = foundPath?.spm_chomp(), !sdkRoot.isEmpty else {
             return nil
         }
         _sdkRoot = AbsolutePath(sdkRoot)

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -341,7 +341,7 @@ public final class PackageBuilder {
 
         // Ensure no dupicate target definitions are found.
         let duplicateTargetNames: [String] = manifest.targets.map({ $0.name
-        }).findDuplicates()
+        }).spm_findDuplicates()
         
         if !duplicateTargetNames.isEmpty {
             throw Target.Error.duplicateTargets(duplicateTargetNames)

--- a/Sources/PackageLoading/PackageDescription4Loader.swift
+++ b/Sources/PackageLoading/PackageDescription4Loader.swift
@@ -129,7 +129,7 @@ extension PackageDependencyDescription {
 
             // If the dependency URL starts with '~/', try to expand it.
             if url.hasPrefix("~/") {
-                return fileSystem.homeDirectory.appending(RelativePath(url.dropFirst(2).str)).asString
+                return fileSystem.homeDirectory.appending(RelativePath(String(url.dropFirst(2)))).asString
             }
 
             // If the dependency URL is not remote, try to "fix" it.

--- a/Sources/PackageLoading/Target+PkgConfig.swift
+++ b/Sources/PackageLoading/Target+PkgConfig.swift
@@ -116,7 +116,7 @@ extension SystemPackageProviderDescription {
             // to the latest version. Instead use the version as symlinked
             // in /usr/local/opt/(NAME)/lib/pkgconfig.
             struct Static {
-                static let value = { try? Process.checkNonZeroExit(args: "brew", "--prefix").chomp() }()
+                static let value = { try? Process.checkNonZeroExit(args: "brew", "--prefix").spm_chomp() }()
             }
             guard let brewPrefix = Static.value else { return [] }
             return packages.map({ AbsolutePath(brewPrefix).appending(components: "opt", $0, "lib", "pkgconfig") })

--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -55,7 +55,7 @@ public class Target: ObjectIdentifierProtocol {
         self.sources = sources
         self.dependencies = dependencies
         self.productDependencies = productDependencies
-        self.c99name = self.name.mangledToC99ExtendedIdentifier()
+        self.c99name = self.name.spm_mangledToC99ExtendedIdentifier()
     }
 }
 

--- a/Sources/TestSupport/FileSystemExtensions.swift
+++ b/Sources/TestSupport/FileSystemExtensions.swift
@@ -53,7 +53,7 @@ extension FileSystem {
         do {
             try createDirectory(root, recursive: true)
             for path in files {
-                let path = root.appending(RelativePath(path.dropFirst().str))
+                let path = root.appending(RelativePath(String(path.dropFirst())))
                 try createDirectory(path.parentDirectory, recursive: true)
                 try writeFileContents(path, bytes: "")
             }

--- a/Sources/TestSupport/GitRepositoryExtensions.swift
+++ b/Sources/TestSupport/GitRepositoryExtensions.swift
@@ -24,7 +24,7 @@ public extension GitRepository {
     /// Returns current branch name. If HEAD is on a detached state, this returns HEAD.
     func currentBranch() throws -> String {
         return try Process.checkNonZeroExit(
-            args: Git.tool, "-C", path.asString, "rev-parse", "--abbrev-ref", "HEAD").chomp()
+            args: Git.tool, "-C", path.asString, "rev-parse", "--abbrev-ref", "HEAD").spm_chomp()
     }
 
     /// Stage a file.

--- a/Sources/Utility/ArgumentParser.swift
+++ b/Sources/Utility/ArgumentParser.swift
@@ -539,7 +539,7 @@ public final class ArgumentParser {
                 results[argument.name] = array
             } else {
                 // We expect only one value for non-array arguments.
-                guard let value = values.only else {
+                guard let value = values.spm_only else {
                     assertionFailure()
                     return
                 }
@@ -821,7 +821,7 @@ public final class ArgumentParser {
                     argumentsIterator: argumentsIterator,
                     currentArgument: argumentString)
             } else {
-                let (argumentString, value) = argumentString.split(around: "=")
+                let (argumentString, value) = argumentString.spm_split(around: "=")
                 // Get the corresponding option for the option argument.
                 guard let optionArgument = optionsMap[argumentString] else {
                     throw ArgumentParserError.unknownOption(argumentString)

--- a/Sources/Utility/CollectionExtensions.swift
+++ b/Sources/Utility/CollectionExtensions.swift
@@ -10,7 +10,7 @@
 
 extension Collection where Iterator.Element : Equatable {
     /// Split around a delimiting subsequence with maximum number of splits == 2
-    func split(around delimiter: [Iterator.Element]) -> ([Iterator.Element], [Iterator.Element]?) {
+    func spm_split(around delimiter: [Iterator.Element]) -> ([Iterator.Element], [Iterator.Element]?) {
 
         let orig = Array(self)
         let end = orig.endIndex

--- a/Sources/Utility/PkgConfig.swift
+++ b/Sources/Utility/PkgConfig.swift
@@ -67,7 +67,7 @@ struct PCFileFinder {
         if PCFileFinder.pkgConfigPaths == nil {
             do {
                 let searchPaths = try Process.checkNonZeroExit(
-                args: "pkg-config", "--variable", "pc_path", "pkg-config").chomp()
+                args: "pkg-config", "--variable", "pc_path", "pkg-config").spm_chomp()
                 PCFileFinder.pkgConfigPaths = searchPaths.split(separator: ":").map({ AbsolutePath(String($0)) })
             } catch {
                 diagnostics.emit(data: PkgConfigExecutionDiagnostic())
@@ -209,16 +209,16 @@ struct PkgConfigParser {
             // Remove commented or any trailing comment from the line.
             let uncommentedLine = removeComment(line: line)
             // Ignore any empty or whitespace line.
-            guard let line = uncommentedLine.chuzzle() else { continue }
+            guard let line = uncommentedLine.spm_chuzzle() else { continue }
 
             if line.contains(":") {
                 // Found a key-value pair.
                 try parseKeyValue(line: line)
             } else if line.contains("=") {
                 // Found a variable.
-                let (name, maybeValue) = line.split(around: "=")
-                let value = maybeValue?.chuzzle() ?? ""
-                variables[name.chuzzle() ?? ""] = try resolveVariables(value)
+                let (name, maybeValue) = line.spm_split(around: "=")
+                let value = maybeValue?.spm_chuzzle() ?? ""
+                variables[name.spm_chuzzle() ?? ""] = try resolveVariables(value)
             } else {
                 // Unexpected thing in the pc file, abort.
                 throw PkgConfigError.parsingError("Unexpected line: \(line) in \(pcFile.asString)")
@@ -228,8 +228,8 @@ struct PkgConfigParser {
 
     private mutating func parseKeyValue(line: String) throws {
         precondition(line.contains(":"))
-        let (key, maybeValue) = line.split(around: ":")
-        let value = try resolveVariables(maybeValue?.chuzzle() ?? "")
+        let (key, maybeValue) = line.spm_split(around: ":")
+        let value = try resolveVariables(maybeValue?.spm_chuzzle() ?? "")
         switch key {
         case "Requires":
             dependencies = try parseDependencies(value)

--- a/Sources/Utility/Platform.swift
+++ b/Sources/Utility/Platform.swift
@@ -22,7 +22,7 @@ public enum Platform {
     // Lazily return current platform.
     public static var currentPlatform = Platform.findCurrentPlatform()
     private static func findCurrentPlatform() -> Platform? {
-        guard let uname = try? Process.checkNonZeroExit(args: "uname").chomp().lowercased() else { return nil }
+        guard let uname = try? Process.checkNonZeroExit(args: "uname").spm_chomp().lowercased() else { return nil }
         switch uname {
         case "darwin":
             return .darwin

--- a/Sources/Utility/StringExtensions.swift
+++ b/Sources/Utility/StringExtensions.swift
@@ -14,7 +14,7 @@ extension String {
      all trailing \n (UNIX) or all trailing \r\n (Windows) (it will
      not remove mixed occurrences of both separators.
     */
-    public func chomp(separator: String? = nil) -> String {
+    public func spm_chomp(separator: String? = nil) -> String {
         func scrub(_ separator: String) -> String {
             var E = endIndex
             while String(self[startIndex..<E]).hasSuffix(separator) && E > startIndex {
@@ -43,7 +43,7 @@ extension String {
      
          return userInput.chuzzle() ?? "default value"
     */
-    public func chuzzle() -> String? {
+    public func spm_chuzzle() -> String? {
         var cc = self
 
         loop: while true {
@@ -73,8 +73,8 @@ extension String {
 
     /// Splits string around a delimiter string into up to two substrings
     /// If delimiter is not found, the second returned substring is nil
-    public func split(around delimiter: String) -> (String, String?) {
-        let comps = self.split(around: Array(delimiter))
+    public func spm_split(around delimiter: String) -> (String, String?) {
+        let comps = self.spm_split(around: Array(delimiter))
         let head = String(comps.0)
         if let tail = comps.1 {
             return (head, String(tail))

--- a/Sources/Utility/StringMangling.swift
+++ b/Sources/Utility/StringMangling.swift
@@ -13,7 +13,7 @@
 extension String {
 
     /// Returns a form of the string that is a valid bundle identifier
-    public func mangledToBundleIdentifier() -> String {
+    public func spm_mangledToBundleIdentifier() -> String {
         let mangledUnichars: [UInt16] = self.utf16.map({
             switch $0 {
             case
@@ -40,7 +40,7 @@ extension String {
     /// replacing any invalid characters in an unspecified but consistent way).
     /// The output string is guaranteed to be non-empty as long as the input
     /// string is non-empty.
-    public func mangledToC99ExtendedIdentifier() -> String {
+    public func spm_mangledToC99ExtendedIdentifier() -> String {
         // Map invalid C99-invalid Unicode scalars to a replacement character.
         let replacementUnichar: UnicodeScalar = "_"
         var mangledUnichars: [UnicodeScalar] = self.unicodeScalars.map({
@@ -250,7 +250,7 @@ extension String {
 
     /// Mangles the contents to a valid C99 Extended Identifier.  This method
     /// is the mutating version of `mangledToC99ExtendedIdentifier()`.
-    public mutating func mangleToC99ExtendedIdentifier() {
-        self = mangledToC99ExtendedIdentifier()
+    public mutating func spm_mangleToC99ExtendedIdentifier() {
+        self = spm_mangledToC99ExtendedIdentifier()
     }
 }

--- a/Sources/Utility/URL.swift
+++ b/Sources/Utility/URL.swift
@@ -18,7 +18,7 @@ public struct URL {
     public static func scheme(_ url: String) -> String? {
 
         func prefixOfSplitBy(_ delimiter: String) -> String? {
-            let (head, tail) = url.split(around: delimiter)
+            let (head, tail) = url.spm_split(around: delimiter)
             if tail == nil {
                 //not found
                 return nil

--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -99,7 +99,7 @@ public struct Destination {
         } else {
             // No value in env, so search for it.
             let sdkPathStr = try Process.checkNonZeroExit(
-                arguments: ["xcrun", "--sdk", "macosx", "--show-sdk-path"], environment: environment).chomp()
+                arguments: ["xcrun", "--sdk", "macosx", "--show-sdk-path"], environment: environment).spm_chomp()
             guard !sdkPathStr.isEmpty else {
                 throw DestinationError.invalidInstallation("default SDK not found")
             }
@@ -138,7 +138,7 @@ public struct Destination {
             return path
         }
         let platformPath = try? Process.checkNonZeroExit(
-            arguments: ["xcrun", "--sdk", "macosx", "--show-sdk-platform-path"], environment: environment).chomp()
+            arguments: ["xcrun", "--sdk", "macosx", "--show-sdk-platform-path"], environment: environment).spm_chomp()
 
         if let platformPath = platformPath, !platformPath.isEmpty {
            _sdkPlatformFrameworkPath = AbsolutePath(platformPath).appending(

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -53,7 +53,7 @@ public final class InitPackage {
         self.packageType = packageType
         self.destinationPath = destinationPath
         self.pkgname = name
-        self.moduleName = name.mangledToC99ExtendedIdentifier()
+        self.moduleName = name.spm_mangledToC99ExtendedIdentifier()
     }
 
     /// Actually creates the new package at the destinationPath

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -155,7 +155,7 @@ public final class UserToolchain: Toolchain {
             clangCompiler = value
         } else {
             // No value in env, so search for `clang`.
-            let foundPath = try Process.checkNonZeroExit(arguments: whichClangArgs, environment: processEnvironment).chomp()
+            let foundPath = try Process.checkNonZeroExit(arguments: whichClangArgs, environment: processEnvironment).spm_chomp()
             guard !foundPath.isEmpty else {
                 throw InvalidToolchainDiagnostic("could not find `clang`")
             }
@@ -197,7 +197,7 @@ public final class UserToolchain: Toolchain {
       #if os(macOS)
         // FIXME: We should have some general utility to find tools.
         let xctestFindArgs = ["xcrun", "--sdk", "macosx", "--find", "xctest"]
-        self.xctest = try AbsolutePath(validating: Process.checkNonZeroExit(arguments: xctestFindArgs, environment: environment).chomp())
+        self.xctest = try AbsolutePath(validating: Process.checkNonZeroExit(arguments: xctestFindArgs, environment: environment).spm_chomp())
       #else
         self.xctest = nil
       #endif

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -279,7 +279,7 @@ func xcodeProject(
     func createSourceGroup(named groupName: String, for targets: [ResolvedTarget], in parentGroup: Xcode.Group) -> Xcode.Group? {
         // Look for the special case of a single target in a flat layout.
         let needsSourcesGroup: Bool
-        if let target = targets.only {
+        if let target = targets.spm_only {
             // FIXME: This is somewhat flaky; packages should have a notion of
             // what kind of layout they have.  But at least this is just a
             // heuristic and won't affect the functioning of the Xcode project.
@@ -446,7 +446,7 @@ func xcodeProject(
                 targetSettings.common.ENABLE_TESTABILITY = "YES"
                 targetSettings.common.PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)"
                 targetSettings.common.PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)"
-                targetSettings.common.PRODUCT_BUNDLE_IDENTIFIER = target.c99name.mangledToBundleIdentifier()
+                targetSettings.common.PRODUCT_BUNDLE_IDENTIFIER = target.c99name.spm_mangledToBundleIdentifier()
                 targetSettings.common.SKIP_INSTALL = "YES"
             } else {
                 targetSettings.common.SWIFT_FORCE_STATIC_LINK_STDLIB = "NO"

--- a/Tests/BasicPerformanceTests/StringConversionsPerfTests.swift
+++ b/Tests/BasicPerformanceTests/StringConversionsPerfTests.swift
@@ -20,7 +20,7 @@ class StringConversionsPerfTests: XCTestCasePerf {
             let N = 100
             var length = 0
             for _ in 0..<N {
-                let shell = string.shellEscaped()
+                let shell = string.spm_shellEscaped()
                 length = length &+ shell.utf8.count
             }
 

--- a/Tests/BasicTests/CollectionAlgorithmsTests.swift
+++ b/Tests/BasicTests/CollectionAlgorithmsTests.swift
@@ -15,16 +15,16 @@ import Basic
 class CollectionAlgorithmsTests: XCTestCase {
     func testRIndex() {
         let str = "hello"
-        XCTAssertEqual(str.rindex(of: "h"), str.startIndex)
-        XCTAssertEqual(str.rindex(of: "h", from: str.index(after: str.startIndex)), nil)
-        XCTAssertEqual(str.rindex(of: "o"), str.index(of: "o"))
-        XCTAssertEqual(str.rindex(of: "l"), str.index(after: str.index(where: { $0 == "l" })!))
-        XCTAssertEqual(str.rindex(of: "x"), nil)
+        XCTAssertEqual(str.spm_rindex(of: "h"), str.startIndex)
+        XCTAssertEqual(str.spm_rindex(of: "h", from: str.index(after: str.startIndex)), nil)
+        XCTAssertEqual(str.spm_rindex(of: "o"), str.index(of: "o"))
+        XCTAssertEqual(str.spm_rindex(of: "l"), str.index(after: str.index(where: { $0 == "l" })!))
+        XCTAssertEqual(str.spm_rindex(of: "x"), nil)
     }
 
     func testFindDuplicates() {
-        XCTAssertEqual([1, 2, 3, 2, 1].findDuplicates(), [2, 1])
-        XCTAssertEqual(["foo", "bar"].findDuplicates(), [])
-        XCTAssertEqual(["foo", "Foo"].findDuplicates(), [])
+        XCTAssertEqual([1, 2, 3, 2, 1].spm_findDuplicates(), [2, 1])
+        XCTAssertEqual(["foo", "bar"].spm_findDuplicates(), [])
+        XCTAssertEqual(["foo", "Foo"].spm_findDuplicates(), [])
     }
 }

--- a/Tests/BasicTests/CollectionExtensionsTests.swift
+++ b/Tests/BasicTests/CollectionExtensionsTests.swift
@@ -13,8 +13,8 @@ import Basic
 
 class CollectionExtensionsTests: XCTestCase {
     func testOnly() {
-        XCTAssertEqual([String]().only, nil)
-        XCTAssertEqual([42].only, 42)
-        XCTAssertEqual([42, 24].only, nil)
+        XCTAssertEqual([String]().spm_only, nil)
+        XCTAssertEqual([42].spm_only, 42)
+        XCTAssertEqual([42, 24].spm_only, nil)
     }
 }

--- a/Tests/BasicTests/DictionaryExtensionsTests.swift
+++ b/Tests/BasicTests/DictionaryExtensionsTests.swift
@@ -20,11 +20,11 @@ class DictionaryExtensionTests: XCTestCase {
         XCTAssertEqual(Dictionary(items: [(1, 1), (1, nil)]), [:])
         XCTAssertEqual(Dictionary(items: [(1, 1), (2, nil), (3, 4)]), [1: 1, 3: 4])
 
-        XCTAssertEqual(["foo": "1", "bar": "2", "baz": "f"].flatMapValues({ Int($0) }), ["foo": 1, "bar": 2])
+        XCTAssertEqual(["foo": "1", "bar": "2", "baz": "f"].spm_flatMapValues({ Int($0) }), ["foo": 1, "bar": 2])
     }
 
     func testCreateDictionary() {
-        XCTAssertEqual([("foo", 1), ("bar", 2)].createDictionary({ $0 }), ["foo": 1, "bar": 2])
-        XCTAssertEqual(["foo", "bar"].createDictionary({ ($0[$0.startIndex], $0) }), ["f": "foo", "b": "bar"])
+        XCTAssertEqual([("foo", 1), ("bar", 2)].spm_createDictionary({ $0 }), ["foo": 1, "bar": 2])
+        XCTAssertEqual(["foo", "bar"].spm_createDictionary({ ($0[$0.startIndex], $0) }), ["f": "foo", "b": "bar"])
     }
 }

--- a/Tests/BasicTests/StringConversionsTests.swift
+++ b/Tests/BasicTests/StringConversionsTests.swift
@@ -16,25 +16,25 @@ class StringConversionTests: XCTestCase {
     func testShellEscaped() {
 
         var str = "hello-_123"
-        XCTAssertEqual("hello-_123", str.shellEscaped())
+        XCTAssertEqual("hello-_123", str.spm_shellEscaped())
 
         str = "hello world"
-        XCTAssertEqual("'hello world'", str.shellEscaped())
+        XCTAssertEqual("'hello world'", str.spm_shellEscaped())
 
         str = "hello 'world"
-        str.shellEscape()
+        str.spm_shellEscape()
         XCTAssertEqual("'hello '\\''world'", str)
 
         str = "hello world swift"
-        XCTAssertEqual("'hello world swift'", str.shellEscaped())
+        XCTAssertEqual("'hello world swift'", str.spm_shellEscaped())
 
         str = "hello?world"
-        XCTAssertEqual("'hello?world'", str.shellEscaped())
+        XCTAssertEqual("'hello?world'", str.spm_shellEscaped())
 
         str = "hello\nworld"
-        XCTAssertEqual("'hello\nworld'", str.shellEscaped())
+        XCTAssertEqual("'hello\nworld'", str.spm_shellEscaped())
 
         str = "hello\nA\"B C>D*[$;()^><"
-        XCTAssertEqual("'hello\nA\"B C>D*[$;()^><'", str.shellEscaped())
+        XCTAssertEqual("'hello\nA\"B C>D*[$;()^><'", str.spm_shellEscaped())
     }
 }

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -24,7 +24,7 @@ import Workspace
 final class PackageToolTests: XCTestCase {
     @discardableResult
     private func execute(_ args: [String], packagePath: AbsolutePath? = nil) throws -> String {
-        return try SwiftPMProduct.SwiftPackage.execute(args, packagePath: packagePath).chomp()
+        return try SwiftPMProduct.SwiftPackage.execute(args, packagePath: packagePath).spm_chomp()
     }
 
     func testUsage() throws {
@@ -373,14 +373,14 @@ final class PackageToolTests: XCTestCase {
 
             // Build and sanity check.
             _ = try build()
-            XCTAssertEqual(try Process.checkNonZeroExit(arguments: exec).chomp(), "\(5)")
+            XCTAssertEqual(try Process.checkNonZeroExit(arguments: exec).spm_chomp(), "\(5)")
 
             // Get path to bar checkout.
             let barPath = try SwiftPMProduct.packagePath(for: "bar", packageRoot: fooPath)
 
             // Checks the content of checked out bar.swift.
             func checkBar(_ value: Int, file: StaticString = #file, line: UInt = #line) throws {
-                let contents = try localFileSystem.readFileContents(barPath.appending(components:"Sources", "bar.swift")).asString?.chomp()
+                let contents = try localFileSystem.readFileContents(barPath.appending(components:"Sources", "bar.swift")).asString?.spm_chomp()
                 XCTAssert(contents?.hasSuffix("\(value)") ?? false, file: file, line: line)
             }
 

--- a/Tests/FunctionalTests/ToolsVersionTests.swift
+++ b/Tests/FunctionalTests/ToolsVersionTests.swift
@@ -87,17 +87,17 @@ class ToolsVersionTests: XCTestCase {
                     """
             }
             _ = try SwiftPMProduct.SwiftPackage.execute(
-                ["tools-version", "--set", "4.0"], packagePath: primaryPath).chomp()
+                ["tools-version", "--set", "4.0"], packagePath: primaryPath).spm_chomp()
 
             // Build the primary package.
             _ = try SwiftPMProduct.SwiftBuild.execute([], packagePath: primaryPath)
             let exe = primaryPath.appending(components: ".build", Destination.host.target, "debug", "Primary").asString
             // v1 should get selected because v1.0.1 depends on a (way) higher set of tools.
-            XCTAssertEqual(try Process.checkNonZeroExit(args: exe).chomp(), "foo@1.0")
+            XCTAssertEqual(try Process.checkNonZeroExit(args: exe).spm_chomp(), "foo@1.0")
 
             // Set the tools version to something high.
             _ = try SwiftPMProduct.SwiftPackage.execute(
-                ["tools-version", "--set", "10000.1"], packagePath: primaryPath).chomp()
+                ["tools-version", "--set", "10000.1"], packagePath: primaryPath).spm_chomp()
 
             do {
                 _ = try SwiftPMProduct.SwiftBuild.execute([], packagePath: primaryPath)
@@ -118,7 +118,7 @@ class ToolsVersionTests: XCTestCase {
                     """
             }
             _ = try SwiftPMProduct.SwiftPackage.execute(
-                ["tools-version", "--set", "4.0"], packagePath: primaryPath).chomp()
+                ["tools-version", "--set", "4.0"], packagePath: primaryPath).spm_chomp()
 
             do {
                 _ = try SwiftPMProduct.SwiftBuild.execute([], packagePath: primaryPath)
@@ -140,7 +140,7 @@ class ToolsVersionTests: XCTestCase {
                     """
              }
              _ = try SwiftPMProduct.SwiftPackage.execute(
-                 ["tools-version", "--set", "4.0"], packagePath: primaryPath).chomp()
+                 ["tools-version", "--set", "4.0"], packagePath: primaryPath).spm_chomp()
              _ = try SwiftPMProduct.SwiftBuild.execute([], packagePath: primaryPath)
         }
     }

--- a/Tests/PackageGraphTests/DependencyResolverTests.swift
+++ b/Tests/PackageGraphTests/DependencyResolverTests.swift
@@ -881,7 +881,7 @@ private func checkResolution(_ resolver: MockDependencyResolver, constraints: [M
 
     // Check the solution against our oracle.
     if let solution = solution {
-        guard let onlySolution = maximalSolutions.only else {
+        guard let onlySolution = maximalSolutions.spm_only else {
             return XCTFail("solver unexpectedly found: \(solution) when there are no viable solutions")
         }
         if solution != onlySolution {

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -56,7 +56,7 @@ class GitRepositoryTests: XCTestCase {
             // FIXME: It would be nice if we had a deterministic hash here...
             XCTAssertEqual(revision.identifier, 
                 try Process.popen(
-                    args: Git.tool, "-C", testRepoPath.asString, "rev-parse", "--verify", "1.2.3").utf8Output().chomp())
+                    args: Git.tool, "-C", testRepoPath.asString, "rev-parse", "--verify", "1.2.3").utf8Output().spm_chomp())
             if let revision = try? repository.resolveRevision(tag: "<invalid>") {
                 XCTFail("unexpected resolution of invalid tag to \(revision)")
             }
@@ -65,7 +65,7 @@ class GitRepositoryTests: XCTestCase {
 
             XCTAssertEqual(master.identifier,
                 try Process.checkNonZeroExit(
-                    args: Git.tool, "-C", testRepoPath.asString, "rev-parse", "--verify", "master").chomp())
+                    args: Git.tool, "-C", testRepoPath.asString, "rev-parse", "--verify", "master").spm_chomp())
 
             // Check that git hashes resolve to themselves.
             let masterIdentifier = try repository.resolveRevision(identifier: master.identifier)

--- a/Tests/UtilityTests/ArgumentParserTests.swift
+++ b/Tests/UtilityTests/ArgumentParserTests.swift
@@ -463,28 +463,28 @@ class ArgumentParserTests: XCTestCase {
     func testPathArgument() {
         // Test that relative path is resolved.
         do {
-            let actual = try! SwiftPMProduct.TestSupportExecutable.execute(["pathArgumentTest", "some/path"]).chomp()
+            let actual = try! SwiftPMProduct.TestSupportExecutable.execute(["pathArgumentTest", "some/path"]).spm_chomp()
             let expected = localFileSystem.currentWorkingDirectory!.appending(RelativePath("some/path")).asString
             XCTAssertEqual(actual, expected)
         }
 
         // Test that relative path starting with ./ is resolved.
         do {
-            let actual = try! SwiftPMProduct.TestSupportExecutable.execute(["pathArgumentTest", "./some/path"]).chomp()
+            let actual = try! SwiftPMProduct.TestSupportExecutable.execute(["pathArgumentTest", "./some/path"]).spm_chomp()
             let expected = localFileSystem.currentWorkingDirectory!.appending(RelativePath("./some/path")).asString
             XCTAssertEqual(actual, expected)
         }
 
         // Test that relative path starting with ../ is resolved.
         do {
-            let actual = try! SwiftPMProduct.TestSupportExecutable.execute(["pathArgumentTest", "../other/path"]).chomp()
+            let actual = try! SwiftPMProduct.TestSupportExecutable.execute(["pathArgumentTest", "../other/path"]).spm_chomp()
             let expected = localFileSystem.currentWorkingDirectory!.appending(RelativePath("../other/path")).asString
             XCTAssertEqual(actual, expected)
         }
 
         // Test that absolute path is resolved.
         do {
-            let actual = try! SwiftPMProduct.TestSupportExecutable.execute(["pathArgumentTest", "/bin/echo"]).chomp()
+            let actual = try! SwiftPMProduct.TestSupportExecutable.execute(["pathArgumentTest", "/bin/echo"]).spm_chomp()
             XCTAssertEqual(actual, "/bin/echo")
         }
     }

--- a/Tests/UtilityTests/CollectionTests.swift
+++ b/Tests/UtilityTests/CollectionTests.swift
@@ -20,11 +20,11 @@ class CollectionTests: XCTestCase {
             XCTAssertEqual(lhs.1 ?? [], rhs.1 ?? [], file: file, line: line)
         }
         
-        eq([].split(around: [":"]), ([], nil))
-        eq(["f", "o", "o"].split(around: [":"]), (["f", "o", "o"], nil))
-        eq(["f", "o", "o", ":"].split(around: [":"]), (["f", "o", "o"], []))
-        eq([":", "b", "a", "r"].split(around: [":"]), ([], ["b", "a", "r"]))
-        eq(["f", "o", "o", ":", "b", "a", "r"].split(around: [":"]), (["f", "o", "o"], ["b", "a", "r"]))
+        eq([].spm_split(around: [":"]), ([], nil))
+        eq(["f", "o", "o"].spm_split(around: [":"]), (["f", "o", "o"], nil))
+        eq(["f", "o", "o", ":"].spm_split(around: [":"]), (["f", "o", "o"], []))
+        eq([":", "b", "a", "r"].spm_split(around: [":"]), ([], ["b", "a", "r"]))
+        eq(["f", "o", "o", ":", "b", "a", "r"].spm_split(around: [":"]), (["f", "o", "o"], ["b", "a", "r"]))
     }
 }
 

--- a/Tests/UtilityTests/ProgressBarTests.swift
+++ b/Tests/UtilityTests/ProgressBarTests.swift
@@ -56,7 +56,7 @@ final class ProgressBarTests: XCTestCase {
         // Make sure to read the complete output before checking it.
         thread.join()
         pty.closeMaster()
-        XCTAssertTrue(output.chuzzle()?.hasPrefix("\u{1B}[36m\u{1B}[1mTestHeader\u{1B}[0m") ?? false)
+        XCTAssertTrue(output.spm_chuzzle()?.hasPrefix("\u{1B}[36m\u{1B}[1mTestHeader\u{1B}[0m") ?? false)
     }
 
     private func runProgressBar(_ bar: ProgressBarProtocol) {

--- a/Tests/UtilityTests/StringConversionTests.swift
+++ b/Tests/UtilityTests/StringConversionTests.swift
@@ -14,43 +14,43 @@ import Utility
 class StringConversionTests: XCTestCase {
 
     func testManglingToBundleIdentifier() {
-        XCTAssertEqual("foo".mangledToBundleIdentifier(), "foo")
-        XCTAssertEqual("1foo__ò".mangledToBundleIdentifier(), "1foo---")
-        XCTAssertEqual("com.example.🐴🔄".mangledToBundleIdentifier(), "com.example.----")
-        XCTAssertEqual("٠٠٠".mangledToBundleIdentifier(), "---")
+        XCTAssertEqual("foo".spm_mangledToBundleIdentifier(), "foo")
+        XCTAssertEqual("1foo__ò".spm_mangledToBundleIdentifier(), "1foo---")
+        XCTAssertEqual("com.example.🐴🔄".spm_mangledToBundleIdentifier(), "com.example.----")
+        XCTAssertEqual("٠٠٠".spm_mangledToBundleIdentifier(), "---")
     }
 
     func testManglingToC99ExtendedIdentifier() {
         
         // Simple cases.
-        XCTAssertEqual("foo".mangledToC99ExtendedIdentifier(), "foo")
+        XCTAssertEqual("foo".spm_mangledToC99ExtendedIdentifier(), "foo")
         
         // Edge cases.
-        XCTAssertEqual("".mangledToC99ExtendedIdentifier(), "")
-        XCTAssertEqual("_".mangledToC99ExtendedIdentifier(), "_")
-        XCTAssertEqual("\n".mangledToC99ExtendedIdentifier(), "_")
+        XCTAssertEqual("".spm_mangledToC99ExtendedIdentifier(), "")
+        XCTAssertEqual("_".spm_mangledToC99ExtendedIdentifier(), "_")
+        XCTAssertEqual("\n".spm_mangledToC99ExtendedIdentifier(), "_")
         
         // Invalid non-leading characters.
-        XCTAssertEqual("_-".mangledToC99ExtendedIdentifier(), "__")
-        XCTAssertEqual("foo-bar".mangledToC99ExtendedIdentifier(), "foo_bar")
+        XCTAssertEqual("_-".spm_mangledToC99ExtendedIdentifier(), "__")
+        XCTAssertEqual("foo-bar".spm_mangledToC99ExtendedIdentifier(), "foo_bar")
         
         // Invalid leading characters.
-        XCTAssertEqual("1".mangledToC99ExtendedIdentifier(), "_")
-        XCTAssertEqual("1foo".mangledToC99ExtendedIdentifier(), "_foo")
-        XCTAssertEqual("٠٠٠".mangledToC99ExtendedIdentifier(), "_٠٠")
-        XCTAssertEqual("12 3".mangledToC99ExtendedIdentifier(), "_2_3")
+        XCTAssertEqual("1".spm_mangledToC99ExtendedIdentifier(), "_")
+        XCTAssertEqual("1foo".spm_mangledToC99ExtendedIdentifier(), "_foo")
+        XCTAssertEqual("٠٠٠".spm_mangledToC99ExtendedIdentifier(), "_٠٠")
+        XCTAssertEqual("12 3".spm_mangledToC99ExtendedIdentifier(), "_2_3")
         
         // FIXME: There are lots more interesting test cases to add here.
         var str1 = ""
-        str1.mangleToC99ExtendedIdentifier()
+        str1.spm_mangleToC99ExtendedIdentifier()
         XCTAssertEqual(str1, "")
 
         var str2 = "_"
-        str2.mangleToC99ExtendedIdentifier()
+        str2.spm_mangleToC99ExtendedIdentifier()
         XCTAssertEqual(str2, "_")
 
         var str3 = "-"
-        str3.mangleToC99ExtendedIdentifier()
+        str3.spm_mangleToC99ExtendedIdentifier()
         XCTAssertEqual(str3, "_")
     }
 }

--- a/Tests/UtilityTests/StringTests.swift
+++ b/Tests/UtilityTests/StringTests.swift
@@ -12,34 +12,34 @@
 import XCTest
 
 class StringTests: XCTestCase {
-    func testTrailingChomp() {
-        XCTAssertEqual("abc\n".chomp(), "abc")
-        XCTAssertEqual("abc\r\n".chomp(), "abc")
-        XCTAssertEqual("abc\r\n\r\n".chomp(), "abc")
-        XCTAssertEqual("abc\r\n\r\r\n".chomp(), "abc\r\n\r")
-        XCTAssertEqual("abc\n \n".chomp(), "abc\n ")
+    func testTrailing() {
+        XCTAssertEqual("abc\n".spm_chomp(), "abc")
+        XCTAssertEqual("abc\r\n".spm_chomp(), "abc")
+        XCTAssertEqual("abc\r\n\r\n".spm_chomp(), "abc")
+        XCTAssertEqual("abc\r\n\r\r\n".spm_chomp(), "abc\r\n\r")
+        XCTAssertEqual("abc\n \n".spm_chomp(), "abc\n ")
     }
     
-    func testSeparatorChomp() {
-        XCTAssertEqual("abc".chomp(separator: "c"), "ab")
-        XCTAssertEqual("abc\n".chomp(separator: "c"), "abc\n")
-        XCTAssertEqual("abc\n c".chomp(separator: "c"), "abc\n ")
+    func testSeparator() {
+        XCTAssertEqual("abc".spm_chomp(separator: "c"), "ab")
+        XCTAssertEqual("abc\n".spm_chomp(separator: "c"), "abc\n")
+        XCTAssertEqual("abc\n c".spm_chomp(separator: "c"), "abc\n ")
     }
 
-    func testEmptyChomp() {
-        XCTAssertEqual("".chomp(), "")
-        XCTAssertEqual(" ".chomp(), " ")
-        XCTAssertEqual("\n\n".chomp(), "")
+    func testEmpty() {
+        XCTAssertEqual("".spm_chomp(), "")
+        XCTAssertEqual(" ".spm_chomp(), " ")
+        XCTAssertEqual("\n\n".spm_chomp(), "")
     }
 
     func testChuzzle() {
-        XCTAssertNil("".chuzzle())
-        XCTAssertNil(" ".chuzzle())
-        XCTAssertNil(" \t ".chuzzle())
-        XCTAssertNil(" \t\n".chuzzle())
-        XCTAssertNil(" \t\r\n".chuzzle())
-        XCTAssertEqual(" a\t\r\n".chuzzle(), "a")
-        XCTAssertEqual("b".chuzzle(), "b")
+        XCTAssertNil("".spm_chuzzle())
+        XCTAssertNil(" ".spm_chuzzle())
+        XCTAssertNil(" \t ".spm_chuzzle())
+        XCTAssertNil(" \t\n".spm_chuzzle())
+        XCTAssertNil(" \t\r\n".spm_chuzzle())
+        XCTAssertEqual(" a\t\r\n".spm_chuzzle(), "a")
+        XCTAssertEqual("b".spm_chuzzle(), "b")
     }
     
     func testSplitAround() {
@@ -48,11 +48,11 @@ class StringTests: XCTestCase {
             XCTAssertEqual(lhs.1, rhs.1, file: file, line: line)
         }
         
-        eq("".split(around: "::"), ("", nil))
-        eq("foo".split(around: "::"), ("foo", nil))
-        eq("foo::".split(around: "::"), ("foo", ""))
-        eq("::bar".split(around: "::"), ("", "bar"))
-        eq("foo::bar".split(around: "::"), ("foo", "bar"))
+        eq("".spm_split(around: "::"), ("", nil))
+        eq("foo".spm_split(around: "::"), ("foo", nil))
+        eq("foo::".spm_split(around: "::"), ("foo", ""))
+        eq("::bar".spm_split(around: "::"), ("", "bar"))
+        eq("foo::bar".spm_split(around: "::"), ("foo", "bar"))
     }
 }
 

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -55,7 +55,7 @@ class GenerateXcodeprojTests: XCTestCase {
             // We can only validate this on OS X.
             // Don't allow TOOLCHAINS to be overriden here, as it breaks the test below.
             let output = try Process.checkNonZeroExit(
-                args: "env", "-u", "TOOLCHAINS", "xcodebuild", "-list", "-project", outpath.asString).chomp()
+                args: "env", "-u", "TOOLCHAINS", "xcodebuild", "-list", "-project", outpath.asString).spm_chomp()
 
             XCTAssertTrue(output.hasPrefix("""
                Information about project "DummyProjectName":


### PR DESCRIPTION
Extensions are very easily leaked into the clients. Since Swift doesn't
have the concept of private imports at this point, it is not safe to
have public stdlib extensions as it can easily cause collisions in the
downstream clients even though they might not directly depend on
SwiftPM. This patch prefixes most of the public stdlib extensions in the
SwiftPM codebase. All future additions should also have the prefix.

<rdar://problem/45200636> SwiftPM should not be exporting Swift stdlib additions