### PR TITLE
Android: add native platform support

### DIFF
--- a/Fixtures/Miscellaneous/EchoExecutable/Sources/secho/main.swift
+++ b/Fixtures/Miscellaneous/EchoExecutable/Sources/secho/main.swift
@@ -1,4 +1,4 @@
-#if os(Linux)
+#if canImport(Glibc)
 	import Glibc
 #else
 	import Darwin.C

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -226,6 +226,8 @@ public struct BuildParameters: Encodable {
     var currentPlatform: PackageModel.Platform {
         if self.triple.isDarwin() {
             return .macOS
+        } else if self.triple.isAndroid() {
+            return .android
         } else {
             return .linux
         }

--- a/Sources/Build/Triple.swift
+++ b/Sources/Build/Triple.swift
@@ -128,7 +128,10 @@ public struct Triple: Encodable {
     public static let s390xLinux = try! Triple("s390x-unknown-linux")
     public static let arm64Linux = try! Triple("aarch64-unknown-linux")
     public static let armLinux = try! Triple("armv7-unknown-linux-gnueabihf")
-    public static let android = try! Triple("armv7-unknown-linux-androideabi")
+    public static let armAndroid = try! Triple("armv7a-unknown-linux-androideabi")
+    public static let arm64Android = try! Triple("aarch64-unknown-linux-android")
+    public static let x86_64Android = try! Triple("x86_64-unknown-linux-android")
+    public static let i686Android = try! Triple("i686-unknown-linux-android")
     public static let windows = try! Triple("x86_64-unknown-windows-msvc")
 
   #if os(macOS)
@@ -148,6 +151,16 @@ public struct Triple: Encodable {
       public static let hostTriple: Triple = .arm64Linux
     #elseif arch(arm)
       public static let hostTriple: Triple = .armLinux    
+    #endif
+  #elseif os(Android)
+    #if arch(arm)
+      public static let hostTriple: Triple = .armAndroid
+    #elseif arch(arm64)
+      public static let hostTriple: Triple = .arm64Android
+    #elseif arch(x86_64)
+      public static let hostTriple: Triple = .x86_64Android
+    #elseif arch(i386)
+      public static let hostTriple: Triple = .i686Android
     #endif
   #endif
 }

--- a/Sources/Build/Triple.swift
+++ b/Sources/Build/Triple.swift
@@ -101,6 +101,10 @@ public struct Triple: Encodable {
         return nil
     }
 
+    public func isAndroid() -> Bool {
+        return os == .linux && abi == .android
+    }
+
     public func isDarwin() -> Bool {
         return vendor == .apple || os == .macOS || os == .darwin
     }

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -375,6 +375,12 @@ public class SwiftTool<Options: ToolOptions> {
                 action.__sigaction_u.__sa_handler = SIG_DFL
                 sigaction(SIGINT, &action, nil)
                 kill(getpid(), SIGINT)
+              #elseif os(Android)
+                // Install the default signal handler.
+                var action = sigaction()
+                action.sa_handler = SIG_DFL
+                sigaction(SIGINT, &action, nil)
+                kill(getpid(), SIGINT)
               #else
                 var action = sigaction()
                 action.__sigaction_handler = unsafeBitCast(

--- a/Sources/PackageDescription4/Package.swift
+++ b/Sources/PackageDescription4/Package.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
 #elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 import Darwin.C

--- a/Sources/PackageDescription4/SupportedPlatforms.swift
+++ b/Sources/PackageDescription4/SupportedPlatforms.swift
@@ -37,6 +37,10 @@ public struct Platform: Encodable {
     /// The Windows platform
     @available(_PackageDescription, introduced: 5.2)
     public static let windows: Platform = Platform(name: "windows")
+
+    /// The Android platform
+    @available(_PackageDescription, introduced: 5.2)
+    public static let android: Platform = Platform(name: "android")
 }
 
 /// A platform that the Swift package supports.

--- a/Sources/PackageModel/Platform.swift
+++ b/Sources/PackageModel/Platform.swift
@@ -29,7 +29,7 @@ public final class PlatformRegistry {
 
     /// The static list of known platforms.
     private static var _knownPlatforms: [Platform] {
-        return [.macOS, .iOS, .tvOS, .watchOS, .linux]
+        return [.macOS, .iOS, .tvOS, .watchOS, .linux, .android]
     }
 }
 
@@ -55,6 +55,7 @@ public struct Platform: Equatable, Hashable {
     public static let tvOS: Platform = Platform(name: "tvos", oldestSupportedVersion: "9.0")
     public static let watchOS: Platform = Platform(name: "watchos", oldestSupportedVersion: "2.0")
     public static let linux: Platform = Platform(name: "linux", oldestSupportedVersion: .unknown)
+    public static let android: Platform = Platform(name: "android", oldestSupportedVersion: .unknown)
 }
 
 /// Represents a platform version.

--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -312,7 +312,7 @@ public final class Process: ObjectIdentifierProtocol {
         try _process?.run()
       #else
         // Initialize the spawn attributes.
-      #if canImport(Darwin)
+      #if canImport(Darwin) || os(Android)
         var attributes: posix_spawnattr_t? = nil
       #else
         var attributes = posix_spawnattr_t()
@@ -357,7 +357,7 @@ public final class Process: ObjectIdentifierProtocol {
         posix_spawnattr_setflags(&attributes, Int16(flags))
 
         // Setup the file actions.
-      #if canImport(Darwin)
+      #if canImport(Darwin) || os(Android)
         var fileActions: posix_spawn_file_actions_t? = nil
       #else
         var fileActions = posix_spawn_file_actions_t()

--- a/Sources/TSCLibc/libc.swift
+++ b/Sources/TSCLibc/libc.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-#if os(Linux)
+#if canImport(Glibc)
 @_exported import Glibc
 #elseif os(Windows)
 @_exported import MSVCRT

--- a/Sources/TSCUtility/FSWatch.swift
+++ b/Sources/TSCUtility/FSWatch.swift
@@ -428,55 +428,76 @@ public final class Inotify {
 // FIXME: <rdar://problem/45794219> Swift should provide shims for FD_ macros
 
 private func FD_ZERO(_ set: inout fd_set) {
+      #if os(Android)
+	set.fds_bits = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+      #else
 	set.__fds_bits = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+      #endif
 }
 
 private func FD_SET(_ fd: Int32, _ set: inout fd_set) {
     let intOffset = Int(fd / 16)
     let bitOffset = Int(fd % 16)
+  #if os(Android)
+    var fd_bits = set.fds_bits
+    let mask: UInt = 1 << bitOffset
+  #else
+    var fd_bits = set.__fds_bits
     let mask = 1 << bitOffset
+  #endif
     switch intOffset {
-        case 0: set.__fds_bits.0 = set.__fds_bits.0 | mask
-        case 1: set.__fds_bits.1 = set.__fds_bits.1 | mask
-        case 2: set.__fds_bits.2 = set.__fds_bits.2 | mask
-        case 3: set.__fds_bits.3 = set.__fds_bits.3 | mask
-        case 4: set.__fds_bits.4 = set.__fds_bits.4 | mask
-        case 5: set.__fds_bits.5 = set.__fds_bits.5 | mask
-        case 6: set.__fds_bits.6 = set.__fds_bits.6 | mask
-        case 7: set.__fds_bits.7 = set.__fds_bits.7 | mask
-        case 8: set.__fds_bits.8 = set.__fds_bits.8 | mask
-        case 9: set.__fds_bits.9 = set.__fds_bits.9 | mask
-        case 10: set.__fds_bits.10 = set.__fds_bits.10 | mask
-        case 11: set.__fds_bits.11 = set.__fds_bits.11 | mask
-        case 12: set.__fds_bits.12 = set.__fds_bits.12 | mask
-        case 13: set.__fds_bits.13 = set.__fds_bits.13 | mask
-        case 14: set.__fds_bits.14 = set.__fds_bits.14 | mask
-        case 15: set.__fds_bits.15 = set.__fds_bits.15 | mask
+        case 0: fd_bits.0 = fd_bits.0 | mask
+        case 1: fd_bits.1 = fd_bits.1 | mask
+        case 2: fd_bits.2 = fd_bits.2 | mask
+        case 3: fd_bits.3 = fd_bits.3 | mask
+        case 4: fd_bits.4 = fd_bits.4 | mask
+        case 5: fd_bits.5 = fd_bits.5 | mask
+        case 6: fd_bits.6 = fd_bits.6 | mask
+        case 7: fd_bits.7 = fd_bits.7 | mask
+        case 8: fd_bits.8 = fd_bits.8 | mask
+        case 9: fd_bits.9 = fd_bits.9 | mask
+        case 10: fd_bits.10 = fd_bits.10 | mask
+        case 11: fd_bits.11 = fd_bits.11 | mask
+        case 12: fd_bits.12 = fd_bits.12 | mask
+        case 13: fd_bits.13 = fd_bits.13 | mask
+        case 14: fd_bits.14 = fd_bits.14 | mask
+        case 15: fd_bits.15 = fd_bits.15 | mask
         default: break
     }
+  #if os(Android)
+    set.fds_bits = fd_bits
+  #else
+    set.__fds_bits = fd_bits
+  #endif
 }
 
 private func FD_ISSET(_ fd: Int32, _ set: inout fd_set) -> Bool {
     let intOffset = Int(fd / 32)
     let bitOffset = Int(fd % 32)
+  #if os(Android)
+    let fd_bits = set.fds_bits
+    let mask: UInt = 1 << bitOffset
+  #else
+    let fd_bits = set.__fds_bits
     let mask = 1 << bitOffset
+  #endif
     switch intOffset {
-        case 0: return set.__fds_bits.0 & mask != 0
-        case 1: return set.__fds_bits.1 & mask != 0
-        case 2: return set.__fds_bits.2 & mask != 0
-        case 3: return set.__fds_bits.3 & mask != 0
-        case 4: return set.__fds_bits.4 & mask != 0
-        case 5: return set.__fds_bits.5 & mask != 0
-        case 6: return set.__fds_bits.6 & mask != 0
-        case 7: return set.__fds_bits.7 & mask != 0
-        case 8: return set.__fds_bits.8 & mask != 0
-        case 9: return set.__fds_bits.9 & mask != 0
-        case 10: return set.__fds_bits.10 & mask != 0
-        case 11: return set.__fds_bits.11 & mask != 0
-        case 12: return set.__fds_bits.12 & mask != 0
-        case 13: return set.__fds_bits.13 & mask != 0
-        case 14: return set.__fds_bits.14 & mask != 0
-        case 15: return set.__fds_bits.15 & mask != 0
+        case 0: return fd_bits.0 & mask != 0
+        case 1: return fd_bits.1 & mask != 0
+        case 2: return fd_bits.2 & mask != 0
+        case 3: return fd_bits.3 & mask != 0
+        case 4: return fd_bits.4 & mask != 0
+        case 5: return fd_bits.5 & mask != 0
+        case 6: return fd_bits.6 & mask != 0
+        case 7: return fd_bits.7 & mask != 0
+        case 8: return fd_bits.8 & mask != 0
+        case 9: return fd_bits.9 & mask != 0
+        case 10: return fd_bits.10 & mask != 0
+        case 11: return fd_bits.11 & mask != 0
+        case 12: return fd_bits.12 & mask != 0
+        case 13: return fd_bits.13 & mask != 0
+        case 14: return fd_bits.14 & mask != 0
+        case 15: return fd_bits.15 & mask != 0
         default: return false
     }
 }

--- a/Sources/TSCUtility/IndexStore.swift
+++ b/Sources/TSCUtility/IndexStore.swift
@@ -193,6 +193,8 @@ public final class IndexStoreAPI {
         self.path = path
 #if os(Windows)
         let flags: DLOpenFlags = []
+#elseif os(Android)
+        let flags: DLOpenFlags = [.lazy, .local, .first]
 #else
         let flags: DLOpenFlags = [.lazy, .local, .first, .deepBind]
 #endif

--- a/Sources/TSCUtility/InterruptHandler.swift
+++ b/Sources/TSCUtility/InterruptHandler.swift
@@ -65,6 +65,8 @@ public final class InterruptHandler {
         var action = sigaction()
       #if canImport(Darwin)
         action.__sigaction_u.__sa_handler = signalHandler
+      #elseif os(Android)
+        action.sa_handler = signalHandler
       #else
         action.__sigaction_handler = unsafeBitCast(
             signalHandler,

--- a/Sources/TSCUtility/Platform.swift
+++ b/Sources/TSCUtility/Platform.swift
@@ -13,6 +13,7 @@ import Foundation
 
 /// Recognized Platform types.
 public enum Platform {
+    case android
     case darwin
     case linux(LinuxFlavor)
 
@@ -32,6 +33,10 @@ public enum Platform {
         case "linux":
             if localFileSystem.isFile(AbsolutePath("/etc/debian_version")) {
                 return .linux(.debian)
+            }
+            if localFileSystem.isFile(AbsolutePath("/system/bin/toolbox")) ||
+               localFileSystem.isFile(AbsolutePath("/system/bin/toybox")) {
+                return .android
             }
         default:
             return nil

--- a/Sources/TSCUtility/dlopen.swift
+++ b/Sources/TSCUtility/dlopen.swift
@@ -60,7 +60,9 @@ public struct DLOpenFlags: RawRepresentable, OptionSet {
     public static let deepBind: DLOpenFlags = DLOpenFlags(rawValue: 0)
   #else
     public static let first: DLOpenFlags = DLOpenFlags(rawValue: 0)
+  #if !os(Android)
     public static let deepBind: DLOpenFlags = DLOpenFlags(rawValue: RTLD_DEEPBIND)
+  #endif
   #endif
   #endif
 

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -439,7 +439,7 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testUnicode() {
-        #if !os(Linux) // TODO: - Linux has trouble with this and needs investigation.
+        #if !os(Linux) && !os(Android) // TODO: - Linux has trouble with this and needs investigation.
         fixture(name: "Miscellaneous/Unicode") { prefix in
             // See the fixture manifest for an explanation of this string.
             let complicatedString = "πשּׁµ𝄞🇺🇳🇮🇱x̱̱̱̱̱̄̄̄̄̄"

--- a/Tests/FunctionalTests/ModuleMapTests.swift
+++ b/Tests/FunctionalTests/ModuleMapTests.swift
@@ -26,7 +26,7 @@ class ModuleMapsTestCase: XCTestCase {
             try systemQuietly(["clang", "-shared", input.pathString, "-o", output.pathString])
 
             var Xld = ["-L", outdir.pathString]
-        #if os(Linux)
+        #if os(Linux) || os(Android)
             Xld += ["-rpath", outdir.pathString]
         #endif
 

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -1376,6 +1376,7 @@ class PackageBuilderTests: XCTestCase {
             "ios": "8.0",
             "tvos": "9.0",
             "watchos": "2.0",
+            "android": "0.0",
         ]
 
         PackageBuilderTester(manifest, in: fs) { result in
@@ -1411,6 +1412,7 @@ class PackageBuilderTests: XCTestCase {
             "linux": "0.0",
             "ios": "8.0",
             "watchos": "2.0",
+            "android": "0.0",
         ]
 
         PackageBuilderTester(manifest, in: fs) { result in

--- a/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/Tests/TSCBasicTests/FileSystemTests.swift
@@ -391,7 +391,7 @@ class FileSystemTests: XCTestCase {
     }
 
     func testSetAttribute() throws {
-      #if os(macOS) || os(Linux)
+      #if os(macOS) || os(Linux) || os(Android)
         mktmpdir { path in
             let fs = TSCBasic.localFileSystem
 


### PR DESCRIPTION
This pull was used to build SPM natively on Android in [the Termux app](https://termux.com/), similar to apple/swift#27167. The first commit consists of compile-time changes that were needed to build SPM itself natively on an Android host, whereas the second commit adds some support for using SPM to build for Android. None of the second commit was needed to run the SPM tests on Android, so any of it can be removed if it interferes with any other plans for Android compilation, though there's currently only two mentions of Android in the SPM source.

This pull was tested against the 10/24 source snapshot and out of 623 test cases run, it reports 72 failing. Most are related to looking for PackageDescription4 and other dependencies of SPM itself, [which fails here because it can't find them relative to the test case's temporary path](https://github.com/apple/swift-package-manager/blob/e266c21086e36e16fc05e9af85e223c7afbe6c01/Sources/PackageLoading/PackageBuilder.swift#L482). A couple `print`s show that that code path isn't hit on linux, but I'm not familiar enough with the SPM source yet to fix that. In the meantime, I thought I'd get the rest of these changes in.

I also had to disable interpreting the SPM manifest to generate the JSON version when bootstrapping, similar to #2363, instead extracting the same command and generating the JSON by compiling the source. Finally, I had to tweak the bootstrap script:
```
diff --git a/Utilities/bootstrap b/Utilities/bootstrap
index 765b2488..afd9b09c 100755
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -265,6 +265,7 @@ class Target(object):
         if args.foundation_path:
             import_paths.append(args.foundation_path)
             other_args.extend(["-Xcc", "-F" + args.foundation_path])
+            other_args.extend(["-Xcc", "-D__ANDROID_API__=23", "-Xcc", "-U_GNU_SOURCE"])
             import_paths.append(os.path.join(args.foundation_path, "swift"))
         if args.libdispatch_build_dir:
             import_paths.append(os.path.join(args.libdispatch_build_dir, 'lib'))
@@ -583,6 +584,7 @@ class llbuild(object):
                 if platform.system() == 'Linux':
                     link_command.extend(
                         ["-Xlinker", "-rpath=$ORIGIN/../lib/swift/linux"])
+                    link_command.extend(["-Xlinker", "-landroid-spawn"])
                 if self.args.foundation_path:
                     link_command.extend([
                         "-L", self.args.foundation_path,
@@ -1063,7 +1065,15 @@ def main():
     # Compute the build paths.
     if platform.system() == 'Darwin':
         build_target = "x86_64-apple-macosx"
-    elif platform.system() == 'Linux':              
+    elif platform.system() == 'Linux':
+        if 'ANDROID_DATA' in os.environ:
+            if platform.machine().startswith("armv7"):
+                build_target = 'armv7-unknown-linux-androideabi'
+            elif platform.machine() == 'aarch64':
+                build_target = 'aarch64-unknown-linux-android'
+            else:
+                raise SystemExit("ERROR: unsupported Android platform:",platform.machine())
+
         if platform.machine() == 'x86_64':
             build_target = "x86_64-unknown-linux-gnu"
         elif platform.machine() == "i686":
@@ -1075,7 +1085,7 @@ def main():
         elif platform.machine().startswith("armv7"):
             build_target = 'armv7-unknown-linux-gnueabihf'
         elif platform.machine() == 'aarch64':
-            build_target = 'aarch64-unknown-linux'
+            build_target = 'aarch64-unknown-linux-android'
         else:
             raise SystemExit("ERROR: unsupported machine:",platform.machine())
     elif platform.system() == 'Windows':
@@ -1269,6 +1279,7 @@ def main():
         else:
             embed_rpath = "@executable_path/../lib/swift/macosx"
     build_flags.extend(["-Xlinker", "-rpath", "-Xlinker", embed_rpath])
+    build_flags.extend(["-Xlinker", "-landroid-spawn"])
     if args.verbose:
         build_flags.append("-v")
 
@@ -1282,6 +1293,8 @@ def main():
         # Pass -F flag for CoreFoundation.
         build_flags.extend(["-Xswiftc", "-Xcc", "-Xswiftc", "-F{}".format(faketoolchain_includedir)])
 
+        build_flags.extend(["-Xswiftc", "-Xcc", "-Xswiftc", "-D__ANDROID_API__=23"])
+        build_flags.extend(["-Xswiftc", "-Xcc", "-Xswiftc", "-U_GNU_SOURCE"])
         # Pass -I for underlying Dispatch module.
         build_flags.extend(["-Xswiftc", "-I{}".format(os.path.join(faketoolchain_includedir, "dispatch"))])
 ```
The two preprocessor definitions are needed because [Bionic's `strerror_r` used to return a different type before API 23](https://android.googlesource.com/platform/bionic/+/master/libc/include/string.h#96); linking against android-spawn because Termux backported and shipped `posix_spawn` in a separate library; and I'm unsure why that last `build_target` change was needed, given the prior change for Android (without it, two directories are created with both names and the build errors out). I plan to try cross-compiling SPM itself for Android, so I'll submit a pull for all those build changes later.

Two other minor issues while I'm here:
- The build output warns against [calling `-fmodules-cache-path` on clang from the bootstrap script](https://github.com/apple/swift-package-manager/blob/3dcd3a314a0bbe6bafad315126d2d810bd8da1ff/Utilities/bootstrap#L300), on both Android and [linux](https://forums.swift.org/t/swift-build-failure-on-aur-package/30328):
```
clang-8: warning: argument unused during compilation: '-fmodules-cache-path=/home/pacman/aur/swift-language/src/build/Ninja-ReleaseAssert/swiftpm-linux-x86_64/.bootstrap/ModuleCache' [-Wunused-command-line-argument]
```
I'm guessing it's expected that Swift's forked clang is used, but unless it's installed in the system itself, the bootstrap script isn't configured that way. I'm unsure if this was intended or if it matters.
- I don't think the bootstrap script compiles in parallel, would be worthwhile to add that to speed up full rebuilds. I saw nice speed gains when Saleem added that for Foundation, apple/swift-corelibs-foundation#2129.