### PR TITLE
Revert "Prepare SwiftPM for the addition of Result to the stdlib"

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -9,7 +9,6 @@
  */
 
 import Basic
-import enum Basic.Result
 import Build
 import PackageLoading
 import PackageGraph

--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -9,7 +9,6 @@
 */
 
 import Basic
-import enum Basic.Result
 import struct Utility.Version
 import class Foundation.NSDate
 

--- a/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
@@ -11,7 +11,6 @@
 import Dispatch
 
 import Basic
-import enum Basic.Result
 import PackageLoading
 import PackageModel
 import SourceControl

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -9,7 +9,6 @@
 */
 
 import Basic
-import enum Basic.Result
 import PackageModel
 import Utility
 import SPMLLBuild

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -12,7 +12,6 @@ import Dispatch
 import class Foundation.OperationQueue
 
 import Basic
-import enum Basic.Result
 import Utility
 
 /// Delegate to notify clients about actions being performed by RepositoryManager.

--- a/Sources/TestSupport/MockDependencyResolver.swift
+++ b/Sources/TestSupport/MockDependencyResolver.swift
@@ -11,7 +11,6 @@ import XCTest
 import Dispatch
 
 import Basic
-import enum Basic.Result
 import PackageGraph
 import SourceControl
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -9,7 +9,6 @@
 */
 
 import Basic
-import enum Basic.Result
 import Foundation
 import PackageLoading
 import PackageModel

--- a/Tests/BasicTests/AwaitTests.swift
+++ b/Tests/BasicTests/AwaitTests.swift
@@ -12,7 +12,6 @@ import XCTest
 import Dispatch
 
 import Basic
-import enum Basic.Result
 
 class AwaitTests: XCTestCase {
 

--- a/Tests/BasicTests/ResultTests.swift
+++ b/Tests/BasicTests/ResultTests.swift
@@ -11,7 +11,6 @@
 import XCTest
 
 import Basic
-import enum Basic.Result
 import TestSupport
 
 private enum DummyError: Swift.Error {


### PR DESCRIPTION
Reverts apple/swift-package-manager#1912. The compiler change in https://github.com/apple/swift/pull/21370 is meant to keep existing `Result` types working by introducing an appropriate name-shadowing rule.