### PR TITLE
workaround SR-10616

### DIFF
--- a/Utilities/build_ubuntu_cross_compilation_toolchain
+++ b/Utilities/build_ubuntu_cross_compilation_toolchain
@@ -243,7 +243,7 @@ cat > "$cross_tc_basename/ubuntu-xenial-destination.json" <<EOF
         "-fPIC"
     ],
     "extra-swiftc-flags": [
-        "-use-ld=lld", "-tools-directory", "$(pwd)/$cross_tc_basename/$xc_tc_name/usr/bin"
+        "-use-ld=lld", "-target", "x86_64-unknown-linux", "-tools-directory", "$(pwd)/$cross_tc_basename/$xc_tc_name/usr/bin"
     ],
     "extra-cpp-flags": [
         "-lstdc++"


### PR DESCRIPTION
Presumably, commit fbbeffbb87bc626cf589fb373c7ce89aa625818a took the necessary
`-target` parameters off the swiftc command line that is used to link.
This leads to cross compilation no longer working, this adds a temporary
workaround to the build_ubuntu_cross_compilation_toolchain script to
force the target parameter back.

For more info see: https://bugs.swift.org/browse/SR-10616