### PR TITLE
[Build] Fix debugging for products built by SwiftPM

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -229,6 +229,29 @@ public struct BuildParameters: Encodable {
         return BuildSettings.Scope(target.underlyingTarget.buildSettings, boundCondition: (currentPlatform, configuration))
     }
 
+    /// Represents the debugging strategy.
+    ///
+    /// Swift binaries requires the swiftmodule files in order for lldb to work.
+    /// On Darwin, linker can directly take the swiftmodule file path using the
+    /// -add_ast_path flag. On other platforms, we convert the swiftmodule into
+    /// an object file using Swift's modulewrap tool.
+    enum DebuggingStrategy {
+        case swiftAST
+        case modulewrap
+    }
+
+    /// The debugging strategy according to the current build parameters.
+    var debuggingStrategy: DebuggingStrategy? {
+        guard configuration == .debug else {
+            return nil
+        }
+
+        if triple.isDarwin() {
+            return .swiftAST
+        }
+        return .modulewrap
+    }
+
     /// A shim struct for toolchain so we can encode it without having to write encode(to:) for
     /// entire BuildParameters by hand.
     struct _Toolchain: Encodable {
@@ -486,6 +509,13 @@ public final class SwiftTargetBuildDescription {
     /// The path to the swiftmodule file after compilation.
     var moduleOutputPath: AbsolutePath {
         return buildParameters.buildPath.appending(component: target.c99name + ".swiftmodule")
+    }
+
+    /// The path to the wrapped swift module which is created using the modulewrap tool. This is required
+    /// for supporting debugging on non-Darwin platforms (On Darwin, we just pass the swiftmodule to the linker
+    /// using the `-add_ast_path` flag).
+    var wrappedModuleOutputPath: AbsolutePath {
+        return tempsPath.appending(component: target.c99name + ".swiftmodule.o")
     }
 
     /// The path to the swifinterface file after compilation.
@@ -747,6 +777,9 @@ public final class ProductBuildDescription {
     /// The list of targets that are going to be linked statically in this product.
     fileprivate var staticTargets: [ResolvedTarget] = []
 
+    /// The list of Swift modules that should be passed to the linker. This is required for debugging to work.
+    fileprivate var swiftASTs: [AbsolutePath] = []
+
     /// Path to the temporary directory for this product.
     var tempsPath: AbsolutePath {
         return buildParameters.buildPath.appending(component: product.name + ".product")
@@ -869,6 +902,10 @@ public final class ProductBuildDescription {
 
         // Add arguments from declared build settings.
         args += self.buildSettingsFlags()
+
+        // Add AST paths to make the product debuggable. This array is only populated when we're
+        // building for Darwin in debug configuration.
+        args += swiftASTs.flatMap{ ["-Xlinker", "-add_ast_path", "-Xlinker", $0.pathString] }
 
         // User arguments (from -Xlinker and -Xswiftc) should follow generated arguments to allow user overrides
         args += buildParameters.linkerFlags
@@ -1181,6 +1218,28 @@ public class BuildPlan {
             if case let target as ClangTarget = target.underlyingTarget, target.isCXX {
                 buildProduct.additionalFlags += self.buildParameters.toolchain.extraCPPFlags
                 break
+            }
+        }
+
+        for target in dependencies.staticTargets {
+            switch target.underlyingTarget {
+            case is SwiftTarget:
+                // Swift targets are guaranteed to have a corresponding Swift description.
+                guard case .swift(let description) = targetMap[target]! else { fatalError() }
+
+                // Based on the debugging strategy, we either need to pass swiftmodule paths to the
+                // product or link in the wrapped module object. This is required for properly debugging
+                // Swift products. Debugging statergy is computed based on the current platform we're
+                // building for and is nil for the release configuration.
+                switch buildParameters.debuggingStrategy {
+                case .swiftAST:
+                    buildProduct.swiftASTs.append(description.moduleOutputPath)
+                case .modulewrap:
+                    buildProduct.objects += [description.wrappedModuleOutputPath]
+                case nil:
+                    break
+                }
+            default: break
             }
         }
 

--- a/Sources/Build/llbuild.swift
+++ b/Sources/Build/llbuild.swift
@@ -296,6 +296,20 @@ public final class LLBuildManifestGenerator {
         buildTarget.outputs.insert(target.moduleOutputPath.pathString)
         let tool = SwiftCompilerTool(target: target, inputs: inputs.values)
         buildTarget.cmds.insert(Command(name: target.target.getCommandName(config: buildConfig), tool: tool))
+
+        // Add commands to perform the module wrapping Swift modules when debugging statergy is `modulewrap`.
+        if plan.buildParameters.debuggingStrategy == .modulewrap {
+            let modulewrapTool = ShellTool(
+                description: "Wrapping AST for \(target.target.name) for debugging",
+                inputs: [target.moduleOutputPath.pathString],
+                outputs: [target.wrappedModuleOutputPath.pathString],
+                args: [target.buildParameters.toolchain.swiftCompiler.pathString,
+                       "-modulewrap", target.moduleOutputPath.pathString, "-o",
+                       target.wrappedModuleOutputPath.pathString],
+                allowMissingInputs: false)
+            buildTarget.cmds.insert(Command(name: target.wrappedModuleOutputPath.pathString, tool: modulewrapTool))
+        }
+
         return buildTarget
     }
 


### PR DESCRIPTION
This implements proper debugging support on both Darwin and Linux. On
Darwin, this means SwiftPM will pass the swiftmodule file to the linker
and on Linux, it'll link the wrapped module obtained using Swift
compiler's modulewrap subtool.

<rdar://problem/29228963>
<rdar://problem/52118932>

https://bugs.swift.org/browse/SR-3280