### PR TITLE
[SR-9696] Confirm some errors to LocalizedError

### DIFF
--- a/Sources/SPMUtility/ArgumentParser.swift
+++ b/Sources/SPMUtility/ArgumentParser.swift
@@ -68,6 +68,12 @@ public enum ArgumentConversionError: Swift.Error {
     case custom(String)
 }
 
+extension ArgumentConversionError: LocalizedError {
+    public var errorDescription: String? {
+        return description
+    }
+}
+
 extension ArgumentConversionError: CustomStringConvertible {
     public var description: String {
         switch self {

--- a/Sources/SPMUtility/ArgumentParser.swift
+++ b/Sources/SPMUtility/ArgumentParser.swift
@@ -31,6 +31,12 @@ public enum ArgumentParserError: Swift.Error {
     case expectedArguments(ArgumentParser, [String])
 }
 
+extension ArgumentParserError: LocalizedError {
+    public var errorDescription: String? {
+        return description
+    }
+}
+
 extension ArgumentParserError: CustomStringConvertible {
     public var description: String {
         switch self {


### PR DESCRIPTION
closes SR-9696

https://bugs.swift.org/browse/SR-9696

`ArgumentParserError` and `ArgumentConversionError` make confirming to `LocalizeError`.
This PR may help to read error when using these errors as directly.