### PR TITLE
Use generic TargetTriple in BuildTests

### DIFF
--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -123,7 +123,7 @@ final class BuildPlanTests: XCTestCase {
             "-emit-executable",
             "-Xlinker", "-rpath=$ORIGIN",
             "@/path/to/build/debug/exe.product/Objects.LinkFileList",
-            "-target", "x86_64-unknown-linux",
+            "-target", defaultTargetTriple,
         ]
       #endif
 
@@ -236,7 +236,7 @@ final class BuildPlanTests: XCTestCase {
             "-o", "/path/to/build/release/exe", "-module-name", "exe", "-emit-executable",
             "-Xlinker", "-rpath=$ORIGIN",
             "@/path/to/build/release/exe.product/Objects.LinkFileList",
-            "-target", "x86_64-unknown-linux",
+            "-target", defaultTargetTriple,
         ])
       #endif
     }
@@ -332,7 +332,7 @@ final class BuildPlanTests: XCTestCase {
             "-Xlinker", "-rpath=$ORIGIN",
             "@/path/to/build/debug/exe.product/Objects.LinkFileList",
             "-runtime-compatibility-version", "none",
-            "-target", "x86_64-unknown-linux",
+            "-target", defaultTargetTriple,
         ])
       #endif
 
@@ -391,7 +391,7 @@ final class BuildPlanTests: XCTestCase {
             "-Xlinker", "-rpath=$ORIGIN",
             "@/path/to/build/debug/exe.product/Objects.LinkFileList",
             "-runtime-compatibility-version", "none",
-            "-target", "x86_64-unknown-linux",
+            "-target", defaultTargetTriple,
         ])
       #endif
 
@@ -464,7 +464,7 @@ final class BuildPlanTests: XCTestCase {
             "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable",
             "-Xlinker", "-rpath=$ORIGIN",
             "@/path/to/build/debug/exe.product/Objects.LinkFileList",
-            "-target", "x86_64-unknown-linux",
+            "-target", defaultTargetTriple,
         ])
       #endif
     }
@@ -607,7 +607,7 @@ final class BuildPlanTests: XCTestCase {
             "/path/to/build/debug/PkgPackageTests.xctest", "-module-name", "PkgPackageTests", "-emit-executable",
             "-Xlinker", "-rpath=$ORIGIN",
             "@/path/to/build/debug/PkgPackageTests.product/Objects.LinkFileList",
-            "-target", "x86_64-unknown-linux",
+            "-target", defaultTargetTriple,
         ])
       #endif
     }
@@ -659,7 +659,7 @@ final class BuildPlanTests: XCTestCase {
             "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable",
             "-Xlinker", "-rpath=$ORIGIN",
             "@/path/to/build/debug/exe.product/Objects.LinkFileList",
-            "-target", "x86_64-unknown-linux",
+            "-target", defaultTargetTriple,
         ])
       #endif
     }
@@ -760,7 +760,7 @@ final class BuildPlanTests: XCTestCase {
             "-o", "/path/to/build/debug/Foo", "-module-name", "Foo", "-lBar-Baz", "-emit-executable",
             "-Xlinker", "-rpath=$ORIGIN",
             "@/path/to/build/debug/Foo.product/Objects.LinkFileList",
-            "-target", "x86_64-unknown-linux",
+            "-target", defaultTargetTriple,
         ])
 
         XCTAssertEqual(barLinkArgs, [
@@ -769,7 +769,7 @@ final class BuildPlanTests: XCTestCase {
             "-module-name", "Bar_Baz", "-emit-library",
             "-Xlinker", "-rpath=$ORIGIN",
             "@/path/to/build/debug/Bar-Baz.product/Objects.LinkFileList",
-            "-target", "x86_64-unknown-linux",
+            "-target", defaultTargetTriple,
         ])
       #endif
 
@@ -827,7 +827,7 @@ final class BuildPlanTests: XCTestCase {
                 "-o", "/path/to/build/debug/liblib.so", "-module-name", "lib",
                 "-emit-library", "-Xlinker", "-rpath=$ORIGIN",
                 "@/path/to/build/debug/lib.product/Objects.LinkFileList",
-                "-target", "x86_64-unknown-linux",
+                "-target", defaultTargetTriple,
             ]
         #endif
 
@@ -891,8 +891,8 @@ final class BuildPlanTests: XCTestCase {
             
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), ["/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable", "@/path/to/build/debug/exe.product/Objects.LinkFileList", "-runtime-compatibility-version", "none", "-target", "x86_64-apple-macosx10.10"])
     #else
-        XCTAssertEqual(try result.buildProduct(for: "lib").linkArguments(), ["/fake/path/to/swiftc", "-lstdc++", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/liblib.so", "-module-name", "lib", "-emit-library", "-Xlinker", "-rpath=$ORIGIN", "@/path/to/build/debug/lib.product/Objects.LinkFileList", "-runtime-compatibility-version", "none", "-target", "x86_64-unknown-linux"])
-        XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), ["/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable", "-Xlinker", "-rpath=$ORIGIN", "@/path/to/build/debug/exe.product/Objects.LinkFileList", "-runtime-compatibility-version", "none", "-target", "x86_64-unknown-linux"])
+        XCTAssertEqual(try result.buildProduct(for: "lib").linkArguments(), ["/fake/path/to/swiftc", "-lstdc++", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/liblib.so", "-module-name", "lib", "-emit-library", "-Xlinker", "-rpath=$ORIGIN", "@/path/to/build/debug/lib.product/Objects.LinkFileList", "-runtime-compatibility-version", "none", "-target", defaultTargetTriple])
+        XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), ["/fake/path/to/swiftc", "-g", "-L", "/path/to/build/debug", "-o", "/path/to/build/debug/exe", "-module-name", "exe", "-emit-executable", "-Xlinker", "-rpath=$ORIGIN", "@/path/to/build/debug/exe.product/Objects.LinkFileList", "-runtime-compatibility-version", "none", "-target", defaultTargetTriple])
     #endif
     }
 


### PR DESCRIPTION
Replace the hardcoded target triple with the generic target triple variable `defaultTargetTriple`, so that tests on platforms rather than x86_64 got passed.