### PR TITLE
Fix Process Launching on Windows

### DIFF
--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -60,7 +60,7 @@ public struct AbsolutePath: Hashable {
     /// or relative; if relative, `basePath` is used as the anchor; if absolute,
     /// it is used as is, and in this case `basePath` is ignored.
     public init(_ str: String, relativeTo basePath: AbsolutePath) {
-        if str.hasPrefix("/") {
+        if str.isAbsolutePath {
             self.init(str)
         } else {
             self.init(basePath, RelativePath(str))


### PR DESCRIPTION
- The env variable is "Path", not "PATH" on Windows
- Reuse the found path as the executable url, else foundation assumes
  it's in the cwd
- The executable name shouldn't be passed as the first argument, that is
  handled by Foundation's Process
- Actually return the data that we received