### PR TITLE
[Commands] Add support for SWIFTPM_MIRROR_CONFIG override

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -423,6 +423,12 @@ public class SwiftTool<Options: ToolOptions> {
     }
 
     func configFilePath() throws -> AbsolutePath {
+        // Look for the override in the environment.
+        if let envPath = Process.env["SWIFTPM_MIRROR_CONFIG"] {
+            return try AbsolutePath(validating: envPath)
+        }
+
+        // Otherwise, use the default path.
         return try getPackageRoot().appending(components: ".swiftpm", "config")
     }
 


### PR DESCRIPTION
<rdar://problem/45418410> SWIFTPM_MIRROR_CONFIG environment variable does not seem to be working as expected