### PR TITLE
[WIP] Improve dependency resolver

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -68,5 +68,8 @@ public class ToolOptions {
     /// The mode to use for indexing-while-building feature.
     public var indexStoreMode: BuildParameters.IndexStoreMode = .auto
 
+    /// Enable the experimental new dependency resolver based on Pubgrub.
+    public var enablePubgrubResolver = false
+
     public required init() {}
 }

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -377,6 +377,11 @@ public class SwiftTool<Options: ToolOptions> {
                 usage: "Disable indexing-while-building feature"),
             to: { if $1 { $0.indexStoreMode = .off } })
 
+        binder.bind(
+            option: parser.add(option: "--enable-pubgrub-resolver", kind: Bool.self,
+                               usage: "[Experimental] Enable the new Pubgrub dependency resolver"),
+            to: { $0.enablePubgrubResolver = $1 })
+
         // Let subclasses bind arguments.
         type(of: self).defineArguments(parser: parser, binder: binder)
 
@@ -485,6 +490,7 @@ public class SwiftTool<Options: ToolOptions> {
             config: try getSwiftPMConfig(),
             repositoryProvider: provider,
             isResolverPrefetchingEnabled: options.shouldEnableResolverPrefetching,
+            enablePubgrubResolver: options.enablePubgrubResolver,
             skipUpdate: options.skipDependencyUpdate
         )
         _workspace = workspace

