### PR TITLE
[Build] Add -gnu in x86_64 Linux's triple

### DIFF
--- a/Sources/Build/Triple.swift
+++ b/Sources/Build/Triple.swift
@@ -122,7 +122,7 @@ public struct Triple: Encodable {
     }
 
     public static let macOS = try! Triple("x86_64-apple-macosx")
-    public static let x86_64Linux = try! Triple("x86_64-unknown-linux")
+    public static let x86_64Linux = try! Triple("x86_64-unknown-linux-gnu")
     public static let i686Linux = try! Triple("i686-unknown-linux")
     public static let ppc64leLinux = try! Triple("powerpc64le-unknown-linux")
     public static let s390xLinux = try! Triple("s390x-unknown-linux")

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -1044,7 +1044,7 @@ def main():
         build_target = "x86_64-apple-macosx"
     elif platform.system() == 'Linux':              
         if platform.machine() == 'x86_64':
-            build_target = "x86_64-unknown-linux"
+            build_target = "x86_64-unknown-linux-gnu"
         elif platform.machine() == "i686":
             build_target = "i686-unknown-linux"
         elif platform.machine() == 's390x':


### PR DESCRIPTION
Absense of environment in the triple seems to cause issues during
debugging. Adding this to unblock my integration test but we should just
switch to asking clang for the host target triple using `clang
-print-target-triple`.