### PR TITLE
Add `platforms` to dump-package output

### DIFF
--- a/Fixtures/DependencyResolution/External/Complex/app/Package.swift
+++ b/Fixtures/DependencyResolution/External/Complex/app/Package.swift
@@ -1,8 +1,14 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
     name: "Dealer",
+    platforms: [
+        .macOS(.v10_12),
+        .iOS(.v10),
+        .tvOS(.v11),
+        .watchOS(.v5)
+    ],
     dependencies: [
         .package(url: "../deck-of-playing-cards", from: "1.0.0"),
     ],

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -175,6 +175,7 @@ extension Manifest {
         try container.encode(dependencies, forKey: .dependencies)
         try container.encode(products, forKey: .products)
         try container.encode(targets, forKey: .targets)
+        try container.encode(platforms, forKey: .platforms)
     }
 }
 

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -107,7 +107,26 @@ final class PackageToolTests: XCTestCase {
             let json = try JSON(bytes: ByteString(encodingAsUTF8: dumpOutput))
             guard case let .dictionary(contents) = json else { XCTFail("unexpected result"); return }
             guard case let .string(name)? = contents["name"] else { XCTFail("unexpected result"); return }
+            guard case let .array(platforms)? = contents["platforms"] else { XCTFail("unexpected result"); return }
             XCTAssertEqual(name, "Dealer")
+            XCTAssertEqual(platforms, [
+                .dictionary([
+                    "platformName": .string("macos"),
+                    "version": .string("10.12")
+                ]),
+                .dictionary([
+                    "platformName": .string("ios"),
+                    "version": .string("10.0")
+                ]),
+                .dictionary([
+                    "platformName": .string("tvos"),
+                    "version": .string("11.0")
+                ]),
+                .dictionary([
+                    "platformName": .string("watchos"),
+                    "version": .string("5.0")
+                ]),
+            ])
         }
     }
 


### PR DESCRIPTION
Supplements one fixture to validate the platforms output.

Clone of #1991 