### PR TITLE
[Xcodeproj] Use "en" for developmentRegion

### DIFF
--- a/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
+++ b/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
@@ -50,7 +50,7 @@ extension Xcode.Project: PropertyListSerializable {
         dict["attributes"] = .dictionary(["LastUpgradeCheck": .string("9999"),
                                           "LastSwiftMigration": .string("9999")])
         dict["compatibilityVersion"] = .string("Xcode 3.2")
-        dict["developmentRegion"] = .string("English")
+        dict["developmentRegion"] = .string("en")
         // Build settings are a bit tricky; in Xcode, each is stored in a named
         // XCBuildConfiguration object, and the list of build configurations is
         // in turn stored in an XCConfigurationList.  In our simplified model,


### PR DESCRIPTION
"English" as a development region (as well as other spelled out languages) has been deprecated for many years. While Xcode 10.2 is the first Xcode release to make this a formal warning, all versions of Xcode that support Swift will be happy with ISO codes.

Localizations from project generated from `master`:
<img width="1001" alt="Screen Shot 2019-04-06 at 1 49 02 PM" src="https://user-images.githubusercontent.com/24365857/55757489-058c9d00-5a22-11e9-993e-110a99eca36e.png">

Localizations from project generated from this branch:
<img width="698" alt="Screen Shot 2019-04-08 at 5 18 31 PM" src="https://user-images.githubusercontent.com/24365857/55757590-569c9100-5a22-11e9-8028-1f0a36f1c0c0.png">
