### PR TITLE
Adopt initial split of Foundation into multiple modules

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -1129,6 +1129,7 @@ def main():
 
             # Add libFoundation.
             symlink_force(os.path.join(args.foundation_path, 'libFoundation.so'), libswiftdir)
+            symlink_force(os.path.join(args.foundation_path, 'libFoundationSoil.so'), libswiftdir)
 
             # Add Foundation's swiftmodule.
             for module_file in ["Foundation.swiftmodule", "Foundation.swiftdoc"]:

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -1129,7 +1129,7 @@ def main():
 
             # Add libFoundation.
             symlink_force(os.path.join(args.foundation_path, 'libFoundation.so'), libswiftdir)
-            symlink_force(os.path.join(args.foundation_path, 'libFoundationSoil.so'), libswiftdir)
+            symlink_force(os.path.join(args.foundation_path, 'libFoundationBase.so'), libswiftdir)
 
             # Add Foundation's swiftmodule.
             for module_file in ["Foundation.swiftmodule", "Foundation.swiftdoc"]:

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -1132,7 +1132,7 @@ def main():
             symlink_force(os.path.join(args.foundation_path, 'libFoundationBase.so'), libswiftdir)
 
             # Add Foundation's swiftmodule.
-            for module_file in ["Foundation.swiftmodule", "Foundation.swiftdoc"]:
+            for module_file in ["Foundation.swiftmodule", "Foundation.swiftdoc", "FoundationBase.swiftmodule", "FoundationBase.swiftdoc"]:
                 symlink_force(os.path.join(args.foundation_path, 'swift', module_file), libincludedir)
 
             # Add CoreFoundation "framework". This just contains the header and the modulemap.


### PR DESCRIPTION
Ensure that component module libraries are now picked up alongside Foundation’s.