### PR TITLE
filelock Workspace

### DIFF
--- a/Sources/Basic/Lock.swift
+++ b/Sources/Basic/Lock.swift
@@ -31,49 +31,85 @@ enum ProcessLockError: Swift.Error {
     case unableToAquireLock(errno: Int32)
 }
 
-/// Provides functionality to aquire a lock on a file via POSIX's flock() method.
+/// Provides functionality to aquire an exclusive lock on a file via POSIX's flock() method.
 /// It can be used for things like serializing concurrent mutations on a shared resource
-/// by mutiple instances of a process. The `FileLock` is not thread-safe.
+/// by mutiple instances of a process.
 public final class FileLock {
+    private typealias FileDescriptor = CInt
+
     /// File descriptor to the lock file.
-    private var fd: CInt?
+    private var fd: FileDescriptor?
+
+    private let _lock = NSLock()
 
     /// Path to the lock file.
-    private let lockFile: AbsolutePath
+    public let path: AbsolutePath
 
     /// Create an instance of process lock with a name and the path where
     /// the lock file can be created.
     ///
     /// Note: The cache path should be a valid directory.
-    public init(name: String, cachePath: AbsolutePath) {
-        self.lockFile = cachePath.appending(component: name + ".lock")
+    public init(name: String, in directory: AbsolutePath) {
+        self.path = directory.appending(component: name)
+    }
+
+    /// Attempts to acquire a lock and immediately returns a Boolean value
+    /// that indicates whether the attempt was successful.
+    ///
+    /// - Returns: `true` if the lock was acquired, otherwise `false`.
+    public func `try`() -> Bool {
+        _lock.lock()
+        defer { _lock.unlock() }
+
+        // Open the lock file.
+        if self.fd == nil, let fd = try? openFile(at: path) {
+            self.fd = fd
+        }
+
+        guard let fd = self.fd else { return false }
+
+        // Aquire lock on the file.
+        while flock(fd, LOCK_EX | LOCK_NB) != 0 {
+            switch errno {
+            case EWOULDBLOCK: // non-blocking lock not available
+                return false
+            case EINTR: // Retry if interrupted.
+                continue
+            default:
+                return false
+            }
+        }
+
+        return true
     }
 
     /// Try to aquire a lock. This method will block until lock the already aquired by other process.
     ///
     /// Note: This method can throw if underlying POSIX methods fail.
     public func lock() throws {
+        _lock.lock()
+        defer { _lock.unlock() }
+
         // Open the lock file.
-        if fd == nil {
-            let fd = SPMLibc.open(lockFile.pathString, O_WRONLY | O_CREAT | O_CLOEXEC, 0o666)
-            if fd == -1 {
-                throw FileSystemError(errno: errno)
-            }
-            self.fd = fd
+        if self.fd == nil {
+            self.fd = try openFile(at: path)
         }
+
         // Aquire lock on the file.
-        while true {
-            if flock(fd!, LOCK_EX) == 0 {
-                break
-            }
+        while flock(self.fd!, LOCK_EX) != 0 {
             // Retry if interrupted.
-            if errno == EINTR { continue }
+            if errno == EINTR {
+                continue
+            }
             throw ProcessLockError.unableToAquireLock(errno: errno)
         }
     }
 
     /// Unlock the held lock.
     public func unlock() {
+        _lock.lock()
+        defer { _lock.unlock() }
+
         guard let fd = fd else { return }
         flock(fd, LOCK_UN)
     }
@@ -85,8 +121,17 @@ public final class FileLock {
 
     /// Execute the given block while holding the lock.
     public func withLock<T>(_ body: () throws -> T) throws -> T {
-        try lock()
-        defer { unlock() }
+        try self.lock()
+        defer { self.unlock() }
         return try body()
+    }
+
+    private func openFile(at path: AbsolutePath) throws -> FileDescriptor {
+        // Open the lock file.
+        let fd = SPMLibc.open(path.pathString, O_WRONLY | O_CREAT | O_CLOEXEC, 0o666)
+        if fd == -1 {
+            throw FileSystemError(errno: errno)
+        }
+        return fd
     }
 }

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -55,7 +55,11 @@ public class SwiftBuildTool: SwiftTool<BuildToolOptions> {
 
            // Create the build plan and build.
            let plan = try BuildPlan(buildParameters: buildParameters(), graph: loadPackageGraph(), diagnostics: diagnostics)
+
+           let workspace = try getActiveWorkspace()
+           workspace.lockWorkspace()
            try build(plan: plan, subset: subset)
+           workspace.unlockWorkspace()
 
         case .binPath:
             try print(buildParameters().buildPath.description)

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -556,7 +556,6 @@ public class SwiftTool<Options: ToolOptions> {
     func loadPackageGraph(
         createREPLProduct: Bool = false
     ) throws -> PackageGraph {
-        do {
             let workspace = try getActiveWorkspace()
 
             // Fetch and load the package graph.
@@ -573,9 +572,6 @@ public class SwiftTool<Options: ToolOptions> {
                 throw Diagnostics.fatalError
             }
             return graph
-        } catch {
-            throw error
-        }
     }
 
     /// Returns the user toolchain to compile the actual product.

--- a/Sources/TestSupport/TestWorkspace.swift
+++ b/Sources/TestSupport/TestWorkspace.swift
@@ -250,9 +250,9 @@ public final class TestWorkspace {
         roots: [String] = [],
         deps: [TestWorkspace.PackageDependency],
         _ result: (PackageGraph, DiagnosticsEngine) -> ()
-    ) {
+    ) throws {
         let dependencies = deps.map({ $0.convert(packagesDir) })
-        checkPackageGraph(roots: roots, dependencies: dependencies, result)
+        try checkPackageGraph(roots: roots, dependencies: dependencies, result)
     }
 
     public func checkPackageGraph(
@@ -260,12 +260,12 @@ public final class TestWorkspace {
         dependencies: [PackageGraphRootInput.PackageDependency] = [],
         forceResolvedVersions: Bool = false,
         _ result: (PackageGraph, DiagnosticsEngine) -> ()
-    ) {
+    ) throws {
         let diagnostics = DiagnosticsEngine()
         let workspace = createWorkspace()
         let rootInput = PackageGraphRootInput(
             packages: rootPaths(for: roots), dependencies: dependencies)
-        let graph = workspace.loadPackageGraph(
+        let graph = try workspace.loadPackageGraph(
             root: rootInput, forceResolvedVersions: forceResolvedVersions, diagnostics: diagnostics)
         result(graph, diagnostics)
     }

--- a/Sources/TestSupportExecutable/main.swift
+++ b/Sources/TestSupportExecutable/main.swift
@@ -13,7 +13,7 @@ import SPMUtility
 ///   - path: Path to a file which will be mutated.
 ///   - content: Integer that should be added in that file.
 func fileLockTest(cacheDir: AbsolutePath, path: AbsolutePath, content: Int) throws {
-    let lock = FileLock(name: "TestLock", cachePath: cacheDir)
+    let lock = FileLock(name: "TestLock.lock", in: cacheDir)
     try lock.withLock {
         // Get thr current contents of the file if any.
         let currentData: Int

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -301,7 +301,7 @@ public class Workspace {
     fileprivate let skipUpdate: Bool
 
     /// Workspace lock. Available for local file system only.
-    private let workspaceFileLock: FileLock?
+    private var workspaceFileLock: FileLock?
 
     /// Typealias for dependency resolver we use in the workspace.
     fileprivate typealias PackageDependencyResolver = DependencyResolver
@@ -368,10 +368,11 @@ public class Workspace {
         self.managedDependencies = ManagedDependencies(dataPath: dataPath, fileSystem: fileSystem)
 
         // FileLock uses local filesystem internally, hence won't work with any FileSystem
+        self.workspaceFileLock = nil
         if fileSystem === localFileSystem {
-            self.workspaceFileLock = FileLock(name: "workspace.lock", in: dataPath)
-        } else {
-            self.workspaceFileLock = nil
+            if let _ = try? localFileSystem.createDirectory(dataPath, recursive: true) {
+                self.workspaceFileLock = FileLock(name: "workspace.lock", in: dataPath)
+            }
         }
     }
 

--- a/Tests/BasicTests/LockTests.swift
+++ b/Tests/BasicTests/LockTests.swift
@@ -39,7 +39,7 @@ class LockTests: XCTestCase {
         let N = 10
         let threads = (1...N).map { idx in
             return Thread {
-                _ = try! SwiftPMProduct.TestSupportExecutable.execute(["fileLockTest", tempDir.path.pathString, sharedResource.path.pathString, String(idx)])
+                _ = try! SwiftPMProduct.TestSupportExecutable.execute(["fileLockTest", "test.lock", tempDir.path.pathString, sharedResource.path.pathString, String(idx)])
             }
         }
         threads.forEach { $0.start() }
@@ -50,11 +50,23 @@ class LockTests: XCTestCase {
 
     func testFileLockTry() throws {
         let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
-        let fileLock = FileLock(name: "lock", in: tempDir.path)
+        let fileLock = FileLock(name: "test.lock", in: tempDir.path)
 
+        let lockThread = Thread {
+            try! SwiftPMProduct.TestSupportExecutable.execute(["fileLockLock", "test.lock", tempDir.path.pathString, "3"])
+        }
+
+        lockThread.start()
+
+        // wait for the fileLockLock process to launch and acquire a lock
+        XCTAssertTrue(waitForFile(tempDir.path.appending(component: "test.lock")))
+        // try lock
+        XCTAssertFalse(fileLock.try())
+        // wait for lock
         try fileLock.lock()
-        XCTAssertTrue(fileLock.try())
         fileLock.unlock()
         XCTAssertTrue(fileLock.try())
+
+        lockThread.join()
     }
 }

--- a/Tests/BasicTests/LockTests.swift
+++ b/Tests/BasicTests/LockTests.swift
@@ -47,4 +47,14 @@ class LockTests: XCTestCase {
 
         XCTAssertEqual(try localFileSystem.readFileContents(sharedResource.path).description, String((N * (N + 1) / 2 )))
     }
+
+    func testFileLockTry() throws {
+        let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
+        let fileLock = FileLock(name: "lock", in: tempDir.path)
+
+        try fileLock.lock()
+        XCTAssertTrue(fileLock.try())
+        fileLock.unlock()
+        XCTAssertTrue(fileLock.try())
+    }
 }

--- a/Tests/BasicTests/XCTestManifests.swift
+++ b/Tests/BasicTests/XCTestManifests.swift
@@ -198,6 +198,7 @@ extension LockTests {
     static let __allTests__LockTests = [
         ("testBasics", testBasics),
         ("testFileLock", testFileLock),
+        ("testFileLockTry", testFileLockTry),
     ]
 }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -73,7 +73,7 @@ final class WorkspaceTests: XCTestCase {
             .init(name: "Quix", requirement: .upToNextMajor(from: "1.0.0")),
             .init(name: "Baz", requirement: .exact("1.0.0")),
         ]
-        workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Baz", "Foo", "Quix")
@@ -102,7 +102,7 @@ final class WorkspaceTests: XCTestCase {
         // Remove state file and check we can get the state back automatically.
         try fs.removeFileTree(stateFile)
 
-        workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { _, _ in }
+        try workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { _, _ in }
         XCTAssertTrue(fs.exists(stateFile))
 
         // Remove state file and check we get back to a clean state.
@@ -211,7 +211,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        workspace.checkPackageGraph(roots: ["Foo", "Bar"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Foo", "Bar"]) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Bar", "Foo")
                 result.check(packages: "Bar", "Baz", "Foo")
@@ -276,7 +276,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        workspace.checkPackageGraph(roots: ["Foo", "Bar", "Overridden/bazzz"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Foo", "Bar", "Overridden/bazzz"]) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Bar", "Foo", "Baz")
                 result.check(packages: "Bar", "Baz", "Foo")
@@ -345,7 +345,7 @@ final class WorkspaceTests: XCTestCase {
             workspace.manifestLoader.manifests[barGitKey] = manifest.with(url: "/tmp/ws/pkgs/Bar.git")
         }
 
-        workspace.checkPackageGraph(dependencies: dependencies) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(dependencies: dependencies) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(packages: "Bar", "Foo")
                 result.check(targets: "Bar", "Foo")
@@ -393,7 +393,7 @@ final class WorkspaceTests: XCTestCase {
             packages: []
         )
 
-        workspace.checkPackageGraph(roots: ["Foo", "Nested/Foo"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Foo", "Nested/Foo"]) { (graph, diagnostics) in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(diagnostic: .equal("found multiple top-level packages named 'Foo'"), behavior: .error)
             }
@@ -444,7 +444,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        workspace.checkPackageGraph(roots: ["Foo", "Baz"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Foo", "Baz"]) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Baz", "Foo")
                 result.check(packages: "Baz", "Foo")
@@ -505,7 +505,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Load only Foo right now so Baz is loaded from remote.
-        workspace.checkPackageGraph(roots: ["Foo"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Foo"]) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Baz", "Foo")
@@ -522,7 +522,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Now load with Baz as a root package.
         workspace.delegate.events = []
-        workspace.checkPackageGraph(roots: ["Foo", "Baz"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Foo", "Baz"]) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Baz", "Foo")
                 result.check(packages: "Baz", "Foo")
@@ -587,7 +587,7 @@ final class WorkspaceTests: XCTestCase {
             ),
         ]
 
-        workspace.checkPackageGraph(dependencies: dependencies) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(dependencies: dependencies) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(packages: "Bar", "Foo")
                 result.check(targets: "Bar", "Foo")
@@ -650,7 +650,7 @@ final class WorkspaceTests: XCTestCase {
             let deps: [TestWorkspace.PackageDependency] = [
                 .init(name: "A", requirement: .exact("1.0.0"))
             ]
-            workspace.checkPackageGraph(deps: deps) { (graph, diagnostics) in
+            try workspace.checkPackageGraph(deps: deps) { (graph, diagnostics) in
                 PackageGraphTester(graph) { result in
                     result.check(packages: "A", "AA")
                     result.check(targets: "A", "AA")
@@ -673,7 +673,7 @@ final class WorkspaceTests: XCTestCase {
             let deps: [TestWorkspace.PackageDependency] = [
                 .init(name: "A", requirement: .exact("1.0.1"))
             ]
-            workspace.checkPackageGraph(deps: deps) { (graph, diagnostics) in
+            try workspace.checkPackageGraph(deps: deps) { (graph, diagnostics) in
                 PackageGraphTester(graph) { result in
                     result.check(dependencies: "AA", target: "A")
                 }
@@ -741,7 +741,7 @@ final class WorkspaceTests: XCTestCase {
             .init(name: "A", requirement: .exact("1.0.0")),
             .init(name: "B", requirement: .exact("1.0.0")),
         ]
-        workspace.checkPackageGraph(deps: deps) { (_, diagnostics) in
+        try workspace.checkPackageGraph(deps: deps) { (_, diagnostics) in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(diagnostic: .contains("dependency graph is unresolvable;"), behavior: .error)
             }
@@ -880,7 +880,7 @@ final class WorkspaceTests: XCTestCase {
             packages: []
         )
 
-        workspace.checkPackageGraph(roots: ["A", "B", "C"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["A", "B", "C"]) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(packages: "A", "B", "C")
                 result.check(targets: "A", "B", "C")
@@ -951,7 +951,7 @@ final class WorkspaceTests: XCTestCase {
         let deps: [TestWorkspace.PackageDependency] = [
             .init(name: "Foo", requirement: .exact("1.0.0")),
         ]
-        workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Bar", "Foo", "Root")
@@ -967,7 +967,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkUpdate(roots: ["Root"]) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
-        workspace.checkPackageGraph(roots: ["Root"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"]) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
@@ -1023,7 +1023,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Load package graph.
-        workspace.checkPackageGraph(roots: ["Root"]) { (_, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"]) { (_, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -1108,7 +1108,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Load the graph with one root.
-        workspace.checkPackageGraph(roots: ["Root1"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root1"]) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(packages: "Foo", "Root1")
             }
@@ -1122,7 +1122,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Load the graph with both roots.
-        workspace.checkPackageGraph(roots: ["Root1", "Root2"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root1", "Root2"]) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(packages: "Bar", "Foo", "Root1", "Root2")
             }
@@ -1191,7 +1191,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        workspace.checkPackageGraph(roots: ["Root1"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root1"]) { (graph, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -1253,7 +1253,7 @@ final class WorkspaceTests: XCTestCase {
         let deps: [TestWorkspace.PackageDependency] = [
             .init(name: "Bar", requirement: .revision(barRevision))
         ]
-        workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Bar", "Foo", "Root")
@@ -1300,7 +1300,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Load initial version.
-        workspace.checkPackageGraph(roots: ["Root"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"]) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
@@ -1364,7 +1364,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Load the graph.
-        workspace.checkPackageGraph(roots: ["Root"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"]) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
@@ -1374,7 +1374,7 @@ final class WorkspaceTests: XCTestCase {
 
         try fs.removeFileTree(workspace.createWorkspace().checkoutsPath)
 
-        workspace.checkPackageGraph(roots: ["Root"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"]) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
@@ -1419,7 +1419,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        workspace.checkPackageGraph(roots: ["Root"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"]) { (graph, diagnostics) in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(diagnostic: .contains("/tmp/ws/pkgs/Foo @ 1.0.0..<2.0.0"), behavior: .error)
             }
@@ -1466,20 +1466,20 @@ final class WorkspaceTests: XCTestCase {
         try fs.writeFileContents(roots[1], bytes: "// swift-tools-version:4.1.0")
         try fs.writeFileContents(roots[2], bytes: "// swift-tools-version:3.1")
 
-        workspace.checkPackageGraph(roots: ["Foo"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Foo"]) { (graph, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
         }
-        workspace.checkPackageGraph(roots: ["Bar"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Bar"]) { (graph, diagnostics) in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(diagnostic: .equal("package at '/tmp/ws/roots/Bar' is using Swift tools version 4.1.0 but the installed version is 4.0.0"), behavior: .error, location: "/tmp/ws/roots/Bar")
             }
         }
-        workspace.checkPackageGraph(roots: ["Foo", "Bar"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Foo", "Bar"]) { (graph, diagnostics) in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(diagnostic: .equal("package at '/tmp/ws/roots/Bar' is using Swift tools version 4.1.0 but the installed version is 4.0.0"), behavior: .error, location: "/tmp/ws/roots/Bar")
             }
         }
-        workspace.checkPackageGraph(roots: ["Baz"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Baz"]) { (graph, diagnostics) in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(diagnostic: .equal("package at '/tmp/ws/roots/Baz' is using Swift tools version 3.1.0 which is no longer supported; use 4.0.0 or newer instead"), behavior: .error, location: "/tmp/ws/roots/Baz")
             }
@@ -1531,7 +1531,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Load the graph.
-        workspace.checkPackageGraph(roots: ["Root"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"]) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Bar", "Foo", "Root")
@@ -1628,7 +1628,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Load the graph.
-        workspace.checkPackageGraph(roots: ["Root"]) { _, _ in }
+        try workspace.checkPackageGraph(roots: ["Root"]) { _, _ in }
 
         // Edit foo.
         let fooPath = workspace.createWorkspace().editablesPath.appending(component: "Foo")
@@ -1642,7 +1642,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Remove the edited package.
         try fs.removeFileTree(fooPath)
-        workspace.checkPackageGraph(roots: ["Root"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"]) { (graph, diagnostics) in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(diagnostic: .equal("dependency 'foo' was being edited but is missing; falling back to original checkout"), behavior: .warning)
             }
@@ -1680,7 +1680,7 @@ final class WorkspaceTests: XCTestCase {
         let ws = workspace.createWorkspace()
 
         // Load the graph and edit foo.
-        workspace.checkPackageGraph(deps: deps) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(deps: deps) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(packages: "Foo")
             }
@@ -1698,7 +1698,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertNoDiagnostics(diagnostics)
         }
         XCTAssertMatch(workspace.delegate.events, [.equal("removing repo: /tmp/ws/pkgs/Foo")])
-        workspace.checkPackageGraph(deps: []) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(deps: []) { (graph, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -1766,7 +1766,7 @@ final class WorkspaceTests: XCTestCase {
             .init(name: "Foo", requirement: .exact("1.0.0")),
         ]
         // Load the graph.
-        workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Bar", "Foo", "Root")
@@ -1876,7 +1876,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Initial resolution.
-        workspace.checkPackageGraph(roots: ["Foo"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Foo"]) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Bar", "Foo")
@@ -1903,7 +1903,7 @@ final class WorkspaceTests: XCTestCase {
             targets: manifest.targets
         )
 
-        workspace.checkPackageGraph(roots: ["Foo"]) { (_, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Foo"]) { (_, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies() { result in
@@ -1955,7 +1955,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // Load the graph.
-        workspace.checkPackageGraph(roots: ["Root"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"]) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
@@ -1984,7 +1984,7 @@ final class WorkspaceTests: XCTestCase {
         let deps: [TestWorkspace.PackageDependency] = [
             .init(name: "Bar", requirement: .exact("1.1.0")),
         ]
-        workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(diagnostic: .contains("/tmp/ws/pkgs/Bar @ 1.1.0"), behavior: .error)
             }
@@ -2088,7 +2088,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        workspace.checkPackageGraph(roots: ["Foo"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Foo"]) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Bar", "Baz", "Foo")
@@ -2165,7 +2165,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        workspace.checkPackageGraph(roots: ["Foo"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Foo"]) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Foo")
@@ -2210,7 +2210,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        workspace.checkPackageGraph(roots: ["Foo"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Foo"]) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Bar", "Foo")
@@ -2278,7 +2278,7 @@ final class WorkspaceTests: XCTestCase {
         var deps: [TestWorkspace.PackageDependency] = [
             .init(name: "Foo", requirement: .branch("develop"))
         ]
-        workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
@@ -2292,7 +2292,7 @@ final class WorkspaceTests: XCTestCase {
         deps = [
             .init(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
         ]
-        workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies() { result in
@@ -2302,7 +2302,7 @@ final class WorkspaceTests: XCTestCase {
         deps = [
             .init(name: "Foo", requirement: .branch("develop"))
         ]
-        workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies() { result in
@@ -2347,7 +2347,7 @@ final class WorkspaceTests: XCTestCase {
         var deps: [TestWorkspace.PackageDependency] = [
             .init(name: "Foo", requirement: .localPackage),
         ]
-        workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
@@ -2361,7 +2361,7 @@ final class WorkspaceTests: XCTestCase {
         deps = [
             .init(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
         ]
-        workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies() { result in
@@ -2371,7 +2371,7 @@ final class WorkspaceTests: XCTestCase {
         deps = [
             .init(name: "Foo", requirement: .localPackage),
         ]
-        workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies() { result in
@@ -2427,7 +2427,7 @@ final class WorkspaceTests: XCTestCase {
         var deps: [TestWorkspace.PackageDependency] = [
             .init(name: "Foo", requirement: .localPackage),
         ]
-        workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "Foo", "Root")
@@ -2441,7 +2441,7 @@ final class WorkspaceTests: XCTestCase {
         deps = [
             .init(name: "Foo2", requirement: .localPackage),
         ]
-        workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies() { result in
@@ -2497,7 +2497,7 @@ final class WorkspaceTests: XCTestCase {
          var deps: [TestWorkspace.PackageDependency] = [
              .init(name: "Foo", requirement: .localPackage),
          ]
-         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
+         try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
              PackageGraphTester(graph) { result in
                  result.check(roots: "Root")
                  result.check(packages: "Foo", "Root")
@@ -2515,7 +2515,7 @@ final class WorkspaceTests: XCTestCase {
          deps = [
              .init(name: "Nested/Foo", requirement: .localPackage),
          ]
-         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
+         try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
              XCTAssertNoDiagnostics(diagnostics)
          }
          workspace.checkManagedDependencies() { result in
@@ -2561,7 +2561,7 @@ final class WorkspaceTests: XCTestCase {
         let deps: [TestWorkspace.PackageDependency] = [
             .init(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
         ]
-        workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies() { result in
@@ -2571,7 +2571,7 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
         }
 
-        workspace.checkPackageGraph(roots: ["Root"], deps: []) { (_, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"], deps: []) { (_, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies() { result in
@@ -2650,7 +2650,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        workspace.checkPackageGraph(roots: ["Foo"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Foo"]) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Foo", "Dep", "Bar")
@@ -2671,7 +2671,7 @@ final class WorkspaceTests: XCTestCase {
             .init(name: "Bam", requirement: .upToNextMajor(from: "1.0.0")),
         ]
 
-        workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { (graph, diagnostics) in
              PackageGraphTester(graph) { result in
                  result.check(roots: "Foo")
                  result.check(packages: "Foo", "Dep", "Baz")
@@ -2773,7 +2773,7 @@ final class WorkspaceTests: XCTestCase {
          var deps: [TestWorkspace.PackageDependency] = [
              .init(name: "Bar", requirement: .exact("1.0.0")),
          ]
-         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
+         try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
              PackageGraphTester(graph) { result in
                  result.check(roots: "Root")
                  result.check(packages: "Bar", "Foo", "Root")
@@ -2797,7 +2797,7 @@ final class WorkspaceTests: XCTestCase {
          deps = [
              .init(name: "Bar", requirement: .exact("1.1.0")),
          ]
-         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
+         try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
              PackageGraphTester(graph) { result in
                  result.check(roots: "Root")
                  result.check(packages: "Bar", "Foo", "Root")
@@ -2863,7 +2863,7 @@ final class WorkspaceTests: XCTestCase {
         let deps: [TestWorkspace.PackageDependency] = [
             .init(name: "Bar", requirement: .revision("develop")),
         ]
-        workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies() { result in
@@ -2890,7 +2890,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Check force resolve. This should produce an error because the resolved file is out-of-date.
-        workspace.checkPackageGraph(roots: ["Root"], forceResolvedVersions: true) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"], forceResolvedVersions: true) { (graph, diagnostics) in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(diagnostic: "cannot update Package.resolved file because automatic resolution is disabled", checkContains: true, behavior: .error)
             }
@@ -2905,7 +2905,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // A normal resolution.
-        workspace.checkPackageGraph(roots: ["Root"]) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"]) { (graph, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies() { result in
@@ -2918,7 +2918,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // This force resolution should succeed.
-        workspace.checkPackageGraph(roots: ["Root"], forceResolvedVersions: true) { (graph, diagnostics) in
+        try workspace.checkPackageGraph(roots: ["Root"], forceResolvedVersions: true) { (graph, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
         }
         workspace.checkManagedDependencies() { result in

--- a/Tests/WorkspaceTests/XCTestManifests.swift
+++ b/Tests/WorkspaceTests/XCTestManifests.swift
@@ -81,6 +81,7 @@ extension WorkspaceTests {
         ("testToolsVersionRootPackages", testToolsVersionRootPackages),
         ("testTransitiveDependencySwitchWithSameIdentity", testTransitiveDependencySwitchWithSameIdentity),
         ("testUpdate", testUpdate),
+        ("testWorkspaceResolutionKind", testWorkspaceResolutionKind),
     ]
 }
 


### PR DESCRIPTION
https://github.com/apple/swift-package-manager/pull/2036

Set a file lock in the Workspace.dataPath whenever workspace is in use. Path to the lock is public so it is possible to use the lock by other process.