### PR TITLE
[Workspace] Make managed dependencies state file resilient

### DIFF
--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -276,6 +276,11 @@ public final class ManagedDependencies: SimplePersistanceProtocol {
         try self.persistence.saveState(self)
     }
 
+     /// Returns true if the state file exists on the filesystem.
+     public func stateFileExists() -> Bool {
+         return persistence.stateFileExists()
+     }
+
     public var values: AnySequence<ManagedDependency> {
         return AnySequence<ManagedDependency>(dependencyMap.values)
     }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1589,6 +1589,12 @@ extension Workspace {
     /// If some edited dependency is removed from the file system, mark it as unedited and
     /// fallback on the original checkout.
     fileprivate func fixManagedDependencies(with diagnostics: DiagnosticsEngine) {
+
+        // Reset managed dependencies if the state file was removed during the lifetime of the Workspace object.
+        if managedDependencies.values.contains(where: { _ in true }) && !managedDependencies.stateFileExists() {
+            try? managedDependencies.reset()
+        }
+
         for dependency in managedDependencies.values {
             diagnostics.wrap {
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -97,6 +97,14 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "quix", at: .checkout(.version("1.2.0")))
         }
 
+        let stateFile = workspace.createWorkspace().managedDependencies.statePath
+
+        // Remove state file and check we can get the state back automatically.
+        try fs.removeFileTree(stateFile)
+
+        workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { _, _ in }
+        XCTAssertTrue(fs.exists(stateFile))
+
         // Remove state file and check we get back to a clean state.
         try fs.removeFileTree(workspace.createWorkspace().managedDependencies.statePath)
         workspace.closeWorkspace()


### PR DESCRIPTION
<rdar://problem/45786628> ManagedDepenency needs to be resilient against having the the state file removed underneath it