### PR TITLE
Add functionality to mechanically edit Package.swift file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -263,3 +263,14 @@ if getenv("SWIFTPM_BOOTSTRAP") == nil {
     ]
     package.targets.first(where: { $0.name == "SPMLLBuild" })!.dependencies += ["llbuildSwift"]
 }
+
+if getenv("SWIFTPM_BUILD_PACKAGE_EDITOR") != nil {
+    package.targets += [
+        .target(name: "SPMPackageEditor", dependencies: ["Workspace", "SwiftSyntax"]),
+        .target(name: "swiftpm-manifest-tool", dependencies: ["SPMPackageEditor"]),
+        .testTarget(name: "SPMPackageEditorTests", dependencies: ["SPMPackageEditor", "TestSupport"]),
+    ]
+    package.dependencies += [
+        .package(path: "../swift-syntax"),
+    ]
+}

--- a/Sources/SPMPackageEditor/ManifestRewriter.swift
+++ b/Sources/SPMPackageEditor/ManifestRewriter.swift
@@ -1,0 +1,438 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2019 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import SwiftSyntax
+
+/// A package manifest rewriter.
+///
+/// This class provides functionality for rewriting the
+/// Swift package manifest using the SwiftSyntax library.
+///
+/// Similar to SwiftSyntax, this class only deals with the
+/// syntax and has no functionality for semantics of the manifest.
+public final class ManifestRewriter {
+
+    enum Error: Swift.Error {
+        case error(String)
+    }
+
+    /// The contents of the original manifest.
+    public let originalManifest: String
+
+    /// The contents of the edited manifest.
+    public var editedManifest: String {
+        return editedSource.description
+    }
+
+    /// The edited manifest syntax.
+    private var editedSource: Syntax
+
+    /// Create a new manfiest editor with the given contents.
+    public init(_ manifest: String) throws {
+        self.originalManifest = manifest
+        self.editedSource = try SyntaxParser.parse(source: manifest)
+    }
+
+    /// Add a package dependency.
+    public func addPackageDependency(
+        url: String,
+        requirement: PackageDependencyRequirement
+    ) throws {
+        // Find Package initializer.
+        let packageFinder = PackageInitFinder()
+        editedSource.walk(packageFinder)
+
+        guard let initFnExpr = packageFinder.packageInit else {
+            throw Error.error("Couldn't find Package initializer")
+        }
+
+        // Find dependencies section in the argument list of Package(...).
+        let packageDependenciesFinder = DependenciesArrayFinder()
+        initFnExpr.argumentList.walk(packageDependenciesFinder)
+
+        let packageDependencies: ArrayExprSyntax
+        if let existingPackageDependencies = packageDependenciesFinder.dependenciesArrayExpr {
+            packageDependencies = existingPackageDependencies
+        } else {
+            // We didn't find a dependencies section so insert one.
+            let argListWithDependencies = DependenciesArrayWriter().visit(initFnExpr.argumentList)
+
+            // Find the inserted section.
+            let packageDependenciesFinder = DependenciesArrayFinder()
+            argListWithDependencies.walk(packageDependenciesFinder)
+            packageDependencies = packageDependenciesFinder.dependenciesArrayExpr!
+        }
+
+        // Add the the package dependency entry.
+       let newManifest = PackageDependencyWriter(
+            url: url,
+            requirement: requirement
+        ).visit(packageDependencies).root
+
+        self.editedSource = newManifest
+    }
+
+    /// Add a target dependency.
+    public func addTargetDependency(
+        target: String,
+        dependency: String
+    ) throws {
+        // Find Package initializer.
+        let packageFinder = PackageInitFinder()
+        editedSource.walk(packageFinder)
+
+        guard let initFnExpr = packageFinder.packageInit else {
+            throw Error.error("Couldn't find Package initializer")
+        }
+
+        // Find the `targets: []` array.
+        let targetsArrayFinder = TargetsArrayFinder()
+        initFnExpr.argumentList.walk(targetsArrayFinder)
+        guard let targetsArrayExpr = targetsArrayFinder.targets else {
+            throw Error.error("Couldn't find targets label")
+        }
+
+        // Find the target node.
+        let targetFinder = TargetFinder(name: target)
+        targetsArrayExpr.walk(targetFinder)
+        guard let targetNode = targetFinder.foundTarget else {
+            throw Error.error("Couldn't find target \(target)")
+        }
+
+        let targetDependencyFinder = DependenciesArrayFinder()
+        targetNode.walk(targetDependencyFinder)
+
+        guard let targetDependencies = targetDependencyFinder.dependenciesArrayExpr else {
+            throw Error.error("Couldn't find dependencies section")
+        }
+
+        // Add the target dependency entry.
+        let newManifest = TargetDependencyWriter(
+            dependencyName: dependency
+        ).visit(targetDependencies).root
+
+        self.editedSource = newManifest
+    }
+
+    /// Add a new target.
+    public func addTarget(
+        targetName: String,
+        type: TargetType = .regular
+    ) throws {
+        // Find Package initializer.
+        let packageFinder = PackageInitFinder()
+        editedSource.walk(packageFinder)
+
+        guard let initFnExpr = packageFinder.packageInit else {
+            throw Error.error("Couldn't find Package initializer")
+        }
+
+        let targetsFinder = TargetsArrayFinder()
+        initFnExpr.argumentList.walk(targetsFinder)
+
+        guard let targetsNode = targetsFinder.targets else {
+            throw Error.error("Couldn't find targets section")
+        }
+
+        let newManifest = NewTargetWriter(
+            name: targetName, targetType: type
+        ).visit(targetsNode).root
+
+        self.editedSource = newManifest
+    }
+}
+
+// MARK: - Syntax Visitors
+
+/// Package init finder.
+final class PackageInitFinder: SyntaxVisitor {
+
+    /// Reference to the function call of the package initializer.
+    private(set) var packageInit: FunctionCallExprSyntax?
+
+    override func shouldVisit(_ kind: SyntaxKind) -> Bool {
+        return kind == .initializerClause
+    }
+
+    override func visit(_ node: InitializerClauseSyntax) -> SyntaxVisitorContinueKind {
+        if let fnCall = node.value as? FunctionCallExprSyntax,
+            let identifier = fnCall.calledExpression.firstToken,
+            identifier.text == "Package" {
+            assert(packageInit == nil, "Found two package initializers")
+            packageInit = fnCall
+        }
+        return .skipChildren
+    }
+}
+
+/// Finder for "dependencies" array syntax.
+final class DependenciesArrayFinder: SyntaxVisitor {
+
+    private(set) var dependenciesArrayExpr: ArrayExprSyntax?
+
+    override func visit(_ node: FunctionCallArgumentSyntax) -> SyntaxVisitorContinueKind {
+        guard node.label?.text == "dependencies" else {
+            return .skipChildren
+        }
+
+        // We have custom code like foo + bar + [] (hopefully there is an array expr here).
+        if let seq = node.expression as? SequenceExprSyntax {
+            dependenciesArrayExpr = seq.elements.first(where: { $0 is ArrayExprSyntax }) as? ArrayExprSyntax
+        } else if let arrayExpr = node.expression as? ArrayExprSyntax {
+            dependenciesArrayExpr = arrayExpr
+        }
+
+        // FIXME: If we find a dependencies section but not an array expr, then we should
+        // not try to insert one later. i.e. return error if depsArray is nil.
+
+        return .skipChildren
+    }
+}
+
+/// Finder for targets array expression.
+final class TargetsArrayFinder: SyntaxVisitor {
+
+    /// The found targets array expr.
+    private(set) var targets: ArrayExprSyntax?
+
+    override func visit(_ node: FunctionCallArgumentSyntax) -> SyntaxVisitorContinueKind {
+        if node.label?.text == "targets",
+            let expr = node.expression as? ArrayExprSyntax {
+            assert(targets == nil, "Found two targets labels")
+            targets = expr
+        }
+        return .skipChildren
+    }
+}
+
+/// Finds a given target in a list of targets.
+final class TargetFinder: SyntaxVisitor {
+
+    let targetToFind: String
+    private(set) var foundTarget: FunctionCallArgumentListSyntax?
+
+    init(name: String) {
+        self.targetToFind = name
+    }
+
+    override func visit(_ node: FunctionCallArgumentSyntax) -> SyntaxVisitorContinueKind {
+        guard case .identifier(let label)? = node.label?.tokenKind else {
+            return .skipChildren
+        }
+        guard label == "name", let targetNameExpr = node.expression as? StringLiteralExprSyntax else {
+            return .skipChildren
+        }
+        guard case .stringLiteral(let targetName) = targetNameExpr.stringLiteral.tokenKind else {
+            return .skipChildren
+        }
+
+        if targetName == "\"" + self.targetToFind + "\"" {
+            self.foundTarget = node.parent as? FunctionCallArgumentListSyntax
+            return .skipChildren
+        }
+
+        return .skipChildren
+    }
+}
+
+// MARK: - Syntax Rewriters
+
+/// Writer for "dependencies" array syntax.
+final class DependenciesArrayWriter: SyntaxRewriter {
+
+    override func visit(_ node: FunctionCallArgumentListSyntax) -> Syntax {
+        let leadingTrivia = node.firstToken?.leadingTrivia ?? .zero
+
+        let dependenciesArg = SyntaxFactory.makeFunctionCallArgument(
+            label: SyntaxFactory.makeIdentifier("dependencies", leadingTrivia: leadingTrivia),
+            colon: SyntaxFactory.makeColonToken(trailingTrivia: .spaces(1)),
+            expression: SyntaxFactory.makeArrayExpr(
+                leftSquare: SyntaxFactory.makeLeftSquareBracketToken(),
+                elements: SyntaxFactory.makeBlankArrayElementList(),
+                rightSquare: SyntaxFactory.makeRightSquareBracketToken()),
+            trailingComma: SyntaxFactory.makeCommaToken()
+        )
+
+        // FIXME: This is not correct, we need to find the
+        // proper position for inserting `dependencies: []`.
+        return node.inserting(dependenciesArg, at: 1)
+    }
+}
+
+/// Writer for inserting a trailing comma in an array expr.
+final class ArrayTrailingCommaWriter: SyntaxRewriter {
+    let lastElement: ArrayElementSyntax
+
+    init(lastElement: ArrayElementSyntax) {
+        self.lastElement = lastElement
+    }
+
+    override func visit(_ node: ArrayElementSyntax) -> Syntax {
+        guard lastElement == node else {
+            return node
+        }
+        return node.withTrailingComma(SyntaxFactory.makeCommaToken(trailingTrivia: .spaces(1)))
+    }
+}
+
+/// Package dependency writer.
+final class PackageDependencyWriter: SyntaxRewriter {
+
+    /// The dependency url to write.
+    let url: String
+
+    /// The dependency requirement.
+    let requirement: PackageDependencyRequirement
+
+    init(url: String, requirement: PackageDependencyRequirement) {
+        self.url = url
+        self.requirement = requirement
+    }
+
+    override func visit(_ node: ArrayExprSyntax) -> ExprSyntax {
+        // FIXME: We should get the trivia from the closing brace.
+        let leadingTrivia: Trivia = [.newlines(1), .spaces(8)]
+
+        let dotPackageExpr = SyntaxFactory.makeMemberAccessExpr(
+            base: nil,
+            dot: SyntaxFactory.makePeriodToken(leadingTrivia: leadingTrivia),
+            name: SyntaxFactory.makeIdentifier("package"),
+            declNameArguments: nil
+        )
+
+        var args: [FunctionCallArgumentSyntax] = []
+
+        let firstArgLabel = requirement == .localPackage ? "path" : "url"
+        let url = SyntaxFactory.makeFunctionCallArgument(
+            label: SyntaxFactory.makeIdentifier(firstArgLabel),
+            colon: SyntaxFactory.makeColonToken(trailingTrivia: .spaces(1)),
+            expression: SyntaxFactory.makeStringLiteralExpr(self.url),
+            trailingComma: requirement == .localPackage ? nil : SyntaxFactory.makeCommaToken(trailingTrivia: .spaces(1))
+        )
+        args.append(url)
+
+        // FIXME: Handle other types of requirements.
+        if requirement != .localPackage {
+            let secondArg = SyntaxFactory.makeFunctionCallArgument(
+                label: SyntaxFactory.makeIdentifier("from"),
+                colon: SyntaxFactory.makeColonToken(trailingTrivia: .spaces(1)),
+                expression: SyntaxFactory.makeStringLiteralExpr(requirement.ref!),
+                trailingComma: nil
+            )
+            args.append(secondArg)
+        }
+
+        let expr = SyntaxFactory.makeFunctionCallExpr(
+            calledExpression: dotPackageExpr,
+            leftParen: SyntaxFactory.makeLeftParenToken(),
+            argumentList: SyntaxFactory.makeFunctionCallArgumentList(args),
+            rightParen: SyntaxFactory.makeRightParenToken(),
+            trailingClosure: nil
+        )
+
+        let newDependencyElement = SyntaxFactory.makeArrayElement(
+            expression: expr,
+            trailingComma: SyntaxFactory.makeCommaToken()
+        )
+
+        let rightBrace = SyntaxFactory.makeRightSquareBracketToken(
+            leadingTrivia: [.newlines(1), .spaces(4)])
+
+        return node.addArrayElement(newDependencyElement)
+            .withRightSquare(rightBrace)
+    }
+}
+
+/// Writer for inserting a target dependency.
+final class TargetDependencyWriter: SyntaxRewriter {
+
+    /// The name of the dependency to write.
+    let dependencyName: String
+
+    init(dependencyName name: String) {
+        self.dependencyName = name
+    }
+
+    override func visit(_ node: ArrayExprSyntax) -> ExprSyntax {
+        var node = node
+
+        // Insert trailing comma, if needed.
+        if node.elements.count > 0 {
+            let lastElement = node.elements.map{$0}.last!
+            let trailingTriviaWriter = ArrayTrailingCommaWriter(lastElement: lastElement)
+            let newElements = trailingTriviaWriter.visit(node.elements)
+            node = node.withElements((newElements as! ArrayElementListSyntax))
+        }
+
+        let newDependencyElement = SyntaxFactory.makeArrayElement(
+            expression: SyntaxFactory.makeStringLiteralExpr(self.dependencyName),
+            trailingComma: nil
+        )
+
+        return node.addArrayElement(newDependencyElement)
+    }
+}
+
+/// Writer for inserting a new target in a targets array.
+final class NewTargetWriter: SyntaxRewriter {
+
+    let name: String
+    let targetType: TargetType
+
+    init(name: String, targetType: TargetType) {
+        self.name = name
+        self.targetType = targetType
+    }
+
+    override func visit(_ node: ArrayExprSyntax) -> ExprSyntax {
+
+        let leadingTrivia: Trivia = [.newlines(1), .spaces(8)]
+        let leadingTriviaArgs: Trivia = leadingTrivia.appending(.spaces(4))
+
+        let dotPackageExpr = SyntaxFactory.makeMemberAccessExpr(
+            base: nil,
+            dot: SyntaxFactory.makePeriodToken(leadingTrivia: leadingTrivia),
+            name: SyntaxFactory.makeIdentifier(targetType.factoryMethodName),
+            declNameArguments: nil
+        )
+
+        let nameArg = SyntaxFactory.makeFunctionCallArgument(
+            label: SyntaxFactory.makeIdentifier("name", leadingTrivia: leadingTriviaArgs),
+            colon: SyntaxFactory.makeColonToken(trailingTrivia: .spaces(1)),
+            expression: SyntaxFactory.makeStringLiteralExpr(self.name),
+            trailingComma: SyntaxFactory.makeCommaToken()
+        )
+
+        let emptyArray = SyntaxFactory.makeArrayExpr(leftSquare: SyntaxFactory.makeLeftSquareBracketToken(), elements: SyntaxFactory.makeBlankArrayElementList(), rightSquare: SyntaxFactory.makeRightSquareBracketToken())
+        let depenenciesArg = SyntaxFactory.makeFunctionCallArgument(
+            label: SyntaxFactory.makeIdentifier("dependencies", leadingTrivia: leadingTriviaArgs),
+            colon: SyntaxFactory.makeColonToken(trailingTrivia: .spaces(1)),
+            expression: emptyArray,
+            trailingComma: nil
+        )
+
+        let expr = SyntaxFactory.makeFunctionCallExpr(
+            calledExpression: dotPackageExpr,
+            leftParen: SyntaxFactory.makeLeftParenToken(),
+            argumentList: SyntaxFactory.makeFunctionCallArgumentList([
+                nameArg, depenenciesArg,
+                ]),
+            rightParen: SyntaxFactory.makeRightParenToken(),
+            trailingClosure: nil
+        )
+
+        let newDependencyElement = SyntaxFactory.makeArrayElement(
+            expression: expr,
+            trailingComma: SyntaxFactory.makeCommaToken()
+        )
+
+        return node.addArrayElement(newDependencyElement)
+    }
+}

