### PR TITLE
[bootstrap] Improve CMake caching

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -889,8 +889,8 @@ def build_llbuild(args):
     llbuild_source_dir = args.llbuild_source_dir
 
     # Run CMake if needed.
-    # FIXME: Is this check enough?
-    if not os.path.isfile(os.path.join(llbuild_build_dir, "CMakeCache.txt")):
+    cmake_cache_path = os.path.join(llbuild_build_dir, "CMakeCache.txt")
+    if not os.path.isfile(cmake_cache_path) or not args.swiftc_path in open(cmake_cache_path).read():
         mkdir_p(llbuild_build_dir)
         cmd = ["cmake", "-G", "Ninja", "-DCMAKE_BUILD_TYPE:=Debug", "-DCMAKE_C_COMPILER:=clang", "-DCMAKE_CXX_COMPILER:=clang++", "-DLLBUILD_SUPPORT_BINDINGS:=Swift", "-DSWIFTC_EXECUTABLE:=%s" % (args.swiftc_path), llbuild_source_dir]
         subprocess.check_call(cmd, cwd=llbuild_build_dir)


### PR DESCRIPTION
Previously, we would only care if "CMakeCache.txt" exists, this adds a check for whether we are using the correct `swiftc`. This resolves and issue when switching between different versions of Xcode.

rdar://problem/46454067