### PR TITLE
Change enum Arch case ppc64le to powerpc64le for PowerPC(ppc64le)

### DIFF
--- a/Sources/Build/Triple.swift
+++ b/Sources/Build/Triple.swift
@@ -33,7 +33,7 @@ public struct Triple {
     public enum Arch: String {
         case x86_64
         case i686
-        case ppc64le
+        case powerpc64le
         case s390x
         case aarch64
         case armv7


### PR DESCRIPTION
Change enum Arch case ppc64le to powerpc64le for PowerPC(ppc64le)