### PR TITLE
[Workspace] Allow overriding path to runtime libraries

### DIFF
--- a/Documentation/Development.md
+++ b/Documentation/Development.md
@@ -178,3 +178,9 @@ want to use a debug compiler with SwiftPM.
 ```sh
 $ SWIFT_EXEC=/path/to/my/built/swiftc swift build
 ```
+
+## Overriding path to the runtime libraries
+
+SwiftPM computes the path of runtime libraries relative to where it is
+installed. This path can be overridden by setting the environment variable
+`SWIFTPM_PD_LIBS` to a directory containing the libraries.

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -212,9 +212,17 @@ public final class UserToolchain: Toolchain {
             "--sysroot", destination.sdk.asString
         ] + destination.extraCCFlags
 
+        // Compute the path of directory containing the PackageDescription libraries.
+        let pdLibDir: AbsolutePath 
+        if let pdLibDirEnvStr = getenv("SWIFTPM_PD_LIBS"), let pdLibDirEnv = try? AbsolutePath(validating: pdLibDirEnvStr) {
+            pdLibDir = pdLibDirEnv
+        } else {
+            pdLibDir = binDir.parentDirectory.appending(components: "lib", "swift", "pm")
+        }
+
         manifestResources = UserManifestResources(
             swiftCompiler: swiftCompilers.manifest,
-            libDir: binDir.parentDirectory.appending(components: "lib", "swift", "pm"),
+            libDir: pdLibDir,
             sdkRoot: self.destination.sdk
         )
     }


### PR DESCRIPTION
Exposes an env variable SWIFTPM_PD_LIBS to allow overriding path to the
runtime libraries.

<rdar://problem/45327949>