### PR TITLE
[PackageLoading] Implement support for file content-based manifest ca…

### DIFF
--- a/Sources/SPMLLBuild/llbuild.swift
+++ b/Sources/SPMLLBuild/llbuild.swift
@@ -95,7 +95,7 @@ public final class LLBuildEngine {
         return T.BuildValue(value)
     }
 
-    public func attachDB(path: String, schemaVersion: Int = 1) throws {
+    public func attachDB(path: String, schemaVersion: Int = 2) throws {
         try engine.attachDB(path: path, schemaVersion: schemaVersion)
     }
 

--- a/Tests/PackageLoadingTests/XCTestManifests.swift
+++ b/Tests/PackageLoadingTests/XCTestManifests.swift
@@ -92,6 +92,7 @@ extension PackageDescription4_2LoadingTests {
         ("testBuildSettings", testBuildSettings),
         ("testCacheInvalidationOnEnv", testCacheInvalidationOnEnv),
         ("testCaching", testCaching),
+        ("testContentBasedCaching", testContentBasedCaching),
         ("testDuplicateDependencyDecl", testDuplicateDependencyDecl),
         ("testLLBuildEngineErrors", testLLBuildEngineErrors),
         ("testNotAbsoluteDependencyPath", testNotAbsoluteDependencyPath),


### PR DESCRIPTION
…ching

This implements support for caching content-based manifest which don't
have an actual fixed location on disk. This happens during dependency
resolution since we get the manifest contents via git cat-file command.
Previously, such manifests were not being cached which meant we always
had to evaluate them during dependency resolution. This would be a big
issue for PubGrub since it ends up looking at a bunch of versions
upfront to compute the bounds (see #2306). Overall, this ends up
providing a great win because we only have to evaluate the manifest when
its content changes between the versions which is most likely the place
where the dependency bound lies.

<rdar://problem/49493581>