### PR TITLE
Add .swiftpm folder to default GitIgnore file

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -174,6 +174,7 @@ public final class InitPackage {
             stream <<< """
                 .DS_Store
                 /.build
+                /.swiftpm
                 /Packages
                 /*.xcodeproj
                 xcuserdata/


### PR DESCRIPTION
I noticed that when I use SPM project from Xcode, `.swiftpm` folder is created. Would be good to ignore it by default. 