### PR TITLE
Add Windows as a Supported Platform

### DIFF
--- a/Sources/PackageDescription4/SupportedPlatforms.swift
+++ b/Sources/PackageDescription4/SupportedPlatforms.swift
@@ -33,6 +33,10 @@ public struct Platform: Encodable {
 
     /// The Linux platform.
     public static let linux: Platform = Platform(name: "linux")
+
+    /// The Windows platform
+    @available(_PackageDescription, introduced: 5.2)
+    public static let windows: Platform = Platform(name: "windows")
 }
 
 /// A platform that the Swift package supports.


### PR DESCRIPTION
Gated behind version 5.2. This will allow for example, Windows specific
c/cxx flags to be passed to build indexstoredb and llbuild.

See also: https://forums.swift.org/t/adding-support-for-windows-as-a-platform/30158