### PR TITLE
Drop support for swift language version 4.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:4.2
 
 /*
  This source file is part of the Swift.org open source project
@@ -239,7 +239,7 @@ let package = Package(
             name: "XcodeprojTests",
             dependencies: ["Xcodeproj", "TestSupport"]),
     ],
-    swiftLanguageVersions: [4]
+    swiftLanguageVersions: [.v4_2]
 )
 
 // Add package dependency on llbuild when not bootstrapping.

--- a/Sources/Basic/ByteString.swift
+++ b/Sources/Basic/ByteString.swift
@@ -90,18 +90,6 @@ extension ByteString: CustomStringConvertible {
     }
 }
 
-#if !swift(>=4.2)
-extension ByteString {
-    public var hashValue: Int {
-        var result = contents.count
-        for byte in contents {
-            result = result &* 31 &+ Int(byte)
-        }
-        return result
-    }
-}
-#endif
-
 /// ByteStreamable conformance for a ByteString.
 extension ByteString: ByteStreamable {
     public func write(to stream: OutputByteStream) {

--- a/Sources/Utility/Version.swift
+++ b/Sources/Utility/Version.swift
@@ -45,21 +45,6 @@ public struct Version: Hashable {
     }
 }
 
-#if !swift(>=4.2)
-extension Version {
-    public var hashValue: Int {
-        let mul: UInt64 = 0x9ddfea08eb382d69
-        var result: UInt64 = 0
-        result = (result &* mul) ^ UInt64(bitPattern: Int64(major.hashValue))
-        result = (result &* mul) ^ UInt64(bitPattern: Int64(minor.hashValue))
-        result = (result &* mul) ^ UInt64(bitPattern: Int64(patch.hashValue))
-        result = prereleaseIdentifiers.reduce(result, { ($0 &* mul) ^ UInt64(bitPattern: Int64($1.hashValue)) })
-        result = buildMetadataIdentifiers.reduce(result, { ($0 &* mul) ^ UInt64(bitPattern: Int64($1.hashValue)) })
-        return Int(truncatingIfNeeded: result)
-    }
-}
-#endif
-
 extension Version: Comparable {
 
     func isEqualWithoutPrerelease(_ other: Version) -> Bool {


### PR DESCRIPTION
This will also simplify slightly the following PR that implements `hash(into:)`.