### PR TITLE
Refactor Path so that it works on windows

### DIFF
--- a/Sources/Basic/FileSystem.swift
+++ b/Sources/Basic/FileSystem.swift
@@ -203,7 +203,7 @@ public extension FileSystem {
     func chmod(_ mode: FileMode, path: AbsolutePath) throws {
         try chmod(mode, path: path, options: [])
     }
-    
+
     // Unless the file system type provides an override for this method, throw
     // if `atomically` is `true`, otherwise fall back to whatever implementation already exists.
     func writeFileContents(_ path: AbsolutePath, bytes: ByteString, atomically: Bool) throws {
@@ -351,7 +351,7 @@ private class LocalFileSystem: FileSystem {
             break
         }
     }
-    
+
     func writeFileContents(_ path: AbsolutePath, bytes: ByteString, atomically: Bool) throws {
         // Perform non-atomic writes using the fast path.
         if !atomically {
@@ -657,7 +657,7 @@ public class InMemoryFileSystem: FileSystem {
         // Write the file.
         contents.entries[path.basename] = Node(.file(bytes))
     }
-    
+
     public func writeFileContents(_ path: AbsolutePath, bytes: ByteString, atomically: Bool) throws {
         // In memory file system's writeFileContents is already atomic, so ignore the parameter here
         // and just call the base implementation.
@@ -706,8 +706,8 @@ public class RerootedFileSystemView: FileSystem {
 
     /// Adjust the input path for the underlying file system.
     private func formUnderlyingPath(_ path: AbsolutePath) -> AbsolutePath {
-        if path == AbsolutePath.root {
-            return root
+        if path.isRoot {
+            return path
         } else {
             // FIXME: Optimize?
             return root.appending(RelativePath(String(path.pathString.dropFirst(1))))
@@ -779,7 +779,7 @@ extension FileSystem {
     /// Print the filesystem tree of the given path.
     ///
     /// For debugging only.
-    public func dumpTree(at path: AbsolutePath = .root) {
+    public func dumpTree(at path: AbsolutePath) {
         print(".")
         do {
             try recurse(fs: self, path: path)

--- a/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
@@ -271,7 +271,7 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
             return isValid
         }))
     }
-    
+
     /// The opened repository.
     let repository: Repository
 
@@ -343,7 +343,7 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
         let tag = knownVersions[version]!
         let revision = try repository.resolveRevision(tag: tag)
         let fs = try repository.openFileView(revision: revision)
-        return try toolsVersionLoader.load(at: .root, fileSystem: fs)
+        return try toolsVersionLoader.load(at: AbsolutePath("/"), fileSystem: fs)
     }
 
     public override func getDependencies(at version: Version) throws -> [RepositoryPackageConstraint] {
@@ -396,7 +396,7 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
         let packageURL = identifier.repository.url
 
         // Load the tools version.
-        let toolsVersion = try toolsVersionLoader.load(at: .root, fileSystem: fs)
+        let toolsVersion = try toolsVersionLoader.load(at: AbsolutePath("/"), fileSystem: fs)
 
         // Validate the tools version.
         try toolsVersion.validateToolsVersion(
@@ -404,7 +404,7 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
 
         // Load the manifest.
         let manifest = try manifestLoader.load(
-            package: AbsolutePath.root,
+            package: AbsolutePath("/"),
             baseURL: packageURL,
             version: version,
             manifestVersion: toolsVersion.manifestVersion,

--- a/Sources/SPMUtility/Platform.swift
+++ b/Sources/SPMUtility/Platform.swift
@@ -1,9 +1,9 @@
 /*
  This source file is part of the Swift.org open source project
- 
+
  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
- 
+
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
@@ -15,7 +15,7 @@ import Foundation
 public enum Platform {
     case darwin
     case linux(LinuxFlavor)
-    
+
     /// Recognized flavors of linux.
     public enum LinuxFlavor {
         case debian
@@ -61,12 +61,16 @@ public enum Platform {
     ///
     /// - Note: This method returns `nil` if the value is an invalid path.
     private static func getConfstr(_ name: Int32) -> AbsolutePath? {
-        let len = confstr(name, nil, 0)
-        let tmp = UnsafeMutableBufferPointer(start: UnsafeMutablePointer<Int8>.allocate(capacity: len), count:len)
-        defer { tmp.deallocate() }
-        guard confstr(name, tmp.baseAddress, len) == len else { return nil }
-        let value = String(cString: tmp.baseAddress!)
-        guard value.hasSuffix(AbsolutePath.root.pathString) else { return nil }
-        return resolveSymlinks(AbsolutePath(value))
+        #if !os(Windows)
+            let len = confstr(name, nil, 0)
+            let tmp = UnsafeMutableBufferPointer(start: UnsafeMutablePointer<Int8>.allocate(capacity: len), count:len)
+            defer { tmp.deallocate() }
+            guard confstr(name, tmp.baseAddress, len) == len else { return nil }
+            let value = String(cString: tmp.baseAddress!)
+            guard value.hasSuffix("/") else { return nil }
+            return resolveSymlinks(AbsolutePath(value))
+        #else
+            return nil
+        #endif
     }
 }

--- a/Sources/TestSupport/FileSystemExtensions.swift
+++ b/Sources/TestSupport/FileSystemExtensions.swift
@@ -39,7 +39,7 @@ extension InMemoryFileSystem {
     /// Create a new file system with an empty file at each provided path.
     public convenience init(emptyFiles files: [String]) {
         self.init()
-        self.createEmptyFiles(at: .root, files: files)
+        self.createEmptyFiles(at: AbsolutePath("/"), files: files)
     }
 }
 

--- a/Tests/BasicTests/FileSystemTests.swift
+++ b/Tests/BasicTests/FileSystemTests.swift
@@ -104,7 +104,7 @@ class FileSystemTests: XCTestCase {
             XCTAssertEqual(fs.exists(source), false)
             XCTAssertEqual(fs.exists(source, followSymlink: true), false)
             XCTAssertEqual(fs.exists(source, followSymlink: false), true)
-            
+
             // None exist.
 
             try fs.removeFileTree(source)
@@ -116,7 +116,7 @@ class FileSystemTests: XCTestCase {
 
     func testLocalCreateDirectory() throws {
         let fs = Basic.localFileSystem
-        
+
         let tmpDir = try TemporaryDirectory(prefix: #function, removeTreeOnDeinit: true)
         do {
             let testPath = tmpDir.path.appending(component: "new-dir")
@@ -138,7 +138,7 @@ class FileSystemTests: XCTestCase {
 
     func testLocalReadWriteFile() throws {
         let fs = Basic.localFileSystem
-        
+
         let tmpDir = try TemporaryDirectory(prefix: #function, removeTreeOnDeinit: true)
         // Check read/write of a simple file.
         let testData = (0..<1000).map { $0.description }.joined(separator: ", ")
@@ -147,7 +147,7 @@ class FileSystemTests: XCTestCase {
         XCTAssertTrue(fs.isFile(filePath))
         let data = try! fs.readFileContents(filePath)
         XCTAssertEqual(data, ByteString(testData))
-        
+
         // Atomic writes
         let inMemoryFilePath = AbsolutePath("/file.text")
         XCTAssertNoThrow(try Basic.InMemoryFileSystem(files: [:]).writeFileContents(inMemoryFilePath, bytes: ByteString(testData), atomically: true))
@@ -163,11 +163,11 @@ class FileSystemTests: XCTestCase {
         XCTAssertNoThrow(try fs.writeFileContents(filePath2, bytes: byteString, atomically: true))
         let read2 = try fs.readFileContents(filePath2)
         XCTAssertEqual(read2, byteString)
-                
+
         // Check overwrite of a file.
         try! fs.writeFileContents(filePath, bytes: "Hello, new world!")
         XCTAssertEqual(try! fs.readFileContents(filePath), "Hello, new world!")
-    
+
         // Check read/write of a directory.
         XCTAssertThrows(FileSystemError.ioError) {
             _ = try fs.readFileContents(filePath.parentDirectory)
@@ -176,7 +176,7 @@ class FileSystemTests: XCTestCase {
             try fs.writeFileContents(filePath.parentDirectory, bytes: [])
         }
         XCTAssertEqual(try! fs.readFileContents(filePath), "Hello, new world!")
-    
+
         // Check read/write against root.
         XCTAssertThrows(FileSystemError.ioError) {
             _ = try fs.readFileContents(AbsolutePath("/"))
@@ -185,7 +185,7 @@ class FileSystemTests: XCTestCase {
             try fs.writeFileContents(AbsolutePath("/"), bytes: [])
         }
         XCTAssert(fs.exists(filePath))
-    
+
         // Check read/write into a non-directory.
         XCTAssertThrows(FileSystemError.notDirectory) {
             _ = try fs.readFileContents(filePath.appending(component: "not-possible"))
@@ -194,7 +194,7 @@ class FileSystemTests: XCTestCase {
             try fs.writeFileContents(filePath.appending(component: "not-possible"), bytes: [])
         }
         XCTAssert(fs.exists(filePath))
-    
+
         // Check read/write into a missing directory.
         let missingDir = tmpDir.path.appending(components: "does", "not", "exist")
         XCTAssertThrows(FileSystemError.noEntry) {
@@ -247,7 +247,7 @@ class FileSystemTests: XCTestCase {
         let fs = InMemoryFileSystem()
         // Make sure root entry isn't created.
         try! fs.createDirectory(AbsolutePath("/"), recursive: true)
-        let rootContents = try! fs.getDirectoryContents(.root)
+        let rootContents = try! fs.getDirectoryContents(AbsolutePath("/"))
         XCTAssertEqual(rootContents, [])
 
         let subdir = AbsolutePath("/new-dir/subdir")
@@ -257,13 +257,13 @@ class FileSystemTests: XCTestCase {
         // Check duplicate creation.
         try! fs.createDirectory(subdir, recursive: true)
         XCTAssert(fs.isDirectory(subdir))
-        
+
         // Check non-recursive subdir creation.
         let subsubdir = subdir.appending(component: "new-subdir")
         XCTAssert(!fs.isDirectory(subsubdir))
         try! fs.createDirectory(subsubdir, recursive: false)
         XCTAssert(fs.isDirectory(subsubdir))
-        
+
         // Check non-recursive failing subdir case.
         let newsubdir = AbsolutePath("/very-new-dir/subdir")
         XCTAssert(!fs.isDirectory(newsubdir))
@@ -271,7 +271,7 @@ class FileSystemTests: XCTestCase {
             try fs.createDirectory(newsubdir, recursive: false)
         }
         XCTAssert(!fs.isDirectory(newsubdir))
-        
+
         // Check directory creation over a file.
         let filePath = AbsolutePath("/mach_kernel")
         try! fs.writeFileContents(filePath, bytes: [0xCD, 0x0D])
@@ -284,7 +284,7 @@ class FileSystemTests: XCTestCase {
         }
         XCTAssert(fs.exists(filePath) && !fs.isDirectory(filePath))
     }
-    
+
     func testInMemoryReadWriteFile() {
         let fs = InMemoryFileSystem()
         try! fs.createDirectory(AbsolutePath("/new-dir/subdir"), recursive: true)
@@ -303,7 +303,7 @@ class FileSystemTests: XCTestCase {
         // Check overwrite of a file.
         try! fs.writeFileContents(filePath, bytes: "Hello, new world!")
         XCTAssertEqual(try! fs.readFileContents(filePath), "Hello, new world!")
-        
+
         // Check read/write of a directory.
         XCTAssertThrows(FileSystemError.isDirectory) {
             _ = try fs.readFileContents(filePath.parentDirectory)
@@ -312,7 +312,7 @@ class FileSystemTests: XCTestCase {
             try fs.writeFileContents(filePath.parentDirectory, bytes: [])
         }
         XCTAssertEqual(try! fs.readFileContents(filePath), "Hello, new world!")
-        
+
         // Check read/write against root.
         XCTAssertThrows(FileSystemError.isDirectory) {
             _ = try fs.readFileContents(AbsolutePath("/"))
@@ -322,7 +322,7 @@ class FileSystemTests: XCTestCase {
         }
         XCTAssert(fs.exists(filePath))
         XCTAssertTrue(fs.isFile(filePath))
-        
+
         // Check read/write into a non-directory.
         XCTAssertThrows(FileSystemError.notDirectory) {
             _ = try fs.readFileContents(filePath.appending(component: "not-possible"))
@@ -331,7 +331,7 @@ class FileSystemTests: XCTestCase {
             try fs.writeFileContents(filePath.appending(component: "not-possible"), bytes: [])
         }
         XCTAssert(fs.exists(filePath))
-        
+
         // Check read/write into a missing directory.
         let missingDir = AbsolutePath("/does/not/exist")
         XCTAssertThrows(FileSystemError.noEntry) {
@@ -360,7 +360,7 @@ class FileSystemTests: XCTestCase {
 
     func testInMemRemoveFileTree() throws {
         let fs = InMemoryFileSystem() as FileSystem
-        try removeFileTreeTester(fs: fs, basePath: .root)
+        try removeFileTreeTester(fs: fs, basePath: AbsolutePath("/"))
     }
 
 

--- a/Tests/BasicTests/PathShimTests.swift
+++ b/Tests/BasicTests/PathShimTests.swift
@@ -17,7 +17,7 @@ class PathShimTests : XCTestCase {
 
     func testResolvingSymlinks() {
         // Make sure the root path resolves to itself.
-        XCTAssertEqual(resolveSymlinks(AbsolutePath.root), AbsolutePath.root)
+        XCTAssertEqual(resolveSymlinks(AbsolutePath("/")), AbsolutePath("/"))
 
         // For the rest of the tests we'll need a temporary directory.
         let tmpDir = try! TemporaryDirectory(removeTreeOnDeinit: true)

--- a/Tests/BasicTests/PathTests.swift
+++ b/Tests/BasicTests/PathTests.swift
@@ -14,7 +14,7 @@ import Foundation
 import Basic
 
 class PathTests: XCTestCase {
-    
+
     func testBasics() {
         XCTAssertEqual(AbsolutePath("/").pathString, "/")
         XCTAssertEqual(AbsolutePath("/a").pathString, "/a")
@@ -24,7 +24,7 @@ class PathTests: XCTestCase {
         XCTAssertEqual(RelativePath("a/b/c").pathString, "a/b/c")
         XCTAssertEqual(RelativePath("~").pathString, "~")  // `~` is not special
     }
-    
+
     func testStringInitialization() {
         let abs1 = AbsolutePath("/")
         let abs2 = AbsolutePath(abs1, ".")
@@ -40,7 +40,7 @@ class PathTests: XCTestCase {
         let abs6 = AbsolutePath("~/bla", relativeTo: base)  // `~` isn't special
         XCTAssertEqual(abs6, AbsolutePath("/base/path/~/bla"))
     }
-    
+
     func testStringLiteralInitialization() {
         let abs = AbsolutePath("/")
         XCTAssertEqual(abs.pathString, "/")
@@ -49,28 +49,28 @@ class PathTests: XCTestCase {
         let rel2 = RelativePath("~")
         XCTAssertEqual(rel2.pathString, "~")  // `~` is not special
     }
-    
+
     func testRepeatedPathSeparators() {
         XCTAssertEqual(AbsolutePath("/ab//cd//ef").pathString, "/ab/cd/ef")
         XCTAssertEqual(AbsolutePath("/ab///cd//ef").pathString, "/ab/cd/ef")
         XCTAssertEqual(RelativePath("ab//cd//ef").pathString, "ab/cd/ef")
         XCTAssertEqual(RelativePath("ab//cd///ef").pathString, "ab/cd/ef")
     }
-    
+
     func testTrailingPathSeparators() {
         XCTAssertEqual(AbsolutePath("/ab/cd/ef/").pathString, "/ab/cd/ef")
         XCTAssertEqual(AbsolutePath("/ab/cd/ef//").pathString, "/ab/cd/ef")
         XCTAssertEqual(RelativePath("ab/cd/ef/").pathString, "ab/cd/ef")
         XCTAssertEqual(RelativePath("ab/cd/ef//").pathString, "ab/cd/ef")
     }
-    
+
     func testDotPathComponents() {
         XCTAssertEqual(AbsolutePath("/ab/././cd//ef").pathString, "/ab/cd/ef")
         XCTAssertEqual(AbsolutePath("/ab/./cd//ef/.").pathString, "/ab/cd/ef")
         XCTAssertEqual(RelativePath("ab/./cd/././ef").pathString, "ab/cd/ef")
         XCTAssertEqual(RelativePath("ab/./cd/ef/.").pathString, "ab/cd/ef")
     }
-    
+
     func testDotDotPathComponents() {
         XCTAssertEqual(AbsolutePath("/..").pathString, "/")
         XCTAssertEqual(AbsolutePath("/../../../../..").pathString, "/")
@@ -86,7 +86,7 @@ class PathTests: XCTestCase {
         XCTAssertEqual(RelativePath("../abc/.././").pathString, "..")
         XCTAssertEqual(RelativePath("abc/..").pathString, ".")
     }
-    
+
     func testCombinationsAndEdgeCases() {
         XCTAssertEqual(AbsolutePath("///").pathString, "/")
         XCTAssertEqual(AbsolutePath("/./").pathString, "/")
@@ -115,7 +115,7 @@ class PathTests: XCTestCase {
         XCTAssertEqual(RelativePath("a/..").pathString, ".")
         XCTAssertEqual(RelativePath("a/../////../////./////").pathString, "..")
     }
-        
+
     func testDirectoryNameExtraction() {
         XCTAssertEqual(AbsolutePath("/").dirname, "/")
         XCTAssertEqual(AbsolutePath("/a").dirname, "/")
@@ -132,7 +132,7 @@ class PathTests: XCTestCase {
         XCTAssertEqual(RelativePath("").dirname, ".")
         XCTAssertEqual(RelativePath(".").dirname, ".")
     }
-    
+
     func testBaseNameExtraction() {
         XCTAssertEqual(AbsolutePath("/").basename, "/")
         XCTAssertEqual(AbsolutePath("/a").basename, "a")
@@ -148,7 +148,7 @@ class PathTests: XCTestCase {
         XCTAssertEqual(RelativePath("").basename, ".")
         XCTAssertEqual(RelativePath(".").basename, ".")
     }
-    
+
     func testSuffixExtraction() {
         XCTAssertEqual(RelativePath("a").suffix, nil)
         XCTAssertEqual(RelativePath("a").extension, nil)
@@ -173,7 +173,7 @@ class PathTests: XCTestCase {
         XCTAssertEqual(RelativePath(".a.foo.bar.baz").suffix, ".baz")
         XCTAssertEqual(RelativePath(".a.foo.bar.baz").extension, "baz")
     }
-    
+
     func testParentDirectory() {
         XCTAssertEqual(AbsolutePath("/").parentDirectory, AbsolutePath("/"))
         XCTAssertEqual(AbsolutePath("/").parentDirectory.parentDirectory, AbsolutePath("/"))
@@ -181,7 +181,7 @@ class PathTests: XCTestCase {
         XCTAssertEqual(AbsolutePath("/bar/../foo/..//").parentDirectory.parentDirectory, AbsolutePath("/"))
         XCTAssertEqual(AbsolutePath("/bar/../foo/..//yabba/a/b").parentDirectory.parentDirectory, AbsolutePath("/yabba"))
     }
-    
+
     func testConcatenation() {
         XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("")).pathString, "/")
         XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath(".")).pathString, "/")
@@ -191,7 +191,7 @@ class PathTests: XCTestCase {
         XCTAssertEqual(AbsolutePath(AbsolutePath("/bar"), RelativePath("../foo")).pathString, "/foo")
         XCTAssertEqual(AbsolutePath(AbsolutePath("/bar"), RelativePath("../foo/..//")).pathString, "/")
         XCTAssertEqual(AbsolutePath(AbsolutePath("/bar/../foo/..//yabba/"), RelativePath("a/b")).pathString, "/yabba/a/b")
-        
+
         XCTAssertEqual(AbsolutePath("/").appending(RelativePath("")).pathString, "/")
         XCTAssertEqual(AbsolutePath("/").appending(RelativePath(".")).pathString, "/")
         XCTAssertEqual(AbsolutePath("/").appending(RelativePath("..")).pathString, "/")
@@ -215,7 +215,7 @@ class PathTests: XCTestCase {
         XCTAssertEqual(AbsolutePath("/").appending(components: ".").pathString, "/")
         XCTAssertEqual(AbsolutePath("/").appending(components: "..", "a").pathString, "/a")
     }
-    
+
     func testPathComponents() {
         XCTAssertEqual(AbsolutePath("/").components, ["/"])
         XCTAssertEqual(AbsolutePath("/.").components, ["/"])
@@ -225,7 +225,7 @@ class PathTests: XCTestCase {
         XCTAssertEqual(AbsolutePath("/bar/../foo").components, ["/", "foo"])
         XCTAssertEqual(AbsolutePath("/bar/../foo/..//").components, ["/"])
         XCTAssertEqual(AbsolutePath("/bar/../foo/..//yabba/a/b/").components, ["/", "yabba", "a", "b"])
-        
+
         XCTAssertEqual(RelativePath("").components, ["."])
         XCTAssertEqual(RelativePath(".").components, ["."])
         XCTAssertEqual(RelativePath("..").components, [".."])
@@ -243,7 +243,7 @@ class PathTests: XCTestCase {
         XCTAssertEqual(RelativePath("a/../////../////./////").components, [".."])
         XCTAssertEqual(RelativePath("abc").components, ["abc"])
     }
-    
+
     func testRelativePathFromAbsolutePaths() {
         XCTAssertEqual(AbsolutePath("/").relative(to: AbsolutePath("/")), RelativePath("."));
         XCTAssertEqual(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/")), RelativePath("a/b/c/d"));
@@ -253,7 +253,7 @@ class PathTests: XCTestCase {
         XCTAssertEqual(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/a/c/d")), RelativePath("../../b/c/d"));
         XCTAssertEqual(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/b/c/d")), RelativePath("../../../a/b/c/d"));
     }
-    
+
     func testComparison() {
         XCTAssertTrue(AbsolutePath("/") <= AbsolutePath("/"));
         XCTAssertTrue(AbsolutePath("/abc") < AbsolutePath("/def"));
@@ -271,12 +271,12 @@ class PathTests: XCTestCase {
         XCTAssertFalse(AbsolutePath("/foo/bar").contains(AbsolutePath("/foo/bar/baz")))
         XCTAssertFalse(AbsolutePath("/foo/bar").contains(AbsolutePath("/bar")))
     }
-    
+
     func testAbsolutePathValidation() {
         XCTAssertNoThrow(try AbsolutePath(validating: "/a/b/c/d"))
 
         XCTAssertThrowsError(try AbsolutePath(validating: "~/a/b/d")) { error in
-            XCTAssertEqual("\(error)", "invalid absolute path '~/a/b/d'; absolute path must begin with '/'")
+            XCTAssertEqual("\(error)", "invalid path '~/a/b/d'; path must not begin with '~'")
         }
 
         XCTAssertThrowsError(try AbsolutePath(validating: "a/b/d")) { error in
@@ -288,11 +288,11 @@ class PathTests: XCTestCase {
         XCTAssertNoThrow(try RelativePath(validating: "a/b/c/d"))
 
         XCTAssertThrowsError(try RelativePath(validating: "/a/b/d")) { error in
-            XCTAssertEqual("\(error)", "invalid relative path '/a/b/d'; relative path should not begin with '/' or '~'")
+            XCTAssertEqual("\(error)", "invalid relative path '/a/b/d'; relative path should not begin with '/', a drive or '~'")
         }
 
         XCTAssertThrowsError(try RelativePath(validating: "~/a/b/d")) { error in
-            XCTAssertEqual("\(error)", "invalid relative path '~/a/b/d'; relative path should not begin with '/' or '~'")
+            XCTAssertEqual("\(error)", "invalid path '~/a/b/d'; path must not begin with '~'")
         }
     }
 
@@ -339,8 +339,8 @@ class PathTests: XCTestCase {
     }
 
     // FIXME: We also need tests for join() operations.
-    
+
     // FIXME: We also need tests for dirname, basename, suffix, etc.
-    
+
     // FIXME: We also need test for stat() operations.
 }

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -21,12 +21,12 @@ import TestSupport
 private class MockRepository: Repository {
     /// The fake URL of the repository.
     let url: String
-    
+
     /// The known repository versions, as a map of tags to manifests.
     let versions: [Version: Manifest]
 
     let fs: FileSystem
-    
+
     init(fs: FileSystem, url: String, versions: [Version: Manifest]) {
         self.fs = fs
         self.url = url
@@ -103,7 +103,7 @@ private class MockRepositories: RepositoryProvider {
     func checkoutExists(at path: AbsolutePath) throws -> Bool {
         return false
     }
-    
+
     func open(repository: RepositorySpecifier, at path: AbsolutePath) throws -> Repository {
         return repositories[repository.url]!
     }
@@ -233,7 +233,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
     func testVprefixVersions() throws {
         let fs = InMemoryFileSystem()
 
-        let repoPath = AbsolutePath.root.appending(component: "some-repo")
+        let repoPath = AbsolutePath("/").appending(component: "some-repo")
         let filePath = repoPath.appending(component: "Package.swift")
 
         let specifier = RepositorySpecifier(url: repoPath.pathString)
@@ -250,7 +250,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         let inMemRepoProvider = InMemoryGitRepositoryProvider()
         inMemRepoProvider.add(specifier: specifier, repository: repo)
 
-        let p = AbsolutePath.root.appending(component: "repoManager")
+        let p = AbsolutePath("/").appending(component: "repoManager")
         try fs.createDirectory(p, recursive: true)
         let repositoryManager = RepositoryManager(
             path: p,
@@ -270,7 +270,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
     func testVersions() throws {
         let fs = InMemoryFileSystem()
 
-        let repoPath = AbsolutePath.root.appending(component: "some-repo")
+        let repoPath = AbsolutePath("/").appending(component: "some-repo")
         let filePath = repoPath.appending(component: "Package.swift")
 
         let specifier = RepositorySpecifier(url: repoPath.pathString)
@@ -297,7 +297,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         let inMemRepoProvider = InMemoryGitRepositoryProvider()
         inMemRepoProvider.add(specifier: specifier, repository: repo)
 
-        let p = AbsolutePath.root.appending(component: "repoManager")
+        let p = AbsolutePath("/").appending(component: "repoManager")
         try fs.createDirectory(p, recursive: true)
         let repositoryManager = RepositoryManager(
             path: p,
@@ -352,13 +352,13 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             }
         }
     }
-    
+
     func testPrereleaseVersions() throws {
         let fs = InMemoryFileSystem()
-        
-        let repoPath = AbsolutePath.root.appending(component: "some-repo")
+
+        let repoPath = AbsolutePath("/").appending(component: "some-repo")
         let filePath = repoPath.appending(component: "Package.swift")
-        
+
         let specifier = RepositorySpecifier(url: repoPath.pathString)
         let repo = InMemoryGitRepository(path: repoPath, fs: fs)
         try repo.createDirectory(repoPath, recursive: true)
@@ -371,18 +371,18 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         try repo.tag(name: "1.0.2-dev")
         try repo.tag(name: "1.0.2-dev.2")
         try repo.tag(name: "1.0.4-alpha")
-        
+
         let inMemRepoProvider = InMemoryGitRepositoryProvider()
         inMemRepoProvider.add(specifier: specifier, repository: repo)
-        
-        let p = AbsolutePath.root.appending(component: "repoManager")
+
+        let p = AbsolutePath("/").appending(component: "repoManager")
         try fs.createDirectory(p, recursive: true)
         let repositoryManager = RepositoryManager(
             path: p,
             provider: inMemRepoProvider,
             delegate: MockResolverDelegate(),
             fileSystem: fs)
-        
+
         let provider = RepositoryPackageContainerProvider(
             repositoryManager: repositoryManager,
             manifestLoader: MockManifestLoader(manifests: [:]))
@@ -391,13 +391,13 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         let v = container.versions(filter: { _ in true }).map{$0}
         XCTAssertEqual(v, ["1.0.4-alpha", "1.0.2-dev.2", "1.0.2-dev", "1.0.1", "1.0.0", "1.0.0-beta.1", "1.0.0-alpha.1"])
     }
-    
+
     func testSimultaneousVersions() throws {
         let fs = InMemoryFileSystem()
-        
-        let repoPath = AbsolutePath.root.appending(component: "some-repo")
+
+        let repoPath = AbsolutePath("/").appending(component: "some-repo")
         let filePath = repoPath.appending(component: "Package.swift")
-        
+
         let specifier = RepositorySpecifier(url: repoPath.pathString)
         let repo = InMemoryGitRepository(path: repoPath, fs: fs)
         try repo.createDirectory(repoPath, recursive: true)
@@ -409,18 +409,18 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         try repo.tag(name: "v1.0.2")
         try repo.tag(name: "1.0.4")
         try repo.tag(name: "v2.0.1")
-        
+
         let inMemRepoProvider = InMemoryGitRepositoryProvider()
         inMemRepoProvider.add(specifier: specifier, repository: repo)
-        
-        let p = AbsolutePath.root.appending(component: "repoManager")
+
+        let p = AbsolutePath("/").appending(component: "repoManager")
         try fs.createDirectory(p, recursive: true)
         let repositoryManager = RepositoryManager(
             path: p,
             provider: inMemRepoProvider,
             delegate: MockResolverDelegate(),
             fileSystem: fs)
-        
+
         let provider = RepositoryPackageContainerProvider(
             repositoryManager: repositoryManager,
             manifestLoader: MockManifestLoader(manifests: [:]))

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -137,19 +137,19 @@ class ModuleMapGeneration: XCTestCase {
 }
 
 func ModuleMapTester(_ name: String, includeDir: String = "include", in fileSystem: FileSystem, _ body: (ModuleMapResult) -> Void) {
-    let includeDir = AbsolutePath.root.appending(component: includeDir)
-    let target = ClangTarget(name: name, cLanguageStandard: nil, cxxLanguageStandard: nil, includeDir: includeDir, isTest: false, sources: Sources(paths: [], root: .root))
+    let includeDir = AbsolutePath("/").appending(component: includeDir)
+    let target = ClangTarget(name: name, cLanguageStandard: nil, cxxLanguageStandard: nil, includeDir: includeDir, isTest: false, sources: Sources(paths: [], root: AbsolutePath("/")))
     let warningStream = BufferedOutputByteStream()
     var generator = ModuleMapGenerator(for: target, fileSystem: fileSystem, warningStream: warningStream)
     var diagnostics = Set<String>()
     do {
-        try generator.generateModuleMap(inDir: .root)
+        try generator.generateModuleMap(inDir: AbsolutePath("/"))
         // FIXME: Find a better way.
         diagnostics = Set(warningStream.bytes.description.split(separator: "\n").map(String.init))
     } catch {
       diagnostics.insert("\(error)")
     }
-    let genPath = AbsolutePath.root.appending(components: "module.modulemap")
+    let genPath = AbsolutePath("/").appending(components: "module.modulemap")
     let result = ModuleMapResult(diagnostics: diagnostics, path: genPath, fs: fileSystem)
     body(result)
     result.validateDiagnostics()

--- a/Tests/PackageLoadingTests/PD4LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4LoadingTests.swift
@@ -27,10 +27,10 @@ class PackageDescription4LoadingTests: XCTestCase {
         body: (Manifest) -> Void) throws
     {
         let fs = InMemoryFileSystem()
-        let manifestPath = AbsolutePath.root.appending(component: Manifest.filename)
+        let manifestPath = AbsolutePath("/").appending(component: Manifest.filename)
         try fs.writeFileContents(manifestPath, bytes: contents)
         let m = try manifestLoader.load(
-            package: AbsolutePath.root,
+            package: AbsolutePath("/"),
             baseURL: "/foo",
             manifestVersion: .v4,
             fileSystem: fs)
@@ -376,7 +376,7 @@ class PackageDescription4LoadingTests: XCTestCase {
 
     func testManifestWithWarnings() throws {
         let fs = InMemoryFileSystem()
-        let manifestPath = AbsolutePath.root.appending(component: Manifest.filename)
+        let manifestPath = AbsolutePath("/").appending(component: Manifest.filename)
         let stream = BufferedOutputByteStream()
 
         stream <<< """
@@ -393,7 +393,7 @@ class PackageDescription4LoadingTests: XCTestCase {
 
         let diagnostics = DiagnosticsEngine()
         let manifest = try manifestLoader.load(
-            package: .root, baseURL: "/foo",
+            package: AbsolutePath("/"), baseURL: "/foo",
             manifestVersion: .v4, fileSystem: fs,
             diagnostics: diagnostics
         )

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -26,10 +26,10 @@ class PackageDescription4_2LoadingTests: XCTestCase {
         body: (Manifest) -> Void
     ) throws {
         let fs = InMemoryFileSystem()
-        let manifestPath = AbsolutePath.root.appending(component: Manifest.filename)
+        let manifestPath = AbsolutePath("/").appending(component: Manifest.filename)
         try fs.writeFileContents(manifestPath, bytes: contents)
         let m = try manifestLoader.load(
-            package: AbsolutePath.root,
+            package: AbsolutePath("/"),
             baseURL: "/foo",
             manifestVersion: .v4_2,
             fileSystem: fs)
@@ -360,7 +360,7 @@ class PackageDescription4_2LoadingTests: XCTestCase {
             "\(currentVersion.major)"
         ]
         for (i, key) in possibleSuffixes.enumerated() {
-            let root = AbsolutePath.root
+            let root = AbsolutePath("/")
             // Create a temporary FS with the version we want to test, and everything else as bogus.
             let fs = InMemoryFileSystem()
             // Write the good manifests.
@@ -446,7 +446,7 @@ class PackageDescription4_2LoadingTests: XCTestCase {
             XCTAssertEqual(urls, ["/foo/path/to/foo1", "/foo1", "/foo1.git", "/foo2.git", "/foo2.git"])
         }
     }
-    
+
     func testNotAbsoluteDependencyPath() throws {
         let stream = BufferedOutputByteStream()
         stream <<< """
@@ -463,7 +463,7 @@ class PackageDescription4_2LoadingTests: XCTestCase {
             ]
         )
         """
-        
+
         do {
             try loadManifestThrowing(stream.bytes) { _ in }
             XCTFail("Unexpected success")

--- a/Tests/PackageLoadingTests/PD5LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5LoadingTests.swift
@@ -26,10 +26,10 @@ class PackageDescription5LoadingTests: XCTestCase {
         body: (Manifest) -> Void
     ) throws {
         let fs = InMemoryFileSystem()
-        let manifestPath = AbsolutePath.root.appending(component: Manifest.filename)
+        let manifestPath = AbsolutePath("/").appending(component: Manifest.filename)
         try fs.writeFileContents(manifestPath, bytes: contents)
         let m = try manifestLoader.load(
-            package: AbsolutePath.root,
+            package: AbsolutePath("/"),
             baseURL: "/foo",
             manifestVersion: .v5,
             fileSystem: fs)

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -1571,7 +1571,7 @@ class PackageBuilderTests: XCTestCase {
         )
 
         PackageBuilderTester(manifest1, path: AbsolutePath("/pkg"), in: fs) { result in
-            result.checkDiagnostic("invalid relative path '/Sources/headers'; relative path should not begin with '/' or '~'")
+            result.checkDiagnostic("invalid relative path '/Sources/headers'; relative path should not begin with '/', a drive or '~'")
         }
 
         let manifest2 = Manifest.createManifest(
@@ -1650,7 +1650,7 @@ final class PackageBuilderTester {
     @discardableResult
     init(
         _ manifest: Manifest,
-        path: AbsolutePath = .root,
+        path: AbsolutePath = AbsolutePath("/"),
         shouldCreateMultipleTestProducts: Bool = false,
         createREPLProduct: Bool = false,
         in fs: FileSystem,

--- a/Tests/SourceControlTests/InMemoryGitRepositoryTests.swift
+++ b/Tests/SourceControlTests/InMemoryGitRepositoryTests.swift
@@ -19,7 +19,7 @@ import TestSupport
 class InMemoryGitRepositoryTests: XCTestCase {
     func testBasics() throws {
         let fs = InMemoryFileSystem()
-        let repo = InMemoryGitRepository(path: .root, fs: fs)
+        let repo = InMemoryGitRepository(path: AbsolutePath("/"), fs: fs)
 
         try repo.createDirectory(AbsolutePath("/new-dir/subdir"), recursive: true)
         XCTAssertTrue(!repo.hasUncommittedChanges())
@@ -75,7 +75,7 @@ class InMemoryGitRepositoryTests: XCTestCase {
     func testProvider() throws {
         let v1 = "1.0.0"
         let v2 = "2.0.0"
-        let repo = InMemoryGitRepository(path: .root, fs: InMemoryFileSystem())
+        let repo = InMemoryGitRepository(path: AbsolutePath("/"), fs: InMemoryFileSystem())
 
         let specifier = RepositorySpecifier(url: "/foo")
         try repo.createDirectory(AbsolutePath("/new-dir/subdir"), recursive: true)

--- a/Tests/UtilityTests/SimplePersistenceTests.swift
+++ b/Tests/UtilityTests/SimplePersistenceTests.swift
@@ -26,7 +26,7 @@ fileprivate class Foo: SimplePersistanceProtocol {
             fileSystem: fileSystem,
             schemaVersion: 1,
             supportedSchemaVersions: [0],
-            statePath: AbsolutePath.root.appending(components: "subdir", "state.json")
+            statePath: AbsolutePath("/").appending(components: "subdir", "state.json")
         )
     }
 
@@ -71,7 +71,7 @@ fileprivate enum Bar {
             self.persistence = SimplePersistence(
                 fileSystem: fileSystem,
                 schemaVersion: 1,
-                statePath: AbsolutePath.root.appending(components: "subdir", "state.json")
+                statePath: AbsolutePath("/").appending(components: "subdir", "state.json")
             )
         }
 
@@ -97,7 +97,7 @@ fileprivate enum Bar {
             self.persistence = SimplePersistence(
                 fileSystem: fileSystem,
                 schemaVersion: 1,
-                statePath: AbsolutePath.root.appending(components: "subdir", "state.json")
+                statePath: AbsolutePath("/").appending(components: "subdir", "state.json")
             )
         }
 
@@ -118,7 +118,7 @@ fileprivate enum Bar {
 class SimplePersistenceTests: XCTestCase {
     func testBasics() throws {
         let fs = InMemoryFileSystem()
-        let stateFile = AbsolutePath.root.appending(components: "subdir", "state.json")
+        let stateFile = AbsolutePath("/").appending(components: "subdir", "state.json")
         let foo = Foo(int: 1, path: AbsolutePath("/hello"), fileSystem: fs)
         // Restoring right now should return false because state is not present.
         XCTAssertFalse(try foo.restore())
@@ -152,7 +152,7 @@ class SimplePersistenceTests: XCTestCase {
         // Test that we don't overwrite the json in case we find keys we don't need.
 
         let fs = InMemoryFileSystem()
-        let stateFile = AbsolutePath.root.appending(components: "subdir", "state.json")
+        let stateFile = AbsolutePath("/").appending(components: "subdir", "state.json")
 
         // Create and save v2 object.
         let v2 = Bar.V2(int: 100, string: "hello", fileSystem: fs)
@@ -181,7 +181,7 @@ class SimplePersistenceTests: XCTestCase {
 
     func testCanLoadFromOldSchema() throws {
         let fs = InMemoryFileSystem()
-        let stateFile = AbsolutePath.root.appending(components: "subdir", "state.json")
+        let stateFile = AbsolutePath("/").appending(components: "subdir", "state.json")
         try fs.writeFileContents(stateFile) {
             $0 <<< """
                 {

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -93,7 +93,7 @@ class GenerateXcodeprojTests: XCTestCase {
 
         let options = XcodeprojOptions(xcconfigOverrides: AbsolutePath("/doesntexist"))
         do {
-            _ = try xcodeProject(xcodeprojPath: AbsolutePath.root.appending(component: "xcodeproj"),
+            _ = try xcodeProject(xcodeprojPath: AbsolutePath("/").appending(component: "xcodeproj"),
                                  graph: graph, extraDirs: [], extraFiles: [], options: options, fileSystem: fileSystem, diagnostics: diagnostics)
             XCTFail("Project generation should have failed")
         } catch ProjectGenerationError.xcconfigOverrideNotFound(let path) {
@@ -124,7 +124,7 @@ class GenerateXcodeprojTests: XCTestCase {
         XCTAssertNoDiagnostics(diagnostics)
 
         _ = try xcodeProject(
-            xcodeprojPath: AbsolutePath.root.appending(component: "xcodeproj"),
+            xcodeprojPath: AbsolutePath("/").appending(component: "xcodeproj"),
             graph: graph, extraDirs: [], extraFiles: [],
             options: XcodeprojOptions(), fileSystem: fileSystem,
             diagnostics: diagnostics, warningStream: warningStream)

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -45,7 +45,7 @@ class PackageGraphTests: XCTestCase {
                     ],
                     targets: [
                         TargetDescription(
-                            name: "Foo", 
+                            name: "Foo",
                             settings: [
                                 .init(tool: .swift, name: .define, value: ["CUSTOM"]),
                                 .init(tool: .swift, name: .define, value: ["LINUX"], condition: .init(platformNames: ["linux"])),
@@ -73,8 +73,8 @@ class PackageGraphTests: XCTestCase {
         XCTAssertNoDiagnostics(diagnostics)
 
         let options = XcodeprojOptions(xcconfigOverrides: AbsolutePath("/Overrides.xcconfig"))
-        
-        let project = try xcodeProject(xcodeprojPath: AbsolutePath.root.appending(component: "xcodeproj"), graph: g, extraDirs: [], extraFiles: [], options: options, fileSystem: fs, diagnostics: diagnostics)
+
+        let project = try xcodeProject(xcodeprojPath: AbsolutePath("/").appending(component: "xcodeproj"), graph: g, extraDirs: [], extraFiles: [], options: options, fileSystem: fs, diagnostics: diagnostics)
 
         XcodeProjectTester(project) { result in
             result.check(projectDir: "Bar")
@@ -219,7 +219,7 @@ class PackageGraphTests: XCTestCase {
             }
         }
     }
-    
+
     func testModulemap() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Bar/Sources/Sea/include/Sea.h",
@@ -287,9 +287,9 @@ class PackageGraphTests: XCTestCase {
             ]
         )
         XCTAssertNoDiagnostics(diagnostics)
-        
-        let project = try xcodeProject(xcodeprojPath: AbsolutePath.root.appending(component: "xcodeproj"), graph: g, extraDirs: [], extraFiles: [], options: XcodeprojOptions(), fileSystem: fs, diagnostics: diagnostics)
-        
+
+        let project = try xcodeProject(xcodeprojPath: AbsolutePath("/").appending(component: "xcodeproj"), graph: g, extraDirs: [], extraFiles: [], options: XcodeprojOptions(), fileSystem: fs, diagnostics: diagnostics)
+
         XcodeProjectTester(project) { result in
             result.check(projectDir: "Pkg")
             result.check(target: "HelperTool") { targetResult in
@@ -347,7 +347,7 @@ class PackageGraphTests: XCTestCase {
                         TargetDescription(name: "c", dependencies: ["a"]),
                         TargetDescription(name: "d", dependencies: ["b"]),
                         TargetDescription(name: "libd", dependencies: ["d"]),
-        
+
                         TargetDescription(name: "aTests", dependencies: ["a"], type: .test),
                         TargetDescription(name: "bcTests", dependencies: ["b", "c"], type: .test),
                         TargetDescription(name: "dTests", dependencies: ["d"], type: .test),


### PR DESCRIPTION
Even though this diff is large, it's rather trivial.

The Path.swift file was assuming POSIX, and because we want to support Windows, we need to remove this assumption.

I'm adding support for standard windows paths of the form DRIVE_LETTER:\abc\...\xyz. More complex NT path are not worth support for the time being. The code only has 3 `#if os`, which means that most of it is quite portable.

I had to remove the Path.root constant, because it doesn't make sense in a cross-platform environment. People will have to be explicit about "/" when they assume a posix context.

All tests pass

There are some mechanisms in SwiftPM that deal with in-memory filesystems. These flows will break on Windows, so we'll have to fix them eventually, probably by creating a virtual filesystem and forcing posix on it via its constructor.