### PR TITLE
Avoid new-line on progress when never updated

### DIFF
--- a/Sources/Utility/ProgressAnimation.swift
+++ b/Sources/Utility/ProgressAnimation.swift
@@ -95,6 +95,7 @@ public final class MultiLineNinjaProgressAnimation: ProgressAnimationProtocol {
 /// A redrawing ninja-like progress animation.
 public final class RedrawingNinjaProgressAnimation: ProgressAnimationProtocol {
     private let terminal: TerminalController
+    private var hasDisplayedProgress = false
 
     init(terminal: TerminalController) {
         self.terminal = terminal
@@ -106,10 +107,13 @@ public final class RedrawingNinjaProgressAnimation: ProgressAnimationProtocol {
         terminal.clearLine()
         terminal.write("[\(step)/\(total)] ")
         terminal.write(text)
+        hasDisplayedProgress = true
     }
 
     public func complete(success: Bool) {
-        terminal.endLine()
+        if hasDisplayedProgress {
+            terminal.endLine()
+        }
     }
 
     public func clear() {

--- a/Tests/UtilityTests/XCTestManifests.swift
+++ b/Tests/UtilityTests/XCTestManifests.swift
@@ -62,8 +62,10 @@ extension ProgressAnimationTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__ProgressAnimationTests = [
-        ("testNinjaProgressAnimation", testNinjaProgressAnimation),
-        ("testPercentProgressAnimation", testPercentProgressAnimation),
+        ("testNinjaProgressAnimationDumbTerminal", testNinjaProgressAnimationDumbTerminal),
+        ("testNinjaProgressAnimationTTY", testNinjaProgressAnimationTTY),
+        ("testPercentProgressAnimationDumbTerminal", testPercentProgressAnimationDumbTerminal),
+        ("testPercentProgressAnimationTTY", testPercentProgressAnimationTTY),
     ]
 }
 


### PR DESCRIPTION
While adding a test that verifies the fix, I refactored the progress tests to avoid repetition.