### PR TITLE
[PackageGraph] Fix a bug related to overridden packages and unsafe flags

### DIFF
--- a/Sources/PackageGraph/PackageGraphLoader.swift
+++ b/Sources/PackageGraph/PackageGraphLoader.swift
@@ -97,7 +97,7 @@ public struct PackageGraphLoader {
         config: SwiftPMConfig = SwiftPMConfig(),
         externalManifests: [Manifest],
         requiredDependencies: Set<PackageReference> = [],
-        unsafeAllowedDependencies: Set<PackageReference> = [],
+        unsafeAllowedPackages: Set<PackageReference> = [],
         diagnostics: DiagnosticsEngine,
         fileSystem: FileSystem = localFileSystem,
         shouldCreateMultipleTestProducts: Bool = false,
@@ -177,7 +177,7 @@ public struct PackageGraphLoader {
             config: config,
             manifestToPackage: manifestToPackage,
             rootManifestSet: rootManifestSet,
-            unsafeAllowedDependencies: unsafeAllowedDependencies,
+            unsafeAllowedPackages: unsafeAllowedPackages,
             diagnostics: diagnostics
         )
 
@@ -236,7 +236,7 @@ private func createResolvedPackages(
     manifestToPackage: [Manifest: Package],
     // FIXME: This shouldn't be needed once <rdar://problem/33693433> is fixed.
     rootManifestSet: Set<Manifest>,
-    unsafeAllowedDependencies: Set<PackageReference>,
+    unsafeAllowedPackages: Set<PackageReference>,
     diagnostics: DiagnosticsEngine
 ) -> [ResolvedPackage] {
 
@@ -245,7 +245,7 @@ private func createResolvedPackages(
         guard let package = manifestToPackage[$0] else {
             return nil
         }
-        let isAllowedToVendUnsafeProducts = unsafeAllowedDependencies.contains{ $0.path == package.manifest.url }
+        let isAllowedToVendUnsafeProducts = unsafeAllowedPackages.contains{ $0.path == package.manifest.url }
         return ResolvedPackageBuilder(package, isAllowedToVendUnsafeProducts: isAllowedToVendUnsafeProducts)
     })
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -151,8 +151,8 @@ public class Workspace {
             return computePackageURLs().missing
         }
 
-        /// Returns the list of package dependencies which are allowed to vend products with unsafe flags.
-        func unsafeAllowedDependencies() -> Set<PackageReference> {
+        /// Returns the list of packages which are allowed to vend products with unsafe flags.
+        func unsafeAllowedPackages() -> Set<PackageReference> {
             var result = Set<PackageReference>()
 
             for dependency in dependencies {
@@ -168,6 +168,9 @@ public class Workspace {
                     result.insert(dependency.packageRef)
                 }
             }
+
+            // Root packages are always allowed to use unsafe flags.
+            result.formUnion(root.packageRefs)
 
             return result
         }
@@ -692,7 +695,7 @@ extension Workspace {
             config: config,
             externalManifests: externalManifests,
             requiredDependencies: manifests.computePackageURLs().required,
-            unsafeAllowedDependencies: manifests.unsafeAllowedDependencies(),
+            unsafeAllowedPackages: manifests.unsafeAllowedPackages(),
             diagnostics: diagnostics,
             fileSystem: fileSystem,
             shouldCreateMultipleTestProducts: createMultipleTestProducts,

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3103,6 +3103,16 @@ final class WorkspaceTests: XCTestCase {
             fs: fs,
             roots: [
                 TestPackage(
+                    name: "Bar",
+                    targets: [
+                        TestTarget(name: "Bar", settings: [.init(tool: .swift, name: .unsafeFlags, value: ["-F", "/tmp"])]),
+                    ],
+                    products: [
+                        TestProduct(name: "Bar", targets: ["Bar"]),
+                    ],
+                    versions: ["1.0.0", nil]
+                ),
+                TestPackage(
                     name: "Foo",
                     targets: [
                         TestTarget(name: "Foo", dependencies: ["Bar", "Baz"]),
@@ -3142,7 +3152,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         // We should only see errors about use of unsafe flag in the version-based dependency.
-        workspace.checkPackageGraph(roots: ["Foo"]) { (graph, diagnostics) in
+        workspace.checkPackageGraph(roots: ["Foo", "Bar"]) { (graph, diagnostics) in
             DiagnosticsEngineTester(diagnostics, ignoreNotes: true) { result in
                result.check(diagnostic: .equal("the target 'Baz' in product 'Baz' contains unsafe build flags"), behavior: .error)
            }


### PR DESCRIPTION
SwiftPM wasn't allowing using unsafe flags in a root package that is
overriding another package.

<rdar://problem/53781795>