### PR TITLE
[Workspace] Remove graph data API

### DIFF
--- a/Sources/TestSupport/TestWorkspace.swift
+++ b/Sources/TestSupport/TestWorkspace.swift
@@ -271,20 +271,6 @@ public final class TestWorkspace {
         result(graph, diagnostics)
     }
 
-    public func checkGraphData(
-        roots: [String] = [],
-        deps: [TestWorkspace.PackageDependency],
-        _ result: (PackageGraph, [ResolvedPackage: ManagedDependency], DiagnosticsEngine) -> ()
-    ) {
-        let dependencies = deps.map({ $0.convert(packagesDir) })
-        let diagnostics = DiagnosticsEngine()
-        let workspace = createWorkspace()
-        let rootInput = PackageGraphRootInput(
-            packages: rootPaths(for: roots), dependencies: dependencies)
-        let graphData = workspace.loadGraphData(root: rootInput, diagnostics: diagnostics)
-        result(graphData.graph, graphData.dependencyMap, diagnostics)
-    }
-
     public enum State {
         public enum CheckoutState {
             case version(Utility.Version)

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -637,43 +637,6 @@ extension Workspace {
         _resolve(root: root, diagnostics: diagnostics)
     }
 
-	/// Load the package graph data.
-	///
-	/// This method returns the package graph, and the mapping between each
-	/// package and its corresponding managed dependency.
-	///
-	/// The current managed dependencies will be reported via the delegate
-	/// before and after loading the package graph.
-    public func loadGraphData(
-        root: PackageGraphRootInput,
-        createMultipleTestProducts: Bool = false,
-        diagnostics: DiagnosticsEngine
-    ) -> (graph: PackageGraph, dependencyMap: [ResolvedPackage: ManagedDependency]) {
-
-        // Load the package graph.
-        let graph = loadPackageGraph(
-            root: root,
-            createMultipleTestProducts: createMultipleTestProducts,
-            diagnostics: diagnostics)
-
-        // Report the updated managed dependencies.
-        delegate?.managedDependenciesDidUpdate(managedDependencies.values)
-
-        // Create the dependency map by associating each resolved package with its corresponding managed dependency.
-        let managedDependenciesByIdentity = Dictionary(items: managedDependencies.values.map({ ($0.packageRef.identity, $0) }))
-        let dependencyMap = graph.packages.compactMap({ package -> (ResolvedPackage, ManagedDependency)? in
-            // FIXME: We should use package name directly once this radar is fixed:
-            // <rdar://problem/33693433> Ensure that identity and package name
-            // are the same once we have an API to specify identity in the
-            // manifest file
-            let identity = PackageReference.computeIdentity(packageURL: package.manifest.url)
-            guard let dependency = managedDependenciesByIdentity[identity] else { return nil }
-            return (package, dependency)
-        })
-
-        return (graph, Dictionary(items: dependencyMap))
-    }
-
     /// Loads and returns manifests at the given paths.
     public func loadRootManifests(
         packages: [AbsolutePath],

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -657,66 +657,6 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
-    func testGraphData() throws {
-        let sandbox = AbsolutePath("/tmp/ws/")
-        let fs = InMemoryFileSystem()
-
-        let workspace = try TestWorkspace(
-            sandbox: sandbox,
-            fs: fs,
-            roots: [
-            ],
-            packages: [
-                TestPackage(
-                    name: "A",
-                    targets: [
-                        TestTarget(name: "A"),
-                    ],
-                    products: [],
-                    versions: ["1.0.0", "1.5.1"]
-                ),
-                TestPackage(
-                    name: "B",
-                    targets: [
-                        TestTarget(name: "B"),
-                    ],
-                    products: [],
-                    versions: ["1.0.0"]
-                ),
-            ]
-        )
-
-        let deps: [TestWorkspace.PackageDependency] = [
-            .init(name: "A", requirement: .exact("1.0.0")),
-            .init(name: "B", requirement: .exact("1.0.0")),
-        ]
-        workspace.checkGraphData(deps: deps) { (graph, dependencyMap, diagnostics) in
-            PackageGraphTester(graph) { result in
-                result.check(packages: "A", "B")
-                result.check(targets: "A", "B")
-            }
-
-            // Check package association.
-            XCTAssertEqual(dependencyMap[graph.lookup("A")]?.packageRef.identity, "a")
-            XCTAssertEqual(dependencyMap[graph.lookup("B")]?.packageRef.identity, "b")
-            XCTAssertNoDiagnostics(diagnostics)
-        }
-        // Check delegates.
-        let currentDeps = workspace.createWorkspace().managedDependencies.values.map{$0.packageRef}
-        XCTAssertEqual(workspace.delegate.managedDependenciesData[0].map{$0.packageRef}, currentDeps)
-
-        // Load graph data again.
-        workspace.checkGraphData(deps: deps) { (graph, dependencyMap, diagnostics) in
-            // Check package association.
-            XCTAssertEqual(dependencyMap[graph.lookup("A")]?.packageRef.identity, "a")
-            XCTAssertEqual(dependencyMap[graph.lookup("B")]?.packageRef.identity, "b")
-            XCTAssertNoDiagnostics(diagnostics)
-        }
-        // Check delegates.
-        XCTAssertEqual(workspace.delegate.managedDependenciesData[1].map{$0.packageRef}, currentDeps)
-        XCTAssertEqual(workspace.delegate.managedDependenciesData.count, 2)
-    }
-
     func testLoadingRootManifests() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()

--- a/Tests/WorkspaceTests/XCTestManifests.swift
+++ b/Tests/WorkspaceTests/XCTestManifests.swift
@@ -54,7 +54,6 @@ extension WorkspaceTests {
         ("testDependencySwitchWithSameIdentity", testDependencySwitchWithSameIdentity),
         ("testEditDependency", testEditDependency),
         ("testForceResolveToResolvedVersions", testForceResolveToResolvedVersions),
-        ("testGraphData", testGraphData),
         ("testGraphRootDependencies", testGraphRootDependencies),
         ("testInterpreterFlags", testInterpreterFlags),
         ("testIsResolutionRequired", testIsResolutionRequired),


### PR DESCRIPTION
This API is not really required and can be removed.

<rdar://problem/45384503> Remove loadGraphData API from Workspace