### PR TITLE
Ignore xcuserdata/

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -176,6 +176,7 @@ public final class InitPackage {
                 /.build
                 /Packages
                 /*.xcodeproj
+                xcuserdata/
 
                 """
         }


### PR DESCRIPTION
Now that SwiftPM is more likely to checked in alongside with Xcode
artifacts, ignore the commonly ignored Xcode artifacts.

(cherry-picked from #2184)