### PR TITLE
Allow specifying `sdkRoot` for `ManifestLoader`

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -154,12 +154,14 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         manifestResources: ManifestResourceProvider,
         isManifestSandboxEnabled: Bool = true,
         cacheDir: AbsolutePath? = nil,
+        sdkRoot: AbsolutePath? = nil,
         delegate: ManifestLoaderDelegate? = nil
     ) {
         self.resources = manifestResources
         self.isManifestSandboxEnabled = isManifestSandboxEnabled
         self.delegate = delegate
         self.cacheDir = cacheDir
+        self._sdkRoot = sdkRoot
     }
 
     @available(*, deprecated)


### PR DESCRIPTION
We can avoid shelling out to `xcrun` in case the client already knows the right path.

rdar://problem/46417631