--- a/Sources/SPMPackageEditor/PackageEditor.swift
+++ b/Sources/SPMPackageEditor/PackageEditor.swift
@@ -1,0 +1,298 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2019 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import SPMUtility
+import Basic
+import SourceControl
+import PackageLoading
+import PackageModel
+import Workspace
+import Foundation
+
+/// An editor for Swift packages.
+///
+/// This class provides high-level functionality for performing
+/// editing operations a package.
+public final class PackageEditor {
+
+    /// Reference to the package editor context.
+    let context: PackageEditorContext
+
+    /// Create a package editor instance.
+    public convenience init(buildDir: AbsolutePath) throws {
+        self.init(context: try PackageEditorContext(buildDir: buildDir))
+    }
+
+    /// Create a package editor instance.
+    public init(context: PackageEditorContext) {
+        self.context = context
+    }
+
+    /// The file system to perform disk operations on.
+    var fs: FileSystem {
+        return context.fs
+    }
+
+    /// Add a package dependency.
+    public func addPackageDependency(options: Options.AddPackageDependency) throws {
+        var options = options
+
+        // Validate that the package doesn't already contain this dependency.
+        // FIXME: We need to handle version-specific manifests.
+        let loadedManifest = try context.loadManifest(at: options.manifestPath.parentDirectory)
+        let containsDependency = loadedManifest.dependencies.contains {
+            return PackageReference.computeIdentity(packageURL: options.url) == PackageReference.computeIdentity(packageURL: $0.url)
+        }
+        guard !containsDependency else {
+            throw StringError("Already has dependency \(options.url)")
+        }
+
+        // If the input URL is a path, force the requirement to be a local package.
+        if SPMUtility.URL.scheme(options.url) == nil {
+            assert(options.requirement == nil || options.requirement == .localPackage)
+            options.requirement = .localPackage
+        }
+
+        // Load the dependency manifest depending on the inputs.
+        let dependencyManifest: Manifest
+        let requirement: PackageDependencyRequirement
+        if options.requirement == .localPackage {
+            // For local packages, load the manifest and get the first library product name.
+            let path = AbsolutePath(options.url, relativeTo: fs.currentWorkingDirectory!)
+            dependencyManifest = try context.loadManifest(at: path)
+            requirement = .localPackage
+        } else {
+            // Otherwise, first lookup the dependency.
+            let spec = RepositorySpecifier(url: options.url)
+            let handle = try await{ context.repositoryManager.lookup(repository: spec, completion: $0) }
+            let repo = try handle.open()
+
+            // Compute the requirement.
+            if let inputRequirement = options.requirement {
+                requirement = inputRequirement
+            } else {
+                // Use the latest version or the master branch.
+                let versions = repo.tags.compactMap{ Version(string: $0) }
+                let latestVersion = versions.filter({ $0.prereleaseIdentifiers.isEmpty }).max() ?? versions.max()
+                requirement = latestVersion.map{ PackageDependencyRequirement.upToNextMajor($0.description) } ?? PackageDependencyRequirement.branch("master")
+            }
+
+            // Load the manifest.
+            let revision = try repo.resolveRevision(identifier: requirement.ref!)
+            let repoFS = try repo.openFileView(revision: revision)
+            dependencyManifest = try context.loadManifest(at: .root, fs: repoFS)
+        }
+
+        // Add the package dependency.
+        let manifestContents = try fs.readFileContents(options.manifestPath).cString
+        let editor = try ManifestRewriter(manifestContents)
+        try editor.addPackageDependency(url: options.url, requirement: requirement)
+
+        // Add the product in the first regular target, if possible.
+        let productName = dependencyManifest.products.filter{ $0.type.isLibrary }.map{ $0.name }.first
+        let destTarget = loadedManifest.targets.filter{ $0.type == .regular }.first
+        if let product = productName,
+            let destTarget = destTarget,
+            !destTarget.dependencies.containsDependency(product) {
+            try editor.addTargetDependency(target: destTarget.name, dependency: product)
+        }
+
+        // FIXME: We should verify our edits by loading the edited manifest before writing it to disk.
+        try fs.writeFileContents(options.manifestPath, bytes: ByteString(encodingAsUTF8: editor.editedManifest))
+    }
+
+    /// Add a new target.
+    public func addTarget(options: Options.AddTarget) throws {
+        let manifest = options.manifestPath
+        let targetName = options.targetName
+        let testTargetName = targetName + "Tests"
+
+        // Validate that the package doesn't already contain this dependency.
+        // FIXME: We need to handle version-specific manifests.
+        let loadedManifest = try context.loadManifest(at: options.manifestPath.parentDirectory)
+        if loadedManifest.targets.contains(where: { $0.name == targetName }) {
+            throw StringError("Already has a target named \(targetName)")
+        }
+
+        let manifestContents = try fs.readFileContents(options.manifestPath).cString
+        let editor = try ManifestRewriter(manifestContents)
+        try editor.addTarget(targetName: targetName)
+        try editor.addTarget(targetName: testTargetName, type: .test)
+        try editor.addTargetDependency(target: testTargetName, dependency: targetName)
+
+        // FIXME: We should verify our edits by loading the edited manifest before writing it to disk.
+        try fs.writeFileContents(manifest, bytes: ByteString(encodingAsUTF8: editor.editedManifest))
+
+        // Write template files.
+        let targetPath = manifest.parentDirectory.appending(components: "Sources", targetName)
+        if !localFileSystem.exists(targetPath) {
+            let file = targetPath.appending(components: targetName + ".swift")
+            try fs.createDirectory(targetPath)
+            try fs.writeFileContents(file, bytes: "")
+        }
+
+        let testTargetPath = manifest.parentDirectory.appending(components: "Tests", testTargetName)
+        if !fs.exists(testTargetPath) {
+            let file = testTargetPath.appending(components: testTargetName + ".swift")
+            try fs.createDirectory(testTargetPath)
+            try fs.writeFileContents(file) {
+                $0 <<< """
+                import XCTest
+                @testable import \(targetName)
+
+                final class \(testTargetName): XCTestCase {
+                    func testExample() {
+                    }
+                }
+                """
+            }
+        }
+    }
+}
+
+extension Array where Element == TargetDescription.Dependency {
+    func containsDependency(_ other: String) -> Bool {
+        return self.contains {
+            switch $0 {
+            case .target(let name), .product(let name, _), .byName(let name):
+                return name == other
+            }
+        }
+    }
+}
+
+/// The types of target.
+public enum TargetType {
+    case regular
+    case test
+
+    /// The name of the factory method for a target type.
+    var factoryMethodName: String {
+        switch self {
+        case .regular: return "target"
+        case .test: return "testTarget"
+        }
+    }
+}
+
+public enum PackageDependencyRequirement: Equatable {
+    case exact(String)
+    case revision(String)
+    case branch(String)
+    case upToNextMajor(String)
+    case upToNextMinor(String)
+    case localPackage
+
+    var ref: String? {
+        switch self {
+        case .exact(let ref): return ref
+        case .revision(let ref): return ref
+        case .branch(let ref): return ref
+        case .upToNextMajor(let ref): return ref
+        case .upToNextMinor(let ref): return ref
+        case .localPackage: return nil
+        }
+    }
+}
+
+public enum Options {
+    public struct AddPackageDependency {
+        public var manifestPath: AbsolutePath
+        public var url: String
+        public var requirement: PackageDependencyRequirement?
+
+        public init(
+            manifestPath: AbsolutePath,
+            url: String,
+            requirement: PackageDependencyRequirement? = nil
+        ) {
+            self.manifestPath = manifestPath
+            self.url = url
+            self.requirement = requirement
+        }
+    }
+
+    public struct AddTarget {
+        public var manifestPath: AbsolutePath
+        public var targetName: String
+        public var targetType: TargetType
+
+        public init(
+            manifestPath: AbsolutePath,
+            targetName: String,
+            targetType: TargetType = .regular
+        ) {
+            self.manifestPath = manifestPath
+            self.targetName = targetName
+            self.targetType = targetType
+        }
+    }
+}
+
+extension ProductType {
+    var isLibrary: Bool {
+        switch self {
+        case .library:
+            return true
+        case .executable, .test:
+            return false
+        }
+    }
+}
+
+/// The global context for package editor.
+public final class PackageEditorContext {
+
+    /// Path to the build directory of the package.
+    let buildDir: AbsolutePath
+
+    /// The manifest loader.
+    let manifestLoader: ManifestLoaderProtocol
+
+    /// The repository manager.
+    let repositoryManager: RepositoryManager
+
+    /// The file system in use.
+    let fs: FileSystem
+
+    public init(buildDir: AbsolutePath, fs: FileSystem = localFileSystem) throws {
+        self.buildDir = buildDir
+        self.fs = fs
+
+        // Create toolchain.
+        let hostToolchain = try UserToolchain(destination: .hostDestination())
+        self.manifestLoader = ManifestLoader(manifestResources: hostToolchain.manifestResources)
+
+        let repositoriesPath = buildDir.appending(component: "repositories")
+        self.repositoryManager = RepositoryManager(
+            path: repositoriesPath,
+            provider: GitRepositoryProvider()
+        )
+    }
+
+    /// Load the manifest at the given path.
+    func loadManifest(
+        at path: AbsolutePath,
+        fs: FileSystem? = nil
+    ) throws -> Manifest {
+        let fs = fs ?? self.fs
+
+        let toolsVersion = try ToolsVersionLoader().load(
+            at: path, fileSystem: fs)
+
+        return try manifestLoader.load(
+            package: path,
+            baseURL: path.description,
+            version: nil,
+            manifestVersion: toolsVersion.manifestVersion,
+            fileSystem: fs
+        )
+    }
+}

