### PR TITLE
Properly look for git on Windows

### DIFF
--- a/Sources/TSCBasic/misc.swift
+++ b/Sources/TSCBasic/misc.swift
@@ -48,9 +48,14 @@ public func getEnvSearchPaths(
     currentWorkingDirectory: AbsolutePath?
 ) -> [AbsolutePath] {
     // Compute search paths from PATH variable.
-    return (pathString ?? "").split(separator: ":").map(String.init).compactMap({ pathString in
+  #if os(Windows)
+    let sep: Character = ";"
+  #else
+    let sep: Character = ":"
+  #endif
+    return (pathString ?? "").split(separator: sep).map(String.init).compactMap({ pathString in
         // If this is an absolute path, we're done.
-        if pathString.first == "/" {
+        if pathString.isAbsolutePath {
             return AbsolutePath(pathString)
         }
         // Otherwise convert it into absolute path relative to the working directory.

--- a/Sources/TSCUtility/Git.swift
+++ b/Sources/TSCUtility/Git.swift
@@ -57,7 +57,11 @@ public class Git {
     }
 
     /// A shell command to run for Git. Can be either a name or a path.
+  #if os(Windows)
+    public static var tool: String = "git.exe"
+  #else
     public static var tool: String = "git"
+  #endif
 
     /// Returns true if the git reference name is well formed.
     public static func checkRefFormat(ref: String) -> Bool {


### PR DESCRIPTION
- Look for git.exe instead of git
- The Path environment variable on Windows is ';' delimited