### PR TITLE
Adding support for glibc 2.30

### DIFF
--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -366,9 +366,9 @@ public final class Process: ObjectIdentifierProtocol {
         defer { posix_spawn_file_actions_destroy(&fileActions) }
 
         // Workaround for https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=89e435f3559c53084498e9baad22172b64429362
-	// Change allowing for newer version of glibc
-	guard let devNull = strdup("/dev/null") as Optional else {
-	    throw SystemError.posix_spawn(0, arguments)
+        // Change allowing for newer version of glibc
+        guard let devNull = strdup("/dev/null") as Optional else {
+            throw SystemError.posix_spawn(0, arguments)
         }
         defer { free(devNull) }
         // Open /dev/null as stdin.

--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -366,7 +366,10 @@ public final class Process: ObjectIdentifierProtocol {
         defer { posix_spawn_file_actions_destroy(&fileActions) }
 
         // Workaround for https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=89e435f3559c53084498e9baad22172b64429362
-        let devNull = strdup("/dev/null")
+	// Change allowing for newer version of glibc
+	guard let devNull = strdup("/dev/null") as Optional else {
+	    throw SystemError.posix_spawn(0, arguments)
+        }
         defer { free(devNull) }
         // Open /dev/null as stdin.
         posix_spawn_file_actions_addopen(&fileActions, 0, devNull, O_RDONLY, 0)
@@ -392,7 +395,7 @@ public final class Process: ObjectIdentifierProtocol {
 
         let argv = CStringArray(arguments)
         let env = CStringArray(environment.map({ "\($0.0)=\($0.1)" }))
-        let rv = posix_spawnp(&processID, argv.cArray[0], &fileActions, &attributes, argv.cArray, env.cArray)
+        let rv = posix_spawnp(&processID, (argv.cArray[0] as Optional)!, &fileActions, &attributes, argv.cArray, env.cArray)
 
         guard rv == 0 else {
             throw SystemError.posix_spawn(rv, arguments)

--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -367,7 +367,7 @@ public final class Process: ObjectIdentifierProtocol {
 
         // Workaround for https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=89e435f3559c53084498e9baad22172b64429362
         // Change allowing for newer version of glibc
-        guard let devNull = strdup("/dev/null") as Optional else {
+        guard let devNull = strdup("/dev/null") else {
             throw SystemError.posix_spawn(0, arguments)
         }
         defer { free(devNull) }

--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -395,7 +395,7 @@ public final class Process: ObjectIdentifierProtocol {
 
         let argv = CStringArray(arguments)
         let env = CStringArray(environment.map({ "\($0.0)=\($0.1)" }))
-        let rv = posix_spawnp(&processID, (argv.cArray[0] as Optional)!, &fileActions, &attributes, argv.cArray, env.cArray)
+        let rv = posix_spawnp(&processID, argv.cArray[0]!, &fileActions, &attributes, argv.cArray, env.cArray)
 
         guard rv == 0 else {
             throw SystemError.posix_spawn(rv, arguments)


### PR DESCRIPTION
On systems like Fedora and Arch, glibc 2.30 is the default version, this PR fixes some errors compiling SwiftPM.

This have been tested and compiles on the latest Arch Linux using glibc 2.30, i haven't tested on Ubuntu, since i figure there are CI in place to test that :)