--- a/Sources/swiftpm-manifest-tool/main.swift
+++ b/Sources/swiftpm-manifest-tool/main.swift
@@ -1,0 +1,135 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2019 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import Basic
+import SPMUtility
+import func POSIX.exit
+
+import SPMPackageEditor
+import class PackageModel.Manifest
+
+enum ToolError: Error {
+    case error(String)
+    case noManifest
+}
+
+enum Mode: String {
+    case addPackageDependency = "add-package"
+    case addTarget = "add-target"
+    case help
+}
+
+struct Options {
+    struct AddPackageDependency {
+        let url: String
+    }
+    struct AddTarget {
+        let name: String
+    }
+    var dataPath: AbsolutePath = AbsolutePath("/tmp")
+    var addPackageDependency: AddPackageDependency?
+    var addTarget: AddTarget?
+    var mode = Mode.help
+}
+
+/// Finds the Package.swift manifest file in the current working directory.
+func findPackageManifest() -> AbsolutePath? {
+    guard let cwd = localFileSystem.currentWorkingDirectory else {
+        return nil
+    }
+
+    let manifestPath = cwd.appending(component: Manifest.filename)
+    return localFileSystem.isFile(manifestPath) ? manifestPath : nil
+}
+
+final class PackageIndex {
+
+    struct Entry: Codable {
+        let name: String
+        let url: String
+    }
+
+    // Name -> URL
+    private(set) var index: [String: String]
+
+    init() throws {
+        index = [:]
+
+        let indexFile = localFileSystem.homeDirectory.appending(components: ".swiftpm", "package-mapping.json")
+        guard localFileSystem.isFile(indexFile) else {
+            return
+        }
+
+        let bytes = try localFileSystem.readFileContents(indexFile).contents
+        let entries = try JSONDecoder().decode(Array<Entry>.self, from: Data(bytes: bytes, count: bytes.count))
+
+        index = Dictionary(uniqueKeysWithValues: entries.map{($0.name, $0.url)})
+    }
+}
+
+do {
+    let binder = ArgumentBinder<Options>()
+
+    let parser = ArgumentParser(
+        usage: "subcommand",
+        overview: "Tool for editing the Package.swift manifest file")
+
+    // Add package dependency.
+    let packageDependencyParser = parser.add(subparser: Mode.addPackageDependency.rawValue, overview: "Add a new package dependency")
+    binder.bind(
+        positional: packageDependencyParser.add(positional: "package-url", kind: String.self, usage: "Dependency URL"),
+        to: { $0.addPackageDependency = Options.AddPackageDependency(url: $1) })
+
+    // Add Target.
+    let addTargetParser = parser.add(subparser: Mode.addTarget.rawValue, overview: "Add a new target")
+    binder.bind(
+        positional: addTargetParser.add(positional: "target-name", kind: String.self, usage: "Target name"),
+        to: { $0.addTarget = Options.AddTarget(name: $1) })
+
+    // Bind the mode.
+    binder.bind(
+        parser: parser,
+        to: { $0.mode = Mode(rawValue: $1)! })
+
+    // Parse the options.
+    var options = Options()
+    let result = try parser.parse(Array(CommandLine.arguments.dropFirst()))
+    try binder.fill(parseResult: result, into: &options)
+
+    // Find the Package.swift file in cwd.
+    guard let manifest = findPackageManifest() else {
+        throw ToolError.noManifest
+    }
+    options.dataPath = (localFileSystem.currentWorkingDirectory ?? AbsolutePath("/tmp")).appending(component: ".build")
+
+    switch options.mode {
+    case .addPackageDependency:
+        var url = options.addPackageDependency!.url
+        url = try PackageIndex().index[url] ?? url
+
+        let editor = try PackageEditor(buildDir: options.dataPath)
+        try editor.addPackageDependency(options: .init(manifestPath: manifest, url: url, requirement: nil))
+
+    case .addTarget:
+        let targetOptions = options.addTarget!
+
+        let editor = try PackageEditor(buildDir: options.dataPath)
+        try editor.addTarget(options: .init(manifestPath: manifest, targetName: targetOptions.name, targetType: .regular))
+
+    case .help:
+        parser.printUsage(on: stdoutStream)
+    }
+
+} catch {
+    stderrStream <<< String(describing: error) <<< "\n"
+    stderrStream.flush()
+    POSIX.exit(1)
+}

