### PR TITLE
Fix SR-7829: Bad error message when a tag doesn't exist

### DIFF
--- a/Sources/TestSupport/DiagnosticsEngine.swift
+++ b/Sources/TestSupport/DiagnosticsEngine.swift
@@ -26,7 +26,7 @@ public enum StringCheck: ExpressibleByStringLiteral {
         case .equal(let str):
             XCTAssertEqual(str, input, file: file, line: line)
         case .contains(let str):
-            XCTAssert(input.contains(str), "\(str) does not contain \(input)", file: file, line: line)
+            XCTAssert(input.contains(str), "\(input) does not contain \(str)", file: file, line: line)
         }
     }
 


### PR DESCRIPTION
Fixes [SR-7829](https://bugs.swift.org/browse/SR-7829).

Hi, this is my first contribution here, so let me know if there's anything I should do differently!

Given a `Package.swift` which depends on a tag which does not exist, like so:
```swift
.package(url: "https://github.com/apple/swift-package-manager.git", .exact("123.0.0"))
```
SwiftPM would generate a diagnostic like this:
```
error: dependency graph is unresolvable; found these conflicting requirements:

Dependencies: 
    https://github.com/apple/swift-package-manager.git @ 123.0.0
```
After this patch it generates this error:
```
error: couldn't find tags for the following specified versions:
    swift-package-manager[https://github.com/apple/swift-package-manager.git] @ 123.0.0
```

Some questions:
1. Is the place I do the diagnosis here a reasonable place to do so? 
2. Does it make sense to make this its own `DependencyResolverError`? The current solution prevents an unsatisfiable error from being thrown in the case that there's a missing tag in any of the dependencies. I thought that made sense because an error like this might confuse the rest of the dependency graph, but I could instead try to emit both diagnostics.
3. How does the wording of the error message sound? Should I switch to using the `PackageReference`'s `.path` instead of using its description? I modeled it off `DependencyResolverError.incompatibleConstraints`, but the original error just uses the path.