### PR TITLE
Use Result from the Standard Library

### DIFF
--- a/Sources/Build/BuildDelegate.swift
+++ b/Sources/Build/BuildDelegate.swift
@@ -77,7 +77,7 @@ final class TestDiscoveryCommand: CustomLLBuildCommand {
         assert(tool is TestDiscoveryTool, "Unexpected tool \(tool)")
 
         let index = ctx.buildParameters.indexStore
-        let api = try ctx.indexStoreAPI.dematerialize()
+        let api = try ctx.indexStoreAPI.get()
         let store = try IndexStore.open(store: index, api: api)
 
         // FIXME: We can speed this up by having one llbuild command per object file.

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -347,7 +347,7 @@ public class SwiftTestTool: SwiftTool<TestToolOptions> {
             testBinary.pathString
         ]
         let result = try Process.popen(arguments: args)
-        try localFileSystem.writeFileContents(path, bytes: ByteString(result.output.dematerialize()))
+        try localFileSystem.writeFileContents(path, bytes: ByteString(result.output.get()))
     }
 
     /// Builds the "test" target if enabled in options.

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -438,7 +438,7 @@ public class SwiftTool<Options: ToolOptions> {
     }
 
     func getSwiftPMConfig() throws -> SwiftPMConfig {
-        return try _swiftpmConfig.dematerialize()
+        return try _swiftpmConfig.get()
     }
     private lazy var _swiftpmConfig: Result<SwiftPMConfig, AnyError> = {
         return Result(anyError: { SwiftPMConfig(path: try configFilePath()) })
@@ -561,11 +561,11 @@ public class SwiftTool<Options: ToolOptions> {
 
     /// Returns the user toolchain to compile the actual product.
     func getToolchain() throws -> UserToolchain {
-        return try _destinationToolchain.dematerialize()
+        return try _destinationToolchain.get()
     }
 
     func getManifestLoader() throws -> ManifestLoader {
-        return try _manifestLoader.dematerialize()
+        return try _manifestLoader.get()
     }
 
     private func computeLLBuildTargetName(for subset: BuildSubset, buildParameters: BuildParameters) throws -> String {
@@ -712,7 +712,7 @@ public class SwiftTool<Options: ToolOptions> {
 
     /// Return the build parameters.
     func buildParameters() throws -> BuildParameters {
-        return try _buildParameters.dematerialize()
+        return try _buildParameters.get()
     }
     private lazy var _buildParameters: Result<BuildParameters, AnyError> = {
         return Result(anyError: {
@@ -759,7 +759,7 @@ public class SwiftTool<Options: ToolOptions> {
         return Result(anyError: {
             try ManifestLoader(
                 // Always use the host toolchain's resources for parsing manifest.
-                manifestResources: self._hostToolchain.dematerialize().manifestResources,
+                manifestResources: self._hostToolchain.get().manifestResources,
                 isManifestSandboxEnabled: !self.options.shouldDisableSandbox,
                 cacheDir: self.options.shouldDisableManifestCaching ? nil : self.buildPath
             )

--- a/Sources/PackageGraph/Pubgrub.swift
+++ b/Sources/PackageGraph/Pubgrub.swift
@@ -428,7 +428,7 @@ final class PartialSolution {
         }
 
         let newTerm = _negative[pkg].flatMap{ term.intersect(with: $0) } ?? term
-        
+
         if newTerm.isPositive {
             _negative[pkg] = nil
             _positive[pkg] = newTerm
@@ -994,7 +994,7 @@ public final class PubgrubDependencyResolver {
 
                     changed.removeAll(keepingCapacity: false)
                     changed.append(pkg)
-                    
+
                     break loop
                 case .almostSatisfied(let package):
                     changed.append(package)
@@ -1789,7 +1789,7 @@ private final class ContainerProvider {
     private let fetchCondition = Condition()
 
     /// The list of fetched containers.
-    private var _fetchedContainers: [PackageReference: TSCBasic.Result<PubGrubPackageContainer, AnyError>] = [:]
+    private var _fetchedContainers: [PackageReference: Result<PubGrubPackageContainer, AnyError>] = [:]
 
     /// The set of containers requested so far.
     private var _prefetchingContainers: Set<PackageReference> = []
@@ -1799,7 +1799,7 @@ private final class ContainerProvider {
         return try fetchCondition.whileLocked {
             // Return the cached container, if available.
             if let container = _fetchedContainers[identifier] {
-                return try container.dematerialize()
+                return try container.get()
             }
 
             // If this container is being prefetched, wait for that to complete.
@@ -1809,13 +1809,13 @@ private final class ContainerProvider {
 
             // The container may now be available in our cache if it was prefetched.
             if let container = _fetchedContainers[identifier] {
-                return try container.dematerialize()
+                return try container.get()
             }
 
             // Otherwise, fetch the container synchronously.
             let container = try await { provider.getContainer(for: identifier, skipUpdate: skipUpdate, completion: $0) }
             let pubGrubContainer = PubGrubPackageContainer(container, pinsStore: pinsStore)
-            self._fetchedContainers[identifier] = TSCBasic.Result(pubGrubContainer)
+            self._fetchedContainers[identifier] = .success(pubGrubContainer)
             return pubGrubContainer
         }
     }

--- a/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
@@ -70,7 +70,7 @@ public class RepositoryPackageContainerProvider: PackageContainerProvider {
                     toolsVersionLoader: self.toolsVersionLoader,
                     currentToolsVersion: self.currentToolsVersion,
                     fs: self.repositoryManager.fileSystem)
-                completion(Result(container))
+                completion(.success(container))
             }
             return
         }

--- a/Sources/SPMTestSupport/MockDependencyResolver.swift
+++ b/Sources/SPMTestSupport/MockDependencyResolver.swift
@@ -212,7 +212,7 @@ public struct MockPackagesProvider: PackageContainerProvider {
         completion: @escaping (Result<PackageContainer, AnyError>
     ) -> Void) {
         DispatchQueue.global().async {
-            completion(self.containersByIdentifier[identifier].map(Result.init) ??
+            completion(self.containersByIdentifier[identifier].map{ .success($0) } ??
                 Result(MockLoadingError.unknownModule))
         }
     }

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -432,7 +432,7 @@ public class GitRepository: Repository, WorkingCheckout {
                 ]
                 let argsWithSh = ["sh", "-c", args.joined(separator: " ")]
                 let result = try Process.popen(arguments: argsWithSh)
-                let output = try result.output.dematerialize()
+                let output = try result.output.get()
 
                 let outputs: [String] = output.split(separator: 0).map({ String(decoding: $0, as: Unicode.UTF8.self) })
 

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -271,7 +271,7 @@ public class RepositoryManager {
                         try self.provider.fetch(repository: handle.repository, to: repositoryPath)
                         // Update status to available.
                         handle.status = .available
-                        result = Result(handle)
+                        result = .success(handle)
                     } catch {
                         handle.status = .error
                         fetchError = error

--- a/Sources/TSCBasic/Await.swift
+++ b/Sources/TSCBasic/Await.swift
@@ -15,7 +15,7 @@
 /// - Returns: The value wrapped by the async method's result.
 /// - Throws: The error wrapped by the async method's result
 public func await<T, ErrorType>(_ body: (@escaping (Result<T, ErrorType>) -> Void) -> Void) throws -> T {
-    return try await(body).dematerialize()
+    return try await(body).get()
 }
 
 public func await<T>(_ body: (@escaping (T) -> Void) -> Void) -> T {

--- a/Sources/TSCBasic/CodableResult.swift
+++ b/Sources/TSCBasic/CodableResult.swift
@@ -1,0 +1,62 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2019 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// Codable wrapper for Result
+public struct CodableResult<Success, Failure>: Codable where Success: Codable, Failure: Codable & Error {
+    private enum CodingKeys: String, CodingKey {
+        case success, failure
+    }
+    
+    public let result: Result<Success, Failure>
+    public init(result: Result<Success, Failure>) {
+        self.result = result
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self.result {
+        case .success(let value):
+            var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .success)
+            try unkeyedContainer.encode(value)
+        case .failure(let error):
+            var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .failure)
+            try unkeyedContainer.encode(error)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        guard let key = values.allKeys.first(where: values.contains) else {
+            throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Did not find a matching key"))
+        }
+        switch key {
+        case .success:
+            var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
+            let value = try unkeyedValues.decode(Success.self)
+            self.init(result: .success(value))
+        case .failure:
+            var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
+            let error = try unkeyedValues.decode(Failure.self)
+            self.init(result: .failure(error))
+        }
+    }
+}
+
+extension CodableResult where Failure == StringError {
+    public init(body: () throws -> Success) {
+        do {
+            self.init(result: .success(try body()))
+        } catch let error as StringError {
+            self.init(result: .failure(error))
+        } catch {
+            self.init(result: .failure(StringError(String(describing: error))))
+        }
+    }
+}

--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -89,12 +89,12 @@ public struct ProcessResult: CustomStringConvertible {
     
     /// Converts stdout output bytes to string, assuming they're UTF8.
     public func utf8Output() throws -> String {
-        return String(decoding: try output.dematerialize(), as: Unicode.UTF8.self)
+        return String(decoding: try output.get(), as: Unicode.UTF8.self)
     }
 
     /// Converts stderr output bytes to string, assuming they're UTF8.
     public func utf8stderrOutput() throws -> String {
-        return String(decoding: try stderrOutput.dematerialize(), as: Unicode.UTF8.self)
+        return String(decoding: try stderrOutput.get(), as: Unicode.UTF8.self)
     }
 
     public var description: String {
@@ -201,10 +201,10 @@ public final class Process: ObjectIdentifierProtocol {
   #endif
 
     /// If redirected, stdout result and reference to the thread reading the output.
-    private var stdout: (result: Result<[UInt8], AnyError>, thread: Thread?) = (Result([]), nil)
+    private var stdout: (result: Result<[UInt8], AnyError>, thread: Thread?) = (.success([]), nil)
 
     /// If redirected, stderr result and reference to the thread reading the output.
-    private var stderr: (result: Result<[UInt8], AnyError>, thread: Thread?) = (Result([]), nil)
+    private var stderr: (result: Result<[UInt8], AnyError>, thread: Thread?) = (.success([]), nil)
 
     /// Queue to protect concurrent reads.
     private let serialQueue = DispatchQueue(label: "org.swift.swiftpm.process")
@@ -516,7 +516,7 @@ public final class Process: ObjectIdentifierProtocol {
         // Close the read end of the output pipe.
         close(fd)
         // Construct the output result.
-        return error.map(Result.init) ?? Result(out)
+        return error.map(Result.init) ?? .success(out)
     }
   #endif
 

--- a/Sources/TSCBasic/Result.swift
+++ b/Sources/TSCBasic/Result.swift
@@ -1,86 +1,12 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
-
-/// An simple enum which is either a value or an error.
-/// It can be used for error handling in situations where try catch is
-/// problematic to use, for eg: asynchronous APIs.
-public enum Result<Value, ErrorType: Swift.Error> {
-    /// Indicates success with value in the associated object.
-    case success(Value)
-
-    /// Indicates failure with error inside the associated object.
-    case failure(ErrorType)
-
-    /// Initialiser for value.
-    public init(_ value: Value) {
-        self = .success(value)
-    }
-
-    /// Initialiser for error.
-    public init(_ error: ErrorType) {
-        self = .failure(error)
-    }
-
-    /// Initialise with something that can throw ErrorType.
-    public init(_ body: () throws -> Value) throws {
-        do {
-            self = .success(try body())
-        } catch let error as ErrorType {
-            self = .failure(error)
-        }
-    }
-
-    /// Get the value if success else throw the saved error.
-    public func dematerialize() throws -> Value {
-        switch self {
-        case .success(let value):
-            return value
-        case .failure(let error):
-            throw error
-        }
-    }
-
-    /// Evaluates the given closure when this Result instance has a value.
-    public func map<U>(_ transform: (Value) throws -> U) rethrows -> Result<U, ErrorType> {
-        switch self {
-        case .success(let value):
-            return Result<U, ErrorType>(try transform(value))
-        case .failure(let error):
-            return Result<U, ErrorType>(error)
-        }
-    }
-
-    /// Evaluates the given closure when this Result instance has a value, passing the unwrapped value as a parameter.
-    ///
-    /// The closure returns a Result instance itself which can have value or not.
-    public func flatMap<U>(_ transform: (Value) -> Result<U, ErrorType>) -> Result<U, ErrorType> {
-        switch self {
-            case .success(let value):
-                return transform(value)
-            case .failure(let error):
-                return Result<U, ErrorType>(error)
-        }
-    }
-
-}
-
-extension Result: CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case .success(let value):
-            return "Result(\(value))"
-        case .failure(let error):
-            return "Result(\(error))"
-        }
-    }
-}
 
 /// A type erased error enum.
 public struct AnyError: Swift.Error, CustomStringConvertible {
@@ -114,9 +40,9 @@ public struct StringError: Equatable, Codable, CustomStringConvertible, Error {
 }
 
 // AnyError specific helpers.
-extension Result where ErrorType == AnyError {
+extension Result where Failure == AnyError {
     /// Initialise with something that throws AnyError.
-    public init(anyError body: () throws -> Value) {
+    public init(anyError body: () throws -> Success) {
         do {
             self = .success(try body())
         } catch {
@@ -132,11 +58,11 @@ extension Result where ErrorType == AnyError {
     /// Evaluates the given throwing closure when this Result instance has a value.
     ///
     /// The final result will either be the transformed value or any error thrown by the closure.
-    public func mapAny<U>(_ transform: (Value) throws -> U) -> Result<U, AnyError> {
+    public func mapAny<U>(_ transform: (Success) throws -> U) -> Result<U, AnyError> {
         switch self {
         case .success(let value):
             do {
-                return Result<U, AnyError>(try transform(value))
+                return Result<U, AnyError>.success(try transform(value))
             } catch {
                 return Result<U, AnyError>(error)
             }
@@ -146,54 +72,17 @@ extension Result where ErrorType == AnyError {
     }
 }
 
-extension Result where ErrorType == StringError {
+extension Result where Failure == StringError {
     /// Create an instance of Result<Value, StringError>.
     ///
     /// Errors will be encoded as StringError using their description.
-    public init(string body: () throws -> Value) {
+    public init(string body: () throws -> Success) {
         do {
             self = .success(try body())
         } catch let error as StringError {
             self = .failure(error)
         } catch {
             self = .failure(StringError(String(describing: error)))
-        }
-    }
-}
-
-extension Result: Equatable where Value: Equatable, ErrorType: Equatable {}
-
-extension Result: Codable where Value: Codable, ErrorType: Codable {
-    private enum CodingKeys: String, CodingKey {
-        case success, failure
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        switch self {
-        case .success(let value):
-            var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .success)
-            try unkeyedContainer.encode(value)
-        case .failure(let error):
-            var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .failure)
-            try unkeyedContainer.encode(error)
-        }
-    }
-
-    public init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        guard let key = values.allKeys.first(where: values.contains) else {
-            throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Did not find a matching key"))
-        }
-        switch key {
-        case .success:
-            var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
-            let value = try unkeyedValues.decode(Value.self)
-            self = .success(value)
-        case .failure:
-            var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
-            let error = try unkeyedValues.decode(ErrorType.self)
-            self = .failure(error)
         }
     }
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2042,6 +2042,6 @@ public final class LoadableResult<Value> {
 
     /// Load and return the value.
     public func load() throws -> Value {
-        return try loadResult().dematerialize()
+        return try loadResult().get()
     }
 }

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -1932,7 +1932,7 @@ public struct MockProvider: PackageContainerProvider {
         completion: @escaping (Result<PackageContainer, AnyError>
         ) -> Void) {
         DispatchQueue.global().async {
-            completion(self.containersByIdentifier[identifier].map(Result.init) ??
+            completion(self.containersByIdentifier[identifier].map{ .success($0) } ??
                 Result(_MockLoadingError.unknownModule))
         }
     }

--- a/Tests/TSCBasicTests/AwaitTests.swift
+++ b/Tests/TSCBasicTests/AwaitTests.swift
@@ -21,7 +21,7 @@ class AwaitTests: XCTestCase {
 
     func async(_ param: String, _ completion: @escaping (Result<String, AnyError>) -> Void) {
         DispatchQueue.global().async {
-            completion(Result(param))
+            completion(.success(param))
         }
     }
 

--- a/Tests/TSCBasicTests/XCTestManifests.swift
+++ b/Tests/TSCBasicTests/XCTestManifests.swift
@@ -344,9 +344,6 @@ extension ResultTests {
     // to regenerate.
     static let __allTests__ResultTests = [
         ("testAnyError", testAnyError),
-        ("testBasics", testBasics),
-        ("testFlatMap", testFlatMap),
-        ("testMap", testMap),
         ("testMapAny", testMapAny),
     ]
 }


### PR DESCRIPTION
This Pull Request removes implementation of `Result` from the Basic module - in favor of using the same enum from the Standard Library.

`Basic.Result` was a public type so this change can possibly be breaking, but in this case projects using it should probably be using the Standard Library version anyway. Code using `AnyError` and `StringError` will continue to work as public extensions on `Swift.Result`

I've broken down the refactoring into small commits for reviewers convenience and I am planning to squash if the PR will be accepted.