--- a/Tests/SPMPackageEditorTests/AddPackageDependencyTests.swift
+++ b/Tests/SPMPackageEditorTests/AddPackageDependencyTests.swift
@@ -1,0 +1,236 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2019 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+@testable import SPMPackageEditor
+
+final class AddPackageDependencyTests: XCTestCase {
+    func testAddPackageDependency() throws {
+        let manifest = """
+            // swift-tools-version:5.0
+            import PackageDescription
+
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                ],
+                targets: [
+                    .target(
+                        name: "exec",
+                        dependencies: []),
+                    .testTarget(
+                        name: "execTests",
+                        dependencies: ["exec"]),
+                ]
+            )
+            """
+        
+        
+        let editor = try ManifestRewriter(manifest)
+        try editor.addPackageDependency(
+            url: "https://github.com/foo/goo",
+            requirement: .upToNextMajor("1.0.1")
+        )
+        
+        XCTAssertEqual(editor.editedManifest, """
+            // swift-tools-version:5.0
+            import PackageDescription
+
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                ],
+                targets: [
+                    .target(
+                        name: "exec",
+                        dependencies: []),
+                    .testTarget(
+                        name: "execTests",
+                        dependencies: ["exec"]),
+                ]
+            )
+            """)
+    }
+
+    func testAddPackageDependency2() throws {
+        let manifest = """
+            let package = Package(
+                name: "exec",
+                dependencies: [],
+                targets: [
+                    .target(name: "exec"),
+                ]
+            )
+            """
+
+
+        let editor = try ManifestRewriter(manifest)
+        try editor.addPackageDependency(
+            url: "https://github.com/foo/goo",
+            requirement: .upToNextMajor("1.0.1")
+        )
+
+        XCTAssertEqual(editor.editedManifest, """
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                ],
+                targets: [
+                    .target(name: "exec"),
+                ]
+            )
+            """)
+    }
+
+    func testAddPackageDependency3() throws {
+        let manifest = """
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    // Here is a comment.
+                    .package(url: "https://github.com/foo/bar", .branch("master")),
+                ],
+                targets: [
+                    .target(name: "exec"),
+                ]
+            )
+            """
+
+
+        let editor = try ManifestRewriter(manifest)
+        try editor.addPackageDependency(
+            url: "https://github.com/foo/goo",
+            requirement: .upToNextMajor("1.0.1")
+        )
+
+        XCTAssertEqual(editor.editedManifest, """
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    // Here is a comment.
+                    .package(url: "https://github.com/foo/bar", .branch("master")),
+                    .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                ],
+                targets: [
+                    .target(name: "exec"),
+                ]
+            )
+            """)
+    }
+
+    func testAddPackageDependency4() throws {
+        let manifest = """
+            let package = Package(
+                name: "exec",
+                targets: [
+                    .target(name: "exec"),
+                ]
+            )
+            """
+
+
+        let editor = try ManifestRewriter(manifest)
+        try editor.addPackageDependency(
+            url: "https://github.com/foo/goo",
+            requirement: .upToNextMajor("1.0.1")
+        )
+
+        XCTAssertEqual(editor.editedManifest, """
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                ],
+                targets: [
+                    .target(name: "exec"),
+                ]
+            )
+            """)
+    }
+
+    func testAddPackageDependency5() throws {
+        // FIXME: This is broken, we end up removing the comment.
+        let manifest = """
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    // Here is a comment.
+                ],
+                targets: [
+                    .target(name: "exec"),
+                ]
+            )
+            """
+
+
+        let editor = try ManifestRewriter(manifest)
+        try editor.addPackageDependency(
+            url: "https://github.com/foo/goo",
+            requirement: .upToNextMajor("1.0.1")
+        )
+
+        XCTAssertEqual(editor.editedManifest, """
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                ],
+                targets: [
+                    .target(name: "exec"),
+                ]
+            )
+            """)
+    }
+
+    func testAddPackageDependency6() throws {
+        let manifest = """
+            let myDeps = [
+                .package(url: "https://github.com/foo/foo", from: "1.0.2"),
+            ]
+
+            let package = Package(
+                name: "exec",
+                dependencies: myDeps + [
+                    .package(url: "https://github.com/foo/bar", from: "1.0.3"),
+                ],
+                targets: [
+                    .target(name: "exec"),
+                ]
+            )
+            """
+
+
+        let editor = try ManifestRewriter(manifest)
+        try editor.addPackageDependency(
+            url: "https://github.com/foo/goo",
+            requirement: .upToNextMajor("1.0.1")
+        )
+
+        XCTAssertEqual(editor.editedManifest, """
+            let myDeps = [
+                .package(url: "https://github.com/foo/foo", from: "1.0.2"),
+            ]
+
+            let package = Package(
+                name: "exec",
+                dependencies: myDeps + [
+                    .package(url: "https://github.com/foo/bar", from: "1.0.3"),
+                    .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                ],
+                targets: [
+                    .target(name: "exec"),
+                ]
+            )
+            """)
+    }
+}

