### PR TITLE
build: add a CMake based build for bootstrapping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,28 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+cmake_minimum_required(VERSION 3.15.1)
+
+project(SwiftPM LANGUAGES C Swift)
+
+set(CMAKE_Swift_LANGUAGE_VERSION 4.2)
+set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+option(BUILD_SHARED_LIBS "Build shared libraryes by default" YES)
+
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  execute_process(COMMAND xcrun --sdk macosx --show-sdk-path
+    OUTPUT_VARIABLE CMAKE_OSX_SYSROOT
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
+add_subdirectory(Sources)

--- a/Sources/Basic/CMakeLists.txt
+++ b/Sources/Basic/CMakeLists.txt
@@ -1,0 +1,59 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_library(Basic
+  Await.swift
+  ByteString.swift
+  CacheableSequence.swift
+  CollectionAlgorithms.swift
+  CollectionExtensions.swift
+  Condition.swift
+  CStringArray.swift
+  DeltaAlgorithm.swift
+  DiagnosticsEngine.swift
+  DictionaryExtensions.swift
+  DictionaryLiteralExtensions.swift
+  EditDistance.swift
+  FileInfo.swift
+  FileSystem.swift
+  GraphAlgorithms.swift
+  JSON.swift
+  JSONMapper.swift
+  KeyedPair.swift
+  LazyCache.swift
+  Lock.swift
+  misc.swift
+  ObjectIdentifierProtocol.swift
+  OrderedDictionary.swift
+  OrderedSet.swift
+  OutputByteStream.swift
+  Path.swift
+  PathShims.swift
+  Process.swift
+  ProcessEnv.swift
+  ProcessSet.swift
+  RegEx.swift
+  Result.swift
+  SHA256.swift
+  SortedArray.swift
+  StringConversions.swift
+  SynchronizedQueue.swift
+  TemporaryFile.swift
+  TerminalController.swift
+  Thread.swift
+  Tuple.swift)
+target_link_libraries(Basic PUBLIC
+  SPMLibc)
+# NOTE(compnerd) workaround for CMake not setting up include flags yet
+set_target_properties(Basic PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+install(TARGETS Basic
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/Sources/Build/CMakeLists.txt
+++ b/Sources/Build/CMakeLists.txt
@@ -1,0 +1,29 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_library(Build
+  BuildDelegate.swift
+  BuildPlan.swift
+  Command.swift
+  llbuild.swift
+  Sanitizers.swift
+  SwiftCompilerOutputParser.swift
+  Toolchain.swift
+  ToolProtocol.swift
+  Triple.swift)
+target_link_libraries(Build PUBLIC
+  Basic
+  PackageGraph)
+# NOTE(compnerd) workaround for CMake not setting up include flags yet
+set_target_properties(Build PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+install(TARGETS Build
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,0 +1,28 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_subdirectory(Basic)
+add_subdirectory(Build)
+add_subdirectory(clibc)
+add_subdirectory(Commands)
+add_subdirectory(PackageDescription4)
+add_subdirectory(PackageGraph)
+add_subdirectory(PackageLoading)
+add_subdirectory(PackageModel)
+add_subdirectory(SourceControl)
+add_subdirectory(SPMLibc)
+add_subdirectory(SPMLLBuild)
+add_subdirectory(SPMUtility)
+add_subdirectory(swift-build)
+add_subdirectory(swift-run)
+add_subdirectory(swift-test)
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  add_subdirectory(swiftpm-xctest-helper)
+endif()
+add_subdirectory(Workspace)
+add_subdirectory(Xcodeproj)

--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -1,0 +1,39 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_library(Commands
+  Completions+bash.swift
+  Completions+zsh.swift
+  Describe.swift
+  Error.swift
+  GenerateLinuxMain.swift
+  MultiRootSupport.swift
+  Options.swift
+  show-dependencies.swift
+  SwiftBuildTool.swift
+  SwiftPackageTool.swift
+  SwiftRunTool.swift
+  SwiftTestTool.swift
+  SwiftTool.swift
+  WatchmanHelper.swift)
+target_link_libraries(Commands PUBLIC
+  Basic
+  Build
+  PackageGraph
+  SourceControl
+  SPMUtility
+  Xcodeproj
+  Workspace)
+# NOTE(compnerd) workaround for CMake not setting up include flags yet
+set_target_properties(Commands PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+install(TARGETS Commands
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/Sources/PackageDescription4/CMakeLists.txt
+++ b/Sources/PackageDescription4/CMakeLists.txt
@@ -1,0 +1,34 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+foreach(PACKAGE_DESCRIPTION_VERSION 4 4_2)
+  add_library(PD${PACKAGE_DESCRIPTION_VERSION}
+    BuildSettings.swift
+    LanguageStandardSettings.swift
+    Package.swift
+    PackageDependency.swift
+    PackageRequirement.swift
+    Product.swift
+    SupportedPlatforms.swift
+    Target.swift
+    Version+StringLiteralConvertible.swift
+    Version.swift)
+  target_compile_definitions(PD${PACKAGE_DESCRIPTION_VERSION} PRIVATE
+    PACKAGE_DESCRIPTION_${PACKAGE_DESCRIPTION_VERSION})
+  set_target_properties(PD${PACKAGE_DESCRIPTION_VERSION} PROPERTIES
+    Swift_MODULE_NAME PackageDescription
+    Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/runtimes/${PACKAGE_DESCRIPTION_VERSION}
+    OUTPUT_NAME PackageDescription
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/runtimes/${PACKAGE_DESCRIPTION_VERSION}
+    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/runtimes/${PACKAGE_DESCRIPTION_VERSION})
+endforeach()
+
+install(TARGETS PD4 PD4_2
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/Sources/PackageGraph/CMakeLists.txt
+++ b/Sources/PackageGraph/CMakeLists.txt
@@ -1,0 +1,30 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_library(PackageGraph
+  DependencyResolver.swift
+  PackageGraph.swift
+  PackageGraphLoader.swift
+  PackageGraphRoot.swift
+  Pubgrub.swift
+  RawPackageConstraints.swift
+  RepositoryPackageContainerProvider.swift)
+target_link_libraries(PackageGraph PUBLIC
+  Basic
+  PackageLoading
+  PackageModel
+  SourceControl
+  SPMUtility)
+# NOTE(compnerd) workaround for CMake not setting up include flags yet
+set_target_properties(PackageGraph PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+install(TARGETS PackageGraph
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/Sources/PackageLoading/CMakeLists.txt
+++ b/Sources/PackageLoading/CMakeLists.txt
@@ -1,0 +1,31 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_library(PackageLoading
+  Diagnostics.swift
+  ManifestBuilder.swift
+  ManifestLoader.swift
+  ModuleMapGenerator.swift
+  PackageBuilder.swift
+  PackageDescription4Loader.swift
+  Target+PkgConfig.swift
+  ToolsVersionLoader.swift
+  UserManifestResources.swift)
+target_link_libraries(PackageLoading PUBLIC
+  Basic
+  PackageModel
+  SPMUtility
+  SPMLLBuild)
+# NOTE(compnerd) workaround for CMake not setting up include flags yet
+set_target_properties(PackageLoading PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+install(TARGETS PackageLoading
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/Sources/PackageModel/CMakeLists.txt
+++ b/Sources/PackageModel/CMakeLists.txt
@@ -1,0 +1,30 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_library(PackageModel
+  BuildSettings.swift
+  Manifest.swift
+  Package.swift
+  PackageModel+Codable.swift
+  Platform.swift
+  Product.swift
+  ResolvedModels.swift
+  Sources.swift
+  Target.swift
+  ToolsVersion.swift)
+target_link_libraries(PackageModel PUBLIC
+  Basic
+  SPMUtility)
+# NOTE(compnerd) workaround for CMake not setting up include flags yet
+set_target_properties(PackageModel PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+install(TARGETS PackageModel
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/Sources/SPMLLBuild/CMakeLists.txt
+++ b/Sources/SPMLLBuild/CMakeLists.txt
@@ -1,0 +1,21 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_library(SPMLLBuild
+  llbuild.swift)
+target_link_libraries(SPMLLBuild PUBLIC
+  Basic
+  SPMUtility)
+# NOTE(compnerd) workaround for CMake not setting up include flags yet
+set_target_properties(SPMLLBuild PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+install(TARGETS SPMLLBuild
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/Sources/SPMLibc/CMakeLists.txt
+++ b/Sources/SPMLibc/CMakeLists.txt
@@ -1,0 +1,22 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_library(SPMLibc
+  libc.swift)
+target_compile_options(SPMLibc PRIVATE
+  -autolink-force-load)
+target_link_libraries(SPMLibc PUBLIC
+  clibc)
+# NOTE(compnerd) workaround for CMake not setting up include flags yet
+set_target_properties(SPMLibc PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+install(TARGETS SPMLibc
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/Sources/SPMUtility/CMakeLists.txt
+++ b/Sources/SPMUtility/CMakeLists.txt
@@ -1,0 +1,35 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_library(SPMUtility
+  ArgumentParser.swift
+  ArgumentParserShellCompletion.swift
+  BuildFlags.swift
+  CollectionExtensions.swift
+  Diagnostics.swift
+  dlopen.swift
+  FSWatch.swift
+  Git.swift
+  IndexStore.swift
+  InterruptHandler.swift
+  misc.swift
+  PkgConfig.swift
+  Platform.swift
+  ProgressAnimation.swift
+  SimplePersistence.swift
+  StringExtensions.swift
+  StringMangling.swift
+  URL.swift
+  Verbosity.swift
+  Version.swift
+  Versioning.swift)
+target_link_libraries(SPMUtility PUBLIC
+  Basic)
+# NOTE(compnerd) workaround for CMake not setting up include flags yet
+set_target_properties(SPMUtility PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/SourceControl/CMakeLists.txt
+++ b/Sources/SourceControl/CMakeLists.txt
@@ -1,0 +1,25 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_library(SourceControl
+  GitRepository.swift
+  InMemoryGitRepository.swift
+  Repository.swift
+  RepositoryManager.swift
+  SwiftPMConfig.swift)
+target_link_libraries(SourceControl PUBLIC
+  Basic
+  SPMUtility)
+# NOTE(compnerd) workaround for CMake not setting up include flags yet
+set_target_properties(SourceControl PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+install(TARGETS SourceControl
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/Sources/Workspace/CMakeLists.txt
+++ b/Sources/Workspace/CMakeLists.txt
@@ -1,0 +1,34 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_library(Workspace
+  CheckoutState.swift
+  Destination.swift
+  Diagnostics.swift
+  Export.swift
+  InitPackage.swift
+  ManagedDependency.swift
+  PinsStore.swift
+  ToolsVersionWriter.swift
+  UserToolchain.swift
+  Workspace.swift)
+target_link_libraries(Workspace PUBLIC
+  Basic
+  Build
+  PackageGraph
+  PackageModel
+  SourceControl
+  Xcodeproj)
+# NOTE(compnerd) workaround for CMake not setting up include flags yet
+set_target_properties(Workspace PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+install(TARGETS Workspace
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/Sources/Xcodeproj/CMakeLists.txt
+++ b/Sources/Xcodeproj/CMakeLists.txt
@@ -1,0 +1,27 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_library(Xcodeproj
+  generate.swift
+  pbxproj.swift
+  PropertyList.swift
+  SchemesGenerator.swift
+  Target+PBXProj.swift
+  XcodeProjectModel.swift
+  XcodeProjectModelSerialization.swift)
+target_link_libraries(Xcodeproj PUBLIC
+  Basic
+  PackageGraph)
+# NOTE(compnerd) workaround for CMake not setting up include flags yet
+set_target_properties(Xcodeproj PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+install(TARGETS Xcodeproj
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/Sources/clibc/CMakeLists.txt
+++ b/Sources/clibc/CMakeLists.txt
@@ -1,0 +1,17 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_library(clibc STATIC
+  libc.c)
+target_include_directories(clibc PUBLIC
+  include)
+
+if(NOT BUILD_SHARED_LIBS)
+  install(TARGETS clibc
+    ARCHIVE DESTINATION lib)
+endif()

--- a/Sources/swift-build/CMakeLists.txt
+++ b/Sources/swift-build/CMakeLists.txt
@@ -1,0 +1,15 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_executable(swift-build
+  main.swift)
+target_link_libraries(swift-build PRIVATE
+  Commands)
+
+install(TARGETS swift-build
+  DESTINATION bin)

--- a/Sources/swift-run/CMakeLists.txt
+++ b/Sources/swift-run/CMakeLists.txt
@@ -1,0 +1,15 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_executable(swift-run
+  main.swift)
+target_link_libraries(swift-run PRIVATE
+  Commands)
+
+install(TARGETS swift-run
+  RUNTIME DESTINATION bin)

--- a/Sources/swift-test/CMakeLists.txt
+++ b/Sources/swift-test/CMakeLists.txt
@@ -1,0 +1,15 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_executable(swift-test
+  main.swift)
+target_link_libraries(swift-test PRIVATE
+  Commands)
+
+install(TARGETS swift-test
+  RUNTIME DESTINATION bin)

--- a/Sources/swiftpm-xctest-helper/CMakeLists.txt
+++ b/Sources/swiftpm-xctest-helper/CMakeLists.txt
@@ -1,0 +1,13 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_executable(swiftpm-xctest-helper
+  main.swift)
+
+install(TARGETS swiftpm-xctest-helper
+  RUNTIME DESTINATION bin)


### PR DESCRIPTION
This enables proper use of modern CMake for building s-p-m.  This makes
it extremely easy to bootstrap swift-package-manager for other
platforms.