### PR TITLE
[Commands] Add test support for multiroot packages

### DIFF
--- a/Sources/Commands/MultiRootSupport.swift
+++ b/Sources/Commands/MultiRootSupport.swift
@@ -65,6 +65,8 @@ final class XcodeWorkspaceLoader {
 
             if fs.exists(path.appending(component: Manifest.filename)) {
                 result.append(path)
+            } else {
+                diagnostics.emit(data: LoaderWarning(message: "ignoring non-package fileref \(path)"))
             }
         }
         return result


### PR DESCRIPTION
Extends the testing command for multiroot packages (see previous
commit). The test discovery doesn't work with this yet but that can be
fixed in a later commit.

<rdar://problem/53723874> Add a way to test multi root packages with swift-test