### PR TITLE
Fix Up ProcessSet for Windows

### DIFF
--- a/Sources/Basic/ProcessSet.swift
+++ b/Sources/Basic/ProcessSet.swift
@@ -89,7 +89,11 @@ public final class ProcessSet {
                 }
             }
             // Send kill signal to all processes.
+          #if os(Windows)
+            self.signalAll(SIGTERM)
+          #else
             self.signalAll(SIGKILL)
+          #endif
         }
 
         thread.start()


### PR DESCRIPTION
Windows doesn't have SIGKILL, we'll use SIGTERM instead