### PR TITLE
[Build] Pass -L flag directly to Swift compiler

### DIFF
--- a/Tests/BuildTests/XCTestManifests.swift
+++ b/Tests/BuildTests/XCTestManifests.swift
@@ -17,6 +17,7 @@ extension BuildPlanTests {
         ("testCppModule", testCppModule),
         ("testDynamicProducts", testDynamicProducts),
         ("testExecAsDependency", testExecAsDependency),
+        ("testExtraBuildFlags", testExtraBuildFlags),
         ("testIndexStore", testIndexStore),
         ("testNonReachableProductsAndTargets", testNonReachableProductsAndTargets),
         ("testPkgConfigGenericDiagnostic", testPkgConfigGenericDiagnostic),


### PR DESCRIPTION
Avoid prefixing -Xlinker to search paths otherwise they get appended to
the end of the search list which can lead to linking system libraries
instead of user ones.

<rdar://problem/46408766> Pass -L flags directly to the swift compiler
https://bugs.swift.org/browse/SR-9347