### PR TITLE
QOL changes in Basic to replace asString by CustomStringConvertible

### DIFF
--- a/Sources/Basic/ByteString.swift
+++ b/Sources/Basic/ByteString.swift
@@ -59,9 +59,21 @@ public struct ByteString: ExpressibleByArrayLiteral, Hashable {
     public var count: Int {
         return _bytes.count
     }
+}
+
+/// Conform to CustomDebugStringConvertible.
+extension ByteString: CustomStringConvertible {
+    /// Return the string decoded as a UTF8 sequence, or traps if not possible.
+    public var description: String {
+        guard let description = validDescription else {
+            fatalError("invalid byte string: \(cString)")
+        }
+
+        return description
+    }
 
     /// Return the string decoded as a UTF8 sequence, if possible.
-    public var asString: String? {
+    public var validDescription: String? {
         // FIXME: This is very inefficient, we need a way to pass a buffer. It
         // is also wrong if the string contains embedded '\0' characters.
         let tmp = _bytes + [UInt8(0)]
@@ -72,7 +84,7 @@ public struct ByteString: ExpressibleByArrayLiteral, Hashable {
 
     /// Return the string decoded as a UTF8 sequence, substituting replacement
     /// characters for ill-formed UTF8 sequences.
-    public var asReadableString: String {
+    public var cString: String {
         // FIXME: This is very inefficient, we need a way to pass a buffer. It
         // is also wrong if the string contains embedded '\0' characters.
         let tmp = _bytes + [UInt8(0)]
@@ -80,13 +92,10 @@ public struct ByteString: ExpressibleByArrayLiteral, Hashable {
             return String(cString: unsafeBitCast(ptr.baseAddress, to: UnsafePointer<CChar>.self))
         }
     }
-}
 
-/// Conform to CustomStringConvertible.
-extension ByteString: CustomStringConvertible {
-    public var description: String {
-        // For now, default to the "readable string" representation.
-        return "<ByteString:\"\(asReadableString)\">"
+    @available(*, deprecated, message: "use description or validDescription instead")
+    public var asString: String? {
+        return validDescription
     }
 }
 

--- a/Sources/Basic/DiagnosticsEngine.swift
+++ b/Sources/Basic/DiagnosticsEngine.swift
@@ -314,7 +314,7 @@ public class DiagnosticsEngine: CustomStringConvertible {
             stream <<< diag.localizedDescription <<< ", "
         }
         stream <<< "]"
-        return stream.bytes.asString!
+        return stream.bytes.description
     }
 }
 

--- a/Sources/Basic/JSON.swift
+++ b/Sources/Basic/JSON.swift
@@ -109,10 +109,7 @@ extension JSON {
 
     /// Encode a JSON item into a JSON string
     public func toString(prettyPrint: Bool = false) -> String {
-        guard let contents = self.toBytes(prettyPrint: prettyPrint).asString else {
-            fatalError("Failed to serialize JSON: \(self)")
-        }
-        return contents
+        return toBytes(prettyPrint: prettyPrint).description
     }
 }
 
@@ -311,13 +308,25 @@ extension Bool: JSONSerializable {
 
 extension AbsolutePath: JSONSerializable {
     public func toJSON() -> JSON {
-        return .string(asString)
+        return .string(description)
     }
 }
 
 extension RelativePath: JSONSerializable {
     public func toJSON() -> JSON {
-        return .string(asString)
+        return .string(description)
+    }
+}
+
+extension Array: JSONSerializable where Element: JSONSerializable {
+    public func toJSON() -> JSON {
+        return .array(self.map({ $0.toJSON() }))
+    }
+}
+
+extension Dictionary: JSONSerializable where Key == String, Value: JSONSerializable {
+    public func toJSON() -> JSON {
+        return .dictionary(self.mapValues({ $0.toJSON() }))
     }
 }
 

--- a/Sources/Basic/Lock.swift
+++ b/Sources/Basic/Lock.swift
@@ -55,7 +55,7 @@ public final class FileLock {
     public func lock() throws {
         // Open the lock file.
         if fd == nil {
-            let fd = SPMLibc.open(lockFile.asString, O_WRONLY | O_CREAT | O_CLOEXEC, 0o666)
+            let fd = SPMLibc.open(lockFile.description, O_WRONLY | O_CREAT | O_CLOEXEC, 0o666)
             if fd == -1 {
                 throw FileSystemError(errno: errno)
             }

--- a/Sources/Basic/OutputByteStream.swift
+++ b/Sources/Basic/OutputByteStream.swift
@@ -342,6 +342,18 @@ public func <<< (stream: OutputByteStream, value: ByteStreamable) -> OutputByteS
     return stream
 }
 
+@discardableResult
+public func <<< (stream: OutputByteStream, value: CustomStringConvertible) -> OutputByteStream {
+    value.description.write(to: stream)
+    return stream
+}
+
+@discardableResult
+public func <<< (stream: OutputByteStream, value: ByteStreamable & CustomStringConvertible) -> OutputByteStream {
+    value.write(to: stream)
+    return stream
+}
+
 extension UInt8: ByteStreamable {
     public func write(to stream: OutputByteStream) {
         stream.write(self)
@@ -434,6 +446,10 @@ public struct Format {
         }
     }
 
+    /// Write the input CustomStringConvertible encoded as a JSON object.
+    static public func asJSON<T: CustomStringConvertible>(_ value: T) -> ByteStreamable {
+        return JSONEscapedStringStreamable(value: value.description)
+    }
     /// Write the input string encoded as a JSON object.
     static public func asJSON(_ string: String) -> ByteStreamable {
         return JSONEscapedStringStreamable(value: string)
@@ -448,6 +464,10 @@ public struct Format {
         }
     }
 
+    /// Write the input string list encoded as a JSON object.
+    static public func asJSON<T: CustomStringConvertible>(_ items: [T]) -> ByteStreamable {
+        return JSONEscapedStringListStreamable(items: items.map({ $0.description }))
+    }
     /// Write the input string list encoded as a JSON object.
     //
     // FIXME: We might be able to make this more generic through the use of a "JSONEncodable" protocol.
@@ -651,7 +671,7 @@ public final class LocalFileOutputByteStream: FileOutputByteStream {
     ///
     /// - Throws: FileSystemError
     public init(_ path: AbsolutePath, closeOnDeinit: Bool = true, buffered: Bool = true) throws {
-        guard let filePointer = fopen(path.asString, "wb") else {
+        guard let filePointer = fopen(path.description, "wb") else {
             throw FileSystemError(errno: errno)
         }
         self.filePointer = filePointer

--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -181,8 +181,8 @@ public struct AbsolutePath: Hashable {
     public func appending(components names: String...) -> AbsolutePath {
         // FIXME: This doesn't seem a particularly efficient way to do this.
         return names.reduce(self, { path, name in
-                path.appending(component: name)
-            })
+            path.appending(component: name)
+        })
     }
 
     /// NOTE: We will most likely want to add other `appending()` methods, such
@@ -199,28 +199,12 @@ public struct AbsolutePath: Hashable {
     /// Root directory (whose string representation is just a path separator).
     public static let root = AbsolutePath("/")
 
-    /// Normalized string representation (the normalization rules are described
-    /// in the documentation of the initializer).  This string is never empty.
-    public var asString: String {
-        return _impl.string
-    }
-
-    // FIXME: We should investigate if it would be more efficient to instead
-    // return a path component iterator that does all its work lazily, moving
-    // from one path separator to the next on-demand.
-    //
     /// Returns an array of strings that make up the path components of the
     /// absolute path.  This is the same sequence of strings as the basenames
     /// of each successive path component, starting from the root.  Therefore
     /// the first path component of an absolute path is always `/`.
     public var components: [String] {
-        // FIXME: This isn't particularly efficient; needs optimization, and
-        // in fact, it might well be best to return a custom iterator so we
-        // don't have to allocate everything up-front.  It would be backed by
-        // the path string and just return a slice at a time.
-        return ["/"] + _impl.string.components(separatedBy: "/").filter({
-            !$0.isEmpty
-        })
+        return ["/"] + _impl.components
     }
 }
 
@@ -287,34 +271,20 @@ public struct RelativePath: Hashable {
         return _impl.extension
     }
 
-    /// Normalized string representation (the normalization rules are described
-    /// in the documentation of the initializer).  This string is never empty.
-    public var asString: String {
-        return _impl.string
-    }
-
-    // FIXME: We should investigate if it would be more efficient to instead
-    // return a path component iterator that does all its work lazily, moving
-    // from one path separator to the next on-demand.
-    //
     /// Returns an array of strings that make up the path components of the
     /// relative path.  This is the same sequence of strings as the basenames
     /// of each successive path component.  Therefore the returned array of
     /// path components is never empty; even an empty path has a single path
     /// component: the `.` string.
     public var components: [String] {
-        // FIXME: This isn't particularly efficient; needs optimization, and
-        // in fact, it might well be best to return a custom iterator so we
-        // don't have to allocate everything up-front.  It would be backed by
-        // the path string and just return a slice at a time.
-        return _impl.string.components(separatedBy: "/").filter({ !$0.isEmpty })
+        return _impl.components
     }
 }
 
 extension AbsolutePath: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        try container.encode(asString)
+        try container.encode(description)
     }
 
     public init(from decoder: Decoder) throws {
@@ -326,7 +296,7 @@ extension AbsolutePath: Codable {
 extension RelativePath: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        try container.encode(asString)
+        try container.encode(description)
     }
 
     public init(from decoder: Decoder) throws {
@@ -338,23 +308,31 @@ extension RelativePath: Codable {
 // Make absolute paths Comparable.
 extension AbsolutePath: Comparable {
     public static func < (lhs: AbsolutePath, rhs: AbsolutePath) -> Bool {
-        return lhs.asString < rhs.asString
+        return lhs.description < rhs.description
     }
 }
 
-/// Make absolute paths CustomStringConvertible.
-extension AbsolutePath: CustomStringConvertible {
+/// Make absolute paths CustomStringConvertible and CustomDebugStringConvertible.
+extension AbsolutePath: CustomStringConvertible, CustomDebugStringConvertible {
     public var description: String {
+        return _impl.string
+    }
+
+    public var debugDescription: String {
         // FIXME: We should really be escaping backslashes and quotes here.
-        return "<AbsolutePath:\"\(asString)\">"
+        return "<AbsolutePath:\"\(_impl.string)\">"
     }
 }
 
-/// Make relative paths CustomStringConvertible.
+/// Make relative paths CustomStringConvertible and CustomDebugStringConvertible.
 extension RelativePath: CustomStringConvertible {
     public var description: String {
+        return _impl.string
+    }
+
+    public var debugDescription: String {
         // FIXME: We should really be escaping backslashes and quotes here.
-        return "<RelativePath:\"\(asString)\">"
+        return "<RelativePath:\"\(_impl.string)\">"
     }
 }
 
@@ -414,6 +392,18 @@ private struct PathImpl: Hashable {
 
     fileprivate var `extension`: String? {
         return suffix(withDot: false)
+    }
+
+    // FIXME: We should investigate if it would be more efficient to instead
+    // return a path component iterator that does all its work lazily, moving
+    // from one path separator to the next on-demand.
+    //
+    fileprivate var components: [String] {
+        // FIXME: This isn't particularly efficient; needs optimization, and
+        // in fact, it might well be best to return a custom iterator so we
+        // don't have to allocate everything up-front.  It would be backed by
+        // the path string and just return a slice at a time.
+        return string.components(separatedBy: "/").filter({ !$0.isEmpty })
     }
 
     /// Returns suffix with leading `.` if withDot is true otherwise without it. 

--- a/Sources/Basic/PathShims.swift
+++ b/Sources/Basic/PathShims.swift
@@ -31,9 +31,9 @@ import Foundation
 /// non-existent path, then this function returns nil.
 func stat(_ path: AbsolutePath, followSymlink: Bool = true) throws -> SPMLibc.stat {
     if followSymlink {
-        return try stat(path.asString)
+        return try stat(path.description)
     }
-    return try lstat(path.asString)
+    return try lstat(path.description)
 }
 
 /// Returns true if and only if `path` refers to an existent file system entity.
@@ -77,7 +77,7 @@ public func isSymlink(_ path: AbsolutePath) -> Bool {
 
 /// Returns the "real path" corresponding to `path` by resolving any symbolic links.
 public func resolveSymlinks(_ path: AbsolutePath) -> AbsolutePath {
-    let pathStr = path.asString
+    let pathStr = path.description
     guard let resolvedPathStr = try? POSIX.realpath(pathStr) else { return path }
     // FIXME: We should measure if it's really more efficient to compare the strings first.
     return (resolvedPathStr == pathStr) ? path : AbsolutePath(resolvedPathStr)
@@ -86,15 +86,15 @@ public func resolveSymlinks(_ path: AbsolutePath) -> AbsolutePath {
 /// Creates a new, empty directory at `path`.  If needed, any non-existent ancestor paths are also created.  If there is
 /// already a directory at `path`, this function does nothing (in particular, this is not considered to be an error).
 public func makeDirectories(_ path: AbsolutePath) throws {
-    try FileManager.default.createDirectory(atPath: path.asString, withIntermediateDirectories: true, attributes: [:])
+    try FileManager.default.createDirectory(atPath: path.description, withIntermediateDirectories: true, attributes: [:])
 }
 
 /// Creates a symbolic link at `path` whose content points to `dest`.  If `relative` is true, the symlink contents will
 /// be a relative path, otherwise it will be absolute.
 public func createSymlink(_ path: AbsolutePath, pointingAt dest: AbsolutePath, relative: Bool = true) throws {
-    let destString = relative ? dest.relative(to: path.parentDirectory).asString : dest.asString
-    let rv = SPMLibc.symlink(destString, path.asString)
-    guard rv == 0 else { throw SystemError.symlink(errno, path.asString, dest: destString) }
+    let destString = relative ? dest.relative(to: path.parentDirectory).description : dest.description
+    let rv = SPMLibc.symlink(destString, path.description)
+    guard rv == 0 else { throw SystemError.symlink(errno, path.description, dest: destString) }
 }
 
 /// The current working directory of the processs.
@@ -200,16 +200,16 @@ extension AbsolutePath {
     public func prettyPath(cwd: AbsolutePath? = localFileSystem.currentWorkingDirectory) -> String {
         guard let dir = cwd else {
             // No current directory, display as is.
-            return self.asString
+            return self.description
         }
         // FIXME: Instead of string prefix comparison we should add a proper API
         // to AbsolutePath to determine ancestry.
         if self == dir {
             return "."
-        } else if self.asString.hasPrefix(dir.asString + "/") {
-            return "./" + self.relative(to: dir).asString
+        } else if self.description.hasPrefix(dir.description + "/") {
+            return "./" + self.relative(to: dir).description
         } else {
-            return self.asString
+            return self.description
         }
     }
 }

--- a/Sources/Basic/Process.swift
+++ b/Sources/Basic/Process.swift
@@ -603,7 +603,7 @@ extension ProcessResult.Error: CustomStringConvertible {
                 }
             }
             
-            return stream.bytes.asString!
+            return stream.bytes.description
         }
     }
 }

--- a/Sources/Basic/TemporaryFile.swift
+++ b/Sources/Basic/TemporaryFile.swift
@@ -108,7 +108,7 @@ public final class TemporaryFile {
         // Convert path to a C style string terminating with null char to be an valid input
         // to mkstemps method. The XXXXXX in this string will be replaced by a random string
         // which will be the actual path to the temporary file.
-        var template = [UInt8](path.asString.utf8).map({ Int8($0) }) + [Int8(0)]
+        var template = [UInt8](path.description.utf8).map({ Int8($0) }) + [Int8(0)]
 
         fd = SPMLibc.mkstemps(&template, Int32(suffix.utf8.count))
         // If mkstemps failed then throw error.
@@ -121,7 +121,7 @@ public final class TemporaryFile {
     /// Remove the temporary file before deallocating.
     deinit {
         if deleteOnClose {
-            unlink(path.asString)
+            unlink(path.description)
         }
     }
 }
@@ -204,7 +204,7 @@ public final class TemporaryDirectory {
         // Convert path to a C style string terminating with null char to be an valid input
         // to mkdtemp method. The XXXXXX in this string will be replaced by a random string
         // which will be the actual path to the temporary directory.
-        var template = [UInt8](path.asString.utf8).map({ Int8($0) }) + [Int8(0)]
+        var template = [UInt8](path.description.utf8).map({ Int8($0) }) + [Int8(0)]
 
         if SPMLibc.mkdtemp(&template) == nil {
             throw MakeDirectoryError(errno: errno)
@@ -216,9 +216,9 @@ public final class TemporaryDirectory {
     /// Remove the temporary file before deallocating.
     deinit {
         if shouldRemoveTreeOnDeinit {
-            _ = try? FileManager.default.removeItem(atPath: path.asString)
+            _ = try? FileManager.default.removeItem(atPath: path.description)
         } else {
-            rmdir(path.asString)
+            rmdir(path.description)
         }
     }
 }

--- a/Sources/Basic/TerminalController.swift
+++ b/Sources/Basic/TerminalController.swift
@@ -158,10 +158,7 @@ public final class TerminalController {
     public func wrap(_ string: String, inColor color: Color, bold: Bool = false) -> String {
         let stream = BufferedOutputByteStream()
         writeWrapped(string, inColor: color, bold: bold, stream: stream)
-        guard let string = stream.bytes.asString else {
-            fatalError("Couldn't get string value from stream.")
-        }
-        return string
+        return stream.bytes.description
     }
 
     private func writeWrapped(_ string: String, inColor color: Color, bold: Bool = false, stream: OutputByteStream) {

--- a/Sources/Basic/misc.swift
+++ b/Sources/Basic/misc.swift
@@ -145,6 +145,6 @@ extension CodableRange: Codable {
 extension AbsolutePath {
     /// File URL created from the normalized string representation of the path.
     public var asURL: Foundation.URL {
-         return URL(fileURLWithPath: asString)
+         return URL(fileURLWithPath: description)
     }
 }

--- a/Sources/Build/ToolProtocol.swift
+++ b/Sources/Build/ToolProtocol.swift
@@ -102,7 +102,7 @@ struct SwiftCompilerTool: ToolProtocol {
 
     /// Outputs produced by the tool.
     var outputs: [String] {
-        return target.objects.map({ $0.asString }) + [target.moduleOutputPath.asString]
+        return target.objects.map({ $0.description }) + [target.moduleOutputPath.description]
     }
 
     /// The underlying Swift build target.
@@ -118,25 +118,25 @@ struct SwiftCompilerTool: ToolProtocol {
     func append(to stream: OutputByteStream) {
         stream <<< "    tool: swift-compiler\n"
         stream <<< "    executable: "
-            <<< Format.asJSON(target.buildParameters.toolchain.swiftCompiler.asString) <<< "\n"
+            <<< Format.asJSON(target.buildParameters.toolchain.swiftCompiler) <<< "\n"
         stream <<< "    module-name: "
             <<< Format.asJSON(target.target.c99name) <<< "\n"
         stream <<< "    module-output-path: "
-            <<< Format.asJSON(target.moduleOutputPath.asString) <<< "\n"
+            <<< Format.asJSON(target.moduleOutputPath) <<< "\n"
         stream <<< "    inputs: "
             <<< Format.asJSON(inputs) <<< "\n"
         stream <<< "    outputs: "
             <<< Format.asJSON(outputs) <<< "\n"
         stream <<< "    import-paths: "
-            <<< Format.asJSON([target.buildParameters.buildPath.asString]) <<< "\n"
+            <<< Format.asJSON([target.buildParameters.buildPath]) <<< "\n"
         stream <<< "    temps-path: "
-            <<< Format.asJSON(target.tempsPath.asString) <<< "\n"
+            <<< Format.asJSON(target.tempsPath) <<< "\n"
         stream <<< "    objects: "
-            <<< Format.asJSON(target.objects.map({ $0.asString })) <<< "\n"
+            <<< Format.asJSON(target.objects) <<< "\n"
         stream <<< "    other-args: "
             <<< Format.asJSON(target.compileArguments()) <<< "\n"
         stream <<< "    sources: "
-            <<< Format.asJSON(target.target.sources.paths.map({ $0.asString })) <<< "\n"
+            <<< Format.asJSON(target.target.sources.paths) <<< "\n"
         stream <<< "    is-library: "
             <<< Format.asJSON(target.target.type == .library || target.target.type == .test) <<< "\n"
         stream <<< "    enable-whole-module-optimization: "

--- a/Sources/Commands/Describe.swift
+++ b/Sources/Commands/Describe.swift
@@ -34,7 +34,7 @@ extension Package: JSONSerializable {
     func describe(on stream: OutputByteStream) {
         stream <<< """
             Name: \(name)
-            Path: \(path.asString)
+            Path: \(path)
             Modules:\n
             """
         for target in targets.sorted(by: { $0.name > $1.name }) {
@@ -44,10 +44,10 @@ extension Package: JSONSerializable {
     }
 
     public func toJSON() -> JSON {
-        return .dictionary([
-            "name": .string(name),
-            "path": .string(path.asString),
-            "targets": .array(targets.sorted(by: { $0.name > $1.name }).map({ $0.toJSON() })),
+        return .init([
+            "name": name,
+            "path": path,
+            "targets": targets.sorted(by: { $0.name > $1.name }),
         ])
     }
 }
@@ -64,26 +64,26 @@ extension Target: JSONSerializable {
         stream <<< Format.asRepeating(string: " ", count: indent)
             <<< "Module type: " <<< String(describing: Swift.type(of: self)) <<< "\n"
         stream <<< Format.asRepeating(string: " ", count: indent)
-            <<< "Path: " <<< sources.root.asString <<< "\n"
+            <<< "Path: " <<< sources.root <<< "\n"
         stream <<< Format.asRepeating(string: " ", count: indent)
-            <<< "Sources: " <<< sources.relativePaths.map({ $0.asString }).joined(separator: ", ") <<< "\n"
+            <<< "Sources: " <<< sources.relativePaths.map({ $0.description }).joined(separator: ", ") <<< "\n"
     }
 
     public func toJSON() -> JSON {
-        return .dictionary([
-            "name": .string(name),
-            "c99name": .string(c99name),
-            "type": type.toJSON(),
-            "module_type": .string(String(describing: Swift.type(of: self))),
-            "path": .string(sources.root.asString),
-            "sources": sources.toJSON(),
+        return .init([
+            "name": name,
+            "c99name": c99name,
+            "type": type,
+            "module_type": String(describing: Swift.type(of: self)),
+            "path": sources.root,
+            "sources": sources
         ])
     }
 }
 
 extension Sources: JSONSerializable {
     public func toJSON() -> JSON {
-        return .array(relativePaths.map({ .string($0.asString) }))
+        return .array(relativePaths.map({ .string($0.description) }))
     }
 }
 

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -58,7 +58,7 @@ public class SwiftBuildTool: SwiftTool<BuildToolOptions> {
            try build(plan: plan, subset: subset)
 
         case .binPath:
-            try print(buildParameters().buildPath.asString)
+            try print(buildParameters().buildPath)
 
         case .version:
             print(Versioning.currentVersion.completeDisplayString)

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -190,11 +190,11 @@ public class SwiftRunTool: SwiftTool<RunToolOptions> {
         // Make sure we are running from the original working directory.
         let cwd: AbsolutePath? = localFileSystem.currentWorkingDirectory
         if cwd == nil || originalWorkingDirectory != cwd {
-            try POSIX.chdir(originalWorkingDirectory.asString)
+            try POSIX.chdir(originalWorkingDirectory.description)
         }
 
         let pathRelativeToWorkingDirectory = excutablePath.relative(to: originalWorkingDirectory)
-        try exec(path: excutablePath.asString, args: [pathRelativeToWorkingDirectory.asString] + arguments)
+        try exec(path: excutablePath.description, args: [pathRelativeToWorkingDirectory.description] + arguments)
     }
 
     /// Determines if a path points to a valid swift file.

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -387,7 +387,7 @@ public class SwiftTool<Options: ToolOptions> {
             if let packagePath = options.packagePath ?? options.chdir {
                 // FIXME: This should be an API which takes AbsolutePath and maybe
                 // should be moved to file system APIs with currentWorkingDirectory.
-                try POSIX.chdir(packagePath.asString)
+                try POSIX.chdir(packagePath.description)
             }
 
             let processSet = ProcessSet()
@@ -626,7 +626,7 @@ public class SwiftTool<Options: ToolOptions> {
     }
 
     func runLLBuild(manifest: AbsolutePath, llbuildTarget: String) throws {
-        assert(localFileSystem.isFile(manifest), "llbuild manifest not present: \(manifest.asString)")
+        assert(localFileSystem.isFile(manifest), "llbuild manifest not present: \(manifest)")
         if options.shouldEnableLLBuildLibrary {
             try runLLBuildAsLibrary(manifest: manifest, llbuildTarget: llbuildTarget)
         } else {
@@ -635,8 +635,8 @@ public class SwiftTool<Options: ToolOptions> {
     }
 
     func runLLBuildAsLibrary(manifest: AbsolutePath, llbuildTarget: String) throws {
-        let databasePath = buildPath.appending(component: "build.db").asString
-        let buildSystem = BuildSystem(buildFile: manifest.asString, databaseFile: databasePath, delegate: buildDelegate)
+        let databasePath = buildPath.appending(component: "build.db").description
+        let buildSystem = BuildSystem(buildFile: manifest.description, databaseFile: databasePath, delegate: buildDelegate)
         buildDelegate.isVerbose = verbosity != .concise
         buildDelegate.onCommmandFailure = { [weak buildSystem] in buildSystem?.cancel() }
 
@@ -668,7 +668,7 @@ public class SwiftTool<Options: ToolOptions> {
         }
       #endif
 
-        args += [try getToolchain().llbuild.asString, "-f", manifest.asString, llbuildTarget]
+        args += [try getToolchain().llbuild.description, "-f", manifest.description, llbuildTarget]
         if verbosity != .concise {
             args.append("-v")
         }
@@ -678,7 +678,7 @@ public class SwiftTool<Options: ToolOptions> {
         // We override the temporary directory so tools assuming full access to
         // the tmp dir can create files here freely, provided they respect this
         // variable.
-        env["TMPDIR"] = tempDir.asString
+        env["TMPDIR"] = tempDir.description
 
         // Run llbuild and print output on standard streams.
         let process = Process(arguments: args, environment: env, outputRedirection: shouldRedirectStdoutToStderr ? .collect : .none)
@@ -847,19 +847,19 @@ private func sandboxProfile(allowedDirectories: [AbsolutePath]) -> String {
     stream <<< "(allow file-write*" <<< "\n"
     for directory in Platform.darwinCacheDirectories() {
         // For compiler module cache.
-        stream <<< "    (regex #\"^\(directory.asString)/org\\.llvm\\.clang.*\")" <<< "\n"
+        stream <<< "    (regex #\"^\(directory)/org\\.llvm\\.clang.*\")" <<< "\n"
         // For archive tool.
-        stream <<< "    (regex #\"^\(directory.asString)/ar.*\")" <<< "\n"
+        stream <<< "    (regex #\"^\(directory)/ar.*\")" <<< "\n"
         // For xcrun cache.
-        stream <<< "    (regex #\"^\(directory.asString)/xcrun.*\")" <<< "\n"
+        stream <<< "    (regex #\"^\(directory)/xcrun.*\")" <<< "\n"
         // For autolink files.
-        stream <<< "    (regex #\"^\(directory.asString)/.*\\.(swift|c)-[0-9a-f]+\\.autolink\")" <<< "\n"
+        stream <<< "    (regex #\"^\(directory)/.*\\.(swift|c)-[0-9a-f]+\\.autolink\")" <<< "\n"
     }
     for directory in allowedDirectories {
-        stream <<< "    (subpath \"\(directory.asString)\")" <<< "\n"
+        stream <<< "    (subpath \"\(directory)\")" <<< "\n"
     }
     stream <<< ")" <<< "\n"
-    return stream.bytes.asString!
+    return stream.bytes.description
 }
 
 extension BuildConfiguration: StringEnumArgument {

--- a/Sources/Commands/WatchmanHelper.swift
+++ b/Sources/Commands/WatchmanHelper.swift
@@ -66,7 +66,7 @@ final class WatchmanHelper {
         stream <<< "set -eu" <<< "\n\n"
         stream <<< "swift package generate-xcodeproj"
         if let xcconfigOverrides = options.xcconfigOverrides {
-            stream <<< " --xcconfig-overrides " <<< xcconfigOverrides.asString
+            stream <<< " --xcconfig-overrides " <<< xcconfigOverrides
         }
         stream <<< "\n"
 
@@ -82,15 +82,15 @@ final class WatchmanHelper {
         var args = [String]()
         args += ["--settle", "2"]
         args += ["-p", "Package.swift", "Package.resolved"]
-        args += ["--run", scriptPath.asString.spm_shellEscaped()]
+        args += ["--run", scriptPath.description.spm_shellEscaped()]
 
         // Find and execute watchman.
         let watchmanMakeToolPath = try self.watchmanMakeToolPath()
 
-        print("Starting:", watchmanMakeToolPath.asString, args.joined(separator: " "))
+        print("Starting:", watchmanMakeToolPath, args.joined(separator: " "))
 
         let pathRelativeToWorkingDirectory = watchmanMakeToolPath.relative(to: packageRoot)
-        try exec(path: watchmanMakeToolPath.asString, args: [pathRelativeToWorkingDirectory.asString] + args)
+        try exec(path: watchmanMakeToolPath.description, args: [pathRelativeToWorkingDirectory.description] + args)
     }
 
     private func watchmanMakeToolPath() throws -> AbsolutePath {

--- a/Sources/Commands/show-dependencies.swift
+++ b/Sources/Commands/show-dependencies.swift
@@ -117,12 +117,12 @@ private final class JSONDumper: DependenciesDumper {
     func dump(dependenciesOf rootpkg: ResolvedPackage) {
         func convert(_ package: ResolvedPackage) -> JSON {
             return .orderedDictionary([
-                    "name": .string(package.name),
-                    "url": .string(package.manifest.url),
-                    "version": .string(package.manifest.version?.description ?? "unspecified"),
-                    "path": .string(package.path.asString),
-                    "dependencies": .array(package.dependencies.map(convert)),
-                ])
+                "name": .string(package.name),
+                "url": .string(package.manifest.url),
+                "version": .string(package.manifest.version?.description ?? "unspecified"),
+                "path": .string(package.path.description),
+                "dependencies": .array(package.dependencies.map(convert)),
+            ])
         }
 
         print(convert(rootpkg).toString(prettyPrint: true))

--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -58,7 +58,7 @@ public enum DependencyResolverError: Error, Equatable, CustomStringConvertible {
                     stream  <<< "\n"
                 }
             }
-            return stream.bytes.asString!
+            return stream.bytes.description
         }
     }
 }

--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -74,7 +74,7 @@ public struct PackageGraphRoot {
             // strip that. We need to design a URL data structure for SwiftPM.
             let filePrefix = "file://"
             if url.hasPrefix(filePrefix) {
-                self.url = AbsolutePath(String(url.dropFirst(filePrefix.count))).asString
+                self.url = AbsolutePath(String(url.dropFirst(filePrefix.count))).description
             } else {
                 self.url = url
             }
@@ -95,7 +95,7 @@ public struct PackageGraphRoot {
     /// Create a package graph root.
     public init(input: PackageGraphRootInput, manifests: [Manifest]) {
         self.packageRefs = zip(input.packages, manifests).map { (path, manifest) in
-            PackageReference(identity: manifest.name.lowercased(), path: path.asString, isLocal: true)
+            PackageReference(identity: manifest.name.lowercased(), path: path.description, isLocal: true)
         }
         self.manifests = manifests
         self.dependencies = input.dependencies

--- a/Sources/PackageGraph/Pubgrub.swift
+++ b/Sources/PackageGraph/Pubgrub.swift
@@ -939,7 +939,7 @@ public final class PubgrubDependencyResolver<
         let stream = BufferedOutputByteStream()
         visit(incompatibility, stream)
 
-        return stream.bytes.asString!
+        return stream.bytes.description
     }
 
     private func visit(

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -309,7 +309,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         // The compiler has special meaning for files with extensions like .ll, .bc etc.
         // Assert that we only try to load files with extension .swift to avoid unexpected loading behavior.
         assert(manifestPath.extension == "swift",
-               "Manifest files must contain .swift suffix in their name, given: \(manifestPath.asString).")
+               "Manifest files must contain .swift suffix in their name, given: \(manifestPath).")
 
         // For now, we load the manifest by having Swift interpret it directly.
         // Eventually, we should have two loading processes, one that loads only
@@ -317,7 +317,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         // and validates it.
 
         // Compute the path to runtime we need to load.
-        let runtimePath = self.runtimePath(for: manifestVersion).asString
+        let runtimePath = self.runtimePath(for: manifestVersion).description
         let interpreterFlags = self.interpreterFlags(for: manifestVersion)
 
         var cmd = [String]()
@@ -329,13 +329,13 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             cmd += ["sandbox-exec", "-p", sandboxProfile()]
         }
       #endif
-        cmd += [resources.swiftCompiler.asString]
+        cmd += [resources.swiftCompiler.description]
         cmd += ["--driver-mode=swift"]
         cmd += bootstrapArgs()
         cmd += verbosity.ccArgs
         cmd += ["-L", runtimePath, "-lPackageDescription"]
         cmd += interpreterFlags
-        cmd += [manifestPath.asString]
+        cmd += [manifestPath.description]
 
         // Create and open a temporary file to write json to.
         let file = try TemporaryFile()
@@ -355,7 +355,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             diagnostics?.emit(data: ManifestLoadingDiagnostic(output: output))
         }
 
-        guard let json = try localFileSystem.readFileContents(file.path).asString else {
+        guard let json = try localFileSystem.readFileContents(file.path).validDescription else {
             throw StringError("the manifest has invalid encoding")
         }
 
@@ -384,10 +384,10 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         let dispatchIncdir = incdir.appending(component: "dispatch")
 
         return [
-            "-I" + incdir.asString,
-            "-I" + dispatchIncdir.asString,
-            "-L" + libdir.asString,
-            "-Xcc", "-F" + incdir.asString,
+            "-I\(incdir)",
+            "-I\(dispatchIncdir)",
+            "-L\(libdir)",
+            "-Xcc", "-F\(incdir)",
         ]
       #endif
     }
@@ -420,12 +420,12 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         var cmd = [String]()
         let runtimePath = self.runtimePath(for: manifestVersion)
         cmd += ["-swift-version", manifestVersion.swiftLanguageVersion.rawValue]
-        cmd += ["-I", runtimePath.asString]
+        cmd += ["-I", runtimePath.description]
       #if os(macOS)
         cmd += ["-target", "x86_64-apple-macosx10.10"]
       #endif
         if let sdkRoot = resources.sdkRoot ?? self.sdkRoot() {
-            cmd += ["-sdk", sdkRoot.asString]
+            cmd += ["-sdk", sdkRoot.description]
         }
         return cmd
     }
@@ -447,7 +447,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
         if isManifestCachingEnabled {
             try localFileSystem.createDirectory(cacheDir, recursive: true)
-            try engine.attachDB(path: cacheDir.appending(component: "manifest.db").asString)
+            try engine.attachDB(path: cacheDir.appending(component: "manifest.db").description)
         }
         _engine = engine
         return engine
@@ -471,10 +471,10 @@ private func sandboxProfile() -> String {
     // Allow writing in temporary locations.
     stream <<< "(allow file-write*" <<< "\n"
     for directory in Platform.darwinCacheDirectories() {
-        stream <<< "    (regex #\"^\(directory.asString)/org\\.llvm\\.clang.*\")" <<< "\n"
+        stream <<< "    (regex #\"^\(directory)/org\\.llvm\\.clang.*\")" <<< "\n"
     }
     stream <<< ")" <<< "\n"
-    return stream.bytes.asString!
+    return stream.bytes.description
 }
 
 // FIXME: We should probably just remove this and make all Manifest errors Codable.

--- a/Sources/PackageLoading/ModuleMapGenerator.swift
+++ b/Sources/PackageLoading/ModuleMapGenerator.swift
@@ -143,8 +143,8 @@ public struct ModuleMapGenerator {
         let umbrellaHeader = path.appending(component: target.c99name + ".h")
         let invalidUmbrellaHeader = path.appending(component: target.name + ".h")
         if target.c99name != target.name && fileSystem.isFile(invalidUmbrellaHeader) {
-            warningStream <<< ("warning: \(invalidUmbrellaHeader.asString) should be renamed to " +
-                "\(umbrellaHeader.asString) to be used as an umbrella header")
+            warningStream <<< "warning: \(invalidUmbrellaHeader) should be renamed to "
+            warningStream <<< "\(umbrellaHeader) to be used as an umbrella header"
             warningStream.flush()
         }
     }
@@ -159,9 +159,9 @@ public struct ModuleMapGenerator {
         stream <<< "module \(target.c99name) {\n"
         switch type {
         case .header(let header):
-            stream <<< "    umbrella header \"\(header.asString)\"\n"
+            stream <<< "    umbrella header \"\(header)\"\n"
         case .directory(let path):
-            stream <<< "    umbrella \"\(path.asString)\"\n"
+            stream <<< "    umbrella \"\(path)\"\n"
         }
         stream <<< "    export *\n"
         stream <<< "}\n"
@@ -193,16 +193,16 @@ extension ModuleMapGenerator.ModuleMapError.UnsupportedIncludeLayoutType: Custom
     public var description: String {
         switch self {
         case .umbrellaHeaderWithAdditionalNonEmptyDirectories(let (umbrella, dirs)):
-            return "umbrella header defined at '\(umbrella.asString)', but directories exist: " +
-                dirs.map({ $0.asString }).sorted().joined(separator: ", ") +
+            return "umbrella header defined at '\(umbrella)', but directories exist: " +
+                dirs.map({ $0.description }).sorted().joined(separator: ", ") +
                 "; consider removing them"
         case .umbrellaHeaderWithAdditionalDirectoriesInIncludeDirectory(let (umbrella, dirs)):
-            return "umbrella header defined at '\(umbrella.asString)', but more than one directories exist: " +
-                dirs.map({ $0.asString }).sorted().joined(separator: ", ") +
+            return "umbrella header defined at '\(umbrella)', but more than one directories exist: " +
+                dirs.map({ $0.description }).sorted().joined(separator: ", ") +
                 "; consider reducing them to one"
         case .umbrellaHeaderWithAdditionalFilesInIncludeDirectory(let (umbrella, files)):
-            return "umbrella header defined at '\(umbrella.asString)', but files exist:" +
-                files.map({ $0.asString }).sorted().joined(separator: ", ") +
+            return "umbrella header defined at '\(umbrella)', but files exist:" +
+                files.map({ $0.description }).sorted().joined(separator: ", ") +
                 "; consider removing them"
         }
     }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -78,10 +78,11 @@ extension ModuleError: CustomStringConvertible {
         case .invalidPublicHeadersDirectory(let name):
             return "public headers directory path for '\(name)' is invalid or not contained in the target"
         case .overlappingSources(let target, let sources):
-            return "target '\(target)' has sources overlapping sources: \(sources.map({$0.asString}).joined(separator: ", "))"
+            return "target '\(target)' has sources overlapping sources: " +
+                sources.map({ $0.description }).joined(separator: ", ")
         case .multipleLinuxMainFound(let package, let linuxMainFiles):
-            let files = linuxMainFiles.map({ $0.asString }).sorted().joined(separator: ", ")
-            return "package '\(package)' has multiple linux main files: \(files)"
+            return "package '\(package)' has multiple linux main files: " +
+                linuxMainFiles.map({ $0.description }).sorted().joined(separator: ", ")
         case .incompatibleToolsVersions(let package, let required, let current):
             if required.isEmpty {
                 return "package '\(package)' supported Swift language versions is empty"
@@ -291,7 +292,7 @@ public final class PackageBuilder {
             // Diagnose broken symlinks.
             if fileSystem.isSymlink(path) {
                 diagnostics.emit(
-                    data: PackageBuilderDiagnostics.BorkenSymlinkDiagnostic(path: path.asString),
+                    data: PackageBuilderDiagnostics.BorkenSymlinkDiagnostic(path: path.description),
                     location: diagnosticLocation()
                 )
             }
@@ -567,7 +568,7 @@ public final class PackageBuilder {
     private func validateModuleName(_ path: AbsolutePath, _ name: String, isTest: Bool) throws {
         if name.isEmpty {
             throw Target.Error.invalidName(
-                path: path.relative(to: packagePath).asString,
+                path: path.relative(to: packagePath).description,
                 problem: .emptyName)
         }
     }
@@ -665,7 +666,7 @@ public final class PackageBuilder {
 
         // Make sure there is no modulemap mixed with the sources.
         if let path = walked.first(where: { $0.basename == moduleMapFilename }) {
-            throw ModuleError.invalidLayout(.modulemapInSources(path.asString))
+            throw ModuleError.invalidLayout(.modulemapInSources(path.description))
         }
         // Select any source files for the C-based languages and for Swift.
         let sources = walked.filter(isValidSource).filter({ !targetExcludedPaths.contains($0) })
@@ -694,7 +695,7 @@ public final class PackageBuilder {
             )
         } else {
             // No Swift sources, so we expect to have C sources, and we create a C target.
-            guard swiftSources.isEmpty else { throw Target.Error.mixedSources(potentialModule.path.asString) }
+            guard swiftSources.isEmpty else { throw Target.Error.mixedSources(potentialModule.path.description) }
             let cSources = Array(clangSources)
             try validateSourcesOverlapping(forTarget: potentialModule.name, sources: cSources)
 
@@ -738,7 +739,7 @@ public final class PackageBuilder {
                 // Ensure that the search path is contained within the package.
                 let subpath = try RelativePath(validating: setting.value[0])
                 guard targetRoot.appending(subpath).contains(packagePath) else {
-                    throw ModuleError.invalidHeaderSearchPath(subpath.asString)
+                    throw ModuleError.invalidHeaderSearchPath(subpath.description)
                 }
 
             case .define:

--- a/Sources/PackageLoading/PackageDescription4Loader.swift
+++ b/Sources/PackageLoading/PackageDescription4Loader.swift
@@ -288,13 +288,13 @@ extension PackageDependencyDescription {
 
             // If the dependency URL starts with '~/', try to expand it.
             if url.hasPrefix("~/") {
-                return fileSystem.homeDirectory.appending(RelativePath(String(url.dropFirst(2)))).asString
+                return fileSystem.homeDirectory.appending(RelativePath(String(url.dropFirst(2)))).description
             }
 
             // If the dependency URL is not remote, try to "fix" it.
             if URL.scheme(url) == nil {
                 // If the URL has no scheme, we treat it as a path (either absolute or relative to the base URL).
-                return AbsolutePath(url, relativeTo: AbsolutePath(baseURL)).asString
+                return AbsolutePath(url, relativeTo: AbsolutePath(baseURL)).description
             }
 
             return url

--- a/Sources/PackageLoading/Target+PkgConfig.swift
+++ b/Sources/PackageLoading/Target+PkgConfig.swift
@@ -127,7 +127,7 @@ extension SystemPackageProviderDescription {
         case .brew(let packages):
             let brewPrefix: String
             if let brewPrefixOverride = brewPrefixOverride {
-                brewPrefix = brewPrefixOverride.asString
+                brewPrefix = brewPrefixOverride.description
             } else {
                 // Homebrew can have multiple versions of the same package. The
                 // user can choose another version than the latest by running

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -63,7 +63,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         public var description: String {
             switch self {
             case .malformed(let versionSpecifier, let file):
-                return "the version specifier '\(versionSpecifier)' in '\(file.asString)' is not valid"
+                return "the version specifier '\(versionSpecifier)' in '\(file)' is not valid"
             }
         }
     }
@@ -91,7 +91,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
                 maxSplits: 1,
                 omittingEmptySubsequences: false)
             let misspellings = ["swift-tool", "tool-version"]
-            if let firstLine = ByteString(splitted[0]).asString,
+            if let firstLine = ByteString(splitted[0]).validDescription,
                misspellings.first(where: firstLine.lowercased().contains) != nil {
                 throw Error.malformed(specifier: firstLine, file: file)
             }
@@ -113,7 +113,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
             maxSplits: 1,
             omittingEmptySubsequences: false)
         // Try to match our regex and see if a valid specifier line.
-        guard let firstLine = ByteString(splitted[0]).asString,
+        guard let firstLine = ByteString(splitted[0]).validDescription,
               let match = ToolsVersionLoader.regex.firstMatch(
                   in: firstLine, options: [], range: NSRange(location: 0, length: firstLine.count)),
               match.numberOfRanges >= 2 else {

--- a/Sources/PackageModel/Sources.swift
+++ b/Sources/PackageModel/Sources.swift
@@ -22,7 +22,7 @@ public struct Sources {
 
     public init(paths: [AbsolutePath], root: AbsolutePath) {
         let relativePaths = paths.map({ $0.relative(to: root) })
-        self.relativePaths = relativePaths.sorted(by: { $0.asString < $1.asString })
+        self.relativePaths = relativePaths.sorted(by: { $0.description < $1.description })
         self.root = root
     }
 

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -402,6 +402,6 @@ extension RepositoryManager: SimplePersistanceProtocol {
 
 extension RepositoryManager.RepositoryHandle: CustomStringConvertible {
     public var description: String {
-        return "<\(type(of: self)) subpath:\(subpath.asString)>"
+        return "<\(type(of: self)) subpath:\(subpath)>"
     }
 }

--- a/Sources/TestSupport/GitRepositoryExtensions.swift
+++ b/Sources/TestSupport/GitRepositoryExtensions.swift
@@ -18,46 +18,46 @@ public extension GitRepository {
 
     /// Create the repository using git init.
     func create() throws {
-        try systemQuietly([Git.tool, "-C", path.asString, "init"])
+        try systemQuietly([Git.tool, "-C", path.description, "init"])
     }
 
     /// Returns current branch name. If HEAD is on a detached state, this returns HEAD.
     func currentBranch() throws -> String {
         return try Process.checkNonZeroExit(
-            args: Git.tool, "-C", path.asString, "rev-parse", "--abbrev-ref", "HEAD").spm_chomp()
+            args: Git.tool, "-C", path.description, "rev-parse", "--abbrev-ref", "HEAD").spm_chomp()
     }
 
     /// Stage a file.
     func stage(file: String) throws {
-        try systemQuietly([Git.tool, "-C", path.asString, "add", file])
+        try systemQuietly([Git.tool, "-C", path.description, "add", file])
     }
 
     /// Stage multiple files.
     func stage(files: String...) throws {
-        try systemQuietly([Git.tool, "-C", path.asString, "add"] + files)
+        try systemQuietly([Git.tool, "-C", path.description, "add"] + files)
     }
 
     /// Stage entire unstaged changes.
     func stageEverything() throws {
-        try systemQuietly([Git.tool, "-C", path.asString, "add", "."])
+        try systemQuietly([Git.tool, "-C", path.description, "add", "."])
     }
 
     /// Commit the staged changes. If the message is not provided a dummy message will be used for the commit.
     func commit(message: String? = nil) throws {
         // FIXME: We don't need to set these everytime but we usually only commit once or twice for a test repo.
-        try systemQuietly([Git.tool, "-C", path.asString, "config", "user.email", "example@example.com"])
-        try systemQuietly([Git.tool, "-C", path.asString, "config", "user.name", "Example Example"])
-        try systemQuietly([Git.tool, "-C", path.asString, "config", "commit.gpgsign", "false"])
-        try systemQuietly([Git.tool, "-C", path.asString, "commit", "-m", message ?? "Add some files."])
+        try systemQuietly([Git.tool, "-C", path.description, "config", "user.email", "example@example.com"])
+        try systemQuietly([Git.tool, "-C", path.description, "config", "user.name", "Example Example"])
+        try systemQuietly([Git.tool, "-C", path.description, "config", "commit.gpgsign", "false"])
+        try systemQuietly([Git.tool, "-C", path.description, "commit", "-m", message ?? "Add some files."])
     }
 
     /// Tag the git repo.
     func tag(name: String) throws {
-        try systemQuietly([Git.tool, "-C", path.asString, "tag", name])
+        try systemQuietly([Git.tool, "-C", path.description, "tag", name])
     }
 
     /// Push the changes to specified remote and branch.
     func push(remote: String, branch: String) throws {
-        try systemQuietly([Git.tool, "-C", path.asString, "push", remote, branch])
+        try systemQuietly([Git.tool, "-C", path.description, "push", remote, branch])
     }
 }

--- a/Sources/TestSupport/MockDependencyGraph.swift
+++ b/Sources/TestSupport/MockDependencyGraph.swift
@@ -105,7 +105,7 @@ public struct MockManifestGraph {
         let repos = Dictionary(items: try packages.map({ package -> (String, RepositorySpecifier) in
             let repoPath = path.appending(component: package.name)
             let tag = package.version?.description ?? "initial"
-            let specifier = RepositorySpecifier(url: repoPath.asString)
+            let specifier = RepositorySpecifier(url: repoPath.description)
 
             // If this is in memory mocked graph.
             if let inMemory = inMemory {
@@ -135,7 +135,7 @@ public struct MockManifestGraph {
         } else {
             // Make a sources folder for our root package.
             try makeDirectories(src)
-            try systemQuietly(["touch", src.appending(component: "foo.swift").asString])
+            try systemQuietly(["touch", src.appending(component: "foo.swift").description])
         }
 
         // Create the root manifest.
@@ -143,7 +143,7 @@ public struct MockManifestGraph {
             name: "Root",
             platforms: [],
             path: path.appending(component: Manifest.filename),
-            url: path.asString,
+            url: path.description,
             version: nil,
             manifestVersion: .v4,
             dependencies: MockManifestGraph.createDependencies(repos: repos, dependencies: rootDeps)
@@ -164,7 +164,7 @@ public struct MockManifestGraph {
             return (MockManifestLoader.Key(url: url, version: package.version), manifest)
         }))
         // Add the root manifest.
-        manifests[MockManifestLoader.Key(url: path.asString, version: nil)] = rootManifest
+        manifests[MockManifestLoader.Key(url: path.description, version: nil)] = rootManifest
 
         manifestLoader = MockManifestLoader(manifests: manifests)
         self.manifests = manifests

--- a/Sources/TestSupport/SwiftPMProduct.swift
+++ b/Sources/TestSupport/SwiftPMProduct.swift
@@ -119,9 +119,9 @@ public enum SwiftPMProduct {
         environment["IS_SWIFTPM_TEST"] = "1"
         environment["SDKROOT"] = nil
 
-        var completeArgs = [path.asString]
+        var completeArgs = [path.description]
         if let packagePath = packagePath {
-            completeArgs += ["--package-path", packagePath.asString]
+            completeArgs += ["--package-path", packagePath.description]
         }
         completeArgs += args
 

--- a/Sources/TestSupport/TestWorkspace.swift
+++ b/Sources/TestSupport/TestWorkspace.swift
@@ -75,7 +75,7 @@ public final class TestWorkspace {
             let packagePath = basePath.appending(RelativePath(package.path ?? package.name))
 
             let sourcesDir = packagePath.appending(component: "Sources")
-            let url = (isRoot ? packagePath : packagesDir.appending(RelativePath(package.path ?? package.name))).asString
+            let url = (isRoot ? packagePath : packagesDir.appending(RelativePath(package.path ?? package.name))).description
             let specifier = RepositorySpecifier(url: url)
             let manifestPath = packagePath.appending(component: Manifest.filename)
             
@@ -170,7 +170,7 @@ public final class TestWorkspace {
 
         fileprivate func convert(_ packagesDir: AbsolutePath) -> PackageGraphRootInput.PackageDependency {
             return PackageGraphRootInput.PackageDependency(
-                url: packagesDir.appending(RelativePath(name)).asString,
+                url: packagesDir.appending(RelativePath(name)).description,
                 requirement: requirement,
                 location: name
             )
@@ -445,7 +445,7 @@ public struct TestDependency {
     }
 
     public func convert(baseURL: AbsolutePath) -> PackageDependencyDescription {
-        return PackageDependencyDescription(url: baseURL.appending(RelativePath(name)).asString, requirement: requirement)
+        return PackageDependencyDescription(url: baseURL.appending(RelativePath(name)).description, requirement: requirement)
     }
 }
 

--- a/Sources/TestSupport/XCTAssertHelpers.swift
+++ b/Sources/TestSupport/XCTAssertHelpers.swift
@@ -95,19 +95,19 @@ public func XCTAssertBuildFails(
 
 public func XCTAssertFileExists(_ path: AbsolutePath, file: StaticString = #file, line: UInt = #line) {
     if !isFile(path) {
-        XCTFail("Expected file doesn't exist: \(path.asString)", file: file, line: line)
+        XCTFail("Expected file doesn't exist: \(path)", file: file, line: line)
     }
 }
 
 public func XCTAssertDirectoryExists(_ path: AbsolutePath, file: StaticString = #file, line: UInt = #line) {
     if !isDirectory(path) {
-        XCTFail("Expected directory doesn't exist: \(path.asString)", file: file, line: line)
+        XCTFail("Expected directory doesn't exist: \(path)", file: file, line: line)
     }
 }
 
 public func XCTAssertNoSuchPath(_ path: AbsolutePath, file: StaticString = #file, line: UInt = #line) {
     if exists(path) {
-        XCTFail("path exists but should not: \(path.asString)", file: file, line: line)
+        XCTFail("path exists but should not: \(path)", file: file, line: line)
     }
 }
 

--- a/Sources/TestSupport/misc.swift
+++ b/Sources/TestSupport/misc.swift
@@ -56,7 +56,7 @@ public func fixture(
 
         // Check that the fixture is really there.
         guard isDirectory(fixtureDir) else {
-            XCTFail("No such fixture: \(fixtureDir.asString)", file: file, line: line)
+            XCTFail("No such fixture: \(fixtureDir)", file: file, line: line)
             return
         }
 
@@ -64,7 +64,7 @@ public func fixture(
         if isFile(fixtureDir.appending(component: "Package.swift")) {
             // It's a single package, so copy the whole directory as-is.
             let dstDir = tmpDir.path.appending(component: copyName)
-            try systemQuietly("cp", "-R", "-H", fixtureDir.asString, dstDir.asString)
+            try systemQuietly("cp", "-R", "-H", fixtureDir.description, dstDir.description)
 
             // Invoke the block, passing it the path of the copied fixture.
             try body(dstDir)
@@ -74,7 +74,7 @@ public func fixture(
                 let srcDir = fixtureDir.appending(component: fileName)
                 guard isDirectory(srcDir) else { continue }
                 let dstDir = tmpDir.path.appending(component: fileName)
-                try systemQuietly("cp", "-R", "-H", srcDir.asString, dstDir.asString)
+                try systemQuietly("cp", "-R", "-H", srcDir.description, dstDir.description)
                 initGitRepo(dstDir, tag: "1.2.3", addFile: false)
             }
 
@@ -114,13 +114,13 @@ public func initGitRepo(
     do {
         if addFile {
             let file = dir.appending(component: "file.swift")
-            try systemQuietly(["touch", file.asString])
+            try systemQuietly(["touch", file.description])
         }
 
-        try systemQuietly([Git.tool, "-C", dir.asString, "init"])
-        try systemQuietly([Git.tool, "-C", dir.asString, "config", "user.email", "example@example.com"])
-        try systemQuietly([Git.tool, "-C", dir.asString, "config", "user.name", "Example Example"])
-        try systemQuietly([Git.tool, "-C", dir.asString, "config", "commit.gpgsign", "false"])
+        try systemQuietly([Git.tool, "-C", dir.description, "init"])
+        try systemQuietly([Git.tool, "-C", dir.description, "config", "user.email", "example@example.com"])
+        try systemQuietly([Git.tool, "-C", dir.description, "config", "user.name", "Example Example"])
+        try systemQuietly([Git.tool, "-C", dir.description, "config", "commit.gpgsign", "false"])
         let repo = GitRepository(path: dir)
         try repo.stageEverything()
         try repo.commit(message: "msg")
@@ -205,9 +205,9 @@ public func loadPackageGraph(
     createREPLProduct: Bool = false
 ) -> PackageGraph {
     let input = PackageGraphRootInput(packages: roots.map({ AbsolutePath($0) }))
-    let rootManifests = manifests.filter({ roots.contains($0.path.parentDirectory.asString) })
+    let rootManifests = manifests.filter({ roots.contains($0.path.parentDirectory.description) })
     let graphRoot = PackageGraphRoot(input: input, manifests: rootManifests)
-    let externalManifests = manifests.filter({ !roots.contains($0.path.parentDirectory.asString) })
+    let externalManifests = manifests.filter({ !roots.contains($0.path.parentDirectory.description) })
 
     return PackageGraphLoader().load(
         root: graphRoot,

--- a/Sources/TestSupportExecutable/main.swift
+++ b/Sources/TestSupportExecutable/main.swift
@@ -18,7 +18,7 @@ func fileLockTest(cacheDir: AbsolutePath, path: AbsolutePath, content: Int) thro
         // Get thr current contents of the file if any.
         let currentData: Int
         if localFileSystem.exists(path) {
-            currentData = Int(try localFileSystem.readFileContents(path).asString!) ?? 0
+            currentData = Int(try localFileSystem.readFileContents(path).description) ?? 0
         } else {
             currentData = 0
         }
@@ -121,7 +121,7 @@ do {
         let handlerTest = try HandlerTest(options.temporaryFile!)
         handlerTest.run()
     case .pathArgumentTest:
-        print(options.absolutePath!.asString)
+        print(options.absolutePath!)
     case .help:
         parser.printUsage(on: stdoutStream)
     }

--- a/Sources/Utility/Diagnostics.swift
+++ b/Sources/Utility/Diagnostics.swift
@@ -143,8 +143,8 @@ public enum PackageLocation {
             if let name = name {
                 stream <<< "'\(name)' "
             }
-            stream <<< packagePath.asString
-            return stream.bytes.asString!
+            stream <<< packagePath
+            return stream.bytes.description
         }
     }
 

--- a/Sources/Utility/FSWatch.swift
+++ b/Sources/Utility/FSWatch.swift
@@ -274,7 +274,7 @@ public final class Inotify {
         /// Add watch for each path.
         for (path, options) in paths {
 
-            let wd = inotify_add_watch(fd, path.asString, UInt32(options.rawValue))
+            let wd = inotify_add_watch(fd, path.description, UInt32(options.rawValue))
             guard wd != -1 else {
                 throw Error.failedToWatch(path)
             }
@@ -566,7 +566,7 @@ public final class FSEventStream {
         self.stream = FSEventStreamCreate(nil,
             callback, 
             &callbackContext, 
-            paths.map({ $0.asString }) as CFArray, 
+            paths.map({ $0.description }) as CFArray, 
             FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
             latency,
             // FIXME: This needs to be customizable.

--- a/Sources/Utility/PkgConfig.swift
+++ b/Sources/Utility/PkgConfig.swift
@@ -68,7 +68,7 @@ struct PCFileFinder {
             do {
                 let pkgConfigPath: String
                 if let brewPrefix = brewPrefix {
-                    pkgConfigPath = brewPrefix.appending(components: "bin", "pkg-config").asString
+                    pkgConfigPath = brewPrefix.appending(components: "bin", "pkg-config").description
                 } else {
                     pkgConfigPath = "pkg-config"
                 }
@@ -208,11 +208,11 @@ struct PkgConfigParser {
         }
 
         // Add pcfiledir variable. This is path to the directory containing the pc file.
-        variables["pcfiledir"] = pcFile.parentDirectory.asString
+        variables["pcfiledir"] = pcFile.parentDirectory.description
 
         let fileContents = try fileSystem.readFileContents(pcFile)
         // FIXME: Should we error out instead if content is not UTF8 representable?
-        for line in fileContents.asString?.components(separatedBy: "\n") ?? [] {
+        for line in fileContents.validDescription?.components(separatedBy: "\n") ?? [] {
             // Remove commented or any trailing comment from the line.
             let uncommentedLine = removeComment(line: line)
             // Ignore any empty or whitespace line.
@@ -228,7 +228,7 @@ struct PkgConfigParser {
                 variables[name.spm_chuzzle() ?? ""] = try resolveVariables(value)
             } else {
                 // Unexpected thing in the pc file, abort.
-                throw PkgConfigError.parsingError("Unexpected line: \(line) in \(pcFile.asString)")
+                throw PkgConfigError.parsingError("Unexpected line: \(line) in \(pcFile)")
             }
         }
     }
@@ -293,9 +293,10 @@ struct PkgConfigParser {
             if operators.contains(arg) {
                 // We should have a version number next, skip.
                 guard it.next() != nil else {
-                    throw PkgConfigError.parsingError(
-                        "Expected version number after \(deps.last.debugDescription) \(arg) in \"\(depString)\" in " +
-                        "\(pcFile.asString)")
+                    throw PkgConfigError.parsingError("""
+                        Expected version number after \(deps.last.debugDescription) \(arg) in \"\(depString)\" in \
+                        \(pcFile)
+                        """)
                 }
             } else {
                 // Otherwise it is a dependency.
@@ -331,7 +332,8 @@ struct PkgConfigParser {
                 // Append the contents before the variable.
                 result += fragment[fragment.startIndex..<variable.startIndex]
                 guard let variableValue = variables[variable.name] else {
-                    throw PkgConfigError.parsingError("Expected a value for variable '\(variable.name)' in \(pcFile.asString). Variables: \(variables)")
+                    throw PkgConfigError.parsingError(
+                        "Expected a value for variable '\(variable.name)' in \(pcFile). Variables: \(variables)")
                 }
                 // Append the value of the variable.
                 result += variableValue
@@ -380,7 +382,7 @@ struct PkgConfigParser {
         }
         guard !inQuotes else {
             throw PkgConfigError.parsingError(
-                "Text ended before matching quote was found in line: \(line) file: \(pcFile.asString)")
+                "Text ended before matching quote was found in line: \(line) file: \(pcFile)")
         }
         saveFragment()
         return splits

--- a/Sources/Utility/Platform.swift
+++ b/Sources/Utility/Platform.swift
@@ -66,7 +66,7 @@ public enum Platform {
         defer { tmp.deallocate() }
         guard confstr(name, tmp.baseAddress, len) == len else { return nil }
         let value = String(cString: tmp.baseAddress!)
-        guard value.hasSuffix(AbsolutePath.root.asString) else { return nil }
+        guard value.hasSuffix(AbsolutePath.root.description) else { return nil }
         return resolveSymlinks(AbsolutePath(value))
     }
 }

--- a/Sources/Utility/SimplePersistence.swift
+++ b/Sources/Utility/SimplePersistence.swift
@@ -31,7 +31,7 @@ extension SimplePersistence.Error: CustomStringConvertible {
             return "unsupported schema version \(version)"
 
         case let .restoreFailure(stateFile, error):
-            return "unable to restore state from \(stateFile.asString); \(error)"
+            return "unable to restore state from \(stateFile); \(error)"
         }
     }
 }

--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -111,7 +111,7 @@ public struct Destination {
 
         // Compute common arguments for clang and swift.
         // This is currently just frameworks path.
-        let commonArgs = Destination.sdkPlatformFrameworkPath(environment: environment).map({ ["-F", $0.asString] }) ?? []
+        let commonArgs = Destination.sdkPlatformFrameworkPath(environment: environment).map({ ["-F", $0.description] }) ?? []
 
         return Destination(
             target: hostTargetTriple,

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -49,7 +49,7 @@ public struct ManifestDuplicateDeclDiagnostic: DiagnosticData {
                     stream <<< "\n"
                 }
 
-                return stream.bytes.asString!
+                return stream.bytes.description
             }, preference: .default)
         }
     )
@@ -122,7 +122,7 @@ public enum ResolverDiagnostics {
                 stream <<< "unversioned"
             }
 
-            return stream.bytes.asString!
+            return stream.bytes.description
         }
 
         /// The conflicting dependencies.
@@ -164,7 +164,7 @@ public enum WorkspaceDiagnostics {
             type: UncommitedChanges.self,
             name: "org.swift.diags.workspace.uncommited-changes",
             description: {
-                $0 <<< "repository" <<< { "'\($0.repositoryPath.asString)'" } <<< "has uncommited changes"
+                $0 <<< "repository" <<< { "'\($0.repositoryPath)'" } <<< "has uncommited changes"
             })
     
         /// The local path to the repository.
@@ -178,7 +178,7 @@ public enum WorkspaceDiagnostics {
             type: UnpushedChanges.self,
             name: "org.swift.diags.workspace.unpushed-changes",
             description: {
-                $0 <<< "repository" <<< { "'\($0.repositoryPath.asString)'" } <<< "has unpushed changes"
+                $0 <<< "repository" <<< { "'\($0.repositoryPath)'" } <<< "has unpushed changes"
             })
         
         /// The local path to the repository.
@@ -259,7 +259,7 @@ public enum WorkspaceDiagnostics {
             type: RequireNewerTools.self,
             name: "org.swift.diags.workspace.\(RequireNewerTools.self)",
             description: {
-                $0 <<< "package at" <<< { "'\($0.packagePath.asString)'" }
+                $0 <<< "package at" <<< { "'\($0.packagePath)'" }
                 $0 <<< "is using Swift tools version" <<< { $0.packageToolsVersion.description }
                 $0 <<< "but the installed version is" <<< { "\($0.installedToolsVersion.description)" }
             })
@@ -280,7 +280,7 @@ public enum WorkspaceDiagnostics {
             type: UnsupportedToolsVersion.self,
             name: "org.swift.diags.workspace.\(UnsupportedToolsVersion.self)",
             description: {
-                $0 <<< "package at" <<< { "'\($0.packagePath.asString)'" }
+                $0 <<< "package at" <<< { "'\($0.packagePath)'" }
                 $0 <<< "is using Swift tools version" <<< { $0.packageToolsVersion.description }
                 $0 <<< "which is no longer supported; use" <<< { $0.minimumRequiredToolsVersion.description }
                 $0 <<< "or newer instead"
@@ -303,7 +303,7 @@ public enum WorkspaceDiagnostics {
             type: MismatchingDestinationPackage.self,
             name: "org.swift.diags.workspace.mismatching-destination-package",
             description: {
-                $0 <<< "package at" <<< { "'\($0.editPath.asString)'" }
+                $0 <<< "package at" <<< { "'\($0.editPath)'" }
                 $0 <<< "is" <<< { $0.destinationPackage ?? "<unknown>" }
                 $0 <<< "but was expecting" <<< { $0.expectedPackage }
             })

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -71,7 +71,7 @@ public final class InitPackage {
     }
 
     private func writePackageFile(_ path: AbsolutePath, body: (OutputByteStream) -> Void) throws {
-        progressReporter?("Creating \(path.relative(to: destinationPath).asString)")
+        progressReporter?("Creating \(path.relative(to: destinationPath))")
         try localFileSystem.writeFileContents(path, body: body)
     }
 
@@ -183,7 +183,7 @@ public final class InitPackage {
         guard exists(sources) == false else {
             return
         }
-        progressReporter?("Creating \(sources.relative(to: destinationPath).asString)/")
+        progressReporter?("Creating \(sources.relative(to: destinationPath))/")
         try makeDirectories(sources)
 
         if packageType == .empty {
@@ -245,7 +245,7 @@ public final class InitPackage {
         guard exists(tests) == false else {
             return
         }
-        progressReporter?("Creating \(tests.relative(to: destinationPath).asString)/")
+        progressReporter?("Creating \(tests.relative(to: destinationPath))/")
         try makeDirectories(tests)
 
         switch packageType {
@@ -351,7 +351,7 @@ public final class InitPackage {
 
     private func writeTestFileStubs(testsPath: AbsolutePath) throws {
         let testModule = testsPath.appending(RelativePath(pkgname + Target.testModuleNameSuffix))
-        progressReporter?("Creating \(testModule.relative(to: destinationPath).asString)/")
+        progressReporter?("Creating \(testModule.relative(to: destinationPath))/")
         try makeDirectories(testModule)
 
         let testClassFile = testModule.appending(RelativePath("\(moduleName)Tests.swift"))

--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -138,7 +138,7 @@ public final class ManagedDependency: JSONMappable, JSONSerializable, CustomStri
     public func toJSON() -> JSON {
         return .init([
             "packageRef": packageRef.toJSON(),
-            "subpath": subpath.asString,
+            "subpath": subpath,
             "basedOn": basedOn.toJSON(),
             "state": state,
         ])

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -103,7 +103,7 @@ public final class UserToolchain: Toolchain {
         func validateCompiler(at path: AbsolutePath?) throws {
             guard let path = path else { return }
             guard localFileSystem.isExecutableFile(path) else {
-                throw InvalidToolchainDiagnostic("could not find the `swiftc` at expected path \(path.asString)")
+                throw InvalidToolchainDiagnostic("could not find the `swiftc` at expected path \(path)")
             }
         }
 
@@ -124,7 +124,7 @@ public final class UserToolchain: Toolchain {
         } else if let SWIFT_EXEC = SWIFT_EXEC {
             resolvedBinDirCompiler = SWIFT_EXEC
         } else {
-            throw InvalidToolchainDiagnostic("could not find the `swiftc` at expected path \(binDirCompiler.asString)")
+            throw InvalidToolchainDiagnostic("could not find the `swiftc` at expected path \(binDirCompiler)")
         }
 
         // The compiler for compilation tasks is SWIFT_EXEC or the bin dir compiler.
@@ -182,7 +182,7 @@ public final class UserToolchain: Toolchain {
     public func getLLVMCov() throws -> AbsolutePath {
         let toolPath = destination.binDir.appending(component: "llvm-cov")
         guard localFileSystem.isExecutableFile(toolPath) else {
-            throw InvalidToolchainDiagnostic("could not find llvm-cov at expected path \(toolPath.asString)")
+            throw InvalidToolchainDiagnostic("could not find llvm-cov at expected path \(toolPath)")
         }
         return toolPath
     }
@@ -191,7 +191,7 @@ public final class UserToolchain: Toolchain {
     public func getLLVMProf() throws -> AbsolutePath {
         let toolPath = destination.binDir.appending(component: "llvm-profdata")
         guard localFileSystem.isExecutableFile(toolPath) else {
-            throw InvalidToolchainDiagnostic("could not find llvm-profdata at expected path \(toolPath.asString)")
+            throw InvalidToolchainDiagnostic("could not find llvm-profdata at expected path \(toolPath)")
         }
         return toolPath
     }
@@ -215,7 +215,7 @@ public final class UserToolchain: Toolchain {
         // Look for llbuild in bin dir.
         llbuild = binDir.appending(component: "swift-build-tool")
         guard localFileSystem.exists(llbuild) else {
-            throw InvalidToolchainDiagnostic("could not find `llbuild` at expected path \(llbuild.asString)")
+            throw InvalidToolchainDiagnostic("could not find `llbuild` at expected path \(llbuild)")
         }
 
 
@@ -229,11 +229,11 @@ public final class UserToolchain: Toolchain {
       #endif
 
         self.extraSwiftCFlags = [
-            "-sdk", destination.sdk.asString
+            "-sdk", destination.sdk.description
         ] + destination.extraSwiftCFlags
 
         self.extraCCFlags = [
-            destination.sysrootFlag, destination.sdk.asString
+            destination.sysrootFlag, destination.sdk.description
         ] + destination.extraCCFlags
 
         // Compute the path of directory containing the PackageDescription libraries.

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -239,7 +239,7 @@ public class Workspace {
                 // We should get the correct one from managed dependency object.
                 let ref = PackageReference(
                     identity: managedDependency.packageRef.identity,
-                    path: workspace.path(for: managedDependency).asString,
+                    path: workspace.path(for: managedDependency).description,
                     isLocal: true
                 )
                 let constraint = RepositoryPackageConstraint(
@@ -666,7 +666,7 @@ extension Workspace {
         diagnostics: DiagnosticsEngine
     ) -> [Manifest] {
         let rootManifests = packages.compactMap({ package -> Manifest? in
-            loadManifest(packagePath: package, url: package.asString, diagnostics: diagnostics)
+            loadManifest(packagePath: package, url: package.description, diagnostics: diagnostics)
         })
 
         // Check for duplicate root packages.
@@ -1489,7 +1489,7 @@ extension Workspace {
                 // the edited checkout is unchanged.
                 if let editedDependency = managedDependencies.values.first(where: {
                     guard $0.basedOn != nil else { return false }
-                    return path(for: $0).asString == packageRef.path
+                    return path(for: $0).description == packageRef.path
                 }) {
                     currentDependency = editedDependency
                     let originalReference = editedDependency.basedOn!.packageRef

--- a/Sources/Xcodeproj/XcodeProjectModel.swift
+++ b/Sources/Xcodeproj/XcodeProjectModel.swift
@@ -106,8 +106,6 @@ public struct Xcode {
             /// directory (which varies depending on active scheme, active run
             /// destination, or even an overridden build setting.
             case buildDir = "BUILT_PRODUCTS_DIR"
-            /// The string form, suitable for use in an Xcode project file.
-            var asString: String { return rawValue }
         }
 
         init(path: String, pathBase: RefPathBase = .groupDir, name: String? = nil) {
@@ -178,7 +176,6 @@ public struct Xcode {
             case framework = "com.apple.product-type.framework"
             case executable = "com.apple.product-type.tool"
             case unitTest = "com.apple.product-type.bundle.unit-test"
-            var asString: String { return rawValue }
         }
         init(objectID: String?, productType: ProductType?, name: String) {
             self.objectID = objectID

--- a/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
+++ b/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
@@ -90,7 +90,7 @@ fileprivate func makeReferenceDict(
     if let name = reference.name {
         dict["name"] = .string(name)
     }
-    dict["sourceTree"] = .string(reference.pathBase.asString)
+    dict["sourceTree"] = .string(reference.pathBase.rawValue)
     return dict
 }
 
@@ -178,7 +178,7 @@ extension Xcode.Target: PropertyListSerializable {
         }))
         dict["productName"] = .string(productName)
         if let productType = productType {
-            dict["productType"] = .string(productType.asString)
+            dict["productType"] = .string(productType.rawValue)
         }
         if let productReference = productReference {
             dict["productReference"] = .identifier(serializer.id(of: productReference))

--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -118,10 +118,10 @@ public func generate(
 
     try generateSchemes(
         graph: graph,
-        container: xcodeprojPath.relative(to: srcroot).asString,
+        container: xcodeprojPath.relative(to: srcroot).description,
         schemesDir: schemesDir,
         options: options,
-        schemeContainer: xcodeprojPath.relative(to: srcroot).asString
+        schemeContainer: xcodeprojPath.relative(to: srcroot).description
     )
 
     for target in graph.reachableTargets where target.type == .library || target.type == .test {

--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -81,7 +81,7 @@ func xcodeProject(
         var interpreterFlags = manifestLoader.interpreterFlags(for: package.manifest.manifestVersion)
         if !interpreterFlags.isEmpty {
             // Patch the interpreter flags to use Xcode supported toolchain macro instead of the resolved path.
-            interpreterFlags[3] = "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/" + package.manifest.manifestVersion.runtimeSubpath.asString
+            interpreterFlags[3] = "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/\(package.manifest.manifestVersion.runtimeSubpath)"
         }
         pdTarget.buildSettings.common.OTHER_SWIFT_FLAGS += interpreterFlags
         pdTarget.buildSettings.common.SWIFT_VERSION = package.manifest.manifestVersion.swiftLanguageVersion.xcodeBuildSettingValue
@@ -98,7 +98,7 @@ func xcodeProject(
     // directory (note that those two directories might or might be the same).
     // The effect is to make any `projectDir`-relative path be relative to the
     // source root directory, i.e. the path of the root package.
-    project.projectDir = sourceRootDir.relative(to: xcodeprojPath.parentDirectory).asString
+    project.projectDir = sourceRootDir.relative(to: xcodeprojPath.parentDirectory).description
 
     // Configure the project settings.
     let projectSettings = project.buildSettings
@@ -193,7 +193,7 @@ func xcodeProject(
         // Create a file reference for the .xcconfig file (with a path relative
         // to the group).
         xcconfigOverridesFileRef = xcconfigsGroup.addFileReference(
-            path: xcconfigPath.relative(to: sourceRootDir).asString,
+            path: xcconfigPath.relative(to: sourceRootDir).description,
             name: xcconfigPath.basename)
 
         // We don't assign the file reference as the xcconfig file reference of
@@ -293,7 +293,7 @@ func xcodeProject(
         // Create a group for each target.
         for target in targets {
             // The sources could be anywhere, so we use a project-relative path.
-            let path = target.sources.root.relative(to: sourceRootDir).asString
+            let path = target.sources.root.relative(to: sourceRootDir).description
             let name = (sourcesGroup == nil ? groupName : target.name)
             let group = (sourcesGroup ?? parentGroup)
                 .addGroup(path: (path == "." ? "" : path), pathBase: .projectDir, name: name)
@@ -349,7 +349,7 @@ func xcodeProject(
             let group = createSourceGroup(named: groupName, for: package.targets.filter({ $0.type != .test }), in: dependenciesGroup)
             if let group = group {
                 let manifestPath = package.path.appending(component: "Package.swift")
-                let manifestFileRef = group.addFileReference(path: manifestPath.asString, name: "Package.swift", fileType: "sourcecode.swift")
+                let manifestFileRef = group.addFileReference(path: manifestPath.description, name: "Package.swift", fileType: "sourcecode.swift")
                 createPackageDescriptionTarget(for: package, manifestFileRef: manifestFileRef)
             }
         }
@@ -362,7 +362,7 @@ func xcodeProject(
     // Add "blue folders" for any other directories at the top level (note that
     // they are not guaranteed to be direct children of the root directory).
     for extraDir in extraDirs {
-        project.mainGroup.addFileReference(path: extraDir.relative(to: sourceRootDir).asString, pathBase: .projectDir)
+        project.mainGroup.addFileReference(path: extraDir.relative(to: sourceRootDir).description, pathBase: .projectDir)
     }
 
     for extraFile in extraFiles {
@@ -444,7 +444,7 @@ func xcodeProject(
         }
 
         let infoPlistFilePath = xcodeprojPath.appending(component: target.infoPlistFileName)
-        targetSettings.common.INFOPLIST_FILE = infoPlistFilePath.relative(to: sourceRootDir).asString
+        targetSettings.common.INFOPLIST_FILE = infoPlistFilePath.relative(to: sourceRootDir).description
 
         if target.type == .test {
             targetSettings.common.CLANG_ENABLE_MODULES = "YES"
@@ -498,14 +498,14 @@ func xcodeProject(
             // See: <rdar://problem/21912068> SourceKit cannot handle relative include paths (working directory)
             switch depModule.underlyingTarget {
               case let systemTarget as SystemLibraryTarget:
-                hdrInclPaths.append("$(SRCROOT)/" + systemTarget.path.relative(to: sourceRootDir).asString)
+                hdrInclPaths.append("$(SRCROOT)/\(systemTarget.path.relative(to: sourceRootDir))")
                 if let pkgArgs = pkgConfigArgs(for: systemTarget, diagnostics: diagnostics) {
                     targetSettings.common.OTHER_LDFLAGS += pkgArgs.libs
                     targetSettings.common.OTHER_SWIFT_FLAGS += pkgArgs.cFlags
                     targetSettings.common.OTHER_CFLAGS += pkgArgs.cFlags
                 }
             case let clangTarget as ClangTarget:
-                hdrInclPaths.append("$(SRCROOT)/" + clangTarget.includeDir.relative(to: sourceRootDir).asString)
+                hdrInclPaths.append("$(SRCROOT)/\(clangTarget.includeDir.relative(to: sourceRootDir))")
               default:
                 continue
             }
@@ -516,7 +516,7 @@ func xcodeProject(
         targetSettings.common.FRAMEWORK_SEARCH_PATHS = ["$(inherited)", "$(PLATFORM_DIR)/Developer/Library/Frameworks"]
 
         // Add a file reference for the target's product.
-        let productRef = productsGroup.addFileReference(path: target.productPath.asString, pathBase: .buildDir, objectID: "\(package.name)::\(target.name)::Product")
+        let productRef = productsGroup.addFileReference(path: target.productPath.description, pathBase: .buildDir, objectID: "\(package.name)::\(target.name)::Product")
 
         // Set that file reference as the target's product reference.
         xcodeTarget.productReference = productRef
@@ -602,7 +602,7 @@ func xcodeProject(
             }
 
             if let moduleMapPath = moduleMapPath {
-                includeGroup.addFileReference(path: moduleMapPath.asString, name: moduleMapPath.basename)
+                includeGroup.addFileReference(path: moduleMapPath.description, name: moduleMapPath.basename)
                 // Save this modulemap path mapped to target so we can later wire it up for its dependees.
                 modulesToModuleMap[target] = (moduleMapPath, isGenerated)
             }
@@ -663,12 +663,12 @@ func xcodeProject(
                 assert(dependency.underlyingTarget is ClangTarget)
                 xcodeTarget.buildSettings.common.OTHER_SWIFT_FLAGS += [
                     "-Xcc",
-                    "-fmodule-map-file=$(SRCROOT)/" + moduleMap.path.relative(to: sourceRootDir).asString,
+                    "-fmodule-map-file=$(SRCROOT)/\(moduleMap.path.relative(to: sourceRootDir))",
                 ]
                 // Workaround for a interface generation bug. <rdar://problem/30071677>
                 if moduleMap.isGenerated {
                     xcodeTarget.buildSettings.common.HEADER_SEARCH_PATHS += [
-                        "$(SRCROOT)/" + moduleMap.path.parentDirectory.relative(to: sourceRootDir).asString
+                        "$(SRCROOT)/\(moduleMap.path.parentDirectory.relative(to: sourceRootDir))"
                     ]
                 }
             }

--- a/Tests/BasicPerformanceTests/OutputByteStreamPerfTests.swift
+++ b/Tests/BasicPerformanceTests/OutputByteStreamPerfTests.swift
@@ -202,17 +202,17 @@ class OutputByteStreamPerfTests: XCTestCasePerf {
             "foo": .string("bar"),
             "bar": .int(2),
             "baz": .array([1, 2, 3].map(JSON.int)),
-            ])
+        ])
 
         let bar = JSON.dictionary([
             "poo": .array([foo, foo, foo]),
             "foo": .int(1),
-            ])
+        ])
 
         let baz = JSON.dictionary([
             "poo": .array([foo, bar, foo]),
             "foo": .int(1),
-            ])
+        ])
 
         let json = JSON.array((0..<100).map { _ in baz })
         measure {

--- a/Tests/BasicPerformanceTests/PathPerfTests.swift
+++ b/Tests/BasicPerformanceTests/PathPerfTests.swift
@@ -24,9 +24,9 @@ class PathPerfTests: XCTestCasePerf {
             var lengths = 0
             for _ in 0 ..< N {
                 let result = absPath.appending(relPath)
-                lengths = lengths &+ result.asString.utf8.count
+                lengths = lengths &+ result.description.utf8.count
             }
-            XCTAssertEqual(lengths, (absPath.asString.utf8.count + 1 + relPath.asString.utf8.count) &* N)
+            XCTAssertEqual(lengths, (absPath.description.utf8.count + 1 + relPath.description.utf8.count) &* N)
         }
     }
     

--- a/Tests/BasicTests/ByteStringTests.swift
+++ b/Tests/BasicTests/ByteStringTests.swift
@@ -41,12 +41,12 @@ class ByteStringTests: XCTestCase {
     }
 
     func testAsString() {
-        XCTAssertEqual(ByteString("hello").asString, "hello")
-        XCTAssertEqual(ByteString([0xFF,0xFF]).asString, nil)
+        XCTAssertEqual(ByteString("hello").validDescription, "hello")
+        XCTAssertEqual(ByteString([0xFF,0xFF]).validDescription, nil)
     }
 
     func testDescription() {
-        XCTAssertEqual(ByteString("Hello, world!").description, "<ByteString:\"Hello, world!\">")
+        XCTAssertEqual(ByteString("Hello, world!").description, "Hello, world!")
     }
     
     func testHashable() {

--- a/Tests/BasicTests/FileSystemTests.swift
+++ b/Tests/BasicTests/FileSystemTests.swift
@@ -56,7 +56,7 @@ class FileSystemTests: XCTestCase {
 
             """
         try! localFileSystem.writeFileContents(executable, bytes: stream.bytes)
-        try! Process.checkNonZeroExit(args: "chmod", "+x", executable.asString)
+        try! Process.checkNonZeroExit(args: "chmod", "+x", executable.description)
         XCTAssertTrue(fs.isExecutableFile(executable))
         XCTAssertFalse(fs.isExecutableFile(sym))
         XCTAssertFalse(fs.isExecutableFile(file.path))

--- a/Tests/BasicTests/JSONTests.swift
+++ b/Tests/BasicTests/JSONTests.swift
@@ -16,7 +16,7 @@ class JSONTests: XCTestCase {
     func testEncoding() {
         // Test the basics of encoding each object type.
         func encode(_ item: JSON) -> String {
-            return item.toBytes().asString ?? "<unrepresentable>"
+            return item.toBytes().validDescription ?? "<unrepresentable>"
         }
 
         XCTAssertEqual(encode(.null), "null")

--- a/Tests/BasicTests/LockTests.swift
+++ b/Tests/BasicTests/LockTests.swift
@@ -39,12 +39,12 @@ class LockTests: XCTestCase {
         let N = 10
         let threads = (1...N).map { idx in
             return Thread {
-                _ = try! SwiftPMProduct.TestSupportExecutable.execute(["fileLockTest", tempDir.path.asString, sharedResource.path.asString, String(idx)])
+                _ = try! SwiftPMProduct.TestSupportExecutable.execute(["fileLockTest", tempDir.path.description, sharedResource.path.description, String(idx)])
             }
         }
         threads.forEach { $0.start() }
         threads.forEach { $0.join() }
 
-        XCTAssertEqual(try localFileSystem.readFileContents(sharedResource.path).asString, String((N * (N + 1) / 2 )))
+        XCTAssertEqual(try localFileSystem.readFileContents(sharedResource.path).description, String((N * (N + 1) / 2 )))
     }
 }

--- a/Tests/BasicTests/OutputByteStreamTests.swift
+++ b/Tests/BasicTests/OutputByteStreamTests.swift
@@ -157,7 +157,7 @@ class OutputByteStreamTests: XCTestCase {
         let tempFile = try TemporaryFile()
 
         func read() -> String? {
-            return try! localFileSystem.readFileContents(tempFile.path).asString
+            return try! localFileSystem.readFileContents(tempFile.path).validDescription
         }
 
         let stream = try LocalFileOutputByteStream(tempFile.path)

--- a/Tests/BasicTests/PathTests.swift
+++ b/Tests/BasicTests/PathTests.swift
@@ -17,13 +17,13 @@ import POSIX
 class PathTests: XCTestCase {
     
     func testBasics() {
-        XCTAssertEqual(AbsolutePath("/").asString, "/")
-        XCTAssertEqual(AbsolutePath("/a").asString, "/a")
-        XCTAssertEqual(AbsolutePath("/a/b/c").asString, "/a/b/c")
-        XCTAssertEqual(RelativePath(".").asString, ".")
-        XCTAssertEqual(RelativePath("a").asString, "a")
-        XCTAssertEqual(RelativePath("a/b/c").asString, "a/b/c")
-        XCTAssertEqual(RelativePath("~").asString, "~")  // `~` is not special
+        XCTAssertEqual(AbsolutePath("/").description, "/")
+        XCTAssertEqual(AbsolutePath("/a").description, "/a")
+        XCTAssertEqual(AbsolutePath("/a/b/c").description, "/a/b/c")
+        XCTAssertEqual(RelativePath(".").description, ".")
+        XCTAssertEqual(RelativePath("a").description, "a")
+        XCTAssertEqual(RelativePath("a/b/c").description, "a/b/c")
+        XCTAssertEqual(RelativePath("~").description, "~")  // `~` is not special
     }
     
     func testStringInitialization() {
@@ -44,77 +44,77 @@ class PathTests: XCTestCase {
     
     func testStringLiteralInitialization() {
         let abs = AbsolutePath("/")
-        XCTAssertEqual(abs.asString, "/")
+        XCTAssertEqual(abs.description, "/")
         let rel1 = RelativePath(".")
-        XCTAssertEqual(rel1.asString, ".")
+        XCTAssertEqual(rel1.description, ".")
         let rel2 = RelativePath("~")
-        XCTAssertEqual(rel2.asString, "~")  // `~` is not special
+        XCTAssertEqual(rel2.description, "~")  // `~` is not special
     }
     
     func testRepeatedPathSeparators() {
-        XCTAssertEqual(AbsolutePath("/ab//cd//ef").asString, "/ab/cd/ef")
-        XCTAssertEqual(AbsolutePath("/ab///cd//ef").asString, "/ab/cd/ef")
-        XCTAssertEqual(RelativePath("ab//cd//ef").asString, "ab/cd/ef")
-        XCTAssertEqual(RelativePath("ab//cd///ef").asString, "ab/cd/ef")
+        XCTAssertEqual(AbsolutePath("/ab//cd//ef").description, "/ab/cd/ef")
+        XCTAssertEqual(AbsolutePath("/ab///cd//ef").description, "/ab/cd/ef")
+        XCTAssertEqual(RelativePath("ab//cd//ef").description, "ab/cd/ef")
+        XCTAssertEqual(RelativePath("ab//cd///ef").description, "ab/cd/ef")
     }
     
     func testTrailingPathSeparators() {
-        XCTAssertEqual(AbsolutePath("/ab/cd/ef/").asString, "/ab/cd/ef")
-        XCTAssertEqual(AbsolutePath("/ab/cd/ef//").asString, "/ab/cd/ef")
-        XCTAssertEqual(RelativePath("ab/cd/ef/").asString, "ab/cd/ef")
-        XCTAssertEqual(RelativePath("ab/cd/ef//").asString, "ab/cd/ef")
+        XCTAssertEqual(AbsolutePath("/ab/cd/ef/").description, "/ab/cd/ef")
+        XCTAssertEqual(AbsolutePath("/ab/cd/ef//").description, "/ab/cd/ef")
+        XCTAssertEqual(RelativePath("ab/cd/ef/").description, "ab/cd/ef")
+        XCTAssertEqual(RelativePath("ab/cd/ef//").description, "ab/cd/ef")
     }
     
     func testDotPathComponents() {
-        XCTAssertEqual(AbsolutePath("/ab/././cd//ef").asString, "/ab/cd/ef")
-        XCTAssertEqual(AbsolutePath("/ab/./cd//ef/.").asString, "/ab/cd/ef")
-        XCTAssertEqual(RelativePath("ab/./cd/././ef").asString, "ab/cd/ef")
-        XCTAssertEqual(RelativePath("ab/./cd/ef/.").asString, "ab/cd/ef")
+        XCTAssertEqual(AbsolutePath("/ab/././cd//ef").description, "/ab/cd/ef")
+        XCTAssertEqual(AbsolutePath("/ab/./cd//ef/.").description, "/ab/cd/ef")
+        XCTAssertEqual(RelativePath("ab/./cd/././ef").description, "ab/cd/ef")
+        XCTAssertEqual(RelativePath("ab/./cd/ef/.").description, "ab/cd/ef")
     }
     
     func testDotDotPathComponents() {
-        XCTAssertEqual(AbsolutePath("/..").asString, "/")
-        XCTAssertEqual(AbsolutePath("/../../../../..").asString, "/")
-        XCTAssertEqual(AbsolutePath("/abc/..").asString, "/")
-        XCTAssertEqual(AbsolutePath("/abc/../..").asString, "/")
-        XCTAssertEqual(AbsolutePath("/../abc").asString, "/abc")
-        XCTAssertEqual(AbsolutePath("/../abc/..").asString, "/")
-        XCTAssertEqual(AbsolutePath("/../abc/../def").asString, "/def")
-        XCTAssertEqual(RelativePath("..").asString, "..")
-        XCTAssertEqual(RelativePath("../..").asString, "../..")
-        XCTAssertEqual(RelativePath(".././..").asString, "../..")
-        XCTAssertEqual(RelativePath("../abc/..").asString, "..")
-        XCTAssertEqual(RelativePath("../abc/.././").asString, "..")
-        XCTAssertEqual(RelativePath("abc/..").asString, ".")
+        XCTAssertEqual(AbsolutePath("/..").description, "/")
+        XCTAssertEqual(AbsolutePath("/../../../../..").description, "/")
+        XCTAssertEqual(AbsolutePath("/abc/..").description, "/")
+        XCTAssertEqual(AbsolutePath("/abc/../..").description, "/")
+        XCTAssertEqual(AbsolutePath("/../abc").description, "/abc")
+        XCTAssertEqual(AbsolutePath("/../abc/..").description, "/")
+        XCTAssertEqual(AbsolutePath("/../abc/../def").description, "/def")
+        XCTAssertEqual(RelativePath("..").description, "..")
+        XCTAssertEqual(RelativePath("../..").description, "../..")
+        XCTAssertEqual(RelativePath(".././..").description, "../..")
+        XCTAssertEqual(RelativePath("../abc/..").description, "..")
+        XCTAssertEqual(RelativePath("../abc/.././").description, "..")
+        XCTAssertEqual(RelativePath("abc/..").description, ".")
     }
     
     func testCombinationsAndEdgeCases() {
-        XCTAssertEqual(AbsolutePath("///").asString, "/")
-        XCTAssertEqual(AbsolutePath("/./").asString, "/")
-        XCTAssertEqual(RelativePath("").asString, ".")
-        XCTAssertEqual(RelativePath(".").asString, ".")
-        XCTAssertEqual(RelativePath("./abc").asString, "abc")
-        XCTAssertEqual(RelativePath("./abc/").asString, "abc")
-        XCTAssertEqual(RelativePath("./abc/../bar").asString, "bar")
-        XCTAssertEqual(RelativePath("foo/../bar").asString, "bar")
-        XCTAssertEqual(RelativePath("foo///..///bar///baz").asString, "bar/baz")
-        XCTAssertEqual(RelativePath("foo/../bar/./").asString, "bar")
-        XCTAssertEqual(RelativePath("../abc/def/").asString, "../abc/def")
-        XCTAssertEqual(RelativePath("././././.").asString, ".")
-        XCTAssertEqual(RelativePath("./././../.").asString, "..")
-        XCTAssertEqual(RelativePath("./").asString, ".")
-        XCTAssertEqual(RelativePath(".//").asString, ".")
-        XCTAssertEqual(RelativePath("./.").asString, ".")
-        XCTAssertEqual(RelativePath("././").asString, ".")
-        XCTAssertEqual(RelativePath("../").asString, "..")
-        XCTAssertEqual(RelativePath("../.").asString, "..")
-        XCTAssertEqual(RelativePath("./..").asString, "..")
-        XCTAssertEqual(RelativePath("./../.").asString, "..")
-        XCTAssertEqual(RelativePath("./////../////./////").asString, "..")
-        XCTAssertEqual(RelativePath("../a").asString, "../a")
-        XCTAssertEqual(RelativePath("../a/..").asString, "..")
-        XCTAssertEqual(RelativePath("a/..").asString, ".")
-        XCTAssertEqual(RelativePath("a/../////../////./////").asString, "..")
+        XCTAssertEqual(AbsolutePath("///").description, "/")
+        XCTAssertEqual(AbsolutePath("/./").description, "/")
+        XCTAssertEqual(RelativePath("").description, ".")
+        XCTAssertEqual(RelativePath(".").description, ".")
+        XCTAssertEqual(RelativePath("./abc").description, "abc")
+        XCTAssertEqual(RelativePath("./abc/").description, "abc")
+        XCTAssertEqual(RelativePath("./abc/../bar").description, "bar")
+        XCTAssertEqual(RelativePath("foo/../bar").description, "bar")
+        XCTAssertEqual(RelativePath("foo///..///bar///baz").description, "bar/baz")
+        XCTAssertEqual(RelativePath("foo/../bar/./").description, "bar")
+        XCTAssertEqual(RelativePath("../abc/def/").description, "../abc/def")
+        XCTAssertEqual(RelativePath("././././.").description, ".")
+        XCTAssertEqual(RelativePath("./././../.").description, "..")
+        XCTAssertEqual(RelativePath("./").description, ".")
+        XCTAssertEqual(RelativePath(".//").description, ".")
+        XCTAssertEqual(RelativePath("./.").description, ".")
+        XCTAssertEqual(RelativePath("././").description, ".")
+        XCTAssertEqual(RelativePath("../").description, "..")
+        XCTAssertEqual(RelativePath("../.").description, "..")
+        XCTAssertEqual(RelativePath("./..").description, "..")
+        XCTAssertEqual(RelativePath("./../.").description, "..")
+        XCTAssertEqual(RelativePath("./////../////./////").description, "..")
+        XCTAssertEqual(RelativePath("../a").description, "../a")
+        XCTAssertEqual(RelativePath("../a/..").description, "..")
+        XCTAssertEqual(RelativePath("a/..").description, ".")
+        XCTAssertEqual(RelativePath("a/../////../////./////").description, "..")
     }
         
     func testDirectoryNameExtraction() {
@@ -184,37 +184,37 @@ class PathTests: XCTestCase {
     }
     
     func testConcatenation() {
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("")).asString, "/")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath(".")).asString, "/")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("..")).asString, "/")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("bar")).asString, "/bar")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/foo/bar"), RelativePath("..")).asString, "/foo")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/bar"), RelativePath("../foo")).asString, "/foo")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/bar"), RelativePath("../foo/..//")).asString, "/")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/bar/../foo/..//yabba/"), RelativePath("a/b")).asString, "/yabba/a/b")
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("")).description, "/")
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath(".")).description, "/")
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("..")).description, "/")
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("bar")).description, "/bar")
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/foo/bar"), RelativePath("..")).description, "/foo")
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/bar"), RelativePath("../foo")).description, "/foo")
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/bar"), RelativePath("../foo/..//")).description, "/")
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/bar/../foo/..//yabba/"), RelativePath("a/b")).description, "/yabba/a/b")
         
-        XCTAssertEqual(AbsolutePath("/").appending(RelativePath("")).asString, "/")
-        XCTAssertEqual(AbsolutePath("/").appending(RelativePath(".")).asString, "/")
-        XCTAssertEqual(AbsolutePath("/").appending(RelativePath("..")).asString, "/")
-        XCTAssertEqual(AbsolutePath("/").appending(RelativePath("bar")).asString, "/bar")
-        XCTAssertEqual(AbsolutePath("/foo/bar").appending(RelativePath("..")).asString, "/foo")
-        XCTAssertEqual(AbsolutePath("/bar").appending(RelativePath("../foo")).asString, "/foo")
-        XCTAssertEqual(AbsolutePath("/bar").appending(RelativePath("../foo/..//")).asString, "/")
-        XCTAssertEqual(AbsolutePath("/bar/../foo/..//yabba/").appending(RelativePath("a/b")).asString, "/yabba/a/b")
+        XCTAssertEqual(AbsolutePath("/").appending(RelativePath("")).description, "/")
+        XCTAssertEqual(AbsolutePath("/").appending(RelativePath(".")).description, "/")
+        XCTAssertEqual(AbsolutePath("/").appending(RelativePath("..")).description, "/")
+        XCTAssertEqual(AbsolutePath("/").appending(RelativePath("bar")).description, "/bar")
+        XCTAssertEqual(AbsolutePath("/foo/bar").appending(RelativePath("..")).description, "/foo")
+        XCTAssertEqual(AbsolutePath("/bar").appending(RelativePath("../foo")).description, "/foo")
+        XCTAssertEqual(AbsolutePath("/bar").appending(RelativePath("../foo/..//")).description, "/")
+        XCTAssertEqual(AbsolutePath("/bar/../foo/..//yabba/").appending(RelativePath("a/b")).description, "/yabba/a/b")
 
-        XCTAssertEqual(AbsolutePath("/").appending(component: "a").asString, "/a")
-        XCTAssertEqual(AbsolutePath("/a").appending(component: "b").asString, "/a/b")
-        XCTAssertEqual(AbsolutePath("/").appending(components: "a", "b").asString, "/a/b")
-        XCTAssertEqual(AbsolutePath("/a").appending(components: "b", "c").asString, "/a/b/c")
+        XCTAssertEqual(AbsolutePath("/").appending(component: "a").description, "/a")
+        XCTAssertEqual(AbsolutePath("/a").appending(component: "b").description, "/a/b")
+        XCTAssertEqual(AbsolutePath("/").appending(components: "a", "b").description, "/a/b")
+        XCTAssertEqual(AbsolutePath("/a").appending(components: "b", "c").description, "/a/b/c")
 
-        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "", "c").asString, "/a/b/c/c")
-        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "").asString, "/a/b/c")
-        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: ".").asString, "/a/b/c")
-        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "..").asString, "/a/b")
-        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "..", "d").asString, "/a/b/d")
-        XCTAssertEqual(AbsolutePath("/").appending(components: "..").asString, "/")
-        XCTAssertEqual(AbsolutePath("/").appending(components: ".").asString, "/")
-        XCTAssertEqual(AbsolutePath("/").appending(components: "..", "a").asString, "/a")
+        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "", "c").description, "/a/b/c/c")
+        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "").description, "/a/b/c")
+        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: ".").description, "/a/b/c")
+        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "..").description, "/a/b")
+        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "..", "d").description, "/a/b/d")
+        XCTAssertEqual(AbsolutePath("/").appending(components: "..").description, "/")
+        XCTAssertEqual(AbsolutePath("/").appending(components: ".").description, "/")
+        XCTAssertEqual(AbsolutePath("/").appending(components: "..", "a").description, "/a")
     }
     
     func testPathComponents() {
@@ -318,8 +318,8 @@ class PathTests: XCTestCase {
             let data = try JSONEncoder().encode(foo)
             let decodedFoo = try JSONDecoder().decode(Foo.self, from: data)
             XCTAssertEqual(foo, decodedFoo)
-            XCTAssertEqual(foo.path.asString, "/path/to/foo")
-            XCTAssertEqual(decodedFoo.path.asString, "/path/to/foo")
+            XCTAssertEqual(foo.path.description, "/path/to/foo")
+            XCTAssertEqual(decodedFoo.path.description, "/path/to/foo")
         }
 
         do {
@@ -334,8 +334,8 @@ class PathTests: XCTestCase {
             let data = try JSONEncoder().encode(bar)
             let decodedBar = try JSONDecoder().decode(Bar.self, from: data)
             XCTAssertEqual(bar, decodedBar)
-            XCTAssertEqual(bar.path.asString, "path/to/bar")
-            XCTAssertEqual(decodedBar.path.asString, "path/to/bar")
+            XCTAssertEqual(bar.path.description, "path/to/bar")
+            XCTAssertEqual(decodedBar.path.description, "path/to/bar")
         }
     }
 

--- a/Tests/BasicTests/ProcessSetTests.swift
+++ b/Tests/BasicTests/ProcessSetTests.swift
@@ -16,7 +16,7 @@ import TestSupport
 
 class ProcessSetTests: XCTestCase {
     func script(_ name: String) -> String {
-        return AbsolutePath(#file).parentDirectory.appending(components: "processInputs", name).asString
+        return AbsolutePath(#file).parentDirectory.appending(components: "processInputs", name).description
     }
 
     func testSigInt() throws {
@@ -42,7 +42,7 @@ class ProcessSetTests: XCTestCase {
                 // Launch the script and notify main thread.
                 let tempFile = try TemporaryFile()
                 let waitFile = tempFile.path
-                let process = Process(args: self.script(scriptName), waitFile.asString)
+                let process = Process(args: self.script(scriptName), waitFile.description)
                 try processSet.add(process)
                 try process.launch()
                 guard waitForFile(waitFile) else {

--- a/Tests/BasicTests/ProcessTests.swift
+++ b/Tests/BasicTests/ProcessTests.swift
@@ -19,7 +19,7 @@ typealias Process = Basic.Process
 
 class ProcessTests: XCTestCase {
     func script(_ name: String) -> String {
-        return AbsolutePath(#file).parentDirectory.appending(components: "processInputs", name).asString
+        return AbsolutePath(#file).parentDirectory.appending(components: "processInputs", name).description
     }
 
     func testBasics() throws {
@@ -50,7 +50,7 @@ class ProcessTests: XCTestCase {
         let stream = BufferedOutputByteStream()
         stream <<< Format.asRepeating(string: "a", count: count)
         try localFileSystem.writeFileContents(file.path, bytes: stream.bytes)
-        let outputCount = try Process.popen(args: "cat", file.path.asString).utf8Output().count
+        let outputCount = try Process.popen(args: "cat", file.path.description).utf8Output().count
         XCTAssert(outputCount == count)
     }
 
@@ -84,7 +84,7 @@ class ProcessTests: XCTestCase {
                 
                 """)
 
-            try withCustomEnv(["PATH": path.asString]) {
+            try withCustomEnv(["PATH": path.description]) {
                 XCTAssertEqual(Process.findExecutable("nonExecutableProgram"), nil)
             }
         }
@@ -100,7 +100,7 @@ class ProcessTests: XCTestCase {
                 
                 """)
 
-            try withCustomEnv(["PATH": path.asString]) {
+            try withCustomEnv(["PATH": path.description]) {
                 do {
                     let process = Process(args: "nonExecutableProgram")
                     try process.launch()
@@ -118,7 +118,7 @@ class ProcessTests: XCTestCase {
         mktmpdir { path in
             let file = path.appending(component: "pidfile")
             let waitFile = path.appending(component: "waitFile")
-            let process = Process(args: script("print-pid"), file.asString, waitFile.asString)
+            let process = Process(args: script("print-pid"), file.description, waitFile.description)
             try process.launch()
             guard waitForFile(waitFile) else {
                 return XCTFail("Couldn't launch the process")
@@ -128,7 +128,7 @@ class ProcessTests: XCTestCase {
             process.signal(SIGINT)
             try process.waitUntilExit()
             // Ensure the process's pid was written.
-            let contents = try localFileSystem.readFileContents(file).asString!
+            let contents = try localFileSystem.readFileContents(file).description
             XCTAssertEqual("\(process.processID)", contents)
             XCTAssertFalse(try Process.running(process.processID))
         }
@@ -137,7 +137,7 @@ class ProcessTests: XCTestCase {
         mktmpdir { path in
             let file = path.appending(component: "pidfile")
             let waitFile = path.appending(component: "waitFile")
-            let process = Process(args: script("subprocess"), file.asString, waitFile.asString)
+            let process = Process(args: script("subprocess"), file.description, waitFile.description)
             try process.launch()
             guard waitForFile(waitFile) else {
                 return XCTFail("Couldn't launch the process")

--- a/Tests/BasicTests/TemporaryFileTests.swift
+++ b/Tests/BasicTests/TemporaryFileTests.swift
@@ -114,7 +114,7 @@ class TemporaryFileTests: XCTestCase {
         }
         XCTAssertTrue(localFileSystem.isDirectory(path))
         // Cleanup.
-        try FileManager.default.removeItem(atPath: path.asString)
+        try FileManager.default.removeItem(atPath: path.description)
         XCTAssertFalse(localFileSystem.isDirectory(path))
 
         // Test temp directory is removed when its not empty and removeTreeOnDeinit is enabled.

--- a/Tests/BasicTests/miscTests.swift
+++ b/Tests/BasicTests/miscTests.swift
@@ -23,14 +23,14 @@ class miscTests: XCTestCase {
             try localFileSystem.writeFileContents(pathEnvClang, bytes: "")
             let pathEnv = [path.appending(component: "pathEnv2"), pathEnv1]
 
-            try! Process.checkNonZeroExit(args: "chmod", "+x", pathEnvClang.asString)
+            try! Process.checkNonZeroExit(args: "chmod", "+x", pathEnvClang.description)
 
             // nil and empty string should fail.
             XCTAssertNil(lookupExecutablePath(filename: nil, currentWorkingDirectory: path, searchPaths: pathEnv))
             XCTAssertNil(lookupExecutablePath(filename: "", currentWorkingDirectory: path, searchPaths: pathEnv))
             
             // Absolute path to a binary should return it.
-            var exec = lookupExecutablePath(filename: pathEnvClang.asString, currentWorkingDirectory: path, searchPaths: pathEnv)
+            var exec = lookupExecutablePath(filename: pathEnvClang.description, currentWorkingDirectory: path, searchPaths: pathEnv)
             XCTAssertEqual(exec, pathEnvClang)
             
             // This should lookup from PATH variable since executable is not present in cwd.
@@ -40,7 +40,7 @@ class miscTests: XCTestCase {
             // Create the binary relative to cwd and make it executable.
             let clang = path.appending(component: "clang")
             try localFileSystem.writeFileContents(clang, bytes: "")
-            try! Process.checkNonZeroExit(args: "chmod", "+x", clang.asString)
+            try! Process.checkNonZeroExit(args: "chmod", "+x", clang.description)
             // We should now find clang which is in cwd.
             exec = lookupExecutablePath(filename: "clang", currentWorkingDirectory: path, searchPaths: pathEnv)
             XCTAssertEqual(exec, clang)

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -376,7 +376,7 @@ final class BuildPlanTests: XCTestCase {
             let yaml = path.appending(component: "debug.yaml")
             let llbuild = LLBuildManifestGenerator(plan, client: "swift-build", resolvedFile: path.appending(component: "Package.resolved"))
             try llbuild.generateManifest(at: yaml)
-            let contents = try localFileSystem.readFileContents(yaml).asString!
+            let contents = try localFileSystem.readFileContents(yaml).description
             XCTAssertTrue(contents.contains("-std=gnu99\",\"-c\",\"/Pkg/Sources/lib/lib.c"))
             XCTAssertTrue(contents.contains("-std=c++1z\",\"-c\",\"/Pkg/Sources/lib/libx.cpp"))
         }
@@ -1084,7 +1084,7 @@ final class BuildPlanTests: XCTestCase {
             let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(config: config, indexStoreMode: mode), graph: graph, diagnostics: diagnostics, fileSystem: fs))
 
             let lib = try result.target(for: "lib").clangTarget()
-            let path = StringPattern.equal(result.plan.buildParameters.indexStore.asString)
+            let path = StringPattern.equal(result.plan.buildParameters.indexStore.description)
 
         #if os(macOS)
             XCTAssertMatch(lib.basicArguments(), [.anySequence, "-index-store-path", path, .anySequence])

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -52,9 +52,9 @@ final class BuildToolTests: XCTestCase {
             let fullPath = resolveSymlinks(path)
             let targetPath = fullPath.appending(components: ".build", Destination.host.target)
             XCTAssertEqual(try execute(["--show-bin-path"], packagePath: fullPath),
-                           targetPath.appending(components: "debug").asString + "\n")
+                           "\(targetPath.appending(components: "debug"))\n")
             XCTAssertEqual(try execute(["-c", "release", "--show-bin-path"], packagePath: fullPath),
-                           targetPath.appending(components: "release").asString + "\n")
+                           "\(targetPath.appending(components: "release"))\n")
 
             // Test symlink.
             _ = try execute([], packagePath: fullPath)

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -148,7 +148,7 @@ final class PackageToolTests: XCTestCase {
             _ = try execute(["init", "--type", "executable"], packagePath: path)
 
             let manifest = path.appending(component: "Package.swift")
-            let contents = try localFileSystem.readFileContents(manifest).asString!
+            let contents = try localFileSystem.readFileContents(manifest).description
             let version = "\(InitPackage.newPackageToolsVersion.major).\(InitPackage.newPackageToolsVersion.minor)"
             XCTAssertTrue(contents.hasPrefix("// swift-tools-version:\(version)\n"))
 
@@ -183,7 +183,7 @@ final class PackageToolTests: XCTestCase {
             _ = try execute(["init", "--name", "CustomName", "--type", "executable"], packagePath: path)
             
             let manifest = path.appending(component: "Package.swift")
-            let contents = try localFileSystem.readFileContents(manifest).asString!
+            let contents = try localFileSystem.readFileContents(manifest).description
             let version = "\(InitPackage.newPackageToolsVersion.major).\(InitPackage.newPackageToolsVersion.minor)"
             XCTAssertTrue(contents.hasPrefix("// swift-tools-version:\(version)\n"))
             
@@ -207,7 +207,7 @@ final class PackageToolTests: XCTestCase {
             _ = try SwiftPMProduct.SwiftPackage.execute(["edit", "baz", "--branch", "bugfix"], packagePath: fooPath)
 
             // Path to the executable.
-            let exec = [fooPath.appending(components: ".build", Destination.host.target, "debug", "foo").asString]
+            let exec = [fooPath.appending(components: ".build", Destination.host.target, "debug", "foo").description]
 
             // We should see it now in packages directory.
             let editsPath = fooPath.appending(components: "Packages", "bar")
@@ -252,7 +252,7 @@ final class PackageToolTests: XCTestCase {
 
             // Test editing with a path i.e. ToT development.
             let bazTot = prefix.appending(component: "tot")
-            try SwiftPMProduct.SwiftPackage.execute(["edit", "baz", "--path", bazTot.asString], packagePath: fooPath)
+            try SwiftPMProduct.SwiftPackage.execute(["edit", "baz", "--path", bazTot.description], packagePath: fooPath)
             XCTAssertTrue(exists(bazTot))
             XCTAssertTrue(isSymlink(bazEditsPath))
 
@@ -268,7 +268,7 @@ final class PackageToolTests: XCTestCase {
             XCTAssertFalse(isSymlink(bazEditsPath))
 
             // Check that on re-editing with path, we don't make a new clone.
-            try SwiftPMProduct.SwiftPackage.execute(["edit", "baz", "--path", bazTot.asString], packagePath: fooPath)
+            try SwiftPMProduct.SwiftPackage.execute(["edit", "baz", "--path", bazTot.description], packagePath: fooPath)
             XCTAssertTrue(isSymlink(bazEditsPath))
             XCTAssertEqual(try localFileSystem.readFileContents(bazTotPackageFile), stream.bytes)
         }
@@ -369,7 +369,7 @@ final class PackageToolTests: XCTestCase {
                 let buildOutput = try SwiftPMProduct.SwiftBuild.execute([], packagePath: fooPath)
                 return buildOutput
             }
-            let exec = [fooPath.appending(components: ".build", Destination.host.target, "debug", "foo").asString]
+            let exec = [fooPath.appending(components: ".build", Destination.host.target, "debug", "foo").description]
 
             // Build and sanity check.
             _ = try build()
@@ -380,7 +380,7 @@ final class PackageToolTests: XCTestCase {
 
             // Checks the content of checked out bar.swift.
             func checkBar(_ value: Int, file: StaticString = #file, line: UInt = #line) throws {
-                let contents = try localFileSystem.readFileContents(barPath.appending(components:"Sources", "bar.swift")).asString?.spm_chomp()
+                let contents = try localFileSystem.readFileContents(barPath.appending(components:"Sources", "bar.swift")).validDescription?.spm_chomp()
                 XCTAssert(contents?.hasSuffix("\(value)") ?? false, file: file, line: line)
             }
 
@@ -551,9 +551,9 @@ final class PackageToolTests: XCTestCase {
             XCTAssertTrue(fs.isFile(configFile))
 
             // Test env override.
-            try execute(["config", "set-mirror", "--package-url", "https://github.com/foo/bar", "--mirror-url", "https://mygithub.com/foo/bar"], packagePath: packageRoot, env: ["SWIFTPM_MIRROR_CONFIG": configOverride.asString])
+            try execute(["config", "set-mirror", "--package-url", "https://github.com/foo/bar", "--mirror-url", "https://mygithub.com/foo/bar"], packagePath: packageRoot, env: ["SWIFTPM_MIRROR_CONFIG": configOverride.description])
             XCTAssertTrue(fs.isFile(configOverride))
-            XCTAssertTrue(try fs.readFileContents(configOverride).asString!.contains("mygithub"))
+            XCTAssertTrue(try fs.readFileContents(configOverride).description.contains("mygithub"))
 
             // Test reading.
             XCTAssertEqual(try execute(["config", "get-mirror", "--package-url", "https://github.com/foo/bar"], packagePath: packageRoot),

--- a/Tests/CommandsTests/RunToolTests.swift
+++ b/Tests/CommandsTests/RunToolTests.swift
@@ -83,7 +83,7 @@ final class RunToolTests: XCTestCase {
 
     func testFileDeprecation() throws {
         fixture(name: "Miscellaneous/EchoExecutable") { path in
-            let filePath = AbsolutePath(path, "Sources/secho/main.swift").asString
+            let filePath = AbsolutePath(path, "Sources/secho/main.swift").description
             XCTAssertEqual(try execute([filePath, "1", "2"], packagePath: path), """
                 "\(getcwd())" "1" "2"
                 warning: 'swift run file.swift' command to interpret swift files is deprecated; use 'swift file.swift' instead

--- a/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
+++ b/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
@@ -20,7 +20,7 @@ class BuildPerfTests: XCTestCasePerf {
     @discardableResult
     func execute(args: [String] = [], packagePath: AbsolutePath) throws -> String {
         // FIXME: We should pass the SWIFT_EXEC at lower level.
-        return try SwiftPMProduct.SwiftBuild.execute(args + [], packagePath: packagePath, env: ["SWIFT_EXEC": Resources.default.swiftCompiler.asString])
+        return try SwiftPMProduct.SwiftBuild.execute(args + [], packagePath: packagePath, env: ["SWIFT_EXEC": Resources.default.swiftCompiler.description])
     }
 
     func clean(packagePath: AbsolutePath) throws {

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -21,7 +21,7 @@ class DependencyResolutionTests: XCTestCase {
         fixture(name: "DependencyResolution/Internal/Simple") { prefix in
             XCTAssertBuilds(prefix)
 
-            let output = try Process.checkNonZeroExit(args: prefix.appending(components: ".build", Destination.host.target, "debug", "Foo").asString)
+            let output = try Process.checkNonZeroExit(args: prefix.appending(components: ".build", Destination.host.target, "debug", "Foo").description)
             XCTAssertEqual(output, "Foo\nBar\n")
         }
     }
@@ -36,7 +36,7 @@ class DependencyResolutionTests: XCTestCase {
         fixture(name: "DependencyResolution/Internal/Complex") { prefix in
             XCTAssertBuilds(prefix)
 
-            let output = try Process.checkNonZeroExit(args: prefix.appending(components: ".build", Destination.host.target, "debug", "Foo").asString)
+            let output = try Process.checkNonZeroExit(args: prefix.appending(components: ".build", Destination.host.target, "debug", "Foo").description)
             XCTAssertEqual(output, "meiow Baz\n")
         }
     }
@@ -61,7 +61,7 @@ class DependencyResolutionTests: XCTestCase {
     func testExternalComplex() {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
             XCTAssertBuilds(prefix.appending(component: "app"))
-            let output = try Process.checkNonZeroExit(args: prefix.appending(components: "app", ".build", Destination.host.target, "debug", "Dealer").asString)
+            let output = try Process.checkNonZeroExit(args: prefix.appending(components: "app", ".build", Destination.host.target, "debug", "Dealer").description)
             XCTAssertEqual(output, "♣︎K\n♣︎Q\n♣︎J\n♣︎10\n♣︎9\n♣︎8\n♣︎7\n♣︎6\n♣︎5\n♣︎4\n")
         }
     }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -118,7 +118,7 @@ class MiscellaneousTestCase: XCTestCase {
     */
     func testInternalDependencyEdges() {
         fixture(name: "Miscellaneous/DependencyEdges/Internal") { prefix in
-            let execpath = prefix.appending(components: ".build", Destination.host.target, "debug", "Foo").asString
+            let execpath = prefix.appending(components: ".build", Destination.host.target, "debug", "Foo").description
 
             XCTAssertBuilds(prefix)
             var output = try Process.checkNonZeroExit(args: execpath)
@@ -142,7 +142,7 @@ class MiscellaneousTestCase: XCTestCase {
     */
     func testExternalDependencyEdges1() {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
-            let execpath = prefix.appending(components: "app", ".build", Destination.host.target, "debug", "Dealer").asString
+            let execpath = prefix.appending(components: "app", ".build", Destination.host.target, "debug", "Dealer").description
 
             let packageRoot = prefix.appending(component: "app")
             XCTAssertBuilds(packageRoot)
@@ -169,7 +169,7 @@ class MiscellaneousTestCase: XCTestCase {
      */
     func testExternalDependencyEdges2() {
         fixture(name: "Miscellaneous/DependencyEdges/External") { prefix in
-            let execpath = [prefix.appending(components: "root", ".build", Destination.host.target, "debug", "dep2").asString]
+            let execpath = [prefix.appending(components: "root", ".build", Destination.host.target, "debug", "dep2").description]
 
             let packageRoot = prefix.appending(component: "root")
             XCTAssertBuilds(prefix.appending(component: "root"))
@@ -236,7 +236,7 @@ class MiscellaneousTestCase: XCTestCase {
           do {
             // Run tests in parallel with verbose output.
             _ = try SwiftPMProduct.SwiftTest.execute(
-                ["--parallel", "--verbose", "--xunit-output", xUnitOutput.asString],
+                ["--parallel", "--verbose", "--xunit-output", xUnitOutput.description],
                 packagePath: prefix)
           } catch SwiftPMProductError.executionFailure(_, let output, _) {
             XCTAssert(output.contains("testExample1"))
@@ -248,7 +248,7 @@ class MiscellaneousTestCase: XCTestCase {
 
           // Check the xUnit output.
           XCTAssertTrue(localFileSystem.exists(xUnitOutput))
-          let contents = try localFileSystem.readFileContents(xUnitOutput).asString!
+          let contents = try localFileSystem.readFileContents(xUnitOutput).description
           XCTAssertTrue(contents.contains("tests=\"3\" failures=\"1\""))
         }
       #endif
@@ -277,13 +277,13 @@ class MiscellaneousTestCase: XCTestCase {
             // Create a shared library.
             let input = systemModule.appending(components: "Sources", "SystemModule.c")
             let output =  systemModule.appending(component: "libSystemModule.\(dynamicLibraryExtension)")
-            try systemQuietly(["clang", "-shared", input.asString, "-o", output.asString])
+            try systemQuietly(["clang", "-shared", input.description, "-o", output.description])
 
             let pcFile = prefix.appending(component: "libSystemModule.pc")
 
             let stream = BufferedOutputByteStream()
             stream <<< """
-                prefix=\(systemModule.asString)
+                prefix=\(systemModule)
                 exec_prefix=${prefix}
                 libdir=${exec_prefix}
                 includedir=${prefix}/Sources/include
@@ -298,7 +298,7 @@ class MiscellaneousTestCase: XCTestCase {
             try localFileSystem.writeFileContents(pcFile, bytes: stream.bytes)
 
             let moduleUser = prefix.appending(component: "SystemModuleUserClang")
-            let env = ["PKG_CONFIG_PATH": prefix.asString]
+            let env = ["PKG_CONFIG_PATH": prefix.description]
             _ = try executeSwiftBuild(moduleUser, env: env)
 
             XCTAssertFileExists(moduleUser.appending(components: ".build", Destination.host.target, "debug", "SystemModuleUserClang"))
@@ -320,26 +320,26 @@ class MiscellaneousTestCase: XCTestCase {
             stream <<< """
                 #!/bin/sh
                 set -e
-                printf "$$" >> \(waitFile.asString)
+                printf "$$" >> \(waitFile)
                 while true; do sleep 1; done
 
                 """
             try localFileSystem.writeFileContents(fakeGit, bytes: stream.bytes)
 
             // Make it executable.
-            _ = try Process.popen(args: "chmod", "+x", fakeGit.asString)
+            _ = try Process.popen(args: "chmod", "+x", fakeGit.description)
 
             // Put fake git in PATH.
             var env = ProcessInfo.processInfo.environment
             let oldPath = env["PATH"]
-            env["PATH"] = fakeGit.parentDirectory.asString
+            env["PATH"] = fakeGit.parentDirectory.description
             if let oldPath = oldPath {
                 env["PATH"] = env["PATH"]! + ":" + oldPath
             }
 
             // Launch swift-build.
             let app = prefix.appending(component: "Bar")
-            let process = Process(args: SwiftPMProduct.SwiftBuild.path.asString, "--package-path", app.asString, environment: env)
+            let process = Process(args: SwiftPMProduct.SwiftBuild.path.description, "--package-path", app.description, environment: env)
             try process.launch()
 
             guard waitForFile(waitFile) else {
@@ -353,7 +353,7 @@ class MiscellaneousTestCase: XCTestCase {
             XCTAssert(result.exitStatus != .terminated(code: 0))
 
             // Process and subprocesses should be dead.
-            let contents = try localFileSystem.readFileContents(waitFile).asString!
+            let contents = try localFileSystem.readFileContents(waitFile).description
             XCTAssertFalse(try Process.running(process.processID))
             XCTAssertFalse(try Process.running(ProcessID(contents)!))
         }

--- a/Tests/FunctionalTests/ModuleMapTests.swift
+++ b/Tests/FunctionalTests/ModuleMapTests.swift
@@ -23,11 +23,11 @@ class ModuleMapsTestCase: XCTestCase {
             let outdir = prefix.appending(components: rootpkg, ".build", Destination.host.target, "debug")
             try makeDirectories(outdir)
             let output = outdir.appending(component: "libfoo.\(Destination.host.dynamicLibraryExtension)")
-            try systemQuietly(["clang", "-shared", input.asString, "-o", output.asString])
+            try systemQuietly(["clang", "-shared", input.description, "-o", output.description])
 
-            var Xld = ["-L", outdir.asString]
+            var Xld = ["-L", outdir.description]
         #if os(Linux)
-            Xld += ["-rpath", outdir.asString]
+            Xld += ["-rpath", outdir.description]
         #endif
 
             try body(prefix, Xld)
@@ -40,9 +40,9 @@ class ModuleMapsTestCase: XCTestCase {
             XCTAssertBuilds(prefix.appending(component: "App"), Xld: Xld)
 
             let targetPath = prefix.appending(components: "App", ".build", Destination.host.target)
-            let debugout = try Process.checkNonZeroExit(args: targetPath.appending(components: "debug", "App").asString)
+            let debugout = try Process.checkNonZeroExit(args: targetPath.appending(components: "debug", "App").description)
             XCTAssertEqual(debugout, "123\n")
-            let releaseout = try Process.checkNonZeroExit(args: targetPath.appending(components: "release", "App").asString)
+            let releaseout = try Process.checkNonZeroExit(args: targetPath.appending(components: "release", "App").description)
             XCTAssertEqual(releaseout, "123\n")
         }
     }
@@ -53,7 +53,7 @@ class ModuleMapsTestCase: XCTestCase {
             XCTAssertBuilds(prefix.appending(component: "packageA"), Xld: Xld)
 
             func verify(_ conf: String, file: StaticString = #file, line: UInt = #line) throws {
-                let out = try Process.checkNonZeroExit(args: prefix.appending(components: "packageA", ".build", Destination.host.target, conf, "packageA").asString)
+                let out = try Process.checkNonZeroExit(args: prefix.appending(components: "packageA", ".build", Destination.host.target, conf, "packageA").description)
                 XCTAssertEqual(out, """
                     calling Y.bar()
                     Y.bar() called

--- a/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
+++ b/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
@@ -48,11 +48,11 @@ class SwiftPMXCTestHelperTests: XCTestCase {
 #if os(macOS)
 func XCTAssertXCTestHelper(_ bundlePath: AbsolutePath, testCases: NSDictionary) {
     do {
-        let env = ["DYLD_FRAMEWORK_PATH": Resources.default.sdkPlatformFrameworksPath.asString]
+        let env = ["DYLD_FRAMEWORK_PATH": Resources.default.sdkPlatformFrameworksPath.description]
         let outputFile = bundlePath.parentDirectory.appending(component: "tests.txt")
-        let _ = try SwiftPMProduct.XCTestHelper.execute([bundlePath.asString, outputFile.asString], env: env)
-        guard let data = NSData(contentsOfFile: outputFile.asString) else {
-            XCTFail("No output found in : \(outputFile.asString)"); return;
+        let _ = try SwiftPMProduct.XCTestHelper.execute([bundlePath.description, outputFile.description], env: env)
+        guard let data = NSData(contentsOfFile: outputFile.description) else {
+            XCTFail("No output found in : \(outputFile)"); return;
         }
         let json = try JSONSerialization.jsonObject(with: data as Data, options: []) as AnyObject
         XCTAssertTrue(json.isEqual(testCases), "\(json) is not equal to \(testCases)")

--- a/Tests/FunctionalTests/ToolsVersionTests.swift
+++ b/Tests/FunctionalTests/ToolsVersionTests.swift
@@ -91,7 +91,7 @@ class ToolsVersionTests: XCTestCase {
 
             // Build the primary package.
             _ = try SwiftPMProduct.SwiftBuild.execute([], packagePath: primaryPath)
-            let exe = primaryPath.appending(components: ".build", Destination.host.target, "debug", "Primary").asString
+            let exe = primaryPath.appending(components: ".build", Destination.host.target, "debug", "Primary").description
             // v1 should get selected because v1.0.1 depends on a (way) higher set of tools.
             XCTAssertEqual(try Process.checkNonZeroExit(args: exe).spm_chomp(), "foo@1.0")
 

--- a/Tests/POSIXTests/PosixTests.swift
+++ b/Tests/POSIXTests/PosixTests.swift
@@ -27,12 +27,12 @@ class PosixTests: XCTestCase {
             try fs.writeFileContents(foo) { _ in }
             XCTAssertTrue(fs.isFile(foo))
 
-            try rename(old: foo.asString, new: bar.asString)
+            try rename(old: foo.description, new: bar.description)
             XCTAssertFalse(fs.isFile(foo))
             XCTAssertTrue(fs.isFile(bar))
 
             do {
-                try rename(old: foo.asString, new: bar.asString)
+                try rename(old: foo.description, new: bar.description)
                 XCTFail()
             } catch SystemError.rename {}
         }

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -100,7 +100,7 @@ class DependencyResolverPerfTests: XCTestCasePerf {
                 manifestLoader: ManifestLoader(manifestResources: Resources.default))
 
             let resolver = DependencyResolver(containerProvider, GitRepositoryResolutionHelper.DummyResolverDelegate())
-            let container = PackageReference(identity: "dep", path: dep.asString)
+            let container = PackageReference(identity: "dep", path: dep.description)
             let constraints = RepositoryPackageConstraint(container: container, versionRequirement: .range("1.0.0"..<"2.0.0"))
             let result = try! resolver.resolve(constraints: [constraints])
             XCTAssert(result.count == 1)
@@ -321,7 +321,7 @@ struct GitRepositoryResolutionHelper {
 
     func resolve(prefetchingEnabled: Bool = false) -> [(container: PackageReference, binding: BoundVersion)] {
         let repositoriesPath = path.appending(component: "repositories")
-        _ = try? systemQuietly(["rm", "-r", repositoriesPath.asString])
+        _ = try? systemQuietly(["rm", "-r", repositoriesPath.description])
         let repositoryManager = RepositoryManager(path: repositoriesPath, provider: GitRepositoryProvider(), delegate: DummyRepositoryManagerDelegate())
         let containerProvider = RepositoryPackageContainerProvider(
             repositoryManager: repositoryManager,

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -236,7 +236,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         let repoPath = AbsolutePath.root.appending(component: "some-repo")
         let filePath = repoPath.appending(component: "Package.swift")
 
-        let specifier = RepositorySpecifier(url: repoPath.asString)
+        let specifier = RepositorySpecifier(url: repoPath.description)
         let repo = InMemoryGitRepository(path: repoPath, fs: fs)
         try repo.createDirectory(repoPath, recursive: true)
         try repo.writeFileContents(filePath, bytes: ByteString(encodingAsUTF8: "// swift-tools-version:\(ToolsVersion.currentToolsVersion)\n"))
@@ -261,7 +261,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         let provider = RepositoryPackageContainerProvider(
                 repositoryManager: repositoryManager,
                 manifestLoader: MockManifestLoader(manifests: [:]))
-        let ref = PackageReference(identity: "foo", path: repoPath.asString)
+        let ref = PackageReference(identity: "foo", path: repoPath.description)
         let container = try await { provider.getContainer(for: ref, completion: $0) }
         let v = container.versions(filter: { _ in true }).map{$0}
         XCTAssertEqual(v, ["2.0.3", "1.0.3", "1.0.2", "1.0.1", "1.0.0"])
@@ -273,7 +273,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         let repoPath = AbsolutePath.root.appending(component: "some-repo")
         let filePath = repoPath.appending(component: "Package.swift")
 
-        let specifier = RepositorySpecifier(url: repoPath.asString)
+        let specifier = RepositorySpecifier(url: repoPath.description)
         let repo = InMemoryGitRepository(path: repoPath, fs: fs)
 
         try repo.createDirectory(repoPath, recursive: true)
@@ -345,7 +345,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         let repoPath = AbsolutePath.root.appending(component: "some-repo")
         let filePath = repoPath.appending(component: "Package.swift")
         
-        let specifier = RepositorySpecifier(url: repoPath.asString)
+        let specifier = RepositorySpecifier(url: repoPath.description)
         let repo = InMemoryGitRepository(path: repoPath, fs: fs)
         try repo.createDirectory(repoPath, recursive: true)
         try repo.writeFileContents(filePath, bytes: ByteString(encodingAsUTF8: "// swift-tools-version:\(ToolsVersion.currentToolsVersion)\n"))
@@ -372,7 +372,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         let provider = RepositoryPackageContainerProvider(
             repositoryManager: repositoryManager,
             manifestLoader: MockManifestLoader(manifests: [:]))
-        let ref = PackageReference(identity: "foo", path: repoPath.asString)
+        let ref = PackageReference(identity: "foo", path: repoPath.description)
         let container = try await { provider.getContainer(for: ref, completion: $0) }
         let v = container.versions(filter: { _ in true }).map{$0}
         XCTAssertEqual(v, ["1.0.4-alpha", "1.0.2-dev.2", "1.0.2-dev", "1.0.1", "1.0.0", "1.0.0-beta.1", "1.0.0-alpha.1"])
@@ -384,7 +384,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         let repoPath = AbsolutePath.root.appending(component: "some-repo")
         let filePath = repoPath.appending(component: "Package.swift")
         
-        let specifier = RepositorySpecifier(url: repoPath.asString)
+        let specifier = RepositorySpecifier(url: repoPath.description)
         let repo = InMemoryGitRepository(path: repoPath, fs: fs)
         try repo.createDirectory(repoPath, recursive: true)
         try repo.writeFileContents(filePath, bytes: ByteString(encodingAsUTF8: "// swift-tools-version:\(ToolsVersion.currentToolsVersion)\n"))
@@ -410,7 +410,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         let provider = RepositoryPackageContainerProvider(
             repositoryManager: repositoryManager,
             manifestLoader: MockManifestLoader(manifests: [:]))
-        let ref = PackageReference(identity: "foo", path: repoPath.asString)
+        let ref = PackageReference(identity: "foo", path: repoPath.description)
         let container = try await { provider.getContainer(for: ref, completion: $0) }
         let v = container.versions(filter: { _ in true }).map{$0}
         XCTAssertEqual(v, ["2.0.1", "1.0.4", "1.0.2", "1.0.1", "1.0.0"])

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -145,7 +145,7 @@ func ModuleMapTester(_ name: String, includeDir: String = "include", in fileSyst
     do {
         try generator.generateModuleMap(inDir: .root)
         // FIXME: Find a better way.
-        diagnostics = Set(warningStream.bytes.asReadableString.split(separator: "\n").map(String.init))
+        diagnostics = Set(warningStream.bytes.description.split(separator: "\n").map(String.init))
     } catch {
       diagnostics.insert("\(error)")
     }

--- a/Tests/PackageLoadingTests/PD4LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4LoadingTests.swift
@@ -31,7 +31,7 @@ class PackageDescription4LoadingTests: XCTestCase {
         try fs.writeFileContents(manifestPath, bytes: contents)
         let m = try manifestLoader.load(
             package: AbsolutePath.root,
-            baseURL: AbsolutePath.root.asString,
+            baseURL: AbsolutePath.root.description,
             manifestVersion: .v4,
             fileSystem: fs)
         guard m.manifestVersion == .v4 else {
@@ -393,7 +393,7 @@ class PackageDescription4LoadingTests: XCTestCase {
 
         let diagnostics = DiagnosticsEngine()
         let manifest = try manifestLoader.load(
-            package: .root, baseURL: AbsolutePath.root.asString,
+            package: .root, baseURL: AbsolutePath.root.description,
             manifestVersion: .v4, fileSystem: fs,
             diagnostics: diagnostics
         )

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -30,7 +30,7 @@ class PackageDescription4_2LoadingTests: XCTestCase {
         try fs.writeFileContents(manifestPath, bytes: contents)
         let m = try manifestLoader.load(
             package: AbsolutePath.root,
-            baseURL: AbsolutePath.root.asString,
+            baseURL: AbsolutePath.root.description,
             manifestVersion: .v4_2,
             fileSystem: fs)
         guard m.manifestVersion == .v4_2 else {
@@ -377,7 +377,7 @@ class PackageDescription4_2LoadingTests: XCTestCase {
                     bytes: bogusManifest)
             }
             // Check we can load the repository.
-            let manifest = try manifestLoader.load(package: root, baseURL: root.asString, manifestVersion: .v4_2, fileSystem: fs)
+            let manifest = try manifestLoader.load(package: root, baseURL: root.description, manifestVersion: .v4_2, fileSystem: fs)
             XCTAssertEqual(manifest.name, "Trivial")
         }
     }
@@ -475,7 +475,7 @@ class PackageDescription4_2LoadingTests: XCTestCase {
                 delegate.clear()
                 let manifest = try! loader.load(
                     package: manifestPath.parentDirectory,
-                    baseURL: manifestPath.asString,
+                    baseURL: manifestPath.description,
                     manifestVersion: .v4_2)
 
                 XCTAssertEqual(delegate.loaded, [manifestPath])
@@ -530,7 +530,7 @@ class PackageDescription4_2LoadingTests: XCTestCase {
                 delegate.clear()
                 let manifest = try! loader.load(
                     package: manifestPath.parentDirectory,
-                    baseURL: manifestPath.asString,
+                    baseURL: manifestPath.description,
                     manifestVersion: .v4_2)
 
                 XCTAssertEqual(delegate.loaded, [manifestPath])

--- a/Tests/PackageLoadingTests/PD5LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5LoadingTests.swift
@@ -30,7 +30,7 @@ class PackageDescription5LoadingTests: XCTestCase {
         try fs.writeFileContents(manifestPath, bytes: contents)
         let m = try manifestLoader.load(
             package: AbsolutePath.root,
-            baseURL: AbsolutePath.root.asString,
+            baseURL: AbsolutePath.root.description,
             manifestVersion: .v5,
             fileSystem: fs)
         guard m.manifestVersion == .v5 else {

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -78,7 +78,7 @@ class PackageBuilderTests: XCTestCase {
             )
 
             PackageBuilderTester(manifest, path: path, in: fs) { result in
-                result.checkDiagnostic("ignoring broken symlink \(linkPath.asString)")
+                result.checkDiagnostic("ignoring broken symlink \(linkPath)")
                 result.checkModule("foo")
             }
         }
@@ -1691,8 +1691,8 @@ final class PackageBuilderTester {
         guard case .package(let package) = result else {
             return XCTFail("Expected package did not load \(self)", file: file, line: line)
         }
-        XCTAssertEqual(target, package.targetSearchPath.asString, file: file, line: line)
-        XCTAssertEqual(testTarget, package.testTargetSearchPath.asString, file: file, line: line)
+        XCTAssertEqual(target, package.targetSearchPath.description, file: file, line: line)
+        XCTAssertEqual(testTarget, package.testTargetSearchPath.description, file: file, line: line)
     }
 
     func checkModule(_ name: String, file: StaticString = #file, line: UInt = #line, _ body: ((ModuleResult) -> Void)? = nil) {
@@ -1746,7 +1746,7 @@ final class PackageBuilderTester {
             guard case let target as ClangTarget = target else {
                 return XCTFail("Include directory is being checked on a non clang target", file: file, line: line)
             }
-            XCTAssertEqual(target.includeDir.asString, includeDir, file: file, line: line)
+            XCTAssertEqual(target.includeDir.description, includeDir, file: file, line: line)
         }
 
         func check(c99name: String? = nil, type: PackageModel.Target.Kind? = nil, file: StaticString = #file, line: UInt = #line) {
@@ -1762,7 +1762,7 @@ final class PackageBuilderTester {
             if let root = root {
                 XCTAssertEqual(target.sources.root, AbsolutePath(root), file: file, line: line)
             }
-            let sources = Set(self.target.sources.relativePaths.map{$0.asString})
+            let sources = Set(self.target.sources.relativePaths.map({ $0.description }))
             XCTAssertEqual(sources, Set(paths), "unexpected source files in \(target.name)", file: file, line: line)
         }
 

--- a/Tests/PackageLoadingTests/PkgConfigTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigTests.swift
@@ -68,10 +68,10 @@ class PkgConfigTests: XCTestCase {
         }
 
         // Pc file.
-        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.asString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.description]) {
             let result = pkgConfigArgs(for: SystemLibraryTarget(pkgConfig: "Foo"), diagnostics: diagnostics)!
             XCTAssertEqual(result.pkgConfigName, "Foo")
-            XCTAssertEqual(result.cFlags, ["-I/path/to/inc", "-I" + inputsDir.asString])
+            XCTAssertEqual(result.cFlags, ["-I/path/to/inc", "-I\(inputsDir)"])
             XCTAssertEqual(result.libs, ["-L/usr/da/lib", "-lSystemModule", "-lok"])
             XCTAssertNil(result.provider)
             XCTAssertNil(result.error)
@@ -79,7 +79,7 @@ class PkgConfigTests: XCTestCase {
         }
 
         // Pc file with non whitelisted flags.
-        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.asString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.description]) {
             let result = pkgConfigArgs(for: SystemLibraryTarget(pkgConfig: "Bar"), diagnostics: diagnostics)!
             XCTAssertEqual(result.pkgConfigName, "Bar")
             XCTAssertEqual(result.cFlags, ["-I/path/to/inc"])

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -41,7 +41,7 @@ class GitRepositoryTests: XCTestCase {
             let testCheckoutPath = path.appending(component: "checkout")
             let provider = GitRepositoryProvider()
             XCTAssertTrue(try provider.checkoutExists(at: testRepoPath))
-            let repoSpec = RepositorySpecifier(url: testRepoPath.asString)
+            let repoSpec = RepositorySpecifier(url: testRepoPath.description)
             try! provider.fetch(repository: repoSpec, to: testCheckoutPath)
 
             // Verify the checkout was made.
@@ -56,7 +56,7 @@ class GitRepositoryTests: XCTestCase {
             // FIXME: It would be nice if we had a deterministic hash here...
             XCTAssertEqual(revision.identifier, 
                 try Process.popen(
-                    args: Git.tool, "-C", testRepoPath.asString, "rev-parse", "--verify", "1.2.3").utf8Output().spm_chomp())
+                    args: Git.tool, "-C", testRepoPath.description, "rev-parse", "--verify", "1.2.3").utf8Output().spm_chomp())
             if let revision = try? repository.resolveRevision(tag: "<invalid>") {
                 XCTFail("unexpected resolution of invalid tag to \(revision)")
             }
@@ -65,7 +65,7 @@ class GitRepositoryTests: XCTestCase {
 
             XCTAssertEqual(master.identifier,
                 try Process.checkNonZeroExit(
-                    args: Git.tool, "-C", testRepoPath.asString, "rev-parse", "--verify", "master").spm_chomp())
+                    args: Git.tool, "-C", testRepoPath.description, "rev-parse", "--verify", "master").spm_chomp())
 
             // Check that git hashes resolve to themselves.
             let masterIdentifier = try repository.resolveRevision(identifier: master.identifier)
@@ -99,7 +99,7 @@ class GitRepositoryTests: XCTestCase {
         mktmpdir { path in
             // Unarchive the static test repository.
             let inputArchivePath = AbsolutePath(#file).parentDirectory.appending(components: "Inputs", "TestRepo.tgz")
-            try systemQuietly(["tar", "-x", "-v", "-C", path.asString, "-f", inputArchivePath.asString])
+            try systemQuietly(["tar", "-x", "-v", "-C", path.description, "-f", inputArchivePath.description])
             let testRepoPath = path.appending(component: "TestRepo")
 
             // Check hash resolution.
@@ -154,7 +154,7 @@ class GitRepositoryTests: XCTestCase {
             initGitRepo(repoPath)
 
             try Process.checkNonZeroExit(
-                args: Git.tool, "-C", repoPath.asString, "submodule", "add", testRepoPath.asString)
+                args: Git.tool, "-C", repoPath.description, "submodule", "add", testRepoPath.description)
             let repo = GitRepository(path: repoPath)
             try repo.stageEverything()
             try repo.commit()
@@ -182,7 +182,7 @@ class GitRepositoryTests: XCTestCase {
             try localFileSystem.createDirectory(testRepoPath.appending(component: "subdir"))
             try localFileSystem.writeFileContents(testRepoPath.appending(components: "subdir", "test-file-2.txt"), bytes: test2FileContents)
             try localFileSystem.writeFileContents(testRepoPath.appending(component: "test-file-3.sh"), bytes: test3FileContents)
-            try! Process.checkNonZeroExit(args: "chmod", "+x", testRepoPath.appending(component: "test-file-3.sh").asString)
+            try! Process.checkNonZeroExit(args: "chmod", "+x", testRepoPath.appending(component: "test-file-3.sh").description)
             let testRepo = GitRepository(path: testRepoPath)
             try testRepo.stage(files: "test-file-1.txt", "subdir/test-file-2.txt", "test-file-3.sh")
             try testRepo.commit()
@@ -191,7 +191,7 @@ class GitRepositoryTests: XCTestCase {
             // Get the the repository via the provider. the provider.
             let testClonePath = path.appending(component: "clone")
             let provider = GitRepositoryProvider()
-            let repoSpec = RepositorySpecifier(url: testRepoPath.asString)
+            let repoSpec = RepositorySpecifier(url: testRepoPath.description)
             try provider.fetch(repository: repoSpec, to: testClonePath)
             let repository = provider.open(repository: repoSpec, at: testClonePath)
 
@@ -263,19 +263,19 @@ class GitRepositoryTests: XCTestCase {
             // Fetch the repository using the provider.
             let testClonePath = path.appending(component: "clone")
             let provider = GitRepositoryProvider()
-            let repoSpec = RepositorySpecifier(url: testRepoPath.asString)
+            let repoSpec = RepositorySpecifier(url: testRepoPath.description)
             try provider.fetch(repository: repoSpec, to: testClonePath)
 
             // Clone off a checkout.
             let checkoutPath = path.appending(component: "checkout")
             try provider.cloneCheckout(repository: repoSpec, at: testClonePath, to: checkoutPath, editable: false)
             // The remote of this checkout should point to the clone.
-            XCTAssertEqual(try GitRepository(path: checkoutPath).remotes()[0].url, testClonePath.asString)
+            XCTAssertEqual(try GitRepository(path: checkoutPath).remotes()[0].url, testClonePath.description)
 
             let editsPath = path.appending(component: "edit")
             try provider.cloneCheckout(repository: repoSpec, at: testClonePath, to: editsPath, editable: true)
             // The remote of this checkout should point to the original repo.
-            XCTAssertEqual(try GitRepository(path: editsPath).remotes()[0].url, testRepoPath.asString)
+            XCTAssertEqual(try GitRepository(path: editsPath).remotes()[0].url, testRepoPath.description)
 
             // Check the working copies.
             for path in [checkoutPath, editsPath] {
@@ -302,7 +302,7 @@ class GitRepositoryTests: XCTestCase {
             // Clone it somewhere.
             let testClonePath = path.appending(component: "clone")
             let provider = GitRepositoryProvider()
-            let repoSpec = RepositorySpecifier(url: testRepoPath.asString)
+            let repoSpec = RepositorySpecifier(url: testRepoPath.description)
             try provider.fetch(repository: repoSpec, to: testClonePath)
             let clonedRepo = provider.open(repository: repoSpec, at: testClonePath)
             XCTAssertEqual(clonedRepo.tags, ["1.2.3"])
@@ -339,12 +339,12 @@ class GitRepositoryTests: XCTestCase {
 
             // Create a bare clone it somewhere because we want to later push into the repo.
             let testBareRepoPath = path.appending(component: "test-repo-bare")
-            try systemQuietly([Git.tool, "clone", "--bare", testRepoPath.asString, testBareRepoPath.asString])
+            try systemQuietly([Git.tool, "clone", "--bare", testRepoPath.description, testBareRepoPath.description])
 
             // Clone it somewhere.
             let testClonePath = path.appending(component: "clone")
             let provider = GitRepositoryProvider()
-            let repoSpec = RepositorySpecifier(url: testBareRepoPath.asString)
+            let repoSpec = RepositorySpecifier(url: testBareRepoPath.description)
             try provider.fetch(repository: repoSpec, to: testClonePath)
 
             // Clone off a checkout.
@@ -379,7 +379,7 @@ class GitRepositoryTests: XCTestCase {
             XCTAssert(try repo.remotes().isEmpty)
 
             // Add a remote via git cli.
-            try systemQuietly([Git.tool, "-C", testRepoPath.asString, "remote", "add", "origin", "../foo"])
+            try systemQuietly([Git.tool, "-C", testRepoPath.description, "remote", "add", "origin", "../foo"])
             // Test if it was added.
             XCTAssertEqual(Dictionary(items: try repo.remotes().map { ($0.0, $0.1) }), ["origin": "../foo"])
             // Change remote.
@@ -434,7 +434,7 @@ class GitRepositoryTests: XCTestCase {
             // Check a non existent revision.
             XCTAssertFalse(repo.exists(revision: Revision(identifier: "nonExistent")))
             // Checkout a new branch using command line.
-            try systemQuietly([Git.tool, "-C", testRepoPath.asString, "checkout", "-b", "TestBranch1"])
+            try systemQuietly([Git.tool, "-C", testRepoPath.description, "checkout", "-b", "TestBranch1"])
             XCTAssert(repo.exists(revision: Revision(identifier: "TestBranch1")))
             XCTAssertEqual(try repo.getCurrentRevision(), currentRevision)
 
@@ -500,7 +500,7 @@ class GitRepositoryTests: XCTestCase {
             // Create repos: foo and bar, foo will have bar as submodule and then later
             // the submodule ref will be updated in foo.
             let fooPath = path.appending(component: "foo-original")
-            let fooSpecifier = RepositorySpecifier(url: fooPath.asString)
+            let fooSpecifier = RepositorySpecifier(url: fooPath.description)
             let fooRepoPath = path.appending(component: "foo-repo")
             let fooWorkingPath = path.appending(component: "foo-working")
             let barPath = path.appending(component: "bar-original")
@@ -532,7 +532,7 @@ class GitRepositoryTests: XCTestCase {
 
             // Add submodule to foo and tag it as 1.0.1
             try foo.checkout(newBranch: "submodule")
-            try systemQuietly([Git.tool, "-C", fooPath.asString, "submodule", "add", barPath.asString, "bar"])
+            try systemQuietly([Git.tool, "-C", fooPath.description, "submodule", "add", barPath.description, "bar"])
             try foo.stageEverything()
             try foo.commit()
             try foo.tag(name: "1.0.1")
@@ -550,12 +550,12 @@ class GitRepositoryTests: XCTestCase {
             // Add something to bar.
             try localFileSystem.writeFileContents(barPath.appending(component: "bar.txt"), bytes: "hello")
             // Add a submodule too to check for recusive submodules.
-            try systemQuietly([Git.tool, "-C", barPath.asString, "submodule", "add", bazPath.asString, "baz"])
+            try systemQuietly([Git.tool, "-C", barPath.description, "submodule", "add", bazPath.description, "baz"])
             try bar.stageEverything()
             try bar.commit()
 
             // Update the ref of bar in foo and tag as 1.0.2
-            try systemQuietly([Git.tool, "-C", fooPath.appending(component: "bar").asString, "pull"])
+            try systemQuietly([Git.tool, "-C", fooPath.appending(component: "bar").description, "pull"])
             try foo.stageEverything()
             try foo.commit()
             try foo.tag(name: "1.0.2")
@@ -586,7 +586,7 @@ class GitRepositoryTests: XCTestCase {
             // Clone it somewhere.
             let testClonePath = path.appending(component: "clone")
             let provider = GitRepositoryProvider()
-            let repoSpec = RepositorySpecifier(url: testRepoPath.asString)
+            let repoSpec = RepositorySpecifier(url: testRepoPath.description)
             try provider.fetch(repository: repoSpec, to: testClonePath)
             let clonedRepo = provider.open(repository: repoSpec, at: testClonePath)
             XCTAssertEqual(clonedRepo.tags, ["1.2.3"])

--- a/Tests/UtilityTests/ArgumentParserTests.swift
+++ b/Tests/UtilityTests/ArgumentParserTests.swift
@@ -88,7 +88,7 @@ class ArgumentParserTests: XCTestCase {
 
         let stream = BufferedOutputByteStream()
         parser.printUsage(on: stream)
-        let usage = stream.bytes.asString!
+        let usage = stream.bytes.description
         XCTAssert(usage.contains("OVERVIEW: Sample overview"))
         XCTAssert(usage.contains("USAGE: SomeBinary sample parser"))
         XCTAssert(usage.contains("  package name of the year\n                          The name of the package"))
@@ -304,7 +304,7 @@ class ArgumentParserTests: XCTestCase {
 
         var stream = BufferedOutputByteStream()
         parser.printUsage(on: stream)
-        var usage = stream.bytes.asString!
+        var usage = stream.bytes.description
 
         XCTAssert(usage.contains("OVERVIEW: Sample overview"))
         XCTAssert(usage.contains("USAGE: SomeBinary sample parser"))
@@ -317,7 +317,7 @@ class ArgumentParserTests: XCTestCase {
 
         stream = BufferedOutputByteStream()
         parserA.printUsage(on: stream)
-        usage = stream.bytes.asString!
+        usage = stream.bytes.description
 
         XCTAssert(usage.contains("OVERVIEW: A!"))
         XCTAssert(!usage.contains("USAGE:"))
@@ -327,7 +327,7 @@ class ArgumentParserTests: XCTestCase {
 
         stream = BufferedOutputByteStream()
         parserB.printUsage(on: stream)
-        usage = stream.bytes.asString!
+        usage = stream.bytes.description
 
         XCTAssert(usage.contains("OVERVIEW: B!"))
         XCTAssert(!usage.contains("USAGE:"))
@@ -464,21 +464,21 @@ class ArgumentParserTests: XCTestCase {
         // Test that relative path is resolved.
         do {
             let actual = try! SwiftPMProduct.TestSupportExecutable.execute(["pathArgumentTest", "some/path"]).spm_chomp()
-            let expected = localFileSystem.currentWorkingDirectory!.appending(RelativePath("some/path")).asString
+            let expected = localFileSystem.currentWorkingDirectory!.appending(RelativePath("some/path")).description
             XCTAssertEqual(actual, expected)
         }
 
         // Test that relative path starting with ./ is resolved.
         do {
             let actual = try! SwiftPMProduct.TestSupportExecutable.execute(["pathArgumentTest", "./some/path"]).spm_chomp()
-            let expected = localFileSystem.currentWorkingDirectory!.appending(RelativePath("./some/path")).asString
+            let expected = localFileSystem.currentWorkingDirectory!.appending(RelativePath("./some/path")).description
             XCTAssertEqual(actual, expected)
         }
 
         // Test that relative path starting with ../ is resolved.
         do {
             let actual = try! SwiftPMProduct.TestSupportExecutable.execute(["pathArgumentTest", "../other/path"]).spm_chomp()
-            let expected = localFileSystem.currentWorkingDirectory!.appending(RelativePath("../other/path")).asString
+            let expected = localFileSystem.currentWorkingDirectory!.appending(RelativePath("../other/path")).description
             XCTAssertEqual(actual, expected)
         }
 

--- a/Tests/UtilityTests/InterruptHandlerTests.swift
+++ b/Tests/UtilityTests/InterruptHandlerTests.swift
@@ -19,9 +19,9 @@ class InterruptHandlerTests: XCTestCase {
         // Disabled because it sometimes hangs the CI, possibly due to https://bugs.swift.org/browse/SR-5042
       #if false
         mktmpdir { path in
-            let exec = SwiftPMProduct.TestSupportExecutable.path.asString
+            let exec = SwiftPMProduct.TestSupportExecutable.path.description
             let waitFile = path.appending(component: "waitFile")
-            let process = Process(args: exec, "interruptHandlerTest", waitFile.asString)
+            let process = Process(args: exec, "interruptHandlerTest", waitFile.description)
             try process.launch()
             guard waitForFile(waitFile) else {
                 return XCTFail("Couldn't launch the process")

--- a/Tests/UtilityTests/PkgConfigParserTests.swift
+++ b/Tests/UtilityTests/PkgConfigParserTests.swift
@@ -18,7 +18,16 @@ final class PkgConfigParserTests: XCTestCase {
     
     func testGTK3PCFile() {
         try! loadPCFile("gtk+-3.0.pc") { parser in
-            XCTAssertEqual(parser.variables, ["libdir": "/usr/local/Cellar/gtk+3/3.18.9/lib", "gtk_host": "x86_64-apple-darwin15.3.0", "includedir": "/usr/local/Cellar/gtk+3/3.18.9/include", "prefix": "/usr/local/Cellar/gtk+3/3.18.9", "gtk_binary_version": "3.0.0", "exec_prefix": "/usr/local/Cellar/gtk+3/3.18.9", "targets": "quartz", "pcfiledir": parser.pcFile.parentDirectory.asString])
+            XCTAssertEqual(parser.variables, [
+                "libdir": "/usr/local/Cellar/gtk+3/3.18.9/lib",
+                "gtk_host": "x86_64-apple-darwin15.3.0",
+                "includedir": "/usr/local/Cellar/gtk+3/3.18.9/include",
+                "prefix": "/usr/local/Cellar/gtk+3/3.18.9",
+                "gtk_binary_version": "3.0.0",
+                "exec_prefix": "/usr/local/Cellar/gtk+3/3.18.9",
+                "targets": "quartz",
+                "pcfiledir": parser.pcFile.parentDirectory.description
+            ])
             XCTAssertEqual(parser.dependencies, ["gdk-3.0", "atk", "cairo", "cairo-gobject", "gdk-pixbuf-2.0", "gio-2.0"])
             XCTAssertEqual(parser.cFlags, ["-I/usr/local/Cellar/gtk+3/3.18.9/include/gtk-3.0"])
             XCTAssertEqual(parser.libs, ["-L/usr/local/Cellar/gtk+3/3.18.9/lib", "-lgtk-3"])
@@ -27,7 +36,7 @@ final class PkgConfigParserTests: XCTestCase {
     
     func testEmptyCFlags() {
         try! loadPCFile("empty_cflags.pc") { parser in
-            XCTAssertEqual(parser.variables, ["prefix": "/usr/local/bin", "exec_prefix": "/usr/local/bin", "pcfiledir": parser.pcFile.parentDirectory.asString])
+            XCTAssertEqual(parser.variables, ["prefix": "/usr/local/bin", "exec_prefix": "/usr/local/bin", "pcfiledir": parser.pcFile.parentDirectory.description])
             XCTAssertEqual(parser.dependencies, ["gdk-3.0", "atk"])
             XCTAssertEqual(parser.cFlags, [])
             XCTAssertEqual(parser.libs, ["-L/usr/local/bin", "-lgtk-3"])
@@ -36,7 +45,7 @@ final class PkgConfigParserTests: XCTestCase {
     
     func testVariableinDependency() {
         try! loadPCFile("deps_variable.pc") { parser in
-            XCTAssertEqual(parser.variables, ["prefix": "/usr/local/bin", "exec_prefix": "/usr/local/bin", "my_dep": "atk", "pcfiledir": parser.pcFile.parentDirectory.asString])
+            XCTAssertEqual(parser.variables, ["prefix": "/usr/local/bin", "exec_prefix": "/usr/local/bin", "my_dep": "atk", "pcfiledir": parser.pcFile.parentDirectory.description])
             XCTAssertEqual(parser.dependencies, ["gdk-3.0", "atk"])
             XCTAssertEqual(parser.cFlags, ["-I"])
             XCTAssertEqual(parser.libs, ["-L/usr/local/bin", "-lgtk-3"])
@@ -54,7 +63,7 @@ final class PkgConfigParserTests: XCTestCase {
     
     func testEscapedSpaces() {
         try! loadPCFile("escaped_spaces.pc") { parser in
-            XCTAssertEqual(parser.variables, ["prefix": "/usr/local/bin", "exec_prefix": "/usr/local/bin", "my_dep": "atk", "pcfiledir": parser.pcFile.parentDirectory.asString])
+            XCTAssertEqual(parser.variables, ["prefix": "/usr/local/bin", "exec_prefix": "/usr/local/bin", "my_dep": "atk", "pcfiledir": parser.pcFile.parentDirectory.description])
             XCTAssertEqual(parser.dependencies, ["gdk-3.0", "atk"])
             XCTAssertEqual(parser.cFlags, ["-I/usr/local/Wine Cellar/gtk+3/3.18.9/include/gtk-3.0", "-I/after/extra/spaces"])
             XCTAssertEqual(parser.libs, ["-L/usr/local/bin", "-lgtk 3", "-wantareal\\here", "-one\\", "-two"])
@@ -69,14 +78,14 @@ final class PkgConfigParserTests: XCTestCase {
             "/usr/lib/pkgconfig/foo.pc",
             "/usr/local/opt/foo/lib/pkgconfig/foo.pc",
             "/custom/foo.pc")
-        XCTAssertEqual("/custom/foo.pc", try PCFileFinder(diagnostics: diagnostics, brewPrefix: nil).locatePCFile(name: "foo", customSearchPaths: [AbsolutePath("/custom")], fileSystem: fs).asString)
-        XCTAssertEqual("/custom/foo.pc", try PkgConfig(name: "foo", additionalSearchPaths: [AbsolutePath("/custom")], diagnostics: diagnostics, fileSystem: fs, brewPrefix: nil).pcFile.asString)
-        XCTAssertEqual("/usr/lib/pkgconfig/foo.pc", try PCFileFinder(diagnostics: diagnostics, brewPrefix: nil).locatePCFile(name: "foo", customSearchPaths: [], fileSystem: fs).asString)
+        XCTAssertEqual("/custom/foo.pc", try PCFileFinder(diagnostics: diagnostics, brewPrefix: nil).locatePCFile(name: "foo", customSearchPaths: [AbsolutePath("/custom")], fileSystem: fs).description)
+        XCTAssertEqual("/custom/foo.pc", try PkgConfig(name: "foo", additionalSearchPaths: [AbsolutePath("/custom")], diagnostics: diagnostics, fileSystem: fs, brewPrefix: nil).pcFile.description)
+        XCTAssertEqual("/usr/lib/pkgconfig/foo.pc", try PCFileFinder(diagnostics: diagnostics, brewPrefix: nil).locatePCFile(name: "foo", customSearchPaths: [], fileSystem: fs).description)
         try withCustomEnv(["PKG_CONFIG_PATH": "/usr/local/opt/foo/lib/pkgconfig"]) {
-            XCTAssertEqual("/usr/local/opt/foo/lib/pkgconfig/foo.pc", try PkgConfig(name: "foo", diagnostics: diagnostics, fileSystem: fs, brewPrefix: nil).pcFile.asString)
+            XCTAssertEqual("/usr/local/opt/foo/lib/pkgconfig/foo.pc", try PkgConfig(name: "foo", diagnostics: diagnostics, fileSystem: fs, brewPrefix: nil).pcFile.description)
         }
         try withCustomEnv(["PKG_CONFIG_PATH": "/usr/local/opt/foo/lib/pkgconfig:/usr/lib/pkgconfig"]) {
-            XCTAssertEqual("/usr/local/opt/foo/lib/pkgconfig/foo.pc", try PkgConfig(name: "foo", diagnostics: diagnostics, fileSystem: fs, brewPrefix: nil).pcFile.asString)
+            XCTAssertEqual("/usr/local/opt/foo/lib/pkgconfig/foo.pc", try PkgConfig(name: "foo", diagnostics: diagnostics, fileSystem: fs, brewPrefix: nil).pcFile.description)
         }
     }
 
@@ -92,7 +101,7 @@ final class PkgConfigParserTests: XCTestCase {
             """
             try localFileSystem.writeFileContents(fakePkgConfig, bytes: stream.bytes)
             // `FileSystem` does not support `chmod` on Linux, so we shell out instead.
-            _ = try Process.popen(args: "chmod", "+x", fakePkgConfig.asString)
+            _ = try Process.popen(args: "chmod", "+x", fakePkgConfig.description)
 
             let diagnostics = DiagnosticsEngine()
             _ = PCFileFinder(diagnostics: diagnostics, brewPrefix: fakePkgConfig.parentDirectory.parentDirectory)

--- a/Tests/UtilityTests/ProgressAnimationTests.swift
+++ b/Tests/UtilityTests/ProgressAnimationTests.swift
@@ -22,7 +22,7 @@ final class ProgressAnimationTests: XCTestCase {
         var animation = PercentProgressAnimation(stream: outStream, header: "TestHeader")
 
         runProgressAnimation(animation)
-        XCTAssertEqual(outStream.bytes.asString, """
+        XCTAssertEqual(outStream.bytes.validDescription, """
             TestHeader
             0%: 0
             10%: 1
@@ -37,7 +37,7 @@ final class ProgressAnimationTests: XCTestCase {
         animation = PercentProgressAnimation(stream: outStream, header: "TestHeader")
 
         animation.complete(success: true)
-        XCTAssertEqual(outStream.bytes.asString, "")
+        XCTAssertEqual(outStream.bytes.validDescription, "")
     }
 
     func testPercentProgressAnimationTTY() throws {
@@ -57,7 +57,7 @@ final class ProgressAnimationTests: XCTestCase {
         var animation = NinjaProgressAnimation(stream: outStream)
 
         runProgressAnimation(animation)
-        XCTAssertEqual(outStream.bytes.asString, """
+        XCTAssertEqual(outStream.bytes.validDescription, """
             [0/10] 0
             [1/10] 1
             [2/10] 2
@@ -71,7 +71,7 @@ final class ProgressAnimationTests: XCTestCase {
         animation = NinjaProgressAnimation(stream: outStream)
 
         animation.complete(success: true)
-        XCTAssertEqual(outStream.bytes.asString, "")
+        XCTAssertEqual(outStream.bytes.validDescription, "")
     }
 
     func testNinjaProgressAnimationTTY() throws {

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -40,7 +40,7 @@ class InitTests: XCTestCase {
             // Verify basic file system content that we expect in the package
             let manifest = path.appending(component: "Package.swift")
             XCTAssertTrue(fs.exists(manifest))
-            let manifestContents = try localFileSystem.readFileContents(manifest).asString!
+            let manifestContents = try localFileSystem.readFileContents(manifest).description
             let version = "\(InitPackage.newPackageToolsVersion.major).\(InitPackage.newPackageToolsVersion.minor)"
             XCTAssertTrue(manifestContents.hasPrefix("// swift-tools-version:\(version)\n"))
             XCTAssertTrue(manifestContents.contains(packageWithNameAndDependencies(with: name)))
@@ -72,13 +72,13 @@ class InitTests: XCTestCase {
             // Verify basic file system content that we expect in the package
             let manifest = path.appending(component: "Package.swift")
             XCTAssertTrue(fs.exists(manifest))
-            let manifestContents = try localFileSystem.readFileContents(manifest).asString!
+            let manifestContents = try localFileSystem.readFileContents(manifest).description
             let version = "\(InitPackage.newPackageToolsVersion.major).\(InitPackage.newPackageToolsVersion.minor)"
             XCTAssertTrue(manifestContents.hasPrefix("// swift-tools-version:\(version)\n"))
             
             let readme = path.appending(component: "README.md")
             XCTAssertTrue(fs.exists(readme))
-            let readmeContents = try localFileSystem.readFileContents(readme).asString!
+            let readmeContents = try localFileSystem.readFileContents(readme).description
             XCTAssertTrue(readmeContents.hasPrefix("# Foo\n"))
 
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "Foo")), ["main.swift"])
@@ -115,13 +115,13 @@ class InitTests: XCTestCase {
             // Verify basic file system content that we expect in the package
             let manifest = path.appending(component: "Package.swift")
             XCTAssertTrue(fs.exists(manifest))
-            let manifestContents = try localFileSystem.readFileContents(manifest).asString!
+            let manifestContents = try localFileSystem.readFileContents(manifest).description
             let version = "\(InitPackage.newPackageToolsVersion.major).\(InitPackage.newPackageToolsVersion.minor)"
             XCTAssertTrue(manifestContents.hasPrefix("// swift-tools-version:\(version)\n"))
 
             let readme = path.appending(component: "README.md")
             XCTAssertTrue(fs.exists(readme))
-            let readmeContents = try localFileSystem.readFileContents(readme).asString!
+            let readmeContents = try localFileSystem.readFileContents(readme).description
             XCTAssertTrue(readmeContents.hasPrefix("# Foo\n"))
 
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "Foo")), ["Foo.swift"])
@@ -156,7 +156,7 @@ class InitTests: XCTestCase {
             // Verify basic file system content that we expect in the package
             let manifest = path.appending(component: "Package.swift")
             XCTAssertTrue(fs.exists(manifest))
-            let manifestContents = try localFileSystem.readFileContents(manifest).asString!
+            let manifestContents = try localFileSystem.readFileContents(manifest).description
             let version = "\(InitPackage.newPackageToolsVersion.major).\(InitPackage.newPackageToolsVersion.minor)"
             XCTAssertTrue(manifestContents.hasPrefix("// swift-tools-version:\(version)\n"))
             XCTAssertTrue(manifestContents.contains(packageWithNameAndDependencies(with: name)))

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -437,12 +437,12 @@ final class WorkspaceTests: XCTestCase {
 
         let dependencies: [PackageGraphRootInput.PackageDependency] = [
             .init(
-                url: workspace.packagesDir.appending(component: "Bar").asString,
+                url: workspace.packagesDir.appending(component: "Bar").description,
                 requirement: .upToNextMajor(from: "1.0.0"),
                 location: ""
             ),
             .init(
-                url: "file://" + workspace.packagesDir.appending(component: "Foo").asString + "/",
+                url: "file://\(workspace.packagesDir.appending(component: "Foo"))/",
                 requirement: .upToNextMajor(from: "1.0.0"),
                 location: ""
             ),
@@ -1412,7 +1412,7 @@ final class WorkspaceTests: XCTestCase {
 
         workspace.loadDependencyManifests(roots: ["Root"]) { (manifests, diagnostics) in
             let editedPackages = manifests.editedPackagesConstraints()
-            XCTAssertEqual(editedPackages.map({ $0.identifier.path }), [fooPath.asString])
+            XCTAssertEqual(editedPackages.map({ $0.identifier.path }), [fooPath.description])
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -2525,8 +2525,8 @@ final class WorkspaceTests: XCTestCase {
             result.check(notPresent: "Baz")
         }
 
-        try workspace.config.set(mirrorURL: workspace.packagesDir.appending(component: "Baz").asString, forPackageURL: workspace.packagesDir.appending(component: "Bar").asString)
-        try workspace.config.set(mirrorURL: workspace.packagesDir.appending(component: "Baz").asString, forPackageURL: workspace.packagesDir.appending(component: "Bam").asString)
+        try workspace.config.set(mirrorURL: workspace.packagesDir.appending(component: "Baz").description, forPackageURL: workspace.packagesDir.appending(component: "Bar").description)
+        try workspace.config.set(mirrorURL: workspace.packagesDir.appending(component: "Baz").description, forPackageURL: workspace.packagesDir.appending(component: "Bam").description)
 
         let deps: [TestWorkspace.PackageDependency] = [
             .init(name: "Bam", requirement: .upToNextMajor(from: "1.0.0")),

--- a/Tests/XcodeprojTests/FunctionalTests.swift
+++ b/Tests/XcodeprojTests/FunctionalTests.swift
@@ -57,12 +57,12 @@ class FunctionalTests: XCTestCase {
             // Create a shared library.
             let input = systemModule.appending(components: "Sources", "SystemModule.c")
             let output =  systemModule.appending(component: "libSystemModule.dylib")
-            try systemQuietly(["clang", "-shared", input.asString, "-o", output.asString])
+            try systemQuietly(["clang", "-shared", input.description, "-o", output.description])
 
             let pcFile = prefix.appending(component: "libSystemModule.pc")
             try! write(path: pcFile) { stream in
                 stream <<< """
-                    prefix=\(prefix.appending(component: "SystemModule").asString)
+                    prefix=\(prefix.appending(component: "SystemModule"))
                     exec_prefix=${prefix}
                     libdir=${exec_prefix}
                     includedir=${prefix}/Sources/include
@@ -75,7 +75,7 @@ class FunctionalTests: XCTestCase {
                     """
             }
             let moduleUser = prefix.appending(component: "SystemModuleUser")
-            let env = ["PKG_CONFIG_PATH": prefix.asString]
+            let env = ["PKG_CONFIG_PATH": prefix.description]
             XCTAssertXcodeprojGen(moduleUser, env: env)
             let pbx = moduleUser.appending(component: "SystemModuleUser.xcodeproj")
             XCTAssertDirectoryExists(pbx)
@@ -143,13 +143,13 @@ func XCTAssertXcodeBuild(project: AbsolutePath, file: StaticString = #file, line
 
         // Override path to the Swift compiler.
         let stream = BufferedOutputByteStream()
-        stream <<< "SWIFT_EXEC = " <<< swiftCompilerPath.asString <<< "\n"
+        stream <<< "SWIFT_EXEC = " <<< swiftCompilerPath <<< "\n"
 
         // Override Swift libary path, if present.
         let swiftLibraryPath = resolveSymlinks(swiftCompilerPath).appending(components: "..", "..", "lib", "swift", "macosx")
         if localFileSystem.exists(swiftCompilerPath) {
-            stream <<< "SWIFT_LIBRARY_PATH = " <<< swiftLibraryPath.asString <<< "\n"
-            stream <<< "TOOLCHAIN_DIR = " <<< swiftCompilerPath.appending(components: "..", "..").asString <<< "\n"
+            stream <<< "SWIFT_LIBRARY_PATH = " <<< swiftLibraryPath <<< "\n"
+            stream <<< "TOOLCHAIN_DIR = " <<< swiftCompilerPath.appending(components: "..", "..") <<< "\n"
         }
         
         // We don't need dSYM generated for tests
@@ -158,7 +158,7 @@ func XCTAssertXcodeBuild(project: AbsolutePath, file: StaticString = #file, line
         try localFileSystem.writeFileContents(xcconfig, bytes: stream.bytes)
 
         try Process.checkNonZeroExit(
-            args: "xcodebuild", "-project", project.asString, "-alltargets", "-xcconfig", xcconfig.asString, environment: env)
+            args: "xcodebuild", "-project", project.description, "-alltargets", "-xcconfig", xcconfig.description, environment: env)
     } catch {
         XCTFail("xcodebuild failed:\n\n\(error)\n", file: file, line: line)
         switch error {

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -55,7 +55,7 @@ class GenerateXcodeprojTests: XCTestCase {
             // We can only validate this on OS X.
             // Don't allow TOOLCHAINS to be overriden here, as it breaks the test below.
             let output = try Process.checkNonZeroExit(
-                args: "env", "-u", "TOOLCHAINS", "xcodebuild", "-list", "-project", outpath.asString).spm_chomp()
+                args: "env", "-u", "TOOLCHAINS", "xcodebuild", "-list", "-project", outpath.description).spm_chomp()
 
             XCTAssertTrue(output.hasPrefix("""
                Information about project "DummyProjectName":
@@ -129,7 +129,7 @@ class GenerateXcodeprojTests: XCTestCase {
             options: XcodeprojOptions(), fileSystem: fileSystem,
             diagnostics: diagnostics, warningStream: warningStream)
 
-        let warnings = warningStream.bytes.asReadableString
+        let warnings = warningStream.bytes.description
         XCTAssertMatch(warnings, .contains("warning: Target 'Modules' conflicts with required framework filenames, rename this target to avoid conflicts."))
     }
 
@@ -144,12 +144,12 @@ class GenerateXcodeprojTests: XCTestCase {
 
             let diagnostics = DiagnosticsEngine()
             let graph = loadPackageGraph(
-                root: packagePath.asString, fs: localFileSystem, diagnostics: diagnostics,
+                root: packagePath.description, fs: localFileSystem, diagnostics: diagnostics,
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
-                        path: packagePath.asString,
-                        url: packagePath.asString,
+                        path: packagePath.description,
+                        url: packagePath.description,
                         targets: [
                             TargetDescription(name: "DummyModule"),
                         ])
@@ -178,12 +178,12 @@ class GenerateXcodeprojTests: XCTestCase {
 
             let diagnostics = DiagnosticsEngine()
             let graph = loadPackageGraph(
-                root: packagePath.asString, fs: localFileSystem, diagnostics: diagnostics,
+                root: packagePath.description, fs: localFileSystem, diagnostics: diagnostics,
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
-                        path: packagePath.asString,
-                        url: packagePath.asString,
+                        path: packagePath.description,
+                        url: packagePath.description,
                         targets: [
                             TargetDescription(name: "DummyModule"),
                         ])
@@ -212,12 +212,12 @@ class GenerateXcodeprojTests: XCTestCase {
 
             let diagnostics = DiagnosticsEngine()
             let graph = loadPackageGraph(
-                root: packagePath.asString, fs: localFileSystem, diagnostics: diagnostics,
+                root: packagePath.description, fs: localFileSystem, diagnostics: diagnostics,
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
-                        path: packagePath.asString,
-                        url: packagePath.asString,
+                        path: packagePath.description,
+                        url: packagePath.description,
                         targets: [
                             TargetDescription(name: "DummyModule"),
                         ])
@@ -249,12 +249,12 @@ class GenerateXcodeprojTests: XCTestCase {
 
             let diagnostics = DiagnosticsEngine()
             let graph = loadPackageGraph(
-                root: packagePath.asString, fs: localFileSystem, diagnostics: diagnostics,
+                root: packagePath.description, fs: localFileSystem, diagnostics: diagnostics,
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
-                        path: packagePath.asString,
-                        url: packagePath.asString,
+                        path: packagePath.description,
+                        url: packagePath.description,
                         targets: [
                             TargetDescription(name: "DummyModule"),
                         ])
@@ -291,12 +291,12 @@ class GenerateXcodeprojTests: XCTestCase {
 
             let diagnostics = DiagnosticsEngine()
             let graph = loadPackageGraph(
-                root: packagePath.asString, fs: localFileSystem, diagnostics: diagnostics,
+                root: packagePath.description, fs: localFileSystem, diagnostics: diagnostics,
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
-                        path: packagePath.asString,
-                        url: packagePath.asString,
+                        path: packagePath.description,
+                        url: packagePath.description,
                         targets: [
                             TargetDescription(name: "DummyModule"),
                         ])


### PR DESCRIPTION
**TL;DR:** This pull request removes `asString` from SwiftPM, and replaces it with conformances to `CustomStringConvertible` and brings related Quality of Life changes.

This is a pre-requisite PR to a future PR that will introduce a new protocol that extends `CustomStringConvertible`. For that purpose, I need several types (specifically `AbstractPath` and `RelativePath`) to conform to it and return the undecorated path. This change has the benefit of improving the ergonomics of using those types, especially in string interpolation. I also took the opportunity to bring related Quality of Life changes surrounding `CustomStringConvertible` when working with `JSONSerializable` and `OutputByteStream`.

Personally, `asString` always felt weird to me compared to `CustomStringConvertible`, which is the canonical Swift way to transform a value into a string representation. 

### `ByteString`

- Rename `asString` to `validDescription`
- Rename `asReadableString` to `cString`
- Change the implementation of `description` to return `validDescription` and trap on invalid UTF-8 sequences.

Those changes simplify the majority of the code in SwiftPM which attempts to transform `ByteString` into a string by replacing

```swift
byteString.asString!
```
into

```swift
byteString.description
```

To check if the string representation is valid, `validDescription` needs to be used now.

### `AbstractPath` and `RelativePath`

- De-duplicate the `components` implementation by moving it into `PathImpl`
- Remove `asString`
- Change the implementation of `description` to returns the undecorated path

This improves a lot of code in SwiftPM that uses paths in print statement and string interpolation by transforming:

```swift
print(path.asString)
return “Couldn’t read \(path.asString)”
```

into

```swift
print(path)
return “Couldn’t read \(path)”
```

### `JSONSerializable`

Add conditional conformances to `JSONSerializable` to `Array` and `Dictionary` which improves

```swift
return JSON.array(files.map({ $0.toJSON() })
```

into

```swift
return files.toJSON()
```

## `OutputByteStream`

- Add overrides of `<<<` for `CustomStringConvertible` to improve:

```swift
stream <<< file.asString
```

into

```swift
stream <<< file
```

- Add `Format.asJSON` overloads for `CustomStringConvertible` and `[CustomStringConvertible]`, which allows to transform:

```swift
stream <<< Format.asJSON(file.asString)
stream <<< Format.asJSON(files.map({ $0.asString }))
```

into

```swift
stream <<< Format.asJSON(file)
stream <<< Format.asJSON(files)
```