### PR TITLE
[FIX] Issue where the presence of non-whitelisted flags would remove all other flags detected from .pc files

### DIFF
--- a/Tests/PackageLoadingTests/PkgConfigTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigTests.swift
@@ -82,8 +82,8 @@ class PkgConfigTests: XCTestCase {
         try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.asString]) {
             let result = pkgConfigArgs(for: SystemLibraryTarget(pkgConfig: "Bar"), diagnostics: diagnostics)!
             XCTAssertEqual(result.pkgConfigName, "Bar")
-            XCTAssertEqual(result.cFlags, [])
-            XCTAssertEqual(result.libs, [])
+            XCTAssertEqual(result.cFlags, ["-I/path/to/inc"])
+            XCTAssertEqual(result.libs, ["-L/usr/da/lib", "-lSystemModule", "-lok"])
             XCTAssertNil(result.provider)
             XCTAssertFalse(result.couldNotFindConfigFile)
             switch result.error {

--- a/Tests/PackageLoadingTests/WhitelistTests.swift
+++ b/Tests/PackageLoadingTests/WhitelistTests.swift
@@ -15,31 +15,21 @@ final class PkgConfigWhitelistTests: XCTestCase {
     func testSimpleFlags() {
         let cFlags = ["-I/usr/local/Cellar/gtk+3/3.18.9/include/gtk-3.0"]
         let libs = ["-L/usr/local/Cellar/gtk+3/3.18.9/lib", "-lgtk-3", "-w"]
-        do {
-            try whitelist(pcFile: "dummy", flags: (cFlags, libs))
-        } catch {
-            XCTFail("Unexpected failure \(error)")
-        }
+        XCTAssertTrue(whitelist(pcFile: "dummy", flags: (cFlags, libs)).unallowed.isEmpty)
     }
 
     func testFlagsWithInvalidFlags() {
         let cFlags = ["-I/usr/local/Cellar/gtk+3/3.18.9/include/gtk-3.0", "-L/hello"]
         let libs = ["-L/usr/local/Cellar/gtk+3/3.18.9/lib", "-lgtk-3", "-module-name", "name", "-werror"]
-        do {
-            try whitelist(pcFile: "dummy", flags: (cFlags, libs))
-        } catch {
-            XCTAssertEqual("\(error)", "non whitelisted flag(s): -L/hello, -module-name, name, -werror")
-        }
+        let unallowed = whitelist(pcFile: "dummy", flags: (cFlags, libs)).unallowed
+        XCTAssertEqual(unallowed, ["-L/hello", "-module-name", "name", "-werror"])
     }
 
     func testFlagsWithValueInNextFlag() {
         let cFlags = ["-I/usr/local", "-I", "/usr/local/Cellar/gtk+3/3.18.9/include/gtk-3.0", "-L/hello"]
         let libs = ["-L", "/usr/lib", "-L/usr/local/Cellar/gtk+3/3.18.9/lib", "-lgtk-3", "-module-name", "-lcool", "ok", "name"]
-        do {
-            try whitelist(pcFile: "dummy", flags: (cFlags, libs))
-        } catch {
-            XCTAssertEqual("\(error)", "non whitelisted flag(s): -L/hello, -module-name, ok, name")
-        }
+        let unallowed = whitelist(pcFile: "dummy", flags: (cFlags, libs)).unallowed
+        XCTAssertEqual(unallowed, ["-L/hello", "-module-name", "ok", "name"])
     }
 
     func testRemoveDefaultFlags() {


### PR DESCRIPTION
The presence of a non-whitelisted flag in a .pc file caused Swift PM to remove all other valid flags. This issue has been described in several bug reports:

- [SR-8822](https://bugs.swift.org/browse/SR-8822)
- [SR-2481](https://bugs.swift.org/browse/SR-2481)
- [SR-4195](https://bugs.swift.org/browse/SR-4195)
- [SR-7689](https://bugs.swift.org/browse/SR-7689)

This fixes the issue by doing some more advanced filtering of invalid flags where the valid flags aren't thrown away anymore (and invalid flags still emit a diagnostic).