### PR TITLE
 [Workspace] Don't validate the pins when there are errors

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1166,6 +1166,10 @@ extension Workspace {
         // Load the current manifests.
         let graphRoot = PackageGraphRoot(input: root, manifests: rootManifests)
         let currentManifests = loadDependencyManifests(root: graphRoot, diagnostics: diagnostics)
+        guard !diagnostics.hasErrors else {
+            return currentManifests
+        }
+
         validatePinsStore(dependencyManifests: currentManifests, diagnostics: diagnostics)
 
         // Abort if pinsStore is unloadable or if diagnostics has errors.


### PR DESCRIPTION
<rdar://problem/47011812> SwiftPM removes the resolved file when the manifest has parsing errors