### PR TITLE
[PubGrub] Use last path component instead of identity in diagnostics

### DIFF
--- a/Sources/PackageGraph/VersionSetSpecifier.swift
+++ b/Sources/PackageGraph/VersionSetSpecifier.swift
@@ -416,7 +416,12 @@ extension VersionSetSpecifier: CustomStringConvertible {
         case .empty:
             return "empty"
         case .ranges(let ranges):
-            return ranges.description
+            return "{" + ranges.map{
+                if $0.lowerBound == $0.upperBound {
+                    return $0.lowerBound.description
+                }
+                return $0.lowerBound.description + "..<" + $0.upperBound.description
+            }.joined(separator: ", ") + "}"
         case .range(let range):
             var upperBound = range.upperBound
             // Patch the version range representation. This shouldn't be

--- a/Sources/PackageModel/Package.swift
+++ b/Sources/PackageModel/Package.swift
@@ -145,6 +145,12 @@ public struct PackageReference: JSONMappable, JSONSerializable, CustomStringConv
     /// a git repository.
     public let isLocal: Bool
 
+    /// Returns the last path component of the path (without .git suffix, if present).
+    public var lastPathComponent: String {
+        guard path.count > 0 else { return "" }
+        return String(path.split(separator: "/").last!).spm_dropGitSuffix()
+    }
+
     /// Create a package reference given its identity and repository.
     public init(identity: String, path: String, name: String? = nil, isLocal: Bool = false) {
         assert(identity == identity.lowercased(), "The identity is expected to be lowercased")


### PR DESCRIPTION
This is just a monotonic improvement on how package names are displayed
in the diagnostics. I need to do more work here (and also actual
diagnostic assertions in unit tests).