### PR TITLE
[Basic] Convert precondition in determineTmpDir into a runtime error

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -18,7 +18,8 @@ import func POSIX.getenv
 public struct BuildParameters {
 
     /// Path to the module cache directory to use for SwiftPM's own tests.
-    public static let swiftpmTestCache = resolveSymlinks(determineTempDirectory()).appending(component: "org.swift.swiftpm.tests-3")
+    // FIXME: Error handling.
+    public static let swiftpmTestCache = resolveSymlinks(try! determineTempDirectory()).appending(component: "org.swift.swiftpm.tests-3")
 
     /// Returns the directory to be used for module cache.
     fileprivate var moduleCache: AbsolutePath {

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -620,7 +620,7 @@ public class SwiftTool<Options: ToolOptions> {
     func runLLBuildAsExecutable(manifest: AbsolutePath, llbuildTarget: String) throws {
         // Create a temporary directory for the build process.
         let tempDirName = "org.swift.swiftpm.\(NSUserName())"
-        let tempDir = Basic.determineTempDirectory().appending(component: tempDirName)
+        let tempDir = try determineTempDirectory().appending(component: tempDirName)
         try localFileSystem.createDirectory(tempDir, recursive: true)
 
         // Run the swift-build-tool with the generated manifest.
@@ -717,10 +717,9 @@ public class SwiftTool<Options: ToolOptions> {
         return Result(anyError: {
             try ManifestLoader(
                 // Always use the host toolchain's resources for parsing manifest.
-                resources: self._hostToolchain.dematerialize().manifestResources,
+                manifestResources: self._hostToolchain.dematerialize().manifestResources,
                 isManifestSandboxEnabled: !self.options.shouldDisableSandbox,
-                isManifestCachingEnabled: !self.options.shouldDisableManifestCaching,
-                cacheDir: self.buildPath
+                cacheDir: self.options.shouldDisableManifestCaching ? nil : self.buildPath
             )
         })
     }()

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -131,20 +131,20 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
     let resources: ManifestResourceProvider
     let isManifestSandboxEnabled: Bool
-    let isManifestCachingEnabled: Bool
-    let cacheDir: AbsolutePath
+    var isManifestCachingEnabled: Bool {
+        return cacheDir != nil
+    }
+    let cacheDir: AbsolutePath!
     let delegate: ManifestLoaderDelegate?
 
     public init(
-        resources: ManifestResourceProvider,
+        manifestResources: ManifestResourceProvider,
         isManifestSandboxEnabled: Bool = true,
-        isManifestCachingEnabled: Bool = true,
-        cacheDir: AbsolutePath = determineTempDirectory(),
+        cacheDir: AbsolutePath? = nil,
         delegate: ManifestLoaderDelegate? = nil
     ) {
-        self.resources = resources
+        self.resources = manifestResources
         self.isManifestSandboxEnabled = isManifestSandboxEnabled
-        self.isManifestCachingEnabled = isManifestCachingEnabled
         self.delegate = delegate
         self.cacheDir = cacheDir
     }
@@ -155,10 +155,8 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         isManifestSandboxEnabled: Bool = true
     ) {
         self.init(
-            resources: resources,
-            isManifestSandboxEnabled: isManifestSandboxEnabled,
-            isManifestCachingEnabled: false,
-            cacheDir: determineTempDirectory()
+            manifestResources: resources,
+            isManifestSandboxEnabled: isManifestSandboxEnabled
        )
     }
 

--- a/Sources/Utility/Platform.swift
+++ b/Sources/Utility/Platform.swift
@@ -44,7 +44,7 @@ public enum Platform {
         var directories = [AbsolutePath]()
         // Compute the directories.
         directories.append(AbsolutePath("/private/var/tmp"))
-        directories.append(Basic.determineTempDirectory())
+        (try? Basic.determineTempDirectory()).map{ directories.append($0) }
       #if os(macOS)
         getConfstr(_CS_DARWIN_USER_TEMP_DIR).map({ directories.append($0) })
         getConfstr(_CS_DARWIN_USER_CACHE_DIR).map({ directories.append($0) })

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -97,7 +97,7 @@ class DependencyResolverPerfTests: XCTestCasePerf {
 
             let containerProvider = RepositoryPackageContainerProvider(
                 repositoryManager: repositoryManager,
-                manifestLoader: ManifestLoader(resources: Resources.default, isManifestCachingEnabled: false, cacheDir: path))
+                manifestLoader: ManifestLoader(manifestResources: Resources.default))
 
             let resolver = DependencyResolver(containerProvider, GitRepositoryResolutionHelper.DummyResolverDelegate())
             let container = PackageReference(identity: "dep", path: dep.asString)

--- a/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
+++ b/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
@@ -15,7 +15,7 @@ import TestSupport
 import PackageLoading
 
 class ManifestLoadingPerfTests: XCTestCasePerf {
-    let manifestLoader = ManifestLoader(resources: Resources.default, isManifestCachingEnabled: false)
+    let manifestLoader = ManifestLoader(manifestResources: Resources.default)
 
     func write(_ bytes: ByteString, body: (AbsolutePath) -> ()) {
         mktmpdir { path in

--- a/Tests/PackageLoadingTests/PD4LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4LoadingTests.swift
@@ -19,7 +19,7 @@ import TestSupport
 import PackageLoading
 
 class PackageDescription4LoadingTests: XCTestCase {
-    let manifestLoader = ManifestLoader(resources: Resources.default, isManifestCachingEnabled: false)
+    let manifestLoader = ManifestLoader(manifestResources: Resources.default)
 
     private func loadManifestThrowing(
         _ contents: ByteString,

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -18,7 +18,7 @@ import PackageLoading
 
 // FIXME: We should share the infra with other loading tests.
 class PackageDescription4_2LoadingTests: XCTestCase {
-    let manifestLoader = ManifestLoader(resources: Resources.default, isManifestCachingEnabled: false)
+    let manifestLoader = ManifestLoader(manifestResources: Resources.default)
 
     private func loadManifestThrowing(
         _ contents: ByteString,
@@ -378,8 +378,9 @@ class PackageDescription4_2LoadingTests: XCTestCase {
             }
 
             let delegate = ManifestTestDelegate()
+
             let manifestLoader = ManifestLoader(
-                resources: Resources.default, cacheDir: path, delegate: delegate)
+                manifestResources: Resources.default, cacheDir: path, delegate: delegate)
 
             func check(loader: ManifestLoader, expectCached: Bool) {
                 delegate.clear()
@@ -422,7 +423,7 @@ class PackageDescription4_2LoadingTests: XCTestCase {
             }
 
             let noCacheLoader = ManifestLoader(
-                resources: Resources.default, isManifestCachingEnabled: false, delegate: delegate)
+                manifestResources: Resources.default, delegate: delegate)
             for _ in 0..<2 {
                 check(loader: noCacheLoader, expectCached: false)
             }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -119,8 +119,7 @@ final class WorkspaceTests: XCTestCase {
                 """
             }
 
-            let manifestLoader = ManifestLoader(
-                resources: Resources.default, isManifestCachingEnabled: false)
+            let manifestLoader = ManifestLoader(manifestResources: Resources.default)
 
             let sandbox = path.appending(component: "ws")
             let ws = Workspace(


### PR DESCRIPTION
This assumption is not always true and we shouldn't be crashing in such
cases.

<rdar://problem/45198013> Turn precondition in determineTempDirectory into a runtime throw