### PR TITLE
Conditional target dependencies manifest api

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -88,7 +88,10 @@ extension BuildParameters {
 
     /// Returns the scoped view of build settings for a given target.
     fileprivate func createScope(for target: ResolvedTarget) -> BuildSettings.Scope {
-        return BuildSettings.Scope(target.underlyingTarget.buildSettings, boundCondition: (currentPlatform, configuration))
+        return BuildSettings.Scope(
+            target.underlyingTarget.buildSettings,
+            environment: BuildEnvironment(platform: currentPlatform, configuration: configuration)
+        )
     }
 }
 

--- a/Sources/PackageDescription4/BuildSettings.swift
+++ b/Sources/PackageDescription4/BuildSettings.swift
@@ -45,7 +45,7 @@ public struct BuildConfiguration: Encodable {
 ///             .define("ENABLE_SOMETHING", .when(configuration: .release)),
 ///         ],
 ///         linkerSettings: [
-///             .linkLibrary("openssl", .when(platforms: [.linux])),
+///             .linkedLibrary("openssl", .when(platforms: [.linux])),
 ///         ]
 ///     ),
 public struct BuildSettingCondition: Encodable {
@@ -228,7 +228,7 @@ public struct SwiftSetting: Encodable {
     /// Use compilation conditions to only compile statements if a certain condition is true.
     /// For example, the Swift compiler will only compile the
     /// statements inside the `#if` block when `ENABLE_SOMETHING` is defined:
-    ///     
+    ///
     ///     #if ENABLE_SOMETHING
     ///        ...
     ///     #endif

--- a/Sources/PackageDescription4/Package.swift
+++ b/Sources/PackageDescription4/Package.swift
@@ -452,6 +452,7 @@ extension Target.Dependency: Encodable {
         case type
         case name
         case package
+        case condition
     }
 
     private enum Kind: String, Codable {
@@ -477,16 +478,19 @@ extension Target.Dependency: Encodable {
         }
       #else
         switch self {
-        case ._targetItem(let name):
+        case ._targetItem(let name, let condition):
             try container.encode(Kind.target, forKey: .type)
             try container.encode(name, forKey: .name)
-        case ._productItem(let name, let package):
+            try container.encode(condition, forKey: .condition)
+        case ._productItem(let name, let package, let condition):
             try container.encode(Kind.product, forKey: .type)
             try container.encode(name, forKey: .name)
             try container.encode(package, forKey: .package)
-        case ._byNameItem(let name):
+            try container.encode(condition, forKey: .condition)
+        case ._byNameItem(let name, let condition):
             try container.encode(Kind.byName, forKey: .type)
             try container.encode(name, forKey: .name)
+            try container.encode(condition, forKey: .condition)
         }
       #endif
     }

--- a/Sources/PackageDescription4/Target.swift
+++ b/Sources/PackageDescription4/Target.swift
@@ -33,9 +33,9 @@ public final class Target {
         case productItem(name: String, package: String?)
         case byNameItem(name: String)
       #else
-        case _targetItem(name: String)
-        case _productItem(name: String, package: String?)
-        case _byNameItem(name: String)
+        case _targetItem(name: String, condition: BuildSettingCondition?)
+        case _productItem(name: String, package: String?, condition: BuildSettingCondition?)
+        case _byNameItem(name: String, condition: BuildSettingCondition?)
       #endif
     }
 
@@ -490,11 +490,12 @@ extension Target.Dependency {
     ///
     /// - parameters:
     ///   - name: The name of the target.
+    @available(_PackageDescription, obsoleted: 5.2)
     public static func target(name: String) -> Target.Dependency {
       #if PACKAGE_DESCRIPTION_4
         return .targetItem(name: name)
       #else
-        return ._targetItem(name: name)
+        return ._targetItem(name: name, condition: nil)
       #endif
     }
 
@@ -508,21 +509,7 @@ extension Target.Dependency {
       #if PACKAGE_DESCRIPTION_4
         return .productItem(name: name, package: package)
       #else
-        return ._productItem(name: name, package: package)
-      #endif
-    }
-
-    /// Creates a dependency on a product from a package dependency.
-    ///
-    /// - parameters:
-    ///   - name: The name of the product.
-    ///   - package: The name of the package.
-    @available(_PackageDescription, introduced: 5.2)
-    public static func product(name: String, package: String) -> Target.Dependency {
-      #if PACKAGE_DESCRIPTION_4
-        return .productItem(name: name, package: package)
-      #else
-        return ._productItem(name: name, package: package)
+        return ._productItem(name: name, package: package, condition: nil)
       #endif
     }
 
@@ -531,13 +518,52 @@ extension Target.Dependency {
     ///
     /// - parameters:
     ///   - name: The name of the dependency, either a target or a product.
+    @available(_PackageDescription, obsoleted: 5.2)
     public static func byName(name: String) -> Target.Dependency {
       #if PACKAGE_DESCRIPTION_4
         return .byNameItem(name: name)
       #else
-        return ._byNameItem(name: name)
+        return ._byNameItem(name: name, condition: nil)
       #endif
     }
+
+  #if !PACKAGE_DESCRIPTION_4
+    /// Creates a dependency on a target in the same package.
+    ///
+    /// - parameters:
+    ///   - name: The name of the target.
+    ///   - condition: The condition under which the dependency is exercised.
+    @available(_PackageDescription, introduced: 5.2)
+    public static func target(name: String, condition: BuildSettingCondition? = nil) -> Target.Dependency {
+        return ._targetItem(name: name, condition: condition)
+    }
+
+    /// Creates a dependency on a product from a package dependency.
+    ///
+    /// - parameters:
+    ///   - name: The name of the product.
+    ///   - package: The name of the package.
+    ///   - condition: The condition under which the dependency is exercised.
+    @available(_PackageDescription, introduced: 5.2)
+    public static func product(
+        name: String,
+        package: String,
+        condition: BuildSettingCondition? = nil
+    ) -> Target.Dependency {
+        return ._productItem(name: name, package: package, condition: condition)
+    }
+
+    /// Creates a by-name dependency that resolves to either a target or a product but
+    /// after the package graph has been loaded.
+    ///
+    /// - parameters:
+    ///   - name: The name of the dependency, either a target or a product.
+    ///   - condition: The condition under which the dependency is exercised.
+    @available(_PackageDescription, introduced: 5.2)
+    public static func byName(name: String, condition: BuildSettingCondition? = nil) -> Target.Dependency {
+        return ._byNameItem(name: name, condition: condition)
+    }
+  #endif
 }
 
 // MARK: ExpressibleByStringLiteral
@@ -552,7 +578,7 @@ extension Target.Dependency: ExpressibleByStringLiteral {
       #if PACKAGE_DESCRIPTION_4
         self = .byNameItem(name: value)
       #else
-        self = ._byNameItem(name: value)
+        self = ._byNameItem(name: value, condition: nil)
       #endif
     }
 }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -275,14 +275,14 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                 for targetDependency in target.dependencies {
                     // If this is a target dependency (or byName that references a target), we don't need to check.
                     if case .target = targetDependency { continue }
-                    if case .byName(let name) = targetDependency, targetNames.contains(name) { continue }
+                    if case .byName(let name, _) = targetDependency, targetNames.contains(name) { continue }
 
                     // If we can't find the package dependency it references, the manifest is invalid.
                     if manifest.packageDependency(referencedBy: targetDependency) == nil {
                         let packageName: String
                         switch targetDependency {
-                        case .product(_, package: let name?),
-                             .byName(let name):
+                        case .product(_, package: let name?, _),
+                             .byName(let name, _):
                             packageName = name
                         default:
                             fatalError("Invalid case: this shouldn't be a target, or a product with no name")

--- a/Sources/PackageModel/PackageModel+Codable.swift
+++ b/Sources/PackageModel/PackageModel+Codable.swift
@@ -143,16 +143,19 @@ extension TargetDescription.Dependency: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
-        case let .target(a1):
+        case let .target(a1, a2):
             var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .target)
             try unkeyedContainer.encode(a1)
-        case let .product(a1, a2):
+            try unkeyedContainer.encode(a2)
+        case let .product(a1, a2, a3):
             var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .product)
             try unkeyedContainer.encode(a1)
             try unkeyedContainer.encode(a2)
-        case let .byName(a1):
+            try unkeyedContainer.encode(a3)
+        case let .byName(a1, a2):
             var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .byName)
             try unkeyedContainer.encode(a1)
+            try unkeyedContainer.encode(a2)
         }
     }
 
@@ -165,16 +168,19 @@ extension TargetDescription.Dependency: Codable {
         case .target:
             var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
             let a1 = try unkeyedValues.decode(String.self)
-            self = .target(name: a1)
+            let a2 = try unkeyedValues.decodeIfPresent(ManifestConditionDescription.self)
+            self = .target(name: a1, condition: a2)
         case .product:
             var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
             let a1 = try unkeyedValues.decode(String.self)
             let a2 = try unkeyedValues.decodeIfPresent(String.self)
-            self = .product(name: a1, package: a2)
+            let a3 = try unkeyedValues.decodeIfPresent(ManifestConditionDescription.self)
+            self = .product(name: a1, package: a2, condition: a3)
         case .byName:
             var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
             let a1 = try unkeyedValues.decode(String.self)
-            self = .byName(name: a1)
+            let a2 = try unkeyedValues.decodeIfPresent(ManifestConditionDescription.self)
+            self = .byName(name: a1, condition: a2)
         }
     }
 }

