### PR TITLE
[CMake] Manually Set swift-version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ cmake_minimum_required(VERSION 3.15.1)
 project(SwiftPM LANGUAGES C Swift)
 
 set(CMAKE_Swift_LANGUAGE_VERSION 4.2)
+if(CMAKE_VERSION VERSION_LESS 3.16)
+  add_compile_options($<$<COMPILE_LANGUAGE:Swift>:-swift-version$<SEMICOLON>4.2>)
+endif()
+
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)


### PR DESCRIPTION
CMAKE_Swift_LANGUAGE_VERSION isn't supported until CMake 3.16 which
isn't generally released yet. For anything less, pass in -swift-version
4.2 with add_compile_options.