### PR TITLE
build: add re-export for Foundation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ else()
     find_package(LLBuild CONFIG REQUIRED)
 endif()
 
+find_package(dispatch QUIET)
+find_package(Foundation QUIET)
+
 add_subdirectory(Sources)
 
 if(SWIFTPM_BUILD_DIR)

--- a/Sources/PackageDescription4/CMakeLists.txt
+++ b/Sources/PackageDescription4/CMakeLists.txt
@@ -42,6 +42,11 @@ foreach(PACKAGE_DESCRIPTION_VERSION 4 4_2)
         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}
     )
 
+    if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+      target_link_libraries(PD${PACKAGE_DESCRIPTION_VERSION} PRIVATE
+        Foundation)
+    endif()
+
     if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
         install(FILES 
             ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}/PackageDescription.swiftinterface


### PR DESCRIPTION
PackageDescription4 requires that Foundation be re-exported for users.