### PR TITLE
[Basic] Fix the lifetime problems of utilities for creating temporary files and directories.

### DIFF
--- a/Sources/Basic/FileSystem.swift
+++ b/Sources/Basic/FileSystem.swift
@@ -354,16 +354,17 @@ private class LocalFileSystem: FileSystem {
         if !atomically {
             return try writeFileContents(path, bytes: bytes)
         }
-        let temp = try TemporaryFile(dir: path.parentDirectory, deleteOnClose: false)
-        do {
-            try writeFileContents(temp.path, bytes: bytes)
-            try FileManager.default.moveItem(atPath: temp.path.pathString, toPath: path.pathString)
-        } catch {
-            // Write or rename failed, delete the temporary file.
-            // Rethrow the original error, however, as that's the
-            // root cause of the failure.
-            _ = try? self.removeFileTree(temp.path)
-            throw error
+        try withTemporaryFile(dir: path.parentDirectory, deleteOnClose: false) { temp in
+            do {
+                try writeFileContents(temp.path, bytes: bytes)
+                try FileManager.default.moveItem(atPath: temp.path.pathString, toPath: path.pathString)
+            } catch {
+                // Write or rename failed, delete the temporary file.
+                // Rethrow the original error, however, as that's the
+                // root cause of the failure.
+                _ = try? self.removeFileTree(temp.path)
+                throw error
+            }
         }
     }
 

--- a/Tests/BasicTests/POSIXTests.swift
+++ b/Tests/BasicTests/POSIXTests.swift
@@ -15,27 +15,30 @@ import Basic
 class POSIXTests : XCTestCase {
 
     func testFileStatus() throws {
-        let file = try TemporaryFile()
-        XCTAssertTrue(localFileSystem.exists(file.path))
-        XCTAssertTrue(localFileSystem.isFile(file.path))
-        XCTAssertFalse(localFileSystem.isDirectory(file.path))
+        try withTemporaryFile { file in
+            XCTAssertTrue(localFileSystem.exists(file.path))
+            XCTAssertTrue(localFileSystem.isFile(file.path))
+            XCTAssertFalse(localFileSystem.isDirectory(file.path))
 
-        let dir = try TemporaryDirectory(removeTreeOnDeinit: true)
-        XCTAssertTrue(localFileSystem.exists(dir.path))
-        XCTAssertFalse(localFileSystem.isFile(dir.path))
-        XCTAssertTrue(localFileSystem.isDirectory(dir.path))
+            try withTemporaryDirectory(removeTreeOnDeinit: true) { dirPath in
+                XCTAssertTrue(localFileSystem.exists(dirPath))
+                XCTAssertFalse(localFileSystem.isFile(dirPath))
+                XCTAssertTrue(localFileSystem.isDirectory(dirPath))
 
-        let sym = dir.path.appending(component: "hello")
-        try createSymlink(sym, pointingAt: file.path)
-        XCTAssertTrue(localFileSystem.exists(sym))
-        XCTAssertTrue(localFileSystem.isFile(sym))
-        XCTAssertFalse(localFileSystem.isDirectory(sym))
+                let sym = dirPath.appending(component: "hello")
+                try createSymlink(sym, pointingAt: file.path)
+                XCTAssertTrue(localFileSystem.exists(sym))
+                XCTAssertTrue(localFileSystem.isFile(sym))
+                XCTAssertFalse(localFileSystem.isDirectory(sym))
 
-        let dir2 = try TemporaryDirectory(removeTreeOnDeinit: true)
-        let dirSym = dir.path.appending(component: "dir2")
-        try createSymlink(dirSym, pointingAt: dir2.path)
-        XCTAssertTrue(localFileSystem.exists(dirSym))
-        XCTAssertFalse(localFileSystem.isFile(dirSym))
-        XCTAssertTrue(localFileSystem.isDirectory(dirSym))
+                try withTemporaryDirectory(removeTreeOnDeinit: true) { dir2Path in
+                    let dirSym = dirPath.appending(component: "dir2")
+                    try createSymlink(dirSym, pointingAt: dir2Path)
+                    XCTAssertTrue(localFileSystem.exists(dirSym))
+                    XCTAssertFalse(localFileSystem.isFile(dirSym))
+                    XCTAssertTrue(localFileSystem.isDirectory(dirSym))
+                }
+            }
+        }
     }
 }

--- a/Tests/BasicTests/PathShimTests.swift
+++ b/Tests/BasicTests/PathShimTests.swift
@@ -20,43 +20,44 @@ class PathShimTests : XCTestCase {
         XCTAssertEqual(resolveSymlinks(AbsolutePath.root), AbsolutePath.root)
 
         // For the rest of the tests we'll need a temporary directory.
-        let tmpDir = try! TemporaryDirectory(removeTreeOnDeinit: true)
-        // FIXME: it would be better to not need to resolve symbolic links, but we end up relying on /tmp -> /private/tmp.
-        let tmpDirPath = resolveSymlinks(tmpDir.path)
+        try! withTemporaryDirectory(removeTreeOnDeinit: true) { path in
+            // FIXME: it would be better to not need to resolve symbolic links, but we end up relying on /tmp -> /private/tmp.
+            let tmpDirPath = resolveSymlinks(path)
 
-        // Create a symbolic link and directory.
-        let slnkPath = tmpDirPath.appending(component: "slnk")
-        let fldrPath = tmpDirPath.appending(component: "fldr")
+            // Create a symbolic link and directory.
+            let slnkPath = tmpDirPath.appending(component: "slnk")
+            let fldrPath = tmpDirPath.appending(component: "fldr")
 
-        // Create a symbolic link pointing at the (so far non-existent) directory.
-        try! createSymlink(slnkPath, pointingAt: fldrPath, relative: true)
+            // Create a symbolic link pointing at the (so far non-existent) directory.
+            try! createSymlink(slnkPath, pointingAt: fldrPath, relative: true)
 
-        // Resolving the symlink should not yet change anything.
-        XCTAssertEqual(resolveSymlinks(slnkPath), slnkPath)
+            // Resolving the symlink should not yet change anything.
+            XCTAssertEqual(resolveSymlinks(slnkPath), slnkPath)
 
-        // Create a directory to be the referent of the symbolic link.
-        try! makeDirectories(fldrPath)
+            // Create a directory to be the referent of the symbolic link.
+            try! makeDirectories(fldrPath)
 
-        // Resolving the symlink should now point at the directory.
-        XCTAssertEqual(resolveSymlinks(slnkPath), fldrPath)
+            // Resolving the symlink should now point at the directory.
+            XCTAssertEqual(resolveSymlinks(slnkPath), fldrPath)
 
-        // Resolving the directory should still not change anything.
-        XCTAssertEqual(resolveSymlinks(fldrPath), fldrPath)
+            // Resolving the directory should still not change anything.
+            XCTAssertEqual(resolveSymlinks(fldrPath), fldrPath)
+        }
     }
 
     func testRescursiveDirectoryCreation() {
         // For the tests we'll need a temporary directory.
-        let tmpDir = try! TemporaryDirectory(removeTreeOnDeinit: true)
+        try! withTemporaryDirectory(removeTreeOnDeinit: true) { path in
+            // Create a directory under several ancestor directories.
+            let dirPath = path.appending(components: "abc", "def", "ghi", "mno", "pqr")
+            try! makeDirectories(dirPath)
 
-        // Create a directory under several ancestor directories.
-        let dirPath = tmpDir.path.appending(components: "abc", "def", "ghi", "mno", "pqr")
-        try! makeDirectories(dirPath)
+            // Check that we were able to actually create the directory.
+            XCTAssertTrue(localFileSystem.isDirectory(dirPath))
 
-        // Check that we were able to actually create the directory.
-        XCTAssertTrue(localFileSystem.isDirectory(dirPath))
-
-        // Check that there's no error if we try to create the directory again.
-        try! makeDirectories(dirPath)
+            // Check that there's no error if we try to create the directory again.
+            try! makeDirectories(dirPath)
+        }
     }
 }
 
