### PR TITLE
[Pubgrub] Print root cause directly if conflict occurs

### DIFF
--- a/Sources/PackageGraph/Pubgrub.swift
+++ b/Sources/PackageGraph/Pubgrub.swift
@@ -797,7 +797,16 @@ public final class PubgrubDependencyResolver {
         }
         decide(root, version: "1.0.0", location: .topLevel)
 
-        try run()
+        do {
+            try run()
+        } catch {
+            if let pubgrubError = error as? PubgrubError,
+                case .unresolvable(let incompatibility) = pubgrubError,
+                case .conflict(var cause, let other) = incompatibility.cause {
+                print("Root cause: \(cause) \(cause.cause) because of \(other) \(other.cause)")
+            }
+            throw error
+        }
 
         let decisions = solution.assignments.filter { $0.isDecision }
         let finalAssignments: [(container: PackageReference, binding: BoundVersion)] = try decisions.compactMap { assignment in


### PR DESCRIPTION
A temporary change, outputting the root cause directly in case of conflict.

The output looks like this:
`
Root cause: {cache[https://github.com/tettoffensive/Cache.git] 4.1.3..<4.2.0} noAvailableVersion because of {¬cache[https://github.com/tettoffensive/Cache.git] 4.1.3..<4.2.0, myserver[/Users/kilian/Desktop/Ian] 1.0.0} root
`