### PR TITLE
[Build] Handle unparsable messages during message size parsing

### DIFF
--- a/Sources/Build/BuildDelegate.swift
+++ b/Sources/Build/BuildDelegate.swift
@@ -430,7 +430,7 @@ fileprivate struct CommandTaskTracker {
             }
 
             finishedCount += 1
-        case .signalled, .skipped:
+        case .unparsableOutput, .signalled, .skipped:
             break
         }
     }
@@ -480,9 +480,10 @@ fileprivate struct CommandTaskTracker {
 
 extension SwiftCompilerMessage {
     fileprivate var verboseProgressText: String? {
-        if case .began(let info) = kind {
+        switch kind {
+        case .began(let info):
             return ([info.commandExecutable] + info.commandArguments).joined(separator: " ")
-        } else {
+        case .skipped, .finished, .signalled, .unparsableOutput:
             return nil
         }
     }
@@ -492,7 +493,9 @@ extension SwiftCompilerMessage {
         case .finished(let info),
              .signalled(let info):
             return info.output
-        default:
+        case .unparsableOutput(let output):
+            return output
+        case .skipped, .began:
             return nil
         }
     }

--- a/Tests/BuildTests/SwiftCompilerOutputParserTests.swift
+++ b/Tests/BuildTests/SwiftCompilerOutputParserTests.swift
@@ -211,7 +211,9 @@ class SwiftCompilerOutputParserTests: XCTestCase {
             2A
 
             """.utf8)
-        delegate.assert(messages: [], errorDescription: "invalid message size")
+        delegate.assert(messages: [
+            SwiftCompilerMessage(name: "unknown", kind: .unparsableOutput("2A"))
+        ], errorDescription: nil)
 
         parser.parse(bytes: """
             119
@@ -223,7 +225,9 @@ class SwiftCompilerOutputParserTests: XCTestCase {
               "signal": 4
             }
             """.utf8)
-        delegate.assert(messages: [], errorDescription: nil)
+        delegate.assert(messages: [
+            SwiftCompilerMessage(name: "link", kind: .signalled(.init(pid: 22699, output: nil)))
+        ], errorDescription: nil)
     }
 
     func testInvalidMessageBytes() {


### PR DESCRIPTION
<rdar://problem/49235252>

Looks like swift compiler can emit a non-parsable message in some cases.

(cherry picked from commit 29f731bd2cd7a8dbd0befbb2089b8c0f55019118)