### PR TITLE
Android: add bootstrap build support and fix tests

### DIFF
--- a/Sources/PackageLoading/Target+PkgConfig.swift
+++ b/Sources/PackageLoading/Target+PkgConfig.swift
@@ -118,6 +118,9 @@ extension SystemPackageProviderDescription {
             if case .linux(.debian) = platform {
                 return true
             }
+            if case .android = platform {
+                return true
+            }
         }
         return false
     }

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -111,7 +111,7 @@ class PackageBuilderTests: XCTestCase {
 
           #if os(Linux)
             result.checkDiagnostic("ignoring target 'MyPackageTests' in package 'MyPackage'; C language in tests is not yet supported")
-          #elseif os(macOS)
+          #elseif os(macOS) || os(Android)
             result.checkProduct("MyPackagePackageTests") { _ in }
           #endif
         }

--- a/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/Tests/TSCBasicTests/FileSystemTests.swift
@@ -181,7 +181,11 @@ class FileSystemTests: XCTestCase {
 
             // Check read/write against root.
             XCTAssertThrows(FileSystemError.ioError) {
+              #if os(Android)
+                _ = try fs.readFileContents(AbsolutePath("/system/"))
+              #else
                 _ = try fs.readFileContents(AbsolutePath("/"))
+              #endif
             }
             XCTAssertThrows(FileSystemError.isDirectory) {
                 try fs.writeFileContents(AbsolutePath("/"), bytes: [])

--- a/Tests/TSCBasicTests/PathShimTests.swift
+++ b/Tests/TSCBasicTests/PathShimTests.swift
@@ -64,16 +64,30 @@ class PathShimTests : XCTestCase {
 class WalkTests : XCTestCase {
 
     func testNonRecursive() {
+      #if os(Android)
+        let root = "/system"
+        var expected = [
+            AbsolutePath("\(root)/usr"),
+            AbsolutePath("\(root)/bin"),
+            AbsolutePath("\(root)/xbin")
+        ]
+      #else
+        let root = ""
         var expected = [
             AbsolutePath("/usr"),
             AbsolutePath("/bin"),
             AbsolutePath("/sbin")
         ]
-        for x in try! walk(AbsolutePath("/"), recursively: false) {
+      #endif
+        for x in try! walk(AbsolutePath("\(root)/"), recursively: false) {
             if let i = expected.firstIndex(of: x) {
                 expected.remove(at: i)
             }
+          #if os(Android)
+            XCTAssertEqual(3, x.components.count)
+          #else
             XCTAssertEqual(2, x.components.count)
+          #endif
         }
         XCTAssertEqual(expected.count, 0)
     }

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -270,6 +270,10 @@ class Target(object):
         if args.llbuild_link_framework:
             other_args.extend(["-F", args.llbuild_build_dir])
 
+        # Don't use GNU strerror_r on Android.
+        if 'ANDROID_DATA' in os.environ:
+            other_args.extend(["-Xcc", "-U_GNU_SOURCE"])
+
         print("    import-paths: %s" % json.dumps(import_paths), file=output)
         print("    other-args: %s" % json.dumps(other_args),
               file=output)
@@ -681,7 +685,7 @@ def process_runtime_libraries(build, args, lib_path):
         cmd = [args.swiftc_path, "-emit-library", "-o", runtime_lib_path,
                "-Xlinker", "--whole-archive",
                "-Xlinker", input_lib_path,
-               "-Xlinker", "--no-whole-archive", "-lswiftGlibc",
+               "-Xlinker", "--no-whole-archive", "-lswiftGlibc", "-lFoundation",
                "-Xlinker", "-rpath=$ORIGIN/../../linux"]
 
     # We need to pass one swift file here to bypass the "no input files"
@@ -1024,7 +1028,14 @@ def main():
     if platform.system() == 'Darwin':
         build_target = "x86_64-apple-macosx"
     elif platform.system() == 'Linux':              
-        if platform.machine() == 'x86_64':
+        if 'ANDROID_DATA' in os.environ:
+            if platform.machine().startswith("armv7"):
+                build_target = 'armv7-unknown-linux-androideabi'
+            elif platform.machine() == 'aarch64':
+                build_target = 'aarch64-unknown-linux-android'
+            else:
+                raise SystemExit("ERROR: unsupported Android platform:",platform.machine())
+        elif platform.machine() == 'x86_64':
             build_target = "x86_64-unknown-linux-gnu"
         elif platform.machine() == "i686":
             build_target = "i686-unknown-linux"
@@ -1174,6 +1185,10 @@ def main():
 
     # Append the versioning build flags.
     build_flags.extend(create_versoning_args(args))
+
+    # Don't use GNU strerror_r on Android.
+    if 'ANDROID_DATA' in os.environ:
+        build_flags.extend(["-Xswiftc", "-Xcc", "-Xswiftc", "-U_GNU_SOURCE"])
 
     # Add llbuild import flags.
     for import_path in llbuild_import_paths(args):


### PR DESCRIPTION
With this pull, I got SPM built natively on Android and all the tests passing with the Nov. 8 source snapshot from the master branch.