### PR TITLE
Bootstrap PackageDescription with -module-cache-path

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -682,6 +682,8 @@ def process_runtime_libraries(build, args, lib_path):
         tf = tempfile.NamedTemporaryFile(suffix=".swift")
         cmd += [tf.name]
 
+    cmd.extend(["-module-cache-path", os.path.join(args.sandbox_path, "ModuleCache")])
+
     subprocess.check_call(cmd)
     return (runtime_module_path, runtime_swiftdoc_path, runtime_lib_path)
 


### PR DESCRIPTION
#2118 did not update the custom invocation of `swiftc` in `process_runtime_libraries()`, which is still causing build failures in CI. This PR corrects that.

Hopefully completes work on rdar://problem/50385698.

(@aciidb0mb3r, does this need to be separately cherry-picked to swift-5.1-branch?)