### PR TITLE
Improve OS version number validation in SupportedPlatforms

### DIFF
--- a/Sources/PackageDescription4/SupportedPlatforms.swift
+++ b/Sources/PackageDescription4/SupportedPlatforms.swift
@@ -47,7 +47,7 @@ public struct SupportedPlatform: Encodable {
 
     /// Create macOS supported platform with the given version string.
     ///
-    /// The version string must be in format: 10.XX.XX
+    /// The version string must be a series of 2 or 3 dot-separated integers, for example "10.10" or "10.10.1".
     public static func macOS(_ versionString: String) -> SupportedPlatform {
         return SupportedPlatform(platform: .macOS, version: SupportedPlatform.MacOSVersion(versionString).version)
     }
@@ -59,7 +59,7 @@ public struct SupportedPlatform: Encodable {
 
     /// Create iOS supported platform with the given version string.
     ///
-    /// The version string must be in format: XX.XX
+    /// The version string must be a series of 2 or 3 dot-separated integers, for example "8.0" or "8.0.1".
     public static func iOS(_ versionString: String) -> SupportedPlatform {
         return SupportedPlatform(platform: .iOS, version: SupportedPlatform.IOSVersion(versionString).version)
     }
@@ -71,7 +71,7 @@ public struct SupportedPlatform: Encodable {
 
     /// Create tvOS supported platform with the given version string.
     ///
-    /// The version string must be in format: XX.XX
+    /// The version string must be a series of 2 or 3 dot-separated integers, for example "9.0" or "9.0.1".
     public static func tvOS(_ versionString: String) -> SupportedPlatform {
         return SupportedPlatform(platform: .tvOS, version: SupportedPlatform.TVOSVersion(versionString).version)
     }
@@ -83,7 +83,7 @@ public struct SupportedPlatform: Encodable {
 
     /// Create watchOS supported platform with the given version string.
     ///
-    /// The version string must be in format: XX.XX
+    /// The version string must be a series of 2 or 3 dot-separated integers, for example "2.0" or "2.0.1".
     public static func watchOS(_ versionString: String) -> SupportedPlatform {
         return SupportedPlatform(platform: .watchOS, version: SupportedPlatform.WatchOSVersion(versionString).version)
     }
@@ -91,33 +91,15 @@ public struct SupportedPlatform: Encodable {
 
 extension SupportedPlatform {
     /// The macOS version.
-    public struct MacOSVersion: Encodable {
+    public struct MacOSVersion: Encodable, AppleOSVersion {
+        fileprivate static let name = "macOS"
+        fileprivate static let minimumMajorVersion = 10
 
         /// The underlying version representation.
         let version: VersionedValue<String>
 
-        private init(_ version: String, supportedVersions: [ManifestVersion]) {
-            let api = "v" + version.split(separator: ".").joined(separator: "_")
-            self.init(VersionedValue(version, api: api, versions: supportedVersions))
-        }
-
-        private init(_ version: VersionedValue<String>) {
+        fileprivate init(_ version: VersionedValue<String>) {
             self.version = version
-        }
-
-        /// Create a macOS version from the given string.
-        ///
-        /// The version string must be in format: 10.XX.XX
-        fileprivate init(_ string: String) {
-            // Perform a quick validation.
-            let components = string.split(separator: ".", omittingEmptySubsequences: false).map({ Int($0) })
-            var error = components.compactMap({ $0 }).count != components.count
-            error = error || !(components.first == 10 && (components.count == 2 || components.count == 3))
-            if error {
-                errors.append("invalid macOS version string: \(string)")
-            }
-
-            self.init(VersionedValue(string, api: ""))
         }
 
         public static let v10_10: MacOSVersion = .init("10.10", supportedVersions: [.v5])
@@ -127,32 +109,15 @@ extension SupportedPlatform {
         public static let v10_14: MacOSVersion = .init("10.14", supportedVersions: [.v5])
     }
 
-    public struct TVOSVersion: Encodable {
+    public struct TVOSVersion: Encodable, AppleOSVersion {
+        fileprivate static let name = "tvOS"
+        fileprivate static let minimumMajorVersion = 9
+
         /// The underlying version representation.
         let version: VersionedValue<String>
 
-        private init(_ version: String, supportedVersions: [ManifestVersion]) {
-            let api = "v" + version
-            self.init(VersionedValue(version, api: api, versions: supportedVersions))
-        }
-
-        private init(_ version: VersionedValue<String>) {
+        fileprivate init(_ version: VersionedValue<String>) {
             self.version = version
-        }
-
-        /// Create a tvOS version from the given string.
-        ///
-        /// The version string must be in format: XX.XX
-        fileprivate init(_ string: String) {
-            // Perform a quick validation.
-            let components = string.split(separator: ".", omittingEmptySubsequences: false).map({ Int($0) })
-            var error = components.compactMap({ $0 }).count != components.count
-            error = error || !(components.count == 2 || components.count == 3)
-            if error {
-                errors.append("invalid tvOS version string: \(string)")
-            }
-
-            self.init(VersionedValue(string, api: ""))
         }
 
         public static let v9: TVOSVersion = .init("9.0", supportedVersions: [.v5])
@@ -161,32 +126,15 @@ extension SupportedPlatform {
         public static let v12: TVOSVersion = .init("12.0", supportedVersions: [.v5])
     }
 
-    public struct IOSVersion: Encodable {
+    public struct IOSVersion: Encodable, AppleOSVersion {
+        fileprivate static let name = "iOS"
+        fileprivate static let minimumMajorVersion = 2
+
         /// The underlying version representation.
         let version: VersionedValue<String>
 
-        private init(_ version: String, supportedVersions: [ManifestVersion]) {
-            let api = "v" + version
-            self.init(VersionedValue(version, api: api, versions: supportedVersions))
-        }
-
-        private init(_ version: VersionedValue<String>) {
+        fileprivate init(_ version: VersionedValue<String>) {
             self.version = version
-        }
-
-        /// Create an iOS version from the given string.
-        ///
-        /// The version string must be in format: XX.XX
-        fileprivate init(_ string: String) {
-            // Perform a quick validation.
-            let components = string.split(separator: ".", omittingEmptySubsequences: false).map({ Int($0) })
-            var error = components.compactMap({ $0 }).count != components.count
-            error = error || !(components.count == 2 || components.count == 3)
-            if error {
-                errors.append("invalid iOS version string: \(string)")
-            }
-
-            self.init(VersionedValue(string, api: ""))
         }
 
         public static let v8: IOSVersion = .init("8.0", supportedVersions: [.v5])
@@ -196,37 +144,45 @@ extension SupportedPlatform {
         public static let v12: IOSVersion = .init("12.0", supportedVersions: [.v5])
     }
 
-    public struct WatchOSVersion: Encodable {
+    public struct WatchOSVersion: Encodable, AppleOSVersion {
+        fileprivate static let name = "watchOS"
+        fileprivate static let minimumMajorVersion = 2
+
         /// The underlying version representation.
         let version: VersionedValue<String>
 
-        private init(_ version: String, supportedVersions: [ManifestVersion]) {
-            let api = "v" + version
-            self.init(VersionedValue(version, api: api, versions: supportedVersions))
-        }
-
-        private init(_ version: VersionedValue<String>) {
+        fileprivate init(_ version: VersionedValue<String>) {
             self.version = version
-        }
-
-        /// Create a watchOS version from the given string.
-        ///
-        /// The version string must be in format: XX.XX
-        fileprivate init(_ string: String) {
-            // Perform a quick validation.
-            let components = string.split(separator: ".", omittingEmptySubsequences: false).map({ Int($0) })
-            var error = components.compactMap({ $0 }).count != components.count
-            error = error || !(components.count == 2 || components.count == 3)
-            if error {
-                errors.append("invalid watchOS version string: \(string)")
-            }
-
-            self.init(VersionedValue(string, api: ""))
         }
 
         public static let v2: WatchOSVersion = .init("2.0", supportedVersions: [.v5])
         public static let v3: WatchOSVersion = .init("3.0", supportedVersions: [.v5])
         public static let v4: WatchOSVersion = .init("4.0", supportedVersions: [.v5])
         public static let v5: WatchOSVersion = .init("5.0", supportedVersions: [.v5])
+    }
+}
+
+fileprivate protocol AppleOSVersion {
+    static var name: String { get }
+    static var minimumMajorVersion: Int { get }
+    init(_ version: VersionedValue<String>)
+}
+
+fileprivate extension AppleOSVersion {
+    init(_ version: String, supportedVersions: [ManifestVersion]) {
+        let api = "v" + version.split(separator: ".").reversed().drop(while: { $0 == "0" }).reversed().joined(separator: "_")
+        self.init(VersionedValue(version, api: api, versions: supportedVersions))
+    }
+
+    init(_ string: String) {
+        // Perform a quick validation.
+        let components = string.split(separator: ".", omittingEmptySubsequences: false).map({ UInt($0) })
+        var error = components.compactMap({ $0 }).count != components.count
+        error = error || !(components.count == 2 || components.count == 3) || ((components[0] ?? 0) < Self.minimumMajorVersion)
+        if error {
+            errors.append("invalid \(Self.name) version string: \(string)")
+        }
+
+        self.init(VersionedValue(string, api: ""))
     }
 }

--- a/Tests/PackageLoadingTests/PD5LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5LoadingTests.swift
@@ -178,7 +178,7 @@ class PackageDescription5LoadingTests: XCTestCase {
             let package = Package(
                name: "Foo",
                platforms: [
-                   .macOS("11.2"), .iOS("12.x.2"), .tvOS("10..2"),
+                   .macOS("-11.2"), .iOS("12.x.2"), .tvOS("10..2"), .watchOS("1.0"),
                ]
             )
             """
@@ -187,7 +187,7 @@ class PackageDescription5LoadingTests: XCTestCase {
             try loadManifestThrowing(stream.bytes) { _ in }
             XCTFail("Unexpected success")
         } catch ManifestParseError.runtimeManifestErrors(let errors) {
-            XCTAssertEqual(errors, ["invalid macOS version string: 11.2", "invalid iOS version string: 12.x.2", "invalid tvOS version string: 10..2"])
+            XCTAssertEqual(errors, ["invalid macOS version string: -11.2", "invalid iOS version string: 12.x.2", "invalid tvOS version string: 10..2", "invalid watchOS version string: 1.0"])
         }
 
         // Duplicates.


### PR DESCRIPTION
The version string of an Apple platform is a dot-separated series of
2 or 3 positive integers. This improves the validation to ensure that
the version components are non-negative, and that the version number is
within the range of publicly-deployable versions that actually existed
for that platform (this is different from the minimum *supported*
version).

For example, the minimum versions in this validations are the minimum
versions that any API can be documented as being available on:
- iOS 2.0+
- macOS 10.0+
- tvOS 9.0+
- watchOS 2.0+

This also deduplicates the code.