### PR TITLE
[Documentation] Note Ninja/CMake build requirement in development docs

### DIFF
--- a/Documentation/Development.md
+++ b/Documentation/Development.md
@@ -63,6 +63,8 @@ using a [snapshot](https://swift.org/download/#releases) from swift.org.
 	$ cd swiftpm
 	$ Utilities/bootstrap
 	```
+
+    Note: The bootstrap script requires having [Ninja](https://ninja-build.org/) installed.
 	
     This command will build the Package Manager inside `.build/` directory.
     Run the bootstrap script to rebuild after making a change to the source

--- a/Documentation/Development.md
+++ b/Documentation/Development.md
@@ -64,7 +64,7 @@ using a [snapshot](https://swift.org/download/#releases) from swift.org.
 	$ Utilities/bootstrap
 	```
 
-    Note: The bootstrap script requires having [Ninja](https://ninja-build.org/) installed.
+    Note: The bootstrap script requires having [CMake](https://cmake.org/) and [Ninja](https://ninja-build.org/) installed. Please refer to the [Swift project repo](https://github.com/apple/swift/blob/master/README.md#macos) for installation instructions.
 	
     This command will build the Package Manager inside `.build/` directory.
     Run the bootstrap script to rebuild after making a change to the source


### PR DESCRIPTION
Hi there! I was following the development documentation, and I ran into issues because I didn't have Ninja installed. Figured I would make a note that Ninja is required to run the bootstrap.