### PR TITLE
Moved // FIXME: lines that broke doc comments

### DIFF
--- a/Sources/Basic/DiagnosticsEngine.swift
+++ b/Sources/Basic/DiagnosticsEngine.swift
@@ -67,6 +67,11 @@ public func <<< <T>(
     return builder
 }
 
+// FIXME: One thing we should consider is whether we should make the diagnostic
+// a protocol and put these properties on the type, which is conceptually the
+// right modeling, but might be cumbersome of our desired features don't
+// perfectly align with what the language can express.
+//
 /// A unique identifier for a diagnostic.
 ///
 /// Diagnostic identifiers are intended to be a stable representation of a
@@ -76,12 +81,6 @@ public func <<< <T>(
 /// (e.g., a command line tool, an IDE, or a web UI) is expecting to receive
 /// diagnostics and be able to present additional UI affordances or workflows
 /// associated for specific kinds of diagnostics.
-///
-//
-// FIXME: One thing we should consider is whether we should make the diagnostic
-// a protocol and put these properties on the type, which is conceptually the
-// right modeling, but might be cumbersome of our desired features don't
-// perfectly align with what the language can express.
 public class DiagnosticID: ObjectIdentifierProtocol {
 
     /// A piece of a diagnostic description.

--- a/Sources/Basic/FileSystem.swift
+++ b/Sources/Basic/FileSystem.swift
@@ -108,6 +108,8 @@ public enum FileMode {
     }
 }
 
+// FIXME: Design an asynchronous story?
+//
 /// Abstracted access to file system operations.
 ///
 /// This protocol is used to allow most of the codebase to interact with a
@@ -115,8 +117,6 @@ public enum FileMode {
 /// substitute a virtual file system or redirect file system operations.
 ///
 /// NOTE: All of these APIs are synchronous and can block.
-//
-// FIXME: Design an asynchronous story?
 public protocol FileSystem: class {
     /// Check whether the given path exists and is accessible.
     func exists(_ path: AbsolutePath, followSymlink: Bool) -> Bool
@@ -133,10 +133,10 @@ public protocol FileSystem: class {
     /// Check whether the given path is accessible and is a symbolic link.
     func isSymlink(_ path: AbsolutePath) -> Bool
 
-    /// Get the contents of the given directory, in an undefined order.
-    //
     // FIXME: Actual file system interfaces will allow more efficient access to
     // more data than just the name here.
+    //
+    /// Get the contents of the given directory, in an undefined order.
     func getDirectoryContents(_ path: AbsolutePath) throws -> [String]
 
     /// Get the current working directory (similar to `getcwd(3)`), which can be
@@ -157,21 +157,21 @@ public protocol FileSystem: class {
     /// - recursive: If true, create missing parent directories if possible.
     func createDirectory(_ path: AbsolutePath, recursive: Bool) throws
 
+    // FIXME: This is obviously not a very efficient or flexible API.
+    //
     /// Get the contents of a file.
     ///
     /// - Returns: The file contents as bytes, or nil if missing.
-    //
-    // FIXME: This is obviously not a very efficient or flexible API.
     func readFileContents(_ path: AbsolutePath) throws -> ByteString
 
-    /// Write the contents of a file.
-    //
     // FIXME: This is obviously not a very efficient or flexible API.
+    //
+    /// Write the contents of a file.
     func writeFileContents(_ path: AbsolutePath, bytes: ByteString) throws
 
-    /// Write the contents of a file.
-    //
     // FIXME: This is obviously not a very efficient or flexible API.
+    //
+    /// Write the contents of a file.
     func writeFileContents(_ path: AbsolutePath, bytes: ByteString, atomically: Bool) throws
 
     /// Recursively deletes the file system entity at `path`.
@@ -511,9 +511,9 @@ private class LocalFileSystem: FileSystem {
     }
 }
 
-/// Concrete FileSystem implementation which simulates an empty disk.
-//
 // FIXME: This class does not yet support concurrent mutation safely.
+//
+/// Concrete FileSystem implementation which simulates an empty disk.
 public class InMemoryFileSystem: FileSystem {
     private class Node {
         /// The actual node data.

--- a/Sources/Basic/LazyCache.swift
+++ b/Sources/Basic/LazyCache.swift
@@ -8,6 +8,9 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+// FIXME: This wrapper could benefit from local static variables, in which case
+// we could embed the cache object inside the accessor.
+//
 /// Thread-safe lazily cached methods.
 ///
 /// The `lazy` annotation in Swift does not result in a thread-safe accessor,
@@ -25,9 +28,6 @@
 /// ```
 ///
 /// See: https://bugs.swift.org/browse/SR-1042
-//
-// FIXME: This wrapper could benefit from local static variables, in which case
-// we could embed the cache object inside the accessor.
 public struct LazyCache<Class, T> {
     // FIXME: It would be nice to avoid a per-instance lock, but this type isn't
     // intended for creating large numbers of instances of. We also really want

--- a/Sources/Basic/OutputByteStream.swift
+++ b/Sources/Basic/OutputByteStream.swift
@@ -537,9 +537,10 @@ public struct Format {
 /// Inmemory implementation of OutputByteStream.
 public final class BufferedOutputByteStream: _OutputByteStreamBase {
 
-    /// Contents of the stream.
     // FIXME: For inmemory implementation we should be share this buffer with OutputByteStream.
     // One way to do this is by allowing OuputByteStream to install external buffers.
+    //
+    /// Contents of the stream.
     private var contents = [UInt8]()
 
     override public init() {

--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -205,13 +205,14 @@ public struct AbsolutePath: Hashable {
         return _impl.string
     }
 
+    // FIXME: We should investigate if it would be more efficient to instead
+    // return a path component iterator that does all its work lazily, moving
+    // from one path separator to the next on-demand.
+    //
     /// Returns an array of strings that make up the path components of the
     /// absolute path.  This is the same sequence of strings as the basenames
     /// of each successive path component, starting from the root.  Therefore
     /// the first path component of an absolute path is always `/`.
-    // FIXME: We should investigate if it would be more efficient to instead
-    // return a path component iterator that does all its work lazily, moving
-    // from one path separator to the next on-demand.
     public var components: [String] {
         // FIXME: This isn't particularly efficient; needs optimization, and
         // in fact, it might well be best to return a custom iterator so we
@@ -292,14 +293,15 @@ public struct RelativePath: Hashable {
         return _impl.string
     }
 
+    // FIXME: We should investigate if it would be more efficient to instead
+    // return a path component iterator that does all its work lazily, moving
+    // from one path separator to the next on-demand.
+    //
     /// Returns an array of strings that make up the path components of the
     /// relative path.  This is the same sequence of strings as the basenames
     /// of each successive path component.  Therefore the returned array of
     /// path components is never empty; even an empty path has a single path
     /// component: the `.` string.
-    // FIXME: We should investigate if it would be more efficient to instead
-    // return a path component iterator that does all its work lazily, moving
-    // from one path separator to the next on-demand.
     public var components: [String] {
         // FIXME: This isn't particularly efficient; needs optimization, and
         // in fact, it might well be best to return a custom iterator so we

--- a/Sources/Basic/TemporaryFile.swift
+++ b/Sources/Basic/TemporaryFile.swift
@@ -17,8 +17,9 @@ public enum TempFileError: Swift.Error {
     /// Could not create a unique temporary filename.
     case couldNotCreateUniqueName
 
-    /// Some error thrown defined by posix's open().
     // FIXME: This should be factored out into a open error enum.
+    //
+    /// Some error thrown defined by posix's open().
     case other(Int32)
 
     /// Couldn't find a temporary directory.
@@ -131,9 +132,9 @@ extension TemporaryFile: CustomStringConvertible {
     }
 }
 
-/// Contains the error which can be thrown while creating a directory using POSIX's mkdir.
-//
 // FIXME: This isn't right place to declare this, probably POSIX or merge with FileSystemError?
+//
+/// Contains the error which can be thrown while creating a directory using POSIX's mkdir.
 public enum MakeDirectoryError: Swift.Error {
     /// The given path already exists as a directory, file or symbolic link.
     case pathExists

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -17,8 +17,9 @@ import func POSIX.getenv
 
 public struct BuildParameters {
 
-    /// Path to the module cache directory to use for SwiftPM's own tests.
     // FIXME: Error handling.
+    //
+    /// Path to the module cache directory to use for SwiftPM's own tests.
     public static let swiftpmTestCache = resolveSymlinks(try! determineTempDirectory()).appending(component: "org.swift.swiftpm.tests-3")
 
     /// Returns the directory to be used for module cache.

--- a/Sources/PackageDescription4/JSON.swift
+++ b/Sources/PackageDescription4/JSON.swift
@@ -20,8 +20,9 @@ enum JSON {
 }
 
 extension JSON {
-    /// Converts the JSON to string representation.
     // FIXME: No escaping implemented for now.
+    //
+    /// Converts the JSON to string representation.
     func toString() -> String {
         switch self {
         case .null:

--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -35,8 +35,9 @@ public struct PackageGraphRootInput {
 /// Represents the inputs to the package graph.
 public struct PackageGraphRoot {
 
-    /// Represents a top level package dependencies.
     // FIXME: We can kill this now.
+    //
+    /// Represents a top level package dependencies.
     public struct PackageDependency {
 
         public typealias Requirement = PackageModel.PackageDependencyDescription.Requirement

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -431,8 +431,8 @@ private func sandboxProfile() -> String {
     return stream.bytes.asString!
 }
 
-/// Represents a string error.
 // FIXME: We should probably just remove this and make all Manifest errors Codable.
+/// Represents a string error.
 struct StringError: Equatable, Codable, CustomStringConvertible, Error {
 
     /// The description of the error.
@@ -521,8 +521,8 @@ final class ManifestLoadRule: LLBuildRule {
     }
 }
 
-/// A rule to get file info of a file on disk.
 // FIXME: Find a proper place for this rule.
+/// A rule to get file info of a file on disk.
 final class FileInfoRule: LLBuildRule {
 
     struct RuleKey: LLBuildKey {
@@ -564,10 +564,10 @@ final class FileInfoRule: LLBuildRule {
     }
 }
 
+// FIXME: Find a proper place for this rule.
 /// A rule to compute the current version of the pacakge manager.
 ///
 /// This rule will always run.
-// FIXME: Find a proper place for this rule.
 final class SwiftPMVersionRule: LLBuildRule {
 
     struct RuleKey: LLBuildKey {

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -326,7 +326,7 @@ public final class PackageBuilder {
     }
 
     /// Returns path to all the items in a directory.
-    /// FIXME: This is generic functionality, and should move to FileSystem.
+    // FIXME: This is generic functionality, and should move to FileSystem.
     func directoryContents(_ path: AbsolutePath) throws -> [AbsolutePath] {
         return try fileSystem.getDirectoryContents(path).map({ path.appending(component: $0) })
     }

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -52,16 +52,16 @@ public final class Manifest: ObjectIdentifierProtocol, CustomStringConvertible, 
     /// The standard basename for the manifest.
     public static let basename = "Package"
 
-    /// The path of the manifest file.
-    //
     // FIXME: This doesn't belong here, we want the Manifest to be purely tied
     // to the repository state, it shouldn't matter where it is.
+    //
+    /// The path of the manifest file.
     public let path: AbsolutePath
 
-    /// The repository URL the manifest was loaded from.
-    //
     // FIXME: This doesn't belong here, we want the Manifest to be purely tied
     // to the repository state, it shouldn't matter where it is.
+    //
+    /// The repository URL the manifest was loaded from.
     public let url: String
 
     /// The version this package was loaded from, if known.
@@ -199,8 +199,9 @@ public struct TargetDescription: Equatable, Codable {
     /// The exclude patterns.
     public let exclude: [String]
 
-    /// Returns true if the target type is test.
     // FIXME: Kill this.
+    //
+    /// Returns true if the target type is test.
     public var isTest: Bool {
         return type == .test
     }

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -112,8 +112,6 @@ enum GitInterfaceError: Swift.Error {
     case fatalError
 }
 
-/// A basic `git` repository. This class is thread safe.
-//
 // FIXME: Currently, this class is serving two goals, it is the Repository
 // interface used by `RepositoryProvider`, but is also a class which can be
 // instantiated directly against non-RepositoryProvider controlled
@@ -122,6 +120,8 @@ enum GitInterfaceError: Swift.Error {
 // class. It is possible we should rename `Repository` to something more
 // abstract, and change the provider to just return an adaptor around this
 // class.
+//
+/// A basic `git` repository. This class is thread safe.
 public class GitRepository: Repository, WorkingCheckout {
     /// A hash object.
     struct Hash: Hashable {

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -132,11 +132,11 @@ public class RepositoryManager {
     /// The delegate interface.
     private let delegate: RepositoryManagerDelegate?
 
-    /// The map of registered repositories.
-    //
     // FIXME: We should use a more sophisticated map here, which tracks the
     // full specifier but then is capable of efficiently determining if two
     // repositories map to the same location.
+    //
+    /// The map of registered repositories.
     fileprivate var repositories: [String: RepositoryHandle] = [:]
 
     /// The map of serialized repositories.

--- a/Sources/SourceControl/SwiftPMConfig.swift
+++ b/Sources/SourceControl/SwiftPMConfig.swift
@@ -13,10 +13,10 @@ import Foundation
 import Basic
 import Utility
 
-/// Manages a package's configuration.
-///
 // FIXME: We may want to move this class to some other layer once we start
 // supporting more things than just mirrors.
+//
+/// Manages a package's configuration.
 public final class SwiftPMConfig {
 
     enum Error: Swift.Error, CustomStringConvertible {

--- a/Sources/Utility/ArgumentParser.swift
+++ b/Sources/Utility/ArgumentParser.swift
@@ -251,11 +251,11 @@ public enum ArrayParsingStrategy {
 
 /// A protocol representing positional or options argument.
 protocol ArgumentProtocol: Hashable {
-    /// The argument kind of this argument for eg String, Bool etc.
-    ///
     // FIXME: This should be constrained to ArgumentKind but Array can't conform
     // to it: `extension of type 'Array' with constraints cannot have an
     // inheritance clause`.
+    //
+    /// The argument kind of this argument for eg String, Bool etc.
     associatedtype ArgumentKindTy
 
     /// Name of the argument which will be parsed by the parser.
@@ -277,12 +277,12 @@ protocol ArgumentProtocol: Hashable {
     /// The shell completions to offer as values for this argument.
     var completion: ShellCompletion { get }
 
-    /// Parses and returns the argument values from the parser.
-    ///
     // FIXME: Because `ArgumentKindTy`` can't conform to `ArgumentKind`, this
     // function has to be provided a kind (which will be different from
     // ArgumentKindTy for arrays). Once the generics feature exists we can
     // improve this API.
+    //
+    /// Parses and returns the argument values from the parser.
     func parse(_ kind: ArgumentKind.Type, with parser: inout ArgumentParserProtocol) throws -> [ArgumentKind]
 }
 
@@ -481,10 +481,10 @@ final class AnyArgument: ArgumentProtocol, CustomStringConvertible {
     }
 }
 
+// FIXME: We probably don't need this protocol anymore and should convert this to a class.
+//
 /// Argument parser protocol passed in initializers of ArgumentKind to manipulate
 /// parser as needed by the argument.
-///
-// FIXME: We probably don't need this protocol anymore and should convert this to a class.
 public protocol ArgumentParserProtocol {
     /// The current argument being parsed.
     var currentArgument: String { get }

--- a/Sources/Utility/BuildFlags.swift
+++ b/Sources/Utility/BuildFlags.swift
@@ -8,10 +8,10 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-/// Build-tool independent flags.
-//
 // FIXME: This belongs somewhere else, but we don't have a layer specifically
 // for BuildSupport style logic yet.
+//
+/// Build-tool independent flags.
 public struct BuildFlags {
 
     /// Flags to pass to the C compiler.

--- a/Sources/Utility/PkgConfig.swift
+++ b/Sources/Utility/PkgConfig.swift
@@ -173,11 +173,11 @@ public struct PkgConfig {
     }
 }
 
+// FIXME: This is only internal so it can be unit tested.
+//
 /// Parser for the `pkg-config` `.pc` file format.
 ///
 /// See: https://www.freedesktop.org/wiki/Software/pkg-config/
-//
-// FIXME: This is only internal so it can be unit tested.
 struct PkgConfigParser {
     let pcFile: AbsolutePath
     private let fileSystem: FileSystem

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -19,6 +19,8 @@ import Utility
 /// The delegate interface used by the workspace to report status information.
 public protocol WorkspaceDelegate: class {
 
+    // FIXME: This is defunct.
+    //
     /// The workspace is about to load the complete package graph.
     ///
     /// This delegate will only be called if we actually need to fetch and resolve dependencies. 
@@ -27,7 +29,6 @@ public protocol WorkspaceDelegate: class {
     ///   - currentGraph: The current package graph. This is most likely a partial package graph.
     ///   - dependencies: The current managed dependencies in the workspace.
     ///   - missingURLs: The top-level missing packages we need to fetch. This will never be empty.
-    // FIXME: This is defunct.
     func packageGraphWillLoad(currentGraph: PackageGraph, dependencies: AnySequence<ManagedDependency>, missingURLs: Set<String>)
 
     /// The workspace has started fetching this repository.
@@ -1712,6 +1713,8 @@ extension Workspace {
         return path
     }
 
+    // FIXME: @testable internal
+    //
     /// Create a local clone of the given `repository` checked out to `version`.
     ///
     /// If an existing clone is present, the repository will be reset to the
@@ -1722,7 +1725,6 @@ extension Workspace {
     ///   - checkoutState: The state to check out.
     /// - Returns: The path of the local repository.
     /// - Throws: If the operation could not be satisfied.
-    // FIXME: @testable internal
     func clone(
         package: PackageReference,
         at checkoutState: CheckoutState

--- a/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
+++ b/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
@@ -371,6 +371,8 @@ protocol PropertyListDictionaryConvertible {
 }
 
 extension PropertyListDictionaryConvertible {
+    // FIXME: Internal only for unit testing.
+    //
     /// Returns a property list representation of the build settings, in which
     /// every struct field is represented as a dictionary entry.  Fields of
     /// type `String` are represented as `PropertyList.string` values; fields
@@ -382,7 +384,6 @@ extension PropertyListDictionaryConvertible {
     /// applies to classes.  Creating a property list representation is totally
     /// independent of that serialization infrastructure (though it might well
     /// be invoked during of serialization of actual model objects).
-    // FIXME: Internal only for unit testing.
     func asPropertyList() -> PropertyList {
         // Borderline hacky, but the main thing is that adding or changing a
         // build setting does not require any changes to the property list

--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -104,9 +104,10 @@ public func generate(
         extraDirs = []
     }
 
-    /// Generate the contents of project.xcodeproj (inside the .xcodeproj).
     // FIXME: This could be more efficient by directly writing to a stream
     // instead of first creating a string.
+    //
+    /// Generate the contents of project.xcodeproj (inside the .xcodeproj).
     let project = try pbxproj(xcodeprojPath: xcodeprojPath, graph: graph, extraDirs: extraDirs, extraFiles: extraFiles, options: options, diagnostics: diagnostics)
     try open(xcodeprojPath.appending(component: "project.pbxproj")) { stream in
         // Serialize the project model we created to a plist, and return

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -47,10 +47,11 @@ public func pbxproj(
         diagnostics: diagnostics)
 }
 
+// FIXME: Handle case insensitive filesystems.
+//
 /// A set of c99 target names that are invalid for Xcode Framework targets.
 /// They will conflict with the required Framework directory structure,
 /// and cause a linker error (SR-3398).
-// FIXME: Handle case insensitive filesystems.
 fileprivate let invalidXcodeModuleNames = Set(["Modules", "Headers", "Versions"])
 
 func xcodeProject(


### PR DESCRIPTION
I've only moved FIXMEs that were on a line with a normal comment (`//`) that were directly after a doc comment (`///`) which breaks documentation linking to the declaration they are for.