### PR TITLE
Add -gnu in aarch64 Linux's triple

### DIFF
--- a/Sources/Build/Triple.swift
+++ b/Sources/Build/Triple.swift
@@ -136,7 +136,7 @@ public struct Triple: Encodable {
     public static let i686Linux = try! Triple("i686-unknown-linux")
     public static let ppc64leLinux = try! Triple("powerpc64le-unknown-linux")
     public static let s390xLinux = try! Triple("s390x-unknown-linux")
-    public static let arm64Linux = try! Triple("aarch64-unknown-linux")
+    public static let arm64Linux = try! Triple("aarch64-unknown-linux-gnu")
     public static let armLinux = try! Triple("armv7-unknown-linux-gnueabihf")
     public static let armAndroid = try! Triple("armv7a-unknown-linux-androideabi")
     public static let arm64Android = try! Triple("aarch64-unknown-linux-android")


### PR DESCRIPTION
`swift-package-manager` builds for `master-branch` and `swift-5.2-branch` are currently failing on Linux Aarch64 with following error:-
```
File "/usr/lib/python2.7/distutils/file_util.py", line 110, in copy_file
    "can't copy '%s': doesn't exist or not a regular file" % src)
distutils.errors.DistutilsFileError: can't copy '/home/worksonarm_test/jenkins_slave/workspace/swift-master-aarch64/build/buildbot_linux/swiftpm-linux-aarch64/aarch64-unknown-linux-gnu/release/swift-build': doesn't exist or not a regular file
```
Due to the new swiftpm build methods Linux Aarch64 now requires the `-gnu` tag on the triple.

This was adding to x86_64 in https://github.com/apple/swift-package-manager/pull/2353

This is currently causing the build failures on https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-aarch64/

This changed will also need to be applied to the `swift-5.2-branch`