### PR TITLE
Move sysrootFlag into UserToolchain

### DIFF
--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -43,9 +43,6 @@ public struct Destination {
     /// The binDir in the containing the compilers/linker to be used for the compilation.
     public let binDir: AbsolutePath
 
-    /// The compiler flag for specifying the sysroot (eg. `--sysroot` or `-isysroot`).
-    public let sysrootFlag: String
-
     /// Additional flags to be passed to the C compiler.
     public let extraCCFlags: [String]
 
@@ -114,7 +111,6 @@ public struct Destination {
             target: hostTargetTriple,
             sdk: sdkPath,
             binDir: binDir,
-            sysrootFlag: "-isysroot",
             extraCCFlags: commonArgs,
             extraSwiftCFlags: commonArgs,
             extraCPPFlags: ["-lc++"]
@@ -124,7 +120,6 @@ public struct Destination {
             target: hostTargetTriple,
             sdk: .root,
             binDir: binDir,
-            sysrootFlag: "--sysroot",
             extraCCFlags: ["-fPIC"],
             extraSwiftCFlags: [],
             extraCPPFlags: ["-lstdc++"]
@@ -178,7 +173,6 @@ extension Destination: JSONMappable {
             target: Triple(json.get("target")),
             sdk: AbsolutePath(json.get("sdk")),
             binDir: AbsolutePath(json.get("toolchain-bin-dir")),
-            sysrootFlag: json.get("sysroot-flag"),
             extraCCFlags: json.get("extra-cc-flags"),
             extraSwiftCFlags: json.get("extra-swiftc-flags"),
             extraCPPFlags: json.get("extra-cpp-flags")

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -229,7 +229,7 @@ public final class UserToolchain: Toolchain {
         ] + destination.extraSwiftCFlags
 
         self.extraCCFlags = [
-            destination.sysrootFlag, destination.sdk.pathString
+            destination.target.isDarwin() ? "-isysroot" : "--sysroot", destination.sdk.pathString
         ] + destination.extraCCFlags
 
         // Compute the path of directory containing the PackageDescription libraries.


### PR DESCRIPTION
This is also something that doesn't belong here and is not useful
to override at this level.