### PR TITLE
Revert "Update the build animation for each Swift compiler task"

### DIFF
--- a/Sources/Build/BuildDelegate.swift
+++ b/Sources/Build/BuildDelegate.swift
@@ -12,8 +12,6 @@ import Basic
 import SPMUtility
 import SPMLLBuild
 import Dispatch
-import Foundation
-import POSIX
 
 /// Diagnostic error when a llbuild command encounters an error.
 struct LLBuildCommandErrorDiagnostic: DiagnosticData {
@@ -162,21 +160,6 @@ struct LLBuildCommandError: DiagnosticData {
     let message: String
 }
 
-/// Swift Compiler output parsing error
-struct SwiftCompilerOutputParsingError: DiagnosticData {
-    static let id = DiagnosticID(
-        type: SwiftCompilerOutputParsingError.self,
-        name: "org.swift.diags.swift-compiler-output-parsing-error",
-        defaultBehavior: .error,
-        description: {
-            $0 <<< "failed parsing the Swift compiler output: "
-            $0 <<< { $0.message }
-        }
-    )
-
-    let message: String
-}
-
 extension SPMLLBuild.Diagnostic: DiagnosticDataConvertible {
     public var diagnosticData: DiagnosticData {
         switch kind {
@@ -188,20 +171,44 @@ extension SPMLLBuild.Diagnostic: DiagnosticDataConvertible {
 }
 
 private let newLineByte: UInt8 = 10
-public final class BuildDelegate: BuildSystemDelegate, SwiftCompilerOutputParserDelegate {
+public final class BuildDelegate: BuildSystemDelegate {
+    // Track counts of commands based on their CommandStatusKind
+    private struct CommandCounter {
+        var scanningCount = 0
+        var upToDateCount = 0
+        var completedCount = 0
+        var startedCount = 0
+
+        var estimatedMaximum: Int {
+            return completedCount + scanningCount - upToDateCount
+        }
+
+        mutating func update(command: SPMLLBuild.Command, kind: CommandStatusKind) {
+            guard command.shouldShowStatus else { return }
+
+            switch kind {
+            case .isScanning:
+                scanningCount += 1
+            case .isUpToDate:
+                scanningCount -= 1
+                upToDateCount += 1
+                completedCount += 1
+            case .isComplete:
+                scanningCount -= 1
+                completedCount += 1
+            }
+        }
+    }
+
     private let diagnostics: DiagnosticsEngine
     public var outputStream: ThreadSafeOutputByteStream
     public var progressAnimation: ProgressAnimationProtocol
-    public var onCommmandFailure: (() -> Void)?
     public var isVerbose: Bool = false
+    public var onCommmandFailure: (() -> Void)?
+    private var commandCounter = CommandCounter()
     private let queue = DispatchQueue(label: "org.swift.swiftpm.build-delegate")
-    private var taskTracker = CommandTaskTracker()
-    
-    /// Swift parsers keyed by llbuild command name.
-    private var swiftParsers: [String: SwiftCompilerOutputParser] = [:]
 
     public init(
-        plan: BuildPlan,
         diagnostics: DiagnosticsEngine,
         outputStream: OutputByteStream,
         progressAnimation: ProgressAnimationProtocol
@@ -211,12 +218,6 @@ public final class BuildDelegate: BuildSystemDelegate, SwiftCompilerOutputParser
         // https://forums.swift.org/t/allow-self-x-in-class-convenience-initializers/15924
         self.outputStream = outputStream as? ThreadSafeOutputByteStream ?? ThreadSafeOutputByteStream(outputStream)
         self.progressAnimation = progressAnimation
-
-        let buildConfig = plan.buildParameters.configuration.dirname
-        swiftParsers = Dictionary(uniqueKeysWithValues: plan.targetMap.compactMap({ (target, description) in
-            guard case .swift = description else { return nil }
-            return (target.getCommandName(config: buildConfig), SwiftCompilerOutputParser(delegate: self))
-        }))
     }
 
     public var fs: SPMLLBuild.FileSystem? {
@@ -236,6 +237,9 @@ public final class BuildDelegate: BuildSystemDelegate, SwiftCompilerOutputParser
     }
 
     public func commandStatusChanged(_ command: SPMLLBuild.Command, kind: CommandStatusKind) {
+        queue.sync {
+            commandCounter.update(command: command, kind: kind)
+        }
     }
 
     public func commandPreparing(_ command: SPMLLBuild.Command) {
@@ -243,15 +247,18 @@ public final class BuildDelegate: BuildSystemDelegate, SwiftCompilerOutputParser
 
     public func commandStarted(_ command: SPMLLBuild.Command) {
         guard command.shouldShowStatus else { return }
-        guard !swiftParsers.keys.contains(command.name) else { return }
 
         queue.sync {
+            commandCounter.startedCount += 1
+
             if isVerbose {
                 outputStream <<< command.verboseDescription <<< "\n"
                 outputStream.flush()
             } else {
-                taskTracker.commandStarted(command)
-                updateProgress()
+                progressAnimation.update(
+                    step: commandCounter.startedCount,
+                    total: commandCounter.estimatedMaximum,
+                    text: command.description)
             }
         }
     }
@@ -261,14 +268,6 @@ public final class BuildDelegate: BuildSystemDelegate, SwiftCompilerOutputParser
     }
 
     public func commandFinished(_ command: SPMLLBuild.Command, result: CommandResult) {
-        guard command.shouldShowStatus else { return }
-        guard !swiftParsers.keys.contains(command.name) else { return }
-        guard !isVerbose else { return }
-
-        queue.sync {
-            taskTracker.commandFinished(command, result: result)
-            updateProgress()
-        }
     }
 
     public func commandHadError(_ command: SPMLLBuild.Command, message: String) {
@@ -303,15 +302,9 @@ public final class BuildDelegate: BuildSystemDelegate, SwiftCompilerOutputParser
     }
 
     public func commandProcessHadOutput(_ command: SPMLLBuild.Command, process: ProcessHandle, data: [UInt8]) {
-        guard command.shouldShowStatus else { return }
-
-        if let swiftParser = swiftParsers[command.name] {
-            swiftParser.parse(bytes: data)
-        } else {
-            progressAnimation.clear()
-            outputStream <<< data
-            outputStream.flush()
-        }
+        progressAnimation.clear()
+        outputStream <<< data
+        outputStream.flush()
     }
 
     public func commandProcessFinished(
@@ -327,166 +320,5 @@ public final class BuildDelegate: BuildSystemDelegate, SwiftCompilerOutputParser
 
     public func shouldResolveCycle(rules: [BuildKey], candidate: BuildKey, action: CycleAction) -> Bool {
         return false
-    }
-
-    func swiftCompilerDidOutputMessage(_ message: SwiftCompilerMessage) {
-        queue.sync {
-            if isVerbose {
-                if let text = message.verboseProgressText {
-                    outputStream <<< text <<< "\n"
-                    outputStream.flush()
-                }
-            } else {
-                taskTracker.swiftCompilerDidOuputMessage(message)
-                updateProgress()
-            }
-
-            if let output = message.standardOutput {
-                if !isVerbose {
-                    progressAnimation.clear()
-                }
-
-                outputStream <<< output
-                outputStream.flush()
-            }
-        }
-    }
-
-    func swiftCompilerOutputParserDidFail(withError error: Error) {
-        let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
-        diagnostics.emit(data: SwiftCompilerOutputParsingError(message: message))
-        onCommmandFailure?()
-    }
-
-    private func updateProgress() {
-        if let progressText = taskTracker.latestRunningText {
-            progressAnimation.update(
-                step: taskTracker.finishedCount,
-                total: taskTracker.totalCount,
-                text: progressText)
-        }
-    }
-}
-
-/// Tracks tasks based on command status and swift compiler output.
-fileprivate struct CommandTaskTracker {
-    private struct Task {
-        let identifier: String
-        let text: String
-    }
-
-    private var tasks: [Task] = []
-    private(set) var finishedCount = 0
-    private(set) var totalCount = 0
-
-    /// The last task text before the task list was emptied.
-    private var lastText: String?
-    
-    var latestRunningText: String? {
-        return tasks.last?.text ?? lastText
-    }
-    
-    mutating func commandStarted(_ command: SPMLLBuild.Command) {
-        addTask(identifier: command.name, text: command.description)
-        totalCount += 1
-    }
-    
-    mutating func commandFinished(_ command: SPMLLBuild.Command, result: CommandResult) {
-        removeTask(identifier: command.name)
-
-        switch result {
-        case .succeeded:
-            finishedCount += 1
-        case .cancelled, .failed, .skipped:
-            break
-        }
-    }
-    
-    mutating func swiftCompilerDidOuputMessage(_ message: SwiftCompilerMessage) {
-        switch message.kind {
-        case .began(let info):
-            if let text = message.progressText {
-                addTask(identifier: info.pid.description, text: text)
-            }
-
-            totalCount += 1
-        case .finished(let info):
-            removeTask(identifier: info.pid.description)
-            finishedCount += 1
-        case .signalled(let info):
-            removeTask(identifier: info.pid.description)
-        case .skipped:
-            break
-        }
-    }
-    
-    private mutating func addTask(identifier: String, text: String) {
-        tasks.append(Task(identifier: identifier, text: text))
-    }
-    
-    private mutating func removeTask(identifier: String) {
-        if let index = tasks.index(where: { $0.identifier == identifier }) {
-            if tasks.count == 1 {
-                lastText = tasks[0].text
-            }
-
-            tasks.remove(at: index)
-        }
-    }
-}
-
-extension SwiftCompilerMessage {
-    fileprivate var progressText: String? {
-        if case .began(let info) = kind {
-            switch name {
-            case "compile":
-                if let sourceFile = info.inputs.first {
-                    return generateProgressText(prefix: "Compiling", file: sourceFile)
-                }
-            case "link":
-                if let imageFile = info.outputs.first(where: { $0.type == "image" })?.path {
-                    return generateProgressText(prefix: "Linking", file: imageFile)
-                }
-            case "merge-module":
-                if let moduleFile = info.outputs.first(where: { $0.type == "swiftmodule" })?.path {
-                    return generateProgressText(prefix: "Merging module", file: moduleFile)
-                }
-            case "generate-dsym":
-                if let dSYMFile = info.outputs.first(where: { $0.type == "dSYM" })?.path {
-                    return generateProgressText(prefix: "Generating dSYM", file: dSYMFile)
-                }
-            case "generate-pch":
-                if let pchFile = info.outputs.first(where: { $0.type == "pch" })?.path {
-                    return generateProgressText(prefix: "Generating PCH", file: pchFile)
-                }
-            default:
-                break
-            }
-        }
-
-        return nil
-    }
-
-    fileprivate var verboseProgressText: String? {
-        if case .began(let info) = kind {
-            return ([info.commandExecutable] + info.commandArguments).joined(separator: " ")
-        } else {
-            return nil
-        }
-    }
-
-    fileprivate var standardOutput: String? {
-        switch kind {
-        case .finished(let info),
-             .signalled(let info):
-            return info.output
-        default:
-            return nil
-        }
-    }
-
-    private func generateProgressText(prefix: String, file: String) -> String {
-        let relativePath = AbsolutePath(file).relative(to: AbsolutePath(getcwd()))
-        return "\(prefix) \(relativePath)"
     }
 }

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -515,7 +515,6 @@ public final class SwiftTargetBuildDescription {
         args += additionalFlags
         args += moduleCacheArgs
         args += buildParameters.sanitizers.compileSwiftFlags()
-        args += ["-parseable-output"]
 
         // Add arguments needed for code coverage if it is enabled.
         if buildParameters.enableCodeCoverage {

--- a/Sources/SPMUtility/ProgressAnimation.swift
+++ b/Sources/SPMUtility/ProgressAnimation.swift
@@ -71,28 +71,18 @@ public final class SingleLinePercentProgressAnimation: ProgressAnimationProtocol
 
 /// A multi-line ninja-like progress animation.
 public final class MultiLineNinjaProgressAnimation: ProgressAnimationProtocol {
-    private struct Info: Equatable {
-        let step: Int
-        let total: Int
-        let text: String
-    }
-
     private let stream: OutputByteStream
-    private var lastDisplayedText: String? = nil
 
-    public init(stream: OutputByteStream) {
+    init(stream: OutputByteStream) {
         self.stream = stream
     }
 
     public func update(step: Int, total: Int, text: String) {
         assert(step <= total)
 
-        guard text != lastDisplayedText else { return }
-
         stream <<< "[\(step)/\(total)] " <<< text
         stream <<< "\n"
         stream.flush()
-        lastDisplayedText = text
     }
 
     public func complete(success: Bool) {
@@ -152,15 +142,9 @@ public final class NinjaProgressAnimation: DynamicProgressAnimation {
 
 /// A multi-line percent-based progress animation.
 public final class MultiLinePercentProgressAnimation: ProgressAnimationProtocol {
-    private struct Info: Equatable {
-        let percentage: Int
-        let text: String
-    }
-
     private let stream: OutputByteStream
     private let header: String
     private var hasDisplayedHeader = false
-    private var lastDisplayedText: String? = nil
 
     init(stream: OutputByteStream, header: String) {
         self.stream = stream
@@ -181,7 +165,6 @@ public final class MultiLinePercentProgressAnimation: ProgressAnimationProtocol 
         stream <<< "\(percentage)%: " <<< text
         stream <<< "\n"
         stream.flush()
-        lastDisplayedText = text
     }
 
     public func complete(success: Bool) {

--- a/Tests/BuildTests/SwiftCompilerOutputParserTests.swift
+++ b/Tests/BuildTests/SwiftCompilerOutputParserTests.swift
@@ -42,14 +42,14 @@ class SwiftCompilerOutputParserTests: XCTestCase {
         let delegate = MockSwiftCompilerOutputParserDelegate()
         let parser = SwiftCompilerOutputParser(delegate: delegate)
 
-        parser.parse(bytes: "33".utf8)
+        parser.parse(bytes: "22".utf8)
         delegate.assert(messages: [], errorDescription: nil)
 
         parser.parse(bytes: "".utf8)
         delegate.assert(messages: [], errorDescription: nil)
 
         parser.parse(bytes: """
-            8
+            9
             {
               "kind": "began",
               "name": "compile",
@@ -70,9 +70,7 @@ class SwiftCompilerOutputParserTests: XCTestCase {
                   "path": "/var/folders/yc/rgflx8m11p5d71k1ydy0l_pr0000gn/T/test-77d991.o"
                 }
               ],
-              "pid": 22698,
-              "command_executable": "swift",
-              "command_arguments" : ["-frontend", "-c", "-primary-file", "test.swift"]
+              "pid": 22698
             }
             117
 
@@ -81,13 +79,10 @@ class SwiftCompilerOutputParserTests: XCTestCase {
             SwiftCompilerMessage(
                 name: "compile",
                 kind: .began(.init(
-                    pid: 22698,
                     inputs: ["test.swift"],
                     outputs: [.init(
                         type: "object",
-                        path: "/var/folders/yc/rgflx8m11p5d71k1ydy0l_pr0000gn/T/test-77d991.o")],
-                    commandExecutable: "swift",
-                    commandArguments: ["-frontend", "-c", "-primary-file", "test.swift"])))
+                        path: "/var/folders/yc/rgflx8m11p5d71k1ydy0l_pr0000gn/T/test-77d991.o")])))
         ], errorDescription: nil)
 
         parser.parse(bytes: """
@@ -102,9 +97,7 @@ class SwiftCompilerOutputParserTests: XCTestCase {
         delegate.assert(messages: [
             SwiftCompilerMessage(
                 name: "compile",
-                kind: .finished(.init(
-                    pid: 22698,
-                    output: "error: it failed :-(")))
+                kind: .finished(.init(output: "error: it failed :-(")))
         ], errorDescription: nil)
 
         parser.parse(bytes: """
@@ -124,7 +117,7 @@ class SwiftCompilerOutputParserTests: XCTestCase {
               ],
               "pid": 58776
             }
-            299
+            219
             {
               "kind": "began",
               "name": "link",
@@ -137,9 +130,7 @@ class SwiftCompilerOutputParserTests: XCTestCase {
                   "path": "test"
                 }
               ],
-              "pid": 22699,
-              "command_executable": "ld",
-              "command_arguments" : ["-o", "option", "test"]
+              "pid": 22699
             }
             119
             """.utf8)
@@ -154,13 +145,10 @@ class SwiftCompilerOutputParserTests: XCTestCase {
             SwiftCompilerMessage(
                 name: "link",
                 kind: .began(.init(
-                    pid: 22699,
                     inputs: ["/var/folders/yc/rgflx8m11p5d71k1ydy0l_pr0000gn/T/test-77d991.o"],
                     outputs: [.init(
                         type: "image",
-                        path: "test")],
-                    commandExecutable: "ld",
-                    commandArguments: ["-o", "option", "test"])))
+                        path: "test")])))
         ], errorDescription: nil)
 
         parser.parse(bytes: """
@@ -177,9 +165,7 @@ class SwiftCompilerOutputParserTests: XCTestCase {
         delegate.assert(messages: [
             SwiftCompilerMessage(
                 name: "link",
-                kind: .signalled(.init(
-                    pid: 22699,
-                    output: nil)))
+                kind: .signalled(.init(output: nil)))
         ], errorDescription: nil)
     }
 

--- a/Tests/CommandsTests/RunToolTests.swift
+++ b/Tests/CommandsTests/RunToolTests.swift
@@ -44,7 +44,7 @@ final class RunToolTests: XCTestCase {
                 """))
 
             // swift-build-tool output should go to stderr.
-            XCTAssertMatch(try result.utf8stderrOutput(), .regex("Compiling"))
+            XCTAssertMatch(try result.utf8stderrOutput(), .regex("Compil(e|ing) Swift Module"))
             XCTAssertMatch(try result.utf8stderrOutput(), .contains("Linking"))
 
             do {


### PR DESCRIPTION
Reverts apple/swift-package-manager#1934

Following tests started failing: 

```
11:56:13 Failing Tests (4):
11:56:13     swift-package-tests :: swift-package-init-exec.md
11:56:13     swift-package-tests :: swift-package-init-lib.md
11:56:13     swift-package-tests :: swift-package-with-spaces.txt
11:56:13     swift-package-tests :: swift-run.md
```