--- a/Tests/SPMPackageEditorTests/AddTargetDependencyTests.swift
+++ b/Tests/SPMPackageEditorTests/AddTargetDependencyTests.swift
@@ -1,0 +1,142 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2019 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+@testable import SPMPackageEditor
+
+final class AddTargetDependencyTests: XCTestCase {
+    func testAddTargetDependency() throws {
+        let manifest = """
+            // swift-tools-version:5.0
+            import PackageDescription
+
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                ],
+                targets: [
+                    .target(
+                        name: "a",
+                        dependencies: []),
+                    .target(
+                        name: "exec",
+                        dependencies: []),
+                    .target(
+                        name: "c",
+                        dependencies: []),
+                    .testTarget(
+                        name: "execTests",
+                        dependencies: ["exec"]),
+                ]
+            )
+            """
+        
+        let editor = try ManifestRewriter(manifest)
+        try editor.addTargetDependency(
+            target: "exec", dependency: "foo")
+        try editor.addTargetDependency(
+            target: "exec", dependency: "bar")
+        try editor.addTargetDependency(
+            target: "execTests", dependency: "foo")
+
+        XCTAssertEqual(editor.editedManifest, """
+            // swift-tools-version:5.0
+            import PackageDescription
+
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                ],
+                targets: [
+                    .target(
+                        name: "a",
+                        dependencies: []),
+                    .target(
+                        name: "exec",
+                        dependencies: ["foo", "bar"]),
+                    .target(
+                        name: "c",
+                        dependencies: []),
+                    .testTarget(
+                        name: "execTests",
+                        dependencies: ["exec", "foo"]),
+                ]
+            )
+            """)
+    }
+
+    func testAddTargetDependency2() throws {
+        let manifest = """
+            let package = Package(
+                name: "exec",
+                targets: [
+                    .target(
+                        name: "foo",
+                        dependencies: ["bar"]),
+                    .target(
+                        name: "foo1",
+                        dependencies: ["bar",]),
+                    .target(
+                        name: "foo2",
+                        dependencies: []),
+                    .target(
+                        name: "foo3",
+                        dependencies: ["foo", "bar"]),
+                    .target(
+                        name: "foo4",
+                        dependencies: [
+                            "foo", "bar"
+                        ]),
+                ]
+            )
+            """
+
+        let editor = try ManifestRewriter(manifest)
+        try editor.addTargetDependency(
+            target: "foo", dependency: "dep")
+        try editor.addTargetDependency(
+            target: "foo1", dependency: "dep")
+        try editor.addTargetDependency(
+            target: "foo2", dependency: "dep")
+        try editor.addTargetDependency(
+            target: "foo3", dependency: "dep")
+        try editor.addTargetDependency(
+            target: "foo4", dependency: "dep")
+
+        XCTAssertEqual(editor.editedManifest, """
+            let package = Package(
+                name: "exec",
+                targets: [
+                    .target(
+                        name: "foo",
+                        dependencies: ["bar", "dep"]),
+                    .target(
+                        name: "foo1",
+                        dependencies: ["bar", "dep"]),
+                    .target(
+                        name: "foo2",
+                        dependencies: ["dep"]),
+                    .target(
+                        name: "foo3",
+                        dependencies: ["foo", "bar", "dep"]),
+                    .target(
+                        name: "foo4",
+                        dependencies: [
+                            "foo", "bar", "dep"
+                        ]),
+                ]
+            )
+            """)
+    }
+
+}

