### PR TITLE
Add extraCPPFlags to BuildParameters

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -248,6 +248,7 @@ public struct BuildParameters: Encodable {
             try container.encode(toolchain.getClangCompiler(), forKey: .clangCompiler)
 
             try container.encode(toolchain.extraCCFlags, forKey: .extraCCFlags)
+            try container.encode(toolchain.extraCPPFlags, forKey: .extraCPPFlags)
             try container.encode(toolchain.extraSwiftCFlags, forKey: .extraSwiftCFlags)
             try container.encode(toolchain.swiftCompiler, forKey: .swiftCompiler)
         }


### PR DESCRIPTION
Currently the extra-cpp-flags specified in a destination.json file are not
passed through to clang. This is because the extra cpp flags are not being
encoded. This patch fixes that.