### PR TITLE
Add copy and move methods to the FileSystem protocol

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -741,4 +741,12 @@ private class GitFileSystemView: FileSystem {
     func chmod(_ mode: FileMode, path: AbsolutePath, options: Set<FileMode.Option>) throws {
         throw FileSystemError.unsupported
     }
+
+    func copy(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
+        fatalError("will never be supported")
+    }
+
+    func move(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
+        fatalError("will never be supported")
+    }
 }

--- a/Sources/SourceControl/InMemoryGitRepository.swift
+++ b/Sources/SourceControl/InMemoryGitRepository.swift
@@ -235,6 +235,14 @@ extension InMemoryGitRepository: FileSystem {
     public func chmod(_ mode: FileMode, path: AbsolutePath, options: Set<FileMode.Option>) throws {
         try head.fileSystem.chmod(mode, path: path, options: options)
     }
+
+    public func copy(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
+        try head.fileSystem.copy(from: sourcePath, to: destinationPath)
+    }
+
+    public func move(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
+        try head.fileSystem.move(from: sourcePath, to: destinationPath)
+    }
 }
 
 extension InMemoryGitRepository: Repository {

--- a/Sources/TSCTestSupport/XCTAssertHelpers.swift
+++ b/Sources/TSCTestSupport/XCTAssertHelpers.swift
@@ -47,7 +47,7 @@ public func XCTAssertThrows<T: Swift.Error>(
     } catch let error as T {
         XCTAssertEqual(error, expectedError, file: file, line: line)
     } catch {
-        XCTFail("unexpected error thrown", file: file, line: line)
+        XCTFail("unexpected error thrown: \(error)", file: file, line: line)
     }
 }
 
@@ -61,9 +61,9 @@ public func XCTAssertThrows<T: Swift.Error, Ignore>(
         let result = try expression()
         XCTFail("body completed successfully: \(result)", file: file, line: line)
     } catch let error as T {
-        XCTAssertTrue(errorHandler(error), "Error handler returned false")
+        XCTAssertTrue(errorHandler(error), "Error handler returned false", file: file, line: line)
     } catch {
-        XCTFail("unexpected error thrown", file: file, line: line)
+        XCTFail("unexpected error thrown: \(error)", file: file, line: line)
     }
 }
 

--- a/Tests/TSCBasicTests/XCTestManifests.swift
+++ b/Tests/TSCBasicTests/XCTestManifests.swift
@@ -125,6 +125,8 @@ extension FileSystemTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__FileSystemTests = [
+        ("testCopyAndMoveItem", testCopyAndMoveItem),
+        ("testInMemCopyAndMoveItem", testInMemCopyAndMoveItem),
         ("testInMemoryBasics", testInMemoryBasics),
         ("testInMemoryCreateDirectory", testInMemoryCreateDirectory),
         ("testInMemoryFsCopy", testInMemoryFsCopy),


### PR DESCRIPTION
This will be necessary for binary targets to move files around after downloading them.