### PR TITLE
Use local llbuild sources if requested in swift ci

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -258,9 +258,17 @@ import Darwin.C
 #endif
 
 if getenv("SWIFTPM_BOOTSTRAP") == nil {
-    package.dependencies += [
-        .package(url: "https://github.com/apple/swift-llbuild.git", .branch("master")),
-    ]
+    if getenv("SWIFTCI_USE_LOCAL_DEPS") == nil {
+        package.dependencies += [
+            .package(url: "https://github.com/apple/swift-llbuild.git", .branch("master")),
+        ]
+    } else {
+        // In Swift CI, use a local path to llbuild to interoperate with tools
+        // like `update-checkout`, which control the sources externally.
+        package.dependencies += [
+            .package(path: "../llbuild"),
+        ]
+    }
     package.targets.first(where: { $0.name == "SPMLLBuild" })!.dependencies += ["llbuildSwift"]
 }
 


### PR DESCRIPTION
If SWIFTCI_USE_LOCAL_DEPS is set, and we are not bootstrapping, get the
llbuild sources from ../llbuild. This allows packages that import
swiftpm in swift-ci, such as sourcekit-lsp, to get all the sources from
the local checkouts created by update-checkout.