### PR TITLE
Android: fix ABI triple detection, disable C++ modules flags, and bring back bootstrap script tweaks

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -226,13 +226,13 @@ public final class ClangTargetBuildDescription {
             args += buildParameters.indexStoreArguments(for: target)
         }
 
-        if !buildParameters.triple.isWindows() {
-            // Using modules currently conflicts with the Windows SDKs.
+        if !buildParameters.triple.isWindows() && !buildParameters.triple.isAndroid() {
+            // Using modules currently conflicts with the Windows and Android SDKs.
             args += ["-fmodules", "-fmodule-name=" + target.c99name]
         }
         args += ["-I", clangTarget.includeDir.pathString]
         args += additionalFlags
-        if !buildParameters.triple.isWindows() {
+        if !buildParameters.triple.isWindows() && !buildParameters.triple.isAndroid() {
             args += moduleCacheArgs
         }
         args += buildParameters.sanitizers.compileCFlags()

--- a/Sources/Build/Triple.swift
+++ b/Sources/Build/Triple.swift
@@ -61,7 +61,7 @@ public struct Triple: Encodable {
 
     public enum ABI: String, Encodable {
         case unknown
-        case android = "androideabi"
+        case android
     }
 
     public init(_ string: String) throws {
@@ -81,8 +81,7 @@ public struct Triple: Encodable {
             throw Error.unknownOS
         }
 
-        let abiString = components.count > 3 ? components[3] : nil
-        let abi = abiString.flatMap(ABI.init)
+        let abi = components.count > 3 ? Triple.parseABI(components[3]) : nil
 
         self.tripleString = string
         self.arch = arch
@@ -98,6 +97,13 @@ public struct Triple: Encodable {
             }
         }
 
+        return nil
+    }
+
+    fileprivate static func parseABI(_ string: String) -> ABI? {
+        if string.hasPrefix(ABI.android.rawValue) {
+            return ABI.android
+        }
         return nil
     }
 

--- a/Sources/TSCBasic/CMakeLists.txt
+++ b/Sources/TSCBasic/CMakeLists.txt
@@ -62,3 +62,8 @@ install(TARGETS TSCBasic
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
 endif()
+
+# Don't use GNU strerror_r on Android.
+if(CMAKE_SYSTEM_NAME STREQUAL Android)
+  target_compile_options(TSCBasic PUBLIC "SHELL:-Xcc -U_GNU_SOURCE")
+endif()

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -232,7 +232,14 @@ def get_build_target(args):
     if platform.system() == 'Darwin':
         return "x86_64-apple-macosx"
     elif platform.system() == 'Linux':
-        if platform.machine() == 'x86_64':
+        if 'ANDROID_DATA' in os.environ:
+            if platform.machine().startswith('armv7'):
+                return 'armv7a-unknown-linux-androideabi'
+            elif platform.machine() == 'aarch64':
+                return 'aarch64-unknown-linux-android'
+            else:
+                raise SystemExit("ERROR: unsupported Android platform:", platform.machine())
+        elif platform.machine() == 'x86_64':
             return "x86_64-unknown-linux-gnu"
         elif platform.machine() == "i686":
             return "i686-unknown-linux"
@@ -548,10 +555,15 @@ def get_swiftpm_flags(args):
             "-Xlinker", "@executable_path/../../../../../SharedFrameworks",
         ])
 
-    # Add a rpath to find core swift libraries on linux. We don't need a rpath
-    # for Darwin because the Swift libraries are present in the OS.
+    # Add a rpath to find core swift libraries on linux and Android. We don't
+    # need a rpath for Darwin because the Swift libraries are present in the OS.
     if platform.system() == 'Linux':
-        build_flags.extend(["-Xlinker", "-rpath=$ORIGIN/../lib/swift/linux"])
+        if 'ANDROID_DATA' in os.environ:
+            build_flags.extend(["-Xlinker", "-rpath=$ORIGIN/../lib/swift/android"])
+            # Don't use GNU strerror_r on Android.
+            build_flags.extend(["-Xswiftc", "-Xcc", "-Xswiftc", "-U_GNU_SOURCE"])
+        else:
+            build_flags.extend(["-Xlinker", "-rpath=$ORIGIN/../lib/swift/linux"])
 
     return build_flags
 


### PR DESCRIPTION
This pull redoes [the previous tweaks for the old non-CMake bootstrap script](https://github.com/apple/swift-package-manager/pull/2417/files#diff-296aa080a049a48a75c47e0a2926fde0). Since the new bootstrap script rebuilds llbuild by using its Package.swift, rather than the prior approach of linking against the llbuild already built by the Swift build-script, I had problems when building llbuild with SPM because of the C++ modules support.

Removing those flags, as for Windows, gets llbuild and SPM built, with some of those BuildPlanTests now failing, as they explicitly look for that flag.

In the process, I discovered that the `isAndroid()` function I added earlier wasn't working right, as it would only detect `androideabi` and not `android`. As the two appear to be equivalent, with [LLVM just turning the former into the latter](https://github.com/apple/llvm-project/blob/7f19f3b1e3e6dbe263f31af8bd413ce6f18c4fbc/llvm/lib/Support/Triple.cpp#L940), I had the SPM Triple parser do the same.

I also had to modify llbuild's Package.swift to link in ncurses on Android:
```
diff --git a/Package.swift b/Package.swift
index 6141342..6a20665 100644
--- a/Package.swift
+++ b/Package.swift
@@ -150,7 +150,7 @@ let package = Package(
             name: "llvmSupport",
             dependencies: ["llvmDemangle"],
             path: "lib/llvm/Support",
-            linkerSettings: [.linkedLibrary("ncurses", .when(platforms: [.linux, .macOS]))]
+            linkerSettings: [.linkedLibrary("ncurses", .when(platforms: [.linux, .macOS, .android]))]
         ),
     ],
     cxxLanguageStandard: .cxx14
```
which then required changing the SPM version where that's supported locally, so llbuild's SPM manifest could use it:
```
diff --git a/Sources/PackageDescription4/SupportedPlatforms.swift b/Sources/PackageDescription4/SupportedPlatforms.swift
index 06439ebe..8bd41f13 100644
--- a/Sources/PackageDescription4/SupportedPlatforms.swift
+++ b/Sources/PackageDescription4/SupportedPlatforms.swift
@@ -39,7 +39,7 @@ public struct Platform: Encodable {
     public static let windows: Platform = Platform(name: "windows")
 
     /// The Android platform
-    @available(_PackageDescription, introduced: 5.2)
+    @available(_PackageDescription, introduced: 5.0)
     public static let android: Platform = Platform(name: "android")
 }
 
```
Hopefully, that won't be necessary once Swift 5.2 ships though.