### PR TITLE
Don't link runtime compatibility library in pure Clang targets.

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -709,10 +709,12 @@ public final class ProductBuildDescription {
         args += ["-module-name", product.name.spm_mangledToC99ExtendedIdentifier()]
         args += dylibs.map({ "-l" + $0.product.name })
 
-        // Add arguements needed for code coverage if it is enabled.
+        // Add arguments needed for code coverage if it is enabled.
         if buildParameters.enableCodeCoverage {
             args += ["-profile-coverage-mapping", "-profile-generate"]
         }
+
+        let containsSwiftTargets = product.containsSwiftTargets
 
         switch product.type {
         case .library(.automatic):
@@ -731,7 +733,8 @@ public final class ProductBuildDescription {
             args += ["-emit-library"]
         case .executable:
             // Link the Swift stdlib statically if requested.
-            if buildParameters.shouldLinkStaticSwiftStdlib {
+            if containsSwiftTargets,
+               buildParameters.shouldLinkStaticSwiftStdlib {
                 // FIXME: This does not work for linux yet (SR-648).
                 if !buildParameters.triple.isLinux() {
                     args += ["-static-stdlib"]
@@ -748,16 +751,24 @@ public final class ProductBuildDescription {
         args += ["@\(linkFileListPath.pathString)"]
 
         // Embed the swift stdlib library path inside tests and executables on Darwin.
-        switch product.type {
-        case .library: break
-        case .test, .executable:
-            if buildParameters.triple.isDarwin() {
-                let stdlib = buildParameters.toolchain.macosSwiftStdlib
-                args += ["-Xlinker", "-rpath", "-Xlinker", stdlib.pathString]
-            }
+        if containsSwiftTargets {
+          switch product.type {
+          case .library: break
+          case .test, .executable:
+              if buildParameters.triple.isDarwin() {
+                  let stdlib = buildParameters.toolchain.macosSwiftStdlib
+                  args += ["-Xlinker", "-rpath", "-Xlinker", stdlib.pathString]
+              }
+          }
         }
 
-        // Add agruments from declared build settings.
+        // Don't link runtime compatibility patch libraries if there are no
+        // Swift sources in the target.
+        if !containsSwiftTargets {
+          args += ["-runtime-compatibility-version", "none"]
+        }
+
+        // Add arguments from declared build settings.
         args += self.buildSettingsFlags()
 
         // User arguments (from -Xlinker and -Xswiftc) should follow generated arguments to allow user overrides

--- a/Sources/PackageModel/ResolvedModels.swift
+++ b/Sources/PackageModel/ResolvedModels.swift
@@ -178,6 +178,18 @@ public final class ResolvedProduct: ObjectIdentifierProtocol, CustomStringConver
     public var description: String {
         return "<ResolvedProduct: \(name)>"
     }
+
+    /// True if this product contains Swift targets.
+    public var containsSwiftTargets: Bool {
+      //  C targets can't import Swift targets in SwiftPM (at least not right
+      // now), so we can just look at the top-level targets.
+      //
+      // If that ever changes, we'll need to do something more complex here,
+      // recursively checking dependencies for SwiftTargets, and considering
+      // dynamic library targets to be Swift targets (since the dylib could
+      // contain Swift code we don't know about as part of this build).
+      return targets.contains { $0.underlyingTarget is SwiftTarget }
+    }
 }
 
 extension ResolvedTarget.Dependency: CustomStringConvertible {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -310,7 +310,7 @@ final class BuildPlanTests: XCTestCase {
             "/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug",
             "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable",
             "@/path/to/build/debug/exe.product/Objects.LinkFileList",
-            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift/macosx",
+            "-runtime-compatibility-version", "none",
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
@@ -318,6 +318,7 @@ final class BuildPlanTests: XCTestCase {
             "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable",
             "-Xlinker", "-rpath=$ORIGIN",
             "@/path/to/build/debug/exe.product/Objects.LinkFileList",
+            "-runtime-compatibility-version", "none",
         ])
       #endif
 
@@ -366,7 +367,7 @@ final class BuildPlanTests: XCTestCase {
             "/fake/path/to/swiftc", "-lc++", "-g", "-L", "/path/to/build/debug", "-o",
             "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable",
             "@/path/to/build/debug/exe.product/Objects.LinkFileList",
-            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift/macosx",
+            "-runtime-compatibility-version", "none",
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
@@ -374,6 +375,7 @@ final class BuildPlanTests: XCTestCase {
             "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable",
             "-Xlinker", "-rpath=$ORIGIN",
             "@/path/to/build/debug/exe.product/Objects.LinkFileList",
+            "-runtime-compatibility-version", "none",
         ])
       #endif
 
@@ -857,12 +859,12 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(lib.moduleMap, AbsolutePath("/path/to/build/debug/lib.build/module.modulemap"))
 
     #if os(macOS)
-        XCTAssertEqual(try result.buildProduct(for: "lib").linkArguments(), ["/fake/path/to/swiftc", "-lc++", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/liblib.dylib", "-module-name", "lib", "-emit-library", "@/path/to/build/debug/lib.product/Objects.LinkFileList"])
+        XCTAssertEqual(try result.buildProduct(for: "lib").linkArguments(), ["/fake/path/to/swiftc", "-lc++", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/liblib.dylib", "-module-name", "lib", "-emit-library", "@/path/to/build/debug/lib.product/Objects.LinkFileList", "-runtime-compatibility-version", "none"])
             
-        XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), ["/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable", "@/path/to/build/debug/exe.product/Objects.LinkFileList", "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift/macosx",])
+        XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), ["/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable", "@/path/to/build/debug/exe.product/Objects.LinkFileList", "-runtime-compatibility-version", "none"])
     #else
-        XCTAssertEqual(try result.buildProduct(for: "lib").linkArguments(), ["/fake/path/to/swiftc", "-lstdc++", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/liblib.so", "-module-name", "lib", "-emit-library", "-Xlinker", "-rpath=$ORIGIN", "@/path/to/build/debug/lib.product/Objects.LinkFileList"])
-        XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), ["/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable", "-Xlinker", "-rpath=$ORIGIN", "@/path/to/build/debug/exe.product/Objects.LinkFileList"])
+        XCTAssertEqual(try result.buildProduct(for: "lib").linkArguments(), ["/fake/path/to/swiftc", "-lstdc++", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/liblib.so", "-module-name", "lib", "-emit-library", "-Xlinker", "-rpath=$ORIGIN", "@/path/to/build/debug/lib.product/Objects.LinkFileList", "-runtime-compatibility-version", "none"])
+        XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), ["/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable", "-Xlinker", "-rpath=$ORIGIN", "@/path/to/build/debug/exe.product/Objects.LinkFileList", "-runtime-compatibility-version", "none"])
     #endif
     }
 


### PR DESCRIPTION
apple/swift#25030 introduces a compatibility library that can be statically linked into binaries
in order to back-deploy runtime fixes and new features to OSes that shipped with older Swift
runtimes. This library depends on the Swift runtime being linked into the executable, so it will
cause link errors for pure Clang products (and even if it didn't, it would be a waste of code
size). When building a product without any Swift in it, ask Swift to drive the linker without
introducing any runtime compatibility libraries (and shake out a few other unnecessary linker
flags while we're here).

rdar://problem/50057445