### PR TITLE
[PackageLoading] Improve error message when a custom target path does not exist

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -28,7 +28,7 @@ public enum ModuleError: Swift.Error {
     case modulesNotFound([String])
 
     /// Invalid custom path
-    case invalidCustomPath((target: String, path: String))
+    case invalidCustomPath(target: String, path: String)
 
     /// Package layout is invalid.
     case invalidLayout(InvalidLayoutType)
@@ -95,7 +95,7 @@ extension ModuleError: CustomStringConvertible {
         case .unsupportedTargetPath(let targetPath):
             return "target path '\(targetPath)' is not supported; it should be relative to package root"
         case .invalidCustomPath(let target, let path):
-            return "the specified custom path '\(path)' for target '\(target)' does not exist"
+            return "target path '\(path)' for target '\(target)' does not exist"
         case .invalidHeaderSearchPath(let path):
             return "invalid header search path '\(path)'; header search path should not be outside the package root"
         }
@@ -446,7 +446,7 @@ public final class PackageBuilder {
                 if fileSystem.isDirectory(path) {
                     return path
                 }
-                throw ModuleError.invalidCustomPath((target: target.name, path: subpath))
+                throw ModuleError.invalidCustomPath(target: target.name, path: subpath)
             }
 
             // Check if target is present in the predefined directory.

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -27,6 +27,9 @@ public enum ModuleError: Swift.Error {
     /// One or more referenced targets could not be found.
     case modulesNotFound([String])
 
+    /// Invalid custom path
+    case invalidCustomPath((target: String, path: String))
+
     /// Package layout is invalid.
     case invalidLayout(InvalidLayoutType)
 
@@ -91,6 +94,8 @@ extension ModuleError: CustomStringConvertible {
             return "target '\(target)' in package '\(package)' is outside the package root"
         case .unsupportedTargetPath(let targetPath):
             return "target path '\(targetPath)' is not supported; it should be relative to package root"
+        case .invalidCustomPath(let target, let path):
+            return "the specified custom path '\(path)' for target '\(target)' does not exist"
         case .invalidHeaderSearchPath(let path):
             return "invalid header search path '\(path)'; header search path should not be outside the package root"
         }
@@ -441,7 +446,7 @@ public final class PackageBuilder {
                 if fileSystem.isDirectory(path) {
                     return path
                 }
-                throw ModuleError.modulesNotFound([target.name])
+                throw ModuleError.invalidCustomPath((target: target.name, path: subpath))
             }
 
             // Check if target is present in the predefined directory.

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -27,7 +27,7 @@ public enum ModuleError: Swift.Error {
     /// One or more referenced targets could not be found.
     case modulesNotFound([String])
 
-    /// Invalid custom path
+    /// Invalid custom path.
     case invalidCustomPath(target: String, path: String)
 
     /// Package layout is invalid.
@@ -95,7 +95,7 @@ extension ModuleError: CustomStringConvertible {
         case .unsupportedTargetPath(let targetPath):
             return "target path '\(targetPath)' is not supported; it should be relative to package root"
         case .invalidCustomPath(let target, let path):
-            return "target path '\(path)' for target '\(target)' does not exist"
+            return "invalid custom path '\(path)' for target '\(target)'"
         case .invalidHeaderSearchPath(let path):
             return "invalid header search path '\(path)'; header search path should not be outside the package root"
         }

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -1107,13 +1107,11 @@ class PackageBuilderTests: XCTestCase {
             name: "Foo",
             targets: [
                 TargetDescription(name: "Foo", path: "./NotExist")
-                ]
+            ]
         )
 
         PackageBuilderTester(manifest, in: fs) { result in
-
-            result.checkDiagnostic("target path './NotExist' for target 'Foo' does not exist")
-
+            result.checkDiagnostic("invalid custom path './NotExist' for target 'Foo'")
         }
     }
 

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -1100,6 +1100,23 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
+    func testSpecifiedCustomPathDoesNotExist() {
+        let fs = InMemoryFileSystem(emptyFiles: "/Foo.swift")
+
+        let manifest = Manifest.createV4Manifest(
+            name: "Foo",
+            targets: [
+                TargetDescription(name: "Foo", path: "./NotExist")
+                ]
+        )
+
+        PackageBuilderTester(manifest, in: fs) { result in
+
+            result.checkDiagnostic("the specified custom path './NotExist' for target 'Foo' does not exist")
+
+        }
+    }
+
     func testSpecialTargetDir() {
         // Special directory should be src because both target and test target are under it.
         let fs = InMemoryFileSystem(emptyFiles:

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -1112,7 +1112,7 @@ class PackageBuilderTests: XCTestCase {
 
         PackageBuilderTester(manifest, in: fs) { result in
 
-            result.checkDiagnostic("the specified custom path './NotExist' for target 'Foo' does not exist")
+            result.checkDiagnostic("target path './NotExist' for target 'Foo' does not exist")
 
         }
     }


### PR DESCRIPTION
The issue is that even when a custom target path is specified in manifest,
it still shows an error message asking to specify a path. The fix is to check
if a path is already specified but does not exist, then it indicates the path
dose not exist. 

A test is added for the fix.

Resolves [SR-9558](https://bugs.swift.org/browse/SR-9558).