### PR TITLE
build: explicitly link against dispatch and Foundation

### DIFF
--- a/TSC/CMakeLists.txt
+++ b/TSC/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15.1)
 
 project(SwiftTSC LANGUAGES C Swift)
- 
+
 set(SWIFT_VERSION 5)
 set(CMAKE_Swift_LANGUAGE_VERSION ${SWIFT_VERSION})
 if(CMAKE_VERSION VERSION_LESS 3.16)
@@ -9,12 +9,15 @@ if(CMAKE_VERSION VERSION_LESS 3.16)
 endif()
 
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
- 
+
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 option(BUILD_SHARED_LIBS "Build shared libraryes by default" YES)
+
+find_package(dispatch QUIET)
+find_package(Foundation QUIET)
 
 add_subdirectory(Sources)
 add_subdirectory(cmake/modules)

--- a/TSC/Sources/TSCBasic/CMakeLists.txt
+++ b/TSC/Sources/TSCBasic/CMakeLists.txt
@@ -51,6 +51,10 @@ add_library(TSCBasic
   Tuple.swift)
 target_link_libraries(TSCBasic PUBLIC
   TSCLibc)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  target_link_libraries(TSCBasic PUBLIC
+    Foundation)
+endif()
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(TSCBasic PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})


### PR DESCRIPTION
On platforms where Foundation is not provided by the system and you wish
to build against a custom build of Foundation, you need a number of
flags.  This allows you to instead opt for passing `-DFoundation_DIR=`
and `-Ddispatch_DIR=` to CMake when configuring to pick up those paths.