### PR TITLE
Add support for the Scudo sanitizer.

### DIFF
--- a/Fixtures/Miscellaneous/DoubleFree/Package.swift
+++ b/Fixtures/Miscellaneous/DoubleFree/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version:5.1
+
+import PackageDescription
+
+let package = Package(
+    name: "double-free",
+    targets: [
+        .target(
+            name: "lib",
+            dependencies: []),
+        .target(
+            name: "exec",
+            dependencies: ["lib"]),
+        .testTarget(
+            name: "libTests",
+            dependencies: ["lib"]),
+    ]
+)

--- a/Fixtures/Miscellaneous/DoubleFree/README.md
+++ b/Fixtures/Miscellaneous/DoubleFree/README.md
@@ -1,0 +1,3 @@
+# double-free
+
+A description of this package.

--- a/Fixtures/Miscellaneous/DoubleFree/Sources/exec/main.swift
+++ b/Fixtures/Miscellaneous/DoubleFree/Sources/exec/main.swift
@@ -1,0 +1,3 @@
+import lib
+
+executeDoubleFree()

--- a/Fixtures/Miscellaneous/DoubleFree/Sources/lib/lib.swift
+++ b/Fixtures/Miscellaneous/DoubleFree/Sources/lib/lib.swift
@@ -1,0 +1,9 @@
+public func executeDoubleFree() {
+    let size = 512
+
+    let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: size, alignment: 1)
+    buffer[0] = 0
+    buffer.deallocate()
+    buffer.deallocate()
+    print(buffer[0])
+}

--- a/Fixtures/Miscellaneous/DoubleFree/Tests/LinuxMain.swift
+++ b/Fixtures/Miscellaneous/DoubleFree/Tests/LinuxMain.swift
@@ -1,0 +1,8 @@
+import XCTest
+
+import libTests
+
+var tests = [XCTestCaseEntry]()
+tests += libTests.__allTests()
+
+XCTMain(tests)

--- a/Fixtures/Miscellaneous/DoubleFree/Tests/libTests/XCTestManifests.swift
+++ b/Fixtures/Miscellaneous/DoubleFree/Tests/libTests/XCTestManifests.swift
@@ -1,0 +1,15 @@
+import XCTest
+
+extension libTests {
+    static let __allTests = [
+        ("testDoubleFree", testDoubleFree),
+    ]
+}
+
+#if !os(macOS)
+public func __allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(libTests.__allTests),
+    ]
+}
+#endif

--- a/Fixtures/Miscellaneous/DoubleFree/Tests/libTests/libTests.swift
+++ b/Fixtures/Miscellaneous/DoubleFree/Tests/libTests/libTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+import lib
+
+final class libTests: XCTestCase {
+    func testDoubleFree() {
+        executeDoubleFree()
+    }
+}

--- a/Sources/SPMBuildCore/Sanitizers.swift
+++ b/Sources/SPMBuildCore/Sanitizers.swift
@@ -16,6 +16,7 @@ public enum Sanitizer: String, Encodable {
     case address
     case thread
     case undefined
+    case scudo
 
     /// Return an established short name for a sanitizer, e.g. "asan".
     public var shortName: String {
@@ -23,6 +24,7 @@ public enum Sanitizer: String, Encodable {
             case .address: return "asan"
             case .thread: return "tsan"
             case .undefined: return "ubsan"
+            case .scudo: return "scudo"
         }
     }
 }
@@ -72,6 +74,7 @@ extension Sanitizer: StringEnumArgument {
     public static let completion: ShellCompletion = .values([
         (address.rawValue, "enable Address sanitizer"),
         (thread.rawValue, "enable Thread sanitizer"),
-        (undefined.rawValue, "enable Undefined Behavior sanitizer")
+        (undefined.rawValue, "enable Undefined Behavior sanitizer"),
+        (scudo.rawValue, "enable Scudo hardened allocator")
     ])
 }

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -80,4 +80,25 @@ final class TestToolTests: XCTestCase {
         }
         #endif
     }
+
+    func testSanitizeScudo() throws {
+        // This test only runs on Linux because Scudo only runs on Linux
+      #if os(Linux)
+        fixture(name: "Miscellaneous/DoubleFree") { path in
+            let cmdline = {
+                try SwiftPMProduct.SwiftTest.execute(
+                    ["--sanitize=scudo"], packagePath: path)
+            }
+            XCTAssertThrows(try cmdline()) { (error: SwiftPMProductError) in
+                switch error {
+                case .executionFailure(_, _, let error):
+                    XCTAssertMatch(error, .contains("invalid chunk state"))
+                    return true
+                default:
+                    return false
+                }
+            }
+        }
+      #endif
+    }
 }


### PR DESCRIPTION
The Swift PR apple/swift#28538 adds support for the Scudo hardened
allocator to swiftc. This patch adds support for it to Swift Package
Manager, allowing the Package Manager to correctly plumb Scudo through
the entire build pipeline.

See the aforementioned PR for more discussion on the value of supporting
Scudo.

Note that the tests will fail until apple/swift#28538 lands.