### PR TITLE
[Perf] Cache process env

### DIFF
--- a/Sources/Basic/Process.swift
+++ b/Sources/Basic/Process.swift
@@ -159,6 +159,7 @@ public final class Process: ObjectIdentifierProtocol {
     public let verbose: Bool
 
     /// The current environment.
+    @available(*, deprecated, message: "use ProcessEnv.vars instead")
     static public var env: [String: String] {
         return ProcessInfo.processInfo.environment
     }
@@ -233,7 +234,7 @@ public final class Process: ObjectIdentifierProtocol {
     ///     continue running even if the parent is killed or interrupted. Default value is true.
     public init(
         arguments: [String],
-        environment: [String: String] = env,
+        environment: [String: String] = ProcessEnv.vars,
         outputRedirection: OutputRedirection = .collect,
         verbose: Bool = Process.verbose,
         startNewProcessGroup: Bool = true
@@ -256,7 +257,7 @@ public final class Process: ObjectIdentifierProtocol {
             }
             // FIXME: This can be cached.
             let envSearchPaths = getEnvSearchPaths(
-                pathString: Process.env["PATH"],
+                pathString: ProcessEnv.vars["PATH"],
                 currentWorkingDirectory: localFileSystem.currentWorkingDirectory
             )
             // Lookup and cache the executable path.
@@ -545,14 +546,14 @@ extension Process {
     ///     will be inherited.
     /// - Returns: The process result.
     @discardableResult
-    static public func popen(arguments: [String], environment: [String: String] = env) throws -> ProcessResult {
+    static public func popen(arguments: [String], environment: [String: String] = ProcessEnv.vars) throws -> ProcessResult {
         let process = Process(arguments: arguments, environment: environment, outputRedirection: .collect)
         try process.launch()
         return try process.waitUntilExit()
     }
 
     @discardableResult
-    static public func popen(args: String..., environment: [String: String] = env) throws -> ProcessResult {
+    static public func popen(args: String..., environment: [String: String] = ProcessEnv.vars) throws -> ProcessResult {
         return try Process.popen(arguments: args, environment: environment)
     }
 
@@ -564,7 +565,7 @@ extension Process {
     ///     will be inherited.
     /// - Returns: The process output (stdout + stderr).
     @discardableResult
-    static public func checkNonZeroExit(arguments: [String], environment: [String: String] = env) throws -> String {
+    static public func checkNonZeroExit(arguments: [String], environment: [String: String] = ProcessEnv.vars) throws -> String {
         let process = Process(arguments: arguments, environment: environment, outputRedirection: .collect)
         try process.launch()
         let result = try process.waitUntilExit()
@@ -576,11 +577,11 @@ extension Process {
     }
 
     @discardableResult
-    static public func checkNonZeroExit(args: String..., environment: [String: String] = env) throws -> String {
+    static public func checkNonZeroExit(args: String..., environment: [String: String] = ProcessEnv.vars) throws -> String {
         return try checkNonZeroExit(arguments: args, environment: environment)
     }
 
-    public convenience init(args: String..., environment: [String: String] = env, outputRedirection: OutputRedirection = .collect) {
+    public convenience init(args: String..., environment: [String: String] = ProcessEnv.vars, outputRedirection: OutputRedirection = .collect) {
         self.init(arguments: args, environment: environment, outputRedirection: outputRedirection)
     }
 }

--- a/Sources/Basic/ProcessEnv.swift
+++ b/Sources/Basic/ProcessEnv.swift
@@ -15,8 +15,12 @@ import SPMLibc
 public enum ProcessEnv {
 
     /// Returns a dictionary containing the current environment.
-    public static var vars: [String: String] {
-        return ProcessInfo.processInfo.environment
+    public static var vars: [String: String] { _vars }
+    private static var _vars = ProcessInfo.processInfo.environment
+
+    /// Invalidate the cached env.
+    public static func invalidateEnv() {
+        _vars = ProcessInfo.processInfo.environment
     }
 
     /// Set the given key and value in the process's environment.
@@ -34,6 +38,7 @@ public enum ProcessEnv {
             throw SystemError.setenv(errno, key)
         }
       #endif
+        invalidateEnv()
     }
 
     /// Unset the give key in the process's environment.
@@ -49,6 +54,7 @@ public enum ProcessEnv {
             throw SystemError.unsetenv(errno, key)
         }
       #endif
+        invalidateEnv()
     }
 
     /// The current working directory of the process.

--- a/Sources/Basic/TemporaryFile.swift
+++ b/Sources/Basic/TemporaryFile.swift
@@ -55,7 +55,7 @@ public func determineTempDirectory(_ dir: AbsolutePath? = nil) throws -> Absolut
 /// Returns temporary directory location by searching relevant env variables.
 /// Evaluates once per execution.
 private var cachedTempDirectory: AbsolutePath = {
-    return AbsolutePath(Process.env["TMPDIR"] ?? Process.env["TEMP"] ?? Process.env["TMP"] ?? "/tmp/")
+    return AbsolutePath(ProcessEnv.vars["TMPDIR"] ?? ProcessEnv.vars["TEMP"] ?? ProcessEnv.vars["TMP"] ?? "/tmp/")
 }()
 
 /// This class is basically a wrapper over posix's mkstemps() function to creates disposable files.

--- a/Sources/Basic/TerminalController.swift
+++ b/Sources/Basic/TerminalController.swift
@@ -94,7 +94,7 @@ public final class TerminalController {
 
     /// Computes the terminal type of the stream.
     public static func terminalType(_ stream: LocalFileOutputByteStream) -> TerminalType {
-        if Process.env["TERM"] == "dumb" {
+        if ProcessEnv.vars["TERM"] == "dumb" {
             return .dumb
         }
         let isTTY = isatty(fileno(stream.filePointer)) != 0
@@ -107,7 +107,7 @@ public final class TerminalController {
     /// - Returns: Current width of terminal if it was determinable.
     public static func terminalWidth() -> Int? {
         // Try to get from environment.
-        if let columns = Process.env["COLUMNS"], let width = Int(columns) {
+        if let columns = ProcessEnv.vars["COLUMNS"], let width = Int(columns) {
             return width
         }
 

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -30,7 +30,7 @@ public struct BuildParameters {
     fileprivate var moduleCache: AbsolutePath {
         // FIXME: We use this hack to let swiftpm's functional test use shared
         // cache so it doesn't become painfully slow.
-        if let path = Process.env["SWIFTPM_TESTS_MODULECACHE"] {
+        if let path = ProcessEnv.vars["SWIFTPM_TESTS_MODULECACHE"] {
             return AbsolutePath(path)
         }
         return buildPath.appending(component: "ModuleCache")
@@ -324,7 +324,7 @@ public final class ClangTargetBuildDescription {
         //
         // This feature is not widely available in OSS clang. So, we only enable
         // index store for Apple's clang or if explicitly asked to.
-        if Process.env.keys.contains("SWIFTPM_ENABLE_CLANG_INDEX_STORE") {
+        if ProcessEnv.vars.keys.contains("SWIFTPM_ENABLE_CLANG_INDEX_STORE") {
             args += buildParameters.indexStoreArguments
         } else if buildParameters.triple.isDarwin(), (try? buildParameters.toolchain._isClangCompilerVendorApple()) == true {
             args += buildParameters.indexStoreArguments
@@ -525,7 +525,7 @@ public final class SwiftTargetBuildDescription {
 
         // Add arguments to colorize output if stdout is tty
         if buildParameters.isTTY {
-            if Process.env["SWIFTPM_USE_NEW_COLOR_DIAGNOSTICS"] != nil {
+            if ProcessEnv.vars["SWIFTPM_USE_NEW_COLOR_DIAGNOSTICS"] != nil {
                 args += ["-color-diagnostics"]
             } else {
                 args += ["-Xfrontend", "-color-diagnostics"]

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -725,7 +725,7 @@ final class ParallelTestRunner {
         self.numJobs = numJobs
         self.diagnostics = diagnostics
 
-        if Process.env["SWIFTPM_TEST_RUNNER_PROGRESS_BAR"] == "lit" {
+        if ProcessEnv.vars["SWIFTPM_TEST_RUNNER_PROGRESS_BAR"] == "lit" {
             progressAnimation = PercentProgressAnimation(stream: stdoutStream, header: "Testing:")
         } else {
             progressAnimation = NinjaProgressAnimation(stream: stdoutStream)
@@ -965,7 +965,7 @@ fileprivate func constructTestEnvironment(
     options: ToolOptions,
     buildParameters: BuildParameters
 ) throws -> [String: String] {
-    var env = Process.env
+    var env = ProcessEnv.vars
 
     // Add the code coverage related variables.
     if options.shouldEnableCodeCoverage {

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -417,7 +417,7 @@ public class SwiftTool<Options: ToolOptions> {
 
     func configFilePath() throws -> AbsolutePath {
         // Look for the override in the environment.
-        if let envPath = Process.env["SWIFTPM_MIRROR_CONFIG"] {
+        if let envPath = ProcessEnv.vars["SWIFTPM_MIRROR_CONFIG"] {
             return try AbsolutePath(validating: envPath)
         }
 
@@ -753,8 +753,8 @@ private func findPackageRoot() -> AbsolutePath? {
 /// Returns the build path from the environment, if present.
 private func getEnvBuildPath(workingDir: AbsolutePath) -> AbsolutePath? {
     // Don't rely on build path from env for SwiftPM's own tests.
-    guard Process.env["SWIFTPM_TESTS_MODULECACHE"] == nil else { return nil }
-    guard let env = Process.env["SWIFTPM_BUILD_DIR"] else { return nil }
+    guard ProcessEnv.vars["SWIFTPM_TESTS_MODULECACHE"] == nil else { return nil }
+    guard let env = ProcessEnv.vars["SWIFTPM_BUILD_DIR"] else { return nil }
     return AbsolutePath(env, relativeTo: workingDir)
 }
 

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -404,7 +404,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
             // FIXME: Workaround for the module cache bug that's been haunting Swift CI
             // <rdar://problem/48443680>
-            let moduleCachePath = Process.env["SWIFTPM_MODULECACHE_OVERRIDE"] ?? Process.env["SWIFTPM_TESTS_MODULECACHE"]
+            let moduleCachePath = ProcessEnv.vars["SWIFTPM_MODULECACHE_OVERRIDE"] ?? ProcessEnv.vars["SWIFTPM_TESTS_MODULECACHE"]
 
             var cmd = [String]()
           #if os(macOS)

--- a/Sources/SPMUtility/PkgConfig.swift
+++ b/Sources/SPMUtility/PkgConfig.swift
@@ -166,7 +166,7 @@ public struct PkgConfig {
     }
 
     private static var envSearchPaths: [AbsolutePath] {
-        if let configPath = Process.env["PKG_CONFIG_PATH"] {
+        if let configPath = ProcessEnv.vars["PKG_CONFIG_PATH"] {
             return configPath.split(separator: ":").map({ AbsolutePath(String($0)) })
         }
         return []

--- a/Sources/TestSupport/misc.swift
+++ b/Sources/TestSupport/misc.swift
@@ -239,7 +239,7 @@ public func loadPackageGraph(
 /// from different threads, the environment will neither be setup nor restored
 /// correctly.
 public func withCustomEnv(_ env: [String: String], body: () throws -> Void) throws {
-    let state = Array(env.keys).map({ ($0, Process.env[$0]) })
+    let state = Array(env.keys).map({ ($0, ProcessEnv.vars[$0]) })
     let restore = {
         for (key, value) in state {
             if let value = value {

--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -81,7 +81,7 @@ public struct Destination {
     public static func hostDestination(
         _ binDir: AbsolutePath? = nil,
         originalWorkingDirectory: AbsolutePath? = localFileSystem.currentWorkingDirectory,
-        environment: [String:String] = Process.env
+        environment: [String:String] = ProcessEnv.vars
     ) throws -> Destination {
         // Select the correct binDir.
         var customBinDir: AbsolutePath?
@@ -94,7 +94,7 @@ public struct Destination {
       #if os(macOS)
         // Get the SDK.
         let sdkPath: AbsolutePath
-        if let value = lookupExecutablePath(filename: Process.env["SDKROOT"]) {
+        if let value = lookupExecutablePath(filename: ProcessEnv.vars["SDKROOT"]) {
             sdkPath = value
         } else {
             // No value in env, so search for it.
@@ -131,7 +131,7 @@ public struct Destination {
     }
 
     /// Returns macosx sdk platform framework path.
-    public static func sdkPlatformFrameworkPath(environment: [String:String] = Process.env) -> AbsolutePath? {
+    public static func sdkPlatformFrameworkPath(environment: [String:String] = ProcessEnv.vars) -> AbsolutePath? {
         if let path = _sdkPlatformFrameworkPath {
             return path
         }

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -112,7 +112,7 @@ public final class UserToolchain: Toolchain {
     }
 
     private static func lookup(variable: String, searchPaths: [AbsolutePath]) -> AbsolutePath? {
-        return lookupExecutablePath(filename: Process.env[variable], searchPaths: searchPaths)
+        return lookupExecutablePath(filename: ProcessEnv.vars[variable], searchPaths: searchPaths)
     }
 
     /// Environment to use when looking up tools.
@@ -180,13 +180,13 @@ public final class UserToolchain: Toolchain {
         return toolPath
     }
 
-    public init(destination: Destination, environment: [String: String] = Process.env) throws {
+    public init(destination: Destination, environment: [String: String] = ProcessEnv.vars) throws {
         self.destination = destination
         self.processEnvironment = environment
 
         // Get the search paths from PATH.
         let searchPaths = getEnvSearchPaths(
-            pathString: Process.env["PATH"], currentWorkingDirectory: localFileSystem.currentWorkingDirectory)
+            pathString: ProcessEnv.vars["PATH"], currentWorkingDirectory: localFileSystem.currentWorkingDirectory)
 
         self.envSearchPaths = searchPaths
 
@@ -218,7 +218,7 @@ public final class UserToolchain: Toolchain {
         var pdLibDir = UserManifestResources.libDir(forBinDir: binDir)
 
         // Look for an override in the env.
-        if let pdLibDirEnvStr = Process.env["SWIFTPM_PD_LIBS"] {
+        if let pdLibDirEnvStr = ProcessEnv.vars["SWIFTPM_PD_LIBS"] {
             // We pick the first path which exists in a colon seperated list.
             let paths = pdLibDirEnvStr.split(separator: ":").map(String.init)
             for pathString in paths {


### PR DESCRIPTION
Cache ProcessEnv.vars because ProcessInfo.processInfo.environment is
costly and we don't really mutate the env.

<rdar://problem/53828756>