### PR TITLE
[SPMLLBuild] Export llbuild when using llbuildSwift shared library

### DIFF
--- a/Sources/SPMLLBuild/llbuild.swift
+++ b/Sources/SPMLLBuild/llbuild.swift
@@ -11,6 +11,7 @@
 // We either export the llbuildSwift shared library or the llbuild framework.
 #if canImport(llbuildSwift)
 @_exported import llbuildSwift
+@_exported import llbuild
 #else
 @_exported import llbuild
 #endif


### PR DESCRIPTION
... Otherwise we don't see symbols in the llbuild C library.