### PR TITLE
[PackageLoading] Filter versions containing older tools version

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -210,14 +210,14 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
                     // FIXME: Probably lift this error defination to ToolsVersion.
                     throw ToolsVersionLoader.Error.malformed(specifier: value, file: pkg)
                 }
-                try writeToolsVersion(at: pkg, version: toolsVersion, fs: &localFileSystem)
+                try writeToolsVersion(at: pkg, version: toolsVersion, fs: localFileSystem)
 
             case .setCurrent:
                 // Write the tools version with current version but with patch set to zero.
                 // We do this to avoid adding unnecessary constraints to patch versions, if
                 // the package really needs it, they can do it using --set option.
                 try writeToolsVersion(
-                    at: pkg, version: ToolsVersion.currentToolsVersion.zeroedPatch, fs: &localFileSystem)
+                    at: pkg, version: ToolsVersion.currentToolsVersion.zeroedPatch, fs: localFileSystem)
             }
 
         case .generateXcodeproj:

--- a/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
@@ -268,7 +268,15 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
 
             // Otherwise, compute and cache the result.
             let isValid = (try? self.toolsVersion(for: $0)).flatMap({ 
-                self.currentToolsVersion >= $0
+                guard $0 >= ToolsVersion.minimumRequired else {
+                    return false
+                }
+
+                guard self.currentToolsVersion >= $0 else {
+                    return false
+                }
+
+                return true
             }) ?? false
             self.validToolsVersionsCache[$0] = isValid
 

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -45,9 +45,6 @@ public enum ModuleError: Swift.Error {
     /// We found multiple LinuxMain.swift files.
     case multipleLinuxMainFound(package: String, linuxMainFiles: [AbsolutePath])
 
-    /// The package should support version 3 compiler but doesn't.
-    case mustSupportSwift3Compiler(package: String)
-
     /// The tools version in use is not compatible with target's sources.
     case incompatibleToolsVersions(package: String, required: [SwiftLanguageVersion], current: ToolsVersion)
 
@@ -82,8 +79,6 @@ extension ModuleError: CustomStringConvertible {
         case .multipleLinuxMainFound(let package, let linuxMainFiles):
             let files = linuxMainFiles.map({ $0.asString }).sorted().joined(separator: ", ")
             return "package '\(package)' has multiple linux main files: \(files)"
-        case .mustSupportSwift3Compiler(let package):
-            return "package '\(package)' must support Swift 3 because its minimum tools version is 3"
         case .incompatibleToolsVersions(let package, let required, let current):
             if required.isEmpty {
                 return "package '\(package)' supported Swift language versions is empty"

--- a/Sources/PackageModel/ToolsVersion.swift
+++ b/Sources/PackageModel/ToolsVersion.swift
@@ -25,6 +25,9 @@ public struct ToolsVersion: CustomStringConvertible, Comparable {
         "\(Versioning.currentVersion.minor)." +
         "\(Versioning.currentVersion.patch)")!
 
+    /// The minimum tools version that is required by the package manager.
+    public static let minimumRequired: ToolsVersion = .v4
+
     /// Regex pattern to parse tools version. The format is SemVer 2.0 with an
     /// addition that specifying the patch version is optional.
     static let toolsVersionRegex = try! NSRegularExpression(pattern: "^" +

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -137,7 +137,7 @@ public final class InitPackage {
 
         // Write the current tools version.
         try writeToolsVersion(
-            at: manifest.parentDirectory, version: version, fs: &localFileSystem)
+            at: manifest.parentDirectory, version: version, fs: localFileSystem)
     }
 
     private func writeREADMEFile() throws {

--- a/Sources/Workspace/ToolsVersionWriter.swift
+++ b/Sources/Workspace/ToolsVersionWriter.swift
@@ -18,7 +18,7 @@ import Utility
 /// - Parameters:
 ///   - path: The path of the package.
 ///   - version: The version to write.
-public func writeToolsVersion(at path: AbsolutePath, version: ToolsVersion, fs: inout FileSystem) throws {
+public func writeToolsVersion(at path: AbsolutePath, version: ToolsVersion, fs: FileSystem) throws {
     let file = path.appending(component: Manifest.filename)
     assert(fs.isFile(file), "Tools version file not present")
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1033,7 +1033,7 @@ extension Workspace {
                 at: packagePath, fileSystem: fileSystem)
 
             // Make sure the package has the right minimum tools version.
-            guard toolsVersion >= .v4 else {
+            guard toolsVersion >= ToolsVersion.minimumRequired else {
                 throw WorkspaceDiagnostics.IncompatibleToolsVersion(
                     rootPackagePath: packagePath,
                     requiredToolsVersion: .v4,

--- a/Tests/FunctionalTests/VersionSpecificTests.swift
+++ b/Tests/FunctionalTests/VersionSpecificTests.swift
@@ -50,6 +50,10 @@ class VersionSpecificTests: XCTestCase {
 
             // Create the version to test against.
             try fs.writeFileContents(depPath.appending(component: "Package.swift")) {
+                // FIXME: We end up filtering this manifest if it has an invalid
+                // tools version as they're assumed to be v3 manifests. Should we
+                // do something better?
+                $0 <<< "// swift-tools-version:4.2\n"
                 $0 <<< "NOT_A_VALID_PACKAGE"
             }
             try fs.writeFileContents(depPath.appending(component: "foo.swift")) {

--- a/Tests/WorkspaceTests/ToolsVersionWriterTests.swift
+++ b/Tests/WorkspaceTests/ToolsVersionWriterTests.swift
@@ -106,7 +106,7 @@ class ToolsVersionWriterTests: XCTestCase {
         _ result: (ByteString) -> Void
     ) {
         do {
-            var fs: FileSystem = InMemoryFileSystem()
+            let fs: FileSystem = InMemoryFileSystem()
 
             let file = AbsolutePath("/pkg/Package.swift")
 
@@ -114,7 +114,7 @@ class ToolsVersionWriterTests: XCTestCase {
             try fs.writeFileContents(file, bytes: stream.bytes)
 
             try writeToolsVersion(
-                at: file.parentDirectory, version: version, fs: &fs)
+                at: file.parentDirectory, version: version, fs: fs)
 
             result(try fs.readFileContents(file))
         } catch {

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -1238,6 +1238,48 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
+    func testMinimumRequiredToolsVersionInDependencyResolution() throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try TestWorkspace(
+            sandbox: sandbox,
+            fs: fs,
+            roots: [
+                TestPackage(
+                    name: "Root",
+                    targets: [
+                        TestTarget(name: "Root", dependencies: ["Foo"]),
+                    ],
+                    products: [],
+                    dependencies: [
+                        TestDependency(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                    ]
+                ),
+            ],
+            packages: [
+                TestPackage(
+                    name: "Foo",
+                    targets: [
+                        TestTarget(name: "Foo"),
+                    ],
+                    products: [
+                        TestProduct(name: "Foo", targets: ["Foo"]),
+                    ],
+                    versions: ["1.0.0"],
+                    toolsVersion: .v3
+                ),
+            ]
+        )
+
+        workspace.checkPackageGraph(roots: ["Root"]) { (graph, diagnostics) in
+            DiagnosticsEngineTester(diagnostics) { result in
+                result.check(diagnostic: .contains("/tmp/ws/pkgs/Foo @ 1.0.0..<2.0.0"), behavior: .error)
+                result.check(diagnostic: .contains("product dependency 'Foo' not found"), behavior: .error, location: "'Root' /tmp/ws/roots/Root")
+            }
+        }
+    }
+
     func testToolsVersionRootPackages() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()

--- a/Tests/WorkspaceTests/XCTestManifests.swift
+++ b/Tests/WorkspaceTests/XCTestManifests.swift
@@ -64,6 +64,7 @@ extension WorkspaceTests {
         ("testLocalDependencyWithPackageUpdate", testLocalDependencyWithPackageUpdate),
         ("testLocalLocalSwitch", testLocalLocalSwitch),
         ("testLocalVersionSwitch", testLocalVersionSwitch),
+        ("testMinimumRequiredToolsVersionInDependencyResolution", testMinimumRequiredToolsVersionInDependencyResolution),
         ("testMissingEditCanRestoreOriginalCheckout", testMissingEditCanRestoreOriginalCheckout),
         ("testMultipleRootPackages", testMultipleRootPackages),
         ("testPackageMirror", testPackageMirror),


### PR DESCRIPTION
This assumption is not always true and we shouldn't be crashing in such
cases.

<rdar://problem/45198013> Turn precondition in determineTempDirectory into a runtime throw