### PR TITLE
Prefer "#if os(Linux)" to "#if !os(macOS)

### DIFF
--- a/Sources/Commands/GenerateLinuxMain.swift
+++ b/Sources/Commands/GenerateLinuxMain.swift
@@ -57,7 +57,7 @@ final class LinuxMainGenerator {
             let testManifest = target.sources.root.appending(component: "XCTestManifests.swift")
             let stream = try LocalFileOutputByteStream(testManifest)
 
-            stream <<< "#if !os(macOS)" <<< "\n"
+            stream <<< "#if !canImport(ObjectiveC)" <<< "\n"
             stream <<< "import XCTest" <<< "\n"
             for klass in module.classes.lazy.sorted(by: { $0.name < $1.name }) {
                 stream <<< "\n"

--- a/Tests/BasicTests/XCTestManifests.swift
+++ b/Tests/BasicTests/XCTestManifests.swift
@@ -1,4 +1,4 @@
-#if !os(macOS)
+#if !canImport(ObjectiveC)
 import XCTest
 
 extension AwaitTests {

--- a/Tests/BuildTests/XCTestManifests.swift
+++ b/Tests/BuildTests/XCTestManifests.swift
@@ -1,4 +1,4 @@
-#if !os(macOS)
+#if !canImport(ObjectiveC)
 import XCTest
 
 extension BuildPlanTests {

--- a/Tests/CommandsTests/XCTestManifests.swift
+++ b/Tests/CommandsTests/XCTestManifests.swift
@@ -1,4 +1,4 @@
-#if !os(macOS)
+#if !canImport(ObjectiveC)
 import XCTest
 
 extension BuildToolTests {

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -412,7 +412,7 @@ class MiscellaneousTestCase: XCTestCase {
             // Check test manifest.
             let testManifest = prefix.appending(components: "Tests", "ParallelTestsPkgTests", "XCTestManifests.swift")
             XCTAssertEqual(try fs.readFileContents(testManifest), """
-                #if !os(macOS)
+                #if !canImport(ObjectiveC)
                 import XCTest
 
                 extension ParallelTestsFailureTests {

--- a/Tests/FunctionalTests/XCTestManifests.swift
+++ b/Tests/FunctionalTests/XCTestManifests.swift
@@ -1,4 +1,4 @@
-#if !os(macOS)
+#if !canImport(ObjectiveC)
 import XCTest
 
 extension CFamilyTargetTestCase {

--- a/Tests/POSIXTests/XCTestManifests.swift
+++ b/Tests/POSIXTests/XCTestManifests.swift
@@ -1,4 +1,4 @@
-#if !os(macOS)
+#if !canImport(ObjectiveC)
 import XCTest
 
 extension EnvTests {

--- a/Tests/PackageDescription4Tests/XCTestManifests.swift
+++ b/Tests/PackageDescription4Tests/XCTestManifests.swift
@@ -1,4 +1,4 @@
-#if !os(macOS)
+#if !canImport(ObjectiveC)
 import XCTest
 
 extension JSONTests {

--- a/Tests/PackageGraphTests/XCTestManifests.swift
+++ b/Tests/PackageGraphTests/XCTestManifests.swift
@@ -1,4 +1,4 @@
-#if !os(macOS)
+#if !canImport(ObjectiveC)
 import XCTest
 
 extension DependencyResolverTests {

--- a/Tests/PackageLoadingTests/XCTestManifests.swift
+++ b/Tests/PackageLoadingTests/XCTestManifests.swift
@@ -1,4 +1,4 @@
-#if !os(macOS)
+#if !canImport(ObjectiveC)
 import XCTest
 
 extension ModuleMapGeneration {

--- a/Tests/PackageModelTests/XCTestManifests.swift
+++ b/Tests/PackageModelTests/XCTestManifests.swift
@@ -1,4 +1,4 @@
-#if !os(macOS)
+#if !canImport(ObjectiveC)
 import XCTest
 
 extension PackageModelTests {

--- a/Tests/SourceControlTests/XCTestManifests.swift
+++ b/Tests/SourceControlTests/XCTestManifests.swift
@@ -1,4 +1,4 @@
-#if !os(macOS)
+#if !canImport(ObjectiveC)
 import XCTest
 
 extension GitRepositoryTests {

--- a/Tests/TestSupportTests/XCTestManifests.swift
+++ b/Tests/TestSupportTests/XCTestManifests.swift
@@ -1,4 +1,4 @@
-#if !os(macOS)
+#if !canImport(ObjectiveC)
 import XCTest
 
 extension TestSupportTests {

--- a/Tests/UtilityTests/XCTestManifests.swift
+++ b/Tests/UtilityTests/XCTestManifests.swift
@@ -1,4 +1,4 @@
-#if !os(macOS)
+#if !canImport(ObjectiveC)
 import XCTest
 
 extension ArgumentParserTests {

--- a/Tests/WorkspaceTests/XCTestManifests.swift
+++ b/Tests/WorkspaceTests/XCTestManifests.swift
@@ -1,4 +1,4 @@
-#if !os(macOS)
+#if !canImport(ObjectiveC)
 import XCTest
 
 extension InitTests {

--- a/Tests/XcodeprojTests/XCTestManifests.swift
+++ b/Tests/XcodeprojTests/XCTestManifests.swift
@@ -1,4 +1,4 @@
-#if !os(macOS)
+#if !canImport(ObjectiveC)
 import XCTest
 
 extension FunctionalTests {


### PR DESCRIPTION
Currently, projects that use `--generate-linuxmain` will generate a file that breaks iOS and other platforms.

There may be more things that need to be fixed here, but this is a start. I noticed that throughout this project things are cased on `os(macOS)` a _lot_. Perhaps an audit is a good idea?