### PR TITLE
[Utility] Use ssh's batch mode option when cloning repos

### DIFF
--- a/Sources/Utility/Git.swift
+++ b/Sources/Utility/Git.swift
@@ -72,9 +72,15 @@ public class Git {
     /// git from swift build.
     public static var environment: [String: String] {
         var env = ProcessInfo.processInfo.environment
+
         // Disable terminal prompts in git. This will make git error out and return
         // when it needs a user/pass etc instead of hanging the terminal (SR-3981).
         env["GIT_TERMINAL_PROMPT"] = "0"
+
+        // The above is env variable is not enough. However, ssh_config's batch
+        // mode is made for this purpose. see: https://linux.die.net/man/5/ssh_config
+        env["GIT_SSH_COMMAND"] = "ssh -oBatchMode=yes"
+
         return env
     }
 }


### PR DESCRIPTION
SwiftPM currently hangs if git is expecting an input on stdin. This
isn't great as that can happen if the ssh key is password protected or
if the host fingerprint isn't known. We should ideally ask user for
input but shouldn't at least hang in the meantime.

<rdar://problem/30661854> [SR-3981]: Swift package manager doesn't prompt for SSH keys passphrase