### PR TITLE
Make TerminalController compile on Windows

### DIFF
--- a/Sources/Basic/TerminalController.swift
+++ b/Sources/Basic/TerminalController.swift
@@ -115,7 +115,7 @@ public final class TerminalController {
         // Following code does not compile on ppc64le well. TIOCGWINSZ is
         // defined in system ioctl.h file which needs to be used. This is
         // a temporary arrangement and needs to be fixed.
-#if !arch(powerpc64le)
+#if !(arch(powerpc64le) || os(Windows))
         var ws = winsize()
         if ioctl(1, UInt(TIOCGWINSZ), &ws) == 0 {
             return Int(ws.ws_col)


### PR DESCRIPTION
This file will definitely need another look to make sure it actually does what it's supposed to do, but for now, just not using ioctl is enough to get this compiling on Windows.