### PR TITLE
Respect resolved file for branch-based dependencies

### DIFF
--- a/Sources/PackageGraph/CheckoutState.swift
+++ b/Sources/PackageGraph/CheckoutState.swift
@@ -9,7 +9,6 @@
  */
 
 import Basic
-import PackageGraph
 import SourceControl
 import SPMUtility
 
@@ -56,7 +55,7 @@ public struct CheckoutState: Equatable, CustomStringConvertible {
 extension CheckoutState {
 
     /// Returns requirement induced by this state.
-    func requirement() -> PackageRequirement {
+    public func requirement() -> PackageRequirement {
         if let version = version {
             return .versionSet(.exact(version))
         } else if let branch = branch {
@@ -83,15 +82,6 @@ extension CheckoutState: JSONMappable, JSONSerializable {
            "version": version.toJSON(),
            "branch": branch.toJSON(),
        ])
-    }
-}
-
-extension ManagedDependency {
-    public var checkoutState: CheckoutState? {
-        if case .checkout(let checkoutState) = state {
-            return checkoutState
-        }
-        return nil
     }
 }
 

--- a/Sources/PackageGraph/PinsStore.swift
+++ b/Sources/PackageGraph/PinsStore.swift
@@ -12,7 +12,6 @@ import Basic
 import SPMUtility
 import SourceControl
 import PackageModel
-import PackageGraph
 
 public final class PinsStore {
     public struct Pin {
@@ -45,7 +44,7 @@ public final class PinsStore {
     /// The pins map.
     ///
     /// Key -> Package Identity.
-    fileprivate(set) var pinsMap: [String: Pin]
+    public fileprivate(set) var pinsMap: [String: Pin]
 
     /// The current pins.
     public var pins: AnySequence<Pin> {
@@ -71,7 +70,7 @@ public final class PinsStore {
         do {
             _ = try self.persistence.restoreState(self)
         } catch SimplePersistence.Error.restoreFailure {
-            throw WorkspaceDiagnostics.MalformedPackageResolved()
+            throw MalformedPackageResolved()
         }
     }
 
@@ -97,25 +96,6 @@ public final class PinsStore {
     /// This will replace any previous pin with same package name.
     public func add(_ pin: Pin) {
         pinsMap[pin.packageRef.identity] = pin
-    }
-
-    /// Pin a managed dependency at its checkout state.
-    ///
-    /// This method does nothing if the dependency is in edited state.
-    func pin(_ dependency: ManagedDependency) {
-
-        // Get the checkout state.
-        let checkoutState: CheckoutState
-        switch dependency.state {
-        case .checkout(let state):
-            checkoutState = state
-        case .edited, .local:
-            return
-        }
-
-        self.pin(
-            packageRef: dependency.packageRef,
-            state: checkoutState)
     }
 
     /// Unpin all of the currently pinnned dependencies.
@@ -183,47 +163,8 @@ extension PinsStore.Pin: JSONMappable, JSONSerializable, Equatable {
     }
 }
 
-/// A file watcher utility for the Package.resolved file.
-///
-/// This is not intended to be used directly by clients.
-final class ResolvedFileWatcher {
-    private var fswatch: FSWatch!
-    private var existingValue: ByteString?
-    private let valueLock: Lock = Lock()
-    private let resolvedFile: AbsolutePath
-
-    public func updateValue() {
-        valueLock.withLock {
-            self.existingValue = try? localFileSystem.readFileContents(resolvedFile)
-        }
-    }
-
-    init(resolvedFile: AbsolutePath, onChange: @escaping () -> ()) throws {
-        self.resolvedFile = resolvedFile
-
-        let block = { [weak self] (paths: [AbsolutePath]) in
-            guard let self = self else { return }
-
-            // Check if resolved file is part of the received paths.
-            let hasResolvedFile = paths.contains{ $0.appending(component: resolvedFile.basename) == resolvedFile }
-            guard hasResolvedFile else { return }
-
-            self.valueLock.withLock {
-                // Compute the contents of the resolved file and fire the onChange block
-                // if its value is different than existing value.
-                let newValue = try? localFileSystem.readFileContents(resolvedFile)
-                if self.existingValue != newValue {
-                    self.existingValue = newValue
-                    onChange()
-                }
-            }
-        }
-
-        fswatch = FSWatch(paths: [resolvedFile.parentDirectory], latency: 1, block: block)
-        try fswatch.start()
-    }
-
-    deinit {
-        fswatch.stop()
+public struct MalformedPackageResolved: Swift.Error, CustomStringConvertible {
+    public var description: String {
+        return "Package.resolved file is corrupted or malformed; fix or delete the file to continue"
     }
 }

--- a/Sources/PackageGraph/Pubgrub.swift
+++ b/Sources/PackageGraph/Pubgrub.swift
@@ -1271,7 +1271,8 @@ public final class PubgrubDependencyResolver {
                 terms.append(Term(not: dep.identifier, dep.requirement))
                 return Incompatibility(terms, root: root!, cause: .dependency(package: container.identifier))
             }
-        case .revision(let revision):
+        case .revision(let revision, _):
+            // FIXME: Handle branches here.
             return try container.getDependencies(at: revision).map { dep -> Incompatibility in
                 var terms: OrderedSet<Term> = []
                 terms.append(Term(container.identifier, .revision(revision)))
@@ -1616,7 +1617,8 @@ extension BoundVersion {
             fatalError("Cannot create package requirement from excluded version.")
         case .unversioned:
             return .unversioned
-        case .revision(let revision):
+        case .revision(let revision, _):
+            // FIXME: Handle branches here
             return .revision(revision)
         }
     }

--- a/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
@@ -151,6 +151,10 @@ public class BasePackageContainer: PackageContainer {
         fatalError("This should never be called")
     }
 
+    public func getRevision(forIdentifier identifier: String) throws -> Revision {
+        fatalError("This should never be called")
+    }
+
     fileprivate init(
         _ identifier: Identifier,
         config: SwiftPMConfig,
@@ -342,7 +346,7 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
     }
 
     /// Returns revision for the given identifier.
-    public func getRevision(forIdentifier identifier: String) throws -> Revision {
+    public override func getRevision(forIdentifier identifier: String) throws -> Revision {
         return try repository.resolveRevision(identifier: identifier)
     }
 
@@ -431,8 +435,8 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
         switch boundVersion {
         case .version(let version):
             identifier = version.description
-        case .revision(let revision):
-            identifier = revision
+        case .revision(let revision, let pinned):
+            identifier = pinned ?? revision
         case .unversioned, .excluded:
             assertionFailure("Unexpected type requirement \(boundVersion)")
             return self.identifier

--- a/Sources/TestSupport/MockDependencyResolver.swift
+++ b/Sources/TestSupport/MockDependencyResolver.swift
@@ -82,6 +82,10 @@ public enum MockLoadingError: Error {
 }
 
 public class MockPackageContainer: PackageContainer {
+    public func getRevision(forIdentifier identifier: String) throws -> Revision {
+        fatalError()
+    }
+
 
     public typealias Identifier = PackageReference
 

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -405,10 +405,4 @@ public enum WorkspaceDiagnostics {
 
         let name: String
     }
-
-    public struct MalformedPackageResolved: Swift.Error, CustomStringConvertible {
-        public var description: String {
-            return "Package.resolved file is corrupted or malformed; fix or delete the file to continue"
-        }
-    }
 }

--- a/Sources/Workspace/misc.swift
+++ b/Sources/Workspace/misc.swift
@@ -1,0 +1,86 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2018 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import PackageGraph
+
+extension ManagedDependency {
+    public var checkoutState: CheckoutState? {
+        if case .checkout(let checkoutState) = state {
+            return checkoutState
+        }
+        return nil
+    }
+}
+
+extension PinsStore {
+    /// Pin a managed dependency at its checkout state.
+    ///
+    /// This method does nothing if the dependency is in edited state.
+    func pin(_ dependency: ManagedDependency) {
+
+        // Get the checkout state.
+        let checkoutState: CheckoutState
+        switch dependency.state {
+        case .checkout(let state):
+            checkoutState = state
+        case .edited, .local:
+            return
+        }
+
+        self.pin(
+            packageRef: dependency.packageRef,
+            state: checkoutState)
+    }
+}
+
+/// A file watcher utility for the Package.resolved file.
+///
+/// This is not intended to be used directly by clients.
+final class ResolvedFileWatcher {
+    private var fswatch: FSWatch!
+    private var existingValue: ByteString?
+    private let valueLock: Lock = Lock()
+    private let resolvedFile: AbsolutePath
+
+    public func updateValue() {
+        valueLock.withLock {
+            self.existingValue = try? localFileSystem.readFileContents(resolvedFile)
+        }
+    }
+
+    init(resolvedFile: AbsolutePath, onChange: @escaping () -> ()) throws {
+        self.resolvedFile = resolvedFile
+
+        let block = { [weak self] (paths: [AbsolutePath]) in
+            guard let self = self else { return }
+
+            // Check if resolved file is part of the received paths.
+            let hasResolvedFile = paths.contains{ $0.appending(component: resolvedFile.basename) == resolvedFile }
+            guard hasResolvedFile else { return }
+
+            self.valueLock.withLock {
+                // Compute the contents of the resolved file and fire the onChange block
+                // if its value is different than existing value.
+                let newValue = try? localFileSystem.readFileContents(resolvedFile)
+                if self.existingValue != newValue {
+                    self.existingValue = newValue
+                    onChange()
+                }
+            }
+        }
+
+        fswatch = FSWatch(paths: [resolvedFile.parentDirectory], latency: 1, block: block)
+        try fswatch.start()
+    }
+
+    deinit {
+        fswatch.stop()
+    }
+}

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -1112,6 +1112,10 @@ private func AssertError(
 }
 
 public class MockContainer: PackageContainer {
+    public func getRevision(forIdentifier identifier: String) throws -> Revision {
+        fatalError()
+    }
+
     public typealias Dependency = (container: PackageReference, requirement: PackageRequirement)
 
     var name: PackageReference

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -13,7 +13,7 @@ import XCTest
 import Basic
 import SPMUtility
 import PackageModel
-import PackageGraph
+@testable import PackageGraph
 import TestSupport
 import SourceControl
 @testable import Workspace


### PR DESCRIPTION
This will allow us to access PinsStore inside the dependency resolver