### PR TITLE
[WIP][PackageDescription] Add target-specific build settings API

### DIFF
--- a/Sources/PackageDescription4/BuildSettings.swift
+++ b/Sources/PackageDescription4/BuildSettings.swift
@@ -1,0 +1,164 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2018 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// The build configuration such as debug or release.
+public struct BuildConfiguration: Encodable {
+    private let config: String
+
+    private init(_ config: String) {
+        self.config = config
+    }
+
+    /// The debug build configuration.
+    public static let debug: BuildConfiguration = BuildConfiguration("debug")
+
+    /// The release build configuration.
+    public static let release: BuildConfiguration = BuildConfiguration("release")
+}
+
+/// A build setting condition.
+public struct BuildSettingCondition: Encodable {
+
+    private let platforms: [Platform]?
+    private let config: BuildConfiguration?
+
+    private init(platforms: [Platform]?, config: BuildConfiguration?) {
+        self.platforms = platforms
+        self.config = config
+    }
+
+    /// Create a build setting condition.
+    ///
+    /// At least one parameter is mandatory.
+    public static func when(
+        platforms: [Platform]? = nil,
+        configuration: BuildConfiguration? = nil
+    ) -> BuildSettingCondition {
+        // FIXME: This should be an error not a precondition.
+        precondition(!(platforms == nil && configuration == nil))
+        return BuildSettingCondition(platforms: platforms, config: configuration)
+    }
+}
+
+/// The underlying build setting data.
+fileprivate struct BuildSettingData: Encodable {
+
+    /// The name of the build setting.
+    let name: String
+
+    /// The value of the build setting.
+    let value: [String]
+
+    /// The condition at which the build setting should be applied.
+    let condition: BuildSettingCondition?
+}
+
+/// A C-language build setting.
+public struct CSetting: Encodable {
+    private let data: BuildSettingData
+
+    private init(name: String, value: [String], condition: BuildSettingCondition?) {
+        self.data = BuildSettingData(name: name, value: value, condition: condition)
+    }
+
+    /// Provide a header search path relative to the target's root directory.
+    ///
+    /// The path must not escape the package boundary.
+    public static func headerSearchPath(_ path: String, _ condition: BuildSettingCondition? = nil) -> CSetting {
+        return CSetting(name: "headerSearchPath", value: [path], condition: condition)
+    }
+
+    /// Define macro to a value (or 1 if the value is omitted).
+    public static func define(_ name: String, to value: String? = nil, _ condition: BuildSettingCondition? = nil) -> CSetting {
+        var settingValue = [name]
+        if let value = value {
+            settingValue.append(value)
+        }
+        return CSetting(name: "define", value: settingValue, condition: condition)
+    }
+
+    /// Set the given unsafe flags.
+    public static func unsafeFlags(_ flags: [String], _ condition: BuildSettingCondition? = nil) -> CSetting {
+        return CSetting(name: "unsafeFlags", value: flags, condition: condition)
+    }
+}
+
+/// A CXX-language build setting.
+public struct CXXSetting: Encodable {
+    private let data: BuildSettingData
+
+    private init(name: String, value: [String], condition: BuildSettingCondition?) {
+        self.data = BuildSettingData(name: name, value: value, condition: condition)
+    }
+
+    /// Provide a header search path relative to the target's root directory.
+    ///
+    /// The path must not escape the package boundary.
+    public static func headerSearchPath(_ path: String, _ condition: BuildSettingCondition? = nil) -> CXXSetting {
+        return CXXSetting(name: "headerSearchPath", value: [path], condition: condition)
+    }
+
+    /// Define macro to a value (or 1 if the value is omitted).
+    public static func define(_ name: String, to value: String? = nil, _ condition: BuildSettingCondition? = nil) -> CXXSetting {
+        var settingValue = [name]
+        if let value = value {
+            settingValue.append(value)
+        }
+        return CXXSetting(name: "define", value: settingValue, condition: condition)
+    }
+
+    /// Set the given unsafe flags.
+    public static func unsafeFlags(_ flags: [String], _ condition: BuildSettingCondition? = nil) -> CXXSetting {
+        return CXXSetting(name: "unsafeFlags", value: flags, condition: condition)
+    }
+}
+
+/// A Swift language build setting.
+public struct SwiftSetting: Encodable {
+    private let data: BuildSettingData
+
+    private init(name: String, value: [String], condition: BuildSettingCondition?) {
+        self.data = BuildSettingData(name: name, value: value, condition: condition)
+    }
+
+    /// Marks the given conditional compilation flag as true.
+    public static func define(_ name: String, _ condition: BuildSettingCondition? = nil) -> SwiftSetting {
+        return SwiftSetting(name: "define", value: [name], condition: condition)
+    }
+
+    /// Set the given unsafe flags.
+    public static func unsafeFlags(_ flags: [String], _ condition: BuildSettingCondition? = nil) -> SwiftSetting {
+        return SwiftSetting(name: "unsafeFlags", value: flags, condition: condition)
+    }
+}
+
+/// A linker build setting.
+public struct LinkerSetting: Encodable {
+    private let data: BuildSettingData
+
+    private init(name: String, value: [String], condition: BuildSettingCondition?) {
+        self.data = BuildSettingData(name: name, value: value, condition: condition)
+    }
+
+    /// Link a system library.
+    public static func linkedLibrary(_ library: String, _ condition: BuildSettingCondition? = nil) -> LinkerSetting {
+        return LinkerSetting(name: "linkedLibrary", value: [library], condition: condition)
+    }
+
+    /// Link a system framework.
+    public static func linkedFramework(_ framework: String, _ condition: BuildSettingCondition? = nil) -> LinkerSetting {
+        return LinkerSetting(name: "linkedFramework", value: [framework], condition: condition)
+    }
+
+    /// Set the given unsafe flags.
+    public static func unsafeFlags(_ flags: [String], _ condition: BuildSettingCondition? = nil) -> LinkerSetting {
+        return LinkerSetting(name: "unsafeFlags", value: flags, condition: condition)
+    }
+}

