### PR TITLE
UserToolchain: disable use of `-sdk` on !Darwin

### DIFF
--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -205,9 +205,10 @@ public final class UserToolchain: Toolchain {
         self.xctest = nil
       #endif
 
-        self.extraSwiftCFlags = [
-            "-sdk", destination.sdk.pathString
-        ] + destination.extraSwiftCFlags
+        self.extraSwiftCFlags = (destination.target.isDarwin()
+                                    ? ["-sdk", destination.sdk.pathString]
+                                    : [])
+                                  + destination.extraSwiftCFlags
 
         self.extraCCFlags = [
             destination.target.isDarwin() ? "-isysroot" : "--sysroot", destination.sdk.pathString


### PR DESCRIPTION
The non-Darwin targets do not properly support `-sdk`.  Passing this in
during a build prevents the use of `-sdk` for Swift code with the Swift
toolchain and a standalone Swift SDK for a host.  This will allow us to
begin wiring up `-sdk` for such a usage.