### PR TITLE
[Basic] Fix isExecutableFile on directories

### DIFF
--- a/Sources/Basic/FileSystem.swift
+++ b/Sources/Basic/FileSystem.swift
@@ -244,7 +244,7 @@ private class LocalFileSystem: FileSystem {
         guard let filestat = try? POSIX.stat(path.asString) else {
             return false
         }
-        return filestat.st_mode & SPMLibc.S_IXUSR != 0
+        return filestat.st_mode & SPMLibc.S_IXUSR != 0 && filestat.st_mode & S_IFREG != 0
     }
 
     func exists(_ path: AbsolutePath, followSymlink: Bool) -> Bool {

--- a/Tests/BasicTests/FileSystemTests.swift
+++ b/Tests/BasicTests/FileSystemTests.swift
@@ -61,6 +61,7 @@ class FileSystemTests: XCTestCase {
         XCTAssertFalse(fs.isExecutableFile(sym))
         XCTAssertFalse(fs.isExecutableFile(file.path))
         XCTAssertFalse(fs.isExecutableFile(AbsolutePath("/does-not-exist")))
+        XCTAssertFalse(fs.isExecutableFile(AbsolutePath("/")))
 
         // isDirectory()
         XCTAssert(fs.isDirectory(AbsolutePath("/")))


### PR DESCRIPTION
It is not sufficient to look for the 'x' bit to check for an executable
file, since directories typically have 'x' set as well.