### PR TITLE
Adds the README to the project if it exists in the root of the project

### DIFF
--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -104,6 +104,12 @@ public func generate(
         extraDirs = []
     }
 
+    // If there is a project root README, include that in the root of the Xcodeproj
+    let readmePath = xcodeprojPath.parentDirectory.appending(component: "README.md")
+    if localFileSystem.exists(readmePath, followSymlink: false) {
+        extraFiles.append(readmePath)
+    }
+
     // FIXME: This could be more efficient by directly writing to a stream
     // instead of first creating a string.
     //


### PR DESCRIPTION
This is a little bit of guess-work because I couldn't get the full toolchain set up (laziness, not that it's broken I think ) but I think it's worth always adding the root readme to the generated Xcode project. 👍 