--- a/Sources/PackageDescription4/SupportedPlatforms.swift
+++ b/Sources/PackageDescription4/SupportedPlatforms.swift
@@ -8,49 +8,68 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+/// Represents a platform.
+public struct Platform: Encodable {
+
+    /// The name of the platform.
+    fileprivate let name: String
+
+    private init(name: String) {
+        self.name = name
+    }
+
+    public static let macOS: Platform = Platform(name: "macos")
+    public static let iOS: Platform = Platform(name: "ios")
+    public static let tvOS: Platform = Platform(name: "tvos")
+    public static let watchOS: Platform = Platform(name: "watchos")
+    public static let linux: Platform = Platform(name: "linux")
+
+    fileprivate static let all: Platform = Platform(name: "<all>")
+}
+
 /// Represents a platform supported by the package.
 public struct SupportedPlatform: Encodable {
 
-    /// The platform name.
-    let platform: String
+    /// The platform.
+    let platform: Platform
 
     /// The platform version.
     let version: VersionedValue<String>?
 
     /// Creates supported platform instance.
-    init(platform: String, version: VersionedValue<String>? = nil) {
+    init(platform: Platform, version: VersionedValue<String>? = nil) {
         self.platform = platform
         self.version = version
     }
 
     /// The macOS platform.
     public static func macOS(_ version: SupportedPlatform.MacOSVersion) -> SupportedPlatform {
-        return SupportedPlatform(platform: "macos", version: version.version)
+        return SupportedPlatform(platform: .macOS, version: version.version)
     }
 
     /// The iOS platform.
     public static func iOS(_ version: SupportedPlatform.IOSVersion) -> SupportedPlatform {
-        return SupportedPlatform(platform: "ios", version: version.version)
+        return SupportedPlatform(platform: .iOS, version: version.version)
     }
 
     /// The tvOS platform.
     public static func tvOS(_ version: SupportedPlatform.TVOSVersion) -> SupportedPlatform {
-        return SupportedPlatform(platform: "tvos", version: version.version)
+        return SupportedPlatform(platform: .tvOS, version: version.version)
     }
 
     /// The watchOS platform.
     public static func watchOS(_ version: SupportedPlatform.WatchOSVersion) -> SupportedPlatform {
-        return SupportedPlatform(platform: "watchos", version: version.version)
+        return SupportedPlatform(platform: .watchOS, version: version.version)
     }
 
     /// The Linux platform.
     public static func linux() -> SupportedPlatform {
-        return SupportedPlatform(platform: "linux")
+        return SupportedPlatform(platform: .linux)
     }
 
     /// Represents all platforms that are unspecified.
     public static var all: SupportedPlatform {
-        return SupportedPlatform(platform: "<all>")
+        return SupportedPlatform(platform: .all)
     }
 }
 

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -254,6 +254,9 @@ public struct TargetDescription: Equatable, Codable {
     /// The providers of a system library target.
     public let providers: [SystemPackageProviderDescription]?
 
+    /// The target-specific build settings declared in this target.
+    public let settings: [TargetBuildSettingDescription.Setting]
+
     public init(
         name: String,
         dependencies: [Dependency] = [],
@@ -263,7 +266,8 @@ public struct TargetDescription: Equatable, Codable {
         publicHeadersPath: String? = nil,
         type: TargetType = .regular,
         pkgConfig: String? = nil,
-        providers: [SystemPackageProviderDescription]? = nil
+        providers: [SystemPackageProviderDescription]? = nil,
+        settings: [TargetBuildSettingDescription.Setting] = []
     ) {
         switch type {
         case .regular, .test:
@@ -280,6 +284,7 @@ public struct TargetDescription: Equatable, Codable {
         self.type = type
         self.pkgConfig = pkgConfig
         self.providers = providers
+        self.settings = settings
     }
 }
 
@@ -373,4 +378,70 @@ public struct PlatformDescription: Codable, Equatable {
     /// This is a special platform that represents that a package implictly
     /// supports all platforms.
     public static var all: PlatformDescription = PlatformDescription(name: "<all>")
+}
+
+/// A namespace for target-specific build settings.
+public enum TargetBuildSettingDescription {
+
+    /// Represents a build settings condition.
+    public struct Condition: Codable, Equatable {
+
+        public let platformNames: [String]
+        public let config: String?
+
+        public init(platformNames: [String] = [], config: String? = nil) {
+            assert(!(platformNames.isEmpty && config == nil))
+            self.platformNames = platformNames
+            self.config = config
+        }
+    }
+
+    /// The tool for which a build setting is declared.
+    public enum Tool: String, Codable, Equatable, CaseIterable {
+        case c
+        case cxx
+        case swift
+        case linker
+    }
+
+    /// The name of the build setting.
+    public enum SettingName: String, Codable, Equatable {
+        case headerSearchPath
+        case define
+        case linkedLibrary
+        case linkedFramework
+
+        case unsafeFlags
+    }
+
+    /// An individual build setting.
+    public struct Setting: Codable, Equatable {
+
+        /// The tool associated with this setting.
+        public let tool: Tool
+
+        /// The name of the setting.
+        public let name: SettingName
+
+        /// The condition at which the setting should be applied.
+        public let condition: Condition?
+
+        /// The value of the setting.
+        ///
+        /// This is kind of like an "untyped" value since the length
+        /// of the array will depend on the setting type.
+        public let value: [String]
+
+        public init(
+            tool: Tool,
+            name: SettingName,
+            value: [String],
+            condition: Condition? = nil
+        ) {
+            self.tool = tool
+            self.name = name
+            self.value = value
+            self.condition = condition
+        }
+    }
 }

--- a/Tests/PackageLoadingTests/XCTestManifests.swift
+++ b/Tests/PackageLoadingTests/XCTestManifests.swift
@@ -100,6 +100,7 @@ extension PackageDescription5LoadingTests {
     // to regenerate.
     static let __allTests__PackageDescription5LoadingTests = [
         ("testBasics", testBasics),
+        ("testBuildSettings", testBuildSettings),
         ("testPlatforms", testPlatforms),
         ("testSwiftLanguageVersion", testSwiftLanguageVersion),
     ]


### PR DESCRIPTION
This adds the build settings API that is currently being pitched on
Swift evolution. The intent is to add the required infrastruture for
build settings even if we don't end up with an accepted proposal before
the next Swift release. The APIs currently have an underscore to
indicate that they're not officially supported and will be removed if we
don't go through the evolution process.