### PR TITLE
[Workspace] Add --disable-automatic-resolution flag

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -352,8 +352,12 @@ public class SwiftTool<Options: ToolOptions> {
             to: { $0.shouldEnableLLBuildLibrary = $1 })
 
         binder.bind(
-            option: parser.add(option: "--force-resolved-versions", kind: Bool.self,
-                usage: "Force resolve to versions recorded in the Package.resolved file"),
+            option: parser.add(option: "--force-resolved-versions", kind: Bool.self),
+            to: { $0.forceResolvedVersions = $1 })
+
+        binder.bind(
+            option: parser.add(option: "--disable-automatic-resolution", kind: Bool.self,
+               usage: "Disable automatic resolution if Package.resolved file is out-of-date"),
             to: { $0.forceResolvedVersions = $1 })
 
         binder.bind(

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -407,4 +407,15 @@ public enum WorkspaceDiagnostics {
             }
         )
     }
+
+    public struct RequiresResolution: DiagnosticData {
+        public static let id = DiagnosticID(
+            type: RequiresResolution.self,
+            name: "org.swift.diags.workspace.\(RequiresResolution.self)",
+            defaultBehavior: .error,
+            description: {
+                $0 <<< "cannot update Package.resolved file because automatic resolution is disabled"
+            }
+        )
+    }
 }


### PR DESCRIPTION
This flag is similar to the previous --force-resolved-versions except
that now we error out if see that the Package.resolved file is out-of-date.

<rdar://problem/45822895>