### PR TITLE
[Build] Don't truncate commands in verbose mode

### DIFF
--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -709,10 +709,13 @@ final class ParallelTestRunner {
         self.numJobs = numJobs
         self.diagnostics = diagnostics
 
+        let isVerbose = options.verbosity > 0
         if Process.env["SWIFTPM_TEST_RUNNER_PROGRESS_BAR"] == "lit" {
-            progressAnimation = PercentProgressAnimation(stream: stdoutStream, header: "Testing:")
+            progressAnimation = PercentProgressAnimation(stream: stdoutStream,
+                                                         header: "Testing:",
+                                                         isVerbose: isVerbose)
         } else {
-            progressAnimation = NinjaProgressAnimation(stream: stdoutStream)
+            progressAnimation = NinjaProgressAnimation(stream: stdoutStream, isVerbose: isVerbose)
         }
 
         self.options = options

--- a/Sources/SPMUtility/ProgressAnimation.swift
+++ b/Sources/SPMUtility/ProgressAnimation.swift
@@ -131,9 +131,10 @@ public final class RedrawingNinjaProgressAnimation: ProgressAnimationProtocol {
 
 /// A ninja-like progress animation that adapts to the provided output stream.
 public final class NinjaProgressAnimation: DynamicProgressAnimation {
-    public init(stream: OutputByteStream) {
+    public init(stream: OutputByteStream, isVerbose: Bool = false) {
         super.init(
             stream: stream,
+            isVerbose: isVerbose,
             ttyTerminalAnimationFactory: { RedrawingNinjaProgressAnimation(terminal: $0) },
             dumbTerminalAnimationFactory: { SingleLinePercentProgressAnimation(stream: stream, header: nil) },
             defaultAnimationFactory: { MultiLineNinjaProgressAnimation(stream: stream) })
@@ -241,9 +242,10 @@ public final class RedrawingLitProgressAnimation: ProgressAnimationProtocol {
 
 /// A percent-based progress animation that adapts to the provided output stream.
 public final class PercentProgressAnimation: DynamicProgressAnimation {
-    public init(stream: OutputByteStream, header: String) {
+  public init(stream: OutputByteStream, header: String, isVerbose: Bool = false) {
         super.init(
             stream: stream,
+            isVerbose: isVerbose,
             ttyTerminalAnimationFactory: { RedrawingLitProgressAnimation(terminal: $0, header: header) },
             dumbTerminalAnimationFactory: { SingleLinePercentProgressAnimation(stream: stream, header: header) },
             defaultAnimationFactory: { MultiLinePercentProgressAnimation(stream: stream, header: header) })
@@ -256,11 +258,14 @@ public class DynamicProgressAnimation: ProgressAnimationProtocol {
 
     public init(
         stream: OutputByteStream,
+        isVerbose: Bool,
         ttyTerminalAnimationFactory: (TerminalController) -> ProgressAnimationProtocol,
         dumbTerminalAnimationFactory: () -> ProgressAnimationProtocol,
         defaultAnimationFactory: () -> ProgressAnimationProtocol
     ) {
-        if let terminal = TerminalController(stream: stream) {
+        if isVerbose {
+            animation = defaultAnimationFactory()
+        } else if let terminal = TerminalController(stream: stream) {
             animation = ttyTerminalAnimationFactory(terminal)
         } else if let fileStream = stream as? LocalFileOutputByteStream,
             TerminalController.terminalType(fileStream) == .dumb

--- a/Tests/UtilityTests/ProgressAnimationTests.swift
+++ b/Tests/UtilityTests/ProgressAnimationTests.swift
@@ -74,6 +74,25 @@ final class ProgressAnimationTests: XCTestCase {
         XCTAssertEqual(outStream.bytes.validDescription, "")
     }
 
+    func testNinjaProgressAnimationVerbose() throws {
+        let oneHundredDashes = String(repeating: "-", count: 100)
+        let output = try readingTTY { tty in
+            let animation = NinjaProgressAnimation(stream: tty.outStream, isVerbose: true)
+            for i in 0...3 {
+                animation.update(step: i, total: 3, text: oneHundredDashes)
+            }
+            animation.complete(success: true)
+        }
+
+        let newline = "\r\n"
+        XCTAssertEqual(output, """
+            [0/3] \(oneHundredDashes)\(newline)\
+            [1/3] \(oneHundredDashes)\(newline)\
+            [2/3] \(oneHundredDashes)\(newline)\
+            [3/3] \(oneHundredDashes)\(newline)
+            """)
+    }
+
     func testNinjaProgressAnimationTTY() throws {
         var output = try readingTTY { tty in
             let animation = NinjaProgressAnimation(stream: tty.outStream)


### PR DESCRIPTION
Previously, the ninja progress animation would truncate text, even if
--verbose is passed. Now, if --verbose is passed, NinjaProgressAnimation
defaults to the dumb terminal output.