### PR TITLE
[Workspace] Turn an IUO into a throwing error

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1949,7 +1949,9 @@ extension Workspace {
             // annoying. Maybe we should make an SPI on the provider for
             // this?
             let container = try await { containerProvider.getContainer(for: package, skipUpdate: true, completion: $0) } as! RepositoryPackageContainer
-            let tag = container.getTag(for: version)!
+            guard let tag = container.getTag(for: version) else {
+                throw StringError("Internal error: please file a bug at https://bugs.swift.org with this info -- unable to get tag for \(package) \(version); available versions \(container.reversedVersions)")
+            }
             let revision = try container.getRevision(forTag: tag)
             checkoutState = CheckoutState(revision: revision, version: version)
 


### PR DESCRIPTION
There are reports of crashes in this area but it's not clear how would
this ever happen since we shouldn't get here unless we know there is an
available tag for the version. I've added some user visible logging so
someone who runs into this can file a bug.

<rdar://problem/55040410>