### PR TITLE
ArgumentParser: Detect which Parser parsed Result

### DIFF
--- a/Sources/TSCUtility/ArgumentParser.swift
+++ b/Sources/TSCUtility/ArgumentParser.swift
@@ -618,6 +618,11 @@ public final class ArgumentParser {
             return results[arg] != nil
         }
 
+        // Returns true if this result is parsed by given parser.
+        public func isBelong(to parser: ArgumentParser) -> Bool {
+            return parser === self.parser
+        }
+
         /// Get the subparser which was chosen for the given parser.
         public func subparser(_ parser: ArgumentParser) -> String? {
             if parser === self.parser {


### PR DESCRIPTION
Hi!
I added `isBelong(to: ArgumentParser)` method to `ArgumentParser.Result`.
I think this method is needed to detect which subcommand is executed with optional PositionalArgument.

Like this.

```.swift
let parser = ArgumentParser(...)
let subParser1 = parser.add(subparser: "sub1")
let optionalArgument1 = local.add(positional: "sub1_arg", kind: String.self, optional: true)
let subParser2 = parser.add(subparser: "sub2")

// which subparser is given?
let result = try! parser.parse(Array(CommandLine.arguments.dropFirst()))
```

If `isBelong(to: ArgumentParser)` is implemented, We can detect that.

```.swift
let result = try! parser.parse(Array(CommandLine.arguments.dropFirst()))

if result.isBelong(to: subParser1) {
    // this command is executed by subParser`1`.
}
```

Or If you have any idea to detect this without above method, Can you let me know?