### PR TITLE
Improve build animation

### DIFF
--- a/Tests/BuildTests/SwiftCompilerOutputParserTests.swift
+++ b/Tests/BuildTests/SwiftCompilerOutputParserTests.swift
@@ -15,11 +15,11 @@ class MockSwiftCompilerOutputParserDelegate: SwiftCompilerOutputParserDelegate {
     private var messages: [SwiftCompilerMessage] = []
     private var error: Error?
 
-    func swiftCompilerDidOutputMessage(_ message: SwiftCompilerMessage) {
+    func swiftCompilerOutputParser(_ parser: SwiftCompilerOutputParser, didParse message: SwiftCompilerMessage) {
         messages.append(message)
     }
 
-    func swiftCompilerOutputParserDidFail(withError error: Error) {
+    func swiftCompilerOutputParser(_ parser: SwiftCompilerOutputParser, didFailWith error: Error) {
         self.error = error
     }
 
@@ -40,7 +40,7 @@ class MockSwiftCompilerOutputParserDelegate: SwiftCompilerOutputParserDelegate {
 class SwiftCompilerOutputParserTests: XCTestCase {
     func testParse() throws {
         let delegate = MockSwiftCompilerOutputParserDelegate()
-        let parser = SwiftCompilerOutputParser(delegate: delegate)
+        let parser = SwiftCompilerOutputParser(targetName: "dummy", delegate: delegate)
 
         parser.parse(bytes: "33".utf8)
         delegate.assert(messages: [], errorDescription: nil)
@@ -185,7 +185,7 @@ class SwiftCompilerOutputParserTests: XCTestCase {
 
     func testInvalidMessageSizeBytes() {
         let delegate = MockSwiftCompilerOutputParserDelegate()
-        let parser = SwiftCompilerOutputParser(delegate: delegate)
+        let parser = SwiftCompilerOutputParser(targetName: "dummy", delegate: delegate)
 
         parser.parse(bytes: [65, 66, 200, 67, UInt8(ascii: "\n")])
         delegate.assert(messages: [], errorDescription: "invalid UTF8 bytes")
@@ -205,7 +205,7 @@ class SwiftCompilerOutputParserTests: XCTestCase {
 
     func testInvalidMessageSizeValue() {
         let delegate = MockSwiftCompilerOutputParserDelegate()
-        let parser = SwiftCompilerOutputParser(delegate: delegate)
+        let parser = SwiftCompilerOutputParser(targetName: "dummy", delegate: delegate)
 
         parser.parse(bytes: """
             2A
@@ -228,7 +228,7 @@ class SwiftCompilerOutputParserTests: XCTestCase {
 
     func testInvalidMessageBytes() {
         let delegate = MockSwiftCompilerOutputParserDelegate()
-        let parser = SwiftCompilerOutputParser(delegate: delegate)
+        let parser = SwiftCompilerOutputParser(targetName: "dummy", delegate: delegate)
 
         parser.parse(bytes: """
             4
@@ -253,7 +253,7 @@ class SwiftCompilerOutputParserTests: XCTestCase {
 
     func testInvalidMessageMissingField() {
         let delegate = MockSwiftCompilerOutputParserDelegate()
-        let parser = SwiftCompilerOutputParser(delegate: delegate)
+        let parser = SwiftCompilerOutputParser(targetName: "dummy", delegate: delegate)
 
         parser.parse(bytes: """
             23
@@ -278,7 +278,7 @@ class SwiftCompilerOutputParserTests: XCTestCase {
 
     func testInvalidMessageInvalidValue() {
         let delegate = MockSwiftCompilerOutputParserDelegate()
-        let parser = SwiftCompilerOutputParser(delegate: delegate)
+        let parser = SwiftCompilerOutputParser(targetName: "dummy", delegate: delegate)
 
         parser.parse(bytes: """
             23

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -30,11 +30,11 @@ class MiscellaneousTestCase: XCTestCase {
         fixture(name: "DependencyResolution/External/Simple") { prefix in
             let output = try executeSwiftBuild(prefix.appending(component: "Bar"))
             XCTAssertMatch(output, .regex("Resolving .* at 1\\.2\\.3"))
-            XCTAssertMatch(output, .regex("Compiling .*Foo.swift"))
-            XCTAssertMatch(output, .regex("Merging module .*Foo\\.swiftmodule"))
-            XCTAssertMatch(output, .contains("Compiling main.swift"))
-            XCTAssertMatch(output, .regex("Merging module .*Bar\\.swiftmodule"))
-            XCTAssertMatch(output, .regex("Linking .*Bar"))
+            XCTAssertMatch(output, .contains("Compiling Foo Foo.swift"))
+            XCTAssertMatch(output, .contains("Merging module Foo"))
+            XCTAssertMatch(output, .contains("Compiling Bar main.swift"))
+            XCTAssertMatch(output, .contains("Merging module Bar"))
+            XCTAssertMatch(output, .contains("Linking Bar"))
         }
     }
 
@@ -90,7 +90,7 @@ class MiscellaneousTestCase: XCTestCase {
                 try executeSwiftBuild(prefix)
                 XCTFail()
             } catch SwiftPMProductError.executionFailure(let error, let output, _) {
-                XCTAssertMatch(output, .contains("Compiling Foo.swift"))
+                XCTAssertMatch(output, .contains("Compiling CompileFails Foo.swift"))
                 XCTAssertMatch(output, .regex("error: .*\n.*compile_failure"))
 
                 if case ProcessResult.Error.nonZeroExit(let result) = error {


### PR DESCRIPTION
Improved the build animation by:

* Printing `[finished_count/scanned_count]` instead of `[finished_count/started_count]` to get a higher estimate quicker of the total number of tasks
* Printing only when `finished_count` changes, and not when the second value changes, to avoid initial `[0/1]` updates.
* Stripping references to paths inside the build directory to only mention the file name instead