### PR TITLE
Properly conditionalize dependencies in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -207,7 +207,7 @@ let package = Package(
 
 import class Foundation.ProcessInfo
 
-if ProcessInfo.processInfo.environment["SWIFTPM_BOOTSTRAP"] == nil {
+if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         package.dependencies += [
             .package(url: "https://github.com/apple/swift-llbuild.git", .branch("master")),

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -523,10 +523,8 @@ def get_swiftpm_env_cmd(args):
         env_cmd.append("SDKROOT=%s" % args.sysroot)
 
     if args.llbuild_link_framework:
-        # FIXME: We always need to pass this.
-        env_cmd.append("SWIFTPM_BOOTSTRAP=1")
-    else:
-        env_cmd.append("SWIFTCI_USE_LOCAL_DEPS=1")
+        env_cmd.append("SWIFTPM_LLBUILD_FWK=1")
+    env_cmd.append("SWIFTCI_USE_LOCAL_DEPS=1")
 
     libs_joined = ":".join([
         os.path.join(args.bootstrap_dir, "lib"),


### PR DESCRIPTION
Some of the logic for conditionalization was wrong in our
manifest/bootstrap script. For example, tools support core is cloned
when SWIFTCI_USE_LOCAL_DEPS is set but it's not set when linking llbuild
as a framework. Similarly, we should turn SWIFTPM_BOOTSTRAP to something
better that describes its purpose.

<rdar://problem/58303769>