### PR TITLE
[PubGrub] Fix an issue in set difference computation

### DIFF
--- a/Sources/PackageGraph/VersionSetSpecifier.swift
+++ b/Sources/PackageGraph/VersionSetSpecifier.swift
@@ -242,9 +242,15 @@ extension VersionSetSpecifier {
                     if range.lowerBound == range.upperBound {
                         continue
                     }
-                    result.append(exact.nextPatch()..<range.upperBound)
+
+                    if exact.nextPatch() < range.upperBound {
+                        result.append(exact.nextPatch()..<range.upperBound)
+                    }
                 } else {
-                    result += [range.lowerBound..<exact, exact.nextPatch()..<range.upperBound]
+                    result += [range.lowerBound..<exact]
+                    if exact.nextPatch() < range.upperBound {
+                        result += [exact.nextPatch()..<range.upperBound]
+                    }
                 }
             }
             return .union(from: result)

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -1305,6 +1305,44 @@ final class PubgrubTests: XCTestCase {
 
         print(errorMsg)
     }
+
+    func testIncompatibleToolsVersion4() {
+        builder.serve("a", at: "3.2.1", isToolsVersionCompatible: false)
+        builder.serve("a", at: "3.2.2", isToolsVersionCompatible: false)
+        builder.serve("a", at: "3.2.3", isToolsVersionCompatible: false)
+
+        let resolver = builder.create()
+        let dependencies = builder.create(dependencies: [
+            "a": .versionSet(.range("3.2.0"..<"4.0.0")),
+        ])
+
+        let result = resolver.solve(dependencies: dependencies)
+
+        guard let errorMsg = result.errorMsg else {
+            return
+        }
+
+        print(errorMsg)
+    }
+
+    func testIncompatibleToolsVersion5() {
+        builder.serve("a", at: "3.2.0", isToolsVersionCompatible: false)
+        builder.serve("a", at: "3.2.1", isToolsVersionCompatible: false)
+        builder.serve("a", at: "3.2.2", isToolsVersionCompatible: false)
+
+        let resolver = builder.create()
+        let dependencies = builder.create(dependencies: [
+            "a": .versionSet(.range("3.2.0"..<"4.0.0")),
+        ])
+
+        let result = resolver.solve(dependencies: dependencies)
+
+        guard let errorMsg = result.errorMsg else {
+            return
+        }
+
+        print(errorMsg)
+    }
 }
 
 fileprivate extension CheckoutState {

--- a/Tests/PackageGraphTests/VersionSetSpecifierTests.swift
+++ b/Tests/PackageGraphTests/VersionSetSpecifierTests.swift
@@ -92,5 +92,7 @@ final class VersionSetSpecifierTests: XCTestCase {
         XCTAssertEqual(VersionSetSpecifier.ranges(["0.0.0"..<"0.9.1", "1.0.0"..<"2.0.0", "2.0.1"..<"5.0.0"]).difference(.ranges(["1.0.0"..<"1.4.0", "2.4.1"..<"4.0.0"])), .ranges(["0.0.0"..<"0.9.1", "1.4.0"..<"2.0.0", "2.0.1"..<"2.4.1", "4.0.0"..<"5.0.0"]))
 
         XCTAssertEqual(VersionSetSpecifier.ranges(["1.0.0"..<"2.0.0", "2.0.1"..<"5.0.0"]).difference(.range("1.0.0"..<"2.0.0")), .range("2.0.1"..<"5.0.0"))
+        XCTAssertEqual(VersionSetSpecifier.ranges(["3.2.0"..<"3.2.3", "3.2.4"..<"4.0.0"]).difference(.exact("3.2.2")), .ranges(["3.2.0"..<"3.2.2", "3.2.4"..<"4.0.0"]))
+        XCTAssertEqual(VersionSetSpecifier.ranges(["3.2.0"..<"3.2.1", "3.2.3"..<"4.0.0"]).difference(.exact("3.2.0")), .range("3.2.3"..<"4.0.0"))
     }
 }


### PR DESCRIPTION
Handle two cases where the set difference with .ranges and .exact was
being wrongly computed. See the new test cases in
VersionSetSpecifierTests for the examples.

<rdar://problem/54645274>