### PR TITLE
Add .swiftpm/xcode to default gitignore

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -176,7 +176,7 @@ public final class InitPackage {
                 /.build
                 /Packages
                 /*.xcodeproj
-                xcuserdata/
+                /.swiftpm/xcode/
 
                 """
         }


### PR DESCRIPTION
If you use the new SwiftPM + Xcode 11 integration and open the scheme
viewer, Xcode writes a shared scheme. This shared scheme ends up in a
path that wasn't previously covered by this gitignore since it's
normally intended to be checked in. We can't ignore the entire .swiftpm
directory since this can contain other files, but this ignores all Xcode
created artifacts.

This is a follow up to https://github.com/apple/swift-package-manager/pull/2184 and fixes FB6569495