### PR TITLE
Enable `Defines Module` target setting and add included header files for the Clang Lib Target with predefined module map in Xcode generated project file

### DIFF
--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -582,6 +582,13 @@ func xcodeProject(
             // If user provided the modulemap no need to generate.
             if fileSystem.isFile(clangTarget.moduleMapPath) {
                 moduleMapPath = clangTarget.moduleMapPath
+                let headerPhase = xcodeTarget.addHeadersBuildPhase()
+                for case let header as Xcode.FileReference in includeGroup.subitems {
+                  let buildFile = headerPhase.addBuildFile(fileRef: header)
+                  buildFile.settings.ATTRIBUTES = ["Public"]
+                }
+                targetSettings.common.CLANG_ENABLE_MODULES = "YES"
+                targetSettings.common.DEFINES_MODULE = "YES"
             } else if includeGroup.subitems.contains(where: { $0.path == clangTarget.c99name + ".h" }) {
                 // If an umbrella header exists, enable Xcode's builtin module's feature rather than generating
                 // a custom module map. This increases the compatibility of generated Xcode projects.


### PR DESCRIPTION
I found an issue which I'm not sure if this is an intended behaviour or not. The issue is when I try to generate an Xcode Project from some Clang Lib C target have the predefine module.modulemap file but also have header files among several folders (in my case is gRPC), if this is the case then the target in the generated Xcode project will not have the headers in the build phase and it wasn't enabled the `DEFINES MODULE` setting. This results the unusable/unbuildable target in the generated Xcode project.

Related bug issue: https://bugs.swift.org/browse/SR-9559