### PR TITLE
[Workspace] Eliminate suffix from checkouts dirname

### DIFF
--- a/Sources/SourceControl/Repository.swift
+++ b/Sources/SourceControl/Repository.swift
@@ -25,16 +25,20 @@ public struct RepositorySpecifier: Hashable {
     /// This identifier is suitable for use in a file system path, and
     /// unique for each repository.
     public var fileSystemIdentifier: String {
-        var basename = url.components(separatedBy: "/").last!
-        if basename.hasSuffix(".git") {
-            basename = String(basename.dropLast(4))
-        }
-
         // Use first 8 chars of a stable hash.
         let hash = SHA256(url).digestString()
         let suffix = hash.dropLast(hash.count - 8)
 
         return basename + "-" + suffix
+    }
+
+    /// Returns the cleaned basename for the specifier.
+    public var basename: String {
+        var basename = url.components(separatedBy: "/").last!
+        if basename.hasSuffix(".git") {
+            basename = String(basename.dropLast(4))
+        }
+        return basename
     }
 }
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1679,6 +1679,17 @@ extension Workspace {
             return
         }
 
+        // First remove the checkouts that are no longer required.
+        for (packageRef, state) in packageStateChanges {
+            diagnostics.wrap {
+                switch state {
+                case .added, .updated, .unchanged: break
+                case .removed:
+                    try remove(package: packageRef)
+                }
+            }
+        }
+
         // Update or clone new packages.
         for (packageRef, state) in packageStateChanges {
             diagnostics.wrap {
@@ -1687,9 +1698,7 @@ extension Workspace {
                     _ = try clone(package: packageRef, requirement: requirement)
                 case .updated(let requirement):
                     _ = try clone(package: packageRef, requirement: requirement)
-                case .removed:
-                    try remove(package: packageRef)
-                case .unchanged: break
+                case .removed, .unchanged: break
                 }
             }
         }
@@ -1741,7 +1750,7 @@ extension Workspace {
         }
 
         // Clone the repository into the checkouts.
-        let path = checkoutsPath.appending(component: package.repository.fileSystemIdentifier)
+        let path = checkoutsPath.appending(component: package.repository.basename)
 
         try fileSystem.chmod(.userWritable, path: path, options: [.recursive, .onlyFiles])
         try fileSystem.removeFileTree(path)


### PR DESCRIPTION
We don't expect to ever have two checkouts with same name at a time so
there is no need of a suffix for them.

<rdar://problem/46423708>