### PR TITLE
build: update PackageGraph CMakeLists

### DIFF
--- a/Sources/PackageGraph/CMakeLists.txt
+++ b/Sources/PackageGraph/CMakeLists.txt
@@ -13,7 +13,8 @@ add_library(PackageGraph
   PackageGraphRoot.swift
   Pubgrub.swift
   RawPackageConstraints.swift
-  RepositoryPackageContainerProvider.swift)
+  RepositoryPackageContainerProvider.swift
+  VersionSetSpecifier.swift)
 target_link_libraries(PackageGraph PUBLIC
   Basic
   PackageLoading


### PR DESCRIPTION
Update the source list for PackageGraph.  This allows us to bootstrap on
Windows again.