### PR TITLE
[Build] Drop version number from Darwin's build subpath

### DIFF
--- a/Documentation/Development.md
+++ b/Documentation/Development.md
@@ -74,8 +74,8 @@ using a [snapshot](https://swift.org/download/#releases) from swift.org.
 	### Example:
 	```sh
 	$ cd /tmp && mkdir hello && cd hello
-	$ /path/to/swiftpm/.build/x86_64-apple-macosx10.10/debug/swift-package init
-	$ /path/to/swiftpm/.build/x86_64-apple-macosx10.10/debug/swift-build
+	$ /path/to/swiftpm/.build/x86_64-apple-macosx/debug/swift-package init
+	$ /path/to/swiftpm/.build/x86_64-apple-macosx/debug/swift-build
 	```
 
 5. Testing the Swift Package Manager.
@@ -95,10 +95,10 @@ sources or run a single test. Make sure you run the bootstrap script first.
 $ cd swiftpm
 
 # Rebuild just the sources.
-$ .build/x86_64-apple-macosx10.10/debug/spm build
+$ .build/x86_64-apple-macosx/debug/spm build
 
 # Run a single test.
-$ .build/x86_64-apple-macosx10.10/debug/spm test --filter BasicTests.GraphAlgorithmsTests/testCycleDetection
+$ .build/x86_64-apple-macosx/debug/spm test --filter BasicTests.GraphAlgorithmsTests/testCycleDetection
 ```
 
 Note: If you make any changes to `PackageDescription` runtime-related targets,

--- a/Sources/Build/Triple.swift
+++ b/Sources/Build/Triple.swift
@@ -113,7 +113,15 @@ public struct Triple {
         return os == .windows
     }
 
-    public static let macOS = try! Triple("x86_64-apple-macosx10.10")
+    /// Returns the triple string for the given platform version.
+    ///
+    /// This is currently meant for Apple platforms only.
+    public func tripleString(forPlatformVersion version: String) -> String {
+        precondition(isDarwin())
+        return self.tripleString + version
+    }
+
+    public static let macOS = try! Triple("x86_64-apple-macosx")
     public static let x86_64Linux = try! Triple("x86_64-unknown-linux")
     public static let i686Linux = try! Triple("i686-unknown-linux")
     public static let ppc64leLinux = try! Triple("powerpc64le-unknown-linux")

--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -115,7 +115,7 @@ public struct Destination {
             sdk: sdkPath,
             binDir: binDir,
             dynamicLibraryExtension: "dylib",
-            extraCCFlags: ["-arch", "x86_64", "-mmacosx-version-min=10.10"] + commonArgs,
+            extraCCFlags: commonArgs,
             extraSwiftCFlags: commonArgs,
             extraCPPFlags: ["-lc++"]
         )

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -229,12 +229,10 @@ public final class UserToolchain: Toolchain {
       #endif
 
         self.extraSwiftCFlags = [
-            "-target", destination.target,
             "-sdk", destination.sdk.asString
         ] + destination.extraSwiftCFlags
 
         self.extraCCFlags = [
-            "-target", destination.target,
             "--sysroot", destination.sdk.asString
         ] + destination.extraCCFlags
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -267,10 +267,15 @@ final class BuildPlanTests: XCTestCase {
         result.checkTargetsCount(3)
 
         let ext = try result.target(for: "extlib").clangTarget()
-        var args = ["-g", "-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1"]
+        var args: [String] = []
+
       #if os(macOS)
-        args += ["-fobjc-arc"]
+        args += ["-fobjc-arc", "-target", "x86_64-apple-macosx10.10"]
+      #else
+        args += ["-target", "x86_64-unknown-linux"]
       #endif
+
+        args += ["-g", "-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1"]
         args += ["-fblocks", "-fmodules", "-fmodule-name=extlib",
             "-I", "/ExtPkg/Sources/extlib/include", "-fmodules-cache-path=/path/to/build/debug/ModuleCache"]
         XCTAssertEqual(ext.basicArguments(), args)
@@ -278,10 +283,15 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(ext.moduleMap, AbsolutePath("/path/to/build/debug/extlib.build/module.modulemap"))
 
         let exe = try result.target(for: "exe").clangTarget()
-        args = ["-g", "-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1"]
+        args = []
+
       #if os(macOS)
-        args += ["-fobjc-arc"]
+        args += ["-fobjc-arc", "-target", "x86_64-apple-macosx10.10"]
+      #else
+        args += ["-target", "x86_64-unknown-linux"]
       #endif
+
+        args += ["-g", "-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1"]
         args += ["-fblocks", "-fmodules", "-fmodule-name=exe",
             "-I", "/Pkg/Sources/exe/include", "-I", "/Pkg/Sources/lib/include", "-I", "/ExtPkg/Sources/extlib/include",
             "-fmodules-cache-path=/path/to/build/debug/ModuleCache"]
@@ -396,10 +406,15 @@ final class BuildPlanTests: XCTestCase {
         result.checkTargetsCount(2)
         
         let lib = try result.target(for: "lib").clangTarget()
-        var args = ["-g", "-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1"]
+        var args: [String] = []
+
       #if os(macOS)
-        args += ["-fobjc-arc"]
+        args += ["-fobjc-arc", "-target", "x86_64-apple-macosx10.10"]
+      #else
+        args += ["-target", "x86_64-unknown-linux"]
       #endif
+
+        args += ["-g", "-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1"]
         args += ["-fblocks", "-fmodules", "-fmodule-name=lib", "-I", "/Pkg/Sources/lib/include",
             "-fmodules-cache-path=/path/to/build/debug/ModuleCache"]
         XCTAssertEqual(lib.basicArguments(), args)
@@ -777,18 +792,18 @@ final class BuildPlanTests: XCTestCase {
 
         let exe = try result.target(for: "exe").clangTarget()
     #if os(macOS)
-        XCTAssertEqual(exe.basicArguments(), ["-g", "-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1", "-fobjc-arc","-fblocks",  "-fmodules", "-fmodule-name=exe", "-I", "/Pkg/Sources/exe/include", "-fmodules-cache-path=/path/to/build/debug/ModuleCache"])
+        XCTAssertEqual(exe.basicArguments(), ["-fobjc-arc", "-target", "x86_64-apple-macosx10.10", "-g", "-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1", "-fblocks",  "-fmodules", "-fmodule-name=exe", "-I", "/Pkg/Sources/exe/include", "-fmodules-cache-path=/path/to/build/debug/ModuleCache"])
     #else
-        XCTAssertEqual(exe.basicArguments(), ["-g", "-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1", "-fblocks",  "-fmodules", "-fmodule-name=exe", "-I", "/Pkg/Sources/exe/include", "-fmodules-cache-path=/path/to/build/debug/ModuleCache"])
+        XCTAssertEqual(exe.basicArguments(), ["-target", "x86_64-unknown-linux", "-g", "-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1", "-fblocks",  "-fmodules", "-fmodule-name=exe", "-I", "/Pkg/Sources/exe/include", "-fmodules-cache-path=/path/to/build/debug/ModuleCache"])
     #endif
         XCTAssertEqual(exe.objects, [AbsolutePath("/path/to/build/debug/exe.build/main.c.o")])
         XCTAssertEqual(exe.moduleMap, nil)
 
         let lib = try result.target(for: "lib").clangTarget()
     #if os(macOS)
-        XCTAssertEqual(lib.basicArguments(), ["-g", "-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1", "-fobjc-arc","-fblocks",  "-fmodules", "-fmodule-name=lib", "-I", "/Pkg/Sources/lib/include", "-fmodules-cache-path=/path/to/build/debug/ModuleCache"])
+        XCTAssertEqual(lib.basicArguments(), ["-fobjc-arc", "-target", "x86_64-apple-macosx10.10", "-g", "-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1", "-fblocks",  "-fmodules", "-fmodule-name=lib", "-I", "/Pkg/Sources/lib/include", "-fmodules-cache-path=/path/to/build/debug/ModuleCache"])
     #else
-        XCTAssertEqual(lib.basicArguments(), ["-g", "-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1", "-fblocks",  "-fmodules", "-fmodule-name=lib", "-I", "/Pkg/Sources/lib/include", "-fmodules-cache-path=/path/to/build/debug/ModuleCache"])
+        XCTAssertEqual(lib.basicArguments(), ["-target", "x86_64-unknown-linux", "-g", "-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1", "-fblocks",  "-fmodules", "-fmodule-name=lib", "-I", "/Pkg/Sources/lib/include", "-fmodules-cache-path=/path/to/build/debug/ModuleCache"])
     #endif
         XCTAssertEqual(lib.objects, [AbsolutePath("/path/to/build/debug/lib.build/lib.cpp.o")])
         XCTAssertEqual(lib.moduleMap, AbsolutePath("/path/to/build/debug/lib.build/module.modulemap"))
@@ -967,17 +982,18 @@ final class BuildPlanTests: XCTestCase {
         )
         
         let diagnostics = DiagnosticsEngine()
-        let graph = loadPackageGraph(root: "/Pkg", fs: fs, diagnostics: diagnostics,
-                                     manifests: [
-                                        Manifest.createV4Manifest(
-                                            name: "Pkg",
-                                            path: "/Pkg",
-                                            url: "/Pkg",
-                                            targets: [
-                                                TargetDescription(name: "exe", dependencies: ["lib"]),
-                                                TargetDescription(name: "lib", dependencies: []),
-                                                ]),
-                                        ]
+        let graph = loadPackageGraph(
+            root: "/Pkg", fs: fs, diagnostics: diagnostics,
+            manifests: [
+                Manifest.createV4Manifest(
+                    name: "Pkg",
+                    path: "/Pkg",
+                    url: "/Pkg",
+                    targets: [
+                    TargetDescription(name: "exe", dependencies: ["lib"]),
+                    TargetDescription(name: "lib", dependencies: []),
+                ]),
+            ]
         )
         XCTAssertNoDiagnostics(diagnostics)
         
@@ -986,7 +1002,7 @@ final class BuildPlanTests: XCTestCase {
         result.checkTargetsCount(2)
         
         let lib = try result.target(for: "lib").clangTarget()
-        var args = ["-g", "-gcodeview", "-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1"]
+        var args = ["-target", "x86_64-unknown-windows-msvc", "-g", "-gcodeview", "-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1"]
         args += ["-fblocks", "-I", "/Pkg/Sources/lib/include"]
         XCTAssertEqual(lib.basicArguments(), args)
         XCTAssertEqual(lib.objects, [AbsolutePath("/path/to/build/debug/lib.build/lib.c.o")])

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -1005,7 +1005,7 @@ def main():
 
     # Compute the build paths.
     if platform.system() == 'Darwin':
-        build_target = "x86_64-apple-macosx10.10"
+        build_target = "x86_64-apple-macosx"
     elif platform.system() == 'Linux':              
         if platform.machine() == 'x86_64':
             build_target = "x86_64-unknown-linux"


### PR DESCRIPTION
This removes the version number component in Darwin's build dir subpath
to allow having a consistent build path for all packages as they might
have different deployment target once we get ability to specify it.