### PR TITLE
Error Reporting

### DIFF
--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -258,6 +258,16 @@ public enum PackageRequirement: Hashable {
     }
 }
 
+extension PackageRequirement: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .versionSet(let versionSet): return versionSet.description
+        case .revision(let revision): return revision
+        case .unversioned: return "unversioned"
+        }
+    }
+}
+
 /// A container of packages.
 ///
 /// This is the top-level unit of package resolution, i.e. the unit at which

--- a/Sources/PackageGraph/Pubgrub.swift
+++ b/Sources/PackageGraph/Pubgrub.swift
@@ -805,16 +805,7 @@ public final class PubgrubDependencyResolver {
         }
         decide(root, version: .version("1.0.0"), location: .topLevel)
 
-        do {
-            try run()
-        } catch {
-            if let pubgrubError = error as? PubgrubError,
-                case .unresolvable(let incompatibility) = pubgrubError,
-                case .conflict(let cause, let other) = incompatibility.cause {
-                print("Root cause: \(cause) \(cause.cause) because of \(other) \(other.cause)")
-            }
-            throw error
-        }
+        try run()
 
         let decisions = solution.assignments.filter { $0.isDecision }
         let finalAssignments: [(container: PackageReference, binding: BoundVersion)] = try decisions.compactMap { assignment in

--- a/Sources/PackageGraph/Pubgrub.swift
+++ b/Sources/PackageGraph/Pubgrub.swift
@@ -800,7 +800,7 @@ public final class PubgrubDependencyResolver {
             let incompatibility = Incompatibility(
                 Term(root, .versionSet(.exact("1.0.0"))),
                 Term(not: dependency.identifier, dependency.requirement),
-                root: root, cause: .root)
+                root: root, cause: .dependency(package: root))
             add(incompatibility, location: .topLevel)
         }
         decide(root, version: .version("1.0.0"), location: .topLevel)

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -827,8 +827,11 @@ private func AssertUnresolvable(_ result: PubgrubDependencyResolver.Result,
         }
         XCTAssertEqual(Array(incompatibility.terms), [Term("\(rootPackageName)@1.0.0")], file: file, line: line)
         if !skipDiagnosticAssert {
-            // TODO: Ignore additional whitespace.
-            XCTAssertEqual(resolver.reportError(for: rootCause), expectedDiagnostic, file: file, line: line)
+            // Remove all internal newlines and extra outside whitespace.
+            let trimmedDiagnostic = expectedDiagnostic
+                .replacingOccurrences(of: "\n", with: "")
+                .trimmingCharacters(in: .whitespaces)
+            XCTAssertEqual(resolver.diagnosticBuilder.reportError(for: rootCause), trimmedDiagnostic, file: file, line: line)
         }
     }
 }

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -562,7 +562,13 @@ final class PubgrubTests: XCTestCase {
         let resolver = builder.create()
         let result = resolver.solve(root: rootRef, pins: [])
 
-        AssertRootCause(result, ["package@1.0.0"])
+        guard let rootCause = AssertRootCause(result, ["package@1.0.0"]) else {
+            XCTFail("Expected to find rootCause.")
+            return
+        }
+        XCTAssertEqual(resolver.diagnosticBuilder.reportError(for: rootCause), """
+        No versions of package match the requirement 1.0.0. Package is a dependency of root.
+        """)
     }
 
     func testNonExistentPackage() {
@@ -629,7 +635,13 @@ final class PubgrubTests: XCTestCase {
         let resolver = builder.create()
         let result = resolver.solve(root: rootRef, pins: [])
 
-        AssertRootCause(result, [Term("foo@master")])
+        guard let rootCause = AssertRootCause(result, [Term("foo@master")]) else {
+            XCTFail("Expected to find rootCause.")
+            return
+        }
+        XCTAssertEqual(resolver.diagnosticBuilder.reportError(for: rootCause), """
+        Because foo at master depends on bar at master and root depends on bar from 1.0.0, version solving has failed.
+        """)
     }
 
     func testResolutionLinearErrorReporting() {

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -442,8 +442,10 @@ final class PubgrubTests: XCTestCase {
         let result = resolver.solve(root: rootRef, pins: [])
 
         AssertUnresolvable(result, resolver,
-                           diagnostic: "Because no versions of a match the requirement 2.0.0..<3.0.0, version solving has failed.",
-                           skipDiagnosticAssert: true)
+                           diagnostic: """
+        Because no versions of a match the requirement 2.0.0..<3.0.0,
+        version solving has failed.
+        """, skipDiagnosticAssert: true)
     }
 
     func testResolutionNoConflicts() {


### PR DESCRIPTION
Moved most of the current implementation with some minor changes into DiagnosticReportBuilder. 

There's also still a bug where it's reporting the wrong root cause thanks to the change in 
a4639be 😕 

Due to the `skipDiagnosticAssert` param in the relevant tests this currently passes all of them. The graphs are correctly being diagnosed as unresolvable, the diagnostic is wrong though.