### PR TITLE
[SR-8993] - Progress bar update crash when running tests in Xcode

### DIFF
--- a/Sources/Basic/TerminalController.swift
+++ b/Sources/Basic/TerminalController.swift
@@ -79,7 +79,9 @@ public final class TerminalController {
             return nil
         }
 
-        width = TerminalController.terminalWidth() ?? 80 // Assume default if we are not able to determine.
+        // Assume default if we are not able to determine.
+        let terminalWidth = TerminalController.terminalWidth() ?? 80
+        width = terminalWidth == 0 ? 80 : terminalWidth
         self.stream = stream
     }
 

--- a/Sources/Basic/TerminalController.swift
+++ b/Sources/Basic/TerminalController.swift
@@ -79,9 +79,12 @@ public final class TerminalController {
             return nil
         }
 
-        // Assume default if we are not able to determine.
-        let terminalWidth = TerminalController.terminalWidth() ?? 80
-        width = terminalWidth == 0 ? 80 : terminalWidth
+        // Determine the terminal width otherwise assume a default.
+        if let terminalWidth = TerminalController.terminalWidth(), terminalWidth > 0 {
+            width = terminalWidth
+        } else {
+            width = 80
+        }
         self.stream = stream
     }
 


### PR DESCRIPTION
Now TerminalWidth default to 80 if it's nil or zero. This prevent the update progress bar function to crash.