### PR TITLE
Fix bash completion script code

### DIFF
--- a/Sources/TSCUtility/ArgumentParserShellCompletion.swift
+++ b/Sources/TSCUtility/ArgumentParserShellCompletion.swift
@@ -18,8 +18,8 @@ extension ArgumentParser {
     /// Generates part of a completion script for the given shell.
     ///
     /// These aren't complete scripts, as some setup code is required. See
-    /// `Utilities/bash/completions` and `Utilities/zsh/_swift` for example
-    /// usage.
+    /// `Sources/Commands/Completions+bash.swift` and
+    /// `Sources/Commands/Completions+zsh.swift` for example usage.
     public func generateCompletionScript(for shell: Shell, on stream: OutputByteStream) {
         guard let commandName = commandName else { abort() }
         let name = "_\(commandName.replacingOccurrences(of: " ", with: "_"))"


### PR DESCRIPTION
The code that generates the bash-completion script didn't produce a
working script. The generated function was missing the variables for
the currently typed word (`$cur`) and the previously typed word (`$prev`).
The change also includes a call to the `complete` command to register
the function.

The tests were also updated to match the change.