--- a/Tests/SPMPackageEditorTests/AddTargetTests.swift
+++ b/Tests/SPMPackageEditorTests/AddTargetTests.swift
@@ -1,0 +1,74 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2019 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+@testable import SPMPackageEditor
+
+final class AddTargetTests: XCTestCase {
+    func testAddTarget() throws {
+        let manifest = """
+            // swift-tools-version:5.0
+            import PackageDescription
+
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                ],
+                targets: [
+                    .target(
+                        name: "foo",
+                        dependencies: []),
+                    .target(
+                        name: "bar",
+                        dependencies: []),
+                    .testTarget(
+                        name: "fooTests",
+                        dependencies: ["foo", "bar"]),
+                ]
+            )
+            """
+        
+        let editor = try ManifestRewriter(manifest)
+        try editor.addTarget(targetName: "NewTarget")
+        try editor.addTarget(targetName: "NewTargetTests", type: .test)
+        try editor.addTargetDependency(target: "NewTargetTests", dependency: "NewTarget")
+
+        XCTAssertEqual(editor.editedManifest, """
+            // swift-tools-version:5.0
+            import PackageDescription
+
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                ],
+                targets: [
+                    .target(
+                        name: "foo",
+                        dependencies: []),
+                    .target(
+                        name: "bar",
+                        dependencies: []),
+                    .testTarget(
+                        name: "fooTests",
+                        dependencies: ["foo", "bar"]),
+                    .target(
+                        name: "NewTarget",
+                        dependencies: []),
+                    .testTarget(
+                        name: "NewTargetTests",
+                        dependencies: ["NewTarget"]),
+                ]
+            )
+            """)
+    }
+}

