### PR TITLE
[PackageGraph] Use basename as identity of root packages

### DIFF
--- a/Sources/PackageGraph/PackageGraphLoader.swift
+++ b/Sources/PackageGraph/PackageGraphLoader.swift
@@ -129,8 +129,7 @@ public struct PackageGraphLoader {
         // the URL but that shouldn't be needed after <rdar://problem/33693433>
         // Ensure that identity and package name are the same once we have an
         // API to specify identity in the manifest file
-        let manifestMapSequence = root.manifests.map({ ($0.name.lowercased(), $0) }) +
-            externalManifests.map({ (PackageReference.computeIdentity(packageURL: $0.url), $0) })
+        let manifestMapSequence = (root.manifests + externalManifests).map({ (PackageReference.computeIdentity(packageURL: $0.url), $0) })
         let manifestMap = Dictionary(uniqueKeysWithValues: manifestMapSequence)
         let successors: (Manifest) -> [Manifest] = { manifest in
             manifest.dependencies.compactMap({
@@ -269,7 +268,7 @@ private func createResolvedPackages(
     // Create a map of package builders keyed by the package identity.
     let packageMap: [String: ResolvedPackageBuilder] = packageBuilders.spm_createDictionary({
         // FIXME: This shouldn't be needed once <rdar://problem/33693433> is fixed.
-        let identity = rootManifestSet.contains($0.package.manifest) ? $0.package.name.lowercased() : PackageReference.computeIdentity(packageURL: $0.package.manifest.url)
+        let identity = PackageReference.computeIdentity(packageURL: $0.package.manifest.url)
         return (identity, $0)
     })
 

--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -95,7 +95,8 @@ public struct PackageGraphRoot {
     /// Create a package graph root.
     public init(input: PackageGraphRootInput, manifests: [Manifest]) {
         self.packageRefs = zip(input.packages, manifests).map { (path, manifest) in
-            PackageReference(identity: manifest.name.lowercased(), path: path.pathString, isLocal: true)
+            let identity = PackageReference.computeIdentity(packageURL: manifest.url)
+            return PackageReference(identity: identity, path: path.pathString, isLocal: true)
         }
         self.manifests = manifests
         self.dependencies = input.dependencies

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -161,12 +161,13 @@ public class Workspace {
         }
 
         func computePackageURLs() -> (required: Set<PackageReference>, missing: Set<PackageReference>) {
-            let manifestsMap = Dictionary(items:
-                root.manifests.map({ ($0.name.lowercased(), $0) }) +
+            let manifestsMap: [String: Manifest] = Dictionary(items:
+                root.manifests.map({ (PackageReference.computeIdentity(packageURL: $0.url), $0) }) +
                 dependencies.map({ (PackageReference.computeIdentity(packageURL: $0.manifest.url), $0.manifest) }))
 
-            let inputIdentities = root.manifests.map({
-                PackageReference(identity: $0.name.lowercased(), path: $0.url)
+            let inputIdentities: [PackageReference] = root.manifests.map({
+                let identity = PackageReference.computeIdentity(packageURL: $0.url)
+                return PackageReference(identity: identity, path: $0.url)
             }) + root.dependencies.map({
                 let url = workspace.config.mirroredURL(forURL: $0.url)
                 let identity = PackageReference.computeIdentity(packageURL: url)

--- a/Tests/WorkspaceTests/XCTestManifests.swift
+++ b/Tests/WorkspaceTests/XCTestManifests.swift
@@ -76,6 +76,7 @@ extension WorkspaceTests {
         ("testRevisionVersionSwitch", testRevisionVersionSwitch),
         ("testRootAsDependency1", testRootAsDependency1),
         ("testRootAsDependency2", testRootAsDependency2),
+        ("testRootPackagesOverride", testRootPackagesOverride),
         ("testSkipUpdate", testSkipUpdate),
         ("testToolsVersionRootPackages", testToolsVersionRootPackages),
         ("testTransitiveDependencySwitchWithSameIdentity", testTransitiveDependencySwitchWithSameIdentity),

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -37,7 +37,7 @@ class GenerateXcodeprojTests: XCTestCase {
                     Manifest.createV4Manifest(
                         name: "Foo",
                         path: "/",
-                        url: "/",
+                        url: "/foo",
                         targets: [
                             TargetDescription(name: "DummyModuleName"),
                         ])


### PR DESCRIPTION
Using root package's name as the identity doesn't really work properly
because there is no way to override the basename in the urls for
package dependencies. This does require that root package's basename
is same as the dependency url's basename but that is better than having
no solution for this.

<rdar://problem/48520076>