### PR TITLE
[PackageLoading] Avoid using #if Xcode when looking for runtime libra…

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -508,11 +508,16 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             cmd += [resources.swiftCompiler.pathString]
             cmd += ["--driver-mode=swift"]
             cmd += verbosity.ccArgs
-          #if Xcode
-            cmd += ["-F", runtimePath.appending(component: "PackageFrameworks").pathString, "-framework", "PackageDescription"]
-          #else
-            cmd += ["-L", runtimePath.pathString, "-lPackageDescription"]
-          #endif
+
+            // If we got the binDir that means we could be developing SwiftPM in Xcode
+            // which produces a framework for dynamic package products.
+            let runtimeFrameworkPath = runtimePath.appending(component: "PackageFrameworks")
+            if resources.binDir != nil, localFileSystem.exists(runtimeFrameworkPath)  {
+                cmd += ["-F", runtimeFrameworkPath.pathString, "-framework", "PackageDescription"]
+            } else {
+                cmd += ["-L", runtimePath.pathString, "-lPackageDescription"]
+            }
+
             cmd += interpreterFlags
             if let moduleCachePath = moduleCachePath {
                 cmd += ["-module-cache-path", moduleCachePath]


### PR DESCRIPTION
…ires

Some clients might be producing their distribution build using Xcode so
don't assume #if Xcode is only used during swiftpm development.

<rdar://problem/58047454>