### PR TITLE
TemporaryFile: simplify clean up

### DIFF
--- a/Sources/Basic/TemporaryFile.swift
+++ b/Sources/Basic/TemporaryFile.swift
@@ -214,11 +214,7 @@ public final class TemporaryDirectory {
 
     /// Remove the temporary file before deallocating.
     deinit {
-        if shouldRemoveTreeOnDeinit {
-            _ = try? FileManager.default.removeItem(atPath: path.pathString)
-        } else {
-            rmdir(path.pathString)
-        }
+        _ = try? FileManager.default.removeItem(atPath: path.pathString)
     }
 }
 


### PR DESCRIPTION
`FileManger.removeItem(atPath:)` will remove the file or directory.
`rmdir` will only remove the directory if it is empty, which is the
default behaviour unless an explicit delegate is provided to the
FileManager.  Collapse the two cases into one which enables this path to
work on Windows which does not provide `rmdir`.