### PR TITLE
[DNM] Diagnosing CI-only build issues

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,8 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+// This is an empty patch, used to diagnose CI build failures.
+
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
This is an empty patch that lets me invoke swift-ci to diagnose non-locally-reproducible build issues.