### PR TITLE
Isolate ModuleCache for SwiftPM tests

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -26,22 +26,14 @@ public struct BuildParameters {
         case auto
     }
 
-    // FIXME: Error handling.
-    //
-    /// Path to the module cache directory to use for SwiftPM's own tests.
-    public static let swiftpmTestCache = resolveSymlinks(try! determineTempDirectory()).appending(component: "org.swift.swiftpm.tests-3")
-
     /// Returns the directory to be used for module cache.
     fileprivate var moduleCache: AbsolutePath {
-        let base: AbsolutePath
         // FIXME: We use this hack to let swiftpm's functional test use shared
         // cache so it doesn't become painfully slow.
-        if Process.env["IS_SWIFTPM_TEST"] != nil {
-            base = BuildParameters.swiftpmTestCache
-        } else {
-            base = buildPath
+        if let path = Process.env["SWIFTPM_TESTS_MODULECACHE"] {
+            return AbsolutePath(path)
         }
-        return base.appending(component: "ModuleCache")
+        return buildPath.appending(component: "ModuleCache")
     }
 
     /// The path to the data directory.

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -675,7 +675,6 @@ public class SwiftTool<Options: ToolOptions> {
             let allowedDirectories = [
                 tempDir,
                 buildPath,
-                BuildParameters.swiftpmTestCache
             ].map(resolveSymlinks)
             args += ["sandbox-exec", "-p", sandboxProfile(allowedDirectories: allowedDirectories)]
         }
@@ -842,7 +841,7 @@ private func findPackageRoot() -> AbsolutePath? {
 /// Returns the build path from the environment, if present.
 private func getEnvBuildPath(workingDir: AbsolutePath) -> AbsolutePath? {
     // Don't rely on build path from env for SwiftPM's own tests.
-    guard Process.env["IS_SWIFTPM_TEST"] == nil else { return nil }
+    guard Process.env["SWIFTPM_TESTS_MODULECACHE"] == nil else { return nil }
     guard let env = Process.env["SWIFTPM_BUILD_DIR"] else { return nil }
     return AbsolutePath(env, relativeTo: workingDir)
 }

--- a/Sources/TestSupport/SwiftPMProduct.swift
+++ b/Sources/TestSupport/SwiftPMProduct.swift
@@ -115,7 +115,7 @@ public enum SwiftPMProduct {
       #endif
         // FIXME: We use this private environment variable hack to be able to
         // create special conditions in swift-build for swiftpm tests.
-        environment["IS_SWIFTPM_TEST"] = "1"
+        environment["SWIFTPM_TESTS_MODULECACHE"] = self.path.parentDirectory.pathString
         environment["SDKROOT"] = nil
 
         var completeArgs = [path.pathString]


### PR DESCRIPTION
To workaround the ModuleCache issues that we've been seeing on Swift CI
<rdar://problem/51596389>