### PR TITLE
Error out if `publicHeadersPath` is absolute

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -631,7 +631,7 @@ public final class PackageBuilder {
 
         // Compute the path to public headers directory.
         let publicHeaderComponent = manifestTarget?.publicHeadersPath ?? ClangTarget.defaultPublicHeadersComponent
-        let publicHeadersPath = potentialModule.path.appending(RelativePath(publicHeaderComponent))
+        let publicHeadersPath = potentialModule.path.appending(try RelativePath(validating: publicHeaderComponent))
         guard publicHeadersPath.contains(potentialModule.path) else {
             throw ModuleError.invalidPublicHeadersDirectory(potentialModule.name)
         }

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -518,6 +518,32 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
+    func testInvalidPublicHeadersPath() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/Foo/inc/module.modulemap",
+                                    "/Sources/Foo/inc/Foo.h",
+                                    "/Sources/Foo/Foo.c",
+                                    "/Sources/Bar/include/module.modulemap",
+                                    "/Sources/Bar/include/Bar.h",
+                                    "/Sources/Bar/Bar.c"
+        )
+
+        let manifest = Manifest.createV4Manifest(
+            name: "Foo",
+            targets: [
+                TargetDescription(
+                    name: "Foo",
+                    publicHeadersPath: "/inc"),
+                TargetDescription(
+                    name: "Bar"),
+            ]
+        )
+
+        PackageBuilderTester(manifest, in: fs) { result in
+            result.checkDiagnostic("invalid relative path \'/inc\'; relative path should not begin with \'/\' or \'~\'")
+        }
+    }
+
     func testTestsLayoutsv4() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/A/main.swift",

--- a/Tests/PackageLoadingTests/XCTestManifests.swift
+++ b/Tests/PackageLoadingTests/XCTestManifests.swift
@@ -39,6 +39,7 @@ extension PackageBuilderTests {
         ("testExecutableAsADep", testExecutableAsADep),
         ("testInvalidHeaderSearchPath", testInvalidHeaderSearchPath),
         ("testInvalidManifestConfigForNonSystemModules", testInvalidManifestConfigForNonSystemModules),
+        ("testInvalidPublicHeadersPath", testInvalidPublicHeadersPath),
         ("testLinuxMain", testLinuxMain),
         ("testLinuxMainError", testLinuxMainError),
         ("testLinuxMainSearch", testLinuxMainSearch),


### PR DESCRIPTION
Before we were running into a precondition in `RelativePath`.

rdar://problem/52811361