### PR TITLE
[SPMLLBuild] Handle fatal errors from the build engine

### DIFF
--- a/Tests/PackageLoadingTests/XCTestManifests.swift
+++ b/Tests/PackageLoadingTests/XCTestManifests.swift
@@ -92,6 +92,7 @@ extension PackageDescription4_2LoadingTests {
         ("testCacheInvalidationOnEnv", testCacheInvalidationOnEnv),
         ("testCaching", testCaching),
         ("testDuplicateDependencyDecl", testDuplicateDependencyDecl),
+        ("testLLBuildEngineErrors", testLLBuildEngineErrors),
         ("testPackageDependencies", testPackageDependencies),
         ("testPlatforms", testPlatforms),
         ("testRuntimeManifestErrors", testRuntimeManifestErrors),


### PR DESCRIPTION
We were not handling fatal errors from the build engine that can happen
in rare situations (such as the db being deleted while a build is in
progress). In those cases, llbuild returns an empty value for the
overall result and reports errors via the delegate. This implements the
delegate and throws the errors when this happens.