### PR TITLE
[PubGrub] Handle edited/local/branch dependencies using package overr…

### DIFF
--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -345,7 +345,7 @@ public protocol PackageContainerProvider {
 }
 
 /// An individual constraint onto a container.
-public struct PackageContainerConstraint: CustomStringConvertible, Equatable {
+public struct PackageContainerConstraint: CustomStringConvertible, Equatable, Hashable {
 
     /// The identifier for the container the constraint is on.
     public let identifier: PackageReference


### PR DESCRIPTION
…iding facility

This implements properly handling unversioned and branch-based
dependencies using a "package overriding" facility in the resolver. The
main advantage of this approach is that we don't need to backtrack for
branch/unversioned dependencies since it seems way too hard to apply set
relations to these constraints. The fact that unversioned and
branch-based dependencies have an overriding behavior makes using set
relations even harder. We might want to do that at some point but this
approach works well and provides accurate results right now.

<rdar://problem/46075343>