### PR TITLE
Use the correct sysroot spellings on Darwin and Linux

### DIFF
--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -46,6 +46,9 @@ public struct Destination {
     /// The file extension for dynamic libraries (eg. `.so` or `.dylib`)
     public let dynamicLibraryExtension: String
 
+    /// The compiler flag for specifying the sysroot (eg. `--sysroot` or `-isysroot`).
+    public let sysrootFlag: String
+
     /// Additional flags to be passed to the C compiler.
     public let extraCCFlags: [String]
 
@@ -94,7 +97,7 @@ public struct Destination {
       #if os(macOS)
         // Get the SDK.
         let sdkPath: AbsolutePath
-        if let value = lookupExecutablePath(filename: getenv("SYSROOT")) {
+        if let value = lookupExecutablePath(filename: getenv("SDKROOT")) {
             sdkPath = value
         } else {
             // No value in env, so search for it.
@@ -115,6 +118,7 @@ public struct Destination {
             sdk: sdkPath,
             binDir: binDir,
             dynamicLibraryExtension: "dylib",
+            sysrootFlag: "-isysroot",
             extraCCFlags: commonArgs,
             extraSwiftCFlags: commonArgs,
             extraCPPFlags: ["-lc++"]
@@ -125,6 +129,7 @@ public struct Destination {
             sdk: .root,
             binDir: binDir,
             dynamicLibraryExtension: "so",
+            sysrootFlag: "--sysroot",
             extraCCFlags: ["-fPIC"],
             extraSwiftCFlags: [],
             extraCPPFlags: ["-lstdc++"]
@@ -187,6 +192,7 @@ extension Destination: JSONMappable {
             sdk: AbsolutePath(json.get("sdk")),
             binDir: AbsolutePath(json.get("toolchain-bin-dir")),
             dynamicLibraryExtension: json.get("dynamic-library-extension"),
+            sysrootFlag: json.get("sysroot-flag"),
             extraCCFlags: json.get("extra-cc-flags"),
             extraSwiftCFlags: json.get("extra-swiftc-flags"),
             extraCPPFlags: json.get("extra-cpp-flags")

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -233,7 +233,7 @@ public final class UserToolchain: Toolchain {
         ] + destination.extraSwiftCFlags
 
         self.extraCCFlags = [
-            "--sysroot", destination.sdk.asString
+            destination.sysrootFlag, destination.sdk.asString
         ] + destination.extraCCFlags
 
         // Compute the path of directory containing the PackageDescription libraries.

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -1231,7 +1231,10 @@ def main():
         "SWIFTPM_BOOTSTRAP=1",
     ]
     if args.sysroot:
-        env_cmd.append("SYSROOT=" + args.sysroot)
+        if platform.system() == 'Darwin':
+            env_cmd.append("SDKROOT=" + args.sysroot)
+        else:
+            env_cmd.append("SYSROOT=" + args.sysroot)
     cmd = env_cmd + [bootstrapped_product] + build_flags
 
     # Always build tests in stage2.


### PR DESCRIPTION
On Apple platforms, Clang accepts -isysroot to indicate the sysroot,
while on Linux, it is --sysroot. Similarly, on Apple platforms the
environment variable SDKROOT indicates the sysroot, while on Linux it is
SYSROOT.

rdar://47367002