### PR TITLE
[PackageDescription] Allow up to 3 components for all Apple platforms

### DIFF
--- a/Sources/PackageDescription4/SupportedPlatforms.swift
+++ b/Sources/PackageDescription4/SupportedPlatforms.swift
@@ -112,7 +112,7 @@ extension SupportedPlatform {
             // Perform a quick validation.
             let components = string.split(separator: ".", omittingEmptySubsequences: false).map({ Int($0) })
             var error = components.compactMap({ $0 }).count != components.count
-            error = error || (components.count != 2)
+            error = error || !(components.count == 2 || components.count == 3)
             if error {
                 errors.append("invalid tvOS version string: \(string)")
             }
@@ -146,7 +146,7 @@ extension SupportedPlatform {
             // Perform a quick validation.
             let components = string.split(separator: ".", omittingEmptySubsequences: false).map({ Int($0) })
             var error = components.compactMap({ $0 }).count != components.count
-            error = error || (components.count != 2)
+            error = error || !(components.count == 2 || components.count == 3)
             if error {
                 errors.append("invalid iOS version string: \(string)")
             }
@@ -181,7 +181,7 @@ extension SupportedPlatform {
             // Perform a quick validation.
             let components = string.split(separator: ".", omittingEmptySubsequences: false).map({ Int($0) })
             var error = components.compactMap({ $0 }).count != components.count
-            error = error || (components.count != 2)
+            error = error || !(components.count == 2 || components.count == 3)
             if error {
                 errors.append("invalid watchOS version string: \(string)")
             }


### PR DESCRIPTION
Even though we don't really have any deployment target in
iOS/watchOS/tvOS that uses three components, we should still allow it.