### PR TITLE
[PubGrub] Re-enable some cycle related tests

### DIFF
--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -491,7 +491,7 @@ final class PubgrubTests: XCTestCase {
         ])
     }
 
-    func DISABLED_testCycle1() {
+    func testCycle1() {
         builder.serve("foo", at: v1_1, with: ["foo": .versionSet(v1Range)])
 
         let resolver = builder.create()
@@ -500,12 +500,12 @@ final class PubgrubTests: XCTestCase {
         ])
         let result = resolver.solve(dependencies: dependencies)
 
-        guard case .error = result else {
-            return XCTFail("Expected a cycle")
-        }
+        AssertResult(result, [
+            ("foo", .version(v1_1)),
+        ])
     }
 
-    func DISABLED_testCycle2() {
+    func testCycle2() {
         builder.serve("foo", at: v1_1, with: ["bar": .versionSet(v1Range)])
         builder.serve("bar", at: v1, with: ["baz": .versionSet(v1Range)])
         builder.serve("baz", at: v1, with: ["bam": .versionSet(v1Range)])
@@ -517,9 +517,12 @@ final class PubgrubTests: XCTestCase {
         ])
         let result = resolver.solve(dependencies: dependencies)
 
-        guard case .error = result else {
-            return XCTFail("Expected a cycle")
-        }
+        AssertResult(result, [
+            ("foo", .version(v1_1)),
+            ("bar", .version(v1)),
+            ("baz", .version(v1)),
+            ("bam", .version(v1)),
+        ])
     }
 
     func testMissingVersion() {

--- a/Tests/PackageGraphTests/XCTestManifests.swift
+++ b/Tests/PackageGraphTests/XCTestManifests.swift
@@ -60,6 +60,8 @@ extension PubgrubTests {
         ("testConflict1", testConflict1),
         ("testConflict2", testConflict2),
         ("testConflict3", testConflict3),
+        ("testCycle1", testCycle1),
+        ("testCycle2", testCycle2),
         ("testIncompatibilityNormalizeTermsOnInit", testIncompatibilityNormalizeTermsOnInit),
         ("testIncompatibleToolsVersion1", testIncompatibleToolsVersion1),
         ("testIncompatibleToolsVersion2", testIncompatibleToolsVersion2),


### PR DESCRIPTION
These are working correctly now so re-enable them.

Note that cycles are ok in the dependency resolver as long as it's
resolvable. However, they are diagnosed later during package loading.