### PR TITLE
Add default case to switch on CommandResult

### DIFF
--- a/Sources/Build/BuildDelegate.swift
+++ b/Sources/Build/BuildDelegate.swift
@@ -412,6 +412,8 @@ fileprivate struct CommandTaskTracker {
             finishedCount += 1
         case .cancelled, .failed:
             break
+        default:
+            break
         }
     }
     


### PR DESCRIPTION
If new cases are added to CommandResult we need to handle them.
Since we only care about succeeded or skipped commands, we don't
do anything here.

rdar://51069563

This is needed for the following llbuild change: https://github.com/apple/swift-llbuild/pull/487 but makes the code actually more robust to changes on that enum.