### PR TITLE
[SR-3009] Made PathImpl private

### DIFF
--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -361,9 +361,7 @@ extension RelativePath: CustomStringConvertible {
 /// AbsolutePath and RelativePath struct, but PathImpl helps mitigate it.  From
 /// a type safety perspective, absolute paths and relative paths are genuinely
 /// different.
-// FIXME: This is internal due to this bug: https://bugs.swift.org/browse/SR-3009
-// but otherwise should be private.
-struct PathImpl: Hashable {
+private struct PathImpl: Hashable {
     /// Normalized string of the (absolute or relative) path.  Never empty.
     fileprivate let string: String
 


### PR DESCRIPTION
Stumbled upon the TODO that was on `PathImpl`.

It directed to [SR-3009](https://bugs.swift.org/browse/SR-3009). The example project from @aciidb0mb3r now builds and running the same `swift build` command on the package manager also succeeds.