### PR TITLE
Allow overriding path to Homebrew

### DIFF
--- a/Tests/PackageLoadingTests/PkgConfigTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigTests.swift
@@ -98,7 +98,7 @@ class PkgConfigTests: XCTestCase {
     func testDependencies() throws {
         // Use additionalSearchPaths instead of pkgConfigArgs to test handling
         // of search paths when loading dependencies.
-        let result = try PkgConfig(name: "Dependent", additionalSearchPaths: [inputsDir], diagnostics: diagnostics)
+        let result = try PkgConfig(name: "Dependent", additionalSearchPaths: [inputsDir], diagnostics: diagnostics, brewPrefix: nil)
 
         XCTAssertEqual(result.name, "Dependent")
         XCTAssertEqual(result.cFlags, ["-I/path/to/dependent/include", "-I/path/to/dependency/include"])

--- a/Tests/UtilityTests/XCTestManifests.swift
+++ b/Tests/UtilityTests/XCTestManifests.swift
@@ -46,6 +46,7 @@ extension PkgConfigParserTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__PkgConfigParserTests = [
+        ("testBrewPrefix", testBrewPrefix),
         ("testCustomPcFileSearchPath", testCustomPcFileSearchPath),
         ("testEmptyCFlags", testEmptyCFlags),
         ("testEscapedSpaces", testEscapedSpaces),


### PR DESCRIPTION
To be able to test this, I had to funnel through the file system to `Process` and implement support for  `chmod` to the file system.

See <rdar://problem/45825273>