### PR TITLE
Add API for platforms in PackageDescription

### DIFF
--- a/Sources/Basic/JSONMapper.swift
+++ b/Sources/Basic/JSONMapper.swift
@@ -103,6 +103,13 @@ extension JSON {
     public func getArray(_ key: String) throws -> [JSON] {
         return try get(key)
     }
+
+    public func getArray() throws -> [JSON] {
+        guard case .array(let array) = self else {
+            throw MapError.typeMismatch(key: "<self>", expected: Array<JSON>.self, json: self)
+        }
+        return array
+    }
 }
 
 // MARK: - Conformance for basic JSON types.

--- a/Sources/PackageDescription4/ManifestVersion.swift
+++ b/Sources/PackageDescription4/ManifestVersion.swift
@@ -26,7 +26,7 @@ enum ManifestVersion: String, Codable, CaseIterable {
 /// This is for mimicking something like the availability attribute for
 /// PackageDescription APIs.
 /// VersionedValue should never be public type.
-struct VersionedValue<T: Codable>: Codable {
+struct VersionedValue<T: Encodable>: Encodable {
     let supportedVersions: [ManifestVersion]
     let value: T
     let api: String

--- a/Sources/PackageDescription4/Package.swift
+++ b/Sources/PackageDescription4/Package.swift
@@ -63,6 +63,11 @@ public final class Package {
     /// The name of the package.
     public var name: String
 
+  #if !PACKAGE_DESCRIPTION_4
+    /// The list of platforms supported by this package.
+    public var _platforms: [SupportedPlatform]?
+  #endif
+
     /// pkgconfig name to use for C Modules. If present, swiftpm will try to
     /// search for <name>.pc file to get the additional flags needed for the
     /// system target.
@@ -122,6 +127,7 @@ public final class Package {
     /// Construct a package.
     public init(
         name: String,
+        _platforms: [SupportedPlatform]? = nil,
         pkgConfig: String? = nil,
         providers: [SystemPackageProvider]? = nil,
         products: [Product] = [],
@@ -132,6 +138,7 @@ public final class Package {
         cxxLanguageStandard: CXXLanguageStandard? = nil
     ) {
         self.name = name
+        self._platforms = _platforms
         self.pkgConfig = pkgConfig
         self.providers = providers
         self.products = products
@@ -196,6 +203,7 @@ public enum SystemPackageProvider {
 extension Package: Encodable {
     private enum CodingKeys: CodingKey {
         case name
+        case platforms
         case pkgConfig
         case providers
         case products
@@ -209,6 +217,15 @@ extension Package: Encodable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(name, forKey: .name)
+
+      #if !PACKAGE_DESCRIPTION_4
+        if let platforms = self._platforms {
+            // The platforms API was introduced in manifest version 5.
+            let versionedPlatforms = VersionedValue(platforms, api: "platforms", versions: [.v5])
+            try container.encode(versionedPlatforms, forKey: .platforms)
+        }
+      #endif
+
         try container.encode(pkgConfig, forKey: .pkgConfig)
         try container.encode(providers, forKey: .providers)
         try container.encode(products, forKey: .products)

--- a/Sources/PackageDescription4/SupportedPlatforms.swift
+++ b/Sources/PackageDescription4/SupportedPlatforms.swift
@@ -1,0 +1,197 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2018 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// Represents a platform supported by the package.
+public struct SupportedPlatform: Encodable {
+
+    /// The platform name.
+    let platform: String
+
+    /// The platform version.
+    let version: VersionedValue<String>?
+
+    /// Creates supported platform instance.
+    init(platform: String, version: VersionedValue<String>? = nil) {
+        self.platform = platform
+        self.version = version
+    }
+
+    /// The macOS platform.
+    public static func macOS(_ version: SupportedPlatform.MacOSVersion) -> SupportedPlatform {
+        return SupportedPlatform(platform: "macos", version: version.version)
+    }
+
+    /// The iOS platform.
+    public static func iOS(_ version: SupportedPlatform.IOSVersion) -> SupportedPlatform {
+        return SupportedPlatform(platform: "ios", version: version.version)
+    }
+
+    /// The tvOS platform.
+    public static func tvOS(_ version: SupportedPlatform.TVOSVersion) -> SupportedPlatform {
+        return SupportedPlatform(platform: "tvos", version: version.version)
+    }
+
+    /// The watchOS platform.
+    public static func watchOS(_ version: SupportedPlatform.WatchOSVersion) -> SupportedPlatform {
+        return SupportedPlatform(platform: "watchos", version: version.version)
+    }
+
+    /// The Linux platform.
+    public static func linux() -> SupportedPlatform {
+        return SupportedPlatform(platform: "linux")
+    }
+
+    /// Represents all platforms that are unspecified.
+    public static var all: SupportedPlatform {
+        return SupportedPlatform(platform: "<all>")
+    }
+}
+
+extension SupportedPlatform {
+    /// The macOS version.
+    public struct MacOSVersion: Encodable {
+
+        /// The underlying version representation.
+        let version: VersionedValue<String>
+
+        private init(_ version: String, supportedVersions: [ManifestVersion]) {
+            let api = "v" + version.split(separator: ".").joined(separator: "_")
+            self.init(VersionedValue(version, api: api, versions: supportedVersions))
+        }
+
+        private init(_ version: VersionedValue<String>) {
+            self.version = version
+        }
+
+        /// Create a macOS version from the given string.
+        ///
+        /// The version string must be in format: 10.XX.XX
+        public static func version(_ string: String) -> MacOSVersion {
+            // Perform a quick validation.
+            let components = string.split(separator: ".", omittingEmptySubsequences: false).map({ Int($0) })
+            var error = components.compactMap({ $0 }).count != components.count
+            error = error || !(components.first == 10 && (components.count == 2 || components.count == 3))
+            if error {
+                errors.append("invalid macOS version string: \(string)")
+            }
+
+            return self.init(VersionedValue(string, api: ""))
+        }
+
+        public static let v10_10: MacOSVersion = .init("10.10", supportedVersions: [.v5])
+        public static let v10_11: MacOSVersion = .init("10.11", supportedVersions: [.v5])
+        public static let v10_12: MacOSVersion = .init("10.12", supportedVersions: [.v5])
+        public static let v10_13: MacOSVersion = .init("10.13", supportedVersions: [.v5])
+        public static let v10_14: MacOSVersion = .init("10.14", supportedVersions: [.v5])
+    }
+
+    public struct TVOSVersion: Encodable {
+        /// The underlying version representation.
+        let version: VersionedValue<String>
+
+        private init(_ version: String, supportedVersions: [ManifestVersion]) {
+            let api = "v" + version
+            self.init(VersionedValue(version, api: api, versions: supportedVersions))
+        }
+
+        private init(_ version: VersionedValue<String>) {
+            self.version = version
+        }
+
+        /// Create a tvOS version from the given string.
+        ///
+        /// The version string must be in format: XX.XX
+        public static func version(_ string: String) -> TVOSVersion {
+            // Perform a quick validation.
+            let components = string.split(separator: ".", omittingEmptySubsequences: false).map({ Int($0) })
+            var error = components.compactMap({ $0 }).count != components.count
+            error = error || (components.count != 2)
+            if error {
+                errors.append("invalid tvOS version string: \(string)")
+            }
+
+            return self.init(VersionedValue(string, api: ""))
+        }
+
+        public static let v9: TVOSVersion = .init("9.0", supportedVersions: [.v5])
+        public static let v10: TVOSVersion = .init("10.0", supportedVersions: [.v5])
+        public static let v11: TVOSVersion = .init("11.0", supportedVersions: [.v5])
+        public static let v12: TVOSVersion = .init("12.0", supportedVersions: [.v5])
+    }
+
+    public struct IOSVersion: Encodable {
+        /// The underlying version representation.
+        let version: VersionedValue<String>
+
+        private init(_ version: String, supportedVersions: [ManifestVersion]) {
+            let api = "v" + version
+            self.init(VersionedValue(version, api: api, versions: supportedVersions))
+        }
+
+        private init(_ version: VersionedValue<String>) {
+            self.version = version
+        }
+
+        /// Create an iOS version from the given string.
+        ///
+        /// The version string must be in format: XX.XX
+        public static func version(_ string: String) -> IOSVersion {
+            // Perform a quick validation.
+            let components = string.split(separator: ".", omittingEmptySubsequences: false).map({ Int($0) })
+            var error = components.compactMap({ $0 }).count != components.count
+            error = error || (components.count != 2)
+            if error {
+                errors.append("invalid iOS version string: \(string)")
+            }
+
+            return self.init(VersionedValue(string, api: ""))
+        }
+
+        public static let v8: IOSVersion = .init("8.0", supportedVersions: [.v5])
+        public static let v9: IOSVersion = .init("9.0", supportedVersions: [.v5])
+        public static let v10: IOSVersion = .init("10.0", supportedVersions: [.v5])
+        public static let v11: IOSVersion = .init("11.0", supportedVersions: [.v5])
+        public static let v12: IOSVersion = .init("12.0", supportedVersions: [.v5])
+    }
+
+    public struct WatchOSVersion: Encodable {
+        /// The underlying version representation.
+        let version: VersionedValue<String>
+
+        private init(_ version: String, supportedVersions: [ManifestVersion]) {
+            let api = "v" + version
+            self.init(VersionedValue(version, api: api, versions: supportedVersions))
+        }
+
+        private init(_ version: VersionedValue<String>) {
+            self.version = version
+        }
+
+        /// Create a watchOS version from the given string.
+        ///
+        /// The version string must be in format: XX.XX
+        public static func version(_ string: String) -> WatchOSVersion {
+            // Perform a quick validation.
+            let components = string.split(separator: ".", omittingEmptySubsequences: false).map({ Int($0) })
+            var error = components.compactMap({ $0 }).count != components.count
+            error = error || (components.count != 2)
+            if error {
+                errors.append("invalid watchOS version string: \(string)")
+            }
+
+            return self.init(VersionedValue(string, api: ""))
+        }
+
+        public static let v2: WatchOSVersion = .init("2.0", supportedVersions: [.v5])
+        public static let v3: WatchOSVersion = .init("3.0", supportedVersions: [.v5])
+        public static let v4: WatchOSVersion = .init("4.0", supportedVersions: [.v5])
+        public static let v5: WatchOSVersion = .init("5.0", supportedVersions: [.v5])
+    }
+}

--- a/Sources/PackageLoading/ManifestBuilder.swift
+++ b/Sources/PackageLoading/ManifestBuilder.swift
@@ -12,6 +12,7 @@ import PackageModel
 
 struct ManifestBuilder {
     var name: String!
+    var platforms: [PlatformDescription] = []
     var targets: [TargetDescription] = []
     var pkgConfig: String?
     var swiftLanguageVersions: [SwiftLanguageVersion]?

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -242,6 +242,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
         let manifest = Manifest(
             name: manifestBuilder.name,
+            platforms: manifestBuilder.platforms,
             path: inputPath,
             url: baseURL,
             version: version,

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -101,6 +101,9 @@ public final class Manifest: ObjectIdentifierProtocol, CustomStringConvertible, 
     /// The name of the package.
     public let name: String
 
+    /// The declared platforms in the manifest.
+    public let platforms: [PlatformDescription]
+
     /// The declared package dependencies.
     public let dependencies: [PackageDependencyDescription]
 
@@ -127,6 +130,7 @@ public final class Manifest: ObjectIdentifierProtocol, CustomStringConvertible, 
 
     public init(
         name: String,
+        platforms: [PlatformDescription] = [],
         path: AbsolutePath,
         url: String,
         version: Utility.Version? = nil,
@@ -141,6 +145,7 @@ public final class Manifest: ObjectIdentifierProtocol, CustomStringConvertible, 
         targets: [TargetDescription] = []
     ) {
         self.name = name
+        self.platforms = platforms
         self.path = path
         self.url = url
         self.version = version
@@ -354,4 +359,18 @@ public struct PackageDependencyDescription: Equatable, Codable {
         self.url = url
         self.requirement = requirement
     }
+}
+
+public struct PlatformDescription: Codable, Equatable {
+    public let platformName: String
+    public let version: String?
+
+    public init(name: String, version: String? = nil) {
+        self.platformName = name
+        self.version = version
+    }
+
+    /// This is a special platform that represents that a package implictly
+    /// supports all platforms.
+    public static var all: PlatformDescription = PlatformDescription(name: "<all>")
 }

--- a/Tests/PackageLoadingTests/XCTestManifests.swift
+++ b/Tests/PackageLoadingTests/XCTestManifests.swift
@@ -85,6 +85,7 @@ extension PackageDescription4_2LoadingTests {
         ("testCaching", testCaching),
         ("testDuplicateDependencyDecl", testDuplicateDependencyDecl),
         ("testPackageDependencies", testPackageDependencies),
+        ("testPlatforms", testPlatforms),
         ("testRuntimeManifestErrors", testRuntimeManifestErrors),
         ("testSwiftLanguageVersions", testSwiftLanguageVersions),
         ("testSystemLibraryTargets", testSystemLibraryTargets),
@@ -98,6 +99,7 @@ extension PackageDescription5LoadingTests {
     // to regenerate.
     static let __allTests__PackageDescription5LoadingTests = [
         ("testBasics", testBasics),
+        ("testPlatforms", testPlatforms),
         ("testSwiftLanguageVersion", testSwiftLanguageVersion),
     ]
 }


### PR DESCRIPTION
This adds API for declaring platforms in the PackageDescription module.
The API is currently underscored because proposal is going through Swift
evolution.