### PR TITLE
Remove the AnyError type as Error doesn’t need to be erased

### DIFF
--- a/Sources/Build/BuildDelegate.swift
+++ b/Sources/Build/BuildDelegate.swift
@@ -254,7 +254,7 @@ public struct BuildDescription: Codable {
 public final class BuildExecutionContext {
 
     /// Reference to the index store API.
-    var indexStoreAPI: Result<IndexStoreAPI, AnyError> {
+    var indexStoreAPI: Result<IndexStoreAPI, Error> {
         indexStoreAPICache.getValue(self)
     }
 
@@ -283,7 +283,7 @@ public final class BuildExecutionContext {
     // MARK:- Private
 
     private var indexStoreAPICache = LazyCache(createIndexStoreAPI)
-    private func createIndexStoreAPI() -> Result<IndexStoreAPI, AnyError> {
+    private func createIndexStoreAPI() -> Result<IndexStoreAPI, Error> {
         Result {
             let ext = buildParameters.triple.dynamicLibraryExtension
             let indexStoreLib = buildParameters.toolchain.toolchainLibDir.appending(component: "libIndexStore" + ext)

--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -35,20 +35,8 @@ extension Error: CustomStringConvertible {
     }
 }
 
-public func handle(error: Any) {
-    switch error {
-
-    // If we got instance of any error, handle the underlying error.
-    case let anyError as AnyError:
-        handle(error: anyError.underlyingError)
-
-    default:
-        _handle(error)
-    }
-}
-
 // The name has underscore because of SR-4015.
-private func _handle(_ error: Any) {
+func handle(error: Swift.Error) {
 
     switch error {
     case Diagnostics.fatalError:

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -451,8 +451,8 @@ public class SwiftTool<Options: ToolOptions> {
     func getSwiftPMConfig() throws -> SwiftPMConfig {
         return try _swiftpmConfig.get()
     }
-    private lazy var _swiftpmConfig: Result<SwiftPMConfig, AnyError> = {
-        return Result(anyError: { SwiftPMConfig(path: try configFilePath()) })
+    private lazy var _swiftpmConfig: Result<SwiftPMConfig, Swift.Error> = {
+        return Result(catching: { SwiftPMConfig(path: try configFilePath()) })
     }()
 
     /// Holds the currently active workspace.
@@ -615,8 +615,8 @@ public class SwiftTool<Options: ToolOptions> {
     func buildParameters() throws -> BuildParameters {
         return try _buildParameters.get()
     }
-    private lazy var _buildParameters: Result<BuildParameters, AnyError> = {
-        return Result(anyError: {
+    private lazy var _buildParameters: Result<BuildParameters, Swift.Error> = {
+        return Result(catching: {
             let toolchain = try self.getToolchain()
             let triple = toolchain.destination.target
 
@@ -638,10 +638,10 @@ public class SwiftTool<Options: ToolOptions> {
     }()
 
     /// Lazily compute the destination toolchain.
-    private lazy var _destinationToolchain: Result<UserToolchain, AnyError> = {
+    private lazy var _destinationToolchain: Result<UserToolchain, Swift.Error> = {
         // Create custom toolchain if present.
         if let customDestination = self.options.customCompileDestination {
-            return Result(anyError: {
+            return Result(catching: {
                 try UserToolchain(destination: Destination(fromFile: customDestination))
             })
         }
@@ -650,15 +650,15 @@ public class SwiftTool<Options: ToolOptions> {
     }()
 
     /// Lazily compute the host toolchain used to compile the package description.
-    private lazy var _hostToolchain: Result<UserToolchain, AnyError> = {
-        return Result(anyError: {
+    private lazy var _hostToolchain: Result<UserToolchain, Swift.Error> = {
+        return Result(catching: {
             try UserToolchain(destination: Destination.hostDestination(
                         originalWorkingDirectory: self.originalWorkingDirectory))
         })
     }()
 
-    private lazy var _manifestLoader: Result<ManifestLoader, AnyError> = {
-        return Result(anyError: {
+    private lazy var _manifestLoader: Result<ManifestLoader, Swift.Error> = {
+        return Result(catching: {
             try ManifestLoader(
                 // Always use the host toolchain's resources for parsing manifest.
                 manifestResources: self._hostToolchain.get().manifestResources,

--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -224,7 +224,7 @@ public protocol PackageContainerProvider {
     func getContainer(
         for identifier: PackageReference,
         skipUpdate: Bool,
-        completion: @escaping (Result<PackageContainer, AnyError>) -> Void
+        completion: @escaping (Result<PackageContainer, Swift.Error>) -> Void
     )
 }
 
@@ -1207,7 +1207,7 @@ public class DependencyResolver {
     }
 
     /// The list of fetched containers.
-    private var _fetchedContainers: [PackageReference: Swift.Result<Container, AnyError>] = [:]
+    private var _fetchedContainers: [PackageReference: Swift.Result<Container, Error>] = [:]
 
     /// The set of containers requested so far.
     private var _prefetchingContainers: Set<PackageReference> = []

--- a/Sources/PackageGraph/Pubgrub.swift
+++ b/Sources/PackageGraph/Pubgrub.swift
@@ -1799,7 +1799,7 @@ private final class ContainerProvider {
     private let fetchCondition = Condition()
 
     /// The list of fetched containers.
-    private var _fetchedContainers: [PackageReference: Result<PubGrubPackageContainer, AnyError>] = [:]
+    private var _fetchedContainers: [PackageReference: Result<PubGrubPackageContainer, Error>] = [:]
 
     /// The set of containers requested so far.
     private var _prefetchingContainers: Set<PackageReference> = []

--- a/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
@@ -59,7 +59,7 @@ public class RepositoryPackageContainerProvider: PackageContainerProvider {
     public func getContainer(
         for identifier: PackageReference,
         skipUpdate: Bool,
-        completion: @escaping (Result<PackageContainer, AnyError>) -> Void
+        completion: @escaping (Result<PackageContainer, Swift.Error>) -> Void
     ) {
         // If the container is local, just create and return a local package container.
         if identifier.kind != .remote {
@@ -78,7 +78,7 @@ public class RepositoryPackageContainerProvider: PackageContainerProvider {
         // Resolve the container using the repository manager.
         repositoryManager.lookup(repository: identifier.repository, skipUpdate: skipUpdate) { result in
             // Create the container wrapper.
-            let container = result.mapAny { handle -> PackageContainer in
+            let container = result.tryMap { handle -> PackageContainer in
                 // Open the repository.
                 //
                 // FIXME: Do we care about holding this open for the lifetime of the container.

--- a/Sources/SPMTestSupport/MockDependencyResolver.swift
+++ b/Sources/SPMTestSupport/MockDependencyResolver.swift
@@ -71,7 +71,7 @@ extension PackageContainerConstraint {
 extension PackageContainerProvider {
     public func getContainer(
         for identifier: PackageReference,
-        completion: @escaping (Result<PackageContainer, AnyError>) -> Void
+        completion: @escaping (Result<PackageContainer, Error>) -> Void
     ) {
         getContainer(for: identifier, skipUpdate: false, completion: completion)
     }
@@ -209,11 +209,11 @@ public struct MockPackagesProvider: PackageContainerProvider {
     public func getContainer(
         for identifier: PackageReference,
         skipUpdate: Bool,
-        completion: @escaping (Result<PackageContainer, AnyError>
+        completion: @escaping (Result<PackageContainer, Error>
     ) -> Void) {
         DispatchQueue.global().async {
             completion(self.containersByIdentifier[identifier].map{ .success($0) } ??
-                Result(MockLoadingError.unknownModule))
+                .failure(MockLoadingError.unknownModule))
         }
     }
 }

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -39,7 +39,7 @@ public extension RepositoryManagerDelegate {
 /// Manages a collection of bare repositories.
 public class RepositoryManager {
 
-    public typealias LookupResult = Result<RepositoryHandle, AnyError>
+    public typealias LookupResult = Result<RepositoryHandle, Error>
     public typealias LookupCompletion = (LookupResult) -> Void
 
     /// Handle to a managed repository.
@@ -230,7 +230,7 @@ public class RepositoryManager {
 
                 switch handle.status {
                 case .available:
-                    result = LookupResult(anyError: {
+                    result = LookupResult(catching: {
                         // Update the repository when it is being looked up.
                         let repo = try handle.open()
 
@@ -275,7 +275,7 @@ public class RepositoryManager {
                     } catch {
                         handle.status = .error
                         fetchError = error
-                        result = Result(error)
+                        result = .failure(error)
                     }
 
                     // Inform delegate.

--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -47,11 +47,11 @@ public struct ProcessResult: CustomStringConvertible {
 
     /// The output bytes of the process. Available only if the process was
     /// asked to redirect its output and no stdout output closure was set.
-    public let output: Result<[UInt8], AnyError>
+    public let output: Result<[UInt8], Swift.Error>
 
     /// The output bytes of the process. Available only if the process was
     /// asked to redirect its output and no stderr output closure was set.
-    public let stderrOutput: Result<[UInt8], AnyError>
+    public let stderrOutput: Result<[UInt8], Swift.Error>
 
     /// Create an instance using a POSIX process exit status code and output result.
     ///
@@ -60,8 +60,8 @@ public struct ProcessResult: CustomStringConvertible {
         arguments: [String],
         environment: [String: String],
         exitStatusCode: Int32,
-        output: Result<[UInt8], AnyError>,
-        stderrOutput: Result<[UInt8], AnyError>
+        output: Result<[UInt8], Swift.Error>,
+        stderrOutput: Result<[UInt8], Swift.Error>
     ) {
         let exitStatus: ExitStatus
       #if os(Windows)
@@ -83,8 +83,8 @@ public struct ProcessResult: CustomStringConvertible {
         arguments: [String],
         environment: [String: String],
         exitStatus: ExitStatus,
-        output: Result<[UInt8], AnyError>,
-        stderrOutput: Result<[UInt8], AnyError>
+        output: Result<[UInt8], Swift.Error>,
+        stderrOutput: Result<[UInt8], Swift.Error>
     ) {
         self.arguments = arguments
         self.environment = environment
@@ -207,10 +207,10 @@ public final class Process: ObjectIdentifierProtocol {
   #endif
 
     /// If redirected, stdout result and reference to the thread reading the output.
-    private var stdout: (result: Result<[UInt8], AnyError>, thread: Thread?) = (.success([]), nil)
+    private var stdout: (result: Result<[UInt8], Swift.Error>, thread: Thread?) = (.success([]), nil)
 
     /// If redirected, stderr result and reference to the thread reading the output.
-    private var stderr: (result: Result<[UInt8], AnyError>, thread: Thread?) = (.success([]), nil)
+    private var stderr: (result: Result<[UInt8], Swift.Error>, thread: Thread?) = (.success([]), nil)
 
     /// Queue to protect concurrent reads.
     private let serialQueue = DispatchQueue(label: "org.swift.swiftpm.process")
@@ -496,7 +496,7 @@ public final class Process: ObjectIdentifierProtocol {
     /// Reads the given fd and returns its result.
     ///
     /// Closes the fd before returning.
-    private func readOutput(onFD fd: Int32, outputClosure: OutputClosure?) -> Result<[UInt8], AnyError> {
+    private func readOutput(onFD fd: Int32, outputClosure: OutputClosure?) -> Result<[UInt8], Swift.Error> {
         // Read all of the data from the output pipe.
         let N = 4096
         var buf = [UInt8](repeating: 0, count: N + 1)
@@ -527,7 +527,7 @@ public final class Process: ObjectIdentifierProtocol {
         // Close the read end of the output pipe.
         close(fd)
         // Construct the output result.
-        return error.map(Result.init) ?? .success(out)
+        return error.map(Result.failure) ?? .success(out)
     }
   #endif
 

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -50,7 +50,7 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
     func getContainer(
         for identifier: PackageReference,
         skipUpdate: Bool,
-        completion: @escaping (Result<PackageContainer, AnyError>) -> Void
+        completion: @escaping (Result<PackageContainer, Error>) -> Void
     ) {
         // Start by searching manifests from the Workspace's resolved dependencies.
         if let manifest = dependencyManifests.dependencies.first(where: { $1.packageRef == identifier }) {
@@ -78,7 +78,7 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
         }
 
         // As we don't have anything else locally, error out.
-        completion(.init(Diagnostics.fatalError))
+        completion(.failure(Diagnostics.fatalError))
     }
 }
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2016,8 +2016,8 @@ public final class LoadableResult<Value> {
     }
 
     /// Load and return the result.
-    public func loadResult() -> Result<Value, AnyError> {
-        return Result(anyError: {
+    public func loadResult() -> Result<Value, Error> {
+        return Result(catching: {
             try self.construct()
         })
     }

--- a/Tests/PackageGraphTests/DependencyResolverTests.swift
+++ b/Tests/PackageGraphTests/DependencyResolverTests.swift
@@ -233,9 +233,8 @@ class DependencyResolverTests: XCTestCase {
 
             // Check that this throws, because we try to fetch "B".
             let _ = resolver.resolveSubtree(a).map{$0}
-            if case let error as AnyError = resolver.error,
-               case let actualError as MockLoadingError = error.underlyingError {
-                XCTAssertEqual(actualError, MockLoadingError.unknownModule)
+            if case let error as MockLoadingError = resolver.error {
+                XCTAssertEqual(error, MockLoadingError.unknownModule)
             } else {
                 XCTFail("Unexpected or no error in resolver \(resolver.error.debugDescription)")
             }

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -1929,11 +1929,11 @@ public struct MockProvider: PackageContainerProvider {
     public func getContainer(
         for identifier: PackageReference,
         skipUpdate: Bool,
-        completion: @escaping (Result<PackageContainer, AnyError>
-        ) -> Void) {
+        completion: @escaping (Result<PackageContainer, Error>
+    ) -> Void) {
         DispatchQueue.global().async {
             completion(self.containersByIdentifier[identifier].map{ .success($0) } ??
-                Result(_MockLoadingError.unknownModule))
+                .failure(_MockLoadingError.unknownModule))
         }
     }
 }

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -197,7 +197,7 @@ class RepositoryManagerTests: XCTestCase {
                     XCTFail("Unexpected success")
                     return
                 }
-                XCTAssertEqual(error.underlyingError as? DummyError, DummyError.invalidRepository)
+                XCTAssertEqual(error as? DummyError, DummyError.invalidRepository)
                 badLookupExpectation.fulfill()
             }
 

--- a/Tests/TSCBasicTests/AwaitTests.swift
+++ b/Tests/TSCBasicTests/AwaitTests.swift
@@ -19,15 +19,15 @@ class AwaitTests: XCTestCase {
         case error
     }
 
-    func async(_ param: String, _ completion: @escaping (Result<String, AnyError>) -> Void) {
+    func async(_ param: String, _ completion: @escaping (Result<String, Error>) -> Void) {
         DispatchQueue.global().async {
             completion(.success(param))
         }
     }
 
-    func throwingAsync(_ param: String, _ completion: @escaping (Result<String, AnyError>) -> Void) {
+    func throwingAsync(_ param: String, _ completion: @escaping (Result<String, Error>) -> Void) {
         DispatchQueue.global().async {
-            completion(Result(DummyError.error))
+            completion(.failure(DummyError.error))
         }
     }
 
@@ -38,8 +38,8 @@ class AwaitTests: XCTestCase {
         do {
             let value = try await { throwingAsync("Hi", $0) }
             XCTFail("Unexpected success \(value)")
-        } catch let error as AnyError {
-            XCTAssertEqual(error.underlyingError as? DummyError, DummyError.error)
+        } catch {
+            XCTAssertEqual(error as? DummyError, DummyError.error)
         }
     }
 }

--- a/Tests/TSCBasicTests/XCTestManifests.swift
+++ b/Tests/TSCBasicTests/XCTestManifests.swift
@@ -343,8 +343,7 @@ extension ResultTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__ResultTests = [
-        ("testAnyError", testAnyError),
-        ("testMapAny", testMapAny),
+        ("testTryMap", testTryMap),
     ]
 }
 


### PR DESCRIPTION
This is a nice cleanup as `AnyError` is not required since `Result` allows the `Error` protocol to conform to itself. This is required for #2452.