### PR TITLE
SR-12008 SwiftPM: On Linux, enable-test-discovery stumbles over deprecated tests

### DIFF
--- a/Fixtures/Miscellaneous/TestingDeprecatedFunctionality/Package.swift
+++ b/Fixtures/Miscellaneous/TestingDeprecatedFunctionality/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "TestingDeprecatedFunctionality",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "TestingDeprecatedFunctionality",
+            targets: ["TestingDeprecatedFunctionality"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "TestingDeprecatedFunctionality",
+            dependencies: []),
+        .testTarget(
+            name: "TestingDeprecatedFunctionalityTests",
+            dependencies: ["TestingDeprecatedFunctionality"]),
+    ]
+)

--- a/Fixtures/Miscellaneous/TestingDeprecatedFunctionality/Sources/TestingDeprecatedFunctionality/TestingDeprecatedFunctionality.swift
+++ b/Fixtures/Miscellaneous/TestingDeprecatedFunctionality/Sources/TestingDeprecatedFunctionality/TestingDeprecatedFunctionality.swift
@@ -1,0 +1,5 @@
+struct TestingDeprecatedFunctionality {
+    let newText = "New text."
+    @available(*, deprecated, message: "Please use newText instead")
+    let text = "Deprecated text."
+}

--- a/Fixtures/Miscellaneous/TestingDeprecatedFunctionality/Tests/TestingDeprecatedFunctionalityTests/TestingDeprecatedFunctionalityTests.swift
+++ b/Fixtures/Miscellaneous/TestingDeprecatedFunctionality/Tests/TestingDeprecatedFunctionalityTests/TestingDeprecatedFunctionalityTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+@testable import TestingDeprecatedFunctionality
+
+final class TestingDeprecatedFunctionalityTests: XCTestCase {
+    @available(*, deprecated, message: "Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
+    func testDeprecatedFunctionality() {
+        XCTAssertEqual(TestingDeprecatedFunctionality().text, "Deprecated text.")
+    }
+}

--- a/Sources/SPMTestSupport/XCTAssertHelpers.swift
+++ b/Sources/SPMTestSupport/XCTAssertHelpers.swift
@@ -54,10 +54,11 @@ public func XCTAssertSwiftTest(
     _ path: AbsolutePath,
     file: StaticString = #file,
     line: UInt = #line,
-    env: [String: String]? = nil
+    env: [String: String]? = nil,
+    args: [String] = []
 ) {
     do {
-        _ = try SwiftPMProduct.SwiftTest.execute([], packagePath: path, env: env)
+        _ = try SwiftPMProduct.SwiftTest.execute(args, packagePath: path, env: env)
     } catch {
         XCTFail("""
             `swift test' failed:

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -515,4 +515,10 @@ class MiscellaneousTestCase: XCTestCase {
             XCTAssertMatch(diff, .contains("Func Foo.foo() has return type change from Swift.String to Swift.Int"))
         }
     }
+    
+    func testDeprecatedFunctionalityInTests() {
+        fixture(name: "Miscellaneous/TestingDeprecatedFunctionality") { prefix in
+            XCTAssertSwiftTest(prefix, args: ["-Xswiftc", "-warnings-as-errors", "--enable-test-discovery"])
+        }
+    }
 }

--- a/Tests/FunctionalTests/XCTestManifests.swift
+++ b/Tests/FunctionalTests/XCTestManifests.swift
@@ -35,6 +35,7 @@ extension MiscellaneousTestCase {
         ("testCanBuildMoreThanTwiceWithExternalDependencies", testCanBuildMoreThanTwiceWithExternalDependencies),
         ("testCanKillSubprocessOnSigInt", testCanKillSubprocessOnSigInt),
         ("testCompileFailureExitsGracefully", testCompileFailureExitsGracefully),
+        ("testDeprecatedFunctionalityInTests", testDeprecatedFunctionalityInTests),
         ("testExternalDependencyEdges1", testExternalDependencyEdges1),
         ("testExternalDependencyEdges2", testExternalDependencyEdges2),
         ("testInternalDependencyEdges", testInternalDependencyEdges),


### PR DESCRIPTION

####  Motivation

https://bugs.swift.org/browse/SR-12008

#### Modification

- changed file generation for `TestDiscoveryCommand`
- added a basic test and run `swift test --generate-linuxmain`

#### Result

`swift test -Xswiftc -warnings-as-errors --enable-test-discovery` would work without errors on Linux(any environment without Darwin's ObjC runtime?) with tests marked as `deprecated`.

