### PR TITLE
[SR-10794] Close option suggestions

### DIFF
--- a/Sources/Basic/EditDistance.swift
+++ b/Sources/Basic/EditDistance.swift
@@ -37,7 +37,7 @@ public func editDistance(_ first: String, _ second: String) -> Int {
     return distance[a.count][b.count]
 }
 
-/// Finds the "best" match for the given `String` from the given options using`editDistance(_:_:)`.
+/// Finds the "best" match for a `String` from an array of possible options.
 ///
 /// - Parameters:
 ///     - input: The input `String` to match.

--- a/Sources/Basic/EditDistance.swift
+++ b/Sources/Basic/EditDistance.swift
@@ -13,6 +13,8 @@
 /// - Complexity: O(_n*m_), where *n* is the length of the first String and
 ///   *m* is the length of the second one.
 public func editDistance(_ first: String, _ second: String) -> Int {
+    // FIXME: We should use the new `CollectionDifference` API once the
+    // deployment target is bumped.
     let a = Array(first.utf16)
     let b = Array(second.utf16)
     var distance = [[Int]](repeating: [Int](repeating: 0, count: b.count + 1), count: a.count + 1)
@@ -33,4 +35,22 @@ public func editDistance(_ first: String, _ second: String) -> Int {
         }
     }
     return distance[a.count][b.count]
+}
+
+/// Finds the "best" match for the given `String` from the given options using`editDistance(_:_:)`.
+///
+/// - Parameters:
+///     - input: The input `String` to match.
+///     - options: The available options for `input`.
+///
+/// - Returns: The best match from the given `options`, or `nil` if none were sufficiently close.
+public func bestMatch(for input: String, from options: [String]) -> String? {
+    return options
+        .map { ($0, editDistance(input, $0)) }
+        // Filter out unreasonable edit distances. Based on:
+        // https://github.com/apple/swift/blob/37daa03b7dc8fb3c4d91dc560a9e0e631c980326/lib/Sema/TypeCheckNameLookup.cpp#L606
+        .filter { $0.1 <= ($0.0.count + 2) / 3 }
+        // Sort by edit distance
+        .sorted { $0.1 < $1.1 }
+        .first?.0
 }

--- a/Sources/SPMUtility/ArgumentParser.swift
+++ b/Sources/SPMUtility/ArgumentParser.swift
@@ -841,8 +841,9 @@ public final class ArgumentParser {
                 // Get the corresponding option for the option argument.
                 guard let optionArgument = optionsMap[argumentString] else {
                     var suggestion: String?
+                    // TODO: The available check should be removed when the tool chain gets an update that no longer requires it, and the check should be for macOS 10.15.
                     if #available(macOS 9999, *) {
-                        suggestion = optionsMap.keys
+                        suggestion = optionsMap.keys.lazy
                             .map({ ($0, $0.difference(from: argumentString).count) })
                             .filter({ $0.1 < $0.0.count / 2 })
                             .sorted(by: { $0.1 < $1.1 })

--- a/Tests/UtilityTests/ArgumentParserTests.swift
+++ b/Tests/UtilityTests/ArgumentParserTests.swift
@@ -132,6 +132,13 @@ class ArgumentParserTests: XCTestCase {
             XCTAssertEqual(option, "--food")
             XCTAssertEqual(suggestion, "--foo")
         }
+        do {
+            _ = try parser.parse(["--verb"])
+            XCTFail("unexpected success")
+        } catch ArgumentParserError.unknownOption(let option, let suggestion) {
+            XCTAssertEqual(option, "--verb")
+            XCTAssertNil(suggestion)
+        }
 
         do {
             _ = try parser.parse(["foo", "--verbosity"])

--- a/Tests/UtilityTests/ArgumentParserTests.swift
+++ b/Tests/UtilityTests/ArgumentParserTests.swift
@@ -120,8 +120,17 @@ class ArgumentParserTests: XCTestCase {
         do {
             _ = try parser.parse(["foo", "--bar"])
             XCTFail("unexpected success")
-        } catch ArgumentParserError.unknownOption(let option, _) {
+        } catch ArgumentParserError.unknownOption(let option, let suggestion) {
             XCTAssertEqual(option, "--bar")
+            XCTAssertNil(suggestion)
+        }
+
+        do {
+            _ = try parser.parse(["--food"])
+            XCTFail("unexpected success")
+        } catch ArgumentParserError.unknownOption(let option, let suggestion) {
+            XCTAssertEqual(option, "--food")
+            XCTAssertEqual(suggestion, "--foo")
         }
 
         do {

--- a/Tests/UtilityTests/ArgumentParserTests.swift
+++ b/Tests/UtilityTests/ArgumentParserTests.swift
@@ -120,7 +120,7 @@ class ArgumentParserTests: XCTestCase {
         do {
             _ = try parser.parse(["foo", "--bar"])
             XCTFail("unexpected success")
-        } catch ArgumentParserError.unknownOption(let option) {
+        } catch ArgumentParserError.unknownOption(let option, _) {
             XCTAssertEqual(option, "--bar")
         }
 
@@ -286,19 +286,19 @@ class ArgumentParserTests: XCTestCase {
 
         do {
             args = try parser.parse(["--foo", "foo", "b", "--no-fly", "--branch", "bugfix"])
-        } catch ArgumentParserError.unknownOption(let arg) {
+        } catch ArgumentParserError.unknownOption(let arg, _) {
             XCTAssertEqual(arg, "--branch")
         }
 
         do {
             args = try parser.parse(["--foo", "foo", "a", "--branch", "bugfix", "--no-fly"])
-        } catch ArgumentParserError.unknownOption(let arg) {
+        } catch ArgumentParserError.unknownOption(let arg, _) {
             XCTAssertEqual(arg, "--no-fly")
         }
 
         do {
             args = try parser.parse(["a", "--branch", "bugfix", "--foo"])
-        } catch ArgumentParserError.unknownOption(let arg) {
+        } catch ArgumentParserError.unknownOption(let arg, _) {
             XCTAssertEqual(arg, "--foo")
         }
 
@@ -374,7 +374,7 @@ class ArgumentParserTests: XCTestCase {
 
         do {
             args = try parser.parse(["foo", "bar", "--no-fly"])
-        } catch ArgumentParserError.unknownOption(let arg) {
+        } catch ArgumentParserError.unknownOption(let arg, _) {
             XCTAssertEqual(arg, "--no-fly")
         }
     }
@@ -717,7 +717,7 @@ class ArgumentParserTests: XCTestCase {
         do {
             _ = try parser.parse(["-18"])
             XCTFail("unexpected success")
-        } catch ArgumentParserError.unknownOption(let option) {
+        } catch ArgumentParserError.unknownOption(let option, _) {
             XCTAssertEqual(option, "-18")
         }
 


### PR DESCRIPTION
We implemented a closest match comparison on the available options, and chose the option that had the least number of differences.  We limited the solution space to those options that had fewer differences than half the length of the option string.  This solution uses the new Swift 5.1 sequence difference for companions.  If no option meets the match criteria, no option is returned and the default error message is displayed.  We added some tests to verify the comparison.