### PR TITLE
SPMUtility: limit private method to `macOS`

### DIFF
--- a/Sources/SPMUtility/Platform.swift
+++ b/Sources/SPMUtility/Platform.swift
@@ -57,6 +57,7 @@ public enum Platform {
     }
     private static var _darwinCacheDirectories: [AbsolutePath]?
 
+#if os(macOS)
     /// Returns the value of given path variable using `getconf` utility.
     ///
     /// - Note: This method returns `nil` if the value is an invalid path.
@@ -69,4 +70,5 @@ public enum Platform {
         guard value.hasSuffix(AbsolutePath.root.pathString) else { return nil }
         return resolveSymlinks(AbsolutePath(value))
     }
+#endif
 }


### PR DESCRIPTION
This private method is only used on macOS targets, but was globally
defined.  This depends on `confstr` which is part of the C library on
Unix systems.  However, it is not available on Windows.  Limit the
function to the platform where it is used.