### PR TITLE
Add a static version of libSwiftPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,24 @@ let package = Package(
                 "Workspace"
             ]
         ),
+        .library(
+            name: "SwiftPM-auto",
+            targets: [
+                "clibc",
+                "SPMLibc",
+                "POSIX",
+                "Basic",
+                "Utility",
+                "SourceControl",
+                "SPMLLBuild",
+                "PackageModel",
+                "PackageLoading",
+                "PackageGraph",
+                "Build",
+                "Xcodeproj",
+                "Workspace"
+            ]
+        ),
 
         // Collection of general purpose utilities.
         //
@@ -64,7 +82,7 @@ let package = Package(
             dependencies: []),
 
         // MARK: Support libraries
-        
+
         .target(
             /** Shim target to import missing C headers in Darwin and Glibc modulemap. */
             name: "clibc",
@@ -95,7 +113,7 @@ let package = Package(
             dependencies: ["Basic", "Utility"]),
 
         // MARK: Project Model
-        
+
         .target(
             /** Primitive Package model objects */
             name: "PackageModel",
@@ -106,14 +124,14 @@ let package = Package(
             dependencies: ["Basic", "PackageModel", "Utility", "SPMLLBuild"]),
 
         // MARK: Package Dependency Resolution
-        
+
         .target(
             /** Data structures and support for complete package graphs */
             name: "PackageGraph",
             dependencies: ["Basic", "PackageLoading", "PackageModel", "SourceControl", "Utility"]),
-        
+
         // MARK: Package Manager Functionality
-        
+
         .target(
             /** Builds Modules and Products */
             name: "Build",
@@ -128,7 +146,7 @@ let package = Package(
             dependencies: ["Basic", "Build", "PackageGraph", "PackageModel", "SourceControl", "Xcodeproj"]),
 
         // MARK: Commands
-        
+
         .target(
             /** High-level commands */
             name: "Commands",
@@ -164,7 +182,7 @@ let package = Package(
             /** Test support executable */
             name: "TestSupportExecutable",
             dependencies: ["Basic", "POSIX", "Utility"]),
-        
+
         .testTarget(
             name: "BasicTests",
             dependencies: ["TestSupport", "TestSupportExecutable"]),


### PR DESCRIPTION
As discussed [here](https://forums.swift.org/t/using-swiftpm-from-carthage/18912/4).

This will make it easier for command-line tools like Carthage to use code from SwiftPM.