### PR TITLE
[PackageGraph] Supress product dependency not found errors

### DIFF
--- a/Sources/PackageGraph/PackageGraphLoader.swift
+++ b/Sources/PackageGraph/PackageGraphLoader.swift
@@ -380,8 +380,14 @@ private func createResolvedPackages(
             for productRef in targetBuilder.target.productDependencies {
                 // Find the product in this package's dependency products.
                 guard let product = productDependencyMap[productRef.name] else {
-                    let error = PackageGraphError.productDependencyNotFound(name: productRef.name, package: productRef.package)
-                    diagnostics.emit(error, location: diagnosticLocation())
+                    // Only emit a diagnostic if there are no other diagnostics.
+                    // This avoids flooding the diagnostics with product not
+                    // found errors when there are more important errors to
+                    // resolve (like authentication issues).
+                    if !diagnostics.hasErrors {
+                        let error = PackageGraphError.productDependencyNotFound(name: productRef.name, package: productRef.package)
+                        diagnostics.emit(error, location: diagnosticLocation())
+                    }
                     continue
                 }
 

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -499,8 +499,29 @@ class PackageGraphTests: XCTestCase {
         DiagnosticsEngineTester(diagnostics) { result in
             result.check(diagnostic: "target 'Bar' in package 'Bar' contains no valid source files", behavior: .warning)
             result.check(diagnostic: "target 'Bar' referenced in product 'Bar' could not be found", behavior: .error, location: "'Bar' /Bar")
-            result.check(diagnostic: "product dependency 'Bar' not found", behavior: .error, location: "'Foo' /Foo")
+        }
+    }
 
+    func testProductDependencyNotFound() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Foo/Sources/Foo/foo.swift"
+        )
+
+        let diagnostics = DiagnosticsEngine()
+        _ = loadPackageGraph(root: "/Foo", fs: fs, diagnostics: diagnostics,
+            manifests: [
+                Manifest.createV4Manifest(
+                    name: "Foo",
+                    path: "/Foo",
+                    url: "/Foo",
+                    targets: [
+                        TargetDescription(name: "Foo", dependencies: ["Barx"]),
+                    ]),
+            ]
+        )
+
+        DiagnosticsEngineTester(diagnostics) { result in
+            result.check(diagnostic: "product dependency 'Barx' not found", behavior: .error, location: "'Foo' /Foo")
         }
     }
 

--- a/Tests/PackageGraphTests/XCTestManifests.swift
+++ b/Tests/PackageGraphTests/XCTestManifests.swift
@@ -40,6 +40,7 @@ extension PackageGraphTests {
         ("testMultipleDuplicateModules", testMultipleDuplicateModules),
         ("testNestedDuplicateModules", testNestedDuplicateModules),
         ("testProductDependencies", testProductDependencies),
+        ("testProductDependencyNotFound", testProductDependencyNotFound),
         ("testSeveralDuplicateModules", testSeveralDuplicateModules),
         ("testTestTargetDeclInExternalPackage", testTestTargetDeclInExternalPackage),
         ("testUnsafeFlags", testUnsafeFlags),

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -1283,7 +1283,6 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkPackageGraph(roots: ["Root"]) { (graph, diagnostics) in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(diagnostic: .contains("/tmp/ws/pkgs/Foo @ 1.0.0..<2.0.0"), behavior: .error)
-                result.check(diagnostic: .contains("product dependency 'Foo' not found"), behavior: .error, location: "'Root' /tmp/ws/roots/Root")
             }
         }
     }
@@ -2035,7 +2034,6 @@ final class WorkspaceTests: XCTestCase {
             }
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(diagnostic: .contains("1.5.0 contains incompatible dependencies"), behavior: .error)
-                result.check(diagnostic: .contains("product dependency 'Bar' not found"), behavior: .error, location: "'Foo' /tmp/ws/roots/Foo")
             }
         }
     }


### PR DESCRIPTION
These errors are pointless when there are already errors in the graph
and they make it difficult to focus on the real issues.

<rdar://problem/47410017> Supress "product dependency not found" errors when there are already errors in the graph