### PR TITLE
[PackageModel] Make `Declaration.name` public

### DIFF
--- a/Sources/PackageModel/BuildSettings.swift
+++ b/Sources/PackageModel/BuildSettings.swift
@@ -46,7 +46,7 @@ public enum BuildSettings {
         public static let LINK_FRAMEWORKS: Declaration = .init("LINK_FRAMEWORKS")
 
         /// The declaration name.
-        private let name: String
+        public let name: String
     
         private init(_ name: String) {
             self.name = name


### PR DESCRIPTION
Clients might want to transform build settings to strings directly and it seems wasteful to require clients to use switch/case to get the names back.

rdar://problem/46365485