### PR TITLE
[Basic] Use UInt8 as the native process output type.

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -414,9 +414,7 @@ public class GitRepository: Repository, WorkingCheckout {
             let result = try Process.popen(arguments: argsWithSh)
             let output = try result.output.dematerialize()
 
-            let outputs: [String] = output.split(separator: 0).map(Array.init).map({ (bytes: [Int8]) -> String in
-                return String(cString: bytes + [0])
-            })
+            let outputs: [String] = output.split(separator: 0).map{ String(decoding: $0, as: Unicode.UTF8.self) }
 
             guard result.exitStatus == .terminated(code: 0) || result.exitStatus == .terminated(code: 1) else {
                 throw GitInterfaceError.fatalError


### PR DESCRIPTION
 - Using Int8 is weird. Also, throwing on non-UTF8 sequences is so Swift 2, it
   is much cleaner to just use the newer conversion methods.