### PR TITLE
Add support for performing partial package graph updates

### DIFF
--- a/Sources/PackageGraph/PinsStore.swift
+++ b/Sources/PackageGraph/PinsStore.swift
@@ -14,6 +14,8 @@ import SourceControl
 import PackageModel
 
 public final class PinsStore {
+    public typealias PinsMap = [PackageReference.PackageIdentity: PinsStore.Pin]
+
     public struct Pin {
         /// The package reference of the pinned dependency.
         public let packageRef: PackageReference
@@ -42,9 +44,7 @@ public final class PinsStore {
     fileprivate var fileSystem: FileSystem
 
     /// The pins map.
-    ///
-    /// Key -> Package Identity.
-    public fileprivate(set) var pinsMap: [String: Pin]
+    public fileprivate(set) var pinsMap: PinsMap
 
     /// The current pins.
     public var pins: AnySequence<Pin> {

--- a/Sources/PackageModel/Package.swift
+++ b/Sources/PackageModel/Package.swift
@@ -116,6 +116,7 @@ extension Package: ObjectIdentifierProtocol {
 ///
 /// This represents a reference to a package containing its identity and location.
 public struct PackageReference: JSONMappable, JSONSerializable, CustomStringConvertible, Equatable, Hashable {
+    public typealias PackageIdentity = String
 
     /// The kind of package reference.
     public enum Kind: String, Codable {
@@ -148,7 +149,7 @@ public struct PackageReference: JSONMappable, JSONSerializable, CustomStringConv
     }
 
     /// The identity of the package.
-    public let identity: String
+    public let identity: PackageIdentity
 
     /// The name of the package, if available.
     public var name: String {

--- a/Sources/SPMTestSupport/TestWorkspace.swift
+++ b/Sources/SPMTestSupport/TestWorkspace.swift
@@ -248,6 +248,7 @@ public final class TestWorkspace {
     public func checkUpdate(
         roots: [String] = [],
         deps: [TestWorkspace.PackageDependency] = [],
+        packages: [String] = [],
         _ result: (DiagnosticsEngine) -> ()
     ) {
         let dependencies = deps.map({ $0.convert(packagesDir, url: urlForPackage(withName: $0.name)) })
@@ -255,7 +256,7 @@ public final class TestWorkspace {
         let workspace = createWorkspace()
         let rootInput = PackageGraphRootInput(
             packages: rootPaths(for: roots), dependencies: dependencies)
-        workspace.updateDependencies(root: rootInput, diagnostics: diagnostics)
+        workspace.updateDependencies(root: rootInput, packages: packages, diagnostics: diagnostics)
         result(diagnostics)
     }
     

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -963,7 +963,7 @@ final class PubgrubTests: XCTestCase {
             "b": .version(v1),
         ])
 
-        let result = resolver.solve(dependencies: dependencies, pinsStore: pinsStore)
+        let result = resolver.solve(dependencies: dependencies, pinsMap: pinsStore.pinsMap)
 
         // Since a was pinned, we shouldn't have computed bounds for its incomaptibilities.
         let aIncompat = resolver.positiveIncompatibilities(for: builder.reference(for: "a"))![0]
@@ -997,7 +997,7 @@ final class PubgrubTests: XCTestCase {
             "b": .version(v1),
         ])
 
-        let result = resolver.solve(dependencies: dependencies, pinsStore: pinsStore)
+        let result = resolver.solve(dependencies: dependencies, pinsMap: pinsStore.pinsMap)
 
         AssertResult(result, [
             ("a", .version(v1)),
@@ -1023,7 +1023,7 @@ final class PubgrubTests: XCTestCase {
             "b": .branch("master", revision: "master-sha-2"),
         ])
 
-        let result = resolver.solve(dependencies: dependencies, pinsStore: pinsStore)
+        let result = resolver.solve(dependencies: dependencies, pinsMap: pinsStore.pinsMap)
 
         AssertResult(result, [
             ("a", .revision("develop")),

--- a/Tests/WorkspaceTests/XCTestManifests.swift
+++ b/Tests/WorkspaceTests/XCTestManifests.swift
@@ -71,6 +71,7 @@ extension WorkspaceTests {
         ("testMissingEditCanRestoreOriginalCheckout", testMissingEditCanRestoreOriginalCheckout),
         ("testMultipleRootPackages", testMultipleRootPackages),
         ("testPackageMirror", testPackageMirror),
+        ("testPartialUpdate", testPartialUpdate),
         ("testPrecomputeResolution_empty", testPrecomputeResolution_empty),
         ("testPrecomputeResolution_newPackages", testPrecomputeResolution_newPackages),
         ("testPrecomputeResolution_notRequired", testPrecomputeResolution_notRequired),


### PR DESCRIPTION
This adds support for partially updating the package graph. The package update
command will not optionally take a list of package names and only those
packages would be updated. This is done by respecting the entry in
Package.resolved for other packages in the graph. Example invocation:

    swift package update Foo Bar Baz
