### PR TITLE
Only build requested test product if one is specified using --test-product

### DIFF
--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -357,7 +357,8 @@ public class SwiftTestTool: SwiftTool<TestToolOptions> {
         let buildDescription = try getBuildDescription(graph: graph)
 
         if options.shouldBuildTests {
-            try build(buildDescription: buildDescription, subset: .allIncludingTests)
+            let subset = options.testProduct.map(BuildSubset.product) ?? .allIncludingTests
+            try build(buildDescription: buildDescription, subset: subset)
         }
 
         // Find the test product.


### PR DESCRIPTION
Avoid building all the other test products if one test product is requested through the `--test-product` option.