### PR TITLE
[Basic] Add ArraySlice<UInt8> specialization for OutputStreams

### DIFF
--- a/Tests/BasicTests/OutputByteStreamTests.swift
+++ b/Tests/BasicTests/OutputByteStreamTests.swift
@@ -171,6 +171,22 @@ class OutputByteStreamTests: XCTestCase {
         XCTAssertEqual(read(), "Hello World")
     }
 
+    func testLocalFileStreamArraySliceUnbuffered() throws {
+        let tempFile = try TemporaryFile()
+
+        let bytes1k = [UInt8](repeating: 0, count: 1 << 10)
+
+        func read() -> ByteString? {
+            return try! localFileSystem.readFileContents(tempFile.path)
+        }
+
+        let stream = try LocalFileOutputByteStream(tempFile.path, buffered: false)
+        stream.write(bytes1k)
+        stream.flush()
+        XCTAssertEqual(read()!.contents, bytes1k)
+        try stream.close()
+    }
+
     func testThreadSafeStream() {
         var threads = [Thread]()
 


### PR DESCRIPTION
LocalFileOutputStream copies collections into [UInt8] before calling
fwrite in writeImpl. This overhead can be avoided when an ArraySlice is
available. Further, the write() method is always buffered, which
potentially incurs another copy overhead. This change adds an
ArraySlice<UInt8> specialization for OutputStreams and adds an
'unbuffered' option for the accompanying write() method. The combination
of these two changes yielded a 10x performance improvement in a tool
utilizing these from Basic.

rdar://problem/45592874