### PR TITLE
Use `!canImport(ObjectiveC)` instead of `!os(macOS)`

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -367,7 +367,7 @@ public final class InitPackage {
             stream <<< """
                 import XCTest
 
-                #if !os(macOS)
+                #if !canImport(ObjectiveC)
                 public func allTests() -> [XCTestCaseEntry] {
                     return [
                         testCase(\(moduleName)Tests.allTests),


### PR DESCRIPTION
There are a bunch of platforms which are not macOS and still have the ObjC runtime. This also brings this check in line with the `generate-linuxmain` command.

See rdar://problem/46739400