--- a/Sources/PackageGraph/Pubgrub.swift
+++ b/Sources/PackageGraph/Pubgrub.swift
@@ -1,0 +1,937 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import struct Utility.Version
+import Basic
+
+/// A term represents a statement about a package that may be true or false.
+struct Term<Identifier: PackageContainerIdentifier>: Equatable, Hashable {
+    typealias Requirement = PackageContainerConstraint<Identifier>.Requirement
+
+    let package: Identifier
+    let requirement: Requirement
+    let isPositive: Bool
+
+    init(package: Identifier, requirement: Requirement, isPositive: Bool) {
+        self.package = package
+        self.requirement = requirement
+        self.isPositive = isPositive
+    }
+
+    init(_ package: Identifier, _ requirement: Requirement) {
+        self.init(package: package, requirement: requirement, isPositive: true)
+    }
+
+    /// Create a new negative term.
+    init(not package: Identifier, _ requirement: Requirement) {
+        self.init(package: package, requirement: requirement, isPositive: false)
+    }
+
+    /// The same term with an inversed `isPositive` value.
+    var inverse: Term {
+        return Term(package: package,
+                    requirement: requirement,
+                    isPositive: !isPositive)
+    }
+
+    /// Check if this term satisfies another term, e.g. if `self` is true,
+    /// `other` must also be true.
+    func satisfies(other: Term) -> Bool {
+        // TODO: This probably makes more sense as isSatisfied(by:) instead.
+        guard self.package == other.package else { return false }
+
+        let samePolarity = self.isPositive == other.isPositive
+
+        switch (self.requirement, other.requirement) {
+        case (.versionSet(let lhs), .versionSet(let rhs)):
+            switch (lhs, rhs) {
+            case (.empty, _), (_, .empty):
+                return !samePolarity
+            case (.any, _), (_, .any):
+                return samePolarity
+            case (.exact(let lhs), .exact(let rhs)):
+                return lhs == rhs && samePolarity
+            case (.exact(let lhs), .range(let rhs)),
+                 (.range(let rhs), .exact(let lhs)):
+                return (rhs.contains(version: lhs) && samePolarity)
+                    || (!rhs.contains(version: lhs) && !samePolarity)
+            case (.range(let lhs), .range(let rhs)):
+                let equalsOrContains = lhs == rhs || (lhs.contains(rhs) || rhs.contains(lhs))
+                return (equalsOrContains && samePolarity) || (!equalsOrContains && !samePolarity)
+            }
+        case (.revision(let lhs), .revision(let rhs)):
+            return lhs == rhs
+        case (.unversioned, .unversioned):
+            return false
+        default:
+            return false
+        }
+    }
+
+    func isSatisfied(by other: Version) -> Bool {
+        // TODO: isPositive plays a role here as well, doesn't it?
+        switch requirement {
+        case .versionSet(.exact(let version)):
+            return version == other
+        case .versionSet(.range(let range)):
+            return range.contains(other)
+        case .versionSet(.any):
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Create an intersection with another term returning a new term which
+    /// represents the version constraints allowed by both the current and
+    /// given term.
+    /// Returns `nil` if an intersection is not possible (possibly due to
+    /// being constrained on branches, revisions, local, etc. or entirely
+    /// different packages).
+    func intersect(with other: Term) -> Term? {
+        // TODO: This needs more tests.
+        guard self.package == other.package else { return nil }
+        guard case .versionSet(let lhs) = self.requirement, case .versionSet(let rhs) = other.requirement else { return nil }
+
+        let samePolarity = self.isPositive == other.isPositive
+
+        if samePolarity {
+            if case .range(let lhs) = lhs, case .range(let rhs) = rhs {
+                let bothNegative = !self.isPositive && !other.isPositive
+                if bothNegative {
+                    guard lhs.overlaps(rhs) || rhs.overlaps(lhs) else { return nil }
+
+                    let lower = min(lhs.lowerBound, rhs.lowerBound)
+                    let upper = max(lhs.upperBound, rhs.upperBound)
+                    return self.with(.versionSet(.range(lower..<upper)))
+                }
+            }
+
+            let intersection = lhs.intersection(rhs)
+            return Term(package, .versionSet(intersection))
+        } else {
+            switch (lhs, rhs) {
+            case (.exact(let lhs), .exact(let rhs)):
+                return lhs == rhs ? self : nil
+            case (.exact(let exact), .range(let range)), (.range(let range), .exact(let exact)):
+                if range.contains(version: exact) {
+                    return self.with(.versionSet(.range(range.lowerBound..<exact)))
+                }
+                return nil
+            case (.range(let lhs), .range(let rhs)):
+                guard lhs.overlaps(rhs) || rhs.overlaps(lhs) else { return nil }
+                var lower: Range<Version>.Bound
+                var upper: Range<Version>.Bound
+                if lhs.upperBound > rhs.upperBound {
+                    lower = min(rhs.upperBound, lhs.upperBound)
+                    upper = max(rhs.upperBound, lhs.upperBound)
+                } else {
+                    lower = min(lhs.lowerBound, rhs.lowerBound)
+                    upper = max(lhs.lowerBound, rhs.lowerBound)
+                }
+                return self.with(.versionSet(.range(lower..<upper)))
+            default:
+                // This covers any combinations including .empty or .any.
+                return nil
+            }
+        }
+    }
+
+    func difference(with other: Term) -> Term? {
+        return self.intersect(with: other.inverse)
+    }
+
+    private func with(_ requirement: Requirement) -> Term {
+        return Term(package: self.package,
+                    requirement: requirement,
+                    isPositive: self.isPositive)
+    }
+
+    /// Verify if the term fulfills all requirements to be a valid choice for
+    /// making a decision in the given partial solution.
+    /// - There has to exist a positive derivation for it.
+    /// - There has to be no decision for it.
+    /// - The package version has to match all assignments.
+    func isValidDecision(for solution: PartialSolution<Identifier>) -> Bool {
+        for assignment in solution.assignments where assignment.term.package == package {
+            guard !assignment.isDecision else { return false }
+            guard satisfies(other: assignment.term) else { return false }
+        }
+        return true
+    }
+}
+
+private extension Range where Bound == Version {
+    func contains(_ other: Range<Version>) -> Bool {
+        return contains(version: other.lowerBound) &&
+            contains(version: other.upperBound)
+    }
+}
+
+/// A set of terms that are incompatible with each other and can therefore not
+/// all be true at the same time. In dependency resolution, these are derived
+/// from version requirements and when running into unresolvable situations.
+public struct Incompatibility<Identifier: PackageContainerIdentifier>: Equatable, Hashable {
+    let terms: Set<Term<Identifier>>
+    let cause: Cause<Identifier>
+
+    init(_ terms: Term<Identifier>..., cause: Cause<Identifier> = .root) {
+        self.init(Set(terms), cause: cause)
+    }
+
+    init(_ terms: Set<Term<Identifier>>, cause: Cause<Identifier>) {
+        // TODO: Normalize terms so that each package has at most one term referring to it.
+        assert(terms.count > 0,
+               "An incompatibility must contain at least one term.")
+        self.terms = terms
+        self.cause = cause
+    }
+}
+
+extension Incompatibility {
+    /// Every incompatibility has a cause to explain its presence in the
+    /// derivation graph. Only the root incompatibility uses `.root`. All other
+    /// incompatibilities are either obtained from dependency constraints,
+    /// decided upon in decision making or derived during unit propagation or
+    /// conflict resolution.
+    /// Using this information we can build up a derivation graph by following
+    /// the tree of causes. All leaf nodes are external dependencies and all
+    /// internal nodes are derived incompatibilities.
+    ///
+    /// An example graph could look like this:
+    /// ```
+    /// ┌────────────────────────────┐ ┌────────────────────────────┐
+    /// │{foo ^1.0.0, not bar ^2.0.0}│ │{bar ^2.0.0, not baz ^3.0.0}│
+    /// └─────────────┬──────────────┘ └──────────────┬─────────────┘
+    ///               │      ┌────────────────────────┘
+    ///               ▼      ▼
+    /// ┌─────────────┴──────┴───────┐ ┌────────────────────────────┐
+    /// │{foo ^1.0.0, not baz ^3.0.0}│ │{root 1.0.0, not foo ^1.0.0}│
+    /// └─────────────┬──────────────┘ └──────────────┬─────────────┘
+    ///               │   ┌───────────────────────────┘
+    ///               ▼   ▼
+    ///         ┌─────┴───┴──┐
+    ///         │{root 1.0.0}│
+    ///         └────────────┘
+    /// ```
+    indirect enum Cause<Identifier: PackageContainerIdentifier>: Equatable, Hashable {
+        /// represents the root incompatibility
+        case root
+        /// represents a package's dependency
+        case dependency(package: Identifier)
+        /// represents an incompatibility derived from two others during
+        /// conflict resolution
+        case conflict(conflict: Incompatibility, other: Incompatibility)
+        // TODO: Figure out what other cases should be represented here.
+        // - SDK requirements
+        // - no available versions
+        // - package not found
+
+        var isConflict: Bool {
+            if case .conflict = self {
+                return true
+            }
+            return false
+        }
+
+        /// Returns whether this cause can be represented in a single line of the
+        /// error output.
+        var isSingleLine: Bool {
+            guard case .conflict(let lhs, let rhs) = self else {
+                // TODO: Sure?
+                return false
+            }
+            if case .conflict = lhs.cause, case .conflict = rhs.cause {
+                return false
+            }
+            return true
+        }
+    }
+}
+
+/// An assignment that is either decided upon during decision making or derived
+/// from previously known incompatibilities during unit propagation.
+///
+/// All assignments store a term (a package identifier and a version
+/// requirement) and a decision level, which represents the number of decisions
+/// at or before it in the partial solution that caused it to be derived. This
+/// is later used during conflict resolution to figure out how far back to jump
+/// when a conflict is found.
+struct Assignment<Identifier: PackageContainerIdentifier>: Equatable {
+    let term: Term<Identifier>
+    let decisionLevel: Int
+    let cause: Incompatibility<Identifier>?
+    let isDecision: Bool
+
+    private init(term: Term<Identifier>,
+                 decisionLevel: Int,
+                 cause: Incompatibility<Identifier>?,
+                 isDecision: Bool) {
+        self.term = term
+        self.decisionLevel = decisionLevel
+        self.cause = cause
+        self.isDecision = isDecision
+    }
+
+    /// An assignment made during decision making.
+    static func decision(_ term: Term<Identifier>, decisionLevel: Int) -> Assignment {
+        return self.init(term: term,
+                         decisionLevel: decisionLevel,
+                         cause: nil,
+                         isDecision: true)
+    }
+
+    /// An assignment derived from previously known incompatibilities during
+    /// unit propagation.
+    static func derivation(_ term: Term<Identifier>,
+                           cause: Incompatibility<Identifier>,
+                           decisionLevel: Int) -> Assignment {
+        return self.init(term: term,
+                         decisionLevel: decisionLevel,
+                         cause: cause,
+                         isDecision: false)
+    }
+}
+
+/// The partial solution is a constantly updated solution used throughout the
+/// dependency resolution process, tracking know assignments.
+final class PartialSolution<Identifier: PackageContainerIdentifier> {
+    var assignments: [Assignment<Identifier>]
+
+    /// The current decision level.
+    var decisionLevel: Int {
+        return assignments.count
+    }
+
+    init(assignments: [Assignment<Identifier>] = []) {
+        self.assignments = assignments
+    }
+
+    /// The intersection of all positive assignments for each package, minus any
+    /// negative assignments that refer to that package.
+    var positive: [Identifier: Term<Identifier>] {
+        var values: [Identifier: Term<Identifier>] = [:]
+        for val in assignments {
+            let term = values[val.term.package]
+
+            if val.term.isPositive {
+                values[val.term.package] = term != nil ? term!.intersect(with: val.term) : val.term
+            } else {
+                values[val.term.package] = term != nil ? term!.difference(with: val.term) : val.term
+            }
+        }
+        return values
+    }
+
+    /// A list of all packages that have been assigned, but are not yet satisfied.
+    var unsatisfied: [Term<Identifier>] {
+        let decisionTerms = assignments
+            .filter { $0.isDecision }
+            .map { $0.term }
+        return positive.values.filter { !decisionTerms.contains($0) }
+    }
+
+    /// Create a new derivation assignment and add it to the partial solution's
+    /// list of known assignments.
+    func derive(_ term: Term<Identifier>, cause: Incompatibility<Identifier>) {
+        let derivation = Assignment.derivation(term,
+                                               cause: cause,
+                                               decisionLevel: decisionLevel)
+        self.assignments.append(derivation)
+    }
+
+    /// Create a new decision assignment and add it to the partial solution's
+    /// list of known assignments.
+    func decide(_ term: Term<Identifier>) {
+        let decision = Assignment.decision(term, decisionLevel: decisionLevel)
+        self.assignments.append(decision)
+    }
+
+    /// Returns how much a given incompatibility is satisfied by assignments in
+    /// this solution.
+    ///
+    /// Three states are possible:
+    /// - Satisfied: The entire incompatibility is satisfied.
+    /// - Almost Satisfied: All but one term are satisfied.
+    /// - Unsatisfied: At least two terms are unsatisfied.
+    func satisfies(_ incompatibility: Incompatibility<Identifier>) -> Satisfaction<Identifier> {
+        return arraySatisfies(self.assignments, incompatibility: incompatibility)
+    }
+
+    /// Find a pair of assignments, a satisfier and a previous satisfier, for
+    /// which the partial solution satisfies a given incompatibility up to and
+    /// including the satisfier. The previous satisfier represents the first
+    /// assignment in the partial solution *before* the satisfier, for which
+    /// the partial solution also satisfies the given incompatibility if the
+    /// satisfier is also included.
+    ///
+    /// To summarize, assuming at least assignment A1, A2 and A4 are needed to
+    /// satisfy the assignment, (previous: A2, satisfier: A4) will be returned.
+    ///
+    /// In the case that the satisfier alone does not satisfy the
+    /// incompatibility, it is possible that `previous` and `satisifer` refer
+    /// to the same assignment.
+    func earliestSatisfiers(for incompat: Incompatibility<Identifier>) -> (previous: Assignment<Identifier>?, satisfier: Assignment<Identifier>?) {
+
+            var firstSatisfier: Assignment<Identifier>?
+            for idx in assignments.indices {
+                let slice = assignments[...idx]
+                if arraySatisfies(Array(slice), incompatibility: incompat) == .satisfied {
+                    firstSatisfier = assignments[idx]
+                    break
+                }
+            }
+
+            guard let satisfier = firstSatisfier else {
+                // The incompatibility is not (yet) satisfied by this solution's
+                // list of assignments.
+                return (nil, nil)
+            }
+
+            var previous: Assignment<Identifier>?
+            for idx in assignments.indices {
+                let slice = assignments[...idx] + [satisfier]
+                if arraySatisfies(Array(slice), incompatibility: incompat) == .satisfied {
+                    previous = assignments[idx]
+                    break
+                }
+            }
+
+            return (previous, satisfier)
+    }
+
+    /// Backtrack to a specific decision level by dropping all assignments with
+    /// a decision level which is greater.
+    func backtrack(toDecisionLevel decisionLevel: Int) {
+        assignments.removeAll { $0.decisionLevel > decisionLevel }
+    }
+
+    /// Create an intersection of the versions of all assignments referring to
+    /// a given package.
+    /// - Returns: nil if no assignments exist or intersection of versions is
+    ///            invalid.
+    func versionIntersection(for package: Identifier) -> Term<Identifier>? {
+        let packageAssignments = assignments.filter { $0.term.package == package }
+        let firstTerm = packageAssignments.first?.term
+        guard let intersection = packageAssignments
+            .reduce(firstTerm, { result, assignment in
+                guard let res = result?.intersect(with: assignment.term) else {
+                    return nil
+                }
+                return res
+            })
+        else {
+            return nil
+        }
+        return intersection
+    }
+}
+
+fileprivate func arraySatisfies<Identifier: PackageContainerIdentifier>(_ array: [Assignment<Identifier>], incompatibility: Incompatibility<Identifier>) -> Satisfaction<Identifier> {
+    guard array.count > 0 else { return .unsatisfied }
+
+    // Gather all terms which are satisfied by the assignments in the current solution.
+    let satisfiedTerms = incompatibility.terms.filter { term in
+        array.contains(where: { assignment in
+            assignment.term.satisfies(other: term)
+        })
+    }
+
+    switch satisfiedTerms.count {
+    case incompatibility.terms.count:
+        return .satisfied
+    case incompatibility.terms.count - 1:
+        let unsatisfied = incompatibility.terms.first { !satisfiedTerms.contains($0) }
+        return .almostSatisfied(except: unsatisfied!)
+    default:
+        return .unsatisfied
+    }
+}
+
+enum Satisfaction<Identifier: PackageContainerIdentifier>: Equatable {
+    case satisfied
+    case almostSatisfied(except: Term<Identifier>)
+    case unsatisfied
+}
+
+/// The solver that is able to transitively resolve a set of package constraints
+/// specified by a root package.
+public final class PubgrubDependencyResolver<
+    P: PackageContainerProvider,
+    D: DependencyResolverDelegate
+> where P.Container.Identifier == D.Identifier {
+    public typealias Provider = P
+    public typealias Delegate = D
+    public typealias Container = Provider.Container
+    public typealias Identifier = Container.Identifier
+    public typealias Binding = (container: Identifier, binding: BoundVersion)
+
+    /// The type of the constraints the resolver operates on.
+    ///
+    /// Technically this is a container constraint, but that is currently the
+    /// only kind of constraints we operate on.
+    public typealias Constraint = PackageContainerConstraint<Identifier>
+
+    /// The current best guess for a solution satisfying all requirements.
+    var solution = PartialSolution<Identifier>()
+
+    /// A collection of all known incompatibilities matched to the packages they
+    /// refer to. This means an incompatibility can occur several times.
+    var incompatibilities: [Identifier: [Incompatibility<Identifier>]] = [:]
+
+    /// The root package reference.
+    var root: Identifier? {
+        didSet {
+            guard let root = root else { return }
+            // .unversioned might be a better case for the root package, but .versionSet(.any)
+            // ensures that no special handling is necessary for unit propagation
+            // when checking the solution's satisfiability against the root package.
+            add(Incompatibility(Term(not: root, .versionSet(.any)), cause: .root))
+        }
+    }
+
+    /// The container provider used to load package containers.
+    let provider: Provider
+
+    /// The resolver's delegate.
+    let delegate: Delegate?
+
+    /// A subset of packages used during unit propagation.
+    var changed: Set<Identifier> = []
+
+    /// Skip updating containers while fetching them.
+    private let skipUpdate: Bool
+
+    public init(
+        _ provider: Provider,
+        _ delegate: Delegate? = nil,
+        skipUpdate: Bool = false
+    ) {
+        self.provider = provider
+        self.delegate = delegate
+        self.skipUpdate = skipUpdate
+    }
+
+    /// Add a new incompatibility to the list of known incompatibilities.
+    func add(_ incompatibility: Incompatibility<Identifier>) {
+        for package in incompatibility.terms.map({ $0.package }) {
+            if incompatibilities[package] != nil {
+                incompatibilities[package]!.append(incompatibility)
+            } else {
+                incompatibilities[package] = [incompatibility]
+            }
+        }
+    }
+
+    public typealias Result = DependencyResolver<P, D>.Result
+
+    // TODO: This should be the actual (and probably only) entrypoint to version solving.
+    /// Run the resolution algorithm on a root package finding a valid assignment of versions.
+    public func solve(root: Identifier, pins: [Constraint]) -> Result {
+        self.root = root
+        do {
+            return try .success(solve(constraints: [], pins: pins))
+        } catch {
+            return .error(error)
+        }
+    }
+
+    /// Execute the resolution algorithm to find a valid assignment of versions.
+    public func solve(dependencies: [Constraint], pins: [Constraint]) -> Result {
+        guard let root = dependencies.first?.identifier else {
+            fatalError("expected a root package")
+        }
+        self.root = root
+        return solve(root: root, pins: pins)
+    }
+
+    public enum Error: Swift.Error {
+        case unresolvable(Incompatibility<Identifier>)
+    }
+
+    /// Find a set of dependencies that fit the given constraints. If dependency
+    /// resolution is unable to provide a result, an error is thrown.
+    /// - Warning: It is expected that the root package reference has been set
+    ///            before this is called.
+    public func solve(constraints: [Constraint], pins: [Constraint]) throws -> [(container: Identifier, binding: BoundVersion)] {
+        // TODO: Handle pins
+        assert(self.root != nil)
+
+        var next: Identifier? = root
+        while let nxt = next {
+            if let conflict = propagate(nxt) {
+                guard let rootCause = resolve(conflict: conflict) else {
+                    throw Error.unresolvable(conflict)
+                }
+                changed.removeAll()
+
+                guard case Satisfaction.almostSatisfied(except: let term) = solution.satisfies(rootCause) else {
+                    fatalError("""
+                        Expected root cause [\(rootCause)] to almost satisfy the \
+                        current partial solution:
+                        \(solution)
+                        """)
+                }
+                changed.insert(term.package)
+            }
+
+            // If decision making determines that no more decisions are to be
+            // made, it returns nil to signal that version solving is done.
+            next = try makeDecision()
+        }
+
+        return solution.assignments.map { assignment in
+            var boundVersion: BoundVersion
+            switch assignment.term.requirement {
+            case .versionSet(.exact(let version)):
+                boundVersion = .version(version)
+            case .revision(let rev):
+                boundVersion = .revision(rev)
+            case .versionSet(.range(_)):
+                // FIXME: A new requirement type that makes having a range here impossible feels like the correct thing to do.
+                fatalError("Solution should not contain version ranges.")
+            case .unversioned, .versionSet(.any):
+                boundVersion = .unversioned
+            case .versionSet(.empty):
+                fatalError("Solution should not contain empty versionSet requirement.")
+            }
+
+            return (assignment.term.package, boundVersion)
+        }
+    }
+
+    /// Perform unit propagation to derive new assignments based on the current
+    /// partial solution.
+    /// If a conflict is found, the conflicting incompatibility is returned to
+    /// resolve the conflict on.
+    func propagate(_ package: Identifier) -> Incompatibility<Identifier>? {
+        changed.insert(package)
+        while !changed.isEmpty {
+            let package = changed.removeFirst()
+
+            // According to the experience of pub developers, conflict
+            // resolution produces more general incompatibilities later on
+            // making it advantageous to check those first.
+            for incompatibility in incompatibilities[package]?.reversed() ?? [] {
+                    switch solution.satisfies(incompatibility) {
+                    case .unsatisfied:
+                        break
+                    case .satisfied:
+                        return incompatibility
+                    case .almostSatisfied(except: let term):
+                        solution.derive(term.inverse,
+                                        cause: incompatibility)
+                    }
+            }
+        }
+
+        return nil
+    }
+
+    /// Perform conflict resolution to backtrack to the root cause of a
+    /// satisfied incompatibility and create a new incompatibility that blocks
+    /// off the search path that led there.
+    /// Returns nil if version solving is unsuccessful.
+    func resolve(conflict: Incompatibility<Identifier>) -> Incompatibility<Identifier>? {
+        var incompatibility = conflict
+
+        // As long as the incompatibility doesn't specify that version solving
+        // has failed entirely...
+        while !isCompleteFailure(incompatibility) {
+            // Find the earliest assignment so that `incompatibility` is
+            // satisfied by the partial solution up to and including it.
+            // ↳ `satisfier`
+            // Also find the earliest assignment before `satisfier` which
+            // satisfies `incompatibility` up to and including it + `satisfier`.
+            // ↳ `previous`
+            let (previous, satisfier) = solution.earliestSatisfiers(for: incompatibility)
+
+            // `term` is incompatibility's term referring to the same term as
+            // satisfier.
+            let term = incompatibility.terms.first { $0.package == satisfier?.term.package }
+
+            // Decision level is where the root package was selected. According
+            // to PubGrub documentation it's also fine to fall back to 0, but
+            // choosing 1 tends to produce better error output.
+            let previousSatisfierLevel = previous?.decisionLevel ?? 1
+
+            if satisfier?.isDecision ?? false || previousSatisfierLevel != satisfier?.decisionLevel {
+                if incompatibility != conflict {
+                    add(incompatibility)
+                }
+                solution.backtrack(toDecisionLevel: previousSatisfierLevel)
+                return incompatibility
+            } else {
+                // `priorCauseTerms` should be a union of the terms in
+                // `incompatibility` and the terms in `satisfier`'s cause, minus
+                // the terms referring to `satisfier`'s package.
+                var priorCauseTerms = incompatibility.terms.union(satisfier?.cause?.terms ?? [])
+                priorCauseTerms = priorCauseTerms.filter { $0.package != satisfier?.term.package }
+
+                if !satisfier!.term.satisfies(other: term!) {
+                    // add ¬(satisfier \ term) to priorCauseTerms
+                    if satisfier?.term != term {
+                        priorCauseTerms.insert(satisfier!.term.inverse)
+                    }
+                }
+
+                incompatibility = Incompatibility(priorCauseTerms,
+                                                  cause: .conflict(conflict: conflict,
+                                                                   other: incompatibility))
+            }
+        }
+
+        // TODO: Report error with `incompatibility` as the root incompatibility.
+        return nil
+    }
+
+    /// Does a given incompatibility specify that version solving has entirely
+    /// failed? E.g. is this incompatibility either empty or only for the root
+    /// package?
+    private func isCompleteFailure(_ incompatibility: Incompatibility<Identifier>) -> Bool {
+        guard !incompatibility.terms.isEmpty else { return true }
+        return incompatibility.terms.first?.package == root
+    }
+
+    func makeDecision() throws -> Identifier? {
+        // If there are no more unsatisfied terms, version solving is complete.
+        guard !solution.unsatisfied.isEmpty else { return nil }
+
+        // Select a possible candidate from all unsatisfied assignments, making
+        // sure it only exists as a positive derivation and no decision.
+        for candidate in solution.unsatisfied where candidate.isValidDecision(for: solution) {
+            guard let term = solution.versionIntersection(for: candidate.package) else {
+                fatalError("failed to create version intersection for \(candidate.package)")
+            }
+
+            // select an actual `version` of `candidate` that matches `term`
+            let container = try! getContainer(for: term.package)
+            let latestVersion = Array(container.versions { term.isSatisfied(by: $0) }).first
+
+            // if no such version exists
+            //    add incompatibility {term} to incompatibilities and return package's name
+            //    this avoids this range of versions in the future
+            guard let version = latestVersion else {
+                // FIXME: Use correct cause
+                let incompatibility = Incompatibility(term, cause: .root)
+                add(incompatibility)
+                continue
+            }
+
+            // add each incompatibility from version's dependencies to incompatibilities
+            try container.getDependencies(at: version)
+                .map { dep -> Incompatibility<Identifier> in
+                    let terms: Set = [
+                        Term(not: candidate.package, .versionSet(.exact(version))),
+                        Term(dep.identifier, dep.requirement)
+                    ]
+                    return Incompatibility(terms, cause: Incompatibility<Identifier>.Cause.dependency(package: candidate.package))
+                }
+                .forEach { add($0) }
+
+            // add `version` to partial solution as a decision, unless this would produce a conflict in any of the new incompatibilities
+            // FIXME: Use correct cause
+            let candidateIncompat = Incompatibility(Term(candidate.package, .versionSet(.exact(version))),
+                                                    cause: .root)
+//            if case .satisfied = solution.satisfies(candidateIncompat) {
+//                continue // TODO: is this correct?
+//            }
+            solution.decide(Term(candidate.package, .versionSet(.exact(version))))
+
+            return candidate.package
+        }
+
+        return nil
+    }
+
+    // MARK: - Error Reporting
+
+    private var derivations: [Incompatibility<Identifier>: Int] = [:]
+
+    func reportError(for incompatibility: Incompatibility<Identifier>) -> String {
+        /// Populate `derivations`.
+        func countDerivations(_ i: Incompatibility<Identifier>) {
+            derivations[i, default: 0] += 1
+            if case .conflict(let lhs, let rhs) = i.cause {
+                countDerivations(lhs)
+                countDerivations(rhs)
+            }
+        }
+
+        countDerivations(incompatibility)
+
+        let stream = BufferedOutputByteStream()
+        visit(incompatibility, stream)
+
+        return stream.bytes.asString!
+    }
+
+    private func visit(_ incompatibility: Incompatibility<Identifier>,
+                       _ stream: BufferedOutputByteStream,
+                       isConclusion: Bool = false) {
+
+        let isNumbered = isConclusion || derivations[incompatibility]! > 1
+
+        guard case .conflict(let lhs, let rhs) = incompatibility.cause else {
+            // TODO: Do nothing else here?
+            return
+        }
+
+        switch (lhs.cause, rhs.cause) {
+        case (.conflict, .conflict):
+            let lhsLine = lineNumbers[lhs]
+            let rhsLine = lineNumbers[rhs]
+
+            switch (lhsLine, rhsLine) {
+            case (.some(let lhsLine), .some(let rhsLine)):
+                write(incompatibility,
+                      message: "Because \(lhs) (\(lhsLine)) and \(rhs) (\(rhsLine), \(incompatibility).",
+                      isNumbered: isNumbered,
+                      toStream: stream)
+            case (.some(let lhsLine), .none):
+                visit(incompatibility, stream)
+                write(incompatibility,
+                      message: "And because \(lhs) (\(lhsLine)), \(incompatibility).",
+                      isNumbered: isNumbered,
+                      toStream: stream)
+            case (.none, .some(let rhsLine)):
+                visit(incompatibility, stream)
+                write(incompatibility,
+                      message: "And because \(rhs) (\(rhsLine)), \(incompatibility).",
+                      isNumbered: isNumbered,
+                      toStream: stream)
+            case (.none, .none):
+                let singleLineConflict = lhs.cause.isSingleLine
+                let singleLineOther = rhs.cause.isSingleLine
+
+                if singleLineOther || singleLineConflict {
+                    let simple = singleLineOther ? lhs : rhs
+                    let complex = singleLineOther ? rhs : lhs
+                    visit(simple, stream)
+                    visit(complex, stream)
+                    write(incompatibility,
+                          message: "Thus, \(incompatibility)",
+                          isNumbered: isNumbered,
+                          toStream: stream)
+                } else {
+                    visit(lhs, stream, isConclusion: true)
+                    write(incompatibility,
+                          message: "\n",
+                          isNumbered: isNumbered,
+                          toStream: stream)
+
+                    visit(rhs, stream)
+                    // TODO: lhsLine will always be nil here...
+                    write(incompatibility,
+                          message: "And because \(lhs) (\(lhsLine ?? -1)), \(incompatibility).",
+                          isNumbered: isNumbered,
+                          toStream: stream)
+                }
+
+            }
+        case (.conflict, _), (_, .conflict):
+            var derived: Incompatibility<Identifier>
+            var external: Incompatibility<Identifier>
+            if case .conflict = lhs.cause {
+                derived = lhs
+                external = rhs
+            } else {
+                derived = rhs
+                external = lhs
+            }
+
+            if let derivedLine = lineNumbers[derived] {
+                write(incompatibility,
+                      message: "Because \(external) and \(derived) (\(derivedLine)), \(incompatibility).",
+                      isNumbered: isNumbered,
+                      toStream: stream)
+            } else if derivations[incompatibility]! <= 1 {
+                guard case .conflict(let lhs, let rhs) = derived.cause else {
+                    // FIXME
+                    fatalError("unexpected non-conflict")
+                }
+                let collapsedDerived = lhs.cause.isConflict ? rhs : lhs
+                let collapsedExternal = lhs.cause.isConflict ? rhs : lhs
+                visit(collapsedDerived, stream)
+                write(incompatibility,
+                      message: "And because \(collapsedExternal) and \(external), \(incompatibility).",
+                      isNumbered: isNumbered,
+                      toStream: stream)
+            } else {
+                visit(derived, stream)
+                write(incompatibility,
+                      message: "And because \(external), \(incompatibility).",
+                      isNumbered: isNumbered,
+                      toStream: stream)
+            }
+        default:
+            write(incompatibility,
+                  message: "Because \(lhs) and \(rhs), \(incompatibility).",
+                  isNumbered: isNumbered,
+                  toStream: stream)
+        }
+    }
+
+    private var lineNumbers: [Incompatibility<Identifier>: Int] = [:]
+
+    /// Write a given output message to a stream. The message should describe
+    /// the incompatibility and how it as derived. If `isNumbered` is true, a
+    /// line number will be assigned to this incompatibility so that it can be
+    /// referred to again.
+    private func write(_ i: Incompatibility<Identifier>,
+                       message: String,
+                       isNumbered: Bool,
+                       toStream stream: BufferedOutputByteStream) {
+        if isNumbered {
+            let number = lineNumbers.count + 1
+            lineNumbers[i] = number
+            // TODO: Handle `number`
+            stream <<< message
+        } else {
+            stream <<< message
+        }
+    }
+
+    // MARK: - Container Management
+
+    /// Condition for container management structures.
+    private let fetchCondition = Condition()
+
+    /// The list of fetched containers.
+    private var _fetchedContainers: [Identifier: Basic.Result<Container, AnyError>] = [:]
+
+    /// The set of containers requested so far.
+    private var _prefetchingContainers: Set<Identifier> = []
+
+    /// Get the container for the given identifier, loading it if necessary.
+    fileprivate func getContainer(for identifier: Identifier) throws -> Container {
+        return try fetchCondition.whileLocked {
+            // Return the cached container, if available.
+            if let container = _fetchedContainers[identifier] {
+                return try container.dematerialize()
+            }
+
+            // If this container is being prefetched, wait for that to complete.
+            while _prefetchingContainers.contains(identifier) {
+                fetchCondition.wait()
+            }
+
+            // The container may now be available in our cache if it was prefetched.
+            if let container = _fetchedContainers[identifier] {
+                return try container.dematerialize()
+            }
+
+            // Otherwise, fetch the container synchronously.
+            let container = try await { provider.getContainer(for: identifier, skipUpdate: skipUpdate, completion: $0) }
+            self._fetchedContainers[identifier] = Basic.Result(container)
+            return container
+        }
+    }
+}

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -322,7 +322,7 @@ public enum SystemPackageProviderDescription: Equatable {
 public struct PackageDependencyDescription: Equatable, Codable {
 
     /// The dependency requirement.
-    public enum Requirement: Equatable, CustomStringConvertible {
+    public enum Requirement: Equatable, Hashable, CustomStringConvertible {
         case exact(Version)
         case range(Range<Version>)
         case revision(String)

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -279,6 +279,9 @@ public class Workspace {
     /// Enable prefetching containers in resolver.
     fileprivate let isResolverPrefetchingEnabled: Bool
 
+    /// Enable the new Pubgrub dependency resolver.
+    fileprivate let enablePubgrubResolver: Bool
+
     /// Skip updating containers while fetching them.
     fileprivate let skipUpdate: Bool
 
@@ -311,6 +314,7 @@ public class Workspace {
         fileSystem: FileSystem = localFileSystem,
         repositoryProvider: RepositoryProvider = GitRepositoryProvider(),
         isResolverPrefetchingEnabled: Bool = false,
+        enablePubgrubResolver: Bool = false,
         skipUpdate: Bool = false
     ) {
         self.delegate = delegate
@@ -321,6 +325,7 @@ public class Workspace {
         self.currentToolsVersion = currentToolsVersion
         self.toolsVersionLoader = toolsVersionLoader
         self.isResolverPrefetchingEnabled = isResolverPrefetchingEnabled
+        self.enablePubgrubResolver = enablePubgrubResolver
         self.skipUpdate = skipUpdate
 
         let repositoriesPath = self.dataPath.appending(component: "repositories")

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -1,0 +1,475 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import XCTest
+
+import Basic
+import PackageLoading
+import PackageModel
+@testable import PackageGraph
+import SourceControl
+
+private struct MockPGContainer: PackageContainer {
+    typealias Identifier = PackageReference
+    var identifier: PackageReference
+
+    var dependencies: [PackageContainerConstraint<PackageReference>]
+
+    init(identifier: PackageReference, dependencies: [Term<PackageReference>] = []) {
+        self.identifier = identifier
+        self.dependencies = dependencies.map {
+            PackageContainerConstraint(container: $0.package, requirement: $0.requirement)
+        }
+    }
+
+    func versions(filter isIncluded: (Version) -> Bool) -> AnySequence<Version> {
+        return AnySequence {
+            return [Version(stringLiteral: "1.0.0")].makeIterator()
+        }
+    }
+
+    func getDependencies(at version: Version) throws -> [PackageContainerConstraint<PackageReference>] {
+        return dependencies
+    }
+
+    func getDependencies(at revision: String) throws -> [PackageContainerConstraint<PackageReference>] {
+        return []
+    }
+
+    func getUnversionedDependencies() throws -> [PackageContainerConstraint<PackageReference>] {
+        return []
+    }
+
+    func getUpdatedIdentifier(at boundVersion: BoundVersion) throws -> PackageReference {
+        return identifier
+    }
+}
+
+private class MockPGProvider: PackageContainerProvider {
+    typealias Container = MockPGContainer
+
+    var containers: [MockPGContainer.Identifier: MockPGContainer] = [:]
+
+    func getContainer(for identifier: MockPGContainer.Identifier, skipUpdate: Bool, completion: @escaping (Result<MockPGContainer, AnyError>) -> Void) {
+        guard let container = containers[identifier] else {
+            fatalError("container not found")
+        }
+        completion(.success(container))
+    }
+
+    func _register(package: PackageReference, dependencies: [Term<PackageReference>] = []) {
+        containers[package] = MockPGContainer(identifier: package, dependencies: dependencies)
+        dependencies.forEach {
+            containers[$0.package] = MockPGContainer(identifier: $0.package)
+        }
+    }
+}
+
+struct MockPGDelegate: DependencyResolverDelegate {
+    typealias Identifier = PackageReference
+}
+
+private let provider = MockPGProvider()
+private let delegate = MockPGDelegate()
+
+private let solver = PubgrubDependencyResolver(provider, delegate)
+
+private let v1: Version = "1.0.0"
+private let v1_1: Version = "1.1.0"
+private let v2: Version = "2.0.0"
+private let v0_0_0Range: VersionSetSpecifier = .range("0.0.0" ..< "0.0.1")
+private let v1Range: VersionSetSpecifier = .range("1.0.0" ..< "2.0.0")
+private let v1to3Range: VersionSetSpecifier = .range("1.0.0" ..< "3.0.0")
+private let v2Range: VersionSetSpecifier = .range("2.0.0" ..< "3.0.0")
+private let v1_to_3Range: VersionSetSpecifier = .range("1.0.0" ..< "3.0.0")
+private let v2_to_4Range: VersionSetSpecifier = .range("2.0.0" ..< "4.0.0")
+private let v1_0Range: VersionSetSpecifier = .range("1.0.0" ..< "1.1.0")
+private let v1_1Range: VersionSetSpecifier = .range("1.1.0" ..< "1.2.0")
+private let v1_1_0Range: VersionSetSpecifier = .range("1.1.0" ..< "1.1.1")
+private let v2_0_0Range: VersionSetSpecifier = .range("2.0.0" ..< "2.0.1")
+
+let fooRef = PackageReference(identity: "foo", path: "")
+let barRef = PackageReference(identity: "bar", path: "")
+
+let rootRef = PackageReference(identity: "root", path: "")
+let rootCause = Incompatibility(Term(rootRef, .versionSet(.any)))
+
+
+
+final class PubgrubTests: XCTestCase {
+    override func setUp() {
+        solver.reset()
+    }
+
+    func testTermInverse() {
+        let t1 = Term(fooRef, .versionSet(.exact("1.0.0")))
+        XCTAssertFalse(t1.inverse.isPositive)
+        XCTAssertTrue(t1.inverse.inverse.isPositive)
+    }
+
+    func testTermSatisfies() {
+        let tfoo: Term<PackageReference> = Term(fooRef, .versionSet(.exact("1.0.0")))
+
+        XCTAssertFalse(tfoo.satisfies(
+            other: Term(barRef, .unversioned)))
+        XCTAssertTrue(tfoo.satisfies(other: tfoo))
+        XCTAssertTrue(tfoo.satisfies(
+            other: Term(fooRef, .versionSet(.range("1.0.0"..<"2.0.0")))))
+        XCTAssertFalse(tfoo.satisfies(
+            other: Term(fooRef, .versionSet(.range("2.0.0"..<"3.0.0")))))
+
+        XCTAssertFalse(tfoo.satisfies(other: "¬foo@1.0.0"))
+        XCTAssertFalse(tfoo.satisfies(other: "¬foo^1.0.0"))
+        XCTAssertTrue(Term(not: fooRef, .versionSet(.exact("1.0.0"))).satisfies(other: "¬foo^1.0.0"))
+        XCTAssertTrue(Term(not: fooRef, .versionSet(.exact("1.0.0"))).satisfies(other: "foo^2.0.0"))
+        XCTAssertTrue(Term(fooRef, .versionSet(.range("1.0.0"..<"2.0.0"))).satisfies(other: "¬foo@2.0.0"))
+        XCTAssertTrue(Term(fooRef, .versionSet(.range("1.0.0"..<"2.0.0"))).satisfies(other: "¬foo^2.0.0"))
+
+        XCTAssertTrue(Term(fooRef, .versionSet(.range("1.0.0"..<"2.0.0"))).satisfies(
+            other: Term(fooRef, .versionSet(.range("1.0.0"..<"2.0.0")))))
+        XCTAssertTrue(Term(fooRef, .versionSet(.range("1.0.0"..<"1.1.0"))).satisfies(
+            other: Term(fooRef, .versionSet(.range("1.0.0"..<"2.0.0")))))
+        XCTAssertFalse(Term(fooRef, .versionSet(.range("1.0.0"..<"1.1.0"))).satisfies(
+            other: Term(fooRef, .versionSet(.range("2.0.0"..<"3.0.0")))))
+
+        XCTAssertTrue(Term(fooRef, .revision("foobar")).satisfies(
+            other: Term(fooRef, .revision("foobar"))))
+        XCTAssertFalse(Term(fooRef, .revision("foobar")).satisfies(
+            other: Term(fooRef, .revision("barfoo"))))
+    }
+
+    func testTermIntersect() {
+        // foo^1.0.0 ∩ ¬foo@1.5.0 → foo >=1.0.0 <1.5.0
+        XCTAssertEqual(
+            Term(fooRef, .versionSet(.range("1.0.0"..<"2.0.0")))
+                .intersect(with: Term(not: fooRef, .versionSet(.exact("1.5.0")))),
+            Term(fooRef, .versionSet(.range("1.0.0"..<"1.5.0"))))
+
+        // foo^1.0.0 ∩ foo >=1.5.0 <3.0.0 → foo^1.5.0
+        XCTAssertEqual(
+            Term(fooRef, .versionSet(.range("1.0.0"..<"2.0.0")))
+                .intersect(with: Term(fooRef, .versionSet(.range("1.5.0"..<"3.0.0")))),
+            Term(fooRef, .versionSet(.range("1.5.0"..<"2.0.0"))))
+
+        // ¬foo^1.0.0 ∩ ¬foo >=1.5.0 <3.0.0 → ¬foo >=1.0.0 <3.0.0
+        XCTAssertEqual(
+            Term(not: fooRef, .versionSet(.range("1.0.0"..<"2.0.0")))
+                .intersect(with: Term(not: fooRef, .versionSet(.range("1.5.0"..<"3.0.0")))),
+            Term(not: fooRef, .versionSet(.range("1.0.0"..<"3.0.0"))))
+    }
+
+    func testTermIsValidDecision() {
+        let cause = Incompatibility<PackageReference>("cause@0.0.0")
+
+        let s1 = PartialSolution(assignments: [
+            .derivation("a^1.0.0", cause: cause, decisionLevel: 1)
+        ])
+        let t1: Term<PackageReference> = "a@1.5.0"
+        XCTAssertTrue(t1.isValidDecision(for: s1))
+
+        let s2 = PartialSolution(assignments: [
+            .derivation("a^1.0.0", cause: cause, decisionLevel: 1),
+            .decision("a^1.0.0", decisionLevel: 1)
+        ])
+        let t2: Term<PackageReference> = "a@1.5.0"
+        XCTAssertFalse(t2.isValidDecision(for: s2))
+
+        let s3 = PartialSolution(assignments: [
+            .derivation("¬a@1.0.0", cause: cause, decisionLevel: 1)
+        ])
+        let t3: Term<PackageReference> = "a@1.0.0"
+        XCTAssertFalse(t3.isValidDecision(for: s3))
+
+        let s4 = PartialSolution(assignments: [
+            .derivation("a^1.0.0", cause: cause, decisionLevel: 1),
+            .derivation("a^1.5.0", cause: cause, decisionLevel: 2)
+        ])
+        let t4: Term<PackageReference> = "a@1.6.0"
+        XCTAssertTrue(t4.isValidDecision(for: s4))
+
+        let s5 = PartialSolution(assignments: [
+            .derivation("a^1.0.0", cause: cause, decisionLevel: 1),
+            .derivation("a^1.5.0", cause: cause, decisionLevel: 2)
+        ])
+        let t5: Term<PackageReference> = "a@1.2.0"
+        XCTAssertFalse(t5.isValidDecision(for: s5))
+    }
+
+    func testSolutionPositive() {
+        let s1 = PartialSolution<PackageReference>(assignments:[
+            .decision("a^1.5.0", decisionLevel: 0),
+            .decision("b@2.0.0", decisionLevel: 0),
+            .decision("a^1.0.0", decisionLevel: 0)
+        ])
+        XCTAssertEqual(s1.positive.count, 2)
+        let a1 = s1.positive.first { $0.key.identity == "a" }?.value
+        XCTAssertEqual(a1?.requirement, .versionSet(.range("1.5.0"..<"2.0.0")))
+        let b1 = s1.positive.first { $0.key.identity == "b" }?.value
+        XCTAssertEqual(b1?.requirement, .versionSet(.exact("2.0.0")))
+
+        let s2 = PartialSolution<PackageReference>(assignments: [
+            .decision("¬a^1.5.0", decisionLevel: 0),
+            .decision("a^1.0.0", decisionLevel: 0)
+        ])
+        XCTAssertEqual(s2.positive.count, 1)
+        let a2 = s2.positive.first { $0.key.identity == "a" }?.value
+        XCTAssertEqual(a2?.requirement, .versionSet(.range("1.0.0"..<"1.5.0")))
+    }
+
+    func testSolutionUnsatisfied() {
+        let rootIncompat: Incompatibility<PackageReference> = Incompatibility(Term(rootRef, .versionSet(.any)))
+        let s1 = PartialSolution<PackageReference>(assignments: [
+            .derivation("a^1.5.0", cause: rootIncompat, decisionLevel: 0),
+            .decision("b@2.0.0", decisionLevel: 0),
+            .derivation("a^1.0.0", cause: rootIncompat, decisionLevel: 0)
+        ])
+
+        XCTAssertEqual(s1.unsatisfied, [Term("a", .versionSet(.range("1.5.0"..<"2.0.0")))])
+    }
+
+    func testSolutionSatisfiesIncompatibility() {
+        let s1 = PartialSolution<PackageReference>(assignments: [
+            .decision("foo@1.0.0", decisionLevel: 0)
+        ])
+        XCTAssertEqual(s1.satisfies(Incompatibility("foo@1.0.0")), .satisfied)
+
+        let s2 = PartialSolution<PackageReference>(assignments: [
+            .decision("bar@2.0.0", decisionLevel: 0)
+        ])
+        XCTAssertEqual(s2.satisfies(Incompatibility("¬foo@1.0.0", "bar@2.0.0")),
+                       .almostSatisfied(except: "¬foo@1.0.0"))
+
+        let s3 = PartialSolution<PackageReference>(assignments: [
+            .decision("baz@3.0.0", decisionLevel: 0)
+        ])
+        XCTAssertEqual(s3.satisfies(Incompatibility("¬foo@1.0.0", "bar@2.0.0")),
+                       .unsatisfied)
+
+        let s4 = PartialSolution<PackageReference>(assignments: [])
+        XCTAssertEqual(s4.satisfies(Incompatibility("foo@1.0.0")), .unsatisfied)
+
+        let s5 = PartialSolution<PackageReference>(assignments: [
+            .decision("root@1.0.0", decisionLevel: 0),
+            .decision("foo@0.1.0", decisionLevel: 0),
+            .decision("bar@0.2.0", decisionLevel: 0)
+        ])
+        XCTAssertEqual(s5.satisfies(Incompatibility("root@1.0.0", "bar@0.2.0")),
+                       .satisfied)
+    }
+
+    func testSolutionAddAssignments() {
+        let foo = Term(fooRef, .versionSet(.exact("1.0.0")))
+        let bar = Term(barRef, .versionSet(.exact("2.0.0")))
+
+        let solution = PartialSolution<PackageReference>(assignments: [])
+        XCTAssertEqual(solution.decisionLevel, 0)
+        solution.decide(foo)
+        solution.derive(bar, cause: Incompatibility(foo))
+        XCTAssertEqual(solution.decisionLevel, 2)
+
+        XCTAssert(solution.assignments.contains(where: { $0.term == foo }))
+        XCTAssert(solution.assignments.contains(where: { $0.term == bar }))
+        XCTAssertEqual(solution.assignments.count, 2)
+    }
+
+    func testSolutionFindSatisfiers() {
+        let s1 = PartialSolution<PackageReference>(assignments: [
+            .decision("root@1.0.0", decisionLevel: 0),
+            .decision("foo@0.1.0", decisionLevel: 0),
+            .decision("bar@0.2.0", decisionLevel: 0)
+        ])
+
+        let rootAndbar = Incompatibility<PackageReference>("root@1.0.0", "bar@0.2.0")
+        let (previous1, satisfier1) = s1.earliestSatisfiers(for: rootAndbar)
+        XCTAssertEqual(previous1, Assignment.decision("root@1.0.0", decisionLevel: 0))
+        XCTAssertEqual(satisfier1, Assignment.decision("bar@0.2.0", decisionLevel: 0))
+
+
+        let s2 = PartialSolution<PackageReference>(assignments: [
+            .decision("root@1.0.0", decisionLevel: 0),
+            .decision("foo@0.1.0", decisionLevel: 0)
+        ])
+
+        let rootAndfoo = Incompatibility<PackageReference>("root@1.0.0", "foo@0.1.0")
+        let (previous2, satisfier2) = s2.earliestSatisfiers(for: rootAndfoo)
+        XCTAssertEqual(previous2, Assignment.decision("root@1.0.0", decisionLevel: 0))
+        XCTAssertEqual(satisfier2, Assignment.decision("foo@0.1.0", decisionLevel: 0))
+
+
+        let s3 = PartialSolution<PackageReference>(assignments: [
+            .decision("root@1.0.0", decisionLevel: 0)
+        ])
+
+        let root = Incompatibility<PackageReference>("root@1.0.0")
+        let (previous3, satisfier3) = s3.earliestSatisfiers(for: root)
+        XCTAssertEqual(previous3, Assignment.decision("root@1.0.0", decisionLevel: 0))
+        XCTAssertEqual(satisfier3, Assignment.decision("root@1.0.0", decisionLevel: 0))
+    }
+
+    func testSolutionBacktrack() {
+        let solution = PartialSolution<PackageReference>(assignments: [
+            .decision("a@1.0.0", decisionLevel: 1),
+            .decision("b@1.0.0", decisionLevel: 2),
+            .decision("c@1.0.0", decisionLevel: 3),
+        ])
+
+        XCTAssertEqual(solution.assignments.count, 3)
+        solution.backtrack(toDecisionLevel: 2)
+        XCTAssertEqual(solution.assignments.count, 2)
+        solution.backtrack(toDecisionLevel: 0)
+        XCTAssertEqual(solution.assignments.count, 0)
+    }
+
+    func testSolutionVersionIntersection() {
+        let cause = Incompatibility<PackageReference>("cause@0.0.0")
+
+        let s1 = PartialSolution(assignments: [
+            .derivation("a^1.0.0", cause: cause, decisionLevel: 1),
+        ])
+        XCTAssertEqual(s1.versionIntersection(for: "a")?.requirement,
+                       .versionSet(.range("1.0.0"..<"2.0.0")))
+
+        let s2 = PartialSolution(assignments: [
+            .derivation("a^1.0.0", cause: cause, decisionLevel: 1),
+            .derivation("a^1.5.0", cause: cause, decisionLevel: 2)
+        ])
+        XCTAssertEqual(s2.versionIntersection(for: "a")?.requirement,
+                       .versionSet(.range("1.5.0"..<"2.0.0")))
+    }
+
+    func testResolverAddIncompatibility() {
+        XCTAssert(solver.incompatibilities.isEmpty)
+
+        let fooIncompat = Incompatibility(Term(fooRef, .versionSet(.exact("1.0.0"))))
+        solver.add(fooIncompat)
+        XCTAssertEqual(solver.incompatibilities, ["foo": [fooIncompat]])
+
+        let foobarIncompat = Incompatibility(
+            Term(fooRef, .versionSet(.exact("1.0.0"))),
+            Term(barRef, .versionSet(.exact("2.0.0")))
+        )
+        solver.add(foobarIncompat)
+        XCTAssertEqual(solver.incompatibilities, [
+            "foo": [fooIncompat, foobarIncompat],
+            "bar": [foobarIncompat],
+        ])
+    }
+
+    func testResolverUnitPropagation() {
+        // no known incompatibilities should result in no satisfaction checks
+        XCTAssertNil(solver.propagate("root"))
+
+        // even if incompatibilities are present
+        solver.add(Incompatibility(Term(fooRef, .versionSet(.exact("1.0.0")))))
+        XCTAssertNil(solver.propagate("foo"))
+
+        // adding a satisfying term should result in a conflict
+        solver.solution.decide(Term(fooRef, .versionSet(.exact("1.0.0"))))
+        XCTAssertEqual(solver.propagate(fooRef), Incompatibility(Term(fooRef, .versionSet(.exact("1.0.0")))))
+
+        solver.reset()
+        // Unit propagation should derive a new assignment from almost satisfied incompatibilities.
+        solver.add(Incompatibility(Term("root", .versionSet(.any)),
+                                   Term(not: fooRef, .versionSet(.exact("1.0.0")))))
+        solver.solution.decide(Term("root", .versionSet(.any)))
+
+        XCTAssertEqual(solver.solution.assignments.count, 1)
+        XCTAssertNil(solver.propagate(PackageReference(identity: "root", path: "")))
+        XCTAssertEqual(solver.solution.assignments.count, 2)
+    }
+
+    func testResolverConflictResolution() {
+        solver.root = rootRef
+
+        let notRoot = Incompatibility(Term(not: rootRef, .versionSet(.any)), cause: .root)
+        solver.add(notRoot)
+        XCTAssertNil(solver.resolve(conflict: notRoot))
+
+        solver.reset()
+        solver.add(notRoot)
+        solver.add(Incompatibility("foo^1.0.0", cause: .dependency(package: rootRef)))
+        let resolved = solver.resolve(conflict: Incompatibility("foo^1.5.0"))
+        XCTAssertEqual(resolved, Incompatibility(Term(fooRef, .versionSet(.range("1.5.0"..<"2.0.0")))))
+    }
+
+    func testResolverDecisionMaking() {
+        solver.root = rootRef
+
+        // No decision can be made if no unsatisfied terms are available.
+        XCTAssertNil(try solver.makeDecision())
+
+        let solution = PartialSolution(assignments: [
+            .derivation("a^1.0.0", cause: rootCause, decisionLevel: 0)
+        ])
+        solver.reset(solution: solution, root: rootRef)
+
+        XCTAssertEqual(solver.incompatibilities.count, 1)
+
+        solver.provider._register(package: "a", dependencies: ["b^1.0.0"])
+
+        let decision = try! solver.makeDecision()
+        XCTAssertEqual(decision, "a")
+
+        XCTAssertEqual(solver.incompatibilities.count, 3)
+        XCTAssertEqual(solver.incompatibilities["a"], [Incompatibility<PackageReference>("¬a@1.0.0", "b^1.0.0", cause: .dependency(package: "a"))])
+    }
+}
+
+extension Term: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        var value = value
+
+        var isPositive = true
+        if value.hasPrefix("¬") {
+            value.removeFirst()
+            isPositive = false
+        }
+
+        var components: [String] = []
+        var requirement: Requirement
+
+        if value.contains("@") {
+            components = value.split(separator: "@").map(String.init)
+            requirement = .versionSet(.exact(Version(stringLiteral: components[1])))
+        } else if value.contains("^") {
+            components = value.split(separator: "^").map(String.init)
+            let upperMajor = Int(String(components[1].split(separator: ".").first!))! + 1
+            requirement = .versionSet(.range(Version(stringLiteral: components[1])..<Version(stringLiteral: "\(upperMajor).0.0")))
+        } else {
+            fatalError("Unrecognized format")
+        }
+
+        let packageReference: Identifier = PackageReference(identity: components[0], path: "") as! Identifier
+
+        self.init(package: packageReference,
+                  requirement: requirement,
+                  isPositive: isPositive)
+    }
+}
+
+extension PackageReference: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        let ref = PackageReference(identity: value.lowercased(), path: "")
+        self = ref
+    }
+}
+
+private extension PubgrubDependencyResolver {
+    /// Reset a PubgrubDependencyResolver's internal state.
+    func reset(solution: PartialSolution<PackageReference> = PartialSolution(),
+               incompatibilities: [PackageReference: [Incompatibility<PackageReference>]] = [:],
+               changed: Set<PackageReference> = [],
+               root: PackageReference? = nil) {
+        self.solution = solution as! PartialSolution<D.Identifier>
+        self.incompatibilities = incompatibilities as! [D.Identifier : [Incompatibility<D.Identifier>]]
+        self.changed = changed as! Set<D.Identifier>
+        self.root = root as? D.Identifier
+    }
+}


### PR DESCRIPTION
This is a first of probably a few PRs to implement a new dependency resolution algorithm in SwiftPM (my project whilst interning at Apple). It's based on [Pubgrub](https://medium.com/@nex3/pubgrub-2fb6470504f).
The major upside to this will be more descriptive and actionable diagnostics in error cases. Better performance is another side goal. Currently, in the case that dependency resolution fails, SwiftPM is unable to explain to the user why it did, just that it is so. This aims to improve that.

Please note that the code here is still very much a work in progress. It is as of yet still non-functional, but includes necessary types, API and several building blocks. It however currently stills fails at its actual job, resolving dependencies. There are also several TODOs, FIXMEs, fatalError calls and force unwraps which are placeholders for further improvements and improved error handling.

I added a new CLI option (`--enable-pubgrub-resolver`), which uses the new resolver. This will of course be of more use once it actually works 😅

Any review and feedback is very much appreciated!