### PR TITLE
Basic: remove SPMLibc usage in PathShims

### DIFF
--- a/Sources/Basic/PathShims.swift
+++ b/Sources/Basic/PathShims.swift
@@ -17,22 +17,11 @@
  while making it fairly easy to find those calls later.
 */
 
-import SPMLibc
 import Foundation
 
 /// Returns the "real path" corresponding to `path` by resolving any symbolic links.
 public func resolveSymlinks(_ path: AbsolutePath) -> AbsolutePath {
-    let pathStr = path.pathString
-
-    // FIXME: We can't use FileManager's destinationOfSymbolicLink because
-    // that implements readlink and not realpath.
-    if let resultPtr = SPMLibc.realpath(pathStr, nil) {
-        let result = String(cString: resultPtr)
-        // FIXME: We should measure if it's really more efficient to compare the strings first.
-        return result == pathStr ? path : AbsolutePath(result)
-    }
-
-    return path
+    return AbsolutePath(path.pathString.standardizingPath)
 }
 
 /// Creates a new, empty directory at `path`.  If needed, any non-existent ancestor paths are also created.  If there is
@@ -45,8 +34,7 @@ public func makeDirectories(_ path: AbsolutePath) throws {
 /// be a relative path, otherwise it will be absolute.
 public func createSymlink(_ path: AbsolutePath, pointingAt dest: AbsolutePath, relative: Bool = true) throws {
     let destString = relative ? dest.relative(to: path.parentDirectory).pathString : dest.pathString
-    let rv = SPMLibc.symlink(destString, path.pathString)
-    guard rv == 0 else { throw SystemError.symlink(errno, path.pathString, dest: destString) }
+    try FileManager.default.createSymbolicLink(atPath: path.pathString, withDestinationPath: destString)
 }
 
 /// The current working directory of the processs.


### PR DESCRIPTION
Use the Foundation extensions to implement the functionality as wrappers
over the existing API.