### PR TITLE
Fixed a TemporaryFile crash

### DIFF
--- a/Sources/Basic/TemporaryFile.swift
+++ b/Sources/Basic/TemporaryFile.swift
@@ -86,7 +86,7 @@ public struct TemporaryFile {
         // Convert path to a C style string terminating with null char to be an valid input
         // to mkstemps method. The XXXXXX in this string will be replaced by a random string
         // which will be the actual path to the temporary file.
-        var template = [UInt8](path.pathString.utf8).map({ Int8($0) }) + [Int8(0)]
+        var template = Array(path.pathString.utf8CString)
 
         fd = SPMLibc.mkstemps(&template, Int32(suffix.utf8.count))
         // If mkstemps failed then throw error.

--- a/Tests/BasicTests/TemporaryFileTests.swift
+++ b/Tests/BasicTests/TemporaryFileTests.swift
@@ -86,12 +86,7 @@ class TemporaryFileTests: XCTestCase {
     }
     
     func testNonStandardASCIIName() throws {
-        let dir = try determineTempDirectory().appending(component: "Héllo")
-        try localFileSystem.createDirectory(dir)
-        defer {
-            try? localFileSystem.removeFileTree(dir)
-        }
-        try withTemporaryFile(dir: dir) { file in
+        try withTemporaryFile(prefix: "Héllo") { file in
             XCTAssertTrue(localFileSystem.isFile(file.path))
         }
     }

--- a/Tests/BasicTests/TemporaryFileTests.swift
+++ b/Tests/BasicTests/TemporaryFileTests.swift
@@ -84,6 +84,17 @@ class TemporaryFileTests: XCTestCase {
         XCTAssertFalse(localFileSystem.isFile(filePathOne))
         XCTAssertFalse(localFileSystem.isFile(filePathTwo))
     }
+    
+    func testNonStandardASCIIName() throws {
+        let dir = try determineTempDirectory().appending(component: "Héllo")
+        try localFileSystem.createDirectory(dir)
+        defer {
+            try? localFileSystem.removeFileTree(dir)
+        }
+        try withTemporaryFile(dir: dir) { file in
+            XCTAssertTrue(localFileSystem.isFile(file.path))
+        }
+    }
 
     func testBasicTemporaryDirectory() throws {
         // Test can create and remove temp directory.

--- a/Tests/BasicTests/XCTestManifests.swift
+++ b/Tests/BasicTests/XCTestManifests.swift
@@ -406,6 +406,7 @@ extension TemporaryFileTests {
         ("testCanCreateUniqueTempFiles", testCanCreateUniqueTempFiles),
         ("testLeaks", testLeaks),
         ("testNoCleanupTemporaryFile", testNoCleanupTemporaryFile),
+        ("testNonStandardASCIIName", testNonStandardASCIIName),
     ]
 }
 


### PR DESCRIPTION
Fixed a TemporaryFile crash caused by higher ASCII characters in the directory path.