### PR TITLE
Enable passing in an SDK on Windows by setting SDKROOT

### DIFF
--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -114,6 +114,16 @@ public struct Destination: Encodable {
             extraSwiftCFlags: commonArgs,
             extraCPPFlags: ["-lc++"]
         )
+      #elseif os(Windows)
+        let sdkPath = ProcessEnv.vars["SDKROOT"].map { AbsolutePath($0) } ?? .root
+        return Destination(
+            target: hostTargetTriple,
+            sdk: sdkPath,
+            binDir: binDir,
+            extraCCFlags: [],
+            extraSwiftCFlags: [],
+            extraCPPFlags: ["-lstdc++"]
+        )
       #else
         return Destination(
             target: hostTargetTriple,

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -205,10 +205,17 @@ public final class UserToolchain: Toolchain {
         self.xctest = nil
       #endif
 
-        self.extraSwiftCFlags = (destination.target.isDarwin()
-                                    ? ["-sdk", destination.sdk.pathString]
-                                    : [])
-                                  + destination.extraSwiftCFlags
+        if destination.target.isDarwin() {
+            self.extraSwiftCFlags = ["-sdk", destination.sdk.pathString]
+        } else if (destination.target.isWindows()) {
+            self.extraSwiftCFlags = [
+              "-sdk", destination.sdk.pathString,
+              "-resource-dir", destination.sdk.pathString + "\\usr\\lib\\swift",
+              "-L", destination.sdk.pathString + "\\usr\\lib\\swift\\windows"
+            ]
+        } else {
+            self.extraSwiftCFlags = []
+        }
 
         self.extraCCFlags = [
             destination.target.isDarwin() ? "-isysroot" : "--sysroot", destination.sdk.pathString


### PR DESCRIPTION
This allows SwiftPM to find where Foundation is if given an SDK.