### PR TITLE
Basic: replace `symlink` with Foundation

### DIFF
--- a/Sources/Basic/PathShims.swift
+++ b/Sources/Basic/PathShims.swift
@@ -45,8 +45,7 @@ public func makeDirectories(_ path: AbsolutePath) throws {
 /// be a relative path, otherwise it will be absolute.
 public func createSymlink(_ path: AbsolutePath, pointingAt dest: AbsolutePath, relative: Bool = true) throws {
     let destString = relative ? dest.relative(to: path.parentDirectory).pathString : dest.pathString
-    let rv = SPMLibc.symlink(destString, path.pathString)
-    guard rv == 0 else { throw SystemError.symlink(errno, path.pathString, dest: destString) }
+    try FileManager.default.createSymbolicLink(atPath: path.pathString, withDestinationPath: destString)
 }
 
 /// The current working directory of the processs.


### PR DESCRIPTION
Use `createSymbolicLink` from Foundation rather than using `symlink`
from the C library which is not portable (Windows does not provide
`symlink`).