### PR TITLE
Clean up some compile time checks which should be runtime

### DIFF
--- a/Sources/Basic/FileSystem.swift
+++ b/Sources/Basic/FileSystem.swift
@@ -275,15 +275,11 @@ private class LocalFileSystem: FileSystem {
     }
 
     var homeDirectory: AbsolutePath {
-      #if os(macOS)
         if #available(macOS 10.12, *) {
             return AbsolutePath(FileManager.default.homeDirectoryForCurrentUser.path)
         } else {
-            fatalError("Unsupported OS")
+            return AbsolutePath(NSHomeDirectory())
         }
-      #else
-        return AbsolutePath(FileManager.default.homeDirectoryForCurrentUser.path)
-      #endif
     }
 
     func getDirectoryContents(_ path: AbsolutePath) throws -> [String] {

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -729,9 +729,9 @@ public final class ProductBuildDescription {
             // Link the Swift stdlib statically if requested.
             if buildParameters.shouldLinkStaticSwiftStdlib {
                 // FIXME: This does not work for linux yet (SR-648).
-              #if os(macOS)
-                args += ["-static-stdlib"]
-              #endif
+                if !buildParameters.triple.isLinux() {
+                    args += ["-static-stdlib"]
+                }
             }
             args += ["-emit-executable"]
         }


### PR DESCRIPTION
- FileSystem: `if #available(macOS 10.12, *)` is also true on Linux, so
  the #if is a no-op
- The exclusion of -static-stdlib has nothing to do with the host OS,
  this correctly excludes the flag when the *target* is Linux so that
  this works correctly when building on Linux or x-compiling from macOS