### PR TITLE
Revert "[bootstrap] Install swiftinterface instead of swiftmodule for PD"

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -159,7 +159,6 @@ class Target(object):
         self.is_swift = False
         # FIXME: Currently only C libraries are supported in bootstrap script.
         self.is_c = False
-        self.enable_module_interface = False
 
         self.sources = []
         self.module_root_dir = os.path.join(g_source_root, subpath or self.name)
@@ -203,7 +202,6 @@ class Target(object):
                                      link_input_nodes, predecessor_node, target_map):
         # Compute the derived paths.
         module_path = os.path.join(module_dir, "%s.swiftmodule" % (self.name,))
-        module_interface_path = os.path.join(module_dir, "%s.swiftinterface" % (self.name,))
 
         # Create the per-file entries.
         swift_objects = []
@@ -232,13 +230,7 @@ class Target(object):
         compile_swift_node = '<compile-swift-%s>' % (self.name,)
         link_input_nodes.append(compile_swift_node)
 
-        if self.enable_module_interface:
-            other_args.extend(["-enable-library-evolution", "-emit-module-interface-path", module_interface_path])
-            other_args.extend(["-swift-version", "5"])
-        else:
-            # FIXME: We should just update to the newer version.
-            other_args.extend(["-swift-version", "4"])
-
+        other_args.extend(["-swift-version", "4"])
         other_args.extend(["-module-cache-path", os.path.join(args.sandbox_path, "ModuleCache")])
         
         print("  %s:" % json.dumps(compile_swift_node), file=output)
@@ -649,8 +641,6 @@ def build_runtimes(targets, sandbox_path, args):
         target_copy.name = 'PackageDescription'
         target_copy.release = args.release
         target_copy.swiftflags = ["-DPACKAGE_DESCRIPTION_%s" % (version)]
-        if platform.system() == 'Darwin':
-            target_copy.enable_module_interface = True
         build = llbuild(
                 os.path.join(sandbox_path, "runtimes", version), [target_copy], args)
         build.create_manifest()
@@ -661,8 +651,6 @@ def build_runtimes(targets, sandbox_path, args):
 def process_runtime_libraries(build, args, lib_path):
     module_input_path = os.path.join(
         build.module_dir, "PackageDescription.swiftmodule")
-    moduleinterface_input_path = os.path.join(
-        build.module_dir, "PackageDescription.swiftinterface")
     swiftdoc_input_path = os.path.join(
         build.module_dir, "PackageDescription.swiftdoc")
     input_lib_path = os.path.join(
@@ -671,19 +659,13 @@ def process_runtime_libraries(build, args, lib_path):
     mkdir_p(lib_path)
     runtime_module_path = os.path.join(
         lib_path, "PackageDescription.swiftmodule")
-    runtime_moduleinterface_path = os.path.join(
-        lib_path, "PackageDescription.swiftinterface")
     runtime_swiftdoc_path = os.path.join(
         lib_path, "PackageDescription.swiftdoc")
 
-    if platform.system() == 'Darwin':
-        distutils.file_util.copy_file(moduleinterface_input_path, runtime_moduleinterface_path,
-            update=1)
-    else:
-        distutils.file_util.copy_file(module_input_path, runtime_module_path,
-            update=1)
-        distutils.file_util.copy_file(swiftdoc_input_path, runtime_swiftdoc_path,
-            update=1)
+    distutils.file_util.copy_file(module_input_path, runtime_module_path,
+        update=1)
+    distutils.file_util.copy_file(swiftdoc_input_path, runtime_swiftdoc_path,
+        update=1)
 
     if platform.system() == 'Darwin':
         runtime_lib_path = os.path.join(lib_path, "libPackageDescription.dylib")
@@ -692,7 +674,6 @@ def process_runtime_libraries(build, args, lib_path):
                "-Xlinker", "-all_load",
                input_lib_path,
                "-sdk", args.sysroot,
-               "-enable-library-evolution",
                "-target", "x86_64-apple-macosx10.10"]
     elif platform.system() == 'Windows':
         runtime_lib_path = os.path.join(lib_path, "PackageDescription.dll")
@@ -716,7 +697,7 @@ def process_runtime_libraries(build, args, lib_path):
     cmd.extend(["-module-cache-path", os.path.join(args.sandbox_path, "ModuleCache")])
 
     subprocess.check_call(cmd)
-    return (runtime_moduleinterface_path, runtime_module_path, runtime_swiftdoc_path, runtime_lib_path)
+    return (runtime_module_path, runtime_swiftdoc_path, runtime_lib_path)
 
 
 def get_swift_build_tool_path():
@@ -1395,38 +1376,29 @@ def main():
 
             # Install the runtimes.
             for version, runtime in processed_runtimes.items():
-                runtime_moduleinterface_path, runtime_module_path, runtime_swiftdoc_path, runtime_lib_path = runtime
+                runtime_module_path, runtime_swiftdoc_path, runtime_lib_path = runtime
                 install_path = os.path.join(lib_install_path, version)
 
                 # Install library.
                 installBinary(runtime_lib_path, install_path, args)
 
