### PR TITLE
[SR-9872] Add tests for --generate-linuxmain

### DIFF
--- a/Fixtures/Miscellaneous/GenerateLinuxMain/Package.swift
+++ b/Fixtures/Miscellaneous/GenerateLinuxMain/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "GenerateLinuxMain",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "GenerateLinuxMain",
+            targets: ["GenerateLinuxMain"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "GenerateLinuxMain",
+            dependencies: []),
+        .testTarget(
+            name: "GenerateLinuxMainTests",
+            dependencies: ["GenerateLinuxMain"]),
+    ]
+)

--- a/Fixtures/Miscellaneous/GenerateLinuxMain/Sources/GenerateLinuxMain/GenerateLinuxMain.swift
+++ b/Fixtures/Miscellaneous/GenerateLinuxMain/Sources/GenerateLinuxMain/GenerateLinuxMain.swift
@@ -1,0 +1,3 @@
+struct GenerateLinuxMain {
+    var text = "Hello, World!"
+}

--- a/Fixtures/Miscellaneous/GenerateLinuxMain/Tests/GenerateLinuxMainTests/GenerateLinuxMainTests.swift
+++ b/Fixtures/Miscellaneous/GenerateLinuxMain/Tests/GenerateLinuxMainTests/GenerateLinuxMainTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import GenerateLinuxMain
+
+final class GenerateLinuxMainTests: XCTestCase {
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+        XCTAssertEqual(GenerateLinuxMain().text, "Hello, World!")
+    }
+
+    func testAddition() {
+        XCTAssertEqual(1 + 1, 2)
+    }
+
+    static var allTests = [
+        ("testExample", testExample),
+    ]
+}

--- a/Fixtures/Miscellaneous/GenerateLinuxMain/Tests/LinuxMain.swift
+++ b/Fixtures/Miscellaneous/GenerateLinuxMain/Tests/LinuxMain.swift
@@ -1,0 +1,8 @@
+import XCTest
+
+import GenerateLinuxMainTests
+
+var tests = [XCTestCaseEntry]()
+tests += GenerateLinuxMainTests.__allTests()
+
+XCTMain(tests)

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -80,4 +80,26 @@ final class TestToolTests: XCTestCase {
         }
         #endif
     }
+    
+    func testGenerateLinuxMain() throws {
+        #if os(macOS)
+        fixture(name: "Miscellaneous/GenerateLinuxMain") { app in
+            do {
+                let manifests = app.appending(components: "Tests", "GenerateLinuxMainTests", "XCTestManifests.swift")
+                XCTAssertFalse(FileManager.default.fileExists(atPath: manifests.asURL.path))
+                _ = try SwiftPMProduct.SwiftTest.executeProcess(["--generate-linuxmain"], packagePath: app)
+                let content = try String(contentsOf: manifests.asURL)
+                // generated tests are ordered by alphabetical
+                XCTAssertTrue(content.contains("""
+    static let __allTests__GenerateLinuxMainTests = [
+        ("testAddition", testAddition),
+        ("testExample", testExample),
+    ]
+"""))
+            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
+                XCTFail(stderr)
+            }
+        }
+        #endif
+    }
 }


### PR DESCRIPTION
closes SR-9872

https://bugs.swift.org/browse/SR-9872

I added a test case to test `swift test --generate-linuxmain` works correctly.
Generated test cases will be ordered by alphabetical.