### PR TITLE
[Workspace] Include constraints from edited packages when resolving i…

### DIFF
--- a/Sources/SPMTestSupport/TestWorkspace.swift
+++ b/Sources/SPMTestSupport/TestWorkspace.swift
@@ -29,6 +29,7 @@ public final class TestWorkspace {
     public let delegate = TestWorkspaceDelegate()
     let toolsVersion: ToolsVersion
     let skipUpdate: Bool
+    let enablePubGrub: Bool
 
     public init(
         sandbox: AbsolutePath,
@@ -36,7 +37,8 @@ public final class TestWorkspace {
         roots: [TestPackage],
         packages: [TestPackage],
         toolsVersion: ToolsVersion = ToolsVersion.currentToolsVersion,
-        skipUpdate: Bool = false
+        skipUpdate: Bool = false,
+        enablePubGrub: Bool = false
     ) throws {
         self.sandbox = sandbox
         self.fs = fs
@@ -48,6 +50,7 @@ public final class TestWorkspace {
         self.repoProvider = InMemoryGitRepositoryProvider()
         self.toolsVersion = toolsVersion
         self.skipUpdate = skipUpdate
+        self.enablePubGrub = enablePubGrub
 
         try create()
     }
@@ -142,6 +145,7 @@ public final class TestWorkspace {
             config: config,
             fileSystem: fs,
             repositoryProvider: repoProvider,
+            enablePubgrubResolver: enablePubGrub,
             skipUpdate: skipUpdate
         )
         return _workspace!

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -227,7 +227,8 @@ public class Workspace {
             var allConstraints = [RepositoryPackageConstraint]()
 
             for (externalManifest, managedDependency) in dependencies {
-
+                // For edited packages, add a constraint with unversioned requirement so the
+                // resolver doesn't try to resolve it.
                 switch managedDependency.state {
                 case .edited:
                     // FIXME: We shouldn't need to construct a new package reference object here.
@@ -237,16 +238,14 @@ public class Workspace {
                         path: managedDependency.packageRef.path,
                         isLocal: true
                     )
-                    // Add an unversioned constraint if the dependency is in edited state.
                     let constraint = RepositoryPackageConstraint(
                         container: ref,
                         requirement: .unversioned)
                     allConstraints.append(constraint)
-
                 case .checkout, .local:
-                    // For checkouts, add all the constraints in the manifest.
-                    allConstraints += externalManifest.dependencyConstraints(config: workspace.config)
+                    break
                 }
+                allConstraints += externalManifest.dependencyConstraints(config: workspace.config)
             }
             return allConstraints
         }

--- a/Tests/BuildTests/XCTestManifests.swift
+++ b/Tests/BuildTests/XCTestManifests.swift
@@ -20,6 +20,7 @@ extension BuildPlanTests {
         ("testExecBuildTimeDependency", testExecBuildTimeDependency),
         ("testExtraBuildFlags", testExtraBuildFlags),
         ("testIndexStore", testIndexStore),
+        ("testModulewrap", testModulewrap),
         ("testNonReachableProductsAndTargets", testNonReachableProductsAndTargets),
         ("testObjCHeader1", testObjCHeader1),
         ("testObjCHeader2", testObjCHeader2),

--- a/Tests/WorkspaceTests/XCTestManifests.swift
+++ b/Tests/WorkspaceTests/XCTestManifests.swift
@@ -56,6 +56,7 @@ extension WorkspaceTests {
         ("testDependencySwitchWithSameIdentity", testDependencySwitchWithSameIdentity),
         ("testDuplicateRootPackages", testDuplicateRootPackages),
         ("testEditDependency", testEditDependency),
+        ("testEditDependencyHadOverridableConstraints", testEditDependencyHadOverridableConstraints),
         ("testForceResolveToResolvedVersions", testForceResolveToResolvedVersions),
         ("testForceResolveToResolvedVersionsLocalPackage", testForceResolveToResolvedVersionsLocalPackage),
         ("testGraphRootDependencies", testGraphRootDependencies),


### PR DESCRIPTION
…ncrementally

Constraints from edited packages were not participating in the array
that is used to determine if we should re-resolve.

<rdar://problem/56087746>