### PR TITLE
Remove TSCBasic.Dictionary.init(items:)

### DIFF
--- a/Sources/PackageGraph/PinsStore.swift
+++ b/Sources/PackageGraph/PinsStore.swift
@@ -131,7 +131,7 @@ extension PinsStore: SimplePersistanceProtocol {
     }
 
     public func restore(from json: JSON) throws {
-        self.pinsMap = try Dictionary(items: json.get("pins").map({ ($0.packageRef.identity, $0) }))
+        self.pinsMap = try Dictionary(uniqueKeysWithValues: json.get("pins").map({ ($0.packageRef.identity, $0) }))
     }
 
     /// Saves the current state of pins.

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -519,8 +519,8 @@ public final class PackageBuilder {
         }
 
         let targetItems = manifest.targets.map({ ($0.name, $0 as TargetDescription) })
-        let targetMap = Dictionary(uniqueKeysWithValues: targetItems)
-        let potentialModuleMap = Dictionary(uniqueKeysWithValues: potentialModules.map({ ($0.name, $0) }))
+        let targetMap = Dictionary(targetItems, uniquingKeysWith: { $1 })
+        let potentialModuleMap = Dictionary(potentialModules.map({ ($0.name, $0) }), uniquingKeysWith: { $1 })
         let successors: (PotentialModule) -> [PotentialModule] = {
             // No reference of this target in manifest, i.e. it has no dependencies.
             guard let target = targetMap[$0.name] else { return [] }
@@ -984,7 +984,7 @@ public final class PackageBuilder {
         }
 
         // Map containing targets mapped to their names.
-        let modulesMap = Dictionary(uniqueKeysWithValues: targets.map({ ($0.name, $0) }))
+        let modulesMap = Dictionary(targets.map({ ($0.name, $0) }), uniquingKeysWith: { $1 })
 
         /// Helper method to get targets from target names.
         func modulesFrom(targetNames names: [String], product: String) throws -> [Target] {

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -519,8 +519,8 @@ public final class PackageBuilder {
         }
 
         let targetItems = manifest.targets.map({ ($0.name, $0 as TargetDescription) })
-        let targetMap = Dictionary(items: targetItems)
-        let potentialModuleMap = Dictionary(items: potentialModules.map({ ($0.name, $0) }))
+        let targetMap = Dictionary(uniqueKeysWithValues: targetItems)
+        let potentialModuleMap = Dictionary(uniqueKeysWithValues: potentialModules.map({ ($0.name, $0) }))
         let successors: (PotentialModule) -> [PotentialModule] = {
             // No reference of this target in manifest, i.e. it has no dependencies.
             guard let target = targetMap[$0.name] else { return [] }
@@ -984,7 +984,7 @@ public final class PackageBuilder {
         }
 
         // Map containing targets mapped to their names.
-        let modulesMap = Dictionary(items: targets.map({ ($0.name, $0) }))
+        let modulesMap = Dictionary(uniqueKeysWithValues: targets.map({ ($0.name, $0) }))
 
         /// Helper method to get targets from target names.
         func modulesFrom(targetNames names: [String], product: String) throws -> [Target] {

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -50,7 +50,7 @@ extension Manifest {
         let regex = try! RegEx(pattern: "^Package@swift-(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?.swift$")
 
         // Collect all version-specific manifests at the given package path.
-        let versionSpecificManifests = Dictionary(uniqueKeysWithValues: contents.compactMap{ file -> (ToolsVersion, String)? in
+        let versionSpecificManifests = Dictionary(contents.compactMap{ file -> (ToolsVersion, String)? in
             let parsedVersion = regex.matchGroups(in: file)
             guard parsedVersion.count == 1, parsedVersion[0].count == 3 else {
                 return nil
@@ -61,7 +61,7 @@ extension Manifest {
             let patch = parsedVersion[0][2].isEmpty ? 0 : Int(parsedVersion[0][2])!
 
             return (ToolsVersion(version: Version(major, minor, patch)), file)
-        })
+        }, uniquingKeysWith: { $1 })
 
         let regularManifest = packagePath.appending(component: filename)
         let toolsVersionLoader = ToolsVersionLoader(currentToolsVersion: currentToolsVersion)

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -50,7 +50,7 @@ extension Manifest {
         let regex = try! RegEx(pattern: "^Package@swift-(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?.swift$")
 
         // Collect all version-specific manifests at the given package path.
-        let versionSpecificManifests = Dictionary(items: contents.compactMap{ file -> (ToolsVersion, String)? in
+        let versionSpecificManifests = Dictionary(uniqueKeysWithValues: contents.compactMap{ file -> (ToolsVersion, String)? in
             let parsedVersion = regex.matchGroups(in: file)
             guard parsedVersion.count == 1, parsedVersion[0].count == 3 else {
                 return nil

--- a/Sources/SPMTestSupport/MockDependencyGraph.swift
+++ b/Sources/SPMTestSupport/MockDependencyGraph.swift
@@ -102,7 +102,7 @@ public struct MockManifestGraph {
         repoProvider = inMemory?.provider
         // Create the test repositories, we don't need them to have actual
         // contents (the manifests are mocked).
-        let repos = Dictionary(items: try packages.map({ package -> (String, RepositorySpecifier) in
+        let repos = Dictionary(uniqueKeysWithValues: try packages.map({ package -> (String, RepositorySpecifier) in
             let repoPath = path.appending(component: package.name)
             let tag = package.version?.description ?? "initial"
             let specifier = RepositorySpecifier(url: repoPath.pathString)
@@ -150,7 +150,7 @@ public struct MockManifestGraph {
         )
 
         // Create the manifests from mock packages.
-        var manifests = Dictionary(items: packages.map({ package -> (MockManifestLoader.Key, Manifest) in
+        var manifests = Dictionary(uniqueKeysWithValues: packages.map({ package -> (MockManifestLoader.Key, Manifest) in
             let url = repos[package.name]!.url
             let manifest = Manifest(
                 name: package.name,

--- a/Sources/SPMTestSupport/MockDependencyResolver.swift
+++ b/Sources/SPMTestSupport/MockDependencyResolver.swift
@@ -203,7 +203,7 @@ public struct MockPackagesProvider: PackageContainerProvider {
 
     public init(containers: [MockPackageContainer]) {
         self.containers = containers
-        self.containersByIdentifier = Dictionary(items: containers.map({ ($0.identifier, $0) }))
+        self.containersByIdentifier = Dictionary(uniqueKeysWithValues: containers.map({ ($0.identifier, $0) }))
     }
 
     public func getContainer(
@@ -255,7 +255,7 @@ public struct MockGraph {
         guard case let .array(containers)? = dict["containers"] else { fatalError() }
         guard case let .dictionary(result)? = dict["result"] else { fatalError() }
 
-        self.result = Dictionary(items: result.map({ value in
+        self.result = Dictionary(uniqueKeysWithValues: result.map({ value in
             let (container, version) = value
             guard case let .string(str) = version else { fatalError() }
             return (container.lowercased(), Version(string: str)!)

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -390,7 +390,7 @@ extension RepositoryManager: SimplePersistanceProtocol {
         // We will use this to save the state so we don't have to read the other
         // handles when saving the sate of a handle.
         self.serializedRepositories = try json.get("repositories")
-        self.repositories = try Dictionary(items: serializedRepositories.map({
+        self.repositories = try Dictionary(uniqueKeysWithValues: serializedRepositories.map({
             try ($0.0, RepositoryHandle(manager: self, json: $0.1))
         }))
     }

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -390,9 +390,9 @@ extension RepositoryManager: SimplePersistanceProtocol {
         // We will use this to save the state so we don't have to read the other
         // handles when saving the sate of a handle.
         self.serializedRepositories = try json.get("repositories")
-        self.repositories = try Dictionary(uniqueKeysWithValues: serializedRepositories.map({
-            try ($0.0, RepositoryHandle(manager: self, json: $0.1))
-        }))
+        self.repositories = try serializedRepositories.mapValues({
+            try RepositoryHandle(manager: self, json: $0)
+        })
     }
 
     public func toJSON() -> JSON {

--- a/Sources/TSCBasic/DictionaryExtensions.swift
+++ b/Sources/TSCBasic/DictionaryExtensions.swift
@@ -9,22 +9,6 @@
 */
 
 extension Dictionary {
-    /// Convenience initializer to create dictionary from tuples.
-    public init<S: Sequence>(items: S) where S.Iterator.Element == (Key, Value) {
-        self.init(minimumCapacity: items.underestimatedCount)
-        for (key, value) in items {
-            self[key] = value
-        }
-    }
-
-    /// Convenience initializer to create dictionary from tuples.
-    public init<S: Sequence>(items: S) where S.Iterator.Element == (Key, Optional<Value>) {
-        self.init(minimumCapacity: items.underestimatedCount)
-        for (key, value) in items {
-            self[key] = value
-        }
-    }
-
     /// Returns a new dictionary containing the keys of this dictionary with the
     /// values transformed by the given closure, if transformed is not nil.
     public func spm_flatMapValues<T>(_ transform: (Value) throws -> T?) rethrows -> [Key: T] {

--- a/Sources/TSCBasic/JSON.swift
+++ b/Sources/TSCBasic/JSON.swift
@@ -278,7 +278,7 @@ extension JSON {
 
 extension JSON {
     public init(_ dict: [String: JSONSerializable]) {
-        self = .dictionary(Dictionary(items: dict.map({ ($0.0, $0.1.toJSON()) })))
+        self = .dictionary(Dictionary(uniqueKeysWithValues: dict.map({ ($0.0, $0.1.toJSON()) })))
     }
 }
 

--- a/Sources/TSCBasic/JSON.swift
+++ b/Sources/TSCBasic/JSON.swift
@@ -278,7 +278,7 @@ extension JSON {
 
 extension JSON {
     public init(_ dict: [String: JSONSerializable]) {
-        self = .dictionary(Dictionary(uniqueKeysWithValues: dict.map({ ($0.0, $0.1.toJSON()) })))
+        self = .dictionary(dict.mapValues({ $0.toJSON() }))
     }
 }
 

--- a/Sources/TSCBasic/JSONMapper.swift
+++ b/Sources/TSCBasic/JSONMapper.swift
@@ -65,7 +65,7 @@ extension JSON {
             throw MapError.typeMismatch(
                 key: key, expected: Dictionary<String, JSON>.self, json: object)
         }
-        return try Dictionary(uniqueKeysWithValues: value.map({ ($0.0, try T.init(json: $0.1)) }))
+        return try value.mapValues({ try T.init(json: $0) })
     }
 
     /// Returns a JSON mappable dictionary from a given key.

--- a/Sources/TSCBasic/JSONMapper.swift
+++ b/Sources/TSCBasic/JSONMapper.swift
@@ -65,7 +65,7 @@ extension JSON {
             throw MapError.typeMismatch(
                 key: key, expected: Dictionary<String, JSON>.self, json: object)
         }
-        return try Dictionary(items: value.map({ ($0.0, try T.init(json: $0.1)) }))
+        return try Dictionary(uniqueKeysWithValues: value.map({ ($0.0, try T.init(json: $0.1)) }))
     }
 
     /// Returns a JSON mappable dictionary from a given key.

--- a/Sources/TSCUtility/ArgumentParser.swift
+++ b/Sources/TSCUtility/ArgumentParser.swift
@@ -815,7 +815,7 @@ public final class ArgumentParser {
             }
             return result
         })
-        let optionsMap = Dictionary(items: optionsTuple)
+        let optionsMap = Dictionary(uniqueKeysWithValues: optionsTuple)
 
         // Create iterators.
         var positionalArgumentIterator = positionalArguments.makeIterator()

--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -296,7 +296,7 @@ public final class ManagedDependencies: SimplePersistanceProtocol {
     }
 
     public func restore(from json: JSON) throws {
-        self.dependencyMap = try Dictionary(items:
+        self.dependencyMap = try Dictionary(uniqueKeysWithValues:
             json.get("dependencies").map({ ($0.packageRef.path, $0) })
         )
     }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -186,7 +186,7 @@ public class Workspace {
         }
 
         func computePackageURLs() -> (required: Set<PackageReference>, missing: Set<PackageReference>) {
-            let manifestsMap: [String: Manifest] = Dictionary(items:
+            let manifestsMap: [String: Manifest] = Dictionary(uniqueKeysWithValues:
                 root.manifests.map({ (PackageReference.computeIdentity(packageURL: $0.url), $0) }) +
                 dependencies.map({ (PackageReference.computeIdentity(packageURL: $0.manifest.url), $0.manifest) }))
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1831,8 +1831,8 @@ private struct BuildPlanResult {
 
     init(plan: BuildPlan) {
         self.plan = plan
-        self.productMap = Dictionary(items: plan.buildProducts.map{ ($0.product.name, $0) })
-        self.targetMap = Dictionary(items: plan.targetMap.map{ ($0.0.name, $0.1) })
+        self.productMap = Dictionary(uniqueKeysWithValues: plan.buildProducts.map{ ($0.product.name, $0) })
+        self.targetMap = Dictionary(uniqueKeysWithValues: plan.targetMap.map{ ($0.0.name, $0.1) })
     }
 
     func checkTargetsCount(_ count: Int, file: StaticString = #file, line: UInt = #line) {

--- a/Tests/PackageGraphTests/DependencyResolverTests.swift
+++ b/Tests/PackageGraphTests/DependencyResolverTests.swift
@@ -986,7 +986,7 @@ private extension DependencyResolver {
         subjectTo allConstraints: [PackageReference: VersionSetSpecifier] = [:],
         excluding exclusions: [PackageReference: Set<Version>] = [:]
     ) -> AnySequence<VersionAssignmentSet> {
-        let constraints = Dictionary(items: allConstraints.map{ ($0.0, PackageRequirement.versionSet($0.1)) })
+        let constraints = Dictionary(uniqueKeysWithValues: allConstraints.map{ ($0.0, PackageRequirement.versionSet($0.1)) })
         return resolveSubtree(container, subjectTo: PackageContainerConstraintSet(constraints), excluding: exclusions)
     }
 }

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -1923,7 +1923,7 @@ public struct MockProvider: PackageContainerProvider {
 
     public init(containers: [MockContainer]) {
         self.containers = containers
-        self.containersByIdentifier = Dictionary(items: containers.map({ ($0.identifier, $0) }))
+        self.containersByIdentifier = Dictionary(uniqueKeysWithValues: containers.map({ ($0.identifier, $0) }))
     }
 
     public func getContainer(

--- a/Tests/PackageLoadingTests/PD4LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4LoadingTests.swift
@@ -94,7 +94,7 @@ class PackageDescription4LoadingTests: XCTestCase {
 
         loadManifest(stream.bytes) { manifest in
             XCTAssertEqual(manifest.name, "Trivial")
-            let targets = Dictionary(items:
+            let targets = Dictionary(uniqueKeysWithValues:
                 manifest.targets.map({ ($0.name, $0 as TargetDescription ) }))
             let foo = targets["foo"]!
             XCTAssertEqual(foo.name, "foo")
@@ -169,7 +169,7 @@ class PackageDescription4LoadingTests: XCTestCase {
             )
             """
        loadManifest(stream.bytes) { manifest in
-            let deps = Dictionary(items: manifest.dependencies.map{ ($0.url, $0) })
+            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.url, $0) })
             XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(url: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
             XCTAssertEqual(deps["/foo2"], PackageDependencyDescription(url: "/foo2", requirement: .upToNextMajor(from: "1.0.0")))
             XCTAssertEqual(deps["/foo3"], PackageDependencyDescription(url: "/foo3", requirement: .upToNextMinor(from: "1.0.0")))
@@ -193,7 +193,7 @@ class PackageDescription4LoadingTests: XCTestCase {
             )
             """
         loadManifest(stream.bytes) { manifest in
-            let products = Dictionary(items: manifest.products.map{ ($0.name, $0) })
+            let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })
             // Check tool.
             let tool = products["tool"]!
             XCTAssertEqual(tool.name, "tool")
@@ -251,7 +251,7 @@ class PackageDescription4LoadingTests: XCTestCase {
             )
             """
         loadManifest(stream.bytes) { manifest in
-            let targets = Dictionary(items:
+            let targets = Dictionary(uniqueKeysWithValues:
                 manifest.targets.map({ ($0.name, $0 as TargetDescription ) }))
 
             let foo = targets["Foo"]!
@@ -281,7 +281,7 @@ class PackageDescription4LoadingTests: XCTestCase {
             )
             """
         loadManifest(stream.bytes) { manifest in
-            let targets = Dictionary(items:
+            let targets = Dictionary(uniqueKeysWithValues:
                 manifest.targets.map({ ($0.name, $0 as TargetDescription ) }))
 
             let foo = targets["Foo"]!

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -82,7 +82,7 @@ class PackageDescription4_2LoadingTests: XCTestCase {
             XCTAssertEqual(manifest.name, "Trivial")
 
             // Check targets.
-            let targets = Dictionary(items:
+            let targets = Dictionary(uniqueKeysWithValues:
                 manifest.targets.map({ ($0.name, $0 as TargetDescription ) }))
             let foo = targets["foo"]!
             XCTAssertEqual(foo.name, "foo")
@@ -95,11 +95,11 @@ class PackageDescription4_2LoadingTests: XCTestCase {
             XCTAssertEqual(bar.dependencies, ["foo"])
 
             // Check dependencies.
-            let deps = Dictionary(items: manifest.dependencies.map{ ($0.url, $0) })
+            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.url, $0) })
             XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(url: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
 
             // Check products.
-            let products = Dictionary(items: manifest.products.map{ ($0.name, $0) })
+            let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })
 
             let tool = products["tool"]!
             XCTAssertEqual(tool.name, "tool")
@@ -285,7 +285,7 @@ class PackageDescription4_2LoadingTests: XCTestCase {
             )
             """
        loadManifest(stream.bytes) { manifest in
-            let deps = Dictionary(items: manifest.dependencies.map{ ($0.url, $0) })
+            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.url, $0) })
             XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(url: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
             XCTAssertEqual(deps["/foo2"], PackageDependencyDescription(url: "/foo2", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
 
@@ -337,7 +337,7 @@ class PackageDescription4_2LoadingTests: XCTestCase {
             )
             """
        loadManifest(stream.bytes) { manifest in
-            let targets = Dictionary(items:
+            let targets = Dictionary(uniqueKeysWithValues:
                 manifest.targets.map({ ($0.name, $0 as TargetDescription ) }))
             let foo = targets["foo"]!
             XCTAssertEqual(foo.name, "foo")

--- a/Tests/PackageLoadingTests/PD5LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5LoadingTests.swift
@@ -84,7 +84,7 @@ class PackageDescription5LoadingTests: XCTestCase {
             XCTAssertEqual(manifest.name, "Trivial")
 
             // Check targets.
-            let targets = Dictionary(items:
+            let targets = Dictionary(uniqueKeysWithValues:
                 manifest.targets.map({ ($0.name, $0 as TargetDescription ) }))
             let foo = targets["foo"]!
             XCTAssertEqual(foo.name, "foo")
@@ -97,11 +97,11 @@ class PackageDescription5LoadingTests: XCTestCase {
             XCTAssertEqual(bar.dependencies, ["foo"])
 
             // Check dependencies.
-            let deps = Dictionary(items: manifest.dependencies.map{ ($0.url, $0) })
+            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.url, $0) })
             XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(url: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
 
             // Check products.
-            let products = Dictionary(items: manifest.products.map{ ($0.name, $0) })
+            let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })
 
             let tool = products["tool"]!
             XCTAssertEqual(tool.name, "tool")
@@ -488,7 +488,7 @@ class PackageDescription5LoadingTests: XCTestCase {
             XCTAssertEqual(manifest.name, "Foo")
 
             // Check targets.
-            let targets = Dictionary(items:
+            let targets = Dictionary(uniqueKeysWithValues:
                 manifest.targets.map({ ($0.name, $0 as TargetDescription ) }))
             let foo = targets["foo"]!
             XCTAssertEqual(foo.name, "foo")

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -381,10 +381,10 @@ class GitRepositoryTests: XCTestCase {
             // Add a remote via git cli.
             try systemQuietly([Git.tool, "-C", testRepoPath.pathString, "remote", "add", "origin", "../foo"])
             // Test if it was added.
-            XCTAssertEqual(Dictionary(items: try repo.remotes().map { ($0.0, $0.1) }), ["origin": "../foo"])
+            XCTAssertEqual(Dictionary(uniqueKeysWithValues: try repo.remotes().map { ($0.0, $0.1) }), ["origin": "../foo"])
             // Change remote.
             try repo.setURL(remote: "origin", url: "../bar")
-            XCTAssertEqual(Dictionary(items: try repo.remotes().map { ($0.0, $0.1) }), ["origin": "../bar"])
+            XCTAssertEqual(Dictionary(uniqueKeysWithValues: try repo.remotes().map { ($0.0, $0.1) }), ["origin": "../bar"])
             // Try changing remote of non-existant remote.
             do {
                 try repo.setURL(remote: "fake", url: "../bar")

--- a/Tests/TSCBasicTests/DictionaryExtensionsTests.swift
+++ b/Tests/TSCBasicTests/DictionaryExtensionsTests.swift
@@ -14,12 +14,6 @@ import TSCBasic
 class DictionaryExtensionTests: XCTestCase {
 
     func testBasics() {
-        XCTAssertEqual(Dictionary(items: [("foo", 1), ("bar", 2)]), ["foo": 1, "bar": 2])
-        XCTAssertEqual(Dictionary(items: [(1, 1), (1, 2)]), [1: 2])
-
-        XCTAssertEqual(Dictionary(items: [(1, 1), (1, nil)]), [:])
-        XCTAssertEqual(Dictionary(items: [(1, 1), (2, nil), (3, 4)]), [1: 1, 3: 4])
-
         XCTAssertEqual(["foo": "1", "bar": "2", "baz": "f"].spm_flatMapValues({ Int($0) }), ["foo": 1, "bar": 2])
     }
 

--- a/Tests/TSCBasicTests/JSONMapperTests.swift
+++ b/Tests/TSCBasicTests/JSONMapperTests.swift
@@ -64,7 +64,7 @@ fileprivate struct Foo: JSONMappable, JSONSerializable {
             "bar": bar.toJSON(),
             "barOp": barOp.flatMap{$0.toJSON()} ?? .null,
             "barArray": .array(barArray.map{$0.toJSON()}),
-            "dict": .dictionary(Dictionary(items: dict.map{($0.0, .double($0.1))})),
+            "dict": .dictionary(Dictionary(uniqueKeysWithValues: dict.map{($0.0, .double($0.1))})),
         ])
     }
 

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -423,7 +423,7 @@ private class XcodeProjectResult {
 
     init(_ project: Xcode.Project) {
         self.project = project
-        self.targetMap = Dictionary(items: project.targets.map { target -> (String, Xcode.Target) in (target.name, target) })
+        self.targetMap = Dictionary(uniqueKeysWithValues: project.targets.map { target -> (String, Xcode.Target) in (target.name, target) })
     }
 
     func check(projectDir: String, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
Remove TSCBasic.Dictionary.init(items:) to favour using the new Standard Library Dictionary initialisers and replace all uses of it.