### PR TITLE
[Commands] Don't access manifest array directly

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -265,8 +265,9 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
         case .describe:
             let workspace = try getActiveWorkspace()
             let root = try getWorkspaceRoot()
-            let manifest = workspace.loadRootManifests(
-                packages: root.packages, diagnostics: diagnostics)[0]
+            let manifests = workspace.loadRootManifests(
+                packages: root.packages, diagnostics: diagnostics)
+            guard let manifest = manifests.first else { return }
 
             let builder = PackageBuilder(
                 manifest: manifest,
@@ -280,8 +281,9 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
         case .dumpPackage:
             let workspace = try getActiveWorkspace()
             let root = try getWorkspaceRoot()
-            let manifest = workspace.loadRootManifests(
-                packages: root.packages, diagnostics: diagnostics)[0]
+            let manifests = workspace.loadRootManifests(
+                packages: root.packages, diagnostics: diagnostics)
+            guard let manifest = manifests.first else { return }
 
             let encoder = JSONEncoder()
             encoder.userInfo[Manifest.dumpPackageKey] = true


### PR DESCRIPTION
Avoid blindly accessing the first manifest since we don't know if it was
actually loaded or not.

<rdar://problem/53157810> [SR-11146]: Swift dump-package results in a SIGILL (Illegal Instruction)

(cherry picked from commit 09064935cb2791a8bde2d3afaaf651ed9373a0f7)