### PR TITLE
add -DCROSS_COMPILATION_TARGET_LINUX to compiler invocations

### DIFF
--- a/Utilities/build_ubuntu_cross_compilation_toolchain
+++ b/Utilities/build_ubuntu_cross_compilation_toolchain
@@ -240,13 +240,13 @@ cat > "$cross_tc_basename/ubuntu-xenial-destination.json" <<EOF
     "toolchain-bin-dir": "$(pwd)/$cross_tc_basename/$xc_tc_name/usr/bin",
     "target": "x86_64-unknown-linux",
     "extra-cc-flags": [
-        "-fPIC"
+        "-fPIC", "-DCROSS_COMPILATION_TARGET_LINUX"
     ],
     "extra-swiftc-flags": [
-        "-use-ld=lld", "-tools-directory", "$(pwd)/$cross_tc_basename/$xc_tc_name/usr/bin"
+        "-use-ld=lld", "-tools-directory", "$(pwd)/$cross_tc_basename/$xc_tc_name/usr/bin", "-DCROSS_COMPILATION_TARGET_LINUX"
     ],
     "extra-cpp-flags": [
-        "-lstdc++"
+        "-lstdc++", "-DCROSS_COMPILATION_TARGET_LINUX"
     ]
 }
 EOF


### PR DESCRIPTION
Although it's not recommended, many packages use `#if os(...)`
conditionals in their `Package.swift` which assumes that the OS running
`Package.swift` is the same as the one running the resulting binaries.
For cross-compilation that's not true. By passing
`-DCROSS_COMPILATION_TARGET_LINUX` to all compiler invocations, package
authors will be able to change their

    #if os(Linux)

to

    #if CROSS_COMPILATION_TARGET_LINUX || os(Linux)

and we have at least a workaround...