### PR TITLE
[PackageLoading] Disable modulemap mixed with sources check

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -659,13 +659,19 @@ public final class PackageBuilder {
             throw ModuleError.invalidPublicHeadersDirectory(potentialModule.name)
         }
 
+        // Exclude public headers path directory from source searching if it's not
+        // the target root.
+        // FIXME: This means we'll try to assign rules to header files
+        // which is currently not handled by the sources builder.
+        let extraExcludes = publicHeadersPath != potentialModule.path ? [publicHeadersPath] : []
+
         let sourcesBuilder = TargetSourcesBuilder(
             packageName: manifest.name,
             packagePath: packagePath,
             target: manifestTarget,
             path: potentialModule.path,
             additionalFileRules: additionalFileRules,
-            extraExcludes: [publicHeadersPath],
+            extraExcludes: extraExcludes,
             toolsVersion: manifest.toolsVersion,
             fs: fileSystem,
             diags: diagnostics

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -123,12 +123,6 @@ public struct TargetSourcesBuilder {
             throw Target.Error.mixedSources(targetPath)
         }
 
-        // Make sure there is no modulemap mixed with the sources.
-        let moduleMapFiles = pathToRule.filter{ $0.value == .modulemap }
-        if let moduleMapFile = moduleMapFiles.first {
-            throw ModuleError.invalidLayout(.modulemapInSources(moduleMapFile.key))
-        }
-
         return (sources, resources)
     }
 

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -166,12 +166,13 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testModuleMapLayout() throws {
-       var fs = InMemoryFileSystem(emptyFiles:
+        let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/clib/include/module.modulemap",
             "/Sources/clib/include/clib.h",
-            "/Sources/clib/clib.c")
+            "/Sources/clib/clib.c"
+        )
 
-        var manifest = Manifest.createV4Manifest(
+        let manifest = Manifest.createV4Manifest(
             name: "MyPackage",
             targets: [
                 TargetDescription(name: "clib"),
@@ -182,34 +183,6 @@ class PackageBuilderTests: XCTestCase {
                 moduleResult.check(c99name: "clib", type: .library)
                 moduleResult.checkSources(root: "/Sources/clib", paths: "clib.c")
             }
-        }
-
-        fs = InMemoryFileSystem(emptyFiles:
-            "/Sources/clib/module.modulemap",
-            "/Sources/clib/foo.swift")
-        manifest = Manifest.createV4Manifest(
-            name: "MyPackage",
-            targets: [
-                TargetDescription(name: "clib"),
-            ]
-        )
-        PackageBuilderTester(manifest, in: fs) { result in
-            result.checkDiagnostic("package has unsupported layout; modulemap '/Sources/clib/module.modulemap' should be inside the 'include' directory")
-        }
-
-        fs = InMemoryFileSystem(emptyFiles:
-            "/Sources/Foo/module.modulemap",
-            "/Sources/Foo/foo.swift",
-            "/Sources/Bar/bar.swift")
-        manifest = Manifest.createV4Manifest(
-            name: "MyPackage",
-            targets: [
-                TargetDescription(name: "Foo"),
-                TargetDescription(name: "Bar"),
-            ]
-        )
-        PackageBuilderTester(manifest, in: fs) { result in
-            result.checkDiagnostic("package has unsupported layout; modulemap '/Sources/Foo/module.modulemap' should be inside the 'include' directory")
         }
     }
 


### PR DESCRIPTION
I found some bugs in the new target sources builder thanks to benchmark
package. I'll fix them properly in a separate commit but these fixes
should unblock CI. We also need to build swift benchmarks in SwiftPM PR
testing.

<rdar://problem/56780087>