### PR TITLE
removed spm_rindex and replaced usage with lastIndex(of:) from the standard library

### DIFF
--- a/Sources/Basic/CollectionAlgorithms.swift
+++ b/Sources/Basic/CollectionAlgorithms.swift
@@ -8,27 +8,6 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-extension BidirectionalCollection where Iterator.Element : Comparable {
-    /// Returns the index of the last occurrence of `element` or nil if none.
-    ///
-    /// - Parameters:
-    ///   - start: If provided, the `start` index limits the search to a suffix of the collection.
-    //
-    // FIXME: This probably shouldn't take the `from` parameter, the pattern in
-    // the standard library is to use slices for that.
-    public func spm_rindex(of element: Iterator.Element, from start: Index? = nil) -> Index? {
-        let firstIdx = start ?? startIndex
-        var i = endIndex
-        while i > firstIdx {
-            self.formIndex(before: &i)
-            if self[i] == element {
-                return i
-            }
-        }
-        return nil
-    }
-}
-
 extension Sequence where Iterator.Element: Hashable {
 
     /// Finds duplicates in given sequence of Hashables.

--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -373,7 +373,7 @@ private struct PathImpl: Hashable {
         // FIXME: This method seems too complicated; it should be simplified,
         //        if possible, and certainly optimized (using UTF8View).
         // Find the last path separator.
-        guard let idx = string.spm_rindex(of: "/") else {
+        guard let idx = string.lastIndex(of: "/") else {
             // No path separators, so the directory name is `.`.
             return "."
         }
@@ -397,7 +397,7 @@ private struct PathImpl: Hashable {
             return "/"
         }
         // Find the last path separator.
-        guard let idx = string.spm_rindex(of: "/") else {
+        guard let idx = string.lastIndex(of: "/") else {
             // No path separators, so the basename is the whole string.
             return string
         }
@@ -419,14 +419,14 @@ private struct PathImpl: Hashable {
         // FIXME: This method seems too complicated; it should be simplified,
         //        if possible, and certainly optimized (using UTF8View).
         // Find the last path separator, if any.
-        let sIdx = string.spm_rindex(of: "/")
+        let sIdx = string.lastIndex(of: "/")
         // Find the start of the basename.
         let bIdx = (sIdx != nil) ? string.index(after: sIdx!) : string.startIndex
         // Find the last `.` (if any), starting from the second character of
         // the basename (a leading `.` does not make the whole path component
         // a suffix).
-        let fIdx = string.index(bIdx, offsetBy: 1, limitedBy: string.endIndex)
-        if let idx = string.spm_rindex(of: ".", from: fIdx) {
+        let fIdx = string.index(bIdx, offsetBy: 1, limitedBy: string.endIndex) ?? string.startIndex
+        if let idx = string[fIdx...].lastIndex(of: ".") {
             // Unless it's just a `.` at the end, we have found a suffix.
             if string.distance(from: idx, to: string.endIndex) > 1 {
                 let fromIndex = withDot ? idx : string.index(idx, offsetBy: 1)

--- a/Tests/BasicTests/CollectionAlgorithmsTests.swift
+++ b/Tests/BasicTests/CollectionAlgorithmsTests.swift
@@ -13,15 +13,6 @@ import XCTest
 import Basic
 
 class CollectionAlgorithmsTests: XCTestCase {
-    func testRIndex() {
-        let str = "hello"
-        XCTAssertEqual(str.spm_rindex(of: "h"), str.startIndex)
-        XCTAssertEqual(str.spm_rindex(of: "h", from: str.index(after: str.startIndex)), nil)
-        XCTAssertEqual(str.spm_rindex(of: "o"), str.index(of: "o"))
-        XCTAssertEqual(str.spm_rindex(of: "l"), str.index(after: str.index(where: { $0 == "l" })!))
-        XCTAssertEqual(str.spm_rindex(of: "x"), nil)
-    }
-
     func testFindDuplicates() {
         XCTAssertEqual([1, 2, 3, 2, 1].spm_findDuplicates(), [2, 1])
         XCTAssertEqual(["foo", "bar"].spm_findDuplicates(), [])

--- a/Tests/BasicTests/XCTestManifests.swift
+++ b/Tests/BasicTests/XCTestManifests.swift
@@ -48,7 +48,6 @@ extension CollectionAlgorithmsTests {
     // to regenerate.
     static let __allTests__CollectionAlgorithmsTests = [
         ("testFindDuplicates", testFindDuplicates),
-        ("testRIndex", testRIndex),
     ]
 }
 


### PR DESCRIPTION
The implementation of `spm_rindex()` was almost identical to the implementation in of `lastIndex()` from the standard library's extensions for `BidirectionalCollection`.