-                if platform.system() == 'Darwin':
-                    cmd = ["install", "-m", "0644",
-                           runtime_moduleinterface_path, install_path]
-                    note("installing %s: %s" % (
-                        os.path.basename(runtime_moduleinterface_path), ' '.join(cmd)))
-                    result = subprocess.call(cmd)
-                    if result != 0:
-                        error("module install failed with exit status %d" % (result,))
-                else:
-                    # Install module.
-                    cmd = ["install", "-m", "0644",
-                           runtime_module_path, install_path]
-                    note("installing %s: %s" % (
-                        os.path.basename(runtime_module_path), ' '.join(cmd)))
-                    result = subprocess.call(cmd)
-                    if result != 0:
-                        error("module install failed with exit status %d" % (result,))
+                # Install module.
+                cmd = ["install", "-m", "0644",
+                       runtime_module_path, install_path]
+                note("installing %s: %s" % (
+                    os.path.basename(runtime_module_path), ' '.join(cmd)))
+                result = subprocess.call(cmd)
+                if result != 0:
+                    error("module install failed with exit status %d" % (result,))
 
-                    # Install swiftdoc.
-                    cmd = ["install", "-m", "0644",
-                           runtime_swiftdoc_path, install_path]
-                    note("installing %s: %s" % (
-                        os.path.basename(runtime_swiftdoc_path), ' '.join(cmd)))
-                    result = subprocess.call(cmd)
-                    if result != 0:
-                        error("swiftdoc install failed with exit status %d" % (result,))
+                # Install swiftdoc.
+                cmd = ["install", "-m", "0644",
+                       runtime_swiftdoc_path, install_path]
+                note("installing %s: %s" % (
+                    os.path.basename(runtime_swiftdoc_path), ' '.join(cmd)))
+                result = subprocess.call(cmd)
+                if result != 0:
+                    error("swiftdoc install failed with exit status %d" % (result,))
 
     
     # Copy the libSwiftPM library to a directory, if we've been asked to do so.


### PR DESCRIPTION
Reverts apple/swift-package-manager#2355

To unblock CI, going to revert this commit. 

```
19:03:14 /Users/buildnode/jenkins/workspace/oss-swift-incremental-RA-osx/buildbot_incremental/swiftpm-macosx-x86_64/x86_64-apple-macosx/release/swiftc --driver-mode=swift -L /Users/buildnode/jenkins/workspace/oss-swift-incremental-RA-osx/buildbot_incremental/swiftpm-macosx-x86_64/x86_64-apple-macosx/lib/swift/pm/4_2 -lPackageDescription -swift-version 4.2 -I /Users/buildnode/jenkins/workspace/oss-swift-incremental-RA-osx/buildbot_incremental/swiftpm-macosx-x86_64/x86_64-apple-macosx/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.2 /Users/buildnode/jenkins/workspace/oss-swift-incremental-RA-osx/swiftpm/Package.swift -fileno 7
19:03:18 
/Users/buildnode/jenkins/workspace/oss-swift-incremental-RA-osx/swiftpm: error: manifest parse error(s):
19:03:18 Stack dump:
19:03:18 0.	Program arguments: /Users/buildnode/jenkins/workspace/oss-swift-incremental-RA-osx/buildbot_incremental/swift-macosx-x86_64/bin/swift -frontend -interpret /Users/buildnode/jenkins/workspace/oss-swift-incremental-RA-osx/swiftpm/Package.swift -target x86_64-apple-macosx10.10 -enable-objc-interop -sdk /Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -I /Users/buildnode/jenkins/workspace/oss-swift-incremental-RA-osx/buildbot_incremental/swiftpm-macosx-x86_64/x86_64-apple-macosx/lib/swift/pm/4_2 -swift-version 4.2 -package-description-version 4.2 -module-name Package -lPackageDescription -- -fileno 7 
19:03:18 1.	Apple Swift version 5.1-dev (LLVM c5340df2d1, Swift 632399e0f8)
19:03:18 0  swift                    0x00000001050e6265 llvm::sys::PrintStackTrace(llvm::raw_ostream&) + 37
19:03:18 1  swift                    0x00000001050e52a8 llvm::sys::RunSignalHandlers() + 248
19:03:18 2  swift                    0x00000001050e6858 SignalHandler(int) + 264
19:03:18 3  libsystem_platform.dylib 0x00007fff5b36fb5d _sigtramp + 29
19:03:18 4  libsystem_platform.dylib 0x000000000000ffff _sigtramp + 2764702911
19:03:18 5  libsystem_platform.dylib 0x000000010d3a4264 _sigtramp + 2986559268
19:03:18 6  swift                    0x00000001014933b8 llvm::MCJIT::runFunction(llvm::Function*, llvm::ArrayRef<llvm::GenericValue>) + 456
19:03:18 7  swift                    0x0000000101496521 llvm::ExecutionEngine::runFunctionAsMain(llvm::Function*, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, char const* const*) + 1313
19:03:18 8  swift                    0x0000000101488b51 swift::RunImmediately(swift::CompilerInstance&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, swift::IRGenOptions&, swift::SILOptions const&) + 3457
19:03:18 9  swift                    0x000000010147ecdd performCompileStepsPostSILGen(swift::CompilerInstance&, swift::CompilerInvocation&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule> >, bool, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, swift::PrimarySpecificPaths const&, bool, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) + 2557
19:03:18 10 swift                    0x0000000101474138 performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) + 7032
19:03:18 11 swift                    0x0000000101471690 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 3024
19:03:18 12 swift                    0x0000000101418f49 main + 729
19:03:18 13 libdyld.dylib            0x00007fff5b1843d5 start + 1
19:03:18 --- bootstrap: error: build failed with exit status 1
```