### PR TITLE
PackageDescription: use the correct C provider on Win32

### DIFF
--- a/Sources/PackageDescription4/Package.swift
+++ b/Sources/PackageDescription4/Package.swift
@@ -10,8 +10,10 @@
 
 #if os(Linux)
 import Glibc
-#else
+#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 import Darwin.C
+#elseif os(Windows)
+import ucrt
 #endif
 import Foundation
 


### PR DESCRIPTION
Support Windows as an OS and use `ucrt` for the C library.