### PR TITLE
[Workspace] Diagnose basename mismatch when overriding

### DIFF
--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -148,7 +148,25 @@ public struct InvalidToolchainDiagnostic: DiagnosticData, Error {
 
 public enum WorkspaceDiagnostics {
 
-    //MARK: - Errors
+    // MARK: - Errors
+
+    public struct PackageOverrideBasenameMismatch: DiagnosticData, Swift.Error {
+        public static var id = DiagnosticID(
+            type: PackageOverrideBasenameMismatch.self,
+            name: "org.swift.diags.workspace.\(PackageOverrideBasenameMismatch.self)",
+            description: {
+                $0 <<< { $0.diag }
+            }
+        )
+
+        let packageName: String
+        let packageIdentity: String
+        let overrideIdentity: String
+
+        var diag: String {
+            return "unable to override package '\(packageName)' because its basename '\(packageIdentity)' doesn't match directory name '\(overrideIdentity)'"
+        }
+    }
 
     /// The diagnostic triggered when an operation fails because its completion
     /// would loose the uncommited changes in a repository.

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3149,6 +3149,51 @@ final class WorkspaceTests: XCTestCase {
            result.check(dependency: "bar", at: .checkout(.version("1.1.0")))
         }
      }
+
+	func testRootPackagesOverrideBasenameMismatch() throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try TestWorkspace(
+            sandbox: sandbox,
+            fs: fs,
+            roots: [
+                TestPackage(
+                    name: "Baz",
+                    path: "Overridden/bazzz-master",
+                    targets: [
+                        TestTarget(name: "Baz"),
+                    ],
+                    products: [
+                        TestProduct(name: "Baz", targets: ["Baz"]),
+                    ]
+                ),
+            ],
+            packages: [
+                TestPackage(
+                    name: "Baz",
+                    path: "bazzz",
+                    targets: [
+                        TestTarget(name: "Baz"),
+                    ],
+                    products: [
+                        TestProduct(name: "Baz", targets: ["Baz"]),
+                    ],
+                    versions: ["1.0.0"]
+                ),
+            ]
+        )
+
+        let deps: [TestWorkspace.PackageDependency] = [
+            .init(name: "bazzz", requirement: .exact("1.0.0")),
+        ]
+
+        workspace.checkPackageGraph(roots: ["Overridden/bazzz-master"], deps: deps) { (graph, diagnostics) in
+            DiagnosticsEngineTester(diagnostics, ignoreNotes: true) { result in
+                result.check(diagnostic: .equal("unable to override package 'Baz' because its basename 'bazzz' doesn't match directory name 'bazzz-master'"), behavior: .error)
+            }
+        }
+    }
 }
 
 extension PackageGraph {

--- a/Tests/WorkspaceTests/XCTestManifests.swift
+++ b/Tests/WorkspaceTests/XCTestManifests.swift
@@ -80,6 +80,7 @@ extension WorkspaceTests {
         ("testRootAsDependency1", testRootAsDependency1),
         ("testRootAsDependency2", testRootAsDependency2),
         ("testRootPackagesOverride", testRootPackagesOverride),
+        ("testRootPackagesOverrideBasenameMismatch", testRootPackagesOverrideBasenameMismatch),
         ("testSimpleAPI", testSimpleAPI),
         ("testSkipUpdate", testSkipUpdate),
         ("testToolsVersionRootPackages", testToolsVersionRootPackages),


### PR DESCRIPTION
... using local packages

<rdar://problem/52263385> [SR-11032]: Package resolution fails when replacing remote dependency with local dependency