### PR TITLE
[bootstrap] Allow modifying the stdlib RPATH using a build where the stdlib is symlinked into the toolchain

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -789,8 +789,8 @@ def installBinary(binary_path, install_path, swiftc_path, add_rpaths=[], delete_
     if platform.system() == 'Darwin':
         installed_path = os.path.join(
             install_path, os.path.basename(binary_path))
-        stdlib_path = os.path.realpath(
-            os.path.join(os.path.dirname(swiftc_path), "..",
+        stdlib_path = os.path.normpath(
+            os.path.join(os.path.dirname(os.path.realpath(swiftc_path)), "..",
                          "lib", "swift", "macosx"))
         delete_rpath(stdlib_path, installed_path)
 


### PR DESCRIPTION
This is a simple change to use 'normpath', for removing '..' from the stdlib path, instead of 'realpath',
which allows installing swiftpm using a setup where the Swift stdlib is symlinked in.
Without this change RPATH modification fails because the real path string is not found in the binary
(the absolute stdlib RPATH in the binary is relative to the swift binary).

This should have no effect in existing setups.