### PR TITLE
Windows: `BOOL` is now WindowsBool

### DIFF
--- a/Sources/Basic/Lock.swift
+++ b/Sources/Basic/Lock.swift
@@ -79,7 +79,8 @@ public final class FileLock {
         overlapped.Offset = 0
         overlapped.OffsetHigh = 0
         overlapped.hEvent = nil
-        if FALSE == LockFileEx(handle, DWORD(LOCKFILE_EXCLUSIVE_LOCK), 0, DWORD(INT_MAX), DWORD(INT_MAX), &overlapped) {
+        if !LockFileEx(handle, DWORD(LOCKFILE_EXCLUSIVE_LOCK), 0,
+                       DWORD(INT_MAX), DWORD(INT_MAX), &overlapped) {
             throw ProcessLockError.unableToAquireLock(errno: Int32(GetLastError()))
         }
       #else

--- a/Sources/Basic/ProcessEnv.swift
+++ b/Sources/Basic/ProcessEnv.swift
@@ -26,7 +26,7 @@ public enum ProcessEnv {
     /// Set the given key and value in the process's environment.
     public static func setVar(_ key: String, value: String) throws {
       #if os(Windows)
-        guard 0 != key.withCString(encodedAs: UTF16.self, { keyStr in
+        guard key.withCString(encodedAs: UTF16.self, { keyStr in
             value.withCString(encodedAs: UTF16.self) { valStr in
                 SetEnvironmentVariableW(keyStr, valStr)
             }
@@ -44,7 +44,7 @@ public enum ProcessEnv {
     /// Unset the give key in the process's environment.
     public static func unsetVar(_ key: String) throws {
       #if os(Windows)
-        guard 0 != key.withCString(encodedAs: UTF16.self, { keyStr in
+        guard key.withCString(encodedAs: UTF16.self, { keyStr in
             SetEnvironmentVariableW(keyStr, nil)
         }) else {
             throw SystemError.unsetenv(Int32(GetLastError()), key)
@@ -66,7 +66,7 @@ public enum ProcessEnv {
     public static func chdir(_ path: AbsolutePath) throws {
         let path = path.pathString
       #if os(Windows)
-        guard 0 != path.withCString(encodedAs: UTF16.self, {
+        guard path.withCString(encodedAs: UTF16.self, {
             SetCurrentDirectoryW($0)
         }) else {
             throw SystemError.chdir(Int32(GetLastError()), path)

--- a/Sources/SPMUtility/dlopen.swift
+++ b/Sources/SPMUtility/dlopen.swift
@@ -29,7 +29,7 @@ public final class DLHandle {
     public func close() throws {
         if let handle = rawValue {
           #if os(Windows)
-            guard FreeLibrary(handle) != 0 else {
+            guard FreeLibrary(handle) else {
                 throw DLError.close("Failed to FreeLibrary: \(GetLastError())")
             }
           #else


### PR DESCRIPTION
`BOOL` is now properly bridged into a boolean as `WindowsBool`.
Unfortunately, as there is no current CI for s-p-m on Windows, this was
not caught.  Update s-p-m so that we can enable CI.