@@ -92,40 +93,40 @@ class WalkTests : XCTestCase {
     }
 
     func testSymlinksNotWalked() {
-        let tmpDir = try! TemporaryDirectory(removeTreeOnDeinit: true)
-        // FIXME: it would be better to not need to resolve symbolic links, but we end up relying on /tmp -> /private/tmp.
-        let tmpDirPath = resolveSymlinks(tmpDir.path)
+        try! withTemporaryDirectory(removeTreeOnDeinit: true) { path in
+            // FIXME: it would be better to not need to resolve symbolic links, but we end up relying on /tmp -> /private/tmp.
+            let tmpDirPath = resolveSymlinks(path)
 
-        try! makeDirectories(tmpDirPath.appending(component: "foo"))
-        try! makeDirectories(tmpDirPath.appending(components: "bar", "baz", "goo"))
-        try! createSymlink(tmpDirPath.appending(components: "foo", "symlink"), pointingAt: tmpDirPath.appending(component: "bar"), relative: true)
+            try! makeDirectories(tmpDirPath.appending(component: "foo"))
+            try! makeDirectories(tmpDirPath.appending(components: "bar", "baz", "goo"))
+            try! createSymlink(tmpDirPath.appending(components: "foo", "symlink"), pointingAt: tmpDirPath.appending(component: "bar"), relative: true)
 
-        XCTAssertTrue(localFileSystem.isSymlink(tmpDirPath.appending(components: "foo", "symlink")))
-        XCTAssertEqual(resolveSymlinks(tmpDirPath.appending(components: "foo", "symlink")), tmpDirPath.appending(component: "bar"))
-        XCTAssertTrue(localFileSystem.isDirectory(resolveSymlinks(tmpDirPath.appending(components: "foo", "symlink", "baz"))))
+            XCTAssertTrue(localFileSystem.isSymlink(tmpDirPath.appending(components: "foo", "symlink")))
+            XCTAssertEqual(resolveSymlinks(tmpDirPath.appending(components: "foo", "symlink")), tmpDirPath.appending(component: "bar"))
+            XCTAssertTrue(localFileSystem.isDirectory(resolveSymlinks(tmpDirPath.appending(components: "foo", "symlink", "baz"))))
 
-        let results = try! walk(tmpDirPath.appending(component: "foo")).map{ $0 }
+            let results = try! walk(tmpDirPath.appending(component: "foo")).map{ $0 }
 
-        XCTAssertEqual(results, [tmpDirPath.appending(components: "foo", "symlink")])
+            XCTAssertEqual(results, [tmpDirPath.appending(components: "foo", "symlink")])
+        }
     }
 
     func testWalkingADirectorySymlinkResolvesOnce() {
-        let tmpDir = try! TemporaryDirectory(removeTreeOnDeinit: true)
-        let tmpDirPath = tmpDir.path
+        try! withTemporaryDirectory(removeTreeOnDeinit: true) { tmpDirPath in
+            try! makeDirectories(tmpDirPath.appending(components: "foo", "bar"))
+            try! makeDirectories(tmpDirPath.appending(components: "abc", "bar"))
+            try! createSymlink(tmpDirPath.appending(component: "symlink"), pointingAt: tmpDirPath.appending(component: "foo"), relative: true)
+            try! createSymlink(tmpDirPath.appending(components: "foo", "baz"), pointingAt: tmpDirPath.appending(component: "abc"), relative: true)
 
-        try! makeDirectories(tmpDirPath.appending(components: "foo", "bar"))
-        try! makeDirectories(tmpDirPath.appending(components: "abc", "bar"))
-        try! createSymlink(tmpDirPath.appending(component: "symlink"), pointingAt: tmpDirPath.appending(component: "foo"), relative: true)
-        try! createSymlink(tmpDirPath.appending(components: "foo", "baz"), pointingAt: tmpDirPath.appending(component: "abc"), relative: true)
+            XCTAssertTrue(localFileSystem.isSymlink(tmpDirPath.appending(component: "symlink")))
 
-        XCTAssertTrue(localFileSystem.isSymlink(tmpDirPath.appending(component: "symlink")))
+            let results = try! walk(tmpDirPath.appending(component: "symlink")).map{ $0 }.sorted()
 
-        let results = try! walk(tmpDirPath.appending(component: "symlink")).map{ $0 }.sorted()
+            // we recurse a symlink to a directory, so this should work,
+            // but `abc` should not show because `baz` is a symlink too
+            // and that should *not* be followed
 
-        // we recurse a symlink to a directory, so this should work,
-        // but `abc` should not show because `baz` is a symlink too
-        // and that should *not* be followed
-
-        XCTAssertEqual(results, [tmpDirPath.appending(components: "symlink", "bar"), tmpDirPath.appending(components: "symlink", "baz")])
+            XCTAssertEqual(results, [tmpDirPath.appending(components: "symlink", "bar"), tmpDirPath.appending(components: "symlink", "baz")])
+        }
     }
 }

