### PR TITLE
[PubGrub] Add support for handling tools version in the resolver

### DIFF
--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -162,6 +162,9 @@ public protocol PackageContainer {
     /// The identifier for the package.
     var identifier: PackageReference { get }
 
+    /// Returns true if the tools version is compatible at the given version.
+    func isToolsVersionCompatible(at version: Version) -> Bool
+
     /// Get the list of versions which are available for the package.
     ///
     /// The list will be returned in sorted order, with the latest version *first*.

--- a/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
@@ -155,6 +155,10 @@ public class BasePackageContainer: PackageContainer {
         fatalError("This should never be called")
     }
 
+    public func isToolsVersionCompatible(at version: Version) -> Bool {
+        fatalError("This should never be called")
+    }
+
     fileprivate init(
         _ identifier: Identifier,
         config: SwiftPMConfig,
@@ -463,5 +467,9 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
         } catch {
             return false
         }
+    }
+
+    public override func isToolsVersionCompatible(at version: Version) -> Bool {
+        return (try? self.toolsVersion(for: version)).flatMap(self.isValidToolsVersion(_:)) ?? false
     }
 }

--- a/Sources/TestSupport/MockDependencyResolver.swift
+++ b/Sources/TestSupport/MockDependencyResolver.swift
@@ -129,6 +129,10 @@ public class MockPackageContainer: PackageContainer {
         return name
     }
 
+    public func isToolsVersionCompatible(at version: Version) -> Bool {
+        return true
+    }
+
     public convenience init(
         name: String,
         dependenciesByVersion: [Version: [(container: String, versionRequirement: VersionSetSpecifier)]]

--- a/Tests/PackageGraphTests/XCTestManifests.swift
+++ b/Tests/PackageGraphTests/XCTestManifests.swift
@@ -54,12 +54,16 @@ extension PubgrubTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__PubgrubTests = [
+        ("testBranchedBasedPin", testBranchedBasedPin),
         ("testBranchOverriding3", testBranchOverriding3),
         ("testBranchOverriding4", testBranchOverriding4),
         ("testConflict1", testConflict1),
         ("testConflict2", testConflict2),
         ("testConflict3", testConflict3),
         ("testIncompatibilityNormalizeTermsOnInit", testIncompatibilityNormalizeTermsOnInit),
+        ("testIncompatibleToolsVersion1", testIncompatibleToolsVersion1),
+        ("testIncompatibleToolsVersion2", testIncompatibleToolsVersion2),
+        ("testIncompatibleToolsVersion3", testIncompatibleToolsVersion3),
         ("testMissingVersion", testMissingVersion),
         ("testNonExistentPackage", testNonExistentPackage),
         ("testNonVersionDependencyInVersionDependency1", testNonVersionDependencyInVersionDependency1),


### PR DESCRIPTION
This adds support for handling tools version in the resolver as an
incompatibility instead of it being implicit when computing which
version are available. This is a big improvement over the current legacy
resolver where we emit no diagnostics if the resolution fails because of
the tools version.

<rdar://problem/53947020>