### PR TITLE
[Build] Clarify `BuildPlan.Error.missingLinuxMain`

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -788,7 +788,7 @@ public class BuildPlan {
         public var description: String {
             switch self {
             case .missingLinuxMain:
-                return "missing LinuxMain.swift file at top level"
+                return "missing LinuxMain.swift file in the Tests directory"
             case .noBuildableTarget:
                 return "the package does not contain a buildable target"
             }

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -788,7 +788,7 @@ public class BuildPlan {
         public var description: String {
             switch self {
             case .missingLinuxMain:
-                return "missing LinuxMain.swift file"
+                return "missing LinuxMain.swift file at top level"
             case .noBuildableTarget:
                 return "the package does not contain a buildable target"
             }


### PR DESCRIPTION
[SR-8646] BuildPlan.Error.missingLinuxMain description rephrasing

Make it clear that LinuxMain.swift must be at the top level of the Tests directory.

Tests do not appear to quote error messages.