### PR TITLE
[Build] Establish dependency on executable product when available

### DIFF
--- a/Sources/Build/llbuild.swift
+++ b/Sources/Build/llbuild.swift
@@ -205,6 +205,19 @@ public final class LLBuildManifestGenerator {
         func addStaticTargetInputs(_ target: ResolvedTarget) {
             // Ignore C Modules.
             if target.underlyingTarget is SystemLibraryTarget { return }
+
+            // Depend on the binary for executable targets.
+            if target.type == .executable {
+                // FIXME: Optimize.
+                let _product = plan.graph.allProducts.first {
+                    $0.type == .executable && $0.executableModule == target
+                }
+                if let product = _product {
+                    inputs += [plan.productMap[product]!.binary.pathString]
+                }
+                return
+            }
+
             switch plan.targetMap[target] {
             case .swift(let target)?:
                 inputs.insert(target.moduleOutputPath.pathString)

--- a/Tests/BuildTests/XCTestManifests.swift
+++ b/Tests/BuildTests/XCTestManifests.swift
@@ -17,6 +17,7 @@ extension BuildPlanTests {
         ("testCppModule", testCppModule),
         ("testDynamicProducts", testDynamicProducts),
         ("testExecAsDependency", testExecAsDependency),
+        ("testExecBuildTimeDependency", testExecBuildTimeDependency),
         ("testExtraBuildFlags", testExtraBuildFlags),
         ("testIndexStore", testIndexStore),
         ("testNonReachableProductsAndTargets", testNonReachableProductsAndTargets),


### PR DESCRIPTION
This fixes the  build time dependency to depend on the executable
product's binary whenever it is available.

<rdar://problem/52979509>

(cherry picked from commit f425f5a58c2c1b3d4aa6597fa9391bcac39d22c7)