### PR TITLE
[Pubgrub] Kill Solution.versionIntersection(for:)

### DIFF
--- a/Sources/PackageGraph/Pubgrub.swift
+++ b/Sources/PackageGraph/Pubgrub.swift
@@ -1294,49 +1294,10 @@ public final class PubgrubDependencyResolver<
 
     /// Returns the best available version for a given term.
     func getBestAvailableVersion(for term: Term<Identifier>) throws -> Version? {
-        let container = try! getContainer(for: term.package)
-        let availableVersions = container.versions(filter: { term.isSatisfied(by: $0)} )
-
-        // FIXME: Clean this up.
-        for version in availableVersions {
-            // If there is an existing single-positive-term incompatibility
-            // that forbids this version, we should skip right to trying the
-            // next one.
-            let requirements = incompatibilities[term.package]?
-                .filter {
-                    $0.terms.count == 1 &&
-                        $0.terms.first?.package == term.package &&
-                        $0.terms.first?.isPositive == true
-                }
-                .map {
-                    $0.terms.first!.requirement
-            }
-
-            for forbidden in requirements ?? [] {
-                switch forbidden {
-                case .versionSet(let versionSet):
-                    switch versionSet {
-                    case .any:
-                        continue
-                    case .range(let forbidden):
-                        if forbidden.contains(version: version) {
-                            continue
-                        }
-                    case .exact(let forbidden):
-                        if forbidden == version {
-                            continue
-                        }
-                    case .empty:
-                        break
-                    }
-                default:
-                    break
-                }
-            }
-            return version
-        }
-
-        return nil
+        assert(term.isPositive, "Expected term to be positive")
+        let container = try getContainer(for: term.package)
+        let availableVersions = container.versions(filter: { term.isSatisfied(by: $0) } )
+        return availableVersions.first{ _ in true }
     }
 
     /// Returns the incompatibilities of a package at the given version.

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -411,18 +411,18 @@ final class PubgrubTests: XCTestCase {
         XCTAssertEqual(solution.decisionLevel, 1)
     }
 
-    func testSolutionVersionIntersection() {
+    func testPositiveTerms() {
         let s1 = PartialSolution(assignments: [
             .derivation("a^1.0.0", cause: _cause, decisionLevel: 0),
         ])
-        XCTAssertEqual(s1.versionIntersection(for: "a")?.requirement,
+        XCTAssertEqual(s1._positive["a"]?.requirement,
                        .versionSet(.range("1.0.0"..<"2.0.0")))
 
         let s2 = PartialSolution(assignments: [
             .derivation("a^1.0.0", cause: _cause, decisionLevel: 0),
             .derivation("a^1.5.0", cause: _cause, decisionLevel: 0)
         ])
-        XCTAssertEqual(s2.versionIntersection(for: "a")?.requirement,
+        XCTAssertEqual(s2._positive["a"]?.requirement,
                        .versionSet(.range("1.5.0"..<"2.0.0")))
     }
 

--- a/Tests/PackageGraphTests/XCTestManifests.swift
+++ b/Tests/PackageGraphTests/XCTestManifests.swift
@@ -56,6 +56,7 @@ extension PubgrubTests {
     static let __allTests__PubgrubTests = [
         ("testIncompatibilityNormalizeTermsOnInit", testIncompatibilityNormalizeTermsOnInit),
         ("testMissingVersion", testMissingVersion),
+        ("testPositiveTerms", testPositiveTerms),
         ("testResolutionAvoidingConflictResolutionDuringDecisionMaking", testResolutionAvoidingConflictResolutionDuringDecisionMaking),
         ("testResolutionConflictResolutionWithAPartialSatisfier", testResolutionConflictResolutionWithAPartialSatisfier),
         ("testResolutionNoConflicts", testResolutionNoConflicts),
@@ -69,7 +70,6 @@ extension PubgrubTests {
         ("testSolutionIsFinished", testSolutionIsFinished),
         ("testSolutionPositive", testSolutionPositive),
         ("testSolutionUndecided", testSolutionUndecided),
-        ("testSolutionVersionIntersection", testSolutionVersionIntersection),
         ("testTermIntersection", testTermIntersection),
         ("testTermInverse", testTermInverse),
         ("testTermIsValidDecision", testTermIsValidDecision),


### PR DESCRIPTION
This is no longer required because the postive dictionary already
contains the intersections.