### PR TITLE
llbuild manifest name with triple

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -154,7 +154,7 @@ public struct BuildParameters {
     }
 
     public var llbuildManifest: AbsolutePath {
-        return dataPath.appending(components: "..", configuration.dirname + ".yaml")
+        return dataPath.appending(components: "..", configuration.dirname + "-" + triple.tripleString + ".yaml")
     }
 
     public init(


### PR DESCRIPTION
Adds triple to the `lldbuild` manifest filename.

Ideally, `build.db` could use triple as well.