### PR TITLE
Add .swiftpm and Package.resolved to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ xcuserdata
 /default.profraw
 *.xcodeproj
 Utilities/Docker/*.tar.gz
+.swiftpm
+Package.resolved


### PR DESCRIPTION
We shouldn't be tracking these for SwiftPM unless really need to.