### PR TITLE
Basic: Windows does not support `EDQOT`

### DIFF
--- a/Sources/Basic/TemporaryFile.swift
+++ b/Sources/Basic/TemporaryFile.swift
@@ -161,8 +161,12 @@ private extension MakeDirectoryError {
             self = .permissionDenied
         case SPMLibc.ELOOP, SPMLibc.ENOENT, SPMLibc.ENOTDIR:
             self = .unresolvablePathComponent
-        case SPMLibc.ENOMEM, SPMLibc.EDQUOT:
+        case SPMLibc.ENOMEM:
             self = .outOfMemory
+#if !os(Windows)
+        case SPMLibc.EDQUOT:
+            self = .outOfMemory
+#endif
         default:
             self = .other(errno)
         }


### PR DESCRIPTION
There is no equivalent to the POSIX `EDQUOT` error on Windows.  Since it
cannot arise, simply ignore it.