### PR TITLE
Remove use of swift-build-tool from SwiftPM

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -50,9 +50,6 @@ public class ToolOptions {
     /// If should link the Swift stdlib statically.
     public var shouldLinkStaticSwiftStdlib = false
 
-    /// If should enable building with llbuild library.
-    public var shouldEnableLLBuildLibrary = true
-
     /// Skip updating dependencies from their remote during a resolution.
     public var skipDependencyUpdate = false
 

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -212,10 +212,6 @@ public class SwiftTool<Options: ToolOptions> {
     /// The stream to print standard output on.
     fileprivate var stdoutStream: OutputByteStream = Basic.stdoutStream
 
-    /// If true, Redirects the stdout stream to stderr when invoking
-    /// `swift-build-tool`.
-    private var shouldRedirectStdoutToStderr = false
-
     /// Create an instance of this tool.
     ///
     /// - parameter args: The command line arguments to be passed to this tool.
@@ -328,11 +324,6 @@ public class SwiftTool<Options: ToolOptions> {
             option: parser.add(option: "--static-swift-stdlib", kind: Bool.self,
                 usage: "Link Swift stdlib statically"),
             to: { $0.shouldLinkStaticSwiftStdlib = $1 })
-
-        binder.bind(
-            option: parser.add(option: "--enable-llbuild-library", kind: Bool.self,
-                usage: "Enable building with the llbuild library"),
-            to: { $0.shouldEnableLLBuildLibrary = $1 })
 
         binder.bind(
             option: parser.add(option: "--force-resolved-versions", kind: Bool.self),
@@ -514,7 +505,6 @@ public class SwiftTool<Options: ToolOptions> {
 
     /// Start redirecting the standard output stream to the standard error stream.
     func redirectStdoutToStderr() {
-        self.shouldRedirectStdoutToStderr = true
         self.stdoutStream = Basic.stderrStream
         DiagnosticsEngineHandler.default.stdoutStream = Basic.stderrStream
     }
@@ -598,14 +588,14 @@ public class SwiftTool<Options: ToolOptions> {
             return
         }
 
-        let yaml = plan.buildParameters.llbuildManifest
+        let manifest = plan.buildParameters.llbuildManifest
         // Generate the llbuild manifest.
-        let client = options.shouldEnableLLBuildLibrary ? "basic" : "swift-build"
-        let llbuild = LLBuildManifestGenerator(plan, client: client)
-        try llbuild.generateManifest(at: yaml)
+        let llbuild = LLBuildManifestGenerator(plan, client: "basic")
+        try llbuild.generateManifest(at: manifest)
 
         // Run llbuild.
-        try runLLBuild(plan: plan, manifest: yaml, llbuildTarget: llbuildTargetName)
+        assert(localFileSystem.isFile(manifest), "llbuild manifest not present: \(manifest)")
+        try runLLBuild(plan: plan, manifest: manifest, llbuildTarget: llbuildTargetName)
 
         // Create backwards-compatibilty symlink to old build path.
         let oldBuildPath = buildPath.appending(component: options.configuration.dirname)
@@ -616,15 +606,6 @@ public class SwiftTool<Options: ToolOptions> {
     }
 
     func runLLBuild(plan: BuildPlan, manifest: AbsolutePath, llbuildTarget: String) throws {
-        assert(localFileSystem.isFile(manifest), "llbuild manifest not present: \(manifest)")
-        if options.shouldEnableLLBuildLibrary {
-            try runLLBuildAsLibrary(plan: plan, manifest: manifest, llbuildTarget: llbuildTarget)
-        } else {
-            try runLLBuildAsExecutable(manifest: manifest, llbuildTarget: llbuildTarget)
-        }
-    }
-
-    func runLLBuildAsLibrary(plan: BuildPlan, manifest: AbsolutePath, llbuildTarget: String) throws {
         // Setup the build delegate.
         let isVerbose = verbosity != .concise
         let progressAnimation: ProgressAnimationProtocol = isVerbose ?
@@ -644,59 +625,6 @@ public class SwiftTool<Options: ToolOptions> {
         let success = buildSystem.build(target: llbuildTarget)
         progressAnimation.complete(success: success)
         guard success else { throw Diagnostics.fatalError }
-    }
-
-    func runLLBuildAsExecutable(manifest: AbsolutePath, llbuildTarget: String) throws {
-        // Create a temporary directory for the build process.
-        let tempDirName = "org.swift.swiftpm.\(NSUserName())"
-        let tempDir = try determineTempDirectory().appending(component: tempDirName)
-        try localFileSystem.createDirectory(tempDir, recursive: true)
-
-        // Run the swift-build-tool with the generated manifest.
-        var args = [String]()
-
-      #if os(macOS)
-        // If enabled, use sandbox-exec on macOS. This provides some safety
-        // against arbitrary code execution. We only allow the permissions which
-        // are absolutely necessary for performing a build.
-        if !options.shouldDisableSandbox {
-            let allowedDirectories = [
-                tempDir,
-                buildPath,
-            ].map(resolveSymlinks)
-            args += ["sandbox-exec", "-p", sandboxProfile(allowedDirectories: allowedDirectories)]
-        }
-      #endif
-
-        args += [try getToolchain().llbuild.pathString, "-f", manifest.pathString, llbuildTarget]
-        if verbosity != .concise {
-            args.append("-v")
-        }
-
-        // Create the environment for llbuild.
-        var env = Process.env
-        // We override the temporary directory so tools assuming full access to
-        // the tmp dir can create files here freely, provided they respect this
-        // variable.
-        env["TMPDIR"] = tempDir.pathString
-
-        // Run llbuild and print output on standard streams.
-        let process = Process(arguments: args, environment: env, outputRedirection: shouldRedirectStdoutToStderr ? .collect : .none)
-        try process.launch()
-        try processSet.add(process)
-        let result = try process.waitUntilExit()
-
-        // Emit the output to the selected stream if we need to redirect the
-        // stream.
-        if shouldRedirectStdoutToStderr {
-            self.stdoutStream <<< (try result.utf8stderrOutput())
-            self.stdoutStream <<< (try result.utf8Output())
-            self.stdoutStream.flush()
-        }
-
-        guard result.exitStatus == .terminated(code: 0) else {
-            throw ProcessResult.Error.nonZeroExit(result)
-        }
     }
 
     /// Return the build parameters.

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -64,9 +64,6 @@ public final class UserToolchain: Toolchain {
     /// This is only present on macOS.
     public let xctest: AbsolutePath?
 
-    /// Path to llbuild.
-    public let llbuild: AbsolutePath
-
     /// The compilation destination object.
     public let destination: Destination
 
@@ -205,13 +202,6 @@ public final class UserToolchain: Toolchain {
 
         let swiftCompilers = try UserToolchain.determineSwiftCompilers(binDir: binDir, lookup: { UserToolchain.lookup(variable: $0, searchPaths: searchPaths) })
         self.swiftCompiler = swiftCompilers.compile
-
-        // Look for llbuild in bin dir.
-        llbuild = binDir.appending(component: "swift-build-tool")
-        guard localFileSystem.exists(llbuild) else {
-            throw InvalidToolchainDiagnostic("could not find `llbuild` at expected path \(llbuild)")
-        }
-
 
         // We require xctest to exist on macOS.
       #if os(macOS)


### PR DESCRIPTION
We got library-based llbuild execution last year and swift-build-tool invocation is just dead code at this point. We should remove it.

<rdar://problem/51681013>

(cherry picked from commit 0a973d27375ed218989d72731244e2db88280aab)