### PR TITLE
build: adjust for new build layout

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -254,7 +254,7 @@ class Target(object):
 
         if args.foundation_path:
             import_paths.append(args.foundation_path)
-            other_args.extend(["-Xcc", "-F" + os.path.join(args.foundation_path, "CoreFoundation-prefix", "System", "Library", "Frameworks")])
+            other_args.extend(["-Xcc", "-F" + args.foundation_path])
             import_paths.append(os.path.join(args.foundation_path, "swift"))
         if args.libdispatch_build_dir:
             import_paths.append(os.path.join(args.libdispatch_build_dir, "src"))
@@ -1149,8 +1149,7 @@ def main():
                 symlink_force(os.path.join(args.foundation_path, 'swift', module_file), libincludedir)
 
             # Add CoreFoundation "framework". This just contains the header and the modulemap.
-            core_foundation_path = os.path.join(
-                    args.foundation_path, "CoreFoundation-prefix", "System", "Library", "Frameworks", "CoreFoundation.framework")
+            core_foundation_path = os.path.join(args.foundation_path,  "CoreFoundation.framework")
             symlink_force(core_foundation_path, libincludedir)
 
             # Add symlinks for dispatch.


### PR DESCRIPTION
Moving CoreFoundation into the root is needed to actually get the proper
dependency tracking for Foundation builds. This adjusts the use of it
in swift-package-manager.