### PR TITLE
Tests: remove unnecessary import

### DIFF
--- a/Tests/BuildTests/IncrementalBuildTests.swift
+++ b/Tests/BuildTests/IncrementalBuildTests.swift
@@ -13,7 +13,6 @@ import XCTest
 import TestSupport
 import Basic
 import SPMUtility
-import func SPMLibc.sleep
 
 
 /// Functional tests of incremental builds.  These are fairly ad hoc at this


### PR DESCRIPTION
`SPMLibc.sleep` should be replaced with `Thread.Sleep(for:)`.  However,
there is no use of this in the test.  Simply remove the unnecessary
import.