### PR TITLE
[Build] Pass modulemap of dependencies to C targets as well

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1220,6 +1220,13 @@ public class BuildPlan {
             case let target as ClangTarget where target.type == .library:
                 // Setup search paths for C dependencies:
                 clangTarget.additionalFlags += ["-I", target.includeDir.pathString]
+
+                // Add the modulemap of the dependency if it has one.
+                if case let .clang(dependencyTargetDescription)? = targetMap[dependency] {
+                    if let moduleMap = dependencyTargetDescription.moduleMap {
+                        clangTarget.additionalFlags += ["-fmodule-map-file=\(moduleMap.pathString)"]
+                    }
+                }
             case let target as SystemLibraryTarget:
                 clangTarget.additionalFlags += ["-fmodule-map-file=\(target.moduleMapPath.pathString)"]
                 clangTarget.additionalFlags += pkgConfig(for: target).cFlags

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -311,8 +311,12 @@ final class BuildPlanTests: XCTestCase {
 
         args += ["-g", "-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1"]
         args += ["-fblocks", "-fmodules", "-fmodule-name=exe",
-            "-I", "/Pkg/Sources/exe/include", "-I", "/Pkg/Sources/lib/include", "-I", "/ExtPkg/Sources/extlib/include",
-            "-fmodules-cache-path=/path/to/build/debug/ModuleCache"]
+            "-I", "/Pkg/Sources/exe/include", "-I", "/Pkg/Sources/lib/include",
+            "-fmodule-map-file=/path/to/build/debug/lib.build/module.modulemap",
+            "-I", "/ExtPkg/Sources/extlib/include",
+            "-fmodule-map-file=/path/to/build/debug/extlib.build/module.modulemap",
+            "-fmodules-cache-path=/path/to/build/debug/ModuleCache",
+        ]
         XCTAssertEqual(exe.basicArguments(), args)
         XCTAssertEqual(exe.objects, [AbsolutePath("/path/to/build/debug/exe.build/main.c.o")])
         XCTAssertEqual(exe.moduleMap, nil)


### PR DESCRIPTION
This enables ObjC targets to import other ObjC targets using @import.

<rdar://problem/51669951>