### PR TITLE
[Workspace] Add ability to notify when Package.resolved file is changed

### DIFF
--- a/Sources/Workspace/PinsStore.swift
+++ b/Sources/Workspace/PinsStore.swift
@@ -182,3 +182,48 @@ extension PinsStore.Pin: JSONMappable, JSONSerializable, Equatable {
         ])
     }
 }
+
+/// A file watcher utility for the Package.resolved file.
+///
+/// This is not intended to be used directly by clients.
+final class ResolvedFileWatcher {
+    private var fswatch: FSWatch!
+    private var existingValue: ByteString?
+    private let valueLock: Lock = Lock()
+    private let resolvedFile: AbsolutePath
+
+    public func updateValue() {
+        valueLock.withLock {
+            self.existingValue = try? localFileSystem.readFileContents(resolvedFile)
+        }
+    }
+
+    init(resolvedFile: AbsolutePath, onChange: @escaping () -> ()) throws {
+        self.resolvedFile = resolvedFile
+
+        let block = { [weak self] (paths: [AbsolutePath]) in
+            guard let self = self else { return }
+
+            // Check if resolved file is part of the received paths.
+            let hasResolvedFile = paths.contains{ $0.appending(component: resolvedFile.basename) == resolvedFile }
+            guard hasResolvedFile else { return }
+
+            self.valueLock.withLock {
+                // Compute the contents of the resolved file and fire the onChange block
+                // if its value is different than existing value.
+                let newValue = try? localFileSystem.readFileContents(resolvedFile)
+                if self.existingValue != newValue {
+                    self.existingValue = newValue
+                    onChange()
+                }
+            }
+        }
+
+        fswatch = FSWatch(paths: [resolvedFile.parentDirectory], latency: 1, block: block)
+        try fswatch.start()
+    }
+
+    deinit {
+        fswatch.stop()
+    }
+}

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -45,6 +45,11 @@ public protocol WorkspaceDelegate: class {
 
     /// Called when the resolver is about to be run.
     func willResolveDependencies()
+
+    /// Called when the Package.resolved file is changed *outside* of libSwiftPM operations.
+    ///
+    /// This is only fired when activated using Workspace's watchResolvedFile() method.
+    func resolvedFileChanged()
 }
 
 public extension WorkspaceDelegate {
@@ -53,6 +58,7 @@ public extension WorkspaceDelegate {
     func repositoryDidUpdate(_ repository: String) {}
     func willResolveDependencies() {}
     func dependenciesUpToDate() {}
+    func resolvedFileChanged() {}
 }
 
 private class WorkspaceResolverDelegate: DependencyResolverDelegate {
@@ -252,6 +258,9 @@ public class Workspace {
     /// The Pins store. The pins file will be created when first pin is added to pins store.
     public let pinsStore: LoadableResult<PinsStore>
 
+    /// The path to the Package.resolved file for this workspace.
+    public let resolvedFile: AbsolutePath
+
     /// The path for working repository clones (checkouts).
     public let checkoutsPath: AbsolutePath
 
@@ -290,6 +299,8 @@ public class Workspace {
 
     /// Write dependency resolver trace to a file.
     fileprivate let enableResolverTrace: Bool
+
+    fileprivate var resolvedFileWatcher: ResolvedFileWatcher?
 
     /// Typealias for dependency resolver we use in the workspace.
     fileprivate typealias PackageDependencyResolver = DependencyResolver
@@ -336,6 +347,7 @@ public class Workspace {
         self.enablePubgrubResolver = enablePubgrubResolver
         self.skipUpdate = skipUpdate
         self.enableResolverTrace = enableResolverTrace
+        self.resolvedFile = pinsFile
 
         let repositoriesPath = self.dataPath.appending(component: "repositories")
         self.repositoryManager = RepositoryManager(
@@ -904,12 +916,29 @@ extension Workspace {
             }
         }
         diagnostics.wrap({ try pinsStore.saveState() })
+
+        // Ask resolved file watcher to update its value so we don't fire
+        // an extra event if the file was modified by us.
+        self.resolvedFileWatcher?.updateValue()
     }
 }
 
 // MARK: - Utility Functions
 
 extension Workspace {
+
+    /// Watch the Package.resolved for changes.
+    ///
+    /// This is useful if clients want to be notified when the Package.resolved
+    /// file is changed *outside* of libSwiftPM operations. For example, as part
+    /// of a git operation.
+    public func watchResolvedFile() throws {
+        // Return if we're already watching it.
+        guard self.resolvedFileWatcher == nil else { return }
+        self.resolvedFileWatcher = try ResolvedFileWatcher(resolvedFile: self.resolvedFile) { [weak self] in
+            self?.delegate?.resolvedFileChanged()
+        }
+    }
 
     /// Create the cache directories.
     fileprivate func createCacheDirectories(with diagnostics: DiagnosticsEngine) {


### PR DESCRIPTION
This adds a delegate method that will notify clients when the
Package.resolved file is changed outside of libSwiftPM operations. For
example, when a git operation is performed.

<rdar://problem/51762359>

(cherry picked from commit b6ecad4fd250cea74299f956bcecbcc5e5c6902d)