### PR TITLE
SPM should always invoke xcrun using an absolute path

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -648,7 +648,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         // Find SDKROOT on macOS using xcrun.
       #if os(macOS)
         let foundPath = try? Process.checkNonZeroExit(
-            args: "xcrun", "--sdk", "macosx", "--show-sdk-path")
+            args: "/usr/bin/xcrun", "--sdk", "macosx", "--show-sdk-path")
         guard let sdkRoot = foundPath?.spm_chomp(), !sdkRoot.isEmpty else {
             return nil
         }

--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -84,7 +84,7 @@ public struct Destination: Encodable {
         } else {
             // No value in env, so search for it.
             let sdkPathStr = try Process.checkNonZeroExit(
-                arguments: ["xcrun", "--sdk", "macosx", "--show-sdk-path"], environment: environment).spm_chomp()
+                arguments: ["/usr/bin/xcrun", "--sdk", "macosx", "--show-sdk-path"], environment: environment).spm_chomp()
             guard !sdkPathStr.isEmpty else {
                 throw DestinationError.invalidInstallation("default SDK not found")
             }
@@ -129,7 +129,7 @@ public struct Destination: Encodable {
             return path
         }
         let platformPath = try? Process.checkNonZeroExit(
-            arguments: ["xcrun", "--sdk", "macosx", "--show-sdk-platform-path"],
+            arguments: ["/usr/bin/xcrun", "--sdk", "macosx", "--show-sdk-platform-path"],
             environment: environment).spm_chomp()
 
         if let platformPath = platformPath, !platformPath.isEmpty {

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -15,7 +15,7 @@ import protocol Build.Toolchain
 import TSCUtility
 
 #if os(macOS)
-private let whichArgs: [String] = ["xcrun", "--find"]
+private let whichArgs: [String] = ["/usr/bin/xcrun", "--find"]
 #else
 private let whichArgs = ["which"]
 #endif
@@ -215,7 +215,7 @@ public final class UserToolchain: Toolchain {
         // We require xctest to exist on macOS.
       #if os(macOS)
         // FIXME: We should have some general utility to find tools.
-        let xctestFindArgs = ["xcrun", "--sdk", "macosx", "--find", "xctest"]
+        let xctestFindArgs = ["/usr/bin/xcrun", "--sdk", "macosx", "--find", "xctest"]
         self.xctest = try AbsolutePath(validating: Process.checkNonZeroExit(arguments: xctestFindArgs, environment: environment).spm_chomp())
       #else
         self.xctest = nil


### PR DESCRIPTION
Failing to do so will cause the build to fail when running `swift build`
under certain environments such as tests which don't have PATH set.
Further, it is not valid to invoke xcrun from any other location but
/usr/bin, so we should not spend time looking up a constant.