### PR TITLE
[Workspace] Fix a precomputation bug when moving from version to revi…

### DIFF
--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -142,16 +142,18 @@ private struct LocalPackageContainer: PackageContainer {
     }
 
     func getDependencies(at revision: String) throws -> [PackageContainerConstraint] {
-        // Throw an error when the dependency is not at the correct revision to fail resolution.
-        guard dependency?.checkoutState?.revision.identifier == revision else {
-            throw ResolverPrecomputationError.differentRequirement(
-                package: package,
-                state: dependency?.state,
-                requirement: .revision(revision)
-            )
+        // Return the dependencies if the checkout state matches the revision.
+        if let checkoutState = dependency?.checkoutState,
+            checkoutState.version == nil,
+            checkoutState.revision.identifier == revision {
+            return manifest.dependencyConstraints(config: config)
         }
 
-        return manifest.dependencyConstraints(config: config)
+        throw ResolverPrecomputationError.differentRequirement(
+            package: self.package,
+            state: self.dependency?.state,
+            requirement: .revision(revision)
+        )
     }
 
     func getUnversionedDependencies() throws -> [PackageContainerConstraint] {

--- a/Tests/WorkspaceTests/XCTestManifests.swift
+++ b/Tests/WorkspaceTests/XCTestManifests.swift
@@ -80,6 +80,7 @@ extension WorkspaceTests {
         ("testPrecomputeResolution_requirementChange_localToBranch", testPrecomputeResolution_requirementChange_localToBranch),
         ("testPrecomputeResolution_requirementChange_versionToBranch", testPrecomputeResolution_requirementChange_versionToBranch),
         ("testPrecomputeResolution_requirementChange_versionToLocal", testPrecomputeResolution_requirementChange_versionToLocal),
+        ("testPrecomputeResolution_requirementChange_versionToRevision", testPrecomputeResolution_requirementChange_versionToRevision),
         ("testResolutionFailureWithEditedDependency", testResolutionFailureWithEditedDependency),
         ("testResolve", testResolve),
         ("testResolvedFileUpdate", testResolvedFileUpdate),


### PR DESCRIPTION
…sion

Previously, we didn't detect if we moved from version to a revision that
pointed to the same SHA as the previous version.

<rdar://problem/57965934>