### PR TITLE
[PubGrub] Implement bound computation of incompatibilities added duri…

### DIFF
--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -169,6 +169,10 @@ public protocol PackageContainer {
     /// if the previous one did not satisfy all constraints.
     func versions(filter isIncluded: (Version) -> Bool) -> AnySequence<Version>
 
+    /// Get the list of versions in the repository sorted in the reverse order, that is the latest
+    /// version appears first.
+    var reversedVersions: [Version] { get }
+
     // FIXME: We should perhaps define some particularly useful error codes
     // here, so the resolver can handle errors more meaningfully.
     //

--- a/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
@@ -135,6 +135,10 @@ public class BasePackageContainer: PackageContainer {
         fatalError("This should never be called")
     }
 
+    public var reversedVersions: [Version] {
+        fatalError("This should never be called")
+    }
+
     public func getDependencies(at version: Version) throws -> [PackageContainerConstraint] {
         fatalError("This should never be called")
     }
@@ -263,7 +267,7 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
 
     /// The available version list (in reverse order).
     public override func versions(filter isIncluded: (Version) -> Bool) -> AnySequence<Version> {
-        return AnySequence(reversedVersions.filter(isIncluded).lazy.filter({
+        return AnySequence(_reversedVersions.filter(isIncluded).lazy.filter({
             // If we have the result cached, return that.
             if let result = self.validToolsVersionsCache[$0] {
                 return result
@@ -276,6 +280,8 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
         }))
     }
 
+    public override var reversedVersions: [Version] { _reversedVersions }
+
     /// The opened repository.
     let repository: Repository
 
@@ -283,7 +289,7 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
     let knownVersions: [Version: String]
 
     /// The versions in the repository sorted by latest first.
-    let reversedVersions: [Version]
+    let _reversedVersions: [Version]
 
     /// The cached dependency information.
     private var dependenciesCache: [String: (Manifest, [RepositoryPackageConstraint])] = [:]
@@ -314,7 +320,7 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
         })
 
         self.knownVersions = knownVersions
-        self.reversedVersions = [Version](knownVersions.keys).sorted().reversed()
+        self._reversedVersions = [Version](knownVersions.keys).sorted().reversed()
         super.init(
             identifier,
             config: config,

--- a/Sources/TestSupport/MockDependencyResolver.swift
+++ b/Sources/TestSupport/MockDependencyResolver.swift
@@ -105,6 +105,10 @@ public class MockPackageContainer: PackageContainer {
         return AnySequence(_versions.filter(isIncluded))
     }
 
+    public var reversedVersions: [Version] {
+        return _versions
+    }
+
     public func getDependencies(at version: Version) -> [MockPackageConstraint] {
         requestedVersions.insert(version)
         return getDependencies(at: version.description)


### PR DESCRIPTION
…ng decision making

This will implement bound computation of a package dependency when its
being added as an incompatibility during decision making. The basic idea
is to reduce the amount of incompatibilities that are added so pubgrub
is efficiently able to reason about multiple versions of packages.

Bound computation can be costly since we have to iterate the versions
before and after the chosen version but it is an important part of the
algorithm. We might we might need to figure out a way to counter balance
that cost depending on the impact (which I'll measure separately as part
of performance testing).

<rdar://problem/54099969>