### PR TITLE
[SPMUtility] Avoid detecting paths containing @ as URLs with schemes

### DIFF
--- a/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
@@ -220,7 +220,7 @@ public class LocalPackageContainer: BasePackageContainer, CustomStringConvertibl
         currentToolsVersion: ToolsVersion,
         fs: FileSystem = localFileSystem
     ) {
-        assert(URL.scheme(identifier.path) == nil)
+        assert(URL.scheme(identifier.path) == nil, "unexpected scheme \(URL.scheme(identifier.path)!) in \(identifier.path)")
         self.fs = fs
         super.init(
             identifier,

--- a/Sources/SPMUtility/URL.swift
+++ b/Sources/SPMUtility/URL.swift
@@ -30,7 +30,7 @@ public struct URL {
         }
 
         for delim in ["://", "@"] {
-            if let found = prefixOfSplitBy(delim) {
+            if let found = prefixOfSplitBy(delim), !found.contains("/") {
                 return found
             }
         }

--- a/Tests/UtilityTests/StringTests.swift
+++ b/Tests/UtilityTests/StringTests.swift
@@ -65,5 +65,6 @@ class URLTests: XCTestCase {
         XCTAssertEqual(SPMUtility.URL.scheme("ssh@github.com/foo/bar"), "ssh")
         XCTAssertNil(SPMUtility.URL.scheme("github.com/foo/bar"))
         XCTAssertNil(SPMUtility.URL.scheme("user:/github.com/foo/bar"))
+        XCTAssertNil(SPMUtility.URL.scheme("/path/to/something@2/hello"))
     }
 }


### PR DESCRIPTION
This is just a simple fix until we get rid of this method completely..

<rdar://problem/48926287>