### PR TITLE
Optionally use non-frontend color-diagnostics flag

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -519,7 +519,11 @@ public final class SwiftTargetBuildDescription {
 
         // Add arguments to colorize output if stdout is tty
         if buildParameters.isTTY {
-            args += ["-Xfrontend", "-color-diagnostics"]
+            if Process.env["SWIFTPM_USE_NEW_COLOR_DIAGNOSTICS"] != nil {
+                args += ["-color-diagnostics"]
+            } else {
+                args += ["-Xfrontend", "-color-diagnostics"]
+            }
         }
 
         // Add the output for the `.swiftinterface`, if requested.


### PR DESCRIPTION
This fixes Swift doing a full rebuild when you switch between a tty, and
non-tty

https://bugs.swift.org/browse/SR-7982

Depends on https://github.com/apple/swift/pull/24144