### PR TITLE
Add new useful ByteString APIs

### DIFF
--- a/TSC/Tests/TSCBasicTests/ByteStringTests.swift
+++ b/TSC/Tests/TSCBasicTests/ByteStringTests.swift
@@ -67,4 +67,20 @@ class ByteStringTests: XCTestCase {
         s <<< ByteString([1, 2, 3])
         XCTAssertEqual(s.bytes, [1, 2, 3])
     }
+
+    func testWithData() {
+        let byteString = ByteString([0xde, 0xad, 0xbe, 0xef])
+        byteString.withData { data in
+            XCTAssertEqual(data.count, 4)
+            XCTAssertEqual(data[0], 0xde)
+            XCTAssertEqual(data[1], 0xad)
+            XCTAssertEqual(data[2], 0xbe)
+            XCTAssertEqual(data[3], 0xef)
+        }
+    }
+
+    func testHexadecimalRepresentation() {
+        let byteString = ByteString([0xde, 0xad, 0xbe, 0xef])
+        XCTAssertEqual(byteString.hexadecimalRepresentation, "deadbeef")
+    }
 }

--- a/TSC/Tests/TSCBasicTests/XCTestManifests.swift
+++ b/TSC/Tests/TSCBasicTests/XCTestManifests.swift
@@ -20,7 +20,9 @@ extension ByteStringTests {
         ("testByteStreamable", testByteStreamable),
         ("testDescription", testDescription),
         ("testHashable", testHashable),
+        ("testHexadecimalRepresentation", testHexadecimalRepresentation),
         ("testInitializers", testInitializers),
+        ("testWithData", testWithData),
     ]
 }
 


### PR DESCRIPTION
Adds a zero-copy `withData` function to get access to a `Data` instance that wraps the `ByteString`, and a `hexadecimalRepresentation` function.

Both functions are used by the new binary targets implementation.