### PR TITLE
[Build] Provide correct rpath for macOS test bundles

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1123,7 +1123,8 @@ public final class ProductBuildDescription {
         if buildParameters.triple.isLinux() {
             args += ["-Xlinker", "-rpath=$ORIGIN"]
         } else if buildParameters.triple.isDarwin() {
-            args += ["-Xlinker", "-rpath", "-Xlinker", "@loader_path"]
+            let rpath = product.type == .test ? "@loader_path/../../../" : "@loader_path"
+            args += ["-Xlinker", "-rpath", "-Xlinker", rpath]
         }
         args += ["@\(linkFileListPath.pathString)"]
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -609,7 +609,7 @@ final class BuildPlanTests: XCTestCase {
             "/fake/path/to/swiftc", "-L", "/path/to/build/debug", "-o",
             "/path/to/build/debug/PkgPackageTests.xctest/Contents/MacOS/PkgPackageTests", "-module-name",
             "PkgPackageTests", "-Xlinker", "-bundle",
-            "-Xlinker", "-rpath", "-Xlinker", "@loader_path",
+            "-Xlinker", "-rpath", "-Xlinker", "@loader_path/../../../",
             "@/path/to/build/debug/PkgPackageTests.product/Objects.LinkFileList",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift/macosx",
             "-target", "x86_64-apple-macosx10.10",


### PR DESCRIPTION
This will allow test bundles to find any linked dylibs in the build
directory.

<rdar://problem/56793593>