### PR TITLE
[Pubgrub] Minor changes

### DIFF
--- a/Sources/PackageGraph/Pubgrub.swift
+++ b/Sources/PackageGraph/Pubgrub.swift
@@ -797,14 +797,7 @@ public final class PubgrubDependencyResolver {
         }
         decide(root, version: "1.0.0", location: .topLevel)
 
-        do {
-            try run()
-        } catch PubgrubError.unresolvable(let conflict) {
-            throw PubgrubError.unresolvable(conflict)
-        } catch {
-            assertionFailure("Unexpected error \(error)")
-            throw error
-        }
+        try run()
 
         let decisions = solution.assignments.filter { $0.isDecision }
         let finalAssignments: [(container: PackageReference, binding: BoundVersion)] = decisions.map { assignment in

--- a/Sources/PackageGraph/Pubgrub.swift
+++ b/Sources/PackageGraph/Pubgrub.swift
@@ -269,6 +269,8 @@ public struct Incompatibility: Equatable, Hashable {
         }
 
         let normalizedTerms = normalize(terms: terms.contents)
+        assert(normalizedTerms.count > 0,
+               "An incompatibility must contain at least one term after normalization.")
         self.init(terms: OrderedSet(normalizedTerms), cause: cause)
     }
 }
@@ -995,7 +997,6 @@ public final class PubgrubDependencyResolver {
     /// failed, meaning this incompatibility is either empty or only for the root
     /// package.
     private func isCompleteFailure(_ incompatibility: Incompatibility) -> Bool {
-        guard !incompatibility.terms.isEmpty else { return true }
         return incompatibility.terms.count == 1 && incompatibility.terms.first?.package == root
     }
 

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -133,8 +133,8 @@ class DependencyGraphBuilder {
     }
 
     func serve(root: String, with dependencies: [String: VersionSetSpecifier]) {
-        let rootDependencies = dependencies.map {
-            (package: reference(for: $0), requirement: $1)
+        let rootDependencies = dependencies.keys.sorted().map {
+            (package: reference(for: $0), requirement: dependencies[$0]!)
         }
 
         let rootContainer = MockContainer(name: reference(for: root),
@@ -796,10 +796,7 @@ final class PubgrubTests: XCTestCase {
             return XCTFail("Expected unresolvable graph.")
         }
 
-        // FIXME: This is non-deterministic.
-        var foundCause = cause.description == "{foo 1.0.0..<2.0.0}"
-        foundCause = foundCause || cause.description == "{bar 1.0.0..<2.0.0}"
-        XCTAssertTrue(foundCause, "\(cause)")
+        XCTAssertEqual(cause.description, "{foo 1.0.0..<2.0.0}")
     }
 
     func testConflict2() {

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -142,16 +142,6 @@ class DependencyGraphBuilder {
         self.containers[root] = rootContainer
     }
 
-    func serve(root: String, with dependencies: [(String, VersionSetSpecifier)]) {
-        let rootDependencies = dependencies.map {
-            (package: reference(for: $0), requirement: $1)
-        }
-
-        let rootContainer = MockContainer(name: reference(for: root),
-                                          unversionedDependencies: rootDependencies)
-        self.containers[root] = rootContainer
-    }
-
     func serve(_ package: String, at version: Version, with dependencies: [String: VersionSetSpecifier] = [:]) {
         let packageReference = reference(for: package)
         let container = self.containers[package] ?? MockContainer(name: packageReference)
@@ -816,16 +806,16 @@ final class PubgrubTests: XCTestCase {
         }
 
         builder.serve(root: "root", with: [
-            ("config", v2Range),
-            ("foo", v1Range),
+            "config": v2Range,
+            "foo": v1Range,
         ])
         addDeps()
         let resolver1 = builder.create()
         _ = resolver1.solve(root: rootRef, pins: [])
 
         builder.serve(root: "root", with: [
-            ("foo", v1Range),
-            ("config", v2Range),
+            "foo": v1Range,
+            "config": v2Range,
         ])
         addDeps()
         let resolver2 = builder.create()
@@ -834,8 +824,8 @@ final class PubgrubTests: XCTestCase {
 
     func testConflict3() {
         builder.serve(root: "root", with: [
-            ("foo", v1Range),
-            ("config", v2Range),
+            "foo": v1Range,
+            "config": v2Range,
         ])
         builder.serve("foo", at: v1, with: ["config": v1Range])
         builder.serve("config", at: v1)
@@ -851,7 +841,7 @@ final class PubgrubTests: XCTestCase {
             return XCTFail("Expected unresolvable graph.")
         }
 
-        XCTAssertEqual(cause.description, "{config 2.0.0..<3.0.0}")
+        XCTAssertEqual(cause.description, "{foo 1.0.0..<2.0.0}")
     }
 }
 

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -770,11 +770,20 @@ final class PubgrubTests: XCTestCase {
         XCTAssertEqual(unavailable.description, "{package 1.0.0}")
     }
 
-    func DISABLED_testNonExistentPackage() {
+    func testNonExistentPackage() {
         builder.serve(root: "root", with: ["package": .exact(v1)])
 
         let resolver = builder.create()
-        _ = resolver.solve(root: rootRef, pins: [])
+        let result = resolver.solve(root: rootRef, pins: [])
+
+        guard
+            case .error(let error) = result,
+            let anyError = error as? AnyError,
+            let mockError = anyError.underlyingError as? _MockLoadingError,
+            case .unknownModule = mockError
+        else {
+            return XCTFail("Expected unknown module error.")
+        }
     }
 
     func testConflict1() {


### PR DESCRIPTION
Fix non-determinism in tests (thanks to dict iteration in DependencyGraphBuilder) and bubble up errors instead of asserting on non-pubgrub errors. Also assert that incompatibilities have at least a single term after normalization so that the check for that in `isCompleteFailure` can be removed.