### PR TITLE
[PackageModel] Load platform information into the package model

### DIFF
--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -130,7 +130,7 @@ public final class Manifest: ObjectIdentifierProtocol, CustomStringConvertible, 
 
     public init(
         name: String,
-        platforms: [PlatformDescription] = [],
+        platforms: [PlatformDescription],
         path: AbsolutePath,
         url: String,
         version: Utility.Version? = nil,

--- a/Sources/PackageModel/Platform.swift
+++ b/Sources/PackageModel/Platform.swift
@@ -1,0 +1,120 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2018 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// A registry for available platforms.
+public final class PlatformRegistry {
+
+    /// The current registery is hardcoded and static so we can just use
+    /// a singleton for now.
+    public static let `default`: PlatformRegistry = .init()
+
+    /// The list of known platforms.
+    public let knownPlatforms: [Platform]
+
+    /// The mapping of platforms to their name. 
+    public let platformByName: [String: Platform]
+
+    /// Create a registry with the given list of platforms.
+    init(platforms: [Platform] = PlatformRegistry._knownPlatforms) {
+        self.knownPlatforms = platforms
+        self.platformByName = Dictionary(uniqueKeysWithValues: knownPlatforms.map({ ($0.name, $0) }))
+    }
+
+    /// The static list of known platforms.
+    private static var _knownPlatforms: [Platform] {
+        return [.macOS, .iOS, .tvOS, .watchOS, .linux]
+    }
+}
+
+/// Represents a platform.
+public struct Platform: Equatable, Hashable {
+    /// The name of the platform.
+    public let name: String
+
+    /// The oldest supported deployment version by this platform.
+    ///
+    /// We currently hardcode this value but we should load it from the
+    /// SDK's plist file. This value is always present for Apple platforms.
+    public let oldestSupportedVersion: PlatformVersion?
+
+    /// Create a platform.
+    private init(name: String, oldestSupportedVersion: PlatformVersion? = nil) {
+        self.name = name
+        self.oldestSupportedVersion = oldestSupportedVersion
+    }
+    
+    public static let macOS: Platform = Platform(name: "macos", oldestSupportedVersion: "10.10")
+    public static let iOS: Platform = Platform(name: "ios", oldestSupportedVersion: "8.0")
+    public static let tvOS: Platform = Platform(name: "tvos", oldestSupportedVersion: "9.0")
+    public static let watchOS: Platform = Platform(name: "watchos", oldestSupportedVersion: "2.0")
+    public static let linux: Platform = Platform(name: "linux")
+}
+
+/// Represents a platform version.
+public struct PlatformVersion: ExpressibleByStringLiteral, Comparable, Hashable {
+
+    /// The underlying version storage.
+    private let version: Version
+
+    /// The string representation of the version.
+    public var versionString: String {
+        var str = "\(version.major).\(version.minor)"
+        if version.patch != 0 {
+            str += ".\(version.patch)"
+        }
+        return str
+    }
+
+    /// Create a platform version given a string.
+    ///
+    /// The platform version is expected to be in format: X.X.X
+    public init(_ version: String) {
+        let components = version.split(separator: ".").compactMap({ Int($0) })
+        assert(!components.isEmpty && components.count <= 3, version)
+        switch components.count {
+        case 1:
+            self.version = Version(components[0], 0, 0)
+        case 2:
+            self.version = Version(components[0], components[1], 0)
+        case 3:
+            self.version = Version(components[0], components[1], components[3])
+        default:
+            fatalError("Unexpected number of components \(components)")
+        }
+    }
+
+    // MARK:- ExpressibleByStringLiteral
+
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
+
+    // MARK:- Comparable
+
+    public static func < (lhs: PlatformVersion, rhs: PlatformVersion) -> Bool {
+        return lhs.version < rhs.version
+    }
+}
+
+/// Represents a platform supported by a target.
+public struct SupportedPlatform {
+    /// The platform.
+    public let platform: Platform
+
+    /// The minimum required version for this platform.
+    ///
+    /// This value is always present for Apple platforms.
+    public let version: PlatformVersion?
+
+    public init(platform: Platform, version: PlatformVersion? = nil) {
+        self.platform = platform
+        self.version = version
+    }
+}

--- a/Sources/TestSupport/DiagnosticsEngine.swift
+++ b/Sources/TestSupport/DiagnosticsEngine.swift
@@ -45,11 +45,12 @@ public enum StringCheck: ExpressibleByStringLiteral {
 
 public func DiagnosticsEngineTester(
     _ engine: DiagnosticsEngine,
+    ignoreNotes: Bool = false,
     file: StaticString = #file,
     line: UInt = #line,
     result: (DiagnosticsEngineResult) throws -> Void
 ) {
-    let engineResult = DiagnosticsEngineResult(engine)
+    let engineResult = DiagnosticsEngineResult(engine, ignoreNotes: ignoreNotes)
 
     do {
         try result(engineResult)
@@ -67,8 +68,12 @@ final public class DiagnosticsEngineResult {
 
     fileprivate var uncheckedDiagnostics: [Diagnostic]
 
-    init(_ engine: DiagnosticsEngine) {
-        self.uncheckedDiagnostics = engine.diagnostics
+    init(_ engine: DiagnosticsEngine, ignoreNotes: Bool = false) {
+        if ignoreNotes {
+            self.uncheckedDiagnostics = engine.diagnostics.filter({ $0.behavior != .note })
+        } else {
+            self.uncheckedDiagnostics = engine.diagnostics
+        }
     }
 
     public func check(

--- a/Sources/TestSupport/Manifest.swift
+++ b/Sources/TestSupport/Manifest.swift
@@ -30,10 +30,45 @@ extension Manifest {
     ) -> Manifest {
         return Manifest(
             name: name,
+            platforms: [.all],
             path: AbsolutePath(path).appending(component: Manifest.filename),
             url: url,
             version: version,
             manifestVersion: manifestVersion,
+            pkgConfig: pkgConfig,
+            providers: providers,
+            cLanguageStandard: cLanguageStandard,
+            cxxLanguageStandard: cxxLanguageStandard,
+            swiftLanguageVersions: swiftLanguageVersions,
+            dependencies: dependencies,
+            products: products,
+            targets: targets
+        )
+    }
+
+    public static func createManifest(
+        name: String,
+        platforms: [PlatformDescription] = [.all],
+        path: String = "/",
+        url: String = "/",
+        version: Utility.Version? = nil,
+        v: ManifestVersion,
+        pkgConfig: String? = nil,
+        providers: [SystemPackageProviderDescription]? = nil,
+        cLanguageStandard: String? = nil,
+        cxxLanguageStandard: String? = nil,
+        swiftLanguageVersions: [SwiftLanguageVersion]? = nil,
+        dependencies: [PackageDependencyDescription] = [],
+        products: [ProductDescription] = [],
+        targets: [TargetDescription] = []
+    ) -> Manifest {
+        return Manifest(
+            name: name,
+            platforms: platforms,
+            path: AbsolutePath(path).appending(component: Manifest.filename),
+            url: url,
+            version: version,
+            manifestVersion: v,
             pkgConfig: pkgConfig,
             providers: providers,
             cLanguageStandard: cLanguageStandard,

--- a/Sources/TestSupport/MockDependencyGraph.swift
+++ b/Sources/TestSupport/MockDependencyGraph.swift
@@ -141,6 +141,7 @@ public struct MockManifestGraph {
         // Create the root manifest.
         rootManifest = Manifest(
             name: "Root",
+            platforms: [.all],
             path: path.appending(component: Manifest.filename),
             url: path.asString,
             version: nil,
@@ -153,6 +154,7 @@ public struct MockManifestGraph {
             let url = repos[package.name]!.url
             let manifest = Manifest(
                 name: package.name,
+                platforms: [.all],
                 path: AbsolutePath(url).appending(component: Manifest.filename),
                 url: url,
                 version: package.version,

--- a/Sources/TestSupport/TestWorkspace.swift
+++ b/Sources/TestSupport/TestWorkspace.swift
@@ -98,6 +98,7 @@ public final class TestWorkspace {
                 let v = version.flatMap(Version.init(string:))
                 manifests[.init(url: url, version: v)] = Manifest(
                     name: package.name,
+                    platforms: package.platforms,
                     path: manifestPath,
                     url: url,
                     version: v,
@@ -452,6 +453,7 @@ public struct TestDependency {
 public struct TestPackage {
 
     public let name: String
+    public let platforms: [PlatformDescription]
     public let path: String?
     public let targets: [TestTarget]
     public let products: [TestProduct]
@@ -462,6 +464,7 @@ public struct TestPackage {
 
     public init(
         name: String,
+        platforms: [PlatformDescription] = [.all],
         path: String? = nil,
         targets: [TestTarget],
         products: [TestProduct],
@@ -470,6 +473,7 @@ public struct TestPackage {
         toolsVersion: ToolsVersion? = nil
     ) {
         self.name = name
+        self.platforms = platforms
         self.path = path
         self.targets = targets
         self.products = products

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -42,6 +42,7 @@ class PackageGraphPerfTests: XCTestCasePerf {
             // Create manifest.
             let manifest = Manifest(
                 name: name,
+                platforms: [.all],
                 path: AbsolutePath(url).appending(component: Manifest.filename),
                 url: url,
                 version: "1.0.0",

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -188,6 +188,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             versions: [
                 v1: Manifest(
                     name: "Foo",
+                    platforms: [.all],
                     path: AbsolutePath("/Package.swift"),
                     url: "A",
                     version: v1,
@@ -201,6 +202,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             versions: [
                 v2: Manifest(
                     name: "Bar",
+                    platforms: [.all],
                     path: AbsolutePath("/Package.swift"),
                     url: "B",
                     version: v2,

--- a/Tests/PackageLoadingTests/XCTestManifests.swift
+++ b/Tests/PackageLoadingTests/XCTestManifests.swift
@@ -41,6 +41,7 @@ extension PackageBuilderTests {
         ("testMixedSources", testMixedSources),
         ("testModuleMapLayout", testModuleMapLayout),
         ("testMultipleTestProducts", testMultipleTestProducts),
+        ("testPlatforms", testPlatforms),
         ("testPredefinedTargetSearchError", testPredefinedTargetSearchError),
         ("testPublicHeadersPath", testPublicHeadersPath),
         ("testResolvesSystemModulePackage", testResolvesSystemModulePackage),

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -1695,6 +1695,7 @@ final class WorkspaceTests: XCTestCase {
         let manifest = workspace.manifestLoader.manifests[fooKey]!
         workspace.manifestLoader.manifests[fooKey] = Manifest(
             name: manifest.name,
+            platforms: [.all],
             path: manifest.path,
             url: manifest.url,
             version: manifest.version,
@@ -2729,6 +2730,100 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
+        }
+    }
+
+    func testPlatforms() throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try TestWorkspace(
+            sandbox: sandbox,
+            fs: fs,
+            roots: [
+                TestPackage(
+                    name: "Foo",
+                    platforms: [
+                        .init(name: "macos", version: "10.13"),
+                    ],
+                    targets: [
+                        TestTarget(name: "Foo", dependencies: ["Baz"]),
+                    ],
+                    products: [],
+                    dependencies: [
+                        TestDependency(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                    ]
+                ),
+            ],
+            packages: [
+                TestPackage(
+                    name: "Baz",
+                    platforms: [
+                        .init(name: "macos", version: "10.12"),
+                    ],
+                    targets: [
+                        TestTarget(name: "Baz"),
+                    ],
+                    products: [
+                        TestProduct(name: "Baz", targets: ["Baz"]),
+                    ],
+                    versions: ["1.5.0"]
+                ),
+                TestPackage(
+                    name: "Baz",
+                    platforms: [
+                        .init(name: "macos", version: "10.15"),
+                    ],
+                    targets: [
+                        TestTarget(name: "Baz"),
+                    ],
+                    products: [
+                        TestProduct(name: "Baz", targets: ["Baz"]),
+                    ],
+                    versions: ["1.5.1"]
+                ),
+                TestPackage(
+                    name: "Baz",
+                    platforms: [
+                        .init(name: "tvos", version: "10.0"),
+                    ],
+                    targets: [
+                        TestTarget(name: "Baz"),
+                    ],
+                    products: [
+                        TestProduct(name: "Baz", targets: ["Baz"]),
+                    ],
+                    versions: ["1.5.2"]
+                ),
+            ]
+        )
+
+        var deps: [TestWorkspace.PackageDependency] = [
+            .init(name: "Baz", requirement: .exact("1.5.0")),
+        ]
+        workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { (graph, diagnostics) in
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+        workspace.checkManagedDependencies() { result in
+            result.check(dependency: "baz", at: .checkout(.version("1.5.0")))
+        }
+
+        deps = [
+            .init(name: "Baz", requirement: .exact("1.5.1")),
+        ]
+        workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { (graph, diagnostics) in
+            DiagnosticsEngineTester(diagnostics, ignoreNotes: true) { result in
+                result.check(diagnostic: .contains("the product 'Baz' requires minimum platform version 10.15 for macos platform"), behavior: .error)
+            }
+        }
+
+        deps = [
+            .init(name: "Baz", requirement: .exact("1.5.2")),
+        ]
+        workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { (graph, diagnostics) in
+            DiagnosticsEngineTester(diagnostics, ignoreNotes: true) { result in
+                result.check(diagnostic: .contains("the product 'Baz' doesn't support any of the platform required by the target 'Foo'"), behavior: .error)
+            }
         }
     }
 }

--- a/Tests/WorkspaceTests/XCTestManifests.swift
+++ b/Tests/WorkspaceTests/XCTestManifests.swift
@@ -67,6 +67,7 @@ extension WorkspaceTests {
         ("testMissingEditCanRestoreOriginalCheckout", testMissingEditCanRestoreOriginalCheckout),
         ("testMultipleRootPackages", testMultipleRootPackages),
         ("testPackageMirror", testPackageMirror),
+        ("testPlatforms", testPlatforms),
         ("testResolutionFailureWithEditedDependency", testResolutionFailureWithEditedDependency),
         ("testResolve", testResolve),
         ("testResolvedFileUpdate", testResolvedFileUpdate),


### PR DESCRIPTION
This will fill the platform information in the package model and start
making use of it to reject incompatible packages in a graph. This patch
doesn't use the deployment information during the build.