### PR TITLE
Disable pure C package tests for staging.

### DIFF
--- a/Tests/FunctionalTests/CFamilyTargetTests.swift
+++ b/Tests/FunctionalTests/CFamilyTargetTests.swift
@@ -75,6 +75,7 @@ class CFamilyTargetTestCase: XCTestCase {
     }
 
     func testObjectiveCPackageWithTestTarget(){
+      #if DISABLED // rdar://problem/50057445
       #if os(macOS)
         fixture(name: "CFamilyTargets/ObjCmacOSPackage") { prefix in
             // Build the package.
@@ -83,6 +84,7 @@ class CFamilyTargetTestCase: XCTestCase {
             // Run swift-test on package.
             XCTAssertSwiftTest(prefix)
         }
+      #endif
       #endif
     }
 }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -272,6 +272,7 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testPkgConfigCFamilyTargets() throws {
+    #if DISABLED // rdar://problem/50057445
         fixture(name: "Miscellaneous/PkgConfig") { prefix in
             let systemModule = prefix.appending(component: "SystemModule")
             // Create a shared library.
@@ -303,6 +304,7 @@ class MiscellaneousTestCase: XCTestCase {
 
             XCTAssertFileExists(moduleUser.appending(components: ".build", Destination.host.target.tripleString, "debug", "SystemModuleUserClang"))
         }
+    #endif
     }
 
     func testCanKillSubprocessOnSigInt() throws {


### PR DESCRIPTION
Using Swift to link pure C targets relies on a new Swift driver flag
introduced in https://github.com/apple/swift/pull/25330. Stage this in
by disabling tests until that change propagates.

rdar://problem/50057445