### PR TITLE
Resolve Hashable related warnings

### DIFF
--- a/Sources/Basic/KeyedPair.swift
+++ b/Sources/Basic/KeyedPair.swift
@@ -42,8 +42,8 @@ public struct KeyedPair<T, K: Hashable>: Hashable {
         self.key = key
     }
 
-    public var hashValue: Int {
-        return key.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(key)
     }
 }
 public func ==<T, K>(lhs: KeyedPair<T, K>, rhs: KeyedPair<T, K>) -> Bool {

--- a/Sources/Basic/ObjectIdentifierProtocol.swift
+++ b/Sources/Basic/ObjectIdentifierProtocol.swift
@@ -14,8 +14,8 @@
 public protocol ObjectIdentifierProtocol: class, Hashable {}
 
 extension ObjectIdentifierProtocol {
-    public var hashValue: Int {
-        return ObjectIdentifier(self).hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
     }
 
     public static func == (lhs: Self, rhs: Self) -> Bool {

--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -100,23 +100,6 @@ public enum VersionSetSpecifier: Hashable, CustomStringConvertible {
         }
     }
 
-    //FIXME: Remove in 4.2
-    public var hashValue: Int {
-        switch (self) {
-        case .any:
-            return 0xB58D
-
-        case .empty:
-            return 0x7121
-
-        case .range(let range):
-            return 0x4CF3 ^ (range.lowerBound.hashValue &* 31) ^ range.upperBound.hashValue
-
-        case .exact(let version):
-            return 0xD04F ^ version.hashValue
-        }
-    }
-
     /// Check if the set contains a version.
     public func contains(_ version: Version) -> Bool {
         switch self {
@@ -406,15 +389,6 @@ public struct PackageContainerConstraintSet<C: PackageContainer>: Collection, Ha
     /// Get the version set specifier associated with the given package `identifier`.
     public subscript(identifier: Identifier) -> Requirement {
         return constraints[identifier] ?? .versionSet(.any)
-    }
-
-    //FIXME: Remove in 4.2? Perhaps?
-    public var hashValue: Int {
-        var result = 0
-        for c in self.constraints {
-            result ^= c.key.hashValue &* 0x62F ^ c.value.hashValue
-        }
-        return result
     }
 
     /// Create a constraint set by merging the `requirement` for container `identifier`.
@@ -830,8 +804,9 @@ public class DependencyResolver<
         let container: Container
         let allConstraints: ConstraintSet
 
-        var hashValue: Int {
-            return container.identifier.hashValue ^ allConstraints.hashValue
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(container.identifier)
+            hasher.combine(allConstraints)
         }
 
         static func ==(lhs: ResolveSubtreeCacheKey, rhs: ResolveSubtreeCacheKey) -> Bool {

--- a/Sources/PackageModel/Package.swift
+++ b/Sources/PackageModel/Package.swift
@@ -109,12 +109,7 @@ extension Package: CustomStringConvertible {
     }
 }
 
-extension Package: Hashable, Equatable {
-    public var hashValue: Int { return ObjectIdentifier(self).hashValue }
-    
-    public static func == (lhs: Package, rhs: Package) -> Bool {
-        return ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
-    }
+extension Package: ObjectIdentifierProtocol {
 }
 
 /// A package reference.
@@ -163,8 +158,8 @@ public struct PackageReference: JSONMappable, JSONSerializable, CustomStringConv
         return lhs.identity == rhs.identity
     }
 
-    public var hashValue: Int {
-        return identity.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(identity)
     }
 
     public init(json: JSON) throws {

--- a/Sources/Utility/ArgumentParser.swift
+++ b/Sources/Utility/ArgumentParser.swift
@@ -290,8 +290,8 @@ protocol ArgumentProtocol: Hashable {
 extension ArgumentProtocol {
     // MARK: - Conformance for Hashable
 
-    public var hashValue: Int {
-        return name.hashValue
+    public func hash(into hasher: inout Hasher) {
+        return hasher.combine(name)
     }
 
     public static func == (_ lhs: Self, _ rhs: Self) -> Bool {

--- a/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
+++ b/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
@@ -466,8 +466,8 @@ fileprivate class PropertyListSerializer {
             self.object = object
         }
 
-        var hashValue: Int {
-            return ObjectIdentifier(object).hashValue
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(ObjectIdentifier(object))
         }
 
         static func == (lhs: SerializedObjectRef, rhs: SerializedObjectRef) -> Bool {


### PR DESCRIPTION
Took the opportunity to resolve a few FIXMEs that still did not use Swift 4.2's automatic Hashable synthesis.