### PR TITLE
[Basic] Add pathString property to Path

### DIFF
--- a/Sources/Basic/FileSystem.swift
+++ b/Sources/Basic/FileSystem.swift
@@ -242,7 +242,7 @@ public extension FileSystem {
 private class LocalFileSystem: FileSystem {
 
     func isExecutableFile(_ path: AbsolutePath) -> Bool {
-        guard let filestat = try? POSIX.stat(path.description) else {
+        guard let filestat = try? POSIX.stat(path.pathString) else {
             return false
         }
         return filestat.st_mode & SPMLibc.S_IXUSR != 0 && filestat.st_mode & S_IFREG != 0
@@ -287,7 +287,7 @@ private class LocalFileSystem: FileSystem {
     }
 
     func getDirectoryContents(_ path: AbsolutePath) throws -> [String] {
-        guard let dir = SPMLibc.opendir(path.description) else {
+        guard let dir = SPMLibc.opendir(path.pathString) else {
             throw FileSystemError(errno: errno)
         }
         defer { _ = SPMLibc.closedir(dir) }
@@ -329,7 +329,7 @@ private class LocalFileSystem: FileSystem {
 
     func createDirectory(_ path: AbsolutePath, recursive: Bool) throws {
         // Try to create the directory.
-        let result = mkdir(path.description, SPMLibc.S_IRWXU | SPMLibc.S_IRWXG)
+        let result = mkdir(path.pathString, SPMLibc.S_IRWXU | SPMLibc.S_IRWXG)
 
         // If it succeeded, we are done.
         if result == 0 { return }
@@ -354,7 +354,7 @@ private class LocalFileSystem: FileSystem {
 
     func readFileContents(_ path: AbsolutePath) throws -> ByteString {
         // Open the file.
-        let fp = fopen(path.description, "rb")
+        let fp = fopen(path.pathString, "rb")
         if fp == nil {
             throw FileSystemError(errno: errno)
         }
@@ -383,7 +383,7 @@ private class LocalFileSystem: FileSystem {
 
     func writeFileContents(_ path: AbsolutePath, bytes: ByteString) throws {
         // Open the file.
-        let fp = fopen(path.description, "wb")
+        let fp = fopen(path.pathString, "wb")
         if fp == nil {
             throw FileSystemError(errno: errno)
         }
@@ -412,7 +412,7 @@ private class LocalFileSystem: FileSystem {
         let temp = try TemporaryFile(dir: path.parentDirectory, deleteOnClose: false)
         do {
             try writeFileContents(temp.path, bytes: bytes)
-            try POSIX.rename(old: temp.path.description, new: path.description)
+            try POSIX.rename(old: temp.path.pathString, new: path.pathString)
         } catch {
             // Write or rename failed, delete the temporary file.
             // Rethrow the original error, however, as that's the
@@ -424,7 +424,7 @@ private class LocalFileSystem: FileSystem {
 
     func removeFileTree(_ path: AbsolutePath) throws {
         if self.exists(path, followSymlink: false) {
-            try FileManager.default.removeItem(atPath: path.description)
+            try FileManager.default.removeItem(atPath: path.pathString)
         }
     }
 
@@ -441,7 +441,7 @@ private class LocalFileSystem: FileSystem {
         let ftsOptions = recursive ? FTS_PHYSICAL : FTS_LOGICAL
 
         // Get handle to the file hierarchy we want to traverse.
-        let paths = CStringArray([path.description])
+        let paths = CStringArray([path.pathString])
         guard let ftsp = fts_open(paths.cArray, ftsOptions, nil) else {
             throw FileSystemError(errno: errno)
         }
@@ -809,7 +809,7 @@ public class RerootedFileSystemView: FileSystem {
             return root
         } else {
             // FIXME: Optimize?
-            return root.appending(RelativePath(String(path.description.dropFirst(1))))
+            return root.appending(RelativePath(String(path.pathString.dropFirst(1))))
         }
     }
 

--- a/Sources/Basic/JSON.swift
+++ b/Sources/Basic/JSON.swift
@@ -308,13 +308,13 @@ extension Bool: JSONSerializable {
 
 extension AbsolutePath: JSONSerializable {
     public func toJSON() -> JSON {
-        return .string(description)
+        return .string(pathString)
     }
 }
 
 extension RelativePath: JSONSerializable {
     public func toJSON() -> JSON {
-        return .string(description)
+        return .string(pathString)
     }
 }
 

--- a/Sources/Basic/Lock.swift
+++ b/Sources/Basic/Lock.swift
@@ -55,7 +55,7 @@ public final class FileLock {
     public func lock() throws {
         // Open the lock file.
         if fd == nil {
-            let fd = SPMLibc.open(lockFile.description, O_WRONLY | O_CREAT | O_CLOEXEC, 0o666)
+            let fd = SPMLibc.open(lockFile.pathString, O_WRONLY | O_CREAT | O_CLOEXEC, 0o666)
             if fd == -1 {
                 throw FileSystemError(errno: errno)
             }

--- a/Sources/Basic/OutputByteStream.swift
+++ b/Sources/Basic/OutputByteStream.swift
@@ -671,7 +671,7 @@ public final class LocalFileOutputByteStream: FileOutputByteStream {
     ///
     /// - Throws: FileSystemError
     public init(_ path: AbsolutePath, closeOnDeinit: Bool = true, buffered: Bool = true) throws {
-        guard let filePointer = fopen(path.description, "wb") else {
+        guard let filePointer = fopen(path.pathString, "wb") else {
             throw FileSystemError(errno: errno)
         }
         self.filePointer = filePointer

--- a/Sources/Basic/Path.swift
+++ b/Sources/Basic/Path.swift
@@ -199,6 +199,12 @@ public struct AbsolutePath: Hashable {
     /// Root directory (whose string representation is just a path separator).
     public static let root = AbsolutePath("/")
 
+    /// Normalized string representation (the normalization rules are described
+    /// in the documentation of the initializer).  This string is never empty.
+    public var pathString: String {
+        return _impl.string
+    }
+
     /// Returns an array of strings that make up the path components of the
     /// absolute path.  This is the same sequence of strings as the basenames
     /// of each successive path component, starting from the root.  Therefore
@@ -271,6 +277,12 @@ public struct RelativePath: Hashable {
         return _impl.extension
     }
 
+    /// Normalized string representation (the normalization rules are described
+    /// in the documentation of the initializer).  This string is never empty.
+    public var pathString: String {
+        return _impl.string
+    }
+
     /// Returns an array of strings that make up the path components of the
     /// relative path.  This is the same sequence of strings as the basenames
     /// of each successive path component.  Therefore the returned array of
@@ -284,7 +296,7 @@ public struct RelativePath: Hashable {
 extension AbsolutePath: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        try container.encode(description)
+        try container.encode(pathString)
     }
 
     public init(from decoder: Decoder) throws {
@@ -296,7 +308,7 @@ extension AbsolutePath: Codable {
 extension RelativePath: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        try container.encode(description)
+        try container.encode(pathString)
     }
 
     public init(from decoder: Decoder) throws {
@@ -308,19 +320,19 @@ extension RelativePath: Codable {
 // Make absolute paths Comparable.
 extension AbsolutePath: Comparable {
     public static func < (lhs: AbsolutePath, rhs: AbsolutePath) -> Bool {
-        return lhs.description < rhs.description
+        return lhs.pathString < rhs.pathString
     }
 }
 
 /// Make absolute paths CustomStringConvertible and CustomDebugStringConvertible.
 extension AbsolutePath: CustomStringConvertible, CustomDebugStringConvertible {
     public var description: String {
-        return _impl.string
+        return pathString
     }
 
     public var debugDescription: String {
         // FIXME: We should really be escaping backslashes and quotes here.
-        return "<AbsolutePath:\"\(_impl.string)\">"
+        return "<AbsolutePath:\"\(pathString)\">"
     }
 }
 

--- a/Sources/Basic/TemporaryFile.swift
+++ b/Sources/Basic/TemporaryFile.swift
@@ -108,7 +108,7 @@ public final class TemporaryFile {
         // Convert path to a C style string terminating with null char to be an valid input
         // to mkstemps method. The XXXXXX in this string will be replaced by a random string
         // which will be the actual path to the temporary file.
-        var template = [UInt8](path.description.utf8).map({ Int8($0) }) + [Int8(0)]
+        var template = [UInt8](path.pathString.utf8).map({ Int8($0) }) + [Int8(0)]
 
         fd = SPMLibc.mkstemps(&template, Int32(suffix.utf8.count))
         // If mkstemps failed then throw error.
@@ -121,7 +121,7 @@ public final class TemporaryFile {
     /// Remove the temporary file before deallocating.
     deinit {
         if deleteOnClose {
-            unlink(path.description)
+            unlink(path.pathString)
         }
     }
 }
@@ -204,7 +204,7 @@ public final class TemporaryDirectory {
         // Convert path to a C style string terminating with null char to be an valid input
         // to mkdtemp method. The XXXXXX in this string will be replaced by a random string
         // which will be the actual path to the temporary directory.
-        var template = [UInt8](path.description.utf8).map({ Int8($0) }) + [Int8(0)]
+        var template = [UInt8](path.pathString.utf8).map({ Int8($0) }) + [Int8(0)]
 
         if SPMLibc.mkdtemp(&template) == nil {
             throw MakeDirectoryError(errno: errno)
@@ -216,9 +216,9 @@ public final class TemporaryDirectory {
     /// Remove the temporary file before deallocating.
     deinit {
         if shouldRemoveTreeOnDeinit {
-            _ = try? FileManager.default.removeItem(atPath: path.description)
+            _ = try? FileManager.default.removeItem(atPath: path.pathString)
         } else {
-            rmdir(path.description)
+            rmdir(path.pathString)
         }
     }
 }

--- a/Sources/Basic/misc.swift
+++ b/Sources/Basic/misc.swift
@@ -145,6 +145,6 @@ extension CodableRange: Codable {
 extension AbsolutePath {
     /// File URL created from the normalized string representation of the path.
     public var asURL: Foundation.URL {
-         return URL(fileURLWithPath: description)
+         return URL(fileURLWithPath: pathString)
     }
 }

--- a/Sources/Build/ToolProtocol.swift
+++ b/Sources/Build/ToolProtocol.swift
@@ -102,7 +102,7 @@ struct SwiftCompilerTool: ToolProtocol {
 
     /// Outputs produced by the tool.
     var outputs: [String] {
-        return target.objects.map({ $0.description }) + [target.moduleOutputPath.description]
+        return target.objects.map({ $0.pathString }) + [target.moduleOutputPath.pathString]
     }
 
     /// The underlying Swift build target.
@@ -118,25 +118,25 @@ struct SwiftCompilerTool: ToolProtocol {
     func append(to stream: OutputByteStream) {
         stream <<< "    tool: swift-compiler\n"
         stream <<< "    executable: "
-            <<< Format.asJSON(target.buildParameters.toolchain.swiftCompiler) <<< "\n"
+            <<< Format.asJSON(target.buildParameters.toolchain.swiftCompiler.pathString) <<< "\n"
         stream <<< "    module-name: "
             <<< Format.asJSON(target.target.c99name) <<< "\n"
         stream <<< "    module-output-path: "
-            <<< Format.asJSON(target.moduleOutputPath) <<< "\n"
+            <<< Format.asJSON(target.moduleOutputPath.pathString) <<< "\n"
         stream <<< "    inputs: "
             <<< Format.asJSON(inputs) <<< "\n"
         stream <<< "    outputs: "
             <<< Format.asJSON(outputs) <<< "\n"
         stream <<< "    import-paths: "
-            <<< Format.asJSON([target.buildParameters.buildPath]) <<< "\n"
+            <<< Format.asJSON([target.buildParameters.buildPath.pathString]) <<< "\n"
         stream <<< "    temps-path: "
-            <<< Format.asJSON(target.tempsPath) <<< "\n"
+            <<< Format.asJSON(target.tempsPath.pathString) <<< "\n"
         stream <<< "    objects: "
-            <<< Format.asJSON(target.objects) <<< "\n"
+            <<< Format.asJSON(target.objects.map{$0.pathString}) <<< "\n"
         stream <<< "    other-args: "
             <<< Format.asJSON(target.compileArguments()) <<< "\n"
         stream <<< "    sources: "
-            <<< Format.asJSON(target.target.sources.paths) <<< "\n"
+            <<< Format.asJSON(target.target.sources.paths.map{$0.pathString}) <<< "\n"
         stream <<< "    is-library: "
             <<< Format.asJSON(target.target.type == .library || target.target.type == .test) <<< "\n"
         stream <<< "    enable-whole-module-optimization: "

--- a/Sources/Commands/Describe.swift
+++ b/Sources/Commands/Describe.swift
@@ -64,9 +64,9 @@ extension Target: JSONSerializable {
         stream <<< Format.asRepeating(string: " ", count: indent)
             <<< "Module type: " <<< String(describing: Swift.type(of: self)) <<< "\n"
         stream <<< Format.asRepeating(string: " ", count: indent)
-            <<< "Path: " <<< sources.root <<< "\n"
+            <<< "Path: " <<< sources.root.pathString <<< "\n"
         stream <<< Format.asRepeating(string: " ", count: indent)
-            <<< "Sources: " <<< sources.relativePaths.map({ $0.description }).joined(separator: ", ") <<< "\n"
+            <<< "Sources: " <<< sources.relativePaths.map({ $0.pathString }).joined(separator: ", ") <<< "\n"
     }
 
     public func toJSON() -> JSON {
@@ -83,7 +83,7 @@ extension Target: JSONSerializable {
 
 extension Sources: JSONSerializable {
     public func toJSON() -> JSON {
-        return .array(relativePaths.map({ .string($0.description) }))
+        return .array(relativePaths.map({ .string($0.pathString) }))
     }
 }
 

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -58,7 +58,7 @@ public class SwiftBuildTool: SwiftTool<BuildToolOptions> {
            try build(plan: plan, subset: subset)
 
         case .binPath:
-            try print(buildParameters().buildPath)
+            try print(buildParameters().buildPath.pathString)
 
         case .version:
             print(Versioning.currentVersion.completeDisplayString)

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -190,11 +190,11 @@ public class SwiftRunTool: SwiftTool<RunToolOptions> {
         // Make sure we are running from the original working directory.
         let cwd: AbsolutePath? = localFileSystem.currentWorkingDirectory
         if cwd == nil || originalWorkingDirectory != cwd {
-            try POSIX.chdir(originalWorkingDirectory.description)
+            try POSIX.chdir(originalWorkingDirectory.pathString)
         }
 
         let pathRelativeToWorkingDirectory = excutablePath.relative(to: originalWorkingDirectory)
-        try exec(path: excutablePath.description, args: [pathRelativeToWorkingDirectory.description] + arguments)
+        try exec(path: excutablePath.pathString, args: [pathRelativeToWorkingDirectory.pathString] + arguments)
     }
 
     /// Determines if a path points to a valid swift file.

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -340,14 +340,14 @@ public class SwiftTestTool: SwiftTool<TestToolOptions> {
         let codeCovFiles = try localFileSystem.getDirectoryContents(buildParameters.codeCovPath)
 
         // Construct arguments for invoking the llvm-prof tool.
-        var args = [llvmProf.description, "merge", "-sparse"]
+        var args = [llvmProf.pathString, "merge", "-sparse"]
         for file in codeCovFiles {
             let filePath = buildParameters.codeCovPath.appending(component: file)
             if filePath.extension == "profraw" {
-                args.append(filePath.description)
+                args.append(filePath.pathString)
             }
         }
-        args += ["-o", buildParameters.codeCovDataFile.description]
+        args += ["-o", buildParameters.codeCovDataFile.pathString]
 
         try Process.checkNonZeroExit(arguments: args)
     }
@@ -358,10 +358,10 @@ public class SwiftTestTool: SwiftTool<TestToolOptions> {
         let llvmCov = try getToolchain().getLLVMCov()
         let buildParameters = try self.buildParameters()
         let args = [
-            llvmCov.description,
+            llvmCov.pathString,
             "export",
             "-instr-profile=\(buildParameters.codeCovDataFile)",
-            testBinary.description
+            testBinary.pathString
         ]
         let result = try Process.popen(arguments: args)
 
@@ -473,12 +473,12 @@ public class SwiftTestTool: SwiftTool<TestToolOptions> {
         // Run the correct tool.
       #if os(macOS)
         let tempFile = try TemporaryFile()
-        let args = [SwiftTestTool.xctestHelperPath().description, path.description, tempFile.path.description]
+        let args = [SwiftTestTool.xctestHelperPath().pathString, path.pathString, tempFile.path.pathString]
         var env = try constructTestEnvironment(toolchain: try getToolchain(), options: self.options, buildParameters: self.buildParameters())
         // Add the sdk platform path if we have it. If this is not present, we
         // might always end up failing.
         if let sdkPlatformFrameworksPath = Destination.sdkPlatformFrameworkPath() {
-            env["DYLD_FRAMEWORK_PATH"] = sdkPlatformFrameworksPath.description
+            env["DYLD_FRAMEWORK_PATH"] = sdkPlatformFrameworksPath.pathString
         }
         try Process.checkNonZeroExit(arguments: args, environment: env)
         // Read the temporary file's content.
@@ -580,11 +580,11 @@ final class TestRunner {
         guard let xctest = toolchain.xctest else {
             throw TestError.testsExecutableNotFound
         }
-        args = [xctest.description]
+        args = [xctest.pathString]
         if let xctestArg = xctestArg {
             args += ["-XCTest", xctestArg]
         }
-        args += [path.description]
+        args += [path.pathString]
       #else
         args += [path.description]
         if let xctestArg = xctestArg {
@@ -953,7 +953,7 @@ fileprivate func constructTestEnvironment(
         // SwiftPM repeatedly invokes the test binary with the test case name as
         // the filter.
         let codecovProfile = buildParameters.buildPath.appending(components: "codecov", "default%m.profraw")
-        env["LLVM_PROFILE_FILE"] = codecovProfile.description
+        env["LLVM_PROFILE_FILE"] = codecovProfile.pathString
     }
 
   #if !os(macOS)
@@ -966,7 +966,7 @@ fileprivate func constructTestEnvironment(
 
     // Get the runtime libraries.
     var runtimes = try options.sanitizers.sanitizers.map({ sanitizer in
-        return try toolchain.runtimeLibrary(for: sanitizer).description
+        return try toolchain.runtimeLibrary(for: sanitizer).pathString
     })
 
     // Append any existing value to the front.

--- a/Sources/Commands/WatchmanHelper.swift
+++ b/Sources/Commands/WatchmanHelper.swift
@@ -66,7 +66,7 @@ final class WatchmanHelper {
         stream <<< "set -eu" <<< "\n\n"
         stream <<< "swift package generate-xcodeproj"
         if let xcconfigOverrides = options.xcconfigOverrides {
-            stream <<< " --xcconfig-overrides " <<< xcconfigOverrides
+            stream <<< " --xcconfig-overrides " <<< xcconfigOverrides.pathString
         }
         stream <<< "\n"
 
@@ -82,7 +82,7 @@ final class WatchmanHelper {
         var args = [String]()
         args += ["--settle", "2"]
         args += ["-p", "Package.swift", "Package.resolved"]
-        args += ["--run", scriptPath.description.spm_shellEscaped()]
+        args += ["--run", scriptPath.pathString.spm_shellEscaped()]
 
         // Find and execute watchman.
         let watchmanMakeToolPath = try self.watchmanMakeToolPath()
@@ -90,7 +90,7 @@ final class WatchmanHelper {
         print("Starting:", watchmanMakeToolPath, args.joined(separator: " "))
 
         let pathRelativeToWorkingDirectory = watchmanMakeToolPath.relative(to: packageRoot)
-        try exec(path: watchmanMakeToolPath.description, args: [pathRelativeToWorkingDirectory.description] + args)
+        try exec(path: watchmanMakeToolPath.pathString, args: [pathRelativeToWorkingDirectory.pathString] + args)
     }
 
     private func watchmanMakeToolPath() throws -> AbsolutePath {

--- a/Sources/Commands/show-dependencies.swift
+++ b/Sources/Commands/show-dependencies.swift
@@ -120,7 +120,7 @@ private final class JSONDumper: DependenciesDumper {
                 "name": .string(package.name),
                 "url": .string(package.manifest.url),
                 "version": .string(package.manifest.version?.description ?? "unspecified"),
-                "path": .string(package.path.description),
+                "path": .string(package.path.pathString),
                 "dependencies": .array(package.dependencies.map(convert)),
             ])
         }

--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -74,7 +74,7 @@ public struct PackageGraphRoot {
             // strip that. We need to design a URL data structure for SwiftPM.
             let filePrefix = "file://"
             if url.hasPrefix(filePrefix) {
-                self.url = AbsolutePath(String(url.dropFirst(filePrefix.count))).description
+                self.url = AbsolutePath(String(url.dropFirst(filePrefix.count))).pathString
             } else {
                 self.url = url
             }
@@ -95,7 +95,7 @@ public struct PackageGraphRoot {
     /// Create a package graph root.
     public init(input: PackageGraphRootInput, manifests: [Manifest]) {
         self.packageRefs = zip(input.packages, manifests).map { (path, manifest) in
-            PackageReference(identity: manifest.name.lowercased(), path: path.description, isLocal: true)
+            PackageReference(identity: manifest.name.lowercased(), path: path.pathString, isLocal: true)
         }
         self.manifests = manifests
         self.dependencies = input.dependencies

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -317,7 +317,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         // and validates it.
 
         // Compute the path to runtime we need to load.
-        let runtimePath = self.runtimePath(for: manifestVersion).description
+        let runtimePath = self.runtimePath(for: manifestVersion).pathString
         let interpreterFlags = self.interpreterFlags(for: manifestVersion)
 
         var cmd = [String]()
@@ -329,13 +329,13 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             cmd += ["sandbox-exec", "-p", sandboxProfile()]
         }
       #endif
-        cmd += [resources.swiftCompiler.description]
+        cmd += [resources.swiftCompiler.pathString]
         cmd += ["--driver-mode=swift"]
         cmd += bootstrapArgs()
         cmd += verbosity.ccArgs
         cmd += ["-L", runtimePath, "-lPackageDescription"]
         cmd += interpreterFlags
-        cmd += [manifestPath.description]
+        cmd += [manifestPath.pathString]
 
         // Create and open a temporary file to write json to.
         let file = try TemporaryFile()
@@ -420,12 +420,12 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         var cmd = [String]()
         let runtimePath = self.runtimePath(for: manifestVersion)
         cmd += ["-swift-version", manifestVersion.swiftLanguageVersion.rawValue]
-        cmd += ["-I", runtimePath.description]
+        cmd += ["-I", runtimePath.pathString]
       #if os(macOS)
         cmd += ["-target", "x86_64-apple-macosx10.10"]
       #endif
         if let sdkRoot = resources.sdkRoot ?? self.sdkRoot() {
-            cmd += ["-sdk", sdkRoot.description]
+            cmd += ["-sdk", sdkRoot.pathString]
         }
         return cmd
     }
@@ -447,7 +447,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
         if isManifestCachingEnabled {
             try localFileSystem.createDirectory(cacheDir, recursive: true)
-            try engine.attachDB(path: cacheDir.appending(component: "manifest.db").description)
+            try engine.attachDB(path: cacheDir.appending(component: "manifest.db").pathString)
         }
         _engine = engine
         return engine
@@ -471,7 +471,7 @@ private func sandboxProfile() -> String {
     // Allow writing in temporary locations.
     stream <<< "(allow file-write*" <<< "\n"
     for directory in Platform.darwinCacheDirectories() {
-        stream <<< "    (regex #\"^\(directory)/org\\.llvm\\.clang.*\")" <<< "\n"
+        stream <<< "    (regex #\"^\(directory.pathString)/org\\.llvm\\.clang.*\")" <<< "\n"
     }
     stream <<< ")" <<< "\n"
     return stream.bytes.description

--- a/Sources/PackageLoading/ModuleMapGenerator.swift
+++ b/Sources/PackageLoading/ModuleMapGenerator.swift
@@ -143,8 +143,8 @@ public struct ModuleMapGenerator {
         let umbrellaHeader = path.appending(component: target.c99name + ".h")
         let invalidUmbrellaHeader = path.appending(component: target.name + ".h")
         if target.c99name != target.name && fileSystem.isFile(invalidUmbrellaHeader) {
-            warningStream <<< "warning: \(invalidUmbrellaHeader) should be renamed to "
-            warningStream <<< "\(umbrellaHeader) to be used as an umbrella header"
+            warningStream <<< "warning: \(invalidUmbrellaHeader.pathString) should be renamed to "
+            warningStream <<< "\(umbrellaHeader.pathString) to be used as an umbrella header"
             warningStream.flush()
         }
     }
@@ -159,9 +159,9 @@ public struct ModuleMapGenerator {
         stream <<< "module \(target.c99name) {\n"
         switch type {
         case .header(let header):
-            stream <<< "    umbrella header \"\(header)\"\n"
+            stream <<< "    umbrella header \"\(header.pathString)\"\n"
         case .directory(let path):
-            stream <<< "    umbrella \"\(path)\"\n"
+            stream <<< "    umbrella \"\(path.pathString)\"\n"
         }
         stream <<< "    export *\n"
         stream <<< "}\n"
@@ -193,16 +193,16 @@ extension ModuleMapGenerator.ModuleMapError.UnsupportedIncludeLayoutType: Custom
     public var description: String {
         switch self {
         case .umbrellaHeaderWithAdditionalNonEmptyDirectories(let (umbrella, dirs)):
-            return "umbrella header defined at '\(umbrella)', but directories exist: " +
-                dirs.map({ $0.description }).sorted().joined(separator: ", ") +
+            return "umbrella header defined at '\(umbrella.pathString)', but directories exist: " +
+                dirs.map({ $0.pathString }).sorted().joined(separator: ", ") +
                 "; consider removing them"
         case .umbrellaHeaderWithAdditionalDirectoriesInIncludeDirectory(let (umbrella, dirs)):
-            return "umbrella header defined at '\(umbrella)', but more than one directories exist: " +
-                dirs.map({ $0.description }).sorted().joined(separator: ", ") +
+            return "umbrella header defined at '\(umbrella.pathString)', but more than one directories exist: " +
+                dirs.map({ $0.pathString }).sorted().joined(separator: ", ") +
                 "; consider reducing them to one"
         case .umbrellaHeaderWithAdditionalFilesInIncludeDirectory(let (umbrella, files)):
-            return "umbrella header defined at '\(umbrella)', but files exist:" +
-                files.map({ $0.description }).sorted().joined(separator: ", ") +
+            return "umbrella header defined at '\(umbrella.pathString)', but files exist:" +
+                files.map({ $0.pathString }).sorted().joined(separator: ", ") +
                 "; consider removing them"
         }
     }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -82,10 +82,10 @@ extension ModuleError: CustomStringConvertible {
             return "public headers directory path for '\(name)' is invalid or not contained in the target"
         case .overlappingSources(let target, let sources):
             return "target '\(target)' has sources overlapping sources: " +
-                sources.map({ $0.description }).joined(separator: ", ")
+                sources.map({ $0.pathString }).joined(separator: ", ")
         case .multipleLinuxMainFound(let package, let linuxMainFiles):
             return "package '\(package)' has multiple linux main files: " +
-                linuxMainFiles.map({ $0.description }).sorted().joined(separator: ", ")
+                linuxMainFiles.map({ $0.pathString }).sorted().joined(separator: ", ")
         case .incompatibleToolsVersions(let package, let required, let current):
             if required.isEmpty {
                 return "package '\(package)' supported Swift language versions is empty"
@@ -297,7 +297,7 @@ public final class PackageBuilder {
             // Diagnose broken symlinks.
             if fileSystem.isSymlink(path) {
                 diagnostics.emit(
-                    data: PackageBuilderDiagnostics.BorkenSymlinkDiagnostic(path: path.description),
+                    data: PackageBuilderDiagnostics.BorkenSymlinkDiagnostic(path: path.pathString),
                     location: diagnosticLocation()
                 )
             }
@@ -573,7 +573,7 @@ public final class PackageBuilder {
     private func validateModuleName(_ path: AbsolutePath, _ name: String, isTest: Bool) throws {
         if name.isEmpty {
             throw Target.Error.invalidName(
-                path: path.relative(to: packagePath).description,
+                path: path.relative(to: packagePath).pathString,
                 problem: .emptyName)
         }
     }
@@ -671,7 +671,7 @@ public final class PackageBuilder {
 
         // Make sure there is no modulemap mixed with the sources.
         if let path = walked.first(where: { $0.basename == moduleMapFilename }) {
-            throw ModuleError.invalidLayout(.modulemapInSources(path.description))
+            throw ModuleError.invalidLayout(.modulemapInSources(path.pathString))
         }
         // Select any source files for the C-based languages and for Swift.
         let sources = walked.filter(isValidSource).filter({ !targetExcludedPaths.contains($0) })
@@ -700,7 +700,7 @@ public final class PackageBuilder {
             )
         } else {
             // No Swift sources, so we expect to have C sources, and we create a C target.
-            guard swiftSources.isEmpty else { throw Target.Error.mixedSources(potentialModule.path.description) }
+            guard swiftSources.isEmpty else { throw Target.Error.mixedSources(potentialModule.path.pathString) }
             let cSources = Array(clangSources)
             try validateSourcesOverlapping(forTarget: potentialModule.name, sources: cSources)
 
@@ -744,7 +744,7 @@ public final class PackageBuilder {
                 // Ensure that the search path is contained within the package.
                 let subpath = try RelativePath(validating: setting.value[0])
                 guard targetRoot.appending(subpath).contains(packagePath) else {
-                    throw ModuleError.invalidHeaderSearchPath(subpath.description)
+                    throw ModuleError.invalidHeaderSearchPath(subpath.pathString)
                 }
 
             case .define:

--- a/Sources/PackageLoading/PackageDescription4Loader.swift
+++ b/Sources/PackageLoading/PackageDescription4Loader.swift
@@ -288,13 +288,13 @@ extension PackageDependencyDescription {
 
             // If the dependency URL starts with '~/', try to expand it.
             if url.hasPrefix("~/") {
-                return fileSystem.homeDirectory.appending(RelativePath(String(url.dropFirst(2)))).description
+                return fileSystem.homeDirectory.appending(RelativePath(String(url.dropFirst(2)))).pathString
             }
 
             // If the dependency URL is not remote, try to "fix" it.
             if URL.scheme(url) == nil {
                 // If the URL has no scheme, we treat it as a path (either absolute or relative to the base URL).
-                return AbsolutePath(url, relativeTo: AbsolutePath(baseURL)).description
+                return AbsolutePath(url, relativeTo: AbsolutePath(baseURL)).pathString
             }
 
             return url

--- a/Sources/PackageLoading/Target+PkgConfig.swift
+++ b/Sources/PackageLoading/Target+PkgConfig.swift
@@ -127,7 +127,7 @@ extension SystemPackageProviderDescription {
         case .brew(let packages):
             let brewPrefix: String
             if let brewPrefixOverride = brewPrefixOverride {
-                brewPrefix = brewPrefixOverride.description
+                brewPrefix = brewPrefixOverride.pathString
             } else {
                 // Homebrew can have multiple versions of the same package. The
                 // user can choose another version than the latest by running

--- a/Sources/PackageModel/Sources.swift
+++ b/Sources/PackageModel/Sources.swift
@@ -22,7 +22,7 @@ public struct Sources {
 
     public init(paths: [AbsolutePath], root: AbsolutePath) {
         let relativePaths = paths.map({ $0.relative(to: root) })
-        self.relativePaths = relativePaths.sorted(by: { $0.description < $1.description })
+        self.relativePaths = relativePaths.sorted(by: { $0.pathString < $1.pathString })
         self.root = root
     }
 

--- a/Sources/SPMUtility/Diagnostics.swift
+++ b/Sources/SPMUtility/Diagnostics.swift
@@ -143,7 +143,7 @@ public enum PackageLocation {
             if let name = name {
                 stream <<< "'\(name)' "
             }
-            stream <<< packagePath
+            stream <<< packagePath.pathString
             return stream.bytes.description
         }
     }

--- a/Sources/SPMUtility/FSWatch.swift
+++ b/Sources/SPMUtility/FSWatch.swift
@@ -566,7 +566,7 @@ public final class FSEventStream {
         self.stream = FSEventStreamCreate(nil,
             callback, 
             &callbackContext, 
-            paths.map({ $0.description }) as CFArray, 
+            paths.map({ $0.pathString }) as CFArray, 
             FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
             latency,
             // FIXME: This needs to be customizable.

--- a/Sources/SPMUtility/PkgConfig.swift
+++ b/Sources/SPMUtility/PkgConfig.swift
@@ -68,7 +68,7 @@ struct PCFileFinder {
             do {
                 let pkgConfigPath: String
                 if let brewPrefix = brewPrefix {
-                    pkgConfigPath = brewPrefix.appending(components: "bin", "pkg-config").description
+                    pkgConfigPath = brewPrefix.appending(components: "bin", "pkg-config").pathString
                 } else {
                     pkgConfigPath = "pkg-config"
                 }
@@ -208,7 +208,7 @@ struct PkgConfigParser {
         }
 
         // Add pcfiledir variable. This is path to the directory containing the pc file.
-        variables["pcfiledir"] = pcFile.parentDirectory.description
+        variables["pcfiledir"] = pcFile.parentDirectory.pathString
 
         let fileContents = try fileSystem.readFileContents(pcFile)
         // FIXME: Should we error out instead if content is not UTF8 representable?
@@ -228,7 +228,7 @@ struct PkgConfigParser {
                 variables[name.spm_chuzzle() ?? ""] = try resolveVariables(value)
             } else {
                 // Unexpected thing in the pc file, abort.
-                throw PkgConfigError.parsingError("Unexpected line: \(line) in \(pcFile)")
+                throw PkgConfigError.parsingError("Unexpected line: \(line) in \(pcFile.pathString)")
             }
         }
     }
@@ -295,7 +295,7 @@ struct PkgConfigParser {
                 guard it.next() != nil else {
                     throw PkgConfigError.parsingError("""
                         Expected version number after \(deps.last.debugDescription) \(arg) in \"\(depString)\" in \
-                        \(pcFile)
+                        \(pcFile.pathString)
                         """)
                 }
             } else {

--- a/Sources/SPMUtility/Platform.swift
+++ b/Sources/SPMUtility/Platform.swift
@@ -66,7 +66,7 @@ public enum Platform {
         defer { tmp.deallocate() }
         guard confstr(name, tmp.baseAddress, len) == len else { return nil }
         let value = String(cString: tmp.baseAddress!)
-        guard value.hasSuffix(AbsolutePath.root.description) else { return nil }
+        guard value.hasSuffix(AbsolutePath.root.pathString) else { return nil }
         return resolveSymlinks(AbsolutePath(value))
     }
 }

--- a/Sources/TestSupport/GitRepositoryExtensions.swift
+++ b/Sources/TestSupport/GitRepositoryExtensions.swift
@@ -18,46 +18,46 @@ public extension GitRepository {
 
     /// Create the repository using git init.
     func create() throws {
-        try systemQuietly([Git.tool, "-C", path.description, "init"])
+        try systemQuietly([Git.tool, "-C", path.pathString, "init"])
     }
 
     /// Returns current branch name. If HEAD is on a detached state, this returns HEAD.
     func currentBranch() throws -> String {
         return try Process.checkNonZeroExit(
-            args: Git.tool, "-C", path.description, "rev-parse", "--abbrev-ref", "HEAD").spm_chomp()
+            args: Git.tool, "-C", path.pathString, "rev-parse", "--abbrev-ref", "HEAD").spm_chomp()
     }
 
     /// Stage a file.
     func stage(file: String) throws {
-        try systemQuietly([Git.tool, "-C", path.description, "add", file])
+        try systemQuietly([Git.tool, "-C", path.pathString, "add", file])
     }
 
     /// Stage multiple files.
     func stage(files: String...) throws {
-        try systemQuietly([Git.tool, "-C", path.description, "add"] + files)
+        try systemQuietly([Git.tool, "-C", path.pathString, "add"] + files)
     }
 
     /// Stage entire unstaged changes.
     func stageEverything() throws {
-        try systemQuietly([Git.tool, "-C", path.description, "add", "."])
+        try systemQuietly([Git.tool, "-C", path.pathString, "add", "."])
     }
 
     /// Commit the staged changes. If the message is not provided a dummy message will be used for the commit.
     func commit(message: String? = nil) throws {
         // FIXME: We don't need to set these everytime but we usually only commit once or twice for a test repo.
-        try systemQuietly([Git.tool, "-C", path.description, "config", "user.email", "example@example.com"])
-        try systemQuietly([Git.tool, "-C", path.description, "config", "user.name", "Example Example"])
-        try systemQuietly([Git.tool, "-C", path.description, "config", "commit.gpgsign", "false"])
-        try systemQuietly([Git.tool, "-C", path.description, "commit", "-m", message ?? "Add some files."])
+        try systemQuietly([Git.tool, "-C", path.pathString, "config", "user.email", "example@example.com"])
+        try systemQuietly([Git.tool, "-C", path.pathString, "config", "user.name", "Example Example"])
+        try systemQuietly([Git.tool, "-C", path.pathString, "config", "commit.gpgsign", "false"])
+        try systemQuietly([Git.tool, "-C", path.pathString, "commit", "-m", message ?? "Add some files."])
     }
 
     /// Tag the git repo.
     func tag(name: String) throws {
-        try systemQuietly([Git.tool, "-C", path.description, "tag", name])
+        try systemQuietly([Git.tool, "-C", path.pathString, "tag", name])
     }
 
     /// Push the changes to specified remote and branch.
     func push(remote: String, branch: String) throws {
-        try systemQuietly([Git.tool, "-C", path.description, "push", remote, branch])
+        try systemQuietly([Git.tool, "-C", path.pathString, "push", remote, branch])
     }
 }

--- a/Sources/TestSupport/MockDependencyGraph.swift
+++ b/Sources/TestSupport/MockDependencyGraph.swift
@@ -105,7 +105,7 @@ public struct MockManifestGraph {
         let repos = Dictionary(items: try packages.map({ package -> (String, RepositorySpecifier) in
             let repoPath = path.appending(component: package.name)
             let tag = package.version?.description ?? "initial"
-            let specifier = RepositorySpecifier(url: repoPath.description)
+            let specifier = RepositorySpecifier(url: repoPath.pathString)
 
             // If this is in memory mocked graph.
             if let inMemory = inMemory {
@@ -135,7 +135,7 @@ public struct MockManifestGraph {
         } else {
             // Make a sources folder for our root package.
             try makeDirectories(src)
-            try systemQuietly(["touch", src.appending(component: "foo.swift").description])
+            try systemQuietly(["touch", src.appending(component: "foo.swift").pathString])
         }
 
         // Create the root manifest.
@@ -143,7 +143,7 @@ public struct MockManifestGraph {
             name: "Root",
             platforms: [],
             path: path.appending(component: Manifest.filename),
-            url: path.description,
+            url: path.pathString,
             version: nil,
             manifestVersion: .v4,
             dependencies: MockManifestGraph.createDependencies(repos: repos, dependencies: rootDeps)
@@ -164,7 +164,7 @@ public struct MockManifestGraph {
             return (MockManifestLoader.Key(url: url, version: package.version), manifest)
         }))
         // Add the root manifest.
-        manifests[MockManifestLoader.Key(url: path.description, version: nil)] = rootManifest
+        manifests[MockManifestLoader.Key(url: path.pathString, version: nil)] = rootManifest
 
         manifestLoader = MockManifestLoader(manifests: manifests)
         self.manifests = manifests

--- a/Sources/TestSupport/SwiftPMProduct.swift
+++ b/Sources/TestSupport/SwiftPMProduct.swift
@@ -119,9 +119,9 @@ public enum SwiftPMProduct {
         environment["IS_SWIFTPM_TEST"] = "1"
         environment["SDKROOT"] = nil
 
-        var completeArgs = [path.description]
+        var completeArgs = [path.pathString]
         if let packagePath = packagePath {
-            completeArgs += ["--package-path", packagePath.description]
+            completeArgs += ["--package-path", packagePath.pathString]
         }
         completeArgs += args
 

--- a/Sources/TestSupport/TestWorkspace.swift
+++ b/Sources/TestSupport/TestWorkspace.swift
@@ -75,7 +75,7 @@ public final class TestWorkspace {
             let packagePath = basePath.appending(RelativePath(package.path ?? package.name))
 
             let sourcesDir = packagePath.appending(component: "Sources")
-            let url = (isRoot ? packagePath : packagesDir.appending(RelativePath(package.path ?? package.name))).description
+            let url = (isRoot ? packagePath : packagesDir.appending(RelativePath(package.path ?? package.name))).pathString
             let specifier = RepositorySpecifier(url: url)
             let manifestPath = packagePath.appending(component: Manifest.filename)
 
@@ -170,7 +170,7 @@ public final class TestWorkspace {
 
         fileprivate func convert(_ packagesDir: AbsolutePath) -> PackageGraphRootInput.PackageDependency {
             return PackageGraphRootInput.PackageDependency(
-                url: packagesDir.appending(RelativePath(name)).description,
+                url: packagesDir.appending(RelativePath(name)).pathString,
                 requirement: requirement,
                 location: name
             )
@@ -445,7 +445,7 @@ public struct TestDependency {
     }
 
     public func convert(baseURL: AbsolutePath) -> PackageDependencyDescription {
-        return PackageDependencyDescription(url: baseURL.appending(RelativePath(name)).description, requirement: requirement)
+        return PackageDependencyDescription(url: baseURL.appending(RelativePath(name)).pathString, requirement: requirement)
     }
 }
 

--- a/Sources/TestSupport/misc.swift
+++ b/Sources/TestSupport/misc.swift
@@ -64,7 +64,7 @@ public func fixture(
         if isFile(fixtureDir.appending(component: "Package.swift")) {
             // It's a single package, so copy the whole directory as-is.
             let dstDir = tmpDir.path.appending(component: copyName)
-            try systemQuietly("cp", "-R", "-H", fixtureDir.description, dstDir.description)
+            try systemQuietly("cp", "-R", "-H", fixtureDir.pathString, dstDir.pathString)
 
             // Invoke the block, passing it the path of the copied fixture.
             try body(dstDir)
@@ -74,7 +74,7 @@ public func fixture(
                 let srcDir = fixtureDir.appending(component: fileName)
                 guard isDirectory(srcDir) else { continue }
                 let dstDir = tmpDir.path.appending(component: fileName)
-                try systemQuietly("cp", "-R", "-H", srcDir.description, dstDir.description)
+                try systemQuietly("cp", "-R", "-H", srcDir.pathString, dstDir.pathString)
                 initGitRepo(dstDir, tag: "1.2.3", addFile: false)
             }
 
@@ -114,13 +114,13 @@ public func initGitRepo(
     do {
         if addFile {
             let file = dir.appending(component: "file.swift")
-            try systemQuietly(["touch", file.description])
+            try systemQuietly(["touch", file.pathString])
         }
 
-        try systemQuietly([Git.tool, "-C", dir.description, "init"])
-        try systemQuietly([Git.tool, "-C", dir.description, "config", "user.email", "example@example.com"])
-        try systemQuietly([Git.tool, "-C", dir.description, "config", "user.name", "Example Example"])
-        try systemQuietly([Git.tool, "-C", dir.description, "config", "commit.gpgsign", "false"])
+        try systemQuietly([Git.tool, "-C", dir.pathString, "init"])
+        try systemQuietly([Git.tool, "-C", dir.pathString, "config", "user.email", "example@example.com"])
+        try systemQuietly([Git.tool, "-C", dir.pathString, "config", "user.name", "Example Example"])
+        try systemQuietly([Git.tool, "-C", dir.pathString, "config", "commit.gpgsign", "false"])
         let repo = GitRepository(path: dir)
         try repo.stageEverything()
         try repo.commit(message: "msg")
@@ -205,9 +205,9 @@ public func loadPackageGraph(
     createREPLProduct: Bool = false
 ) -> PackageGraph {
     let input = PackageGraphRootInput(packages: roots.map({ AbsolutePath($0) }))
-    let rootManifests = manifests.filter({ roots.contains($0.path.parentDirectory.description) })
+    let rootManifests = manifests.filter({ roots.contains($0.path.parentDirectory.pathString) })
     let graphRoot = PackageGraphRoot(input: input, manifests: rootManifests)
-    let externalManifests = manifests.filter({ !roots.contains($0.path.parentDirectory.description) })
+    let externalManifests = manifests.filter({ !roots.contains($0.path.parentDirectory.pathString) })
 
     return PackageGraphLoader().load(
         root: graphRoot,

--- a/Sources/TestSupportExecutable/main.swift
+++ b/Sources/TestSupportExecutable/main.swift
@@ -121,7 +121,7 @@ do {
         let handlerTest = try HandlerTest(options.temporaryFile!)
         handlerTest.run()
     case .pathArgumentTest:
-        print(options.absolutePath!)
+        print(options.absolutePath!.pathString)
     case .help:
         parser.printUsage(on: stdoutStream)
     }

--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -111,7 +111,7 @@ public struct Destination {
 
         // Compute common arguments for clang and swift.
         // This is currently just frameworks path.
-        let commonArgs = Destination.sdkPlatformFrameworkPath(environment: environment).map({ ["-F", $0.description] }) ?? []
+        let commonArgs = Destination.sdkPlatformFrameworkPath(environment: environment).map({ ["-F", $0.pathString] }) ?? []
 
         return Destination(
             target: hostTargetTriple,

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -259,7 +259,7 @@ public enum WorkspaceDiagnostics {
             type: RequireNewerTools.self,
             name: "org.swift.diags.workspace.\(RequireNewerTools.self)",
             description: {
-                $0 <<< "package at" <<< { "'\($0.packagePath)'" }
+                $0 <<< "package at" <<< { "'\($0.packagePath.pathString)'" }
                 $0 <<< "is using Swift tools version" <<< { $0.packageToolsVersion.description }
                 $0 <<< "but the installed version is" <<< { "\($0.installedToolsVersion.description)" }
             })
@@ -280,7 +280,7 @@ public enum WorkspaceDiagnostics {
             type: UnsupportedToolsVersion.self,
             name: "org.swift.diags.workspace.\(UnsupportedToolsVersion.self)",
             description: {
-                $0 <<< "package at" <<< { "'\($0.packagePath)'" }
+                $0 <<< "package at" <<< { "'\($0.packagePath.pathString)'" }
                 $0 <<< "is using Swift tools version" <<< { $0.packageToolsVersion.description }
                 $0 <<< "which is no longer supported; use" <<< { $0.minimumRequiredToolsVersion.description }
                 $0 <<< "or newer instead"

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -229,11 +229,11 @@ public final class UserToolchain: Toolchain {
       #endif
 
         self.extraSwiftCFlags = [
-            "-sdk", destination.sdk.description
+            "-sdk", destination.sdk.pathString
         ] + destination.extraSwiftCFlags
 
         self.extraCCFlags = [
-            destination.sysrootFlag, destination.sdk.description
+            destination.sysrootFlag, destination.sdk.pathString
         ] + destination.extraCCFlags
 
         // Compute the path of directory containing the PackageDescription libraries.

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -239,7 +239,7 @@ public class Workspace {
                 // We should get the correct one from managed dependency object.
                 let ref = PackageReference(
                     identity: managedDependency.packageRef.identity,
-                    path: workspace.path(for: managedDependency).description,
+                    path: workspace.path(for: managedDependency).pathString,
                     isLocal: true
                 )
                 let constraint = RepositoryPackageConstraint(
@@ -666,7 +666,7 @@ extension Workspace {
         diagnostics: DiagnosticsEngine
     ) -> [Manifest] {
         let rootManifests = packages.compactMap({ package -> Manifest? in
-            loadManifest(packagePath: package, url: package.description, diagnostics: diagnostics)
+            loadManifest(packagePath: package, url: package.pathString, diagnostics: diagnostics)
         })
 
         // Check for duplicate root packages.
@@ -1489,7 +1489,7 @@ extension Workspace {
                 // the edited checkout is unchanged.
                 if let editedDependency = managedDependencies.values.first(where: {
                     guard $0.basedOn != nil else { return false }
-                    return path(for: $0).description == packageRef.path
+                    return path(for: $0).pathString == packageRef.path
                 }) {
                     currentDependency = editedDependency
                     let originalReference = editedDependency.basedOn!.packageRef

--- a/Sources/Xcodeproj/generate().swift
+++ b/Sources/Xcodeproj/generate().swift
@@ -118,10 +118,10 @@ public func generate(
 
     try generateSchemes(
         graph: graph,
-        container: xcodeprojPath.relative(to: srcroot).description,
+        container: xcodeprojPath.relative(to: srcroot).pathString,
         schemesDir: schemesDir,
         options: options,
-        schemeContainer: xcodeprojPath.relative(to: srcroot).description
+        schemeContainer: xcodeprojPath.relative(to: srcroot).pathString
     )
 
     for target in graph.reachableTargets where target.type == .library || target.type == .test {

--- a/Tests/BasicPerformanceTests/PathPerfTests.swift
+++ b/Tests/BasicPerformanceTests/PathPerfTests.swift
@@ -24,9 +24,9 @@ class PathPerfTests: XCTestCasePerf {
             var lengths = 0
             for _ in 0 ..< N {
                 let result = absPath.appending(relPath)
-                lengths = lengths &+ result.description.utf8.count
+                lengths = lengths &+ result.pathString.utf8.count
             }
-            XCTAssertEqual(lengths, (absPath.description.utf8.count + 1 + relPath.description.utf8.count) &* N)
+            XCTAssertEqual(lengths, (absPath.pathString.utf8.count + 1 + relPath.pathString.utf8.count) &* N)
         }
     }
     

--- a/Tests/BasicTests/FileSystemTests.swift
+++ b/Tests/BasicTests/FileSystemTests.swift
@@ -56,7 +56,7 @@ class FileSystemTests: XCTestCase {
 
             """
         try! localFileSystem.writeFileContents(executable, bytes: stream.bytes)
-        try! Process.checkNonZeroExit(args: "chmod", "+x", executable.description)
+        try! Process.checkNonZeroExit(args: "chmod", "+x", executable.pathString)
         XCTAssertTrue(fs.isExecutableFile(executable))
         XCTAssertFalse(fs.isExecutableFile(sym))
         XCTAssertFalse(fs.isExecutableFile(file.path))

--- a/Tests/BasicTests/LockTests.swift
+++ b/Tests/BasicTests/LockTests.swift
@@ -39,7 +39,7 @@ class LockTests: XCTestCase {
         let N = 10
         let threads = (1...N).map { idx in
             return Thread {
-                _ = try! SwiftPMProduct.TestSupportExecutable.execute(["fileLockTest", tempDir.path.description, sharedResource.path.description, String(idx)])
+                _ = try! SwiftPMProduct.TestSupportExecutable.execute(["fileLockTest", tempDir.path.pathString, sharedResource.path.pathString, String(idx)])
             }
         }
         threads.forEach { $0.start() }

--- a/Tests/BasicTests/PathTests.swift
+++ b/Tests/BasicTests/PathTests.swift
@@ -17,13 +17,13 @@ import POSIX
 class PathTests: XCTestCase {
     
     func testBasics() {
-        XCTAssertEqual(AbsolutePath("/").description, "/")
-        XCTAssertEqual(AbsolutePath("/a").description, "/a")
-        XCTAssertEqual(AbsolutePath("/a/b/c").description, "/a/b/c")
-        XCTAssertEqual(RelativePath(".").description, ".")
-        XCTAssertEqual(RelativePath("a").description, "a")
-        XCTAssertEqual(RelativePath("a/b/c").description, "a/b/c")
-        XCTAssertEqual(RelativePath("~").description, "~")  // `~` is not special
+        XCTAssertEqual(AbsolutePath("/").pathString, "/")
+        XCTAssertEqual(AbsolutePath("/a").pathString, "/a")
+        XCTAssertEqual(AbsolutePath("/a/b/c").pathString, "/a/b/c")
+        XCTAssertEqual(RelativePath(".").pathString, ".")
+        XCTAssertEqual(RelativePath("a").pathString, "a")
+        XCTAssertEqual(RelativePath("a/b/c").pathString, "a/b/c")
+        XCTAssertEqual(RelativePath("~").pathString, "~")  // `~` is not special
     }
     
     func testStringInitialization() {
@@ -44,77 +44,77 @@ class PathTests: XCTestCase {
     
     func testStringLiteralInitialization() {
         let abs = AbsolutePath("/")
-        XCTAssertEqual(abs.description, "/")
+        XCTAssertEqual(abs.pathString, "/")
         let rel1 = RelativePath(".")
-        XCTAssertEqual(rel1.description, ".")
+        XCTAssertEqual(rel1.pathString, ".")
         let rel2 = RelativePath("~")
-        XCTAssertEqual(rel2.description, "~")  // `~` is not special
+        XCTAssertEqual(rel2.pathString, "~")  // `~` is not special
     }
     
     func testRepeatedPathSeparators() {
-        XCTAssertEqual(AbsolutePath("/ab//cd//ef").description, "/ab/cd/ef")
-        XCTAssertEqual(AbsolutePath("/ab///cd//ef").description, "/ab/cd/ef")
-        XCTAssertEqual(RelativePath("ab//cd//ef").description, "ab/cd/ef")
-        XCTAssertEqual(RelativePath("ab//cd///ef").description, "ab/cd/ef")
+        XCTAssertEqual(AbsolutePath("/ab//cd//ef").pathString, "/ab/cd/ef")
+        XCTAssertEqual(AbsolutePath("/ab///cd//ef").pathString, "/ab/cd/ef")
+        XCTAssertEqual(RelativePath("ab//cd//ef").pathString, "ab/cd/ef")
+        XCTAssertEqual(RelativePath("ab//cd///ef").pathString, "ab/cd/ef")
     }
     
     func testTrailingPathSeparators() {
-        XCTAssertEqual(AbsolutePath("/ab/cd/ef/").description, "/ab/cd/ef")
-        XCTAssertEqual(AbsolutePath("/ab/cd/ef//").description, "/ab/cd/ef")
-        XCTAssertEqual(RelativePath("ab/cd/ef/").description, "ab/cd/ef")
-        XCTAssertEqual(RelativePath("ab/cd/ef//").description, "ab/cd/ef")
+        XCTAssertEqual(AbsolutePath("/ab/cd/ef/").pathString, "/ab/cd/ef")
+        XCTAssertEqual(AbsolutePath("/ab/cd/ef//").pathString, "/ab/cd/ef")
+        XCTAssertEqual(RelativePath("ab/cd/ef/").pathString, "ab/cd/ef")
+        XCTAssertEqual(RelativePath("ab/cd/ef//").pathString, "ab/cd/ef")
     }
     
     func testDotPathComponents() {
-        XCTAssertEqual(AbsolutePath("/ab/././cd//ef").description, "/ab/cd/ef")
-        XCTAssertEqual(AbsolutePath("/ab/./cd//ef/.").description, "/ab/cd/ef")
-        XCTAssertEqual(RelativePath("ab/./cd/././ef").description, "ab/cd/ef")
-        XCTAssertEqual(RelativePath("ab/./cd/ef/.").description, "ab/cd/ef")
+        XCTAssertEqual(AbsolutePath("/ab/././cd//ef").pathString, "/ab/cd/ef")
+        XCTAssertEqual(AbsolutePath("/ab/./cd//ef/.").pathString, "/ab/cd/ef")
+        XCTAssertEqual(RelativePath("ab/./cd/././ef").pathString, "ab/cd/ef")
+        XCTAssertEqual(RelativePath("ab/./cd/ef/.").pathString, "ab/cd/ef")
     }
     
     func testDotDotPathComponents() {
-        XCTAssertEqual(AbsolutePath("/..").description, "/")
-        XCTAssertEqual(AbsolutePath("/../../../../..").description, "/")
-        XCTAssertEqual(AbsolutePath("/abc/..").description, "/")
-        XCTAssertEqual(AbsolutePath("/abc/../..").description, "/")
-        XCTAssertEqual(AbsolutePath("/../abc").description, "/abc")
-        XCTAssertEqual(AbsolutePath("/../abc/..").description, "/")
-        XCTAssertEqual(AbsolutePath("/../abc/../def").description, "/def")
-        XCTAssertEqual(RelativePath("..").description, "..")
-        XCTAssertEqual(RelativePath("../..").description, "../..")
-        XCTAssertEqual(RelativePath(".././..").description, "../..")
-        XCTAssertEqual(RelativePath("../abc/..").description, "..")
-        XCTAssertEqual(RelativePath("../abc/.././").description, "..")
-        XCTAssertEqual(RelativePath("abc/..").description, ".")
+        XCTAssertEqual(AbsolutePath("/..").pathString, "/")
+        XCTAssertEqual(AbsolutePath("/../../../../..").pathString, "/")
+        XCTAssertEqual(AbsolutePath("/abc/..").pathString, "/")
+        XCTAssertEqual(AbsolutePath("/abc/../..").pathString, "/")
+        XCTAssertEqual(AbsolutePath("/../abc").pathString, "/abc")
+        XCTAssertEqual(AbsolutePath("/../abc/..").pathString, "/")
+        XCTAssertEqual(AbsolutePath("/../abc/../def").pathString, "/def")
+        XCTAssertEqual(RelativePath("..").pathString, "..")
+        XCTAssertEqual(RelativePath("../..").pathString, "../..")
+        XCTAssertEqual(RelativePath(".././..").pathString, "../..")
+        XCTAssertEqual(RelativePath("../abc/..").pathString, "..")
+        XCTAssertEqual(RelativePath("../abc/.././").pathString, "..")
+        XCTAssertEqual(RelativePath("abc/..").pathString, ".")
     }
     
     func testCombinationsAndEdgeCases() {
-        XCTAssertEqual(AbsolutePath("///").description, "/")
-        XCTAssertEqual(AbsolutePath("/./").description, "/")
-        XCTAssertEqual(RelativePath("").description, ".")
-        XCTAssertEqual(RelativePath(".").description, ".")
-        XCTAssertEqual(RelativePath("./abc").description, "abc")
-        XCTAssertEqual(RelativePath("./abc/").description, "abc")
-        XCTAssertEqual(RelativePath("./abc/../bar").description, "bar")
-        XCTAssertEqual(RelativePath("foo/../bar").description, "bar")
-        XCTAssertEqual(RelativePath("foo///..///bar///baz").description, "bar/baz")
-        XCTAssertEqual(RelativePath("foo/../bar/./").description, "bar")
-        XCTAssertEqual(RelativePath("../abc/def/").description, "../abc/def")
-        XCTAssertEqual(RelativePath("././././.").description, ".")
-        XCTAssertEqual(RelativePath("./././../.").description, "..")
-        XCTAssertEqual(RelativePath("./").description, ".")
-        XCTAssertEqual(RelativePath(".//").description, ".")
-        XCTAssertEqual(RelativePath("./.").description, ".")
-        XCTAssertEqual(RelativePath("././").description, ".")
-        XCTAssertEqual(RelativePath("../").description, "..")
-        XCTAssertEqual(RelativePath("../.").description, "..")
-        XCTAssertEqual(RelativePath("./..").description, "..")
-        XCTAssertEqual(RelativePath("./../.").description, "..")
-        XCTAssertEqual(RelativePath("./////../////./////").description, "..")
-        XCTAssertEqual(RelativePath("../a").description, "../a")
-        XCTAssertEqual(RelativePath("../a/..").description, "..")
-        XCTAssertEqual(RelativePath("a/..").description, ".")
-        XCTAssertEqual(RelativePath("a/../////../////./////").description, "..")
+        XCTAssertEqual(AbsolutePath("///").pathString, "/")
+        XCTAssertEqual(AbsolutePath("/./").pathString, "/")
+        XCTAssertEqual(RelativePath("").pathString, ".")
+        XCTAssertEqual(RelativePath(".").pathString, ".")
+        XCTAssertEqual(RelativePath("./abc").pathString, "abc")
+        XCTAssertEqual(RelativePath("./abc/").pathString, "abc")
+        XCTAssertEqual(RelativePath("./abc/../bar").pathString, "bar")
+        XCTAssertEqual(RelativePath("foo/../bar").pathString, "bar")
+        XCTAssertEqual(RelativePath("foo///..///bar///baz").pathString, "bar/baz")
+        XCTAssertEqual(RelativePath("foo/../bar/./").pathString, "bar")
+        XCTAssertEqual(RelativePath("../abc/def/").pathString, "../abc/def")
+        XCTAssertEqual(RelativePath("././././.").pathString, ".")
+        XCTAssertEqual(RelativePath("./././../.").pathString, "..")
+        XCTAssertEqual(RelativePath("./").pathString, ".")
+        XCTAssertEqual(RelativePath(".//").pathString, ".")
+        XCTAssertEqual(RelativePath("./.").pathString, ".")
+        XCTAssertEqual(RelativePath("././").pathString, ".")
+        XCTAssertEqual(RelativePath("../").pathString, "..")
+        XCTAssertEqual(RelativePath("../.").pathString, "..")
+        XCTAssertEqual(RelativePath("./..").pathString, "..")
+        XCTAssertEqual(RelativePath("./../.").pathString, "..")
+        XCTAssertEqual(RelativePath("./////../////./////").pathString, "..")
+        XCTAssertEqual(RelativePath("../a").pathString, "../a")
+        XCTAssertEqual(RelativePath("../a/..").pathString, "..")
+        XCTAssertEqual(RelativePath("a/..").pathString, ".")
+        XCTAssertEqual(RelativePath("a/../////../////./////").pathString, "..")
     }
         
     func testDirectoryNameExtraction() {
@@ -184,37 +184,37 @@ class PathTests: XCTestCase {
     }
     
     func testConcatenation() {
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("")).description, "/")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath(".")).description, "/")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("..")).description, "/")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("bar")).description, "/bar")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/foo/bar"), RelativePath("..")).description, "/foo")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/bar"), RelativePath("../foo")).description, "/foo")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/bar"), RelativePath("../foo/..//")).description, "/")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/bar/../foo/..//yabba/"), RelativePath("a/b")).description, "/yabba/a/b")
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("")).pathString, "/")
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath(".")).pathString, "/")
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("..")).pathString, "/")
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("bar")).pathString, "/bar")
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/foo/bar"), RelativePath("..")).pathString, "/foo")
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/bar"), RelativePath("../foo")).pathString, "/foo")
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/bar"), RelativePath("../foo/..//")).pathString, "/")
+        XCTAssertEqual(AbsolutePath(AbsolutePath("/bar/../foo/..//yabba/"), RelativePath("a/b")).pathString, "/yabba/a/b")
         
-        XCTAssertEqual(AbsolutePath("/").appending(RelativePath("")).description, "/")
-        XCTAssertEqual(AbsolutePath("/").appending(RelativePath(".")).description, "/")
-        XCTAssertEqual(AbsolutePath("/").appending(RelativePath("..")).description, "/")
-        XCTAssertEqual(AbsolutePath("/").appending(RelativePath("bar")).description, "/bar")
-        XCTAssertEqual(AbsolutePath("/foo/bar").appending(RelativePath("..")).description, "/foo")
-        XCTAssertEqual(AbsolutePath("/bar").appending(RelativePath("../foo")).description, "/foo")
-        XCTAssertEqual(AbsolutePath("/bar").appending(RelativePath("../foo/..//")).description, "/")
-        XCTAssertEqual(AbsolutePath("/bar/../foo/..//yabba/").appending(RelativePath("a/b")).description, "/yabba/a/b")
+        XCTAssertEqual(AbsolutePath("/").appending(RelativePath("")).pathString, "/")
+        XCTAssertEqual(AbsolutePath("/").appending(RelativePath(".")).pathString, "/")
+        XCTAssertEqual(AbsolutePath("/").appending(RelativePath("..")).pathString, "/")
+        XCTAssertEqual(AbsolutePath("/").appending(RelativePath("bar")).pathString, "/bar")
+        XCTAssertEqual(AbsolutePath("/foo/bar").appending(RelativePath("..")).pathString, "/foo")
+        XCTAssertEqual(AbsolutePath("/bar").appending(RelativePath("../foo")).pathString, "/foo")
+        XCTAssertEqual(AbsolutePath("/bar").appending(RelativePath("../foo/..//")).pathString, "/")
+        XCTAssertEqual(AbsolutePath("/bar/../foo/..//yabba/").appending(RelativePath("a/b")).pathString, "/yabba/a/b")
 
-        XCTAssertEqual(AbsolutePath("/").appending(component: "a").description, "/a")
-        XCTAssertEqual(AbsolutePath("/a").appending(component: "b").description, "/a/b")
-        XCTAssertEqual(AbsolutePath("/").appending(components: "a", "b").description, "/a/b")
-        XCTAssertEqual(AbsolutePath("/a").appending(components: "b", "c").description, "/a/b/c")
+        XCTAssertEqual(AbsolutePath("/").appending(component: "a").pathString, "/a")
+        XCTAssertEqual(AbsolutePath("/a").appending(component: "b").pathString, "/a/b")
+        XCTAssertEqual(AbsolutePath("/").appending(components: "a", "b").pathString, "/a/b")
+        XCTAssertEqual(AbsolutePath("/a").appending(components: "b", "c").pathString, "/a/b/c")
 
-        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "", "c").description, "/a/b/c/c")
-        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "").description, "/a/b/c")
-        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: ".").description, "/a/b/c")
-        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "..").description, "/a/b")
-        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "..", "d").description, "/a/b/d")
-        XCTAssertEqual(AbsolutePath("/").appending(components: "..").description, "/")
-        XCTAssertEqual(AbsolutePath("/").appending(components: ".").description, "/")
-        XCTAssertEqual(AbsolutePath("/").appending(components: "..", "a").description, "/a")
+        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "", "c").pathString, "/a/b/c/c")
+        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "").pathString, "/a/b/c")
+        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: ".").pathString, "/a/b/c")
+        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "..").pathString, "/a/b")
+        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "..", "d").pathString, "/a/b/d")
+        XCTAssertEqual(AbsolutePath("/").appending(components: "..").pathString, "/")
+        XCTAssertEqual(AbsolutePath("/").appending(components: ".").pathString, "/")
+        XCTAssertEqual(AbsolutePath("/").appending(components: "..", "a").pathString, "/a")
     }
     
     func testPathComponents() {
@@ -318,8 +318,8 @@ class PathTests: XCTestCase {
             let data = try JSONEncoder().encode(foo)
             let decodedFoo = try JSONDecoder().decode(Foo.self, from: data)
             XCTAssertEqual(foo, decodedFoo)
-            XCTAssertEqual(foo.path.description, "/path/to/foo")
-            XCTAssertEqual(decodedFoo.path.description, "/path/to/foo")
+            XCTAssertEqual(foo.path.pathString, "/path/to/foo")
+            XCTAssertEqual(decodedFoo.path.pathString, "/path/to/foo")
         }
 
         do {
@@ -334,8 +334,8 @@ class PathTests: XCTestCase {
             let data = try JSONEncoder().encode(bar)
             let decodedBar = try JSONDecoder().decode(Bar.self, from: data)
             XCTAssertEqual(bar, decodedBar)
-            XCTAssertEqual(bar.path.description, "path/to/bar")
-            XCTAssertEqual(decodedBar.path.description, "path/to/bar")
+            XCTAssertEqual(bar.path.pathString, "path/to/bar")
+            XCTAssertEqual(decodedBar.path.pathString, "path/to/bar")
         }
     }
 

--- a/Tests/BasicTests/ProcessSetTests.swift
+++ b/Tests/BasicTests/ProcessSetTests.swift
@@ -16,7 +16,7 @@ import TestSupport
 
 class ProcessSetTests: XCTestCase {
     func script(_ name: String) -> String {
-        return AbsolutePath(#file).parentDirectory.appending(components: "processInputs", name).description
+        return AbsolutePath(#file).parentDirectory.appending(components: "processInputs", name).pathString
     }
 
     func testSigInt() throws {
@@ -42,7 +42,7 @@ class ProcessSetTests: XCTestCase {
                 // Launch the script and notify main thread.
                 let tempFile = try TemporaryFile()
                 let waitFile = tempFile.path
-                let process = Process(args: self.script(scriptName), waitFile.description)
+                let process = Process(args: self.script(scriptName), waitFile.pathString)
                 try processSet.add(process)
                 try process.launch()
                 guard waitForFile(waitFile) else {

--- a/Tests/BasicTests/ProcessTests.swift
+++ b/Tests/BasicTests/ProcessTests.swift
@@ -19,7 +19,7 @@ typealias Process = Basic.Process
 
 class ProcessTests: XCTestCase {
     func script(_ name: String) -> String {
-        return AbsolutePath(#file).parentDirectory.appending(components: "processInputs", name).description
+        return AbsolutePath(#file).parentDirectory.appending(components: "processInputs", name).pathString
     }
 
     func testBasics() throws {
@@ -50,7 +50,7 @@ class ProcessTests: XCTestCase {
         let stream = BufferedOutputByteStream()
         stream <<< Format.asRepeating(string: "a", count: count)
         try localFileSystem.writeFileContents(file.path, bytes: stream.bytes)
-        let outputCount = try Process.popen(args: "cat", file.path.description).utf8Output().count
+        let outputCount = try Process.popen(args: "cat", file.path.pathString).utf8Output().count
         XCTAssert(outputCount == count)
     }
 
@@ -84,7 +84,7 @@ class ProcessTests: XCTestCase {
                 
                 """)
 
-            try withCustomEnv(["PATH": path.description]) {
+            try withCustomEnv(["PATH": path.pathString]) {
                 XCTAssertEqual(Process.findExecutable("nonExecutableProgram"), nil)
             }
         }
@@ -100,7 +100,7 @@ class ProcessTests: XCTestCase {
                 
                 """)
 
-            try withCustomEnv(["PATH": path.description]) {
+            try withCustomEnv(["PATH": path.pathString]) {
                 do {
                     let process = Process(args: "nonExecutableProgram")
                     try process.launch()
@@ -118,7 +118,7 @@ class ProcessTests: XCTestCase {
         mktmpdir { path in
             let file = path.appending(component: "pidfile")
             let waitFile = path.appending(component: "waitFile")
-            let process = Process(args: script("print-pid"), file.description, waitFile.description)
+            let process = Process(args: script("print-pid"), file.pathString, waitFile.pathString)
             try process.launch()
             guard waitForFile(waitFile) else {
                 return XCTFail("Couldn't launch the process")
@@ -137,7 +137,7 @@ class ProcessTests: XCTestCase {
         mktmpdir { path in
             let file = path.appending(component: "pidfile")
             let waitFile = path.appending(component: "waitFile")
-            let process = Process(args: script("subprocess"), file.description, waitFile.description)
+            let process = Process(args: script("subprocess"), file.pathString, waitFile.pathString)
             try process.launch()
             guard waitForFile(waitFile) else {
                 return XCTFail("Couldn't launch the process")

--- a/Tests/BasicTests/TemporaryFileTests.swift
+++ b/Tests/BasicTests/TemporaryFileTests.swift
@@ -114,7 +114,7 @@ class TemporaryFileTests: XCTestCase {
         }
         XCTAssertTrue(localFileSystem.isDirectory(path))
         // Cleanup.
-        try FileManager.default.removeItem(atPath: path.description)
+        try FileManager.default.removeItem(atPath: path.pathString)
         XCTAssertFalse(localFileSystem.isDirectory(path))
 
         // Test temp directory is removed when its not empty and removeTreeOnDeinit is enabled.

--- a/Tests/BasicTests/miscTests.swift
+++ b/Tests/BasicTests/miscTests.swift
@@ -23,14 +23,14 @@ class miscTests: XCTestCase {
             try localFileSystem.writeFileContents(pathEnvClang, bytes: "")
             let pathEnv = [path.appending(component: "pathEnv2"), pathEnv1]
 
-            try! Process.checkNonZeroExit(args: "chmod", "+x", pathEnvClang.description)
+            try! Process.checkNonZeroExit(args: "chmod", "+x", pathEnvClang.pathString)
 
             // nil and empty string should fail.
             XCTAssertNil(lookupExecutablePath(filename: nil, currentWorkingDirectory: path, searchPaths: pathEnv))
             XCTAssertNil(lookupExecutablePath(filename: "", currentWorkingDirectory: path, searchPaths: pathEnv))
             
             // Absolute path to a binary should return it.
-            var exec = lookupExecutablePath(filename: pathEnvClang.description, currentWorkingDirectory: path, searchPaths: pathEnv)
+            var exec = lookupExecutablePath(filename: pathEnvClang.pathString, currentWorkingDirectory: path, searchPaths: pathEnv)
             XCTAssertEqual(exec, pathEnvClang)
             
             // This should lookup from PATH variable since executable is not present in cwd.
@@ -40,7 +40,7 @@ class miscTests: XCTestCase {
             // Create the binary relative to cwd and make it executable.
             let clang = path.appending(component: "clang")
             try localFileSystem.writeFileContents(clang, bytes: "")
-            try! Process.checkNonZeroExit(args: "chmod", "+x", clang.description)
+            try! Process.checkNonZeroExit(args: "chmod", "+x", clang.pathString)
             // We should now find clang which is in cwd.
             exec = lookupExecutablePath(filename: "clang", currentWorkingDirectory: path, searchPaths: pathEnv)
             XCTAssertEqual(exec, clang)

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1084,7 +1084,7 @@ final class BuildPlanTests: XCTestCase {
             let result = BuildPlanResult(plan: try BuildPlan(buildParameters: mockBuildParameters(config: config, indexStoreMode: mode), graph: graph, diagnostics: diagnostics, fileSystem: fs))
 
             let lib = try result.target(for: "lib").clangTarget()
-            let path = StringPattern.equal(result.plan.buildParameters.indexStore.description)
+            let path = StringPattern.equal(result.plan.buildParameters.indexStore.pathString)
 
         #if os(macOS)
             XCTAssertMatch(lib.basicArguments(), [.anySequence, "-index-store-path", path, .anySequence])

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -52,9 +52,9 @@ final class BuildToolTests: XCTestCase {
             let fullPath = resolveSymlinks(path)
             let targetPath = fullPath.appending(components: ".build", Destination.host.target)
             XCTAssertEqual(try execute(["--show-bin-path"], packagePath: fullPath),
-                           "\(targetPath.appending(components: "debug"))\n")
+                           "\(targetPath.appending(components: "debug").pathString)\n")
             XCTAssertEqual(try execute(["-c", "release", "--show-bin-path"], packagePath: fullPath),
-                           "\(targetPath.appending(components: "release"))\n")
+                           "\(targetPath.appending(components: "release").pathString)\n")
 
             // Test symlink.
             _ = try execute([], packagePath: fullPath)

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -207,7 +207,7 @@ final class PackageToolTests: XCTestCase {
             _ = try SwiftPMProduct.SwiftPackage.execute(["edit", "baz", "--branch", "bugfix"], packagePath: fooPath)
 
             // Path to the executable.
-            let exec = [fooPath.appending(components: ".build", Destination.host.target, "debug", "foo").description]
+            let exec = [fooPath.appending(components: ".build", Destination.host.target, "debug", "foo").pathString]
 
             // We should see it now in packages directory.
             let editsPath = fooPath.appending(components: "Packages", "bar")
@@ -252,7 +252,7 @@ final class PackageToolTests: XCTestCase {
 
             // Test editing with a path i.e. ToT development.
             let bazTot = prefix.appending(component: "tot")
-            try SwiftPMProduct.SwiftPackage.execute(["edit", "baz", "--path", bazTot.description], packagePath: fooPath)
+            try SwiftPMProduct.SwiftPackage.execute(["edit", "baz", "--path", bazTot.pathString], packagePath: fooPath)
             XCTAssertTrue(exists(bazTot))
             XCTAssertTrue(isSymlink(bazEditsPath))
 
@@ -268,7 +268,7 @@ final class PackageToolTests: XCTestCase {
             XCTAssertFalse(isSymlink(bazEditsPath))
 
             // Check that on re-editing with path, we don't make a new clone.
-            try SwiftPMProduct.SwiftPackage.execute(["edit", "baz", "--path", bazTot.description], packagePath: fooPath)
+            try SwiftPMProduct.SwiftPackage.execute(["edit", "baz", "--path", bazTot.pathString], packagePath: fooPath)
             XCTAssertTrue(isSymlink(bazEditsPath))
             XCTAssertEqual(try localFileSystem.readFileContents(bazTotPackageFile), stream.bytes)
         }
@@ -369,7 +369,7 @@ final class PackageToolTests: XCTestCase {
                 let buildOutput = try SwiftPMProduct.SwiftBuild.execute([], packagePath: fooPath)
                 return buildOutput
             }
-            let exec = [fooPath.appending(components: ".build", Destination.host.target, "debug", "foo").description]
+            let exec = [fooPath.appending(components: ".build", Destination.host.target, "debug", "foo").pathString]
 
             // Build and sanity check.
             _ = try build()
@@ -551,7 +551,7 @@ final class PackageToolTests: XCTestCase {
             XCTAssertTrue(fs.isFile(configFile))
 
             // Test env override.
-            try execute(["config", "set-mirror", "--package-url", "https://github.com/foo/bar", "--mirror-url", "https://mygithub.com/foo/bar"], packagePath: packageRoot, env: ["SWIFTPM_MIRROR_CONFIG": configOverride.description])
+            try execute(["config", "set-mirror", "--package-url", "https://github.com/foo/bar", "--mirror-url", "https://mygithub.com/foo/bar"], packagePath: packageRoot, env: ["SWIFTPM_MIRROR_CONFIG": configOverride.pathString])
             XCTAssertTrue(fs.isFile(configOverride))
             XCTAssertTrue(try fs.readFileContents(configOverride).description.contains("mygithub"))
 

--- a/Tests/CommandsTests/RunToolTests.swift
+++ b/Tests/CommandsTests/RunToolTests.swift
@@ -83,7 +83,7 @@ final class RunToolTests: XCTestCase {
 
     func testFileDeprecation() throws {
         fixture(name: "Miscellaneous/EchoExecutable") { path in
-            let filePath = AbsolutePath(path, "Sources/secho/main.swift").description
+            let filePath = AbsolutePath(path, "Sources/secho/main.swift").pathString
             XCTAssertEqual(try execute([filePath, "1", "2"], packagePath: path), """
                 "\(getcwd())" "1" "2"
                 warning: 'swift run file.swift' command to interpret swift files is deprecated; use 'swift file.swift' instead

--- a/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
+++ b/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
@@ -20,7 +20,7 @@ class BuildPerfTests: XCTestCasePerf {
     @discardableResult
     func execute(args: [String] = [], packagePath: AbsolutePath) throws -> String {
         // FIXME: We should pass the SWIFT_EXEC at lower level.
-        return try SwiftPMProduct.SwiftBuild.execute(args + [], packagePath: packagePath, env: ["SWIFT_EXEC": Resources.default.swiftCompiler.description])
+        return try SwiftPMProduct.SwiftBuild.execute(args + [], packagePath: packagePath, env: ["SWIFT_EXEC": Resources.default.swiftCompiler.pathString])
     }
 
     func clean(packagePath: AbsolutePath) throws {

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -21,7 +21,7 @@ class DependencyResolutionTests: XCTestCase {
         fixture(name: "DependencyResolution/Internal/Simple") { prefix in
             XCTAssertBuilds(prefix)
 
-            let output = try Process.checkNonZeroExit(args: prefix.appending(components: ".build", Destination.host.target, "debug", "Foo").description)
+            let output = try Process.checkNonZeroExit(args: prefix.appending(components: ".build", Destination.host.target, "debug", "Foo").pathString)
             XCTAssertEqual(output, "Foo\nBar\n")
         }
     }
@@ -36,7 +36,7 @@ class DependencyResolutionTests: XCTestCase {
         fixture(name: "DependencyResolution/Internal/Complex") { prefix in
             XCTAssertBuilds(prefix)
 
-            let output = try Process.checkNonZeroExit(args: prefix.appending(components: ".build", Destination.host.target, "debug", "Foo").description)
+            let output = try Process.checkNonZeroExit(args: prefix.appending(components: ".build", Destination.host.target, "debug", "Foo").pathString)
             XCTAssertEqual(output, "meiow Baz\n")
         }
     }
@@ -61,7 +61,7 @@ class DependencyResolutionTests: XCTestCase {
     func testExternalComplex() {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
             XCTAssertBuilds(prefix.appending(component: "app"))
-            let output = try Process.checkNonZeroExit(args: prefix.appending(components: "app", ".build", Destination.host.target, "debug", "Dealer").description)
+            let output = try Process.checkNonZeroExit(args: prefix.appending(components: "app", ".build", Destination.host.target, "debug", "Dealer").pathString)
             XCTAssertEqual(output, "♣︎K\n♣︎Q\n♣︎J\n♣︎10\n♣︎9\n♣︎8\n♣︎7\n♣︎6\n♣︎5\n♣︎4\n")
         }
     }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -118,7 +118,7 @@ class MiscellaneousTestCase: XCTestCase {
     */
     func testInternalDependencyEdges() {
         fixture(name: "Miscellaneous/DependencyEdges/Internal") { prefix in
-            let execpath = prefix.appending(components: ".build", Destination.host.target, "debug", "Foo").description
+            let execpath = prefix.appending(components: ".build", Destination.host.target, "debug", "Foo").pathString
 
             XCTAssertBuilds(prefix)
             var output = try Process.checkNonZeroExit(args: execpath)
@@ -142,7 +142,7 @@ class MiscellaneousTestCase: XCTestCase {
     */
     func testExternalDependencyEdges1() {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
-            let execpath = prefix.appending(components: "app", ".build", Destination.host.target, "debug", "Dealer").description
+            let execpath = prefix.appending(components: "app", ".build", Destination.host.target, "debug", "Dealer").pathString
 
             let packageRoot = prefix.appending(component: "app")
             XCTAssertBuilds(packageRoot)
@@ -169,7 +169,7 @@ class MiscellaneousTestCase: XCTestCase {
      */
     func testExternalDependencyEdges2() {
         fixture(name: "Miscellaneous/DependencyEdges/External") { prefix in
-            let execpath = [prefix.appending(components: "root", ".build", Destination.host.target, "debug", "dep2").description]
+            let execpath = [prefix.appending(components: "root", ".build", Destination.host.target, "debug", "dep2").pathString]
 
             let packageRoot = prefix.appending(component: "root")
             XCTAssertBuilds(prefix.appending(component: "root"))
@@ -236,7 +236,7 @@ class MiscellaneousTestCase: XCTestCase {
           do {
             // Run tests in parallel with verbose output.
             _ = try SwiftPMProduct.SwiftTest.execute(
-                ["--parallel", "--verbose", "--xunit-output", xUnitOutput.description],
+                ["--parallel", "--verbose", "--xunit-output", xUnitOutput.pathString],
                 packagePath: prefix)
           } catch SwiftPMProductError.executionFailure(_, let output, _) {
             XCTAssert(output.contains("testExample1"))
@@ -277,13 +277,13 @@ class MiscellaneousTestCase: XCTestCase {
             // Create a shared library.
             let input = systemModule.appending(components: "Sources", "SystemModule.c")
             let output =  systemModule.appending(component: "libSystemModule.\(dynamicLibraryExtension)")
-            try systemQuietly(["clang", "-shared", input.description, "-o", output.description])
+            try systemQuietly(["clang", "-shared", input.pathString, "-o", output.pathString])
 
             let pcFile = prefix.appending(component: "libSystemModule.pc")
 
             let stream = BufferedOutputByteStream()
             stream <<< """
-                prefix=\(systemModule)
+                prefix=\(systemModule.pathString)
                 exec_prefix=${prefix}
                 libdir=${exec_prefix}
                 includedir=${prefix}/Sources/include
@@ -298,7 +298,7 @@ class MiscellaneousTestCase: XCTestCase {
             try localFileSystem.writeFileContents(pcFile, bytes: stream.bytes)
 
             let moduleUser = prefix.appending(component: "SystemModuleUserClang")
-            let env = ["PKG_CONFIG_PATH": prefix.description]
+            let env = ["PKG_CONFIG_PATH": prefix.pathString]
             _ = try executeSwiftBuild(moduleUser, env: env)
 
             XCTAssertFileExists(moduleUser.appending(components: ".build", Destination.host.target, "debug", "SystemModuleUserClang"))

--- a/Tests/FunctionalTests/ModuleMapTests.swift
+++ b/Tests/FunctionalTests/ModuleMapTests.swift
@@ -23,11 +23,11 @@ class ModuleMapsTestCase: XCTestCase {
             let outdir = prefix.appending(components: rootpkg, ".build", Destination.host.target, "debug")
             try makeDirectories(outdir)
             let output = outdir.appending(component: "libfoo.\(Destination.host.dynamicLibraryExtension)")
-            try systemQuietly(["clang", "-shared", input.description, "-o", output.description])
+            try systemQuietly(["clang", "-shared", input.pathString, "-o", output.pathString])
 
-            var Xld = ["-L", outdir.description]
+            var Xld = ["-L", outdir.pathString]
         #if os(Linux)
-            Xld += ["-rpath", outdir.description]
+            Xld += ["-rpath", outdir.pathString]
         #endif
 
             try body(prefix, Xld)
@@ -40,9 +40,9 @@ class ModuleMapsTestCase: XCTestCase {
             XCTAssertBuilds(prefix.appending(component: "App"), Xld: Xld)
 
             let targetPath = prefix.appending(components: "App", ".build", Destination.host.target)
-            let debugout = try Process.checkNonZeroExit(args: targetPath.appending(components: "debug", "App").description)
+            let debugout = try Process.checkNonZeroExit(args: targetPath.appending(components: "debug", "App").pathString)
             XCTAssertEqual(debugout, "123\n")
-            let releaseout = try Process.checkNonZeroExit(args: targetPath.appending(components: "release", "App").description)
+            let releaseout = try Process.checkNonZeroExit(args: targetPath.appending(components: "release", "App").pathString)
             XCTAssertEqual(releaseout, "123\n")
         }
     }
@@ -53,7 +53,7 @@ class ModuleMapsTestCase: XCTestCase {
             XCTAssertBuilds(prefix.appending(component: "packageA"), Xld: Xld)
 
             func verify(_ conf: String, file: StaticString = #file, line: UInt = #line) throws {
-                let out = try Process.checkNonZeroExit(args: prefix.appending(components: "packageA", ".build", Destination.host.target, conf, "packageA").description)
+                let out = try Process.checkNonZeroExit(args: prefix.appending(components: "packageA", ".build", Destination.host.target, conf, "packageA").pathString)
                 XCTAssertEqual(out, """
                     calling Y.bar()
                     Y.bar() called

--- a/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
+++ b/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
@@ -48,10 +48,10 @@ class SwiftPMXCTestHelperTests: XCTestCase {
 #if os(macOS)
 func XCTAssertXCTestHelper(_ bundlePath: AbsolutePath, testCases: NSDictionary) {
     do {
-        let env = ["DYLD_FRAMEWORK_PATH": Resources.default.sdkPlatformFrameworksPath.description]
+        let env = ["DYLD_FRAMEWORK_PATH": Resources.default.sdkPlatformFrameworksPath.pathString]
         let outputFile = bundlePath.parentDirectory.appending(component: "tests.txt")
-        let _ = try SwiftPMProduct.XCTestHelper.execute([bundlePath.description, outputFile.description], env: env)
-        guard let data = NSData(contentsOfFile: outputFile.description) else {
+        let _ = try SwiftPMProduct.XCTestHelper.execute([bundlePath.pathString, outputFile.pathString], env: env)
+        guard let data = NSData(contentsOfFile: outputFile.pathString) else {
             XCTFail("No output found in : \(outputFile)"); return;
         }
         let json = try JSONSerialization.jsonObject(with: data as Data, options: []) as AnyObject

--- a/Tests/FunctionalTests/ToolsVersionTests.swift
+++ b/Tests/FunctionalTests/ToolsVersionTests.swift
@@ -91,7 +91,7 @@ class ToolsVersionTests: XCTestCase {
 
             // Build the primary package.
             _ = try SwiftPMProduct.SwiftBuild.execute([], packagePath: primaryPath)
-            let exe = primaryPath.appending(components: ".build", Destination.host.target, "debug", "Primary").description
+            let exe = primaryPath.appending(components: ".build", Destination.host.target, "debug", "Primary").pathString
             // v1 should get selected because v1.0.1 depends on a (way) higher set of tools.
             XCTAssertEqual(try Process.checkNonZeroExit(args: exe).spm_chomp(), "foo@1.0")
 

--- a/Tests/POSIXTests/PosixTests.swift
+++ b/Tests/POSIXTests/PosixTests.swift
@@ -27,12 +27,12 @@ class PosixTests: XCTestCase {
             try fs.writeFileContents(foo) { _ in }
             XCTAssertTrue(fs.isFile(foo))
 
-            try rename(old: foo.description, new: bar.description)
+            try rename(old: foo.pathString, new: bar.pathString)
             XCTAssertFalse(fs.isFile(foo))
             XCTAssertTrue(fs.isFile(bar))
 
             do {
-                try rename(old: foo.description, new: bar.description)
+                try rename(old: foo.pathString, new: bar.pathString)
                 XCTFail()
             } catch SystemError.rename {}
         }

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -100,7 +100,7 @@ class DependencyResolverPerfTests: XCTestCasePerf {
                 manifestLoader: ManifestLoader(manifestResources: Resources.default))
 
             let resolver = DependencyResolver(containerProvider, GitRepositoryResolutionHelper.DummyResolverDelegate())
-            let container = PackageReference(identity: "dep", path: dep.description)
+            let container = PackageReference(identity: "dep", path: dep.pathString)
             let constraints = RepositoryPackageConstraint(container: container, versionRequirement: .range("1.0.0"..<"2.0.0"))
             let result = try! resolver.resolve(constraints: [constraints])
             XCTAssert(result.count == 1)
@@ -321,7 +321,7 @@ struct GitRepositoryResolutionHelper {
 
     func resolve(prefetchingEnabled: Bool = false) -> [(container: PackageReference, binding: BoundVersion)] {
         let repositoriesPath = path.appending(component: "repositories")
-        _ = try? systemQuietly(["rm", "-r", repositoriesPath.description])
+        _ = try? systemQuietly(["rm", "-r", repositoriesPath.pathString])
         let repositoryManager = RepositoryManager(path: repositoriesPath, provider: GitRepositoryProvider(), delegate: DummyRepositoryManagerDelegate())
         let containerProvider = RepositoryPackageContainerProvider(
             repositoryManager: repositoryManager,

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -236,7 +236,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         let repoPath = AbsolutePath.root.appending(component: "some-repo")
         let filePath = repoPath.appending(component: "Package.swift")
 
-        let specifier = RepositorySpecifier(url: repoPath.description)
+        let specifier = RepositorySpecifier(url: repoPath.pathString)
         let repo = InMemoryGitRepository(path: repoPath, fs: fs)
         try repo.createDirectory(repoPath, recursive: true)
         try repo.writeFileContents(filePath, bytes: ByteString(encodingAsUTF8: "// swift-tools-version:\(ToolsVersion.currentToolsVersion)\n"))
@@ -261,7 +261,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         let provider = RepositoryPackageContainerProvider(
                 repositoryManager: repositoryManager,
                 manifestLoader: MockManifestLoader(manifests: [:]))
-        let ref = PackageReference(identity: "foo", path: repoPath.description)
+        let ref = PackageReference(identity: "foo", path: repoPath.pathString)
         let container = try await { provider.getContainer(for: ref, completion: $0) }
         let v = container.versions(filter: { _ in true }).map{$0}
         XCTAssertEqual(v, ["2.0.3", "1.0.3", "1.0.2", "1.0.1", "1.0.0"])
@@ -273,7 +273,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         let repoPath = AbsolutePath.root.appending(component: "some-repo")
         let filePath = repoPath.appending(component: "Package.swift")
 
-        let specifier = RepositorySpecifier(url: repoPath.description)
+        let specifier = RepositorySpecifier(url: repoPath.pathString)
         let repo = InMemoryGitRepository(path: repoPath, fs: fs)
 
         try repo.createDirectory(repoPath, recursive: true)
@@ -345,7 +345,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         let repoPath = AbsolutePath.root.appending(component: "some-repo")
         let filePath = repoPath.appending(component: "Package.swift")
         
-        let specifier = RepositorySpecifier(url: repoPath.description)
+        let specifier = RepositorySpecifier(url: repoPath.pathString)
         let repo = InMemoryGitRepository(path: repoPath, fs: fs)
         try repo.createDirectory(repoPath, recursive: true)
         try repo.writeFileContents(filePath, bytes: ByteString(encodingAsUTF8: "// swift-tools-version:\(ToolsVersion.currentToolsVersion)\n"))
@@ -372,7 +372,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         let provider = RepositoryPackageContainerProvider(
             repositoryManager: repositoryManager,
             manifestLoader: MockManifestLoader(manifests: [:]))
-        let ref = PackageReference(identity: "foo", path: repoPath.description)
+        let ref = PackageReference(identity: "foo", path: repoPath.pathString)
         let container = try await { provider.getContainer(for: ref, completion: $0) }
         let v = container.versions(filter: { _ in true }).map{$0}
         XCTAssertEqual(v, ["1.0.4-alpha", "1.0.2-dev.2", "1.0.2-dev", "1.0.1", "1.0.0", "1.0.0-beta.1", "1.0.0-alpha.1"])
@@ -384,7 +384,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         let repoPath = AbsolutePath.root.appending(component: "some-repo")
         let filePath = repoPath.appending(component: "Package.swift")
         
-        let specifier = RepositorySpecifier(url: repoPath.description)
+        let specifier = RepositorySpecifier(url: repoPath.pathString)
         let repo = InMemoryGitRepository(path: repoPath, fs: fs)
         try repo.createDirectory(repoPath, recursive: true)
         try repo.writeFileContents(filePath, bytes: ByteString(encodingAsUTF8: "// swift-tools-version:\(ToolsVersion.currentToolsVersion)\n"))
@@ -410,7 +410,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         let provider = RepositoryPackageContainerProvider(
             repositoryManager: repositoryManager,
             manifestLoader: MockManifestLoader(manifests: [:]))
-        let ref = PackageReference(identity: "foo", path: repoPath.description)
+        let ref = PackageReference(identity: "foo", path: repoPath.pathString)
         let container = try await { provider.getContainer(for: ref, completion: $0) }
         let v = container.versions(filter: { _ in true }).map{$0}
         XCTAssertEqual(v, ["2.0.1", "1.0.4", "1.0.2", "1.0.1", "1.0.0"])

--- a/Tests/PackageLoadingTests/PD4LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4LoadingTests.swift
@@ -31,7 +31,7 @@ class PackageDescription4LoadingTests: XCTestCase {
         try fs.writeFileContents(manifestPath, bytes: contents)
         let m = try manifestLoader.load(
             package: AbsolutePath.root,
-            baseURL: AbsolutePath.root.description,
+            baseURL: AbsolutePath.root.pathString,
             manifestVersion: .v4,
             fileSystem: fs)
         guard m.manifestVersion == .v4 else {
@@ -393,7 +393,7 @@ class PackageDescription4LoadingTests: XCTestCase {
 
         let diagnostics = DiagnosticsEngine()
         let manifest = try manifestLoader.load(
-            package: .root, baseURL: AbsolutePath.root.description,
+            package: .root, baseURL: AbsolutePath.root.pathString,
             manifestVersion: .v4, fileSystem: fs,
             diagnostics: diagnostics
         )

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -30,7 +30,7 @@ class PackageDescription4_2LoadingTests: XCTestCase {
         try fs.writeFileContents(manifestPath, bytes: contents)
         let m = try manifestLoader.load(
             package: AbsolutePath.root,
-            baseURL: AbsolutePath.root.description,
+            baseURL: AbsolutePath.root.pathString,
             manifestVersion: .v4_2,
             fileSystem: fs)
         guard m.manifestVersion == .v4_2 else {
@@ -377,7 +377,7 @@ class PackageDescription4_2LoadingTests: XCTestCase {
                     bytes: bogusManifest)
             }
             // Check we can load the repository.
-            let manifest = try manifestLoader.load(package: root, baseURL: root.description, manifestVersion: .v4_2, fileSystem: fs)
+            let manifest = try manifestLoader.load(package: root, baseURL: root.pathString, manifestVersion: .v4_2, fileSystem: fs)
             XCTAssertEqual(manifest.name, "Trivial")
         }
     }
@@ -475,7 +475,7 @@ class PackageDescription4_2LoadingTests: XCTestCase {
                 delegate.clear()
                 let manifest = try! loader.load(
                     package: manifestPath.parentDirectory,
-                    baseURL: manifestPath.description,
+                    baseURL: manifestPath.pathString,
                     manifestVersion: .v4_2)
 
                 XCTAssertEqual(delegate.loaded, [manifestPath])
@@ -530,7 +530,7 @@ class PackageDescription4_2LoadingTests: XCTestCase {
                 delegate.clear()
                 let manifest = try! loader.load(
                     package: manifestPath.parentDirectory,
-                    baseURL: manifestPath.description,
+                    baseURL: manifestPath.pathString,
                     manifestVersion: .v4_2)
 
                 XCTAssertEqual(delegate.loaded, [manifestPath])

--- a/Tests/PackageLoadingTests/PD5LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5LoadingTests.swift
@@ -30,7 +30,7 @@ class PackageDescription5LoadingTests: XCTestCase {
         try fs.writeFileContents(manifestPath, bytes: contents)
         let m = try manifestLoader.load(
             package: AbsolutePath.root,
-            baseURL: AbsolutePath.root.description,
+            baseURL: AbsolutePath.root.pathString,
             manifestVersion: .v5,
             fileSystem: fs)
         guard m.manifestVersion == .v5 else {

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -78,7 +78,7 @@ class PackageBuilderTests: XCTestCase {
             )
 
             PackageBuilderTester(manifest, path: path, in: fs) { result in
-                result.checkDiagnostic("ignoring broken symlink \(linkPath)")
+                result.checkDiagnostic("ignoring broken symlink \(linkPath.pathString)")
                 result.checkModule("foo")
             }
         }
@@ -1706,8 +1706,8 @@ final class PackageBuilderTester {
         guard case .package(let package) = result else {
             return XCTFail("Expected package did not load \(self)", file: file, line: line)
         }
-        XCTAssertEqual(target, package.targetSearchPath.description, file: file, line: line)
-        XCTAssertEqual(testTarget, package.testTargetSearchPath.description, file: file, line: line)
+        XCTAssertEqual(target, package.targetSearchPath.pathString, file: file, line: line)
+        XCTAssertEqual(testTarget, package.testTargetSearchPath.pathString, file: file, line: line)
     }
 
     func checkModule(_ name: String, file: StaticString = #file, line: UInt = #line, _ body: ((ModuleResult) -> Void)? = nil) {
@@ -1761,7 +1761,7 @@ final class PackageBuilderTester {
             guard case let target as ClangTarget = target else {
                 return XCTFail("Include directory is being checked on a non clang target", file: file, line: line)
             }
-            XCTAssertEqual(target.includeDir.description, includeDir, file: file, line: line)
+            XCTAssertEqual(target.includeDir.pathString, includeDir, file: file, line: line)
         }
 
         func check(c99name: String? = nil, type: PackageModel.Target.Kind? = nil, file: StaticString = #file, line: UInt = #line) {
@@ -1777,7 +1777,7 @@ final class PackageBuilderTester {
             if let root = root {
                 XCTAssertEqual(target.sources.root, AbsolutePath(root), file: file, line: line)
             }
-            let sources = Set(self.target.sources.relativePaths.map({ $0.description }))
+            let sources = Set(self.target.sources.relativePaths.map({ $0.pathString }))
             XCTAssertEqual(sources, Set(paths), "unexpected source files in \(target.name)", file: file, line: line)
         }
 

--- a/Tests/PackageLoadingTests/PkgConfigTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigTests.swift
@@ -68,10 +68,10 @@ class PkgConfigTests: XCTestCase {
         }
 
         // Pc file.
-        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.description]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
             let result = pkgConfigArgs(for: SystemLibraryTarget(pkgConfig: "Foo"), diagnostics: diagnostics)!
             XCTAssertEqual(result.pkgConfigName, "Foo")
-            XCTAssertEqual(result.cFlags, ["-I/path/to/inc", "-I\(inputsDir)"])
+            XCTAssertEqual(result.cFlags, ["-I/path/to/inc", "-I\(inputsDir.pathString)"])
             XCTAssertEqual(result.libs, ["-L/usr/da/lib", "-lSystemModule", "-lok"])
             XCTAssertNil(result.provider)
             XCTAssertNil(result.error)
@@ -79,7 +79,7 @@ class PkgConfigTests: XCTestCase {
         }
 
         // Pc file with non whitelisted flags.
-        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.description]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
             let result = pkgConfigArgs(for: SystemLibraryTarget(pkgConfig: "Bar"), diagnostics: diagnostics)!
             XCTAssertEqual(result.pkgConfigName, "Bar")
             XCTAssertEqual(result.cFlags, ["-I/path/to/inc"])

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -41,7 +41,7 @@ class GitRepositoryTests: XCTestCase {
             let testCheckoutPath = path.appending(component: "checkout")
             let provider = GitRepositoryProvider()
             XCTAssertTrue(try provider.checkoutExists(at: testRepoPath))
-            let repoSpec = RepositorySpecifier(url: testRepoPath.description)
+            let repoSpec = RepositorySpecifier(url: testRepoPath.pathString)
             try! provider.fetch(repository: repoSpec, to: testCheckoutPath)
 
             // Verify the checkout was made.
@@ -56,7 +56,7 @@ class GitRepositoryTests: XCTestCase {
             // FIXME: It would be nice if we had a deterministic hash here...
             XCTAssertEqual(revision.identifier,
                 try Process.popen(
-                    args: Git.tool, "-C", testRepoPath.description, "rev-parse", "--verify", "1.2.3").utf8Output().spm_chomp())
+                    args: Git.tool, "-C", testRepoPath.pathString, "rev-parse", "--verify", "1.2.3").utf8Output().spm_chomp())
             if let revision = try? repository.resolveRevision(tag: "<invalid>") {
                 XCTFail("unexpected resolution of invalid tag to \(revision)")
             }
@@ -65,7 +65,7 @@ class GitRepositoryTests: XCTestCase {
 
             XCTAssertEqual(master.identifier,
                 try Process.checkNonZeroExit(
-                    args: Git.tool, "-C", testRepoPath.description, "rev-parse", "--verify", "master").spm_chomp())
+                    args: Git.tool, "-C", testRepoPath.pathString, "rev-parse", "--verify", "master").spm_chomp())
 
             // Check that git hashes resolve to themselves.
             let masterIdentifier = try repository.resolveRevision(identifier: master.identifier)
@@ -99,7 +99,7 @@ class GitRepositoryTests: XCTestCase {
         mktmpdir { path in
             // Unarchive the static test repository.
             let inputArchivePath = AbsolutePath(#file).parentDirectory.appending(components: "Inputs", "TestRepo.tgz")
-            try systemQuietly(["tar", "-x", "-v", "-C", path.description, "-f", inputArchivePath.description])
+            try systemQuietly(["tar", "-x", "-v", "-C", path.pathString, "-f", inputArchivePath.pathString])
             let testRepoPath = path.appending(component: "TestRepo")
 
             // Check hash resolution.
@@ -154,7 +154,7 @@ class GitRepositoryTests: XCTestCase {
             initGitRepo(repoPath)
 
             try Process.checkNonZeroExit(
-                args: Git.tool, "-C", repoPath.description, "submodule", "add", testRepoPath.description)
+                args: Git.tool, "-C", repoPath.pathString, "submodule", "add", testRepoPath.pathString)
             let repo = GitRepository(path: repoPath)
             try repo.stageEverything()
             try repo.commit()
@@ -182,7 +182,7 @@ class GitRepositoryTests: XCTestCase {
             try localFileSystem.createDirectory(testRepoPath.appending(component: "subdir"))
             try localFileSystem.writeFileContents(testRepoPath.appending(components: "subdir", "test-file-2.txt"), bytes: test2FileContents)
             try localFileSystem.writeFileContents(testRepoPath.appending(component: "test-file-3.sh"), bytes: test3FileContents)
-            try! Process.checkNonZeroExit(args: "chmod", "+x", testRepoPath.appending(component: "test-file-3.sh").description)
+            try! Process.checkNonZeroExit(args: "chmod", "+x", testRepoPath.appending(component: "test-file-3.sh").pathString)
             let testRepo = GitRepository(path: testRepoPath)
             try testRepo.stage(files: "test-file-1.txt", "subdir/test-file-2.txt", "test-file-3.sh")
             try testRepo.commit()
@@ -191,7 +191,7 @@ class GitRepositoryTests: XCTestCase {
             // Get the the repository via the provider. the provider.
             let testClonePath = path.appending(component: "clone")
             let provider = GitRepositoryProvider()
-            let repoSpec = RepositorySpecifier(url: testRepoPath.description)
+            let repoSpec = RepositorySpecifier(url: testRepoPath.pathString)
             try provider.fetch(repository: repoSpec, to: testClonePath)
             let repository = provider.open(repository: repoSpec, at: testClonePath)
 
@@ -263,19 +263,19 @@ class GitRepositoryTests: XCTestCase {
             // Fetch the repository using the provider.
             let testClonePath = path.appending(component: "clone")
             let provider = GitRepositoryProvider()
-            let repoSpec = RepositorySpecifier(url: testRepoPath.description)
+            let repoSpec = RepositorySpecifier(url: testRepoPath.pathString)
             try provider.fetch(repository: repoSpec, to: testClonePath)
 
             // Clone off a checkout.
             let checkoutPath = path.appending(component: "checkout")
             try provider.cloneCheckout(repository: repoSpec, at: testClonePath, to: checkoutPath, editable: false)
             // The remote of this checkout should point to the clone.
-            XCTAssertEqual(try GitRepository(path: checkoutPath).remotes()[0].url, testClonePath.description)
+            XCTAssertEqual(try GitRepository(path: checkoutPath).remotes()[0].url, testClonePath.pathString)
 
             let editsPath = path.appending(component: "edit")
             try provider.cloneCheckout(repository: repoSpec, at: testClonePath, to: editsPath, editable: true)
             // The remote of this checkout should point to the original repo.
-            XCTAssertEqual(try GitRepository(path: editsPath).remotes()[0].url, testRepoPath.description)
+            XCTAssertEqual(try GitRepository(path: editsPath).remotes()[0].url, testRepoPath.pathString)
 
             // Check the working copies.
             for path in [checkoutPath, editsPath] {
@@ -302,7 +302,7 @@ class GitRepositoryTests: XCTestCase {
             // Clone it somewhere.
             let testClonePath = path.appending(component: "clone")
             let provider = GitRepositoryProvider()
-            let repoSpec = RepositorySpecifier(url: testRepoPath.description)
+            let repoSpec = RepositorySpecifier(url: testRepoPath.pathString)
             try provider.fetch(repository: repoSpec, to: testClonePath)
             let clonedRepo = provider.open(repository: repoSpec, at: testClonePath)
             XCTAssertEqual(clonedRepo.tags, ["1.2.3"])
@@ -339,12 +339,12 @@ class GitRepositoryTests: XCTestCase {
 
             // Create a bare clone it somewhere because we want to later push into the repo.
             let testBareRepoPath = path.appending(component: "test-repo-bare")
-            try systemQuietly([Git.tool, "clone", "--bare", testRepoPath.description, testBareRepoPath.description])
+            try systemQuietly([Git.tool, "clone", "--bare", testRepoPath.pathString, testBareRepoPath.pathString])
 
             // Clone it somewhere.
             let testClonePath = path.appending(component: "clone")
             let provider = GitRepositoryProvider()
-            let repoSpec = RepositorySpecifier(url: testBareRepoPath.description)
+            let repoSpec = RepositorySpecifier(url: testBareRepoPath.pathString)
             try provider.fetch(repository: repoSpec, to: testClonePath)
 
             // Clone off a checkout.
@@ -379,7 +379,7 @@ class GitRepositoryTests: XCTestCase {
             XCTAssert(try repo.remotes().isEmpty)
 
             // Add a remote via git cli.
-            try systemQuietly([Git.tool, "-C", testRepoPath.description, "remote", "add", "origin", "../foo"])
+            try systemQuietly([Git.tool, "-C", testRepoPath.pathString, "remote", "add", "origin", "../foo"])
             // Test if it was added.
             XCTAssertEqual(Dictionary(items: try repo.remotes().map { ($0.0, $0.1) }), ["origin": "../foo"])
             // Change remote.
@@ -434,7 +434,7 @@ class GitRepositoryTests: XCTestCase {
             // Check a non existent revision.
             XCTAssertFalse(repo.exists(revision: Revision(identifier: "nonExistent")))
             // Checkout a new branch using command line.
-            try systemQuietly([Git.tool, "-C", testRepoPath.description, "checkout", "-b", "TestBranch1"])
+            try systemQuietly([Git.tool, "-C", testRepoPath.pathString, "checkout", "-b", "TestBranch1"])
             XCTAssert(repo.exists(revision: Revision(identifier: "TestBranch1")))
             XCTAssertEqual(try repo.getCurrentRevision(), currentRevision)
 
@@ -500,7 +500,7 @@ class GitRepositoryTests: XCTestCase {
             // Create repos: foo and bar, foo will have bar as submodule and then later
             // the submodule ref will be updated in foo.
             let fooPath = path.appending(component: "foo-original")
-            let fooSpecifier = RepositorySpecifier(url: fooPath.description)
+            let fooSpecifier = RepositorySpecifier(url: fooPath.pathString)
             let fooRepoPath = path.appending(component: "foo-repo")
             let fooWorkingPath = path.appending(component: "foo-working")
             let barPath = path.appending(component: "bar-original")
@@ -532,7 +532,7 @@ class GitRepositoryTests: XCTestCase {
 
             // Add submodule to foo and tag it as 1.0.1
             try foo.checkout(newBranch: "submodule")
-            try systemQuietly([Git.tool, "-C", fooPath.description, "submodule", "add", barPath.description, "bar"])
+            try systemQuietly([Git.tool, "-C", fooPath.pathString, "submodule", "add", barPath.pathString, "bar"])
             try foo.stageEverything()
             try foo.commit()
             try foo.tag(name: "1.0.1")
@@ -550,12 +550,12 @@ class GitRepositoryTests: XCTestCase {
             // Add something to bar.
             try localFileSystem.writeFileContents(barPath.appending(component: "bar.txt"), bytes: "hello")
             // Add a submodule too to check for recusive submodules.
-            try systemQuietly([Git.tool, "-C", barPath.description, "submodule", "add", bazPath.description, "baz"])
+            try systemQuietly([Git.tool, "-C", barPath.pathString, "submodule", "add", bazPath.pathString, "baz"])
             try bar.stageEverything()
             try bar.commit()
 
             // Update the ref of bar in foo and tag as 1.0.2
-            try systemQuietly([Git.tool, "-C", fooPath.appending(component: "bar").description, "pull"])
+            try systemQuietly([Git.tool, "-C", fooPath.appending(component: "bar").pathString, "pull"])
             try foo.stageEverything()
             try foo.commit()
             try foo.tag(name: "1.0.2")
@@ -586,7 +586,7 @@ class GitRepositoryTests: XCTestCase {
             // Clone it somewhere.
             let testClonePath = path.appending(component: "clone")
             let provider = GitRepositoryProvider()
-            let repoSpec = RepositorySpecifier(url: testRepoPath.description)
+            let repoSpec = RepositorySpecifier(url: testRepoPath.pathString)
             try provider.fetch(repository: repoSpec, to: testClonePath)
             let clonedRepo = provider.open(repository: repoSpec, at: testClonePath)
             XCTAssertEqual(clonedRepo.tags, ["1.2.3"])

--- a/Tests/UtilityTests/ArgumentParserTests.swift
+++ b/Tests/UtilityTests/ArgumentParserTests.swift
@@ -464,21 +464,21 @@ class ArgumentParserTests: XCTestCase {
         // Test that relative path is resolved.
         do {
             let actual = try! SwiftPMProduct.TestSupportExecutable.execute(["pathArgumentTest", "some/path"]).spm_chomp()
-            let expected = localFileSystem.currentWorkingDirectory!.appending(RelativePath("some/path")).description
+            let expected = localFileSystem.currentWorkingDirectory!.appending(RelativePath("some/path")).pathString
             XCTAssertEqual(actual, expected)
         }
 
         // Test that relative path starting with ./ is resolved.
         do {
             let actual = try! SwiftPMProduct.TestSupportExecutable.execute(["pathArgumentTest", "./some/path"]).spm_chomp()
-            let expected = localFileSystem.currentWorkingDirectory!.appending(RelativePath("./some/path")).description
+            let expected = localFileSystem.currentWorkingDirectory!.appending(RelativePath("./some/path")).pathString
             XCTAssertEqual(actual, expected)
         }
 
         // Test that relative path starting with ../ is resolved.
         do {
             let actual = try! SwiftPMProduct.TestSupportExecutable.execute(["pathArgumentTest", "../other/path"]).spm_chomp()
-            let expected = localFileSystem.currentWorkingDirectory!.appending(RelativePath("../other/path")).description
+            let expected = localFileSystem.currentWorkingDirectory!.appending(RelativePath("../other/path")).pathString
             XCTAssertEqual(actual, expected)
         }
 

--- a/Tests/UtilityTests/PkgConfigParserTests.swift
+++ b/Tests/UtilityTests/PkgConfigParserTests.swift
@@ -26,7 +26,7 @@ final class PkgConfigParserTests: XCTestCase {
                 "gtk_binary_version": "3.0.0",
                 "exec_prefix": "/usr/local/Cellar/gtk+3/3.18.9",
                 "targets": "quartz",
-                "pcfiledir": parser.pcFile.parentDirectory.description
+                "pcfiledir": parser.pcFile.parentDirectory.pathString
             ])
             XCTAssertEqual(parser.dependencies, ["gdk-3.0", "atk", "cairo", "cairo-gobject", "gdk-pixbuf-2.0", "gio-2.0"])
             XCTAssertEqual(parser.cFlags, ["-I/usr/local/Cellar/gtk+3/3.18.9/include/gtk-3.0"])
@@ -36,7 +36,7 @@ final class PkgConfigParserTests: XCTestCase {
 
     func testEmptyCFlags() {
         try! loadPCFile("empty_cflags.pc") { parser in
-            XCTAssertEqual(parser.variables, ["prefix": "/usr/local/bin", "exec_prefix": "/usr/local/bin", "pcfiledir": parser.pcFile.parentDirectory.description])
+            XCTAssertEqual(parser.variables, ["prefix": "/usr/local/bin", "exec_prefix": "/usr/local/bin", "pcfiledir": parser.pcFile.parentDirectory.pathString])
             XCTAssertEqual(parser.dependencies, ["gdk-3.0", "atk"])
             XCTAssertEqual(parser.cFlags, [])
             XCTAssertEqual(parser.libs, ["-L/usr/local/bin", "-lgtk-3"])
@@ -45,7 +45,7 @@ final class PkgConfigParserTests: XCTestCase {
 
     func testVariableinDependency() {
         try! loadPCFile("deps_variable.pc") { parser in
-            XCTAssertEqual(parser.variables, ["prefix": "/usr/local/bin", "exec_prefix": "/usr/local/bin", "my_dep": "atk", "pcfiledir": parser.pcFile.parentDirectory.description])
+            XCTAssertEqual(parser.variables, ["prefix": "/usr/local/bin", "exec_prefix": "/usr/local/bin", "my_dep": "atk", "pcfiledir": parser.pcFile.parentDirectory.pathString])
             XCTAssertEqual(parser.dependencies, ["gdk-3.0", "atk"])
             XCTAssertEqual(parser.cFlags, ["-I"])
             XCTAssertEqual(parser.libs, ["-L/usr/local/bin", "-lgtk-3"])
@@ -63,7 +63,7 @@ final class PkgConfigParserTests: XCTestCase {
 
     func testEscapedSpaces() {
         try! loadPCFile("escaped_spaces.pc") { parser in
-            XCTAssertEqual(parser.variables, ["prefix": "/usr/local/bin", "exec_prefix": "/usr/local/bin", "my_dep": "atk", "pcfiledir": parser.pcFile.parentDirectory.description])
+            XCTAssertEqual(parser.variables, ["prefix": "/usr/local/bin", "exec_prefix": "/usr/local/bin", "my_dep": "atk", "pcfiledir": parser.pcFile.parentDirectory.pathString])
             XCTAssertEqual(parser.dependencies, ["gdk-3.0", "atk"])
             XCTAssertEqual(parser.cFlags, ["-I/usr/local/Wine Cellar/gtk+3/3.18.9/include/gtk-3.0", "-I/after/extra/spaces"])
             XCTAssertEqual(parser.libs, ["-L/usr/local/bin", "-lgtk 3", "-wantareal\\here", "-one\\", "-two"])
@@ -78,14 +78,14 @@ final class PkgConfigParserTests: XCTestCase {
             "/usr/lib/pkgconfig/foo.pc",
             "/usr/local/opt/foo/lib/pkgconfig/foo.pc",
             "/custom/foo.pc")
-        XCTAssertEqual("/custom/foo.pc", try PCFileFinder(diagnostics: diagnostics, brewPrefix: nil).locatePCFile(name: "foo", customSearchPaths: [AbsolutePath("/custom")], fileSystem: fs).description)
-        XCTAssertEqual("/custom/foo.pc", try PkgConfig(name: "foo", additionalSearchPaths: [AbsolutePath("/custom")], diagnostics: diagnostics, fileSystem: fs, brewPrefix: nil).pcFile.description)
-        XCTAssertEqual("/usr/lib/pkgconfig/foo.pc", try PCFileFinder(diagnostics: diagnostics, brewPrefix: nil).locatePCFile(name: "foo", customSearchPaths: [], fileSystem: fs).description)
+        XCTAssertEqual("/custom/foo.pc", try PCFileFinder(diagnostics: diagnostics, brewPrefix: nil).locatePCFile(name: "foo", customSearchPaths: [AbsolutePath("/custom")], fileSystem: fs).pathString)
+        XCTAssertEqual("/custom/foo.pc", try PkgConfig(name: "foo", additionalSearchPaths: [AbsolutePath("/custom")], diagnostics: diagnostics, fileSystem: fs, brewPrefix: nil).pcFile.pathString)
+        XCTAssertEqual("/usr/lib/pkgconfig/foo.pc", try PCFileFinder(diagnostics: diagnostics, brewPrefix: nil).locatePCFile(name: "foo", customSearchPaths: [], fileSystem: fs).pathString)
         try withCustomEnv(["PKG_CONFIG_PATH": "/usr/local/opt/foo/lib/pkgconfig"]) {
-            XCTAssertEqual("/usr/local/opt/foo/lib/pkgconfig/foo.pc", try PkgConfig(name: "foo", diagnostics: diagnostics, fileSystem: fs, brewPrefix: nil).pcFile.description)
+            XCTAssertEqual("/usr/local/opt/foo/lib/pkgconfig/foo.pc", try PkgConfig(name: "foo", diagnostics: diagnostics, fileSystem: fs, brewPrefix: nil).pcFile.pathString)
         }
         try withCustomEnv(["PKG_CONFIG_PATH": "/usr/local/opt/foo/lib/pkgconfig:/usr/lib/pkgconfig"]) {
-            XCTAssertEqual("/usr/local/opt/foo/lib/pkgconfig/foo.pc", try PkgConfig(name: "foo", diagnostics: diagnostics, fileSystem: fs, brewPrefix: nil).pcFile.description)
+            XCTAssertEqual("/usr/local/opt/foo/lib/pkgconfig/foo.pc", try PkgConfig(name: "foo", diagnostics: diagnostics, fileSystem: fs, brewPrefix: nil).pcFile.pathString)
         }
     }
 
@@ -101,7 +101,7 @@ final class PkgConfigParserTests: XCTestCase {
             """
             try localFileSystem.writeFileContents(fakePkgConfig, bytes: stream.bytes)
             // `FileSystem` does not support `chmod` on Linux, so we shell out instead.
-            _ = try Process.popen(args: "chmod", "+x", fakePkgConfig.description)
+            _ = try Process.popen(args: "chmod", "+x", fakePkgConfig.pathString)
 
             let diagnostics = DiagnosticsEngine()
             _ = PCFileFinder(diagnostics: diagnostics, brewPrefix: fakePkgConfig.parentDirectory.parentDirectory)

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -437,12 +437,12 @@ final class WorkspaceTests: XCTestCase {
 
         let dependencies: [PackageGraphRootInput.PackageDependency] = [
             .init(
-                url: workspace.packagesDir.appending(component: "Bar").description,
+                url: workspace.packagesDir.appending(component: "Bar").pathString,
                 requirement: .upToNextMajor(from: "1.0.0"),
                 location: ""
             ),
             .init(
-                url: "file://\(workspace.packagesDir.appending(component: "Foo"))/",
+                url: "file://\(workspace.packagesDir.appending(component: "Foo").pathString)/",
                 requirement: .upToNextMajor(from: "1.0.0"),
                 location: ""
             ),
@@ -1412,7 +1412,7 @@ final class WorkspaceTests: XCTestCase {
 
         workspace.loadDependencyManifests(roots: ["Root"]) { (manifests, diagnostics) in
             let editedPackages = manifests.editedPackagesConstraints()
-            XCTAssertEqual(editedPackages.map({ $0.identifier.path }), [fooPath.description])
+            XCTAssertEqual(editedPackages.map({ $0.identifier.path }), [fooPath.pathString])
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -2525,8 +2525,8 @@ final class WorkspaceTests: XCTestCase {
             result.check(notPresent: "Baz")
         }
 
-        try workspace.config.set(mirrorURL: workspace.packagesDir.appending(component: "Baz").description, forPackageURL: workspace.packagesDir.appending(component: "Bar").description)
-        try workspace.config.set(mirrorURL: workspace.packagesDir.appending(component: "Baz").description, forPackageURL: workspace.packagesDir.appending(component: "Bam").description)
+        try workspace.config.set(mirrorURL: workspace.packagesDir.appending(component: "Baz").pathString, forPackageURL: workspace.packagesDir.appending(component: "Bar").pathString)
+        try workspace.config.set(mirrorURL: workspace.packagesDir.appending(component: "Baz").pathString, forPackageURL: workspace.packagesDir.appending(component: "Bam").pathString)
 
         let deps: [TestWorkspace.PackageDependency] = [
             .init(name: "Bam", requirement: .upToNextMajor(from: "1.0.0")),

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -55,7 +55,7 @@ class GenerateXcodeprojTests: XCTestCase {
             // We can only validate this on OS X.
             // Don't allow TOOLCHAINS to be overriden here, as it breaks the test below.
             let output = try Process.checkNonZeroExit(
-                args: "env", "-u", "TOOLCHAINS", "xcodebuild", "-list", "-project", outpath.description).spm_chomp()
+                args: "env", "-u", "TOOLCHAINS", "xcodebuild", "-list", "-project", outpath.pathString).spm_chomp()
 
             XCTAssertTrue(output.hasPrefix("""
                Information about project "DummyProjectName":
@@ -144,12 +144,12 @@ class GenerateXcodeprojTests: XCTestCase {
 
             let diagnostics = DiagnosticsEngine()
             let graph = loadPackageGraph(
-                root: packagePath.description, fs: localFileSystem, diagnostics: diagnostics,
+                root: packagePath.pathString, fs: localFileSystem, diagnostics: diagnostics,
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
-                        path: packagePath.description,
-                        url: packagePath.description,
+                        path: packagePath.pathString,
+                        url: packagePath.pathString,
                         targets: [
                             TargetDescription(name: "DummyModule"),
                         ])
@@ -178,12 +178,12 @@ class GenerateXcodeprojTests: XCTestCase {
 
             let diagnostics = DiagnosticsEngine()
             let graph = loadPackageGraph(
-                root: packagePath.description, fs: localFileSystem, diagnostics: diagnostics,
+                root: packagePath.pathString, fs: localFileSystem, diagnostics: diagnostics,
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
-                        path: packagePath.description,
-                        url: packagePath.description,
+                        path: packagePath.pathString,
+                        url: packagePath.pathString,
                         targets: [
                             TargetDescription(name: "DummyModule"),
                         ])
@@ -212,12 +212,12 @@ class GenerateXcodeprojTests: XCTestCase {
 
             let diagnostics = DiagnosticsEngine()
             let graph = loadPackageGraph(
-                root: packagePath.description, fs: localFileSystem, diagnostics: diagnostics,
+                root: packagePath.pathString, fs: localFileSystem, diagnostics: diagnostics,
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
-                        path: packagePath.description,
-                        url: packagePath.description,
+                        path: packagePath.pathString,
+                        url: packagePath.pathString,
                         targets: [
                             TargetDescription(name: "DummyModule"),
                         ])
@@ -249,12 +249,12 @@ class GenerateXcodeprojTests: XCTestCase {
 
             let diagnostics = DiagnosticsEngine()
             let graph = loadPackageGraph(
-                root: packagePath.description, fs: localFileSystem, diagnostics: diagnostics,
+                root: packagePath.pathString, fs: localFileSystem, diagnostics: diagnostics,
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
-                        path: packagePath.description,
-                        url: packagePath.description,
+                        path: packagePath.pathString,
+                        url: packagePath.pathString,
                         targets: [
                             TargetDescription(name: "DummyModule"),
                         ])
@@ -291,12 +291,12 @@ class GenerateXcodeprojTests: XCTestCase {
 
             let diagnostics = DiagnosticsEngine()
             let graph = loadPackageGraph(
-                root: packagePath.description, fs: localFileSystem, diagnostics: diagnostics,
+                root: packagePath.pathString, fs: localFileSystem, diagnostics: diagnostics,
                 manifests: [
                     Manifest.createV4Manifest(
                         name: "Foo",
-                        path: packagePath.description,
-                        url: packagePath.description,
+                        path: packagePath.pathString,
+                        url: packagePath.pathString,
                         targets: [
                             TargetDescription(name: "DummyModule"),
                         ])


### PR DESCRIPTION
<rdar://problem/47575606> Avoid relying on the description property for getting the string representation from AbsolutePath

The `description` property is meant for producing human readable string
representation. We shouldn’t rely on its value for passing the path to
NSURL/NSFileManager etc. This introduces a new `pathString` property that
guarantees the posix representation.