### PR TITLE
[Build] Fix debugging for products built by SwiftPM

### DIFF
--- a/Sources/Build/llbuild.swift
+++ b/Sources/Build/llbuild.swift
@@ -256,6 +256,20 @@ public final class LLBuildManifestGenerator {
         buildTarget.outputs.insert(target.moduleOutputPath.pathString)
         let tool = SwiftCompilerTool(target: target, inputs: inputs.values)
         buildTarget.cmds.insert(Command(name: target.target.getCommandName(config: buildConfig), tool: tool))
+
+        // Add commands to perform the module wrapping Swift modules when debugging statergy is `modulewrap`.
+        if plan.buildParameters.debuggingStrategy == .modulewrap {
+            let modulewrapTool = ShellTool(
+                description: "Wrapping AST for \(target.target.name) for debugging",
+                inputs: [target.moduleOutputPath.pathString],
+                outputs: [target.wrappedModuleOutputPath.pathString],
+                args: [target.buildParameters.toolchain.swiftCompiler.pathString,
+                       "-modulewrap", target.moduleOutputPath.pathString, "-o",
+                       target.wrappedModuleOutputPath.pathString],
+                allowMissingInputs: false)
+            buildTarget.cmds.insert(Command(name: target.wrappedModuleOutputPath.pathString, tool: modulewrapTool))
+        }
+
         return buildTarget
     }
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -114,7 +114,9 @@ final class BuildPlanTests: XCTestCase {
             "-emit-executable",
             "@/path/to/build/debug/exe.product/Objects.LinkFileList",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift/macosx",
-            "-target", "x86_64-apple-macosx10.10",
+            "-target", "x86_64-apple-macosx10.10", "-Xlinker", "-add_ast_path",
+            "-Xlinker", "/path/to/build/debug/exe.swiftmodule", "-Xlinker", "-add_ast_path",
+            "-Xlinker", "/path/to/build/debug/lib.swiftmodule",
         ]
       #else
         let linkArguments = [
@@ -457,6 +459,7 @@ final class BuildPlanTests: XCTestCase {
             "@/path/to/build/debug/exe.product/Objects.LinkFileList",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift/macosx",
             "-target", "x86_64-apple-macosx10.10",
+            "-Xlinker", "-add_ast_path", "-Xlinker", "/path/to/build/debug/exe.swiftmodule",
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
@@ -600,6 +603,8 @@ final class BuildPlanTests: XCTestCase {
             "@/path/to/build/debug/PkgPackageTests.product/Objects.LinkFileList",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift/macosx",
             "-target", "x86_64-apple-macosx10.10",
+            "-Xlinker", "-add_ast_path", "-Xlinker", "/path/to/build/debug/FooTests.swiftmodule",
+            "-Xlinker", "-add_ast_path", "-Xlinker", "/path/to/build/debug/Foo.swiftmodule",
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "PkgPackageTests").linkArguments(), [
@@ -652,6 +657,7 @@ final class BuildPlanTests: XCTestCase {
             "@/path/to/build/debug/exe.product/Objects.LinkFileList",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift/macosx",
             "-target", "x86_64-apple-macosx10.10",
+            "-Xlinker", "-add_ast_path", "-Xlinker", "/path/to/build/debug/exe.swiftmodule",
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
@@ -745,6 +751,7 @@ final class BuildPlanTests: XCTestCase {
             "@/path/to/build/debug/Foo.product/Objects.LinkFileList",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift/macosx",
             "-target", "x86_64-apple-macosx10.10",
+            "-Xlinker", "-add_ast_path", "-Xlinker", "/path/to/build/debug/Foo.swiftmodule"
         ])
 
         XCTAssertEqual(barLinkArgs, [
@@ -753,6 +760,7 @@ final class BuildPlanTests: XCTestCase {
             "-module-name", "Bar_Baz", "-emit-library",
             "@/path/to/build/debug/Bar-Baz.product/Objects.LinkFileList",
             "-target", "x86_64-apple-macosx10.10",
+            "-Xlinker", "-add_ast_path", "-Xlinker", "/path/to/build/debug/Bar.swiftmodule"
         ])
       #else
         XCTAssertEqual(fooLinkArgs, [
@@ -820,6 +828,7 @@ final class BuildPlanTests: XCTestCase {
                 "-emit-library",
                 "@/path/to/build/debug/lib.product/Objects.LinkFileList",
                 "-target", "x86_64-apple-macosx10.10",
+                "-Xlinker", "-add_ast_path", "-Xlinker", "/path/to/build/debug/lib.swiftmodule",
             ]
         #else
             let linkArguments = [
@@ -1384,7 +1393,7 @@ final class BuildPlanTests: XCTestCase {
             XCTAssertMatch(exe, [.anySequence, "-DFOO", "-framework", "CoreData", .end])
 
             let linkExe = try result.buildProduct(for: "exe").linkArguments()
-            XCTAssertMatch(linkExe, [.anySequence, "-lsqlite3", "-llibz", "-framework", "CoreData", "-Ilfoo", "-L", "lbar", .end])
+            XCTAssertMatch(linkExe, [.anySequence, "-lsqlite3", "-llibz", "-framework", "CoreData", "-Ilfoo", "-L", "lbar", .anySequence])
         }
     }
 


### PR DESCRIPTION
This implements proper debugging support on both Darwin and Linux. On
Darwin, this means SwiftPM will pass the swiftmodule file to the linker
and on Linux, it'll link the wrapped module obtained using Swift
compiler's modulewrap subtool.

<rdar://problem/29228963>
<rdar://problem/52118932>

https://bugs.swift.org/browse/SR-3280

This is a cherry-pick commit for <rdar://problem/56673855>

**Note: This change is just for the Linux dot release.**