### PR TITLE
Rename Compile to Compiling to fix tense

### DIFF
--- a/Sources/Build/llbuild.swift
+++ b/Sources/Build/llbuild.swift
@@ -242,7 +242,7 @@ public struct LLBuildManifestGenerator {
 
             args += ["-c", path.source.asString, "-o", path.object.asString]
             let clang = ClangTool(
-                desc: "Compile \(target.target.name) \(path.filename.asString)",
+                desc: "Compiling \(target.target.name) \(path.filename.asString)",
                 //FIXME: Should we add build time dependency on dependent targets?
                 inputs: [path.source.asString],
                 outputs: [path.object.asString],

--- a/Tests/BuildTests/IncrementalBuildTests.swift
+++ b/Tests/BuildTests/IncrementalBuildTests.swift
@@ -45,7 +45,7 @@ final class IncrementalBuildTests: XCTestCase {
             // Check various things that we expect to see in the full build log.
             // FIXME:  This is specific to the format of the log output, which
             // is quite unfortunate but not easily avoidable at the moment.
-            XCTAssertTrue(fullLog.contains("Compile CLibrarySources Foo.c"))
+            XCTAssertTrue(fullLog.contains("Compiling CLibrarySources Foo.c"))
 
             let llbuildManifest = prefix.appending(components: ".build", "debug.yaml")
             
@@ -62,7 +62,7 @@ final class IncrementalBuildTests: XCTestCase {
             
             // Now build again.  This should be an incremental build.
             let log2 = try executeSwiftBuild(prefix)
-            XCTAssertTrue(log2.contains("Compile CLibrarySources Foo.c"))
+            XCTAssertTrue(log2.contains("Compiling CLibrarySources Foo.c"))
 
             // Read the second llbuild manifest.
             let llbuildContents2 = try localFileSystem.readFileContents(llbuildManifest)
@@ -70,7 +70,7 @@ final class IncrementalBuildTests: XCTestCase {
             // Now build again without changing anything.  This should be a null
             // build.
             let log3 = try executeSwiftBuild(prefix)
-            XCTAssertFalse(log3.contains("Compile CLibrarySources Foo.c"))
+            XCTAssertFalse(log3.contains("Compiling CLibrarySources Foo.c"))
 
             // Read the third llbuild manifest.
             let llbuildContents3 = try localFileSystem.readFileContents(llbuildManifest)

--- a/Tests/CommandsTests/RunToolTests.swift
+++ b/Tests/CommandsTests/RunToolTests.swift
@@ -44,7 +44,7 @@ final class RunToolTests: XCTestCase {
                 """))
 
             // swift-build-tool output should go to stderr.
-            XCTAssertMatch(try result.utf8stderrOutput(), .contains("Compile Swift Module"))
+            XCTAssertMatch(try result.utf8stderrOutput(), .regex("Compil(e|ing) Swift Module"))
             XCTAssertMatch(try result.utf8stderrOutput(), .contains("Linking"))
 
             do {

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -309,7 +309,7 @@ class Target(object):
 
             print("  %s:" % json.dumps(object_path), file=output)
             print("    tool: clang", file=output)
-            print("    description: Compile %s" % filename, file=output)
+            print("    description: Compiling %s" % filename, file=output)
             print("    inputs: %s" % json.dumps([source]), file=output)
             print("    outputs: %s" % json.dumps([object_path]), file=output)
             print("    args: %s" % json.dumps(args), file=output)


### PR DESCRIPTION
This only applies to Clang targets. Swift targets will be fixed in llbuild separately, but the tests have been modified in preperation.