### PR TITLE
Actually limit build jobs, fixing SR-10325 again

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -224,7 +224,8 @@ public final class BuildOperation: PackageStructureDelegate {
         let buildSystem = BuildSystem(
             buildFile: buildParameters.llbuildManifest.pathString,
             databaseFile: databasePath,
-            delegate: buildDelegate
+            delegate: buildDelegate,
+            schedulerLanes: buildParameters.jobs
         )
         buildDelegate.onCommmandFailure = { buildSystem.cancel() }
 

--- a/Sources/Build/BuildParameters.swift
+++ b/Sources/Build/BuildParameters.swift
@@ -8,6 +8,8 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import class Foundation.ProcessInfo
+
 import TSCBasic
 import TSCUtility
 
@@ -54,6 +56,9 @@ public struct BuildParameters: Encodable {
     /// The tools version to use.
     public var toolsVersion: ToolsVersion
 
+    /// How many jobs should llbuild and the Swift compiler spawn
+    public var jobs: UInt32
+
     /// If should link the Swift stdlib statically.
     public var shouldLinkStaticSwiftStdlib: Bool
 
@@ -88,6 +93,7 @@ public struct BuildParameters: Encodable {
         destinationTriple: Triple = Triple.hostTriple,
         flags: BuildFlags,
         toolsVersion: ToolsVersion = ToolsVersion.currentToolsVersion,
+        jobs: UInt32 = UInt32(ProcessInfo.processInfo.activeProcessorCount),
         shouldLinkStaticSwiftStdlib: Bool = false,
         shouldEnableManifestCaching: Bool = false,
         sanitizers: EnabledSanitizers = EnabledSanitizers(),
@@ -103,6 +109,7 @@ public struct BuildParameters: Encodable {
         self.triple = destinationTriple
         self.flags = flags
         self.toolsVersion = toolsVersion
+        self.jobs = jobs
         self.shouldLinkStaticSwiftStdlib = shouldLinkStaticSwiftStdlib
         self.shouldEnableManifestCaching = shouldEnableManifestCaching
         self.sanitizers = sanitizers

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -477,7 +477,7 @@ public final class SwiftTargetBuildDescription {
         args += optimizationArguments
         args += testingArguments
         args += ["-g"]
-        args += ["-j\(ProcessInfo.processInfo.activeProcessorCount)"]
+        args += ["-j\(buildParameters.jobs)"]
         args += activeCompilationConditions
         args += additionalFlags
         args += moduleCacheArgs
@@ -553,7 +553,7 @@ public final class SwiftTargetBuildDescription {
         result += optimizationArguments
         result += testingArguments
         result += ["-g"]
-        result += ["-j\(ProcessInfo.processInfo.activeProcessorCount)"]
+        result += ["-j\(buildParameters.jobs)"]
         result += activeCompilationConditions
         result += additionalFlags
         result += moduleCacheArgs
@@ -601,7 +601,7 @@ public final class SwiftTargetBuildDescription {
         result += optimizationArguments
         result += testingArguments
         result += ["-g"]
-        result += ["-j\(ProcessInfo.processInfo.activeProcessorCount)"]
+        result += ["-j\(buildParameters.jobs)"]
         result += activeCompilationConditions
         result += additionalFlags
         result += moduleCacheArgs

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -9,6 +9,7 @@
  */
 
 import func Foundation.NSUserName
+import class Foundation.ProcessInfo
 
 import TSCLibc
 import TSCBasic
@@ -686,6 +687,7 @@ public class SwiftTool<Options: ToolOptions> {
                 toolchain: toolchain,
                 destinationTriple: triple,
                 flags: options.buildFlags,
+                jobs: options.jobs ?? UInt32(ProcessInfo.processInfo.activeProcessorCount),
                 shouldLinkStaticSwiftStdlib: options.shouldLinkStaticSwiftStdlib,
                 sanitizers: options.sanitizers,
                 enableCodeCoverage: options.shouldEnableCodeCoverage,

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -50,7 +50,7 @@ final class BuildPlanTests: XCTestCase {
 
     /// The j argument.
     private var j: String {
-        return "-j\(ProcessInfo.processInfo.activeProcessorCount)"
+        return "-j3"
     }
 
     func mockBuildParameters(
@@ -67,6 +67,7 @@ final class BuildPlanTests: XCTestCase {
             toolchain: MockToolchain(),
             destinationTriple: destinationTriple,
             flags: flags,
+            jobs: 3,
             shouldLinkStaticSwiftStdlib: shouldLinkStaticSwiftStdlib,
             indexStoreMode: indexStoreMode
         )


### PR DESCRIPTION
Rather than passing the number of CPUs everywhere, use the jobs option to limit both the number of llbuild jobs and Swift compiler jobs. @TaborKelly tried to fix this in #2127, but [it was lost when implementing build manifest caching in master](https://github.com/apple/swift-package-manager/commit/87366c916154d80e161e1364d291225798fb51ba#diff-b1d92ba41a0ed8ddabdf8c2604a41504L628), which probably wasn't noticed because it isn't tested.

As this pull applies the same limit to both the number of llbuild jobs and the number of jobs that an instance of the swiftc compiler creates, it's possible that `-j5` will actually spawn 25 compilation processes, ie 5 llbuild swiftc jobs that spawn 5 `swift -frontend` processes each.

Since SPM seems to call the swiftc compiler once for each target and all its files, it seems to depend on how many targets the Package.swift manifest has. I tried it on a manifest with only a single target and this pull works great, but when bootstrapping SPM itself, which has several targets, the above n^2 problem seems to crop up. I didn't actually check how many `swift -frontend` processes were launched, as many of them are short-lived and tough to catch with ps, but when SPM was called with `-j5` there were 5 swiftc invocations running, each with its own `-j5` flag.

This is not a problem for C/C++ llbuild jobs kicked off by SPM, as those compilers don't take a jobs flag, but ideally SPM would account for this somehow, perhaps by counting the number of targets and dividing the jobs by that, passing the former to llbuild and the latter to `swiftc`? For now, this is a simple way to actually give the user some control.

This pull gets rid of all the use of `ProcessInfo.processInfo.activeProcessorCount` except for as a default, other [than this `num-threads` setting passed to llbuild](https://github.com/apple/swift-package-manager/blob/879cb86615f5820990c5d802a55330c869731372/Sources/LLBuildManifest/Tools.swift#L169), which is [apparently only used for WMO](https://github.com/apple/swift-llbuild/commit/1fd0263f#diff-67454dd918539430b5d2f121b8788fbfR2377).