### PR TITLE
IUO adjustments (NFC)

### DIFF
--- a/Sources/Basic/FileSystem.swift
+++ b/Sources/Basic/FileSystem.swift
@@ -664,7 +664,7 @@ public class InMemoryFileSystem: FileSystem {
         // Ignore root and get the parent node's content if its a directory.
         guard !path.isRoot,
               let parent = try? getNode(path.parentDirectory),
-              case .directory(let contents)? = parent?.contents else {
+              case .directory(let contents) = parent.contents else {
             return
         }
         // Set it to nil to release the contents.

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -654,7 +654,7 @@ private class GitFileSystemView: FileSystem {
     }
 
     func isExecutableFile(_ path: AbsolutePath) -> Bool {
-        if let entry = try? getEntry(path), entry?.type == .executableBlob {
+        if let entry = try? getEntry(path), entry.type == .executableBlob {
             return true
         }
         return false


### PR DESCRIPTION
These types are not supposed to be optional in the context.  Remove the
optionality.  This allows building on Windows.