--- a/Tests/SPMPackageEditorTests/PackageEditorTests.swift
+++ b/Tests/SPMPackageEditorTests/PackageEditorTests.swift
@@ -1,0 +1,97 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2019 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import Basic
+import TestSupport
+
+@testable import SPMPackageEditor
+
+final class PackageEditorTests: XCTestCase {
+    func testAddTarget() throws {
+        let manifest = """
+            // swift-tools-version:5.0
+            import PackageDescription
+
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                ],
+                targets: [
+                    .target(
+                        name: "foo",
+                        dependencies: []),
+                    .target(
+                        name: "bar",
+                        dependencies: []),
+                    .testTarget(
+                        name: "fooTests",
+                        dependencies: ["foo", "bar"]),
+                ]
+            )
+            """
+
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/pkg/Package.swift",
+            "/pkg/Sources/foo/source.swift",
+            "/pkg/Sources/bar/source.swift",
+            "/pkg/Tests/fooTests/source.swift",
+            "end")
+
+        let manifestPath = AbsolutePath("/pkg/Package.swift")
+        try fs.writeFileContents(manifestPath) { $0 <<< manifest }
+
+        let context = try PackageEditorContext(
+            buildDir: AbsolutePath("/pkg/foo"), fs: fs)
+        let editor = PackageEditor(context: context)
+
+        XCTAssertThrows(StringError("Already has a target named foo")) {
+            try editor.addTarget(options:
+                .init(manifestPath: manifestPath, targetName: "foo"))
+        }
+
+        try editor.addTarget(options:
+            .init(manifestPath: manifestPath, targetName: "baz"))
+
+        let newManifest = try fs.readFileContents(manifestPath).cString
+        XCTAssertEqual(newManifest, """
+            // swift-tools-version:5.0
+            import PackageDescription
+
+            let package = Package(
+                name: "exec",
+                dependencies: [
+                    .package(url: "https://github.com/foo/goo", from: "1.0.1"),
+                ],
+                targets: [
+                    .target(
+                        name: "foo",
+                        dependencies: []),
+                    .target(
+                        name: "bar",
+                        dependencies: []),
+                    .testTarget(
+                        name: "fooTests",
+                        dependencies: ["foo", "bar"]),
+                    .target(
+                        name: "baz",
+                        dependencies: []),
+                    .testTarget(
+                        name: "bazTests",
+                        dependencies: ["baz"]),
+                ]
+            )
+            """)
+
+        XCTAssertTrue(fs.exists(AbsolutePath("/pkg/Sources/baz/baz.swift")))
+        XCTAssertTrue(fs.exists(AbsolutePath("/pkg/Tests/bazTests/bazTests.swift")))
+    }
+}


### PR DESCRIPTION
This adds functionality to mechanically edit the Package.swift file
using the SwiftSyntax library. The functionality is encapsulated in
a PackageEditor target and is driven using a new "swiftpm-manifest-tool"
tool. This tool is an implementation detail and the actual functionality
will be available using the `swift package` tool.