### PR TITLE
Add SWIFTPM_MODULECACHE_OVERRIDE for Swift CI

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -386,7 +386,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
             // FIXME: Workaround for the module cache bug that's been haunting Swift CI
             // <rdar://problem/48443680>
-            let moduleCachePath = Process.env["SWIFTPM_TESTS_MODULECACHE"]
+            let moduleCachePath = Process.env["SWIFTPM_MODULECACHE_OVERRIDE"] ?? Process.env["SWIFTPM_TESTS_MODULECACHE"]
 
             var cmd = [String]()
           #if os(macOS)


### PR DESCRIPTION
<rdar://problem/51725297>

(cherry picked from commit fba7a31676d5be5e851fd17ce2e6e532f1ab64eb)