### PR TITLE
[PackageGraph] Improve handling of branch-based dependencies

### DIFF
--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -162,6 +162,10 @@ public enum PackageRequirement: Hashable {
     /// requirement.
     case revision(String)
 
+    // The requirement is specified by the branch and an optional revision
+    // within that branch.
+    case branch(String, revision: String?)
+
     /// Un-versioned requirement i.e. a version should not resolved.
     case unversioned
 
@@ -174,7 +178,7 @@ public enum PackageRequirement: Hashable {
                 return true
             }
             return false
-        case .revision:
+        case .revision, .branch:
             return true
         case .unversioned:
             return false
@@ -266,6 +270,13 @@ public protocol PackageContainer {
     /// after the container is available. The updated identifier is returned in result of the
     /// dependency resolution.
     func getUpdatedIdentifier(at boundVersion: BoundVersion) throws -> Identifier
+
+    /// Resolve the revision for an identifier.
+    ///
+    /// The identifier can be a branch name or a revision identifier.
+    ///
+    /// - Throws: If the identifier can not be resolved.
+    func resolveRevision(identifier: String) throws -> String
 }
 
 /// An interface for resolving package containers.
@@ -337,8 +348,13 @@ public enum BoundVersion: Equatable, CustomStringConvertible {
     /// The package assignment is unversioned.
     case unversioned
 
+    /// The package assignment is this revision on the given branch.
+    case revision(String, branch: String?)
+
     /// The package assignment is this revision.
-    case revision(String)
+    public static func revision(_ revision: String) -> BoundVersion {
+        return .revision(revision, branch: nil)
+    }
 
     public var description: String {
         switch self {
@@ -348,7 +364,10 @@ public enum BoundVersion: Equatable, CustomStringConvertible {
             return version.description
         case .unversioned:
             return "unversioned"
-        case .revision(let identifier):
+        case .revision(let identifier, let branch):
+            if let branch = branch {
+                return branch + "[\(identifier)]"
+            }
             return identifier
         }
     }
@@ -447,6 +466,44 @@ public struct PackageContainerConstraintSet<C: PackageContainer>: Collection, Ha
 
         // Exisiting revision requirements always *wins*.
         case (_, .revision):
+            return self
+
+        case (.branch(let lhs), .branch(let rhs)):
+            if lhs == rhs {
+                // We can always merge two identitical branch requirements.
+                return self
+            } else if lhs.0 == rhs.0 {
+                // If there are two requirements for a particular branch, we
+                // pick the one which has a revision.
+                //
+                // We shouldn't merge if both have a bound revision (which
+                // should be impossible unless there are two pins for the
+                // package).
+                assert([lhs.revision, rhs.revision].compactMap{$0}.count == 1)
+
+                if lhs.revision != nil {
+                    var result = self
+                    result.constraints[identifier] = requirement
+                    return result
+                } else if rhs.revision != nil {
+                    return self
+                }
+            }
+
+            return nil
+
+        // We can merge the branch requiement if it currently does not have a requirement.
+        case (.branch, .versionSet(.any)):
+            var result = self
+            result.constraints[identifier] = requirement
+            return result
+
+        // Otherwise, we can't merge the branch requirement.
+        case (.branch, _):
+            return nil
+
+        // Exisiting branch requirements always *wins*.
+        case (_, .branch):
             return self
         }
     }
@@ -606,7 +663,7 @@ struct VersionAssignmentSet<C: PackageContainer>: Equatable, Sequence {
                 // If the package is unversioned or excluded, it doesn't contribute.
                 continue
 
-            case .revision(let identifier):
+            case .revision(let identifier, _):
                 // FIXME: Need caching and error handling here. See the FIXME below.
                 merge(constraints: try! container.getDependencies(at: identifier))
 
@@ -642,12 +699,17 @@ struct VersionAssignmentSet<C: PackageContainer>: Equatable, Sequence {
             }
             return false
 
-        case .revision(let identifier):
+        case .revision(let identifier, let branch):
             // If we already have a revision constraint, it should be same as
             // the one we're trying to set.
             if case .revision(let existingRevision) = constraints[container.identifier] {
-                return existingRevision == identifier
+                return existingRevision == identifier && branch == nil
             }
+
+            if case .branch(let existingBranch, let existingRevision) = constraints[container.identifier] {
+                return existingRevision == identifier && existingBranch == branch
+            }
+
             // Otherwise, it is always valid to set a revision binding. Note
             // that there are rules that prevents versioned constraints from
             // having revision constraints, but that is handled by the resolver.
@@ -1039,6 +1101,17 @@ public class DependencyResolver<
             }
             result = merge(constraints: constraints, binding: .revision(identifier))
 
+        case .branch(let branch, let revision):
+            // Get the revision for the branch if we don't have one. This will resolve
+            // to HEAD of the branch, which usually happen on package update or when
+            // resolving without a resolved file.
+            let resolvedRevision = revision ?? (try? container.resolveRevision(identifier: branch))
+
+            guard let revision = resolvedRevision, let constraints = self.safely({ try container.getDependencies(at: revision) }) else {
+                return AnySequence([])
+            }
+            result = merge(constraints: constraints, binding: .revision(revision, branch: branch))
+
         case .versionSet(let versionSet):
             // The previous valid version that was picked.
             var previousVersion: Version? = nil
@@ -1072,7 +1145,7 @@ public class DependencyResolver<
                         switch $0.requirement {
                         case .versionSet:
                             return nil
-                        case .revision(let revision):
+                        case .revision(let revision), .branch(let revision, _):
                             return (AnyPackageContainerIdentifier($0.identifier), revision)
                         case .unversioned:
                             // FIXME: Maybe we should have metadata inside unversion to signify

--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -131,7 +131,7 @@ extension PackageDependencyDescription.Requirement {
         case .branch(let identifier):
             assert(Git.checkRefFormat(ref: identifier))
 
-            return .revision(identifier)
+            return .branch(identifier, revision: nil)
 
         case .exact(let version):
             return .versionSet(.exact(version))

--- a/Sources/PackageGraph/Pubgrub.swift
+++ b/Sources/PackageGraph/Pubgrub.swift
@@ -186,7 +186,7 @@ extension Term: CustomStringConvertible {
         switch requirement {
         case .unversioned:
             req = "unversioned"
-        case .revision(let rev):
+        case .revision(let rev), .branch(let rev, _):
             req = rev
         case .versionSet(let vs):
             switch vs {
@@ -759,7 +759,9 @@ public final class PubgrubDependencyResolver<
             case .versionSet(.exact(let version)):
                 boundVersion = .version(version)
             case .revision(let rev):
-                boundVersion = .revision(rev)
+                boundVersion = .revision(rev, branch: nil)
+            case .branch(let branch, revision: let rev):
+                boundVersion = .revision(rev!, branch: branch)
             case .versionSet(.range(_)):
                 // FIXME: A new requirement type that makes having a range here impossible feels like the correct thing to do.
                 fatalError("Solution should not contain version ranges.")

--- a/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
@@ -153,6 +153,10 @@ public class BasePackageContainer: PackageContainer {
         fatalError("This should never be called")
     }
 
+    public func resolveRevision(identifier: String) throws -> String {
+        fatalError("This should never be called")
+    }
+
     fileprivate init(
         _ identifier: Identifier,
         config: SwiftPMConfig,
@@ -350,6 +354,10 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
         return try repository.resolveRevision(identifier: identifier)
     }
 
+    public override func resolveRevision(identifier: String) throws -> String {
+        return try getRevision(forIdentifier: identifier).identifier
+    }
+
     /// Returns the tools version of the given version of the package.
     private func toolsVersion(for version: Version) throws -> ToolsVersion {
         let tag = knownVersions[version]!
@@ -429,7 +437,7 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
         switch boundVersion {
         case .version(let version):
             identifier = version.description
-        case .revision(let revision):
+        case .revision(let revision, _):
             identifier = revision
         case .unversioned, .excluded:
             assertionFailure("Unexpected type requirement \(boundVersion)")

--- a/Sources/SourceControl/InMemoryGitRepository.swift
+++ b/Sources/SourceControl/InMemoryGitRepository.swift
@@ -97,9 +97,9 @@ public final class InMemoryGitRepository {
 
     /// Commits the current state of the repository filesystem and returns the commit identifier.
     @discardableResult
-    public func commit() -> String {
+    public func commit(hash: String? = nil) -> String {
         // Create a fake hash for thie commit.
-        let hash = String((NSUUID().uuidString + NSUUID().uuidString).prefix(40))
+        let hash = hash ?? String((NSUUID().uuidString + NSUUID().uuidString).prefix(40))
         head.hash = hash
         // Store the commit in history.
         history[hash] = head.copy()

--- a/Sources/TestSupport/MockDependencyResolver.swift
+++ b/Sources/TestSupport/MockDependencyResolver.swift
@@ -115,6 +115,10 @@ public class MockPackageContainer: PackageContainer {
         return name
     }
 
+    public func resolveRevision(identifier: String) throws -> String {
+        return identifier
+    }
+
     public convenience init(
         name: Identifier,
         dependenciesByVersion: [Version: [(container: Identifier, versionRequirement: VersionSetSpecifier)]]
@@ -162,7 +166,7 @@ extension MockPackageContainer {
                         return (constraint.identifier, versionSet)
                     case .unversioned:
                         fatalError()
-                    case .revision:
+                    case .revision, .branch:
                         fatalError()
                     }
                 })

--- a/Sources/TestSupport/TestWorkspace.swift
+++ b/Sources/TestSupport/TestWorkspace.swift
@@ -105,8 +105,12 @@ public final class TestWorkspace {
                     products: package.products.map({ ProductDescription(name: $0.name, type: .library(.automatic), targets: $0.targets) }),
                     targets: package.targets.map({ $0.convert() })
                 )
-                if let version = version {
-                    try repo.tag(name: version)
+
+                // Tag semver versions and add a commit for non-versions.
+                if let version = v {
+                    try repo.tag(name: version.description)
+                } else if let version = version {
+                    repo.commit(hash: version)
                 }
             }
 

--- a/Sources/Workspace/CheckoutState.swift
+++ b/Sources/Workspace/CheckoutState.swift
@@ -60,7 +60,7 @@ extension CheckoutState {
         if let version = version {
             return .versionSet(.exact(version))
         } else if let branch = branch {
-            return .revision(branch)
+            return .branch(branch, revision: revision.identifier)
         }
         return .revision(revision.identifier)
     }

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -118,6 +118,8 @@ public enum ResolverDiagnostics {
                 stream <<< set.description
             case .revision(let revision):
                 stream <<< revision
+            case .branch(let branch, _):
+                stream <<< branch
             case .unversioned:
                 stream <<< "unversioned"
             }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -33,7 +33,7 @@ class MiscellaneousTestCase: XCTestCase {
         fixture(name: "DependencyResolution/External/Simple") { prefix in
             let output = try executeSwiftBuild(prefix.appending(component: "Bar"))
             XCTAssertTrue(output.contains("Resolving"))
-            XCTAssertTrue(output.contains("at 1.2.3"))
+            XCTAssertTrue(output.contains("at 1.2.3"), output)
         }
     }
 

--- a/Tests/PackageGraphTests/DependencyResolverTests.swift
+++ b/Tests/PackageGraphTests/DependencyResolverTests.swift
@@ -1017,7 +1017,7 @@ where C.Identifier == String
             actual[identifier] = versionSet
         case .unversioned:
             return XCTFail("Unexpected unversioned constraint for \(identifier)", file: file, line: line)
-        case .revision:
+        case .revision, .branch:
             return XCTFail("Unexpected revision constraint for \(identifier)", file: file, line: line)
         }
     }

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -62,6 +62,10 @@ public class _MockPackageContainer: PackageContainer {
         return name
     }
 
+    public func resolveRevision(identifier: String) throws -> String {
+        return identifier
+    }
+
     public convenience init(
         name: Identifier,
         dependenciesByVersion: [Version: [(container: Identifier, versionRequirement: VersionSetSpecifier)]]

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -2729,11 +2729,11 @@ final class WorkspaceTests: XCTestCase {
         }
         workspace.checkManagedDependencies() { result in
             result.check(dependency: "foo", at: .checkout(.version("1.3.2")))
-            result.check(dependency: "bar", at: .checkout(.branch("develop")))
+            result.check(dependency: "bar", at: .checkout(.revision("develop")))
         }
         workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.3.2")))
-            result.check(dependency: "bar", at: .checkout(.branch("develop")))
+            result.check(dependency: "bar", at: .checkout(.revision("develop")))
         }
 
         // Change pin of foo to something else.
@@ -2758,11 +2758,11 @@ final class WorkspaceTests: XCTestCase {
         }
         workspace.checkManagedDependencies() { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
-            result.check(dependency: "bar", at: .checkout(.branch("develop")))
+            result.check(dependency: "bar", at: .checkout(.revision("develop")))
         }
         workspace.checkResolved { result in
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
-            result.check(dependency: "bar", at: .checkout(.branch("develop")))
+            result.check(dependency: "bar", at: .checkout(.revision("develop")))
         }
 
         // A normal resolution.


### PR DESCRIPTION
This improves handling of branch-based inside the resolver which leads
to a deterministic handling of the revision that is picked as part of
the resolution process. This also fixes the bug that branch-based
dependencies were being always resolved from HEAD (if there was no build
cache) when a resolved file was present.

<rdar://problem/45289738> Dependency resolution doesn't respect the resolved file for branch-based dependencies when starting resolution process from scratch