### PR TITLE
Move dynamicLibraryExtension to an extension method on Triple

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -631,7 +631,7 @@ public final class ProductBuildDescription {
         case .library(.static):
             return RelativePath("lib\(name).a")
         case .library(.dynamic):
-            return RelativePath("lib\(name).\(self.buildParameters.toolchain.dynamicLibraryExtension)")
+            return RelativePath("lib\(name)\(self.buildParameters.triple.dynamicLibraryExtension)")
         case .library(.automatic):
             fatalError()
         case .test:

--- a/Sources/Build/Toolchain.swift
+++ b/Sources/Build/Toolchain.swift
@@ -34,9 +34,6 @@ public protocol Toolchain {
 
     /// Additional flags to be passed when compiling with C++.
     var extraCPPFlags: [String] { get }
-
-    /// The dynamic library extension, for e.g. dylib, so.
-    var dynamicLibraryExtension: String { get }
 }
 
 extension Toolchain {

--- a/Sources/Build/Triple.swift
+++ b/Sources/Build/Triple.swift
@@ -151,3 +151,17 @@ public struct Triple {
     #endif
   #endif
 }
+
+extension Triple {
+    /// The file extension for dynamic libraries (eg. `.dll`, `.so`, or `.dylib`)
+    public var dynamicLibraryExtension: String {
+        switch os {
+        case .darwin, .macOS:
+            return ".dylib"
+        case .linux:
+            return ".so"
+        case .windows:
+            return ".dll"
+        }
+    }
+}

--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -43,9 +43,6 @@ public struct Destination {
     /// The binDir in the containing the compilers/linker to be used for the compilation.
     public let binDir: AbsolutePath
 
-    /// The file extension for dynamic libraries (eg. `.so` or `.dylib`)
-    public let dynamicLibraryExtension: String
-
     /// The compiler flag for specifying the sysroot (eg. `--sysroot` or `-isysroot`).
     public let sysrootFlag: String
 
@@ -117,7 +114,6 @@ public struct Destination {
             target: hostTargetTriple,
             sdk: sdkPath,
             binDir: binDir,
-            dynamicLibraryExtension: "dylib",
             sysrootFlag: "-isysroot",
             extraCCFlags: commonArgs,
             extraSwiftCFlags: commonArgs,
@@ -128,7 +124,6 @@ public struct Destination {
             target: hostTargetTriple,
             sdk: .root,
             binDir: binDir,
-            dynamicLibraryExtension: "so",
             sysrootFlag: "--sysroot",
             extraCCFlags: ["-fPIC"],
             extraSwiftCFlags: [],
@@ -156,14 +151,6 @@ public struct Destination {
 
     /// Target triple for the host system.
     private static let hostTargetTriple = Triple.hostTriple
-
-  #if os(macOS)
-    /// Returns the host's dynamic library extension.
-    public static let hostDynamicLibraryExtension = "dylib"
-  #else
-    /// Returns the host's dynamic library extension.
-    public static let hostDynamicLibraryExtension = "so"
-  #endif
 }
 
 extension Destination {
@@ -191,7 +178,6 @@ extension Destination: JSONMappable {
             target: Triple(json.get("target")),
             sdk: AbsolutePath(json.get("sdk")),
             binDir: AbsolutePath(json.get("toolchain-bin-dir")),
-            dynamicLibraryExtension: json.get("dynamic-library-extension"),
             sysrootFlag: json.get("sysroot-flag"),
             extraCCFlags: json.get("extra-cc-flags"),
             extraSwiftCFlags: json.get("extra-swiftc-flags"),

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -56,10 +56,6 @@ public final class UserToolchain: Toolchain {
         return destination.extraCPPFlags
     }
 
-    public var dynamicLibraryExtension: String {
-        return destination.dynamicLibraryExtension
-    }
-
     /// Path of the `swift` interpreter.
     public var swiftInterpreter: AbsolutePath {
         return swiftCompiler.parentDirectory.appending(component: "swift")

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -27,11 +27,6 @@ private struct MockToolchain: Toolchain {
     #else
     let extraCPPFlags: [String] = ["-lstdc++"]
     #endif
-  #if os(macOS)
-    let dynamicLibraryExtension = "dylib"
-  #else
-    let dynamicLibraryExtension = "so"
-  #endif
     func getClangCompiler() throws -> AbsolutePath {
         return AbsolutePath("/fake/path/to/clang")
     }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -21,10 +21,6 @@ typealias ProcessID = Basic.Process.ProcessID
 
 class MiscellaneousTestCase: XCTestCase {
 
-    private var dynamicLibraryExtension: String {
-        return Destination.hostDynamicLibraryExtension
-    }
-
     func testPrintsSelectedDependencyVersion() {
 
         // verifies the stdout contains information about
@@ -276,7 +272,7 @@ class MiscellaneousTestCase: XCTestCase {
             let systemModule = prefix.appending(component: "SystemModule")
             // Create a shared library.
             let input = systemModule.appending(components: "Sources", "SystemModule.c")
-            let output =  systemModule.appending(component: "libSystemModule.\(dynamicLibraryExtension)")
+            let output =  systemModule.appending(component: "libSystemModule\(Destination.host.target.dynamicLibraryExtension)")
             try systemQuietly(["clang", "-shared", input.pathString, "-o", output.pathString])
 
             let pcFile = prefix.appending(component: "libSystemModule.pc")

--- a/Tests/FunctionalTests/ModuleMapTests.swift
+++ b/Tests/FunctionalTests/ModuleMapTests.swift
@@ -22,7 +22,7 @@ class ModuleMapsTestCase: XCTestCase {
             let input = prefix.appending(components: cModuleName, "C", "foo.c")
             let outdir = prefix.appending(components: rootpkg, ".build", Destination.host.target.tripleString, "debug")
             try makeDirectories(outdir)
-            let output = outdir.appending(component: "libfoo.\(Destination.host.dynamicLibraryExtension)")
+            let output = outdir.appending(component: "libfoo\(Destination.host.target.dynamicLibraryExtension)")
             try systemQuietly(["clang", "-shared", input.pathString, "-o", output.pathString])
 
             var Xld = ["-L", outdir.pathString]

--- a/Utilities/build_ubuntu_cross_compilation_toolchain
+++ b/Utilities/build_ubuntu_cross_compilation_toolchain
@@ -239,7 +239,6 @@ cat > "$cross_tc_basename/ubuntu-xenial-destination.json" <<EOF
     "sdk": "$(pwd)/$cross_tc_basename/$linux_sdk_name",
     "toolchain-bin-dir": "$(pwd)/$cross_tc_basename/$xc_tc_name/usr/bin",
     "target": "x86_64-unknown-linux",
-    "dynamic-library-extension": "so",
     "extra-cc-flags": [
         "-fPIC"
     ],


### PR DESCRIPTION
The dynamic library extension is entirely derivable from the target
triple and does not need to be parameterized nor be made part of the
Toolchain.