### PR TITLE
[bootstrap] Don't force enable testability

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -540,8 +540,7 @@ def get_swiftpm_flags(args):
 
     if args.release:
         build_flags.extend([
-            "-Xswiftc", "-enable-testing",
-            "--configuration", "release"
+            "--configuration", "release",
         ])
 
     if args.verbose:


### PR DESCRIPTION
We don't require this anymore since we're no longer using testability.