### PR TITLE
Remove unused dependency

### DIFF
--- a/Sources/Build/llbuild.swift
+++ b/Sources/Build/llbuild.swift
@@ -28,14 +28,10 @@ public struct LLBuildManifestGenerator {
     /// The manifest client name.
     public let client: String
 
-    /// Path to the resolved file.
-    let resolvedFile: AbsolutePath
-
     /// Create a new generator with a build plan.
-    public init(_ plan: BuildPlan, client: String, resolvedFile: AbsolutePath) {
+    public init(_ plan: BuildPlan, client: String) {
         self.plan = plan
         self.client = client
-        self.resolvedFile = resolvedFile
     }
 
     /// A structure for targets in the manifest.

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -615,7 +615,7 @@ public class SwiftTool<Options: ToolOptions> {
         let yaml = plan.buildParameters.llbuildManifest
         // Generate the llbuild manifest.
         let client = options.shouldEnableLLBuildLibrary ? "basic" : "swift-build"
-        let llbuild = LLBuildManifestGenerator(plan, client: client, resolvedFile: try resolvedFilePath())
+        let llbuild = LLBuildManifestGenerator(plan, client: client)
         try llbuild.generateManifest(at: yaml)
 
         // Run llbuild.

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -379,7 +379,7 @@ final class BuildPlanTests: XCTestCase {
 
         mktmpdir { path in
             let yaml = path.appending(component: "debug.yaml")
-            let llbuild = LLBuildManifestGenerator(plan, client: "swift-build", resolvedFile: path.appending(component: "Package.resolved"))
+            let llbuild = LLBuildManifestGenerator(plan, client: "swift-build")
             try llbuild.generateManifest(at: yaml)
             let contents = try localFileSystem.readFileContents(yaml).description
             XCTAssertTrue(contents.contains("-std=gnu99\",\"-c\",\"/Pkg/Sources/lib/lib.c"))


### PR DESCRIPTION
llbuild doesn't need `resolvedFile` path at all.