--- a/Tests/BasicTests/ProcessTests.swift
+++ b/Tests/BasicTests/ProcessTests.swift
@@ -45,13 +45,14 @@ class ProcessTests: XCTestCase {
         XCTAssertEqual(try Process.popen(arguments: ["echo", "hello"]).utf8Output(), "hello\n")
 
         // Test buffer larger than that allocated.
-        let file = try TemporaryFile()
-        let count = 10_000
-        let stream = BufferedOutputByteStream()
-        stream <<< Format.asRepeating(string: "a", count: count)
-        try localFileSystem.writeFileContents(file.path, bytes: stream.bytes)
-        let outputCount = try Process.popen(args: "cat", file.path.pathString).utf8Output().count
-        XCTAssert(outputCount == count)
+        try withTemporaryFile { file in
+            let count = 10_000
+            let stream = BufferedOutputByteStream()
+            stream <<< Format.asRepeating(string: "a", count: count)
+            try localFileSystem.writeFileContents(file.path, bytes: stream.bytes)
+            let outputCount = try Process.popen(args: "cat", file.path.pathString).utf8Output().count
+            XCTAssert(outputCount == count)
+        }
     }
 
     func testCheckNonZeroExit() throws {

--- a/Tests/ExtraTests/Tests/ExtraTests/FSWatchTests.swift
+++ b/Tests/ExtraTests/Tests/ExtraTests/FSWatchTests.swift
@@ -6,36 +6,35 @@ import SPMUtility
 class FSWatchTests: XCTestCase {
 
     func testBasics() throws {
-        let tmpDir = try TemporaryDirectory(removeTreeOnDeinit: true)
-        let path = tmpDir.path
+        try withTemporaryDirectory(removeTreeOnDeinit: true) { path in
+            // Construct the paths that we need to watch.
+            let pathsToWatch = [
+                path.appending(component: "foo"),
+                path.appending(component: "bar"),
+            ]
 
-        // Construct the paths that we need to watch.
-        let pathsToWatch = [
-            path.appending(component: "foo"),
-            path.appending(component: "bar"),
-        ]
+            // Create the paths.
+            for path in pathsToWatch {
+                try localFileSystem.createDirectory(path)
+            }
 
-        // Create the paths.
-        for path in pathsToWatch {
-            try localFileSystem.createDirectory(path)
+            let condition = Condition()
+            let delegate = Delegate(condition)
+
+            let watcher = FSWatch(paths: pathsToWatch, delegate: delegate)
+            try watcher.start()
+
+            for file in ["a", "b", "c"] {
+                let filePath = path.appending(components: "foo", file)
+                try localFileSystem.writeFileContents(filePath, bytes: "")
+            }
+
+            condition.whileLocked {
+                condition.wait()
+            }
+
+            XCTAssertFalse(delegate.receivedEvents.isEmpty)
         }
-
-        let condition = Condition()
-        let delegate = Delegate(condition)
-
-        let watcher = FSWatch(paths: pathsToWatch, delegate: delegate)
-        try watcher.start()
-
-        for file in ["a", "b", "c"] {
-            let filePath = path.appending(components: "foo", file)
-            try localFileSystem.writeFileContents(filePath, bytes: "")
-        }
-
-        condition.whileLocked {
-            condition.wait()
-        }
-
-        XCTAssertFalse(delegate.receivedEvents.isEmpty)
     }
 }
 

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -195,44 +195,45 @@ class InitTests: XCTestCase {
     // MARK: Special case testing
     
     func testInitPackageNonc99Directory() throws {
-        let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
-        XCTAssertTrue(localFileSystem.isDirectory(tempDir.path))
-        
-        // Create a directory with non c99name.
-        let packageRoot = tempDir.path.appending(component: "some-package")
-        let packageName = packageRoot.basename
-        try localFileSystem.createDirectory(packageRoot)
-        XCTAssertTrue(localFileSystem.isDirectory(packageRoot))
-        
-        // Create the package
-        let initPackage = try InitPackage(name: packageName, destinationPath: packageRoot, packageType: InitPackage.PackageType.library)
-        initPackage.progressReporter = { message in
-        }
-        try initPackage.writePackageStructure()
+        try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDirPath in
+            XCTAssertTrue(localFileSystem.isDirectory(tempDirPath))
+            
+            // Create a directory with non c99name.
+            let packageRoot = tempDirPath.appending(component: "some-package")
+            let packageName = packageRoot.basename
+            try localFileSystem.createDirectory(packageRoot)
+            XCTAssertTrue(localFileSystem.isDirectory(packageRoot))
+            
+            // Create the package
+            let initPackage = try InitPackage(name: packageName, destinationPath: packageRoot, packageType: InitPackage.PackageType.library)
+            initPackage.progressReporter = { message in
+            }
+            try initPackage.writePackageStructure()
 
-        // Try building it.
-        XCTAssertBuilds(packageRoot)
-        XCTAssertFileExists(packageRoot.appending(components: ".build", Destination.host.target.tripleString, "debug", "some_package.swiftmodule"))
+            // Try building it.
+            XCTAssertBuilds(packageRoot)
+            XCTAssertFileExists(packageRoot.appending(components: ".build", Destination.host.target.tripleString, "debug", "some_package.swiftmodule"))
+        }
     }
     
     func testNonC99NameExecutablePackage() throws {
-        let tempDir = try TemporaryDirectory(removeTreeOnDeinit: true)
-        XCTAssertTrue(localFileSystem.isDirectory(tempDir.path))
-        
-        let packageRoot = tempDir.path.appending(component: "Foo")
-        try localFileSystem.createDirectory(packageRoot)
-        XCTAssertTrue(localFileSystem.isDirectory(packageRoot))
-        
-        // Create package with non c99name.
-        let initPackage = try InitPackage(name: "package-name", destinationPath: packageRoot, packageType: InitPackage.PackageType.executable)
-        try initPackage.writePackageStructure()
-        
-        #if os(macOS)
-          XCTAssertSwiftTest(packageRoot)
-        #else
-          XCTAssertBuilds(packageRoot)
-        #endif
-        
+        try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDirPath in
+            XCTAssertTrue(localFileSystem.isDirectory(tempDirPath))
+            
+            let packageRoot = tempDirPath.appending(component: "Foo")
+            try localFileSystem.createDirectory(packageRoot)
+            XCTAssertTrue(localFileSystem.isDirectory(packageRoot))
+            
+            // Create package with non c99name.
+            let initPackage = try InitPackage(name: "package-name", destinationPath: packageRoot, packageType: InitPackage.PackageType.executable)
+            try initPackage.writePackageStructure()
+            
+            #if os(macOS)
+              XCTAssertSwiftTest(packageRoot)
+            #else
+              XCTAssertBuilds(packageRoot)
+            #endif
+        }
     }
 
     private func packageWithNameAndDependencies(with name: String) -> String {


### PR DESCRIPTION
Replacing the TemporaryFile/TemporaryDirectory classes with withTemporaryFile/withTemporaryDirectory functions.

Using classes+deinit for resource management is problematic because the lifetime of classes is not guaranteed to be the lexical scope. Compiler optimizations may shrink the lifetime to the last use. One way to fix this is would be to make sure that the TemporaryFile class instances are referenced as long as the managed resource (= the file or directory) is in use. That could be done e.g. with stdlib's withExtendedLifetime function. But that would be cumbersome.

The better way to fix this is to change the ABI to a closure based approach (there are several examples for this in the swift stdlib, e.g. withExtendedLifetime). It does not only fix the lifetime problem, but also makes the lifetime it immediately visible in the source code. Also, it avoids the memory allocation for allocating the class instance.

This change is triggered by a new compiler optimization: https://github.com/apple/swift/pull/26803. With this optimization the temporary file in the ManifestLoader.parse() function would break.
Although it would be easy to workaround the problem just in ManifestLoader.parse(), I decided to do the right fix, which is more future prove.

Implementation note: I kept the TemporaryFile as a struct, because it contains several useful fields. It's passed as argument to the closure. In case of withTemporaryDirectory, only the directory path is relevant, which is now directly passed to the closure. So no need of a TemporaryDirectory struct.