### PR TITLE
Build: add new `executableExtension` property (NFC)

### DIFF
--- a/Sources/Build/Triple.swift
+++ b/Sources/Build/Triple.swift
@@ -182,6 +182,17 @@ extension Triple {
         }
     }
 
+    public var executableExtension: String {
+      switch os {
+      case .darwin, .macOS:
+        return ""
+      case .linux:
+        return ""
+      case .windows:
+        return ".exe"
+      }
+    }
+
     /// The file extension for Foundation-style bundle.
     public var nsbundleExtension: String {
         switch os {


### PR DESCRIPTION
This adds a mirroring property `sharedLibraryExtension` to Triple for
computed values for the extensions.  This is important to ensure that we
will be able to cross-compile properly rather than hardcoding the
extension, which makes execution difficult.