### PR TITLE
[NFC] Move PinsStore to PackageGraph

### DIFF
--- a/Sources/PackageGraph/CMakeLists.txt
+++ b/Sources/PackageGraph/CMakeLists.txt
@@ -7,10 +7,12 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(PackageGraph
+  CheckoutState.swift
   DependencyResolver.swift
   PackageGraph.swift
   PackageGraphLoader.swift
   PackageGraphRoot.swift
+  PinsStore.swift
   Pubgrub.swift
   RawPackageConstraints.swift
   RepositoryPackageContainerProvider.swift)

--- a/Sources/PackageGraph/CheckoutState.swift
+++ b/Sources/PackageGraph/CheckoutState.swift
@@ -9,7 +9,6 @@
  */
 
 import Basic
-import PackageGraph
 import SourceControl
 import SPMUtility
 
@@ -52,7 +51,7 @@ public struct CheckoutState: Equatable, CustomStringConvertible {
         return version?.description ?? branch ?? revision.identifier
     }
 
-    var isBranchOrRevisionBased: Bool {
+    public var isBranchOrRevisionBased: Bool {
         return version == nil
     }
 }
@@ -60,7 +59,7 @@ public struct CheckoutState: Equatable, CustomStringConvertible {
 extension CheckoutState {
 
     /// Returns requirement induced by this state.
-    func requirement() -> PackageRequirement {
+    public func requirement() -> PackageRequirement {
         if let version = version {
             return .versionSet(.exact(version))
         } else if let branch = branch {
@@ -87,15 +86,6 @@ extension CheckoutState: JSONMappable, JSONSerializable {
            "version": version.toJSON(),
            "branch": branch.toJSON(),
        ])
-    }
-}
-
-extension ManagedDependency {
-    public var checkoutState: CheckoutState? {
-        if case .checkout(let checkoutState) = state {
-            return checkoutState
-        }
-        return nil
     }
 }
 

--- a/Sources/PackageGraph/PinsStore.swift
+++ b/Sources/PackageGraph/PinsStore.swift
@@ -12,7 +12,6 @@ import Basic
 import SPMUtility
 import SourceControl
 import PackageModel
-import PackageGraph
 
 public final class PinsStore {
     public struct Pin {
@@ -45,7 +44,7 @@ public final class PinsStore {
     /// The pins map.
     ///
     /// Key -> Package Identity.
-    fileprivate(set) var pinsMap: [String: Pin]
+    public fileprivate(set) var pinsMap: [String: Pin]
 
     /// The current pins.
     public var pins: AnySequence<Pin> {
@@ -97,25 +96,6 @@ public final class PinsStore {
     /// This will replace any previous pin with same package name.
     public func add(_ pin: Pin) {
         pinsMap[pin.packageRef.identity] = pin
-    }
-
-    /// Pin a managed dependency at its checkout state.
-    ///
-    /// This method does nothing if the dependency is in edited state.
-    func pin(_ dependency: ManagedDependency) {
-
-        // Get the checkout state.
-        let checkoutState: CheckoutState
-        switch dependency.state {
-        case .checkout(let state):
-            checkoutState = state
-        case .edited, .local:
-            return
-        }
-
-        self.pin(
-            packageRef: dependency.packageRef,
-            state: checkoutState)
     }
 
     /// Unpin all of the currently pinnned dependencies.
@@ -180,50 +160,5 @@ extension PinsStore.Pin: JSONMappable, JSONSerializable, Equatable {
             "repositoryURL": packageRef.path,
             "state": state,
         ])
-    }
-}
-
-/// A file watcher utility for the Package.resolved file.
-///
-/// This is not intended to be used directly by clients.
-final class ResolvedFileWatcher {
-    private var fswatch: FSWatch!
-    private var existingValue: ByteString?
-    private let valueLock: Lock = Lock()
-    private let resolvedFile: AbsolutePath
-
-    public func updateValue() {
-        valueLock.withLock {
-            self.existingValue = try? localFileSystem.readFileContents(resolvedFile)
-        }
-    }
-
-    init(resolvedFile: AbsolutePath, onChange: @escaping () -> ()) throws {
-        self.resolvedFile = resolvedFile
-
-        let block = { [weak self] (paths: [AbsolutePath]) in
-            guard let self = self else { return }
-
-            // Check if resolved file is part of the received paths.
-            let hasResolvedFile = paths.contains{ $0.appending(component: resolvedFile.basename) == resolvedFile }
-            guard hasResolvedFile else { return }
-
-            self.valueLock.withLock {
-                // Compute the contents of the resolved file and fire the onChange block
-                // if its value is different than existing value.
-                let newValue = try? localFileSystem.readFileContents(resolvedFile)
-                if self.existingValue != newValue {
-                    self.existingValue = newValue
-                    onChange()
-                }
-            }
-        }
-
-        fswatch = FSWatch(paths: [resolvedFile.parentDirectory], latency: 1, block: block)
-        try fswatch.start()
-    }
-
-    deinit {
-        fswatch.stop()
     }
 }

--- a/Sources/Workspace/CMakeLists.txt
+++ b/Sources/Workspace/CMakeLists.txt
@@ -7,16 +7,15 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(Workspace
-  CheckoutState.swift
   Destination.swift
   Diagnostics.swift
   Export.swift
   InitPackage.swift
   ManagedDependency.swift
-  PinsStore.swift
   ToolsVersionWriter.swift
   UserToolchain.swift
-  Workspace.swift)
+  Workspace.swift
+  misc.swift)
 target_link_libraries(Workspace PUBLIC
   Basic
   Build

--- a/Sources/Workspace/misc.swift
+++ b/Sources/Workspace/misc.swift
@@ -1,0 +1,86 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2018 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import PackageGraph
+
+extension ManagedDependency {
+    public var checkoutState: CheckoutState? {
+        if case .checkout(let checkoutState) = state {
+            return checkoutState
+        }
+        return nil
+    }
+}
+
+extension PinsStore {
+    /// Pin a managed dependency at its checkout state.
+    ///
+    /// This method does nothing if the dependency is in edited state.
+    func pin(_ dependency: ManagedDependency) {
+
+        // Get the checkout state.
+        let checkoutState: CheckoutState
+        switch dependency.state {
+        case .checkout(let state):
+            checkoutState = state
+        case .edited, .local:
+            return
+        }
+
+        self.pin(
+            packageRef: dependency.packageRef,
+            state: checkoutState)
+    }
+}
+
+/// A file watcher utility for the Package.resolved file.
+///
+/// This is not intended to be used directly by clients.
+final class ResolvedFileWatcher {
+    private var fswatch: FSWatch!
+    private var existingValue: ByteString?
+    private let valueLock: Lock = Lock()
+    private let resolvedFile: AbsolutePath
+
+    public func updateValue() {
+        valueLock.withLock {
+            self.existingValue = try? localFileSystem.readFileContents(resolvedFile)
+        }
+    }
+
+    init(resolvedFile: AbsolutePath, onChange: @escaping () -> ()) throws {
+        self.resolvedFile = resolvedFile
+
+        let block = { [weak self] (paths: [AbsolutePath]) in
+            guard let self = self else { return }
+
+            // Check if resolved file is part of the received paths.
+            let hasResolvedFile = paths.contains{ $0.appending(component: resolvedFile.basename) == resolvedFile }
+            guard hasResolvedFile else { return }
+
+            self.valueLock.withLock {
+                // Compute the contents of the resolved file and fire the onChange block
+                // if its value is different than existing value.
+                let newValue = try? localFileSystem.readFileContents(resolvedFile)
+                if self.existingValue != newValue {
+                    self.existingValue = newValue
+                    onChange()
+                }
+            }
+        }
+
+        fswatch = FSWatch(paths: [resolvedFile.parentDirectory], latency: 1, block: block)
+        try fswatch.start()
+    }
+
+    deinit {
+        fswatch.stop()
+    }
+}

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -13,7 +13,7 @@ import XCTest
 import Basic
 import SPMUtility
 import PackageModel
-import PackageGraph
+@testable import PackageGraph
 import TestSupport
 import SourceControl
 @testable import Workspace


### PR DESCRIPTION
This will allow us to access PinsStore inside the dependency resolver.