### PR TITLE
fixed usage of readdir_r() to match the man page

### DIFF
--- a/Sources/Basic/FileSystem.swift
+++ b/Sources/Basic/FileSystem.swift
@@ -296,10 +296,10 @@ private class LocalFileSystem: FileSystem {
 
         while true {
             var entryPtr: UnsafeMutablePointer<dirent>? = nil
-            if readdir_r(dir, &entry, &entryPtr) < 0 {
-                // FIXME: Are there ever situation where we would want to
-                // continue here?
-                throw FileSystemError(errno: errno)
+
+            let readdir_rErrno = readdir_r(dir, &entry, &entryPtr)
+            if  readdir_rErrno != 0 {
+                throw FileSystemError(errno: readdir_rErrno)
             }
 
             // If the entry pointer is null, we reached the end of the directory.


### PR DESCRIPTION
I removed the FIXME from the error handling case since none of the man page errors seem recoverable.

* According to the man pages on macOS and Linux `readdir_r()` can fail with several errno values when given invalid pointers.
* On macOS it can also fail by returning `EIO` for I/O failures.
* On linux it can also fail by returning `ENAMETOOLONG` because the directory name is too long for the OS.