### PR TITLE
[SourceControl] Make RepositoryManager resilient against removal of s…

### DIFF
--- a/Sources/Utility/SimplePersistence.swift
+++ b/Sources/Utility/SimplePersistence.swift
@@ -49,7 +49,7 @@ public final class SimplePersistence {
     }
 
     /// The fileSystem to operate on.
-    private var fileSystem: FileSystem
+    private let fileSystem: FileSystem
 
     /// The schema of the state file.
     private let schemaVersion: Int
@@ -148,5 +148,10 @@ public final class SimplePersistence {
         // FIXME: This should write atomically.
         try fileSystem.writeFileContents(
             statePath, bytes: JSON(json).toBytes(prettyPrint: self.prettyPrint))
+    }
+
+    /// Returns true if the state file exists on the filesystem.
+    public func stateFileExists() -> Bool {
+        return fileSystem.exists(statePath)
     }
 }

--- a/Tests/SourceControlTests/XCTestManifests.swift
+++ b/Tests/SourceControlTests/XCTestManifests.swift
@@ -46,6 +46,7 @@ extension RepositoryManagerTests {
         ("testPersistence", testPersistence),
         ("testReset", testReset),
         ("testSkipUpdate", testSkipUpdate),
+        ("testStateFileResilience", testStateFileResilience),
     ]
 }
 


### PR DESCRIPTION
…tate file

This makes the RepositoryManager somewhat resilient against having the
state file removed while the object is still alive. While getting the
handle, we check if the state file is still present.

<rdar://problem/45731250>