### PR TITLE
[Commands] Add an option to force resolution to Package.resolved

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -61,5 +61,8 @@ public class ToolOptions {
     /// Whether to enable code coverage.
     public var shouldEnableCodeCoverage = false
 
+    /// Use Package.resolved file for resolving dependencies.
+    public var forceResolvedVersions = false
+
     public required init() {}
 }

--- a/Sources/TestSupport/TestWorkspace.swift
+++ b/Sources/TestSupport/TestWorkspace.swift
@@ -254,13 +254,15 @@ public final class TestWorkspace {
     public func checkPackageGraph(
         roots: [String] = [],
         dependencies: [PackageGraphRootInput.PackageDependency] = [],
+        forceResolvedVersions: Bool = false,
         _ result: (PackageGraph, DiagnosticsEngine) -> ()
     ) {
         let diagnostics = DiagnosticsEngine()
         let workspace = createWorkspace()
         let rootInput = PackageGraphRootInput(
             packages: rootPaths(for: roots), dependencies: dependencies)
-        let graph = workspace.loadPackageGraph(root: rootInput, diagnostics: diagnostics)
+        let graph = workspace.loadPackageGraph(
+            root: rootInput, forceResolvedVersions: forceResolvedVersions, diagnostics: diagnostics)
         result(graph, diagnostics)
     }
 
@@ -379,8 +381,10 @@ public final class TestWorkspace {
                 switch state {
                 case .version(let version):
                     XCTAssertEqual(pin.state.version, version, file: file, line: line)
-                case .revision, .branch:
-                    XCTFail("Unimplemented", file: file, line: line)
+                case .revision(let revision):
+                    XCTAssertEqual(pin.state.revision.identifier, revision, file: file, line: line)
+                case .branch(let branch):
+                    XCTAssertEqual(pin.state.branch, branch, file: file, line: line)
                 }
             case .edited, .local:
                 XCTFail("Unimplemented", file: file, line: line)

--- a/Tests/WorkspaceTests/XCTestManifests.swift
+++ b/Tests/WorkspaceTests/XCTestManifests.swift
@@ -53,6 +53,7 @@ extension WorkspaceTests {
         ("testDependencyResolutionWithEdit", testDependencyResolutionWithEdit),
         ("testDependencySwitchWithSameIdentity", testDependencySwitchWithSameIdentity),
         ("testEditDependency", testEditDependency),
+        ("testForceResolveToResolvedVersions", testForceResolveToResolvedVersions),
         ("testGraphData", testGraphData),
         ("testGraphRootDependencies", testGraphRootDependencies),
         ("testInterpreterFlags", testInterpreterFlags),


### PR DESCRIPTION
This adds a new flag `--force-resolved-versions` which will force
resolve to versions recorded in the Package.resolved file.

The entries in Package.resolved can be considered as "soft" pins.  Since
the requirements in root manifest and Package.resolved can change
anytime, most SwiftPM operations (that load the package graph) first
check if the current state of things is still correct. However, it is
sometimes useful to force resolve to the dependencies recorded in the
resolved file by entirely bypassing the dependency resolution.

<rdar://problem/45290071> Add option to not re-resolve, but use Package.resolved explicitly