### PR TITLE
Enable SWIFTPM_CUSTOM_BINDIR in Non Debug 

### DIFF
--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -64,9 +64,6 @@ public struct Destination: Encodable {
         //
         // This also means that we should have bootstrapped with the same Swift toolchain
         // we're using inside Xcode otherwise we will not be able to load the runtime libraries.
-        //
-        // FIXME: We may want to allow overriding this using an env variable but that
-        // doesn't seem urgent or extremely useful as of now.
         return AbsolutePath(#file).parentDirectory
             .parentDirectory.parentDirectory.appending(components: ".build", hostTargetTriple.tripleString, "debug")
       #else
@@ -84,10 +81,9 @@ public struct Destination: Encodable {
         environment: [String:String] = ProcessEnv.vars
     ) throws -> Destination {
         // Select the correct binDir.
-        var customBinDir: AbsolutePath?
-      #if DEBUG
-        customBinDir = ProcessEnv.vars["SWIFTPM_CUSTOM_BINDIR"].flatMap{ try? AbsolutePath(validating: $0) }
-      #endif
+        let customBinDir = ProcessEnv
+            .vars["SWIFTPM_CUSTOM_BINDIR"]
+            .flatMap{ try? AbsolutePath(validating: $0) }
         let binDir = customBinDir ?? binDir ?? Destination.hostBinDir(
             originalWorkingDirectory: originalWorkingDirectory)
 


### PR DESCRIPTION
This is particularly useful for Windows which doesn't currently have a
standardized place to install the toolchain to.

~~I'm not at all attached to using `SWIFT_TOOLCHAIN_PATH` so if there's a better name, I can change it.~~