--- a/Sources/SPMTestSupport/TestWorkspace.swift
+++ b/Sources/SPMTestSupport/TestWorkspace.swift
@@ -494,9 +494,9 @@ public struct TestTarget {
     fileprivate func convert() -> TargetDescription {
         switch type {
         case .regular:
-            return TargetDescription(name: name, dependencies: dependencies.map({ .byName(name: $0) }), path: nil, exclude: [], sources: nil, publicHeadersPath: nil, type: .regular, settings: settings)
+            return TargetDescription(name: name, dependencies: dependencies.map({ .byName(name: $0, condition: nil) }), path: nil, exclude: [], sources: nil, publicHeadersPath: nil, type: .regular, settings: settings)
         case .test:
-            return TargetDescription(name: name, dependencies: dependencies.map({ .byName(name: $0) }), path: nil, exclude: [], sources: nil, publicHeadersPath: nil, type: .test, settings: settings)
+            return TargetDescription(name: name, dependencies: dependencies.map({ .byName(name: $0, condition: nil) }), path: nil, exclude: [], sources: nil, publicHeadersPath: nil, type: .test, settings: settings)
         }
     }
 }

--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -618,12 +618,12 @@ func xcodeProject(
             // Process each assignment of a build settings declaration.
             for assignment in assignments {
                 // Skip this assignment if it doesn't contain macOS platform.
-                if let platformsCondition = assignment.conditions.compactMap({ $0 as? BuildSettings.PlatformsCondition }).first {
+                if let platformsCondition = assignment.conditions.compactMap({ $0 as? PlatformsCondition }).first {
                     if !platformsCondition.platforms.contains(.macOS) {
                         continue
                     }
                 }
-                let config = assignment.conditions.compactMap({ $0 as? BuildSettings.ConfigurationCondition }).first?.config
+                let config = assignment.conditions.compactMap({ $0 as? ConfigurationCondition }).first?.configuration
                 appendSetting(assignment.value, forDecl: decl, to: xcodeTarget.buildSettings, config: config)
             }
         }

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -38,7 +38,7 @@ class PackageGraphPerfTests: XCTestCasePerf {
                 let name = "Foo\(pkg + 1)"
                 let depUrl = "/\(name)"
                 dependencies = [PackageDependencyDescription(name: name, url: depUrl, requirement: .upToNextMajor(from: "1.0.0"))]
-                targets = [TargetDescription(name: name, dependencies: [.byName(name: "Foo\(pkg + 1)")], path: ".")]
+                targets = [TargetDescription(name: name, dependencies: [.byName(name: name, condition: nil)], path: ".")]
             }
             // Create manifest.
             let manifest = Manifest(

--- a/Tests/PackageLoadingTests/PD4LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4LoadingTests.swift
@@ -68,7 +68,7 @@ class PackageDescription4LoadingTests: PackageDescriptionLoadingTests {
 
             let expectedDependencies: [TargetDescription.Dependency]
             expectedDependencies = [
-                .byName(name: "dep1"),
+                "dep1",
                 .target(name: "dep2"),
                 .product(name: "dep3", package: "Pkg"),
                 .product(name: "dep4"),

--- a/Tests/PackageLoadingTests/PD5_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5_2LoadingTests.swift
@@ -178,4 +178,36 @@ class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
             XCTAssertEqual(manifest.packageDependency(referencedBy: targetBar.dependencies[0]), nil)
         }
     }
+
+    func testConditionalTargetDependencies() throws {
+        let stream = BufferedOutputByteStream()
+        stream <<< """
+            import PackageDescription
+            let package = Package(
+                name: "Foo",
+                dependencies: [
+                    .package(path: "/Baz"),
+                ],
+                targets: [
+                    .target(name: "Foo", dependencies: [
+                        .target(name: "Biz"),
+                        .target(name: "Bar", condition: .when(platforms: [.linux])),
+                        .product(name: "Baz", package: "Baz", condition: .when(configuration: .release)),
+                        .byName(name: "Bar", condition: .when(platforms: [.watchOS, .iOS], configuration: .debug)),
+                    ]),
+                    .target(name: "Bar"),
+                    .target(name: "Biz"),
+                ]
+            )
+            """
+
+        loadManifest(stream.bytes) { manifest in
+            let dependencies = manifest.targets[0].dependencies
+
+            XCTAssertEqual(dependencies[0], .target(name: "Biz"))
+            XCTAssertEqual(dependencies[1], .target(name: "Bar", condition: .init(platformNames: ["linux"], config: nil)))
+            XCTAssertEqual(dependencies[2], .product(name: "Baz", package: "Baz", condition: .init(platformNames: [], config: "release")))
+            XCTAssertEqual(dependencies[3], .byName(name: "Bar", condition: .init(platformNames: ["watchos", "ios"], config: "debug")))
+        }
+    }
 }

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -1527,30 +1527,48 @@ class PackageBuilderTests: XCTestCase {
 
         PackageBuilderTester(manifest, in: fs) { result in
             result.checkModule("cbar") { result in
-                let scope = BuildSettings.Scope(result.target.buildSettings, boundCondition: (.macOS, .debug))
+                let scope = BuildSettings.Scope(
+                    result.target.buildSettings,
+                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                )
                 XCTAssertEqual(scope.evaluate(.GCC_PREPROCESSOR_DEFINITIONS), ["CCC=2", "CXX"])
                 XCTAssertEqual(scope.evaluate(.HEADER_SEARCH_PATHS), ["Sources/headers", "Sources/cppheaders"])
                 XCTAssertEqual(scope.evaluate(.OTHER_CFLAGS), ["-Icfoo", "-L", "cbar"])
                 XCTAssertEqual(scope.evaluate(.OTHER_CPLUSPLUSFLAGS), ["-Icxxfoo", "-L", "cxxbar"])
 
-                let releaseScope = BuildSettings.Scope(result.target.buildSettings, boundCondition: (.macOS, .release))
+                let releaseScope = BuildSettings.Scope(
+                    result.target.buildSettings,
+                    environment: BuildEnvironment(platform: .macOS, configuration: .release)
+                )
                 XCTAssertEqual(releaseScope.evaluate(.GCC_PREPROCESSOR_DEFINITIONS), ["CCC=2", "CXX", "RCXX"])
             }
 
             result.checkModule("bar") { result in
-                let scope = BuildSettings.Scope(result.target.buildSettings, boundCondition: (.linux, .debug))
+                let scope = BuildSettings.Scope(
+                    result.target.buildSettings,
+                    environment: BuildEnvironment(platform: .linux, configuration: .debug)
+                )
                 XCTAssertEqual(scope.evaluate(.SWIFT_ACTIVE_COMPILATION_CONDITIONS), ["SOMETHING", "LINUX"])
                 XCTAssertEqual(scope.evaluate(.OTHER_SWIFT_FLAGS), ["-Isfoo", "-L", "sbar"])
 
-                let rscope = BuildSettings.Scope(result.target.buildSettings, boundCondition: (.linux, .release))
+                let rscope = BuildSettings.Scope(
+                    result.target.buildSettings,
+                    environment: BuildEnvironment(platform: .linux, configuration: .release)
+                )
                 XCTAssertEqual(rscope.evaluate(.SWIFT_ACTIVE_COMPILATION_CONDITIONS), ["SOMETHING", "LINUX", "RLINUX"])
 
-                let mscope = BuildSettings.Scope(result.target.buildSettings, boundCondition: (.macOS, .debug))
+                let mscope = BuildSettings.Scope(
+                    result.target.buildSettings,
+                    environment: BuildEnvironment(platform: .macOS, configuration: .debug)
+                )
                 XCTAssertEqual(mscope.evaluate(.SWIFT_ACTIVE_COMPILATION_CONDITIONS), ["SOMETHING", "DMACOS"])
             }
 
             result.checkModule("exe") { result in
-                let scope = BuildSettings.Scope(result.target.buildSettings, boundCondition: (.linux, .debug))
+                let scope = BuildSettings.Scope(
+                    result.target.buildSettings,
+                    environment: BuildEnvironment(platform: .linux, configuration: .debug)
+                )
                 XCTAssertEqual(scope.evaluate(.LINK_LIBRARIES), ["sqlite3"])
                 XCTAssertEqual(scope.evaluate(.OTHER_LDFLAGS), ["-Ilfoo", "-L", "lbar"])
                 XCTAssertEqual(scope.evaluate(.LINK_FRAMEWORKS), [])
@@ -1558,7 +1576,10 @@ class PackageBuilderTests: XCTestCase {
                 XCTAssertEqual(scope.evaluate(.OTHER_CFLAGS), [])
                 XCTAssertEqual(scope.evaluate(.OTHER_CPLUSPLUSFLAGS), [])
 
-                let mscope = BuildSettings.Scope(result.target.buildSettings, boundCondition: (.iOS, .debug))
+                let mscope = BuildSettings.Scope(
+                    result.target.buildSettings,
+                    environment: BuildEnvironment(platform: .iOS, configuration: .debug)
+                )
                 XCTAssertEqual(mscope.evaluate(.LINK_LIBRARIES), ["sqlite3"])
                 XCTAssertEqual(mscope.evaluate(.LINK_FRAMEWORKS), ["CoreData"])
 

--- a/Tests/PackageLoadingTests/XCTestManifests.swift
+++ b/Tests/PackageLoadingTests/XCTestManifests.swift
@@ -130,6 +130,7 @@ extension PackageDescription5_2LoadingTests {
         ("testPackageName", testPackageName),
         ("testTargetDependencyProductInvalidPackage", testTargetDependencyProductInvalidPackage),
         ("testTargetDependencyReference", testTargetDependencyReference),
+        ("testConditionalTargetDependencies", testConditionalTargetDependencies),
     ]
 }
 


### PR DESCRIPTION
Manifest API changes to support a future conditional target dependencies evolution proposal.

* I reused the `BuildSettingsCondition` in `PackageDescription`.
* I created a `ManifestConditionDescription` type to hold conditions in the manifest `Target.Dependency` cases.
* I reused `BuildSettingsCondition` and renamed it to `ManifestCondition` to reflect its new status. Similarly, I moved `PlatformsCondition` and `ConfigurationCondition` into the global scope.

I also took the opportunity to make small improvements to the code:

* I created a new `BuildEnvironment` type to name the platform + config tuple.
* I added a `satisfies(_:)` requirement to the `ManifestCondition` protocol to move the verification logic into each conforming type.

Question: I wasn't sure if I could rename `BuildSettingsCondition` in `PackageDescription` without breaking backwards compatibility, so I left it as-is for now.

This PR is based on https://github.com/apple/swift-package-manager/pull/2422, so it needs to be merged before this one.