### PR TITLE
Implement build manifest caching

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -229,14 +229,6 @@ public struct BuildParameters: Encodable {
         return BuildSettings.Scope(target.underlyingTarget.buildSettings, boundCondition: (currentPlatform, configuration))
     }
 
-    func hash() throws -> Data {
-        let encoder = JSONEncoder()
-        if #available(macOS 10.13, *) {
-            encoder.outputFormatting = [.sortedKeys]
-        }
-        return try encoder.encode(self)
-    }
-
     /// A shim struct for toolchain so we can encode it without having to write encode(to:) for
     /// entire BuildParameters by hand.
     struct _Toolchain: Encodable {

--- a/Sources/Build/ToolProtocol.swift
+++ b/Sources/Build/ToolProtocol.swift
@@ -52,6 +52,25 @@ public struct TestDiscoveryTool: ToolProtocol, Codable {
     }
 }
 
+/// Package strcuture tool is used to determine if the package has changed in some way
+/// that requires regenerating the build manifest file. This allows us to skip a lot of
+/// redundent work (package graph loading, build planning, manifest generation) during
+/// incremental builds.
+struct PackageStructureTool: ToolProtocol {
+    static let name: String = "package-structure-tool"
+
+    let inputs: [String]
+    let outputs: [String]
+
+    func append(to stream: OutputByteStream) {
+        stream <<< "    tool: \(Self.name)\n"
+        stream <<< "    description: Planning build\n"
+        stream <<< "    inputs: " <<< Format.asJSON(inputs) <<< "\n"
+        stream <<< "    outputs: " <<< Format.asJSON(outputs) <<< "\n"
+        stream <<< "    allow-missing-inputs: true\n"
+    }
+}
+
 struct ShellTool: ToolProtocol {
     let description: String
     let inputs: [String]

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -86,5 +86,8 @@ public class ToolOptions {
     /// Whether to disable the build planning.
     public var skipBuildPlanning: Bool = false
 
+    /// Whether to enable llbuild manifest caching.
+    public var enableBuildManifestCaching: Bool = false
+
     public required init() {}
 }

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -36,16 +36,7 @@ public class SwiftBuildTool: SwiftTool<BuildToolOptions> {
           #endif
 
             guard let subset = options.buildSubset(diagnostics: diagnostics) else { return }
-
-            let buildParameters = try self.buildParameters()
-            if options.skipBuildPlanning {
-                let buildDescription = try BuildDescription.load(from: buildParameters.buildDescriptionPath)
-                try build(buildDescription: buildDescription, subset: subset)
-            } else {
-                // Create the build plan and build.
-                let plan = try BuildPlan(buildParameters: buildParameters, graph: loadPackageGraph(), diagnostics: diagnostics)
-                try build(plan: plan, subset: subset)
-            }
+            try build(subset: subset)
 
         case .binPath:
             try print(buildParameters().buildPath.description)

--- a/Sources/TestSupport/misc.swift
+++ b/Sources/TestSupport/misc.swift
@@ -143,6 +143,7 @@ private var globalSymbolInMainBinary = 0
 public func executeSwiftBuild(
     _ packagePath: AbsolutePath,
     configuration: Configuration = .Debug,
+    extraArgs: [String] = [],
     Xcc: [String] = [],
     Xld: [String] = [],
     Xswiftc: [String] = [],
@@ -155,6 +156,7 @@ public func executeSwiftBuild(
     case .Release:
         args.append("release")
     }
+    args += extraArgs
     args += Xcc.flatMap({ ["-Xcc", $0] })
     args += Xld.flatMap({ ["-Xlinker", $0] })
     args += Xswiftc.flatMap({ ["-Xswiftc", $0] })

--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -147,6 +147,16 @@ public final class ManagedDependency: JSONMappable, JSONSerializable, CustomStri
     public var description: String {
         return "<ManagedDependency: \(packageRef.name ?? packageRef.identity) \(state)>"
     }
+
+    /// Returns true if the dependency is edited.
+    public var isEdited: Bool {
+        switch state {
+        case .checkout, .local:
+            return false
+        case .edited:
+            return true
+        }
+    }
 }
 
 extension ManagedDependency.State: JSONMappable, JSONSerializable {

--- a/Tests/BuildTests/IncrementalBuildTests.swift
+++ b/Tests/BuildTests/IncrementalBuildTests.swift
@@ -80,6 +80,32 @@ final class IncrementalBuildTests: XCTestCase {
         }
     }
 
-    // FIXME:  We should add a lot more test cases here; the one above is just
-    // a starter test.
+    func testBuildManifestCaching() {
+        fixture(name: "ValidLayouts/SingleModule/Library") { prefix in
+            @discardableResult
+            func build() throws -> String {
+                return try executeSwiftBuild(prefix, extraArgs: ["--enable-build-manifest-caching"])
+            }
+
+            // Perform a full build.
+            try build()
+            // Ensure manifest caching kicks in.
+            try build()
+
+            // Check that we're not re-planning when nothing has changed.
+            let log1 = try build()
+            XCTAssertFalse(log1.contains("PackageStructure") || log1.contains("Planning build"), log1)
+
+            // Check that we do run planning when a new source file is added.
+            let sourceFile = prefix.appending(components: "Sources", "Library", "new.swift")
+            try localFileSystem.writeFileContents(sourceFile, bytes: "")
+            let log2 = try build()
+            XCTAssertTrue(log2.contains("PackageStructure") || log2.contains("Planning build"), log2)
+
+            // Check that we don't run planning when a source file is modified.
+            try localFileSystem.writeFileContents(sourceFile, bytes: "\n\n\n\n")
+            let log3 = try build()
+            XCTAssertFalse(log3.contains("PackageStructure") || log3.contains("Planning build"), log3)
+        }
+    }
 }

--- a/Tests/BuildTests/XCTestManifests.swift
+++ b/Tests/BuildTests/XCTestManifests.swift
@@ -39,6 +39,7 @@ extension IncrementalBuildTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__IncrementalBuildTests = [
+        ("testBuildManifestCaching", testBuildManifestCaching),
         ("testIncrementalSingleModuleCLibraryInSources", testIncrementalSingleModuleCLibraryInSources),
     ]
 }


### PR DESCRIPTION
This implements caching for llbuild manifest behind
--enable-build-manifest-caching flag. This currently only works for
`swift build` invocations but there is enough facility to extend this to
other tools (we need to store more information in BuildDescription).

This works by creating a new command "PackageStructure" which depends on
the directory structure of the package, the package manifest,
Package.resolved file, build parameters and the process env.

<rdar://problem/53901583>

Here are some null build timings with and without build manifest caching (on 6 core/i9):

| Package   | without | with  |
|-----------|---------|-------|
| trivial   |  0.076  | 0.060 |
| swift-nio |  0.198  | 0.102 |
| vapor     |  0.668  | 0.192 |
| unnamed   |  1.177  | 0.216 |