### PR TITLE
Remove @testable from codebase

### DIFF
--- a/Sources/Build/BuildDelegate.swift
+++ b/Sources/Build/BuildDelegate.swift
@@ -511,7 +511,7 @@ public final class BuildDelegate: BuildSystemDelegate, SwiftCompilerOutputParser
         return false
     }
 
-    func swiftCompilerOutputParser(_ parser: SwiftCompilerOutputParser, didParse message: SwiftCompilerMessage) {
+    public func swiftCompilerOutputParser(_ parser: SwiftCompilerOutputParser, didParse message: SwiftCompilerMessage) {
         queue.async {
             if self.isVerbose {
                 if let text = message.verboseProgressText {
@@ -534,7 +534,7 @@ public final class BuildDelegate: BuildSystemDelegate, SwiftCompilerOutputParser
         }
     }
 
-    func swiftCompilerOutputParser(_ parser: SwiftCompilerOutputParser, didFailWith error: Error) {
+    public func swiftCompilerOutputParser(_ parser: SwiftCompilerOutputParser, didFailWith error: Error) {
         let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
         diagnostics.emit(.swiftCompilerOutputParsingError(message))
         onCommmandFailure?()

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -151,7 +151,7 @@ public final class ClangTargetBuildDescription {
     }
 
     /// The modulemap file for this target, if any.
-    private(set) var moduleMap: AbsolutePath?
+    public private(set) var moduleMap: AbsolutePath?
 
     /// Path to the temporary directory for this target.
     var tempsPath: AbsolutePath {
@@ -159,7 +159,7 @@ public final class ClangTargetBuildDescription {
     }
 
     /// The objects in this target.
-    var objects: [AbsolutePath] {
+    public var objects: [AbsolutePath] {
         return compilePaths().map({ $0.object })
     }
 
@@ -349,10 +349,10 @@ public final class SwiftTargetBuildDescription {
     }
 
     /// The list of all source files in the target, including the derived ones.
-    var sources: [AbsolutePath] { target.sources.paths + derivedSources.paths }
+    public var sources: [AbsolutePath] { target.sources.paths + derivedSources.paths }
 
     /// The objects in this target.
-    var objects: [AbsolutePath] {
+    public var objects: [AbsolutePath] {
         let relativePaths = target.sources.relativePaths + derivedSources.relativePaths
         return relativePaths.map{ tempsPath.appending(RelativePath("\($0.pathString).o")) }
     }
@@ -811,7 +811,7 @@ public final class ProductBuildDescription {
     /// The objects in this product.
     ///
     // Computed during build planning.
-    fileprivate(set) var objects = SortedArray<AbsolutePath>()
+    public fileprivate(set) var objects = SortedArray<AbsolutePath>()
 
     /// The dynamic libraries this product needs to link with.
     // Computed during build planning.

--- a/Sources/Build/SwiftCompilerOutputParser.swift
+++ b/Sources/Build/SwiftCompilerOutputParser.swift
@@ -12,29 +12,58 @@ import Foundation
 import TSCBasic
 
 /// Represents a message output by the Swift compiler in JSON output mode.
-struct SwiftCompilerMessage {
-    enum Kind {
-        struct Output {
-            let type: String
-            let path: String
+public struct SwiftCompilerMessage {
+    public enum Kind {
+        public struct Output {
+            public let type: String
+            public let path: String
+
+            public init(type: String, path: String) {
+                self.type = type
+                self.path = path
+            }
         }
 
-        struct BeganInfo {
-            let pid: Int
-            let inputs: [String]
-            let outputs: [Output]
-            let commandExecutable: String
-            let commandArguments: [String]
+        public struct BeganInfo {
+            public let pid: Int
+            public let inputs: [String]
+            public let outputs: [Output]
+            public let commandExecutable: String
+            public let commandArguments: [String]
+
+            public init(
+                pid: Int,
+                inputs: [String],
+                outputs: [Output],
+                commandExecutable: String,
+                commandArguments: [String]
+            ) {
+                self.pid = pid
+                self.inputs = inputs
+                self.outputs = outputs
+                self.commandExecutable = commandExecutable
+                self.commandArguments = commandArguments
+            }
         }
 
-        struct SkippedInfo {
-            let inputs: [String]
-            let outputs: [Output]
+        public struct SkippedInfo {
+            public let inputs: [String]
+            public let outputs: [Output]
+
+            public init(inputs: [String], outputs: [SwiftCompilerMessage.Kind.Output]) {
+                self.inputs = inputs
+                self.outputs = outputs
+            }
         }
 
-        struct OutputInfo {
-            let pid: Int
-            let output: String?
+        public struct OutputInfo {
+            public let pid: Int
+            public let output: String?
+
+            public init(pid: Int, output: String?) {
+                self.pid = pid
+                self.output = output
+            }
         }
 
         case began(BeganInfo)
@@ -44,12 +73,17 @@ struct SwiftCompilerMessage {
         case unparsableOutput(String)
     }
 
-    let name: String
-    let kind: Kind
+    public let name: String
+    public let kind: Kind
+
+    public init(name: String, kind: SwiftCompilerMessage.Kind) {
+        self.name = name
+        self.kind = kind
+    }
 }
 
 /// Protocol for the parser delegate to get notified of parsing events.
-protocol SwiftCompilerOutputParserDelegate: class {
+public protocol SwiftCompilerOutputParserDelegate: class {
     /// Called for each message parsed.
     func swiftCompilerOutputParser(_ parser: SwiftCompilerOutputParser, didParse message: SwiftCompilerMessage)
 
@@ -58,7 +92,7 @@ protocol SwiftCompilerOutputParserDelegate: class {
 }
 
 /// Parser for the Swift compiler JSON output mode.
-final class SwiftCompilerOutputParser {
+public final class SwiftCompilerOutputParser {
 
     /// State of the parser state machine.
     private enum State {
@@ -86,7 +120,7 @@ final class SwiftCompilerOutputParser {
     private let decoder: JSONDecoder
 
     /// Initializes the parser with a delegate to notify of parsing events.
-    init(targetName: String, delegate: SwiftCompilerOutputParserDelegate) {
+    public init(targetName: String, delegate: SwiftCompilerOutputParserDelegate) {
         self.targetName = targetName
         self.delegate = delegate
         let decoder = JSONDecoder()
@@ -97,7 +131,7 @@ final class SwiftCompilerOutputParser {
     /// Parse the next bytes of the Swift compiler JSON output.
     /// - Note: If a parsing error is encountered, the delegate will be notified and the parser won't accept any further
     ///   input.
-    func parse<C>(bytes: C) where C: Collection, C.Element == UInt8 {
+    public func parse<C>(bytes: C) where C: Collection, C.Element == UInt8 {
         guard !hasFailed else { return }
 
         do {
@@ -199,7 +233,7 @@ extension SwiftCompilerMessage: Decodable, Equatable {
         case name
     }
 
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         name = try container.decode(String.self, forKey: .name)
         kind = try Kind(from: decoder)
@@ -211,7 +245,7 @@ extension SwiftCompilerMessage.Kind: Decodable, Equatable {
         case kind
     }
 
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let kind = try container.decode(String.self, forKey: .kind)
         switch kind {

--- a/Sources/Commands/MultiRootSupport.swift
+++ b/Sources/Commands/MultiRootSupport.swift
@@ -20,7 +20,7 @@ import FoundationXML
 /// A bare minimum loader for Xcode workspaces.
 ///
 /// Warning: This is only useful for debugging workspaces that contain Swift packages.
-final class XcodeWorkspaceLoader {
+public final class XcodeWorkspaceLoader {
 
     /// The parsed location.
     private struct Location {
@@ -38,13 +38,13 @@ final class XcodeWorkspaceLoader {
 
     let fs: FileSystem
 
-    init(diagnostics: DiagnosticsEngine, fs: FileSystem = localFileSystem) {
+    public init(diagnostics: DiagnosticsEngine, fs: FileSystem = localFileSystem) {
         self.diagnostics = diagnostics
         self.fs = fs
     }
 
     /// Load the given workspace and return the file ref paths from it.
-    func load(workspace: AbsolutePath) throws -> [AbsolutePath] {
+    public func load(workspace: AbsolutePath) throws -> [AbsolutePath] {
         let path = workspace.appending(component: "contents.xcworkspacedata")
         let contents = try Data(fs.readFileContents(path).contents)
 

--- a/Sources/Commands/WatchmanHelper.swift
+++ b/Sources/Commands/WatchmanHelper.swift
@@ -12,7 +12,7 @@ import TSCBasic
 import TSCUtility
 import Xcodeproj
 
-final class WatchmanHelper {
+public final class WatchmanHelper {
 
     /// Name of the watchman-make tool.
     static let watchmanMakeTool: String = "watchman-make"
@@ -28,7 +28,7 @@ final class WatchmanHelper {
 
     let diagnostics: DiagnosticsEngine
 
-    init(
+    public init(
         diagnostics: DiagnosticsEngine,
         watchmanScriptsDir: AbsolutePath,
         packageRoot: AbsolutePath,
@@ -45,7 +45,7 @@ final class WatchmanHelper {
         try run(scriptPath)
     }
 
-    func createXcodegenScript(_ options: XcodeprojOptions) throws -> AbsolutePath {
+    public func createXcodegenScript(_ options: XcodeprojOptions) throws -> AbsolutePath {
         let scriptPath = watchmanScriptsDir.appending(component: "gen-xcodeproj.sh")
 
         let stream = BufferedOutputByteStream()

--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -319,13 +319,13 @@ public struct PackageContainerConstraintSet: Collection, Hashable {
     /// Create an constraint set from known values.
     ///
     /// The initial constraints should never be unsatisfiable.
-    init(_ constraints: [PackageReference: PackageRequirement]) {
+    public init(_ constraints: [PackageReference: PackageRequirement]) {
         assert(constraints.values.filter({ $0 == .versionSet(.empty) }).isEmpty)
         self.constraints = constraints
     }
 
     /// The list of containers with entries in the set.
-    var containerIdentifiers: AnySequence<PackageReference> {
+    public var containerIdentifiers: AnySequence<PackageReference> {
         return AnySequence(constraints.keys)
     }
 
@@ -398,7 +398,7 @@ public struct PackageContainerConstraintSet: Collection, Hashable {
     ///
     /// - Returns: False if the merger has made the set unsatisfiable; i.e. true
     /// when the resulting set is satisfiable, if it was already so.
-    func merging(
+    public func merging(
         _ constraints: PackageContainerConstraintSet
     ) -> PackageContainerConstraintSet? {
         var result = self
@@ -443,7 +443,7 @@ public struct PackageContainerConstraintSet: Collection, Hashable {
 /// The set itself is designed to only ever contain a consistent set of
 /// assignments, i.e. each assignment should satisfy the induced
 /// `constraints`, but this invariant is not explicitly enforced.
-struct VersionAssignmentSet: Equatable, Sequence {
+public struct VersionAssignmentSet: Equatable, Sequence {
 
     // FIXME: Does it really make sense to key on the identifier here. Should we
     // require referential equality of containers and use that to simplify?
@@ -452,19 +452,19 @@ struct VersionAssignmentSet: Equatable, Sequence {
     fileprivate var assignments: OrderedDictionary<PackageReference, (container: PackageContainer, binding: BoundVersion)>
 
     /// Create an empty assignment.
-    init() {
+    public init() {
         assignments = [:]
     }
 
     /// The assignment for the given container `identifier.
-    subscript(identifier: PackageReference) -> BoundVersion? {
+    public subscript(identifier: PackageReference) -> BoundVersion? {
         get {
             return assignments[identifier]?.binding
         }
     }
 
     /// The assignment for the given `container`.
-    subscript(container: PackageContainer) -> BoundVersion? {
+    public subscript(container: PackageContainer) -> BoundVersion? {
         get {
             return self[container.identifier]
         }
@@ -483,7 +483,7 @@ struct VersionAssignmentSet: Equatable, Sequence {
     ///
     /// - Returns: The new assignment, or nil if the merge cannot be made (the
     /// assignments contain incompatible versions).
-    func merging(_ assignment: VersionAssignmentSet) -> VersionAssignmentSet? {
+    public func merging(_ assignment: VersionAssignmentSet) -> VersionAssignmentSet? {
         // In order to protect the assignment set, we first have to test whether
         // the merged constraint sets are satisfiable.
         //
@@ -520,7 +520,7 @@ struct VersionAssignmentSet: Equatable, Sequence {
     ///
     /// The resulting constraint set is guaranteed to be non-empty for each
     /// mapping, assuming the invariants on the set are followed.
-    var constraints: PackageContainerConstraintSet {
+    public var constraints: PackageContainerConstraintSet {
         // Collect all of the constraints.
         var result = PackageContainerConstraintSet()
 
@@ -561,7 +561,7 @@ struct VersionAssignmentSet: Equatable, Sequence {
     // FIXME: This is currently very inefficient.
     //
     /// Check if the given `binding` for `container` is valid within the assignment.
-    func isValid(binding: BoundVersion, for container: PackageContainer) -> Bool {
+    public func isValid(binding: BoundVersion, for container: PackageContainer) -> Bool {
         switch binding {
         case .excluded:
             // A package can be excluded if there are no constraints on the
@@ -594,7 +594,7 @@ struct VersionAssignmentSet: Equatable, Sequence {
     }
 
     /// Check if the assignment is valid and complete.
-    func checkIfValidAndComplete() -> Bool {
+    public func checkIfValidAndComplete() -> Bool {
         // Validity should hold trivially, because it is an invariant of the collection.
         for (_, assignment) in assignments {
             if !isValid(binding: assignment.binding, for: assignment.container) {
@@ -621,9 +621,9 @@ struct VersionAssignmentSet: Equatable, Sequence {
     // FIXME: This should really be a collection, but that takes significantly
     // more work given our current backing collection.
 
-    typealias Iterator = AnyIterator<(PackageContainer, BoundVersion)>
+    public typealias Iterator = AnyIterator<(PackageContainer, BoundVersion)>
 
-    func makeIterator() -> Iterator {
+    public func makeIterator() -> Iterator {
         var it = assignments.makeIterator()
         return AnyIterator {
             if let (_, next) = it.next() {
@@ -635,7 +635,7 @@ struct VersionAssignmentSet: Equatable, Sequence {
     }
 }
 
-func ==(lhs: VersionAssignmentSet, rhs: VersionAssignmentSet) -> Bool {
+public func ==(lhs: VersionAssignmentSet, rhs: VersionAssignmentSet) -> Bool {
     if lhs.assignments.count != rhs.assignments.count { return false }
     for (container, lhsBinding) in lhs {
         switch rhs[container] {
@@ -720,10 +720,8 @@ public class DependencyResolver {
     /// Lock used to get and set the error variable.
     private let errorLock: Lock = Lock()
 
-    // FIXME: @testable private
-    //
     /// Contains any error encountered during dependency resolution.
-    var error: Swift.Error? {
+    public var error: Swift.Error? {
         get {
             return errorLock.withLock { self.__error }
         } set {
@@ -851,7 +849,7 @@ public class DependencyResolver {
     ///                  constraints for the same container identifier.
     /// - Returns: A satisfying assignment of containers and versions.
     /// - Throws: DependencyResolverError, or errors from the underlying package provider.
-    func resolveAssignment(
+    public func resolveAssignment(
         constraints: [PackageContainerConstraint],
         pins: [PackageContainerConstraint] = []
     ) throws -> VersionAssignmentSet {
@@ -915,8 +913,6 @@ public class DependencyResolver {
     // FIXME: This needs to a way to return information on the failure, or we
     // will need to have it call the delegate directly.
     //
-    // FIXME: @testable private
-    //
     /// Resolve an individual container dependency tree.
     ///
     /// This is the primary method in our bottom-up algorithm for resolving
@@ -931,7 +927,7 @@ public class DependencyResolver {
     ///   - constraints: The external constraints which must be honored by the solution.
     ///   - exclusions: The list of individually excluded package versions.
     /// - Returns: A sequence of feasible solutions, starting with the most preferable.
-    func resolveSubtree(
+    public func resolveSubtree(
         _ container: Container,
         subjectTo allConstraints: PackageContainerConstraintSet,
         excluding allExclusions: [PackageReference: Set<Version>]

--- a/Sources/PackageGraph/PinsStore.swift
+++ b/Sources/PackageGraph/PinsStore.swift
@@ -21,7 +21,7 @@ public final class PinsStore {
         /// The pinned state.
         public let state: CheckoutState
 
-        init(
+        public init(
             packageRef: PackageReference,
             state: CheckoutState
         ) {

--- a/Sources/PackageGraph/Pubgrub.swift
+++ b/Sources/PackageGraph/Pubgrub.swift
@@ -14,27 +14,27 @@ import struct PackageModel.PackageReference
 
 /// A term represents a statement about a package that may be true or false.
 public struct Term: Equatable, Hashable {
-    let package: PackageReference
-    let requirement: VersionSetSpecifier
-    let isPositive: Bool
+    public let package: PackageReference
+    public let requirement: VersionSetSpecifier
+    public let isPositive: Bool
 
-    init(package: PackageReference, requirement: VersionSetSpecifier, isPositive: Bool) {
+    public init(package: PackageReference, requirement: VersionSetSpecifier, isPositive: Bool) {
         self.package = package
         self.requirement = requirement
         self.isPositive = isPositive
     }
 
-    init(_ package: PackageReference, _ requirement: VersionSetSpecifier) {
+    public init(_ package: PackageReference, _ requirement: VersionSetSpecifier) {
         self.init(package: package, requirement: requirement, isPositive: true)
     }
 
     /// Create a new negative term.
-    init(not package: PackageReference, _ requirement: VersionSetSpecifier) {
+    public init(not package: PackageReference, _ requirement: VersionSetSpecifier) {
         self.init(package: package, requirement: requirement, isPositive: false)
     }
 
     /// The same term with an inversed `isPositive` value.
-    var inverse: Term {
+    public var inverse: Term {
         return Term(
             package: package,
             requirement: requirement,
@@ -43,14 +43,14 @@ public struct Term: Equatable, Hashable {
 
     /// Check if this term satisfies another term, e.g. if `self` is true,
     /// `other` must also be true.
-    func satisfies(_ other: Term) -> Bool {
+    public func satisfies(_ other: Term) -> Bool {
         // TODO: This probably makes more sense as isSatisfied(by:) instead.
         guard self.package == other.package else { return false }
         return self.relation(with: other) == .subset
     }
 
     /// Create an intersection with another term.
-    func intersect(with other: Term) -> Term? {
+    public func intersect(with other: Term) -> Term? {
         guard self.package == other.package else { return nil }
         return intersect(withRequirement: other.requirement, andPolarity: other.isPositive)
     }
@@ -60,7 +60,7 @@ public struct Term: Equatable, Hashable {
     /// and given term.
     ///
     /// - returns: `nil` if an intersection is not possible.
-    func intersect(
+    public func intersect(
         withRequirement requirement: VersionSetSpecifier,
         andPolarity otherIsPositive: Bool
     ) -> Term? {
@@ -91,7 +91,7 @@ public struct Term: Equatable, Hashable {
         return Term(package: package, requirement: versionIntersection, isPositive: isPositive)
     }
 
-    func difference(with other: Term) -> Term? {
+    public func difference(with other: Term) -> Term? {
         return self.intersect(with: other.inverse)
     }
 
@@ -100,7 +100,7 @@ public struct Term: Equatable, Hashable {
     /// - There has to exist a positive derivation for it.
     /// - There has to be no decision for it.
     /// - The package version has to match all assignments.
-    func isValidDecision(for solution: PartialSolution) -> Bool {
+    public func isValidDecision(for solution: PartialSolution) -> Bool {
         for assignment in solution.assignments where assignment.term.package == package {
             assert(!assignment.isDecision, "Expected assignment to be a derivation.")
             guard satisfies(assignment.term) else { return false }
@@ -108,7 +108,7 @@ public struct Term: Equatable, Hashable {
         return true
     }
 
-    func relation(with other: Term) -> SetRelation {
+    public func relation(with other: Term) -> SetRelation {
         // From: https://github.com/dart-lang/pub/blob/master/lib/src/solver/term.dart
 
         if self.package != other.package {
@@ -155,7 +155,7 @@ public struct Term: Equatable, Hashable {
         }
     }
 
-    enum SetRelation: Equatable {
+    public enum SetRelation: Equatable {
         /// The sets have nothing in common.
         case disjoint
         /// The sets have elements in common but first set is not a subset of second.
@@ -191,20 +191,20 @@ extension Term: CustomStringConvertible {
 /// all be true at the same time. In dependency resolution, these are derived
 /// from version requirements and when running into unresolvable situations.
 public struct Incompatibility: Equatable, Hashable {
-    let terms: OrderedSet<Term>
-    let cause: Cause
+    public let terms: OrderedSet<Term>
+    public let cause: Cause
 
-    init(terms: OrderedSet<Term>, cause: Cause) {
+    public init(terms: OrderedSet<Term>, cause: Cause) {
         self.terms = terms
         self.cause = cause
     }
 
-    init(_ terms: Term..., root: PackageReference, cause: Cause = .root) {
+    public init(_ terms: Term..., root: PackageReference, cause: Cause = .root) {
         let termSet = OrderedSet(terms)
         self.init(termSet, root: root, cause: cause)
     }
 
-    init(_ terms: OrderedSet<Term>, root: PackageReference, cause: Cause) {
+    public init(_ terms: OrderedSet<Term>, root: PackageReference, cause: Cause) {
         if terms.isEmpty {
             self.init(terms: terms, cause: cause)
             return
@@ -260,10 +260,10 @@ extension Incompatibility {
     ///         │{root 1.0.0}│
     ///         └────────────┘
     /// ```
-    indirect enum Cause: Equatable, Hashable {
-        struct ConflictCause: Hashable {
-            let conflict: Incompatibility
-            let other: Incompatibility
+    public indirect enum Cause: Equatable, Hashable {
+        public struct ConflictCause: Hashable {
+            public let conflict: Incompatibility
+            public let other: Incompatibility
         }
 
         /// The root incompatibility.
@@ -286,14 +286,14 @@ extension Incompatibility {
         /// The package's tools version is incompatible.
         case incompatibleToolsVersion
 
-        var isConflict: Bool {
+        public var isConflict: Bool {
             if case .conflict = self { return true }
             return false
         }
 
         /// Returns whether this cause can be represented in a single line of the
         /// error output.
-        var isSingleLine: Bool {
+        public var isSingleLine: Bool {
             guard case .conflict(let cause) = self else {
                 assertionFailure("unreachable")
                 return false
@@ -312,10 +312,10 @@ extension Incompatibility {
 /// is later used during conflict resolution to figure out how far back to jump
 /// when a conflict is found.
 public struct Assignment: Equatable {
-    let term: Term
-    let decisionLevel: Int
-    let cause: Incompatibility?
-    let isDecision: Bool
+    public let term: Term
+    public let decisionLevel: Int
+    public let cause: Incompatibility?
+    public let isDecision: Bool
 
     private init(
         term: Term,
@@ -330,7 +330,7 @@ public struct Assignment: Equatable {
     }
 
     /// An assignment made during decision making.
-    static func decision(_ term: Term, decisionLevel: Int) -> Assignment {
+    public static func decision(_ term: Term, decisionLevel: Int) -> Assignment {
         assert(term.requirement.isExact, "Cannot create a decision assignment with a non-exact version selection: \(term.requirement)")
 
         return self.init(
@@ -342,7 +342,7 @@ public struct Assignment: Equatable {
 
     /// An assignment derived from previously known incompatibilities during
     /// unit propagation.
-    static func derivation(
+    public static func derivation(
         _ term: Term,
         cause: Incompatibility,
         decisionLevel: Int
@@ -368,30 +368,30 @@ extension Assignment: CustomStringConvertible {
 
 /// The partial solution is a constantly updated solution used throughout the
 /// dependency resolution process, tracking know assignments.
-final class PartialSolution {
+public final class PartialSolution {
     var root: PackageReference?
 
     /// All known assigments.
-    private(set) var assignments: [Assignment]
+    public private(set) var assignments: [Assignment]
 
     /// All known decisions.
-    private(set) var decisions: [PackageReference: Version] = [:]
+    public private(set) var decisions: [PackageReference: Version] = [:]
 
     /// The intersection of all positive assignments for each package, minus any
     /// negative assignments that refer to that package.
-    private(set) var _positive: OrderedDictionary<PackageReference, Term> = [:]
+    public private(set) var _positive: OrderedDictionary<PackageReference, Term> = [:]
 
     /// Union of all negative assignments for a package.
     ///
     /// Only present if a package has no postive assignment.
-    private(set) var _negative: [PackageReference: Term] = [:]
+    public private(set) var _negative: [PackageReference: Term] = [:]
 
     /// The current decision level.
-    var decisionLevel: Int {
+    public var decisionLevel: Int {
         return decisions.count - 1
     }
 
-    init(assignments: [Assignment] = []) {
+    public init(assignments: [Assignment] = []) {
         self.assignments = assignments
         for assignment in assignments {
             register(assignment)
@@ -399,13 +399,13 @@ final class PartialSolution {
     }
 
     /// A list of all packages that have been assigned, but are not yet satisfied.
-    var undecided: [Term] {
+    public var undecided: [Term] {
         return _positive.values.filter { !decisions.keys.contains($0.package) }
     }
 
     /// Create a new derivation assignment and add it to the partial solution's
     /// list of known assignments.
-    func derive(_ term: Term, cause: Incompatibility) {
+    public func derive(_ term: Term, cause: Incompatibility) {
         let derivation = Assignment.derivation(term, cause: cause, decisionLevel: decisionLevel)
         self.assignments.append(derivation)
         register(derivation)
@@ -413,7 +413,7 @@ final class PartialSolution {
 
     /// Create a new decision assignment and add it to the partial solution's
     /// list of known assignments.
-    func decide(_ package: PackageReference, at version: Version) {
+    public func decide(_ package: PackageReference, at version: Version) {
         decisions[package] = version
         let term = Term(package, .exact(version))
         let decision = Assignment.decision(term, decisionLevel: decisionLevel)
@@ -443,7 +443,7 @@ final class PartialSolution {
 
     /// Returns the first Assignment in this solution such that the list of
     /// assignments up to and including that entry satisfies term.
-    func satisfier(for term: Term) -> Assignment {
+    public func satisfier(for term: Term) -> Assignment {
         var assignedTerm: Term?
 
         for assignment in assignments {
@@ -462,7 +462,7 @@ final class PartialSolution {
 
     /// Backtrack to a specific decision level by dropping all assignments with
     /// a decision level which is greater.
-    func backtrack(toDecisionLevel decisionLevel: Int) {
+    public func backtrack(toDecisionLevel decisionLevel: Int) {
         var toBeRemoved: [(Int, Assignment)] = []
 
         for (idx, assignment) in zip(0..., assignments) {
@@ -539,14 +539,14 @@ public final class PubgrubDependencyResolver {
     public typealias Constraint = PackageContainerConstraint
 
     /// The current best guess for a solution satisfying all requirements.
-    var solution = PartialSolution()
+    public var solution = PartialSolution()
 
     /// A collection of all known incompatibilities matched to the packages they
     /// refer to. This means an incompatibility can occur several times.
-    var incompatibilities: [PackageReference: [Incompatibility]] = [:]
+    public var incompatibilities: [PackageReference: [Incompatibility]] = [:]
 
     /// Find all incompatibilities containing a positive term for a given package.
-    func positiveIncompatibilities(for package: PackageReference) -> [Incompatibility]? {
+    public func positiveIncompatibilities(for package: PackageReference) -> [Incompatibility]? {
         guard let all = incompatibilities[package] else {
             return nil
         }
@@ -590,12 +590,12 @@ public final class PubgrubDependencyResolver {
     private var _traceStream: OutputByteStream?
 
     /// Set the package root.
-    func set(_ root: PackageReference) {
+    public func set(_ root: PackageReference) {
         self.root = root
         self.solution.root = root
     }
 
-    enum LogLocation: String {
+    public enum LogLocation: String {
         case topLevel = "top level"
         case unitPropagation = "unit propagation"
         case decisionMaking = "decision making"
@@ -616,7 +616,7 @@ public final class PubgrubDependencyResolver {
         }
     }
 
-    func decide(_ package: PackageReference, version: Version) {
+    public func decide(_ package: PackageReference, version: Version) {
         let term = Term(package, .exact(version))
         // FIXME: Shouldn't we check this _before_ making a decision?
         assert(term.isValidDecision(for: solution))
@@ -628,7 +628,7 @@ public final class PubgrubDependencyResolver {
         solution.derive(term, cause: cause)
     }
 
-    init(
+    public init(
         _ provider: PackageContainerProvider,
         _ delegate: DependencyResolverDelegate? = nil,
         isPrefetchingEnabled: Bool = false,
@@ -655,7 +655,7 @@ public final class PubgrubDependencyResolver {
     }
 
     /// Add a new incompatibility to the list of known incompatibilities.
-    func add(_ incompatibility: Incompatibility, location: LogLocation) {
+    public func add(_ incompatibility: Incompatibility, location: LogLocation) {
         log("incompat: \(incompatibility) \(location)")
         for package in incompatibility.terms.map({ $0.package }) {
             if let incompats = incompatibilities[package] {
@@ -981,7 +981,7 @@ public final class PubgrubDependencyResolver {
     /// partial solution.
     /// If a conflict is found, the conflicting incompatibility is returned to
     /// resolve the conflict on.
-    func propagate(_ package: PackageReference) throws {
+    public func propagate(_ package: PackageReference) throws {
         var changed: OrderedSet<PackageReference> = [package]
 
         while !changed.isEmpty {
@@ -1048,7 +1048,7 @@ public final class PubgrubDependencyResolver {
         case none
     }
 
-    func _resolve(conflict: Incompatibility) throws -> Incompatibility {
+    public func _resolve(conflict: Incompatibility) throws -> Incompatibility {
         log("conflict: \(conflict)")
         // Based on:
         // https://github.com/dart-lang/pub/tree/master/doc/solver.md#conflict-resolution
@@ -1133,7 +1133,7 @@ public final class PubgrubDependencyResolver {
         return incompatibility.terms.isEmpty || (incompatibility.terms.count == 1 && incompatibility.terms.first?.package == root)
     }
 
-    func makeDecision() throws -> PackageReference? {
+    public func makeDecision() throws -> PackageReference? {
         let undecided = solution.undecided
 
         // If there are no more undecided terms, version solving is complete.

--- a/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
@@ -268,7 +268,7 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
 
     /// This is used to remember if tools version of a particular version is
     /// valid or not.
-    private(set) var validToolsVersionsCache: [Version: Bool] = [:]
+    public private(set) var validToolsVersionsCache: [Version: Bool] = [:]
 
     /// The available version list (in reverse order).
     public override func versions(filter isIncluded: (Version) -> Bool) -> AnySequence<Version> {

--- a/Sources/PackageGraph/VersionSetSpecifier.swift
+++ b/Sources/PackageGraph/VersionSetSpecifier.swift
@@ -29,11 +29,11 @@ public enum VersionSetSpecifier: Hashable {
 }
 
 extension VersionSetSpecifier {
-    static func union(from range: Swift.Range<Version>) -> VersionSetSpecifier {
+    public static func union(from range: Swift.Range<Version>) -> VersionSetSpecifier {
         return .union(from: [range])
     }
 
-    static func union(from ranges: [Swift.Range<Version>]) -> VersionSetSpecifier {
+    public static func union(from ranges: [Swift.Range<Version>]) -> VersionSetSpecifier {
         switch ranges.count {
         case 0:
             return .empty

--- a/Sources/PackageLoading/Target+PkgConfig.swift
+++ b/Sources/PackageLoading/Target+PkgConfig.swift
@@ -162,7 +162,7 @@ extension SystemPackageProviderDescription {
 /// compiler/linker. List of allowed flags:
 /// cFlags: -I, -F
 /// libs: -L, -l, -F, -framework, -w
-func whitelist(
+public func whitelist(
     pcFile: String,
     flags: (cFlags: [String], libs: [String])
 ) -> (cFlags: [String], libs: [String], unallowed: [String]) {
@@ -204,7 +204,7 @@ func whitelist(
 ///
 /// This behavior is similar to pkg-config cli tool and helps avoid conflicts between
 /// sdk and default search paths in macOS.
-func removeDefaultFlags(cFlags: [String], libs: [String]) -> ([String], [String]) {
+public func removeDefaultFlags(cFlags: [String], libs: [String]) -> ([String], [String]) {
     /// removes a flag from given array of flags.
     func remove(flag: (String, String), from flags: [String]) -> [String] {
         var result = [String]()

--- a/Sources/SPMTestSupport/TestWorkspace.swift
+++ b/Sources/SPMTestSupport/TestWorkspace.swift
@@ -13,7 +13,7 @@ import XCTest
 import TSCBasic
 import PackageModel
 import PackageLoading
-@testable import Workspace
+import Workspace
 import PackageGraph
 import SourceControl
 

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -138,14 +138,14 @@ enum GitInterfaceError: Swift.Error {
 /// A basic `git` repository. This class is thread safe.
 public class GitRepository: Repository, WorkingCheckout {
     /// A hash object.
-    struct Hash: Hashable {
+    public struct Hash: Hashable {
         // FIXME: We should optimize this representation.
         let bytes: ByteString
 
         /// Create a hash from the given hexadecimal representation.
         ///
         /// - Returns; The hash, or nil if the identifier is invalid.
-        init?(_ identifier: String) {
+        public init?(_ identifier: String) {
             self.init(asciiBytes: ByteString(encodingAsUTF8: identifier).contents)
         }
 
@@ -170,18 +170,18 @@ public class GitRepository: Repository, WorkingCheckout {
     }
 
     /// A commit object.
-    struct Commit: Equatable {
+    public struct Commit: Equatable {
         /// The object hash.
-        let hash: Hash
+        public let hash: Hash
 
         /// The tree contained in the commit.
-        let tree: Hash
+        public let tree: Hash
     }
 
     /// A tree object.
-    struct Tree {
-        struct Entry {
-            enum EntryType {
+    public struct Tree {
+        public struct Entry {
+            public enum EntryType {
                 case blob
                 case commit
                 case executableBlob
@@ -209,20 +209,20 @@ public class GitRepository: Repository, WorkingCheckout {
             }
 
             /// The hash of the object.
-            let hash: Hash
+            public let hash: Hash
 
             /// The type of object referenced.
-            let type: EntryType
+            public let type: EntryType
 
             /// The name of the object.
-            let name: String
+            public let name: String
         }
 
         /// The object hash.
-        let hash: Hash
+        public let hash: Hash
 
         /// The list of contents.
-        let contents: [Entry]
+        public let contents: [Entry]
     }
 
     /// The path of the repository on disk.
@@ -251,7 +251,7 @@ public class GitRepository: Repository, WorkingCheckout {
     /// - parameters:
     ///   - remote: The name of the remote to operate on. It should already be present.
     ///   - url: The new url of the remote.
-    func setURL(remote: String, url: String) throws {
+    public func setURL(remote: String, url: String) throws {
         try queue.sync {
             try Process.checkNonZeroExit(
                 args: Git.tool, "-C", path.pathString, "remote", "set-url", remote, url)
@@ -450,7 +450,7 @@ public class GitRepository: Repository, WorkingCheckout {
     ///
     /// Technically this method can accept much more than a "treeish", it maps
     /// to the syntax accepted by `git rev-parse`.
-    func resolveHash(treeish: String, type: String? = nil) throws -> Hash {
+    public func resolveHash(treeish: String, type: String? = nil) throws -> Hash {
         let specifier: String
         if let type = type {
             specifier = treeish + "^{\(type)}"
@@ -471,7 +471,7 @@ public class GitRepository: Repository, WorkingCheckout {
     }
 
     /// Read the commit referenced by `hash`.
-    func read(commit hash: Hash) throws -> Commit {
+    public func read(commit hash: Hash) throws -> Commit {
         // Currently, we just load the tree, using the typed `rev-parse` syntax.
         let treeHash = try resolveHash(treeish: hash.bytes.description, type: "tree")
 
@@ -479,7 +479,7 @@ public class GitRepository: Repository, WorkingCheckout {
     }
 
     /// Read a tree object.
-    func read(tree hash: Hash) throws -> Tree {
+    public func read(tree hash: Hash) throws -> Tree {
         // Get the contents using `ls-tree`.
         let treeInfo: String = try queue.sync {
             try cachedTrees.memo(key: hash) {

--- a/Sources/TSCBasic/OutputByteStream.swift
+++ b/Sources/TSCBasic/OutputByteStream.swift
@@ -651,7 +651,7 @@ public final class LocalFileOutputByteStream: FileOutputByteStream {
     private var closeOnDeinit: Bool
 
     /// Instantiate using the file pointer.
-    init(filePointer: UnsafeMutablePointer<FILE>, closeOnDeinit: Bool = true, buffered: Bool = true) throws {
+    public init(filePointer: UnsafeMutablePointer<FILE>, closeOnDeinit: Bool = true, buffered: Bool = true) throws {
         self.filePointer = filePointer
         self.closeOnDeinit = closeOnDeinit
         super.init(buffered: buffered)

--- a/Sources/TSCTestSupport/PseudoTerminal.swift
+++ b/Sources/TSCTestSupport/PseudoTerminal.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
-@testable import TSCBasic
+import TSCBasic
 import TSCLibc
 
 public final class PseudoTerminal {

--- a/Sources/TSCUtility/CollectionExtensions.swift
+++ b/Sources/TSCUtility/CollectionExtensions.swift
@@ -10,7 +10,7 @@
 
 extension Collection where Iterator.Element : Equatable {
     /// Split around a delimiting subsequence with maximum number of splits == 2
-    func spm_split(around delimiter: [Iterator.Element]) -> ([Iterator.Element], [Iterator.Element]?) {
+    public func spm_split(around delimiter: [Iterator.Element]) -> ([Iterator.Element], [Iterator.Element]?) {
 
         let orig = Array(self)
         let end = orig.endIndex

--- a/Sources/TSCUtility/PkgConfig.swift
+++ b/Sources/TSCUtility/PkgConfig.swift
@@ -28,12 +28,12 @@ public enum PkgConfigError: Swift.Error, CustomStringConvertible {
     }
 }
 
-struct PCFileFinder {
+public struct PCFileFinder {
     /// DiagnosticsEngine to emit warnings
     let diagnostics: DiagnosticsEngine
 
     /// Cached results of locations `pkg-config` will search for `.pc` files
-    private(set) static var pkgConfigPaths: [AbsolutePath]? // FIXME: @testable(internal)
+    public private(set) static var pkgConfigPaths: [AbsolutePath]? // FIXME: @testable(internal)
     private static var shouldEmitPkgConfigPathsDiagnostic = false
 
     /// The built-in search path list.
@@ -51,7 +51,7 @@ struct PCFileFinder {
     ///
     /// This is needed because on Linux machines, the search paths can be different
     /// from the standard locations that we are currently searching.
-    public init (diagnostics: DiagnosticsEngine, brewPrefix: AbsolutePath?) {
+    public init(diagnostics: DiagnosticsEngine, brewPrefix: AbsolutePath?) {
         self.diagnostics = diagnostics
         if PCFileFinder.pkgConfigPaths == nil {
             do {
@@ -183,22 +183,22 @@ public struct PkgConfig {
 /// Parser for the `pkg-config` `.pc` file format.
 ///
 /// See: https://www.freedesktop.org/wiki/Software/pkg-config/
-struct PkgConfigParser {
-    let pcFile: AbsolutePath
+public struct PkgConfigParser {
+    public let pcFile: AbsolutePath
     private let fileSystem: FileSystem
-    private(set) var variables = [String: String]()
-    var dependencies = [String]()
-    var privateDependencies = [String]()
-    var cFlags = [String]()
-    var libs = [String]()
+    public private(set) var variables = [String: String]()
+    public private(set) var dependencies = [String]()
+    public private(set) var privateDependencies = [String]()
+    public private(set) var cFlags = [String]()
+    public private(set) var libs = [String]()
 
-    init(pcFile: AbsolutePath, fileSystem: FileSystem) {
+    public init(pcFile: AbsolutePath, fileSystem: FileSystem) {
         precondition(fileSystem.isFile(pcFile))
         self.pcFile = pcFile
         self.fileSystem = fileSystem
     }
 
-    mutating func parse() throws {
+    public mutating func parse() throws {
         func removeComment(line: String) -> String {
             if let commentIndex = line.firstIndex(of: "#") {
                 return String(line[line.startIndex..<commentIndex])

--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -68,9 +68,9 @@ public final class ManagedDependency: JSONMappable, JSONSerializable, CustomStri
     ///
     /// This information is useful so it can be restored when users
     /// unedit a package.
-    var basedOn: ManagedDependency?
+    public internal(set) var basedOn: ManagedDependency?
 
-    init(
+    public init(
         packageRef: PackageReference,
         subpath: RelativePath,
         checkoutState: CheckoutState
@@ -82,7 +82,7 @@ public final class ManagedDependency: JSONMappable, JSONSerializable, CustomStri
     }
 
     /// Create a dependency present locally on the filesystem.
-    static func local(
+    public static func local(
         packageRef: PackageReference
     ) -> ManagedDependency {
         return ManagedDependency(
@@ -124,7 +124,7 @@ public final class ManagedDependency: JSONMappable, JSONSerializable, CustomStri
     /// - Parameters:
     ///     - subpath: The subpath inside the editables directory.
     ///     - unmanagedPath: A custom absolute path instead of the subpath.
-    func editedDependency(subpath: RelativePath, unmanagedPath: AbsolutePath?) -> ManagedDependency {
+    public func editedDependency(subpath: RelativePath, unmanagedPath: AbsolutePath?) -> ManagedDependency {
         return ManagedDependency(basedOn: self, subpath: subpath, unmanagedPath: unmanagedPath)
     }
 
@@ -222,7 +222,7 @@ public final class ManagedDependencies: SimplePersistanceProtocol {
     private var dependencyMap: [String: ManagedDependency]
 
     /// Path to the state file.
-    let statePath: AbsolutePath
+    public let statePath: AbsolutePath
 
     /// persistence helper
     let persistence: SimplePersistence
@@ -264,7 +264,7 @@ public final class ManagedDependencies: SimplePersistanceProtocol {
     }
 
     /// Returns the dependency given a name or identity.
-    func dependency(forNameOrIdentity nameOrIdentity: String) throws -> ManagedDependency {
+    public func dependency(forNameOrIdentity nameOrIdentity: String) throws -> ManagedDependency {
         for value in values {
             if value.packageRef.name == nameOrIdentity {
                 return value
@@ -284,7 +284,7 @@ public final class ManagedDependencies: SimplePersistanceProtocol {
         try saveState()
     }
 
-    func saveState() throws {
+    public func saveState() throws {
         try self.persistence.saveState(self)
     }
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -150,7 +150,7 @@ private enum PackageResolver {
 /// This class does *not* support concurrent operations.
 public class Workspace {
     /// A struct representing all the current manifests (root + external) in a package graph.
-    struct DependencyManifests {
+    public struct DependencyManifests {
         /// The package graph root.
         let root: PackageGraphRoot
 
@@ -171,12 +171,12 @@ public class Workspace {
         }
 
         /// Returns all manifests contained in DependencyManifests.
-        func allManifests() -> [Manifest] {
+        public func allManifests() -> [Manifest] {
             return dependencies.map({ $0.manifest })
         }
 
         /// Computes the identities which are declared in the manifests but aren't present in dependencies.
-        func missingPackageURLs() -> Set<PackageReference> {
+        public func missingPackageURLs() -> Set<PackageReference> {
             return computePackageURLs().missing
         }
 
@@ -241,7 +241,6 @@ public class Workspace {
             return (requiredIdentities, missingIdentities)
         }
 
-        // FIXME: @testable(internal)
         /// Returns constraints of the dependencies, including edited package constraints.
         func dependencyConstraints() -> [RepositoryPackageConstraint] {
             var allConstraints = [RepositoryPackageConstraint]()
@@ -272,7 +271,7 @@ public class Workspace {
 
         // FIXME: @testable(internal)
         /// Returns a list of constraints for all 'edited' package.
-        func editedPackagesConstraints() -> [RepositoryPackageConstraint] {
+        public func editedPackagesConstraints() -> [RepositoryPackageConstraint] {
             var constraints = [RepositoryPackageConstraint]()
 
             for (_, managedDependency) in dependencies {
@@ -1064,7 +1063,7 @@ extension Workspace {
     /// This will load the manifests for the root package as well as all the
     /// current dependencies from the working checkouts.
     // @testable internal
-    func loadDependencyManifests(
+    public func loadDependencyManifests(
         root: PackageGraphRoot,
         diagnostics: DiagnosticsEngine
     ) -> DependencyManifests {
@@ -1444,11 +1443,11 @@ extension Workspace {
         return false
     }
 
-    enum ResolutionPrecomputationResult: Equatable {
+    public enum ResolutionPrecomputationResult: Equatable {
         case required(reason: WorkspaceResolveReason)
         case notRequired
 
-        var isRequired: Bool {
+        public var isRequired: Bool {
             switch self {
             case .required: return true
             case .notRequired: return false
@@ -1460,7 +1459,7 @@ extension Workspace {
     ///
     /// - Returns: Returns a result defining whether dependency resolution is required and the reason for it.
     // @testable internal
-    func precomputeResolution(
+    public func precomputeResolution(
         root: PackageGraphRoot,
         dependencyManifests: DependencyManifests,
         pinsStore: PinsStore,
@@ -1917,8 +1916,6 @@ extension Workspace {
         return path
     }
 
-    // FIXME: @testable internal
-    //
     /// Create a local clone of the given `repository` checked out to `version`.
     ///
     /// If an existing clone is present, the repository will be reset to the

--- a/Sources/Xcodeproj/PropertyList.swift
+++ b/Sources/Xcodeproj/PropertyList.swift
@@ -57,7 +57,7 @@ extension PropertyList: CustomStringConvertible {
 
 extension PropertyList {
     /// Serializes the Plist enum to string.
-    func serialize() -> String {
+    public func serialize() -> String {
         return generatePlistRepresentation(plist: self, indentation: Indentation())
     }
 

--- a/Sources/Xcodeproj/SchemesGenerator.swift
+++ b/Sources/Xcodeproj/SchemesGenerator.swift
@@ -13,21 +13,21 @@ import PackageGraph
 import PackageModel
 
 /// Represents a scheme in Xcode for the project generation support.
-struct Scheme {
+public struct Scheme {
 
     /// The name of the scheme.
-    var name: String
+    public var name: String
 
     /// The scheme filename.
-    var filename: String {
+    public var filename: String {
         return name + ".xcscheme"
     }
 
     /// The list of regular targets contained in this scheme.
-    var regularTargets: Set<ResolvedTarget>
+    public var regularTargets: Set<ResolvedTarget>
 
     /// The list of test targets contained in this scheme.
-    var testTargets: Set<ResolvedTarget>
+    public var testTargets: Set<ResolvedTarget>
 
     init(name: String, regularTargets: [ResolvedTarget], testTargets: [ResolvedTarget]) {
         self.name = name
@@ -36,7 +36,7 @@ struct Scheme {
     }
 }
 
-final class SchemesGenerator {
+public final class SchemesGenerator {
 
     private let graph: PackageGraph
     private let container: String
@@ -44,7 +44,7 @@ final class SchemesGenerator {
     private let isCodeCoverageEnabled: Bool
     private let fs: FileSystem
 
-    init(
+    public init(
         graph: PackageGraph,
         container: String,
         schemesDir: AbsolutePath,
@@ -58,7 +58,7 @@ final class SchemesGenerator {
         self.fs = fs
     }
 
-    func buildSchemes() -> [Scheme] {
+    public func buildSchemes() -> [Scheme] {
         let rootPackage = graph.rootPackages[0]
 
         var schemes: [Scheme] = []

--- a/Sources/Xcodeproj/XcodeProjectModel.swift
+++ b/Sources/Xcodeproj/XcodeProjectModel.swift
@@ -60,12 +60,12 @@ public struct Xcode {
     /// a list of targets, and some additional information.  Note that schemes
     /// are outside of the project data model.
     public class Project {
-        let mainGroup: Group
-        var buildSettings: BuildSettingsTable
-        var productGroup: Group?
-        var projectDir: String
-        var targets: [Target]
-        init() {
+        public let mainGroup: Group
+        public var buildSettings: BuildSettingsTable
+        public var productGroup: Group?
+        public var projectDir: String
+        public var targets: [Target]
+        public init() {
             self.mainGroup = Group(path: "")
             self.buildSettings = BuildSettingsTable()
             self.productGroup = nil
@@ -86,12 +86,12 @@ public struct Xcode {
     public class Reference {
         /// Relative path of the reference.  It is usually a literal, but may
         /// in fact contain build settings.
-        var path: String
+        public var path: String
         /// Determines the base path for the reference's relative path.
-        var pathBase: RefPathBase
+        public var pathBase: RefPathBase
         /// Name of the reference, if different from the last path component
         /// (if not set, Xcode will use the last path component as the name).
-        var name: String?
+        public var name: String?
 
         /// Determines the base path for a reference's relative path (this is
         /// what for some reason is called a "source tree" in Xcode).
@@ -108,7 +108,7 @@ public struct Xcode {
             case buildDir = "BUILT_PRODUCTS_DIR"
         }
 
-        init(path: String, pathBase: RefPathBase = .groupDir, name: String? = nil) {
+        public init(path: String, pathBase: RefPathBase = .groupDir, name: String? = nil) {
             self.path = path
             self.pathBase = pathBase
             self.name = name
@@ -117,8 +117,8 @@ public struct Xcode {
 
     /// A reference to a file system entity (a file, folder, etc).
     public class FileReference: Reference {
-        var objectID: String?
-        var fileType: String?
+        public var objectID: String?
+        public var fileType: String?
 
         init(path: String, pathBase: RefPathBase = .groupDir, name: String? = nil, fileType: String? = nil, objectID: String? = nil) {
             super.init(path: path, pathBase: pathBase, name: name)
@@ -131,7 +131,7 @@ public struct Xcode {
     /// The resolved path of a group is used as the base path for any child
     /// references whose source tree type is GroupRelative.
     public class Group: Reference {
-        var subitems = [Reference]()
+        public var subitems = [Reference]()
 
         /// Creates and appends a new Group to the list of subitems.
         /// The new group is returned so that it can be configured.
@@ -161,14 +161,14 @@ public struct Xcode {
 
     /// An Xcode target, representing a single entity to build.
     public class Target {
-        var objectID: String?
-        var name: String
-        var productName: String
-        var productType: ProductType?
-        var buildSettings: BuildSettingsTable
-        var buildPhases: [BuildPhase]
-        var productReference: FileReference?
-        var dependencies: [TargetDependency]
+        public var objectID: String?
+        public var name: String
+        public var productName: String
+        public var productType: ProductType?
+        public var buildSettings: BuildSettingsTable
+        public var buildPhases: [BuildPhase]
+        public var productReference: FileReference?
+        public var dependencies: [TargetDependency]
         public enum ProductType: String {
             case application = "com.apple.product-type.application"
             case staticArchive = "com.apple.product-type.library.static"
@@ -240,14 +240,14 @@ public struct Xcode {
 
         /// A simple wrapper to prevent ownership cycles in the `dependencies`
         /// property.
-        struct TargetDependency {
-            unowned var target: Target
+        public struct TargetDependency {
+            public unowned var target: Target
         }
     }
 
     /// Abstract base class for all build phases in a target.
     public class BuildPhase {
-        var files: [BuildFile] = []
+        public var files: [BuildFile] = []
 
         /// Adds a new build file that refers to `fileRef`.
         @discardableResult public func addBuildFile(fileRef: FileReference) -> BuildFile {
@@ -278,7 +278,7 @@ public struct Xcode {
     /// A "copy files" build phase, i.e. one that copies files to an arbitrary
     /// location relative to the product.
     public class CopyFilesBuildPhase: BuildPhase {
-        var dstDir: String
+        public var dstDir: String
         init(dstDir: String) {
             self.dstDir = dstDir
         }
@@ -286,7 +286,7 @@ public struct Xcode {
 
     /// A "shell script" build phase, i.e. one that runs a custom shell script.
     public class ShellScriptBuildPhase: BuildPhase {
-        var script: String
+        public var script: String
         init(script: String) {
             self.script = script
         }
@@ -295,7 +295,7 @@ public struct Xcode {
     /// A build file, representing the membership of a file reference in a
     /// build phase of a target.
     public class BuildFile {
-        weak var fileRef: FileReference?
+        public weak var fileRef: FileReference?
         init(fileRef: FileReference) {
             self.fileRef = fileRef
         }
@@ -304,7 +304,10 @@ public struct Xcode {
 
         /// A set of file settings.
         public struct Settings {
-            var ATTRIBUTES: [String]?
+            public var ATTRIBUTES: [String]?
+
+            public init() {
+            }
         }
     }
 
@@ -315,18 +318,21 @@ public struct Xcode {
     public class BuildSettingsTable {
         /// Common build settings are in both generated configurations (Debug
         /// and Release).
-        var common = BuildSettings()
+        public var common = BuildSettings()
 
         /// Debug build settings are overlaid over the common settings in the
         /// generated Debug configuration.
-        var debug = BuildSettings()
+        public var debug = BuildSettings()
 
         /// Release build settings are overlaid over the common settings in the
         /// generated Release configuration.
-        var release = BuildSettings()
+        public var release = BuildSettings()
 
         /// An optional file reference to an .xcconfig file.
-        var xcconfigFileRef: FileReference?
+        public var xcconfigFileRef: FileReference?
+
+        public init() {
+        }
 
         /// A set of build settings, which is represented as a struct of optional
         /// build settings.  This is not optimally efficient, but it is great for
@@ -335,52 +341,52 @@ public struct Xcode {
             // Note: although some of these build settings sound like booleans,
             // they are all either strings or arrays of strings, because even
             // a boolean may be a macro reference expression.
-            var CLANG_CXX_LANGUAGE_STANDARD: String?
-            var CLANG_ENABLE_MODULES: String?
-            var CLANG_ENABLE_OBJC_ARC: String?
-            var COMBINE_HIDPI_IMAGES: String?
-            var COPY_PHASE_STRIP: String?
-            var DEBUG_INFORMATION_FORMAT: String?
-            var DEFINES_MODULE: String?
-            var DYLIB_INSTALL_NAME_BASE: String?
-            var EMBEDDED_CONTENT_CONTAINS_SWIFT: String?
-            var ENABLE_NS_ASSERTIONS: String?
-            var ENABLE_TESTABILITY: String?
-            var FRAMEWORK_SEARCH_PATHS: [String]?
-            var GCC_C_LANGUAGE_STANDARD: String?
-            var GCC_OPTIMIZATION_LEVEL: String?
-            var GCC_PREPROCESSOR_DEFINITIONS: [String]?
-            var HEADER_SEARCH_PATHS: [String]?
-            var INFOPLIST_FILE: String?
-            var LD_RUNPATH_SEARCH_PATHS: [String]?
-            var LIBRARY_SEARCH_PATHS: [String]?
-            var MACOSX_DEPLOYMENT_TARGET: String?
-            var IPHONEOS_DEPLOYMENT_TARGET: String?
-            var TVOS_DEPLOYMENT_TARGET: String?
-            var WATCHOS_DEPLOYMENT_TARGET: String?
-            var MODULEMAP_FILE: String?
-            var ONLY_ACTIVE_ARCH: String?
-            var OTHER_CFLAGS: [String]?
-            var OTHER_CPLUSPLUSFLAGS: [String]?
-            var OTHER_LDFLAGS: [String]?
-            var OTHER_SWIFT_FLAGS: [String]?
-            var PRODUCT_BUNDLE_IDENTIFIER: String?
-            var PRODUCT_MODULE_NAME: String?
-            var PRODUCT_NAME: String?
-            var PROJECT_NAME: String?
-            var SDKROOT: String?
-            var SKIP_INSTALL: String?
-            var SUPPORTED_PLATFORMS: [String]?
-            var SWIFT_ACTIVE_COMPILATION_CONDITIONS: [String]?
-            var SWIFT_FORCE_STATIC_LINK_STDLIB: String?
-            var SWIFT_FORCE_DYNAMIC_LINK_STDLIB: String?
-            var SWIFT_OPTIMIZATION_LEVEL: String?
-            var SWIFT_VERSION: String?
-            var TARGET_NAME: String?
-            var USE_HEADERMAP: String?
-            var LD: String?
+            public var CLANG_CXX_LANGUAGE_STANDARD: String?
+            public var CLANG_ENABLE_MODULES: String?
+            public var CLANG_ENABLE_OBJC_ARC: String?
+            public var COMBINE_HIDPI_IMAGES: String?
+            public var COPY_PHASE_STRIP: String?
+            public var DEBUG_INFORMATION_FORMAT: String?
+            public var DEFINES_MODULE: String?
+            public var DYLIB_INSTALL_NAME_BASE: String?
+            public var EMBEDDED_CONTENT_CONTAINS_SWIFT: String?
+            public var ENABLE_NS_ASSERTIONS: String?
+            public var ENABLE_TESTABILITY: String?
+            public var FRAMEWORK_SEARCH_PATHS: [String]?
+            public var GCC_C_LANGUAGE_STANDARD: String?
+            public var GCC_OPTIMIZATION_LEVEL: String?
+            public var GCC_PREPROCESSOR_DEFINITIONS: [String]?
+            public var HEADER_SEARCH_PATHS: [String]?
+            public var INFOPLIST_FILE: String?
+            public var LD_RUNPATH_SEARCH_PATHS: [String]?
+            public var LIBRARY_SEARCH_PATHS: [String]?
+            public var MACOSX_DEPLOYMENT_TARGET: String?
+            public var IPHONEOS_DEPLOYMENT_TARGET: String?
+            public var TVOS_DEPLOYMENT_TARGET: String?
+            public var WATCHOS_DEPLOYMENT_TARGET: String?
+            public var MODULEMAP_FILE: String?
+            public var ONLY_ACTIVE_ARCH: String?
+            public var OTHER_CFLAGS: [String]?
+            public var OTHER_CPLUSPLUSFLAGS: [String]?
+            public var OTHER_LDFLAGS: [String]?
+            public var OTHER_SWIFT_FLAGS: [String]?
+            public var PRODUCT_BUNDLE_IDENTIFIER: String?
+            public var PRODUCT_MODULE_NAME: String?
+            public var PRODUCT_NAME: String?
+            public var PROJECT_NAME: String?
+            public var SDKROOT: String?
+            public var SKIP_INSTALL: String?
+            public var SUPPORTED_PLATFORMS: [String]?
+            public var SWIFT_ACTIVE_COMPILATION_CONDITIONS: [String]?
+            public var SWIFT_FORCE_STATIC_LINK_STDLIB: String?
+            public var SWIFT_FORCE_DYNAMIC_LINK_STDLIB: String?
+            public var SWIFT_OPTIMIZATION_LEVEL: String?
+            public var SWIFT_VERSION: String?
+            public var TARGET_NAME: String?
+            public var USE_HEADERMAP: String?
+            public var LD: String?
 
-            init(
+            public init(
                 CLANG_CXX_LANGUAGE_STANDARD: String? = nil,
                 CLANG_ENABLE_MODULES: String? = nil,
                 CLANG_ENABLE_OBJC_ARC: String? = nil,

--- a/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
+++ b/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
@@ -366,7 +366,7 @@ extension Xcode.BuildSettingsTable: PropertyListSerializable {
     }
 }
 
-protocol PropertyListDictionaryConvertible {
+public protocol PropertyListDictionaryConvertible {
     func asPropertyList() -> PropertyList
 }
 
@@ -384,7 +384,7 @@ extension PropertyListDictionaryConvertible {
     /// applies to classes.  Creating a property list representation is totally
     /// independent of that serialization infrastructure (though it might well
     /// be invoked during of serialization of actual model objects).
-    func asPropertyList() -> PropertyList {
+    public func asPropertyList() -> PropertyList {
         // Borderline hacky, but the main thing is that adding or changing a
         // build setting does not require any changes to the property list
         // representation code.  Using a handcoded serializer might be more

--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -53,7 +53,7 @@ public func pbxproj(
 /// and cause a linker error (SR-3398).
 fileprivate let invalidXcodeModuleNames = Set(["Modules", "Headers", "Versions"])
 
-func xcodeProject(
+public func xcodeProject(
     xcodeprojPath: AbsolutePath,
     graph: PackageGraph,
     extraDirs: [AbsolutePath],

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -16,7 +16,7 @@ import SPMTestSupport
 import PackageModel
 import PackageLoading
 
-@testable import Build
+import Build
 
 #if os(macOS)
     let defaultTargetTriple: String = Triple.hostTriple.tripleString(forPlatformVersion: "10.10")

--- a/Tests/BuildTests/SwiftCompilerOutputParserTests.swift
+++ b/Tests/BuildTests/SwiftCompilerOutputParserTests.swift
@@ -9,7 +9,7 @@
  */
 
 import XCTest
-@testable import Build
+import Build
 
 class MockSwiftCompilerOutputParserDelegate: SwiftCompilerOutputParserDelegate {
     private var messages: [SwiftCompilerMessage] = []

--- a/Tests/CommandsTests/MultiRootSupportTests.swift
+++ b/Tests/CommandsTests/MultiRootSupportTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 import SPMTestSupport
 import TSCBasic
-@testable import Commands
+import Commands
 import Workspace
 
 final class MultiRootSupportTests: XCTestCase {

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -12,14 +12,13 @@ import XCTest
 import Foundation
 
 import TSCBasic
-@testable import Commands
+import Commands
 import Xcodeproj
 import PackageModel
 import SourceControl
 import SPMTestSupport
 import TSCUtility
 import Workspace
-@testable import class Workspace.PinsStore
 
 final class PackageToolTests: XCTestCase {
     @discardableResult

--- a/Tests/PackageDescription4Tests/VersionTests.swift
+++ b/Tests/PackageDescription4Tests/VersionTests.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-@testable import PackageDescription
+import PackageDescription
 import XCTest
 
 class VersionTests: XCTestCase {

--- a/Tests/PackageGraphTests/DependencyResolverTests.swift
+++ b/Tests/PackageGraphTests/DependencyResolverTests.swift
@@ -18,8 +18,6 @@ import struct TSCUtility.Version
 
 import SPMTestSupport
 
-// FIXME: We have no @testable way to import generic structures.
-@testable import PackageGraph
 import PackageModel
 
 private typealias MockPackageConstraint = PackageContainerConstraint

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -15,7 +15,7 @@ import PackageLoading
 import PackageModel
 import SourceControl
 
-@testable import PackageGraph
+import PackageGraph
 
 // There's some useful helper utilities defined below for easier testing:
 //

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -13,7 +13,7 @@ import XCTest
 import TSCBasic
 import PackageLoading
 import PackageModel
-@testable import PackageGraph
+import PackageGraph
 import SourceControl
 
 import SPMTestSupport

--- a/Tests/PackageGraphTests/VersionSetSpecifierTests.swift
+++ b/Tests/PackageGraphTests/VersionSetSpecifierTests.swift
@@ -11,7 +11,7 @@
 import Foundation
 import XCTest
 
-@testable import PackageGraph
+import PackageGraph
 
 final class VersionSetSpecifierTests: XCTestCase {
     func testUnion() {

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 import TSCBasic
 import PackageModel
-@testable import PackageLoading
+import PackageLoading
 
 class ModuleMapGeneration: XCTestCase {
 

--- a/Tests/PackageLoadingTests/WhitelistTests.swift
+++ b/Tests/PackageLoadingTests/WhitelistTests.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-@testable import PackageLoading
+import PackageLoading
 import XCTest
 
 final class PkgConfigWhitelistTests: XCTestCase {

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -16,8 +16,6 @@ import TSCUtility
 
 import SPMTestSupport
 
-@testable import class SourceControl.GitRepository
-
 class GitRepositoryTests: XCTestCase {
     /// Test the basic provider functions.
     func testRepositorySpecifier() {

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -15,8 +15,6 @@ import SourceControl
 
 import SPMTestSupport
 
-@testable import class SourceControl.RepositoryManager
-
 extension RepositoryManager {
     fileprivate func lookupSynchronously(repository: RepositorySpecifier) throws -> RepositoryHandle {
         return try await { self.lookup(repository: repository, completion: $0) }

--- a/Tests/TSCBasicTests/ProcessTests.swift
+++ b/Tests/TSCBasicTests/ProcessTests.swift
@@ -12,7 +12,7 @@ import TSCTestSupport
 import XCTest
 import TSCLibc
 
-@testable import TSCBasic
+import TSCBasic
 
 typealias ProcessID = TSCBasic.Process.ProcessID
 typealias Process = TSCBasic.Process

--- a/Tests/TSCBasicTests/TerminalControllerTests.swift
+++ b/Tests/TSCBasicTests/TerminalControllerTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 import TSCTestSupport
 import TSCLibc
-@testable import TSCBasic
+import TSCBasic
 
 final class TerminalControllerTests: XCTestCase {
     func testBasic() {

--- a/Tests/TSCBasicTests/miscTests.swift
+++ b/Tests/TSCBasicTests/miscTests.swift
@@ -10,7 +10,7 @@
 
 import XCTest
 import TSCTestSupport
-@testable import TSCBasic
+import TSCBasic
 
 class miscTests: XCTestCase {
 

--- a/Tests/TSCUtilityTests/CollectionTests.swift
+++ b/Tests/TSCUtilityTests/CollectionTests.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
-@testable import TSCUtility
+import TSCUtility
 import XCTest
 
 class CollectionTests: XCTestCase {

--- a/Tests/TSCUtilityTests/PkgConfigParserTests.swift
+++ b/Tests/TSCUtilityTests/PkgConfigParserTests.swift
@@ -12,7 +12,7 @@ import XCTest
 import TSCBasic
 import TSCTestSupport
 
-@testable import TSCUtility
+import TSCUtility
 
 final class PkgConfigParserTests: XCTestCase {
 

--- a/Tests/TSCUtilityTests/ProgressAnimationTests.swift
+++ b/Tests/TSCUtilityTests/ProgressAnimationTests.swift
@@ -12,7 +12,7 @@ import XCTest
 import TSCUtility
 import TSCLibc
 import TSCTestSupport
-@testable import TSCBasic
+import TSCBasic
 
 typealias Thread = TSCBasic.Thread
 

--- a/Tests/TSCUtilityTests/StringTests.swift
+++ b/Tests/TSCUtilityTests/StringTests.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-@testable import TSCUtility
+import TSCUtility
 import XCTest
 
 class StringTests: XCTestCase {

--- a/Tests/TSCUtilityTests/miscTests.swift
+++ b/Tests/TSCUtilityTests/miscTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 import TSCBasic
 import TSCTestSupport
-@testable import TSCUtility
+import TSCUtility
 
 class miscTests: XCTestCase {
     func testClangVersionOutput() {

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -13,10 +13,10 @@ import XCTest
 import TSCBasic
 import TSCUtility
 import PackageModel
-@testable import PackageGraph
+import PackageGraph
 import SPMTestSupport
 import SourceControl
-@testable import Workspace
+import Workspace
 
 final class PinsStoreTests: XCTestCase {
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -16,7 +16,7 @@ import PackageModel
 import PackageGraph
 import SourceControl
 import TSCUtility
-@testable import Workspace
+import Workspace
 
 import SPMTestSupport
 

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -13,7 +13,7 @@ import SPMTestSupport
 import PackageGraph
 import PackageModel
 import SourceControl
-@testable import Xcodeproj
+import Xcodeproj
 import TSCUtility
 import XCTest
 

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -14,7 +14,7 @@ import TSCBasic
 import PackageGraph
 import SPMTestSupport
 import PackageModel
-@testable import Xcodeproj
+import Xcodeproj
 
 class PackageGraphTests: XCTestCase {
     func testBasics() throws {

--- a/Tests/XcodeprojTests/PropertyListTests.swift
+++ b/Tests/XcodeprojTests/PropertyListTests.swift
@@ -9,7 +9,7 @@
 */
 
 import XCTest
-@testable import Xcodeproj
+import Xcodeproj
 
 class PropertyListTests: XCTestCase {
     func testBasics() {

--- a/Tests/XcodeprojTests/XcodeProjectModelSerializationTests.swift
+++ b/Tests/XcodeprojTests/XcodeProjectModelSerializationTests.swift
@@ -10,7 +10,7 @@
 
 import TSCBasic
 import SPMTestSupport
-@testable import Xcodeproj
+import Xcodeproj
 import XCTest
 
 class XcodeProjectModelSerializationTests: XCTestCase {

--- a/Tests/XcodeprojTests/XcodeProjectModelTests.swift
+++ b/Tests/XcodeprojTests/XcodeProjectModelTests.swift
@@ -10,7 +10,7 @@
 
 import TSCBasic
 import SPMTestSupport
-@testable import Xcodeproj
+import Xcodeproj
 import XCTest
 
 class XcodeProjectModelTests: XCTestCase {


### PR DESCRIPTION
Remove the usage of @testable imports because they force us to
enable testability in release mode which turns off compiler optimization
that we could be getting without testability. Instead, the APIs should
be public in the first place or we can prefix them with _ to indicate
that they're not expected to be used by the clients. This also allows us
to do proper performance testing.

<rdar://problem/58052876> Remove the usage of @testable from SwiftPM