### PR TITLE
Remove use of swift-build-tool from SwiftPM

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -50,9 +50,6 @@ public class ToolOptions {
     /// If should link the Swift stdlib statically.
     public var shouldLinkStaticSwiftStdlib = false
 
-    /// If should enable building with llbuild library.
-    public var shouldEnableLLBuildLibrary = true
-
     /// Skip updating dependencies from their remote during a resolution.
     public var skipDependencyUpdate = false
 

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -69,9 +69,6 @@ public final class UserToolchain: Toolchain {
     /// This is only present on macOS.
     public let xctest: AbsolutePath?
 
-    /// Path to llbuild.
-    public let llbuild: AbsolutePath
-
     /// The compilation destination object.
     public let destination: Destination
 
@@ -210,13 +207,6 @@ public final class UserToolchain: Toolchain {
 
         let swiftCompilers = try UserToolchain.determineSwiftCompilers(binDir: binDir, lookup: { UserToolchain.lookup(variable: $0, searchPaths: searchPaths) })
         self.swiftCompiler = swiftCompilers.compile
-
-        // Look for llbuild in bin dir.
-        llbuild = binDir.appending(component: "swift-build-tool" + hostExecutableSuffix)
-        guard localFileSystem.exists(llbuild) else {
-            throw InvalidToolchainDiagnostic("could not find `llbuild` at expected path \(llbuild)")
-        }
-
 
         // We require xctest to exist on macOS.
       #if os(macOS)


### PR DESCRIPTION
We got library-based llbuild execution last year and swift-build-tool invocation is just dead code at this point. We should remove it.