### PR TITLE
[SR-11088] Ambiguous Error when Dependency Specifies Incompatible Platform Version

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1039,7 +1039,11 @@ public class BuildPlan {
         //
         // If the product's platform version is greater than ours, then it is incompatible.
         if productPlatform.version > targetPlatform.version {
-            diagnostics.emit(data: ProductRequiresHigherPlatformVersion(product: product.name, platform: productPlatform))
+            diagnostics.emit(data: ProductRequiresHigherPlatformVersion(
+                target: target,
+                product: product.name,
+                platform: productPlatform
+            ))
         }
     }
 
@@ -1276,15 +1280,18 @@ struct ProductRequiresHigherPlatformVersion: DiagnosticData {
         name: "org.swift.diags.\(ProductRequiresHigherPlatformVersion.self)",
         defaultBehavior: .error,
         description: {
-            $0 <<< "the product" <<< { "'\($0.product)'" }
-            $0 <<< "requires minimum platform version" <<< { $0.platform.version.versionString }
-            $0 <<< "for" <<< { $0.platform.platform.name } <<< "platform"
+            $0 <<< "the" <<< { $0.target.type.rawValue } <<< { "'\($0.target.name)'" }
+            $0 <<< "has a minimum platform version lower than"
+            $0 <<< { $0.platform.platform.name } <<< { "\($0.platform.version.versionString)," }
+            $0 <<< "which is required by the product" <<< { "'\($0.product)'" }
     })
 
+    public let target: ResolvedTarget
     public let product: String
     public let platform: SupportedPlatform
 
-    init(product: String, platform: SupportedPlatform) {
+    init(target: ResolvedTarget, product: String, platform: SupportedPlatform) {
+        self.target = target
         self.product = product
         self.platform = platform
     }

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1041,8 +1041,9 @@ public class BuildPlan {
         if productPlatform.version > targetPlatform.version {
             diagnostics.emit(data: ProductRequiresHigherPlatformVersion(
                 target: target,
+                targetPlatform: targetPlatform,
                 product: product.name,
-                platform: productPlatform
+                productPlatform: productPlatform
             ))
         }
     }
@@ -1280,20 +1281,26 @@ struct ProductRequiresHigherPlatformVersion: DiagnosticData {
         name: "org.swift.diags.\(ProductRequiresHigherPlatformVersion.self)",
         defaultBehavior: .error,
         description: {
-            $0 <<< "the" <<< { $0.target.type.rawValue } <<< { "'\($0.target.name)'" }
-            $0 <<< "has a minimum platform version lower than"
-            $0 <<< { $0.platform.platform.name } <<< { "\($0.platform.version.versionString)," }
-            $0 <<< "which is required by the product" <<< { "'\($0.product)'" }
+            $0 <<< "the" <<< { $0.target.type.rawValue } <<< { "'\($0.target.name)'" } <<< "requires"
+            $0 <<< { $0.targetPlatform.platform.name } <<< { "\($0.targetPlatform.version.versionString)," }
+            $0 <<< "but depends on the product" <<< { "'\($0.product)'" } <<< "which requires"
+            $0 <<< { $0.productPlatform.platform.name } <<< { "\($0.productPlatform.version.versionString);" }
+            $0 <<< "consider changing the" <<< { $0.target.type.rawValue } <<< { "'\($0.target.name)'" } <<< "to require"
+            $0 <<< { $0.productPlatform.platform.name } <<< { $0.productPlatform.version.versionString } <<< "or later,"
+            $0 <<< "or the product" <<< { "'\($0.product)'" } <<< "to require"
+            $0 <<< { $0.targetPlatform.platform.name } <<< { $0.targetPlatform.version.versionString } <<< "or earlier."
     })
 
     public let target: ResolvedTarget
+    public let targetPlatform: SupportedPlatform
     public let product: String
-    public let platform: SupportedPlatform
+    public let productPlatform: SupportedPlatform
 
-    init(target: ResolvedTarget, product: String, platform: SupportedPlatform) {
+    init(target: ResolvedTarget, targetPlatform: SupportedPlatform, product: String, productPlatform: SupportedPlatform) {
         self.target = target
+        self.targetPlatform = targetPlatform
         self.product = product
-        self.platform = platform
+        self.productPlatform = productPlatform
     }
 }
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1232,7 +1232,12 @@ final class BuildPlanTests: XCTestCase {
         }
 
         DiagnosticsEngineTester(diagnostics, ignoreNotes: true) { result in
-            result.check(diagnostic: .contains("the library 'ATarget' has a minimum platform version lower than macos 10.14, which is required by the product 'BLibrary'"), behavior: .error)
+            let diagnosticMessage = """
+            the library 'ATarget' requires macos 10.13, but depends on the product 'BLibrary' which requires macos 10.14; \
+            consider changing the library 'ATarget' to require macos 10.14 or later, or the product 'BLibrary' to require \
+            macos 10.13 or earlier.
+            """
+            result.check(diagnostic: .contains(diagnosticMessage), behavior: .error)
         }
     }
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1232,7 +1232,7 @@ final class BuildPlanTests: XCTestCase {
         }
 
         DiagnosticsEngineTester(diagnostics, ignoreNotes: true) { result in
-            result.check(diagnostic: .contains("the product 'BLibrary' requires minimum platform version 10.14 for macos platform"), behavior: .error)
+            result.check(diagnostic: .contains("the library 'ATarget' has a minimum platform version lower than macos 10.14, which is required by the product 'BLibrary'"), behavior: .error)
         }
     }
 


### PR DESCRIPTION
As [SR-11088](https://bugs.swift.org/browse/SR-11088) states, the diagnostic message can be a bit confusing in case a dependency specifies an incompatible platform version. With this pull request, I try to solve this problem using a more clear diagnostic message suggested by the reporter.