### PR TITLE
[PackageLoading] Diagnose zero library target packages for REPL

### DIFF
--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -126,6 +126,16 @@ public enum PackageBuilderDiagnostics {
         let product: String
     }
 
+    struct ZeroLibraryProducts: DiagnosticData {
+        static let id = DiagnosticID(
+            type: ZeroLibraryProducts.self,
+            name: "org.swift.diags.pkg-builder.\(ZeroLibraryProducts.self)",
+            description: {
+                $0 <<< "unable to synthesize a REPL product as there are no library targets in the package"
+            }
+        )
+    }
+
     struct BorkenSymlinkDiagnostic: DiagnosticData {
         static let id = DiagnosticID(
             type: BorkenSymlinkDiagnostic.self,

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -923,12 +923,20 @@ public final class PackageBuilder {
 
         // Create a special REPL product that contains all the library targets.
         if createREPLProduct {
-            let replProduct = Product(
-                name: manifest.name + Product.replProductSuffix,
-                type: .library(.dynamic),
-                targets: targets.filter({ $0.type == .library })
-            )
-            append(replProduct)
+            let libraryTargets = targets.filter({ $0.type == .library })
+            if libraryTargets.isEmpty {
+                diagnostics.emit(
+                    data: PackageBuilderDiagnostics.ZeroLibraryProducts(),
+                    location: diagnosticLocation()
+                )
+            } else {
+                let replProduct = Product(
+                    name: manifest.name + Product.replProductSuffix,
+                    type: .library(.dynamic),
+                    targets: libraryTargets
+                )
+                append(replProduct)
+            }
         }
 
         return products.map({ $0.item })

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -1300,6 +1300,25 @@ class PackageBuilderTests: XCTestCase {
             result.checkDiagnostic("executable product \'foo\' should have exactly one executable target")
         }
     }
+
+    func testBadREPLPackage() {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/exe/main.swift"
+        )
+
+        let manifest = Manifest.createV4Manifest(
+            name: "Pkg",
+            targets: [
+                TargetDescription(name: "exe"),
+            ]
+        )
+
+        PackageBuilderTester(manifest, createREPLProduct: true, in: fs) { result in
+            result.checkModule("exe") { _ in }
+            result.checkProduct("exe") { _ in }
+            result.checkDiagnostic("unable to synthesize a REPL product as there are no library targets in the package")
+        }
+    }
 }
 
 extension PackageModel.Product: ObjectIdentifierProtocol {}
@@ -1327,6 +1346,7 @@ final class PackageBuilderTester {
         _ manifest: Manifest,
         path: AbsolutePath = .root,
         shouldCreateMultipleTestProducts: Bool = false,
+        createREPLProduct: Bool = false,
         in fs: FileSystem,
         file: StaticString = #file,
         line: UInt = #line,
@@ -1337,7 +1357,7 @@ final class PackageBuilderTester {
             // FIXME: We should allow customizing root package boolean.
             let builder = PackageBuilder(
                 manifest: manifest, path: path, fileSystem: fs, diagnostics: diagnostics,
-                isRootPackage: true, shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts)
+                isRootPackage: true, shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts, createREPLProduct: createREPLProduct)
             let loadedPackage = try builder.construct()
             result = .package(loadedPackage)
             uncheckedModules = Set(loadedPackage.targets)

--- a/Tests/PackageLoadingTests/XCTestManifests.swift
+++ b/Tests/PackageLoadingTests/XCTestManifests.swift
@@ -20,6 +20,7 @@ extension PackageBuilderTests {
     // to regenerate.
     static let __allTests__PackageBuilderTests = [
         ("testBadExecutableProductDecl", testBadExecutableProductDecl),
+        ("testBadREPLPackage", testBadREPLPackage),
         ("testBrokenSymlink", testBrokenSymlink),
         ("testCInTests", testCInTests),
         ("testCompatibleSwiftVersions", testCompatibleSwiftVersions),


### PR DESCRIPTION
<rdar://problem/45211659> `swift run --repl` crashes when there are zero library targets in the root package