### PR TITLE
build: update CMake build for new file

### DIFF
--- a/Sources/Workspace/CMakeLists.txt
+++ b/Sources/Workspace/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(Workspace
   Export.swift
   InitPackage.swift
   ManagedDependency.swift
+  ResolverPrecomputationProvider.swift
   ToolsVersionWriter.swift
   UserToolchain.swift
   Workspace.swift


### PR DESCRIPTION
Interpreter support on Windows is currently unavailable.  Support
compiled manifests for Windows.  On other platforms, this can be tested
by setting `_SWIFTPM_USE_COMPILED_MANIFEST` in the environment.  There
are dependencies on swift-tools-support-core for this to actually
function on Windows.