### PR TITLE
[Workspace] Diagnose basename mismatch when overriding

### DIFF
--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -148,7 +148,25 @@ public struct InvalidToolchainDiagnostic: DiagnosticData, Error {
 
 public enum WorkspaceDiagnostics {
 
-    //MARK: - Errors
+    // MARK: - Errors
+
+    public struct PackageOverrideBasenameMismatch: DiagnosticData, Swift.Error {
+        public static var id = DiagnosticID(
+            type: PackageOverrideBasenameMismatch.self,
+            name: "org.swift.diags.workspace.\(PackageOverrideBasenameMismatch.self)",
+            description: {
+                $0 <<< { $0.diag }
+            }
+        )
+
+        let packageName: String
+        let packageIdentity: String
+        let overrideIdentity: String
+
+        var diag: String {
+            return "unable to override package '\(packageName)' because its basename '\(packageIdentity)' doesn't match directory name '\(overrideIdentity)'"
+        }
+    }
 
     /// The diagnostic triggered when an operation fails because its completion
     /// would loose the uncommited changes in a repository.

--- a/Tests/WorkspaceTests/XCTestManifests.swift
+++ b/Tests/WorkspaceTests/XCTestManifests.swift
@@ -80,6 +80,7 @@ extension WorkspaceTests {
         ("testRootAsDependency1", testRootAsDependency1),
         ("testRootAsDependency2", testRootAsDependency2),
         ("testRootPackagesOverride", testRootPackagesOverride),
+        ("testRootPackagesOverrideBasenameMismatch", testRootPackagesOverrideBasenameMismatch),
         ("testSimpleAPI", testSimpleAPI),
         ("testSkipUpdate", testSkipUpdate),
         ("testToolsVersionRootPackages", testToolsVersionRootPackages),


### PR DESCRIPTION
... using local packages

<rdar://problem/52263385> [SR-11032]: Package resolution fails when replacing remote dependency with local dependency

(cherry picked from commit d9c76ac0ab0b3a39dcd63ce4984be3b6e412545c)