### PR TITLE
Allow subparsers to have Usage strings

### DIFF
--- a/Sources/SPMUtility/ArgumentParser.swift
+++ b/Sources/SPMUtility/ArgumentParser.swift
@@ -648,10 +648,10 @@ public final class ArgumentParser {
     }
 
     /// Create a subparser with its help text.
-    private init(subparser overview: String) {
+    private init(subparser overview: String, usage: String = "") {
         self.isSubparser = true
         self.commandName = nil
-        self.usage = ""
+        self.usage = usage
         self.overview = overview
         self.seeAlso = nil
     }
@@ -734,9 +734,9 @@ public final class ArgumentParser {
 
     /// Add a parser with a subcommand name and its corresponding overview.
     @discardableResult
-    public func add(subparser command: String, overview: String) -> ArgumentParser {
+    public func add(subparser command: String, overview: String, usage: String = "") -> ArgumentParser {
         precondition(positionalArguments.isEmpty, "Subparsers are not supported with positional arguments")
-        let parser = ArgumentParser(subparser: overview)
+        let parser = ArgumentParser(subparser: overview, usage: usage)
         subparsers[command] = parser
         return parser
     }
@@ -889,7 +889,7 @@ public final class ArgumentParser {
         stream <<< "OVERVIEW: " <<< overview
 
         // We only print command usage for top level parsers.
-        if !isSubparser {
+        if !usage.isEmpty {
             stream <<< "\n\n"
             // Get the binary name from command line arguments.
             let defaultCommandName = CommandLine.arguments[0].components(separatedBy: "/").last!

--- a/Sources/SPMUtility/ArgumentParser.swift
+++ b/Sources/SPMUtility/ArgumentParser.swift
@@ -734,7 +734,7 @@ public final class ArgumentParser {
 
     /// Add a parser with a subcommand name and its corresponding overview.
     @discardableResult
-    public func add(subparser command: String, overview: String, usage: String = "") -> ArgumentParser {
+    public func add(subparser command: String, usage: String = "", overview: String) -> ArgumentParser {
         precondition(positionalArguments.isEmpty, "Subparsers are not supported with positional arguments")
         let parser = ArgumentParser(subparser: command, usage: usage, overview: overview)
         subparsers[command] = parser

--- a/Sources/SPMUtility/ArgumentParser.swift
+++ b/Sources/SPMUtility/ArgumentParser.swift
@@ -648,9 +648,9 @@ public final class ArgumentParser {
     }
 
     /// Create a subparser with its help text.
-    private init(subparser overview: String, usage: String = "") {
+    private init(subparser commandName: String, usage: String, overview: String) {
         self.isSubparser = true
-        self.commandName = nil
+        self.commandName = commandName
         self.usage = usage
         self.overview = overview
         self.seeAlso = nil
@@ -736,7 +736,7 @@ public final class ArgumentParser {
     @discardableResult
     public func add(subparser command: String, overview: String, usage: String = "") -> ArgumentParser {
         precondition(positionalArguments.isEmpty, "Subparsers are not supported with positional arguments")
-        let parser = ArgumentParser(subparser: overview, usage: usage)
+        let parser = ArgumentParser(subparser: command, usage: usage, overview: overview)
         subparsers[command] = parser
         return parser
     }

--- a/Sources/SPMUtility/ArgumentParser.swift
+++ b/Sources/SPMUtility/ArgumentParser.swift
@@ -888,7 +888,6 @@ public final class ArgumentParser {
 
         stream <<< "OVERVIEW: " <<< overview
 
-        // We only print command usage for top level parsers.
         if !usage.isEmpty {
             stream <<< "\n\n"
             // Get the binary name from command line arguments.

--- a/Tests/UtilityTests/ArgumentParserTests.swift
+++ b/Tests/UtilityTests/ArgumentParserTests.swift
@@ -331,7 +331,7 @@ class ArgumentParserTests: XCTestCase {
         usage = stream.bytes.description
 
         XCTAssert(usage.contains("OVERVIEW: B!"))
-        XCTAssert(usage.contains("USAGE:"))
+        XCTAssert(usage.contains("USAGE: b"))
         XCTAssert(usage.contains("OPTIONS:"))
         XCTAssert(usage.contains("  --no-fly"))
     }

--- a/Tests/UtilityTests/ArgumentParserTests.swift
+++ b/Tests/UtilityTests/ArgumentParserTests.swift
@@ -258,7 +258,7 @@ class ArgumentParserTests: XCTestCase {
         let parserA = parser.add(subparser: "a", overview: "A!")
         let branchOption = parserA.add(option: "--branch", kind: String.self, usage: "The branch to use")
 
-        let parserB = parser.add(subparser: "b", overview: "B!", usage: "b")
+        let parserB = parser.add(subparser: "b", overview: "B!", usage: "usage")
         let noFlyOption = parserB.add(option: "--no-fly", kind: Bool.self, usage: "Should you fly?")
 
         var args = try parser.parse(["--foo", "foo", "--bar", "bar", "a", "--branch", "bugfix"])
@@ -331,7 +331,7 @@ class ArgumentParserTests: XCTestCase {
         usage = stream.bytes.description
 
         XCTAssert(usage.contains("OVERVIEW: B!"))
-        XCTAssert(usage.contains("USAGE: b"))
+        XCTAssert(usage.contains("USAGE: b usage"))
         XCTAssert(usage.contains("OPTIONS:"))
         XCTAssert(usage.contains("  --no-fly"))
     }

--- a/Tests/UtilityTests/ArgumentParserTests.swift
+++ b/Tests/UtilityTests/ArgumentParserTests.swift
@@ -258,7 +258,7 @@ class ArgumentParserTests: XCTestCase {
         let parserA = parser.add(subparser: "a", overview: "A!")
         let branchOption = parserA.add(option: "--branch", kind: String.self, usage: "The branch to use")
 
-        let parserB = parser.add(subparser: "b", overview: "B!", usage: "usage")
+        let parserB = parser.add(subparser: "b", usage: "usage", overview: "B!")
         let noFlyOption = parserB.add(option: "--no-fly", kind: Bool.self, usage: "Should you fly?")
 
         var args = try parser.parse(["--foo", "foo", "--bar", "bar", "a", "--branch", "bugfix"])

--- a/Tests/UtilityTests/ArgumentParserTests.swift
+++ b/Tests/UtilityTests/ArgumentParserTests.swift
@@ -258,7 +258,7 @@ class ArgumentParserTests: XCTestCase {
         let parserA = parser.add(subparser: "a", overview: "A!")
         let branchOption = parserA.add(option: "--branch", kind: String.self, usage: "The branch to use")
 
-        let parserB = parser.add(subparser: "b", overview: "B!")
+        let parserB = parser.add(subparser: "b", overview: "B!", usage: "b")
         let noFlyOption = parserB.add(option: "--no-fly", kind: Bool.self, usage: "Should you fly?")
 
         var args = try parser.parse(["--foo", "foo", "--bar", "bar", "a", "--branch", "bugfix"])
@@ -312,6 +312,7 @@ class ArgumentParserTests: XCTestCase {
         XCTAssert(usage.contains("  --foo       The foo option"))
         XCTAssert(usage.contains("  --parent    The parent option"))
         XCTAssert(usage.contains("SUBCOMMANDS:"))
+        XCTAssert(usage.contains("  a           A!"))
         XCTAssert(usage.contains("  b           B!"))
         XCTAssert(usage.contains("--help"))
 
@@ -330,7 +331,7 @@ class ArgumentParserTests: XCTestCase {
         usage = stream.bytes.description
 
         XCTAssert(usage.contains("OVERVIEW: B!"))
-        XCTAssert(!usage.contains("USAGE:"))
+        XCTAssert(usage.contains("USAGE:"))
         XCTAssert(usage.contains("OPTIONS:"))
         XCTAssert(usage.contains("  --no-fly"))
     }


### PR DESCRIPTION
In larger command line tools there can be a few levels of subparsers and a top level USAGE description may not be able to capture all varieties of sub-commands. It would help users of these tools if they can get USAGE strings for lower level sub parsers.