### PR TITLE
build: clean up the legacy paths

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -1171,7 +1171,7 @@ def main():
 
             # Add XCTest.
             for module_file in ["XCTest.swiftmodule", "XCTest.swiftdoc"]:
-                symlink_force(os.path.join(args.xctest_path, module_file), libincludedir)
+                symlink_force(os.path.join(args.xctest_path, 'swift', module_file), libincludedir)
             symlink_force(os.path.join(args.xctest_path, "libXCTest.so"), libswiftdir)
 
             return (libswiftdir, libincludedir)


### PR DESCRIPTION
The new XCTest build has been CMake based for ages.  This places the
Swift contents in a directory named swift in the build tree.  Update
the search path.