### PR TITLE
build: remove `LLBUILD_FRAMEWORK`, simplify

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@
 
 cmake_minimum_required(VERSION 3.15.1)
 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
+
 project(SwiftPM LANGUAGES C Swift)
 option(USE_VENDORED_TSC "Use vendored version of TSC" OFF)
 
@@ -32,11 +34,9 @@ else()
     find_package(TSC CONFIG REQUIRED)
 endif()
 
-if(LLBUILD_FRAMEWORK)
-    message("Using llbuild framework: ${LLBUILD_FRAMEWORK}")
-else()
-    message("Using libllbuild")
-    find_package(LLBuild CONFIG REQUIRED)
+find_package(LLBuild CONFIG)
+if(NOT LLBuild_FOUND)
+  find_package(LLBuild REQUIRED)
 endif()
 
 find_package(dispatch QUIET)

--- a/Sources/SPMLLBuild/CMakeLists.txt
+++ b/Sources/SPMLLBuild/CMakeLists.txt
@@ -6,40 +6,16 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-# LLBuild currently doesn't export the llbuildSwift target so import it manually for now.
-add_library(libllbuildSwift SHARED IMPORTED GLOBAL)
-
-if(LLBUILD_FRAMEWORK)
-    set_target_properties(libllbuildSwift
-        PROPERTIES
-        IMPORTED_LOCATION ${LLBUILD_FRAMEWORK}
-    )
-else()
-    set(LLBUILD_BUILD_DIR ${LLBuild_DIR}/../..)
-    set_target_properties(libllbuildSwift
-        PROPERTIES
-        FRAMEWORK TRUE
-        IMPORTED_LOCATION ${LLBUILD_BUILD_DIR}/lib
-        INTERFACE_INCLUDE_DIRECTORIES ${LLBUILD_BUILD_DIR}/products/llbuildSwift)
-endif()
-
 add_library(SPMLLBuild
   llbuild.swift)
-
-target_link_libraries(SPMLLBuild PUBLIC
-  TSCBasic
-  TSCUtility
-)
-
-if(LLBUILD_FRAMEWORK)
-    target_link_libraries(SPMLLBuild PUBLIC -F libllbuildSwift)
-else()
-	target_link_libraries(SPMLLBuild PUBLIC libllbuild -L libllbuildSwift)
-endif()
-
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(SPMLLBuild PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+target_link_libraries(SPMLLBuild PUBLIC
+  TSCBasic
+  TSCUtility
+  llbuildSwift)
+
 
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
 install(TARGETS SPMLLBuild

--- a/Utilities/new-bootstrap
+++ b/Utilities/new-bootstrap
@@ -203,7 +203,7 @@ def bootstrap(args):
         cmake_swift_flags = "-sdk " + g_default_sysroot
 
     if args.llbuild_link_framework:
-        llbuild_arg = "-DLLBUILD_FRAMEWORK=%s" % args.llbuild_build_dir
+        llbuild_arg = "-DLLBuild_LIBRARY=%s" % os.path.join(args.llbuild_build_dir, 'llbuild')
     else:
         llbuild_dir = os.path.join(args.llbuild_build_dir, "cmake/modules")
         llbuild_arg = "-DLLBuild_DIR=" + llbuild_dir

--- a/cmake/modules/FindLLBuild.cmake
+++ b/cmake/modules/FindLLBuild.cmake
@@ -1,0 +1,58 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+if(TARGET llbuildSwift)
+  return()
+endif()
+
+include(CMakeFindFrameworks)
+cmake_find_frameworks(llbuild)
+if(llbuild_FRAMEWORKS)
+  if(NOT TARGET llbuildSwift)
+    add_library(llbuildSwift UNKNOWN IMPORTED)
+    set_target_properties(llbuildSwift PROPERTIES
+      FRAMEWORK TRUE
+      INTERFACE_COMPILE_OPTIONS -F${llbuild_FRAMEWORKS}
+      IMPORTED_LOCATION ${llbuild_FRAMEWORKS}/llbuild.framework/llbuild)
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(LLBuild
+    REQUIRED_VARS llbuild_FRAMEWORKS)
+else()
+  find_library(libllbuild_LIBRARIES libllbuild)
+  find_file(libllbuild_INCLUDE_DIRS llbuild/llbuild.h)
+
+  find_library(llbuildSwift_LIBRARIES llbuildSwift)
+  find_file(llbuildSwift_INCLUDE_DIRS llbuildSwift.swiftmodule)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(LLBuild REQUIRED_VARS
+    libllbuild_LIBRARIES
+    libllbuild_INCLUDE_DIRS
+    llbuildSwift_LIBRARIES
+    llbuildSwift_INCLUDE_DIRS)
+
+  if(NOT TARGET libllbuild)
+    add_library(libllbuild UNKNOWN IMPORTED)
+    get_filename_component(libllbuild_INCLUDE_DIRS
+      ${libllbuild_INCLUDE_DIRS} DIRECTORY)
+    set_target_properties(libllbuild PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES ${libllbuild_INCLUDE_DIRS}
+      IMPORTED_LOCATION ${libllbuild_LIBRARIES})
+  endif()
+  if(NOT TARGET llbuildSwift)
+    add_library(llbuildSwift UNKNOWN IMPORTED)
+    get_filename_component(llbuildSwift_INCLUDE_DIRS
+      ${llbuildSwift_INCLUDE_DIRS} DIRECTORY)
+    set_target_properties(llbuildSwift PROPERTIES
+      INTERFACE_LINK_LIBRARIES libllbuild
+      INTERFACE_INCLUDE_DIRECTORIES ${llbuildSwift_INCLUDE_DIRS}
+      IMPORTED_LOCATION ${llbuildSwift_LIBRARIES})
+  endif()
+endif()


### PR DESCRIPTION
This removes the `LLBUILD_FRAMEWORK` option.  Use a proper
FindLLBuild.cmake module that searches for the framework if desired,
allows the user to specify the llbuild to use, or can use the export
targets from an llbuild instance.