### PR TITLE
Add new `manifest` option to `swift package init`

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -22,6 +22,7 @@ public final class InitPackage {
         case library = "library"
         case executable = "executable"
         case systemModule = "system-module"
+        case manifest = "manifest"
 
         public var description: String {
             return rawValue
@@ -63,6 +64,11 @@ public final class InitPackage {
         // FIXME: We should form everything we want to write, then validate that
         // none of it exists, and then act.
         try writeManifestFile()
+
+        if packageType == .manifest {
+            return
+        }
+
         try writeREADMEFile()
         try writeGitIgnore()
         try writeSources()
@@ -96,7 +102,7 @@ public final class InitPackage {
                     name: "\(pkgname)"
                 """)
 
-            if packageType == .library {
+            if packageType == .library || packageType == .manifest {
                 pkgParams.append("""
                     products: [
                         // Products define the executables and libraries produced by a package, and make them visible to other packages.
@@ -114,7 +120,7 @@ public final class InitPackage {
                     ]
                 """)
 
-            if packageType == .library || packageType == .executable {
+            if packageType == .library || packageType == .executable || packageType == .manifest {
                 pkgParams.append("""
                     targets: [
                         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -176,7 +182,7 @@ public final class InitPackage {
     }
 
     private func writeSources() throws {
-        if packageType == .systemModule {
+        if packageType == .systemModule || packageType == .manifest {
             return
         }
         let sources = destinationPath.appending(component: "Sources")
@@ -210,7 +216,7 @@ public final class InitPackage {
                     print("Hello, world!")
 
                     """
-            case .systemModule, .empty:
+            case .systemModule, .empty, .manifest:
                 fatalError("invalid")
             }
         }
@@ -249,7 +255,7 @@ public final class InitPackage {
         try makeDirectories(tests)
 
         switch packageType {
-        case .systemModule, .empty: break
+        case .systemModule, .empty, .manifest: break
         case .library, .executable:
             try writeLinuxMain(testsPath: tests)
             try writeTestFileStubs(testsPath: tests)
@@ -356,7 +362,7 @@ public final class InitPackage {
 
         let testClassFile = testModule.appending(RelativePath("\(moduleName)Tests.swift"))
         switch packageType {
-        case .systemModule, .empty: break
+        case .systemModule, .empty, .manifest: break
         case .library:
             try writeLibraryTestsFile(testClassFile)
         case .executable:

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -164,6 +164,33 @@ class InitTests: XCTestCase {
             XCTAssert(fs.exists(path.appending(component: "module.modulemap")))
         }
     }
+
+    func testInitManifest() throws {
+        mktmpdir { tmpPath in
+            let fs = localFileSystem
+            let path = tmpPath.appending(component: "Foo")
+            let name = path.basename
+            try fs.createDirectory(path)
+
+            // Create the package
+            let initPackage = try InitPackage(name: name, destinationPath: path, packageType: InitPackage.PackageType.manifest)
+            var progressMessages = [String]()
+            initPackage.progressReporter = { message in
+                progressMessages.append(message)
+            }
+            try initPackage.writePackageStructure()
+
+            // Not picky about the specific progress messages, just checking that we got some.
+            XCTAssert(progressMessages.count > 0)
+
+            // Verify basic file system content that we expect in the package
+            let manifest = path.appending(component: "Package.swift")
+            XCTAssertTrue(fs.exists(manifest))
+            let manifestContents = try localFileSystem.readFileContents(manifest).description
+            let version = "\(InitPackage.newPackageToolsVersion.major).\(InitPackage.newPackageToolsVersion.minor)"
+            XCTAssertTrue(manifestContents.hasPrefix("// swift-tools-version:\(version)\n"))
+        }
+    }
     
     // MARK: Special case testing
     

--- a/Tests/WorkspaceTests/XCTestManifests.swift
+++ b/Tests/WorkspaceTests/XCTestManifests.swift
@@ -6,6 +6,7 @@ extension InitTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__InitTests = [
+        ("testInitManifest", testInitManifest),
         ("testInitPackageEmpty", testInitPackageEmpty),
         ("testInitPackageExecutable", testInitPackageExecutable),
         ("testInitPackageLibrary", testInitPackageLibrary),


### PR DESCRIPTION
This will just generate a manifest in the current directory. The contents will be the same as for initializing a library package.

That means the contents will likely not match the filesystem layout, but I think that is OK, this will still make it easier to add a manifest to an existing project. We can improve it in the future and make the generated content based on what is actually there on the filesystem.

rdar://problem/50347943