### PR TITLE
[TSCUtility] Use @_implementationOnly import for TSCclibc

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -88,7 +88,7 @@ let package = Package(
         .target(
             /** Cross-platform access to bare `libc` functionality. */
             name: "TSCLibc",
-            dependencies: ["TSCclibc"]),
+            dependencies: []),
         .target(
             /** TSCBasic support library */
             name: "TSCBasic",
@@ -96,7 +96,7 @@ let package = Package(
         .target(
             /** Abstractions for common operations, should migrate to TSCBasic */
             name: "TSCUtility",
-            dependencies: ["TSCBasic"]),
+            dependencies: ["TSCBasic", "TSCclibc"]),
         
         // MARK: SwiftPM specific support libraries
         

--- a/Sources/TSCLibc/CMakeLists.txt
+++ b/Sources/TSCLibc/CMakeLists.txt
@@ -13,8 +13,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   target_compile_options(TSCLibc PRIVATE
     -autolink-force-load)
 endif()
-target_link_libraries(TSCLibc PUBLIC
-  TSCclibc)
+
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(TSCLibc PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/TSCLibc/libc.swift
+++ b/Sources/TSCLibc/libc.swift
@@ -16,5 +16,3 @@
 #else
 @_exported import Darwin.C
 #endif
-
-@_exported import TSCclibc

--- a/Sources/TSCUtility/CMakeLists.txt
+++ b/Sources/TSCUtility/CMakeLists.txt
@@ -29,8 +29,11 @@ add_library(TSCUtility
   Verbosity.swift
   Version.swift
   Versioning.swift)
+
 target_link_libraries(TSCUtility PUBLIC
+  TSCclibc
   TSCBasic)
+
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(TSCUtility PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/TSCUtility/IndexStore.swift
+++ b/Sources/TSCUtility/IndexStore.swift
@@ -9,32 +9,62 @@
  */
 
 import TSCBasic
-import TSCclibc
+@_implementationOnly import TSCclibc
 
 public final class IndexStore {
-
     public struct TestCaseClass {
         public var name: String
         public var module: String
         public var methods: [String]
     }
 
-    let api: IndexStoreAPI
+    fileprivate var impl: IndexStoreImpl { _impl as! IndexStoreImpl }
+    private let _impl: Any
 
-    var fn: indexstore_functions_t {
-        return api.fn
+    fileprivate init(_ impl: IndexStoreImpl) {
+        self._impl = impl
     }
+
+    static public func open(store path: AbsolutePath, api: IndexStoreAPI) throws -> IndexStore {
+        let impl = try IndexStoreImpl.open(store: path, api: api.impl)
+        return IndexStore(impl)
+    }
+
+    public func listTests(inObjectFile object: AbsolutePath) throws -> [TestCaseClass] {
+        return try impl.listTests(inObjectFile: object)
+    }
+}
+
+public final class IndexStoreAPI {
+
+    fileprivate var impl: IndexStoreAPIImpl {
+        _impl as! IndexStoreAPIImpl
+    }
+    private let _impl: Any
+
+    public init(dylib path: AbsolutePath) throws {
+        self._impl = try IndexStoreAPIImpl(dylib: path)
+    }
+}
+
+private final class IndexStoreImpl {
+
+    typealias TestCaseClass = IndexStore.TestCaseClass
+
+    let api: IndexStoreAPIImpl
+
+    var fn: indexstore_functions_t { api.fn }
 
     let store: indexstore_t
 
-    private init(store: indexstore_t, api: IndexStoreAPI) {
+    private init(store: indexstore_t, api: IndexStoreAPIImpl) {
         self.store = store
         self.api = api
     }
 
-    static public func open(store path: AbsolutePath, api: IndexStoreAPI) throws -> IndexStore {
+    static public func open(store path: AbsolutePath, api: IndexStoreAPIImpl) throws -> IndexStoreImpl {
         if let store = try api.call({ api.fn.store_create(path.pathString, &$0) }) {
-            return IndexStore(store: store, api: api)
+            return IndexStoreImpl(store: store, api: api)
         }
         throw StringError("Unable to open store at \(path)")
     }
@@ -156,16 +186,15 @@ public final class IndexStore {
 }
 
 private class Ref<T> {
-    let api: IndexStoreAPI
+    let api: IndexStoreAPIImpl
     var instance: T
-    init(_ instance: T, api: IndexStoreAPI) {
+    init(_ instance: T, api: IndexStoreAPIImpl) {
         self.instance = instance
         self.api = api
     }
 }
 
-public final class IndexStoreAPI {
-
+private final class IndexStoreAPIImpl {
     /// The path of the index store dylib.
     private let path: AbsolutePath
 

--- a/Sources/TSCUtility/Versioning.swift
+++ b/Sources/TSCUtility/Versioning.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import TSCclibc
+@_implementationOnly import TSCclibc
 
 /// A Swift version number.
 ///

--- a/Sources/TSCclibc/include/TSCclibc.h
+++ b/Sources/TSCclibc/include/TSCclibc.h
@@ -1,7 +1,3 @@
-#if defined(__linux__)
-#include <sys/inotify.h>
-#endif
-
 #define STR_EXPAND(VALUE) #VALUE
 #define STR(VALUE) STR_EXPAND(VALUE)
 


### PR DESCRIPTION
Given most things are in modulemap now, we only need this target for
embedding the versioning info and indexstore APIs. We should also rename
it to TSCCSupport or something.

<rdar://problem/56219970>