### PR TITLE
[PackageLoading] Invalidate manifest cache when env changes

### DIFF
--- a/Tests/PackageLoadingTests/XCTestManifests.swift
+++ b/Tests/PackageLoadingTests/XCTestManifests.swift
@@ -81,6 +81,7 @@ extension PackageDescription4_2LoadingTests {
     // to regenerate.
     static let __allTests__PackageDescription4_2LoadingTests = [
         ("testBasics", testBasics),
+        ("testCacheInvalidationOnEnv", testCacheInvalidationOnEnv),
         ("testCaching", testCaching),
         ("testDuplicateDependencyDecl", testDuplicateDependencyDecl),
         ("testPackageDependencies", testPackageDependencies),


### PR DESCRIPTION
Many packages use env variables to perform conditionals in the manifest
file. This basically means that we need to invalidate the manifest cache
if the env changes. Ideally, SwiftPM should provide an API in
PackageDescription that will allow us to keep track of the exact
variables used by the manifest but this should be good enough for now.

<rdar://problem/45931785> SwiftPM should invalidate manifest cache when the process env changes