### PR TITLE
[Pubgrub] Add an option to generate resolver trace

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -74,5 +74,8 @@ public class ToolOptions {
     /// Whether to enable generation of `.swiftinterface`s alongside `.swiftmodule`s.
     public var shouldEnableParseableModuleInterfaces = false
 
+    /// Write dependency resolver trace to a file.
+    public var enableResolverTrace = false
+
     public required init() {}
 }

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -362,6 +362,10 @@ public class SwiftTool<Options: ToolOptions> {
             option: parser.add(option: "--enable-parseable-module-interfaces", kind: Bool.self),
             to: { $0.shouldEnableParseableModuleInterfaces = $1 })
 
+        binder.bind(
+            option: parser.add(option: "--trace-resolver", kind: Bool.self),
+            to: { $0.enableResolverTrace = $1 })
+
         // Let subclasses bind arguments.
         type(of: self).defineArguments(parser: parser, binder: binder)
 
@@ -469,7 +473,8 @@ public class SwiftTool<Options: ToolOptions> {
             repositoryProvider: provider,
             isResolverPrefetchingEnabled: options.shouldEnableResolverPrefetching,
             enablePubgrubResolver: options.enablePubgrubResolver,
-            skipUpdate: options.skipDependencyUpdate
+            skipUpdate: options.skipDependencyUpdate,
+            enableResolverTrace: options.enableResolverTrace
         )
         _workspace = workspace
         return workspace

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -303,6 +303,9 @@ public class Workspace {
     /// The active package resolver. This is set during a dependency resolution operation.
     fileprivate var activeResolver: PackageResolver?
 
+    /// Write dependency resolver trace to a file.
+    fileprivate let enableResolverTrace: Bool
+
     /// Typealias for dependency resolver we use in the workspace.
     fileprivate typealias PackageDependencyResolver = DependencyResolver
     fileprivate typealias PubgrubResolver = PubgrubDependencyResolver
@@ -334,7 +337,8 @@ public class Workspace {
         repositoryProvider: RepositoryProvider = GitRepositoryProvider(),
         isResolverPrefetchingEnabled: Bool = false,
         enablePubgrubResolver: Bool = false,
-        skipUpdate: Bool = false
+        skipUpdate: Bool = false,
+        enableResolverTrace: Bool = false
     ) {
         self.delegate = delegate
         self.dataPath = dataPath
@@ -346,6 +350,7 @@ public class Workspace {
         self.isResolverPrefetchingEnabled = isResolverPrefetchingEnabled
         self.enablePubgrubResolver = enablePubgrubResolver
         self.skipUpdate = skipUpdate
+        self.enableResolverTrace = enableResolverTrace
 
         let repositoriesPath = self.dataPath.appending(component: "repositories")
         self.repositoryManager = RepositoryManager(
@@ -1595,17 +1600,22 @@ extension Workspace {
     /// Creates resolver for the workspace.
     fileprivate func createResolver() -> PackageResolver {
         let resolverDelegate = WorkspaceResolverDelegate()
+        // Create pubgrub resolver if enabled.
         if enablePubgrubResolver {
-            let resolver = PubgrubResolver(containerProvider, resolverDelegate,
-                                           isPrefetchingEnabled: isResolverPrefetchingEnabled,
-                                           skipUpdate: skipUpdate)
+            let traceFile = enableResolverTrace ? self.dataPath.appending(components: "resolver.trace") : nil
+            let resolver = PubgrubResolver(
+                containerProvider, resolverDelegate,
+                isPrefetchingEnabled: isResolverPrefetchingEnabled,
+                skipUpdate: skipUpdate, traceFile: traceFile)
             return .pubgrub(resolver)
-        } else {
-            let resolver = DependencyResolver(containerProvider, resolverDelegate,
-                                              isPrefetchingEnabled: isResolverPrefetchingEnabled,
-                                              skipUpdate: skipUpdate)
-            return .legacy(resolver)
         }
+
+        // Otherwise, use the legacy resolver.
+        let resolver = DependencyResolver(
+            containerProvider, resolverDelegate,
+            isPrefetchingEnabled: isResolverPrefetchingEnabled,
+            skipUpdate: skipUpdate)
+        return .legacy(resolver)
     }
 
     /// Runs the dependency resolver based on constraints provided and returns the results.


### PR DESCRIPTION
This adds a hidden flag `--trace-resolver` which will generate resolver
trace in the build directory. Useful for debugging.

<rdar://problem/48141259> [PubGrub] Implement an option to redirect the pubgrub log to a trace file