### PR TITLE
Remove unnecessary heading in source docs of SupportedPlatforms.swift

### DIFF
--- a/Sources/PackageDescription4/SupportedPlatforms.swift
+++ b/Sources/PackageDescription4/SupportedPlatforms.swift
@@ -28,8 +28,6 @@ public struct Platform: Encodable {
 
 /// Represents a platform supported by the package.
 ///
-/// # The Supported Platform
-///
 /// By default, the Swift Package Manager assigns a predefined minimum deployment
 /// version for each supported platforms unless configured using the `platforms`
 /// API. This predefined deployment version will be the oldest deployment target


### PR DESCRIPTION
`SupportedPlatforms.swift` contains an extra heading that is unnecessary. This PR deletes it.