### PR TITLE
Use the swift compiler to get the host triple

### DIFF
--- a/Sources/Build/BuildParameters.swift
+++ b/Sources/Build/BuildParameters.swift
@@ -95,7 +95,7 @@ public struct BuildParameters: Encodable {
         dataPath: AbsolutePath,
         configuration: BuildConfiguration,
         toolchain: Toolchain,
-        destinationTriple: Triple = Triple.hostTriple,
+        destinationTriple: Triple? = nil,
         flags: BuildFlags,
         toolsVersion: ToolsVersion = ToolsVersion.currentToolsVersion,
         jobs: UInt32 = UInt32(ProcessInfo.processInfo.activeProcessorCount),
@@ -111,7 +111,7 @@ public struct BuildParameters: Encodable {
         self.dataPath = dataPath
         self.configuration = configuration
         self._toolchain = _Toolchain(toolchain: toolchain)
-        self.triple = destinationTriple
+        self.triple = destinationTriple ?? .getHostTriple(usingSwiftCompiler: toolchain.swiftCompiler)
         self.flags = flags
         self.toolsVersion = toolsVersion
         self.jobs = jobs

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -722,10 +722,10 @@ public class SwiftTool<Options: ToolOptions> {
     private lazy var _buildParameters: Result<BuildParameters, Swift.Error> = {
         return Result(catching: {
             let toolchain = try self.getToolchain()
-            let triple = toolchain.destination.target
+            let triple = toolchain.triple
 
             return BuildParameters(
-                dataPath: buildPath.appending(component: toolchain.destination.target.tripleString),
+                dataPath: buildPath.appending(component: triple.tripleString),
                 configuration: options.configuration,
                 toolchain: toolchain,
                 destinationTriple: triple,

--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -34,7 +34,7 @@ public struct Destination: Encodable {
     ///  - abi = eabi, gnu, android, macho, elf, etc.
     ///
     /// for more information see //https://clang.llvm.org/docs/CrossCompilation.html
-    public let target: Triple
+    public let target: Triple?
 
     /// The SDK used to compile for the destination.
     public let sdk: AbsolutePath
@@ -102,7 +102,7 @@ public struct Destination: Encodable {
         }
 
         return Destination(
-            target: hostTargetTriple,
+            target: nil,
             sdk: sdkPath,
             binDir: binDir,
             extraCCFlags: extraCCFlags,
@@ -111,7 +111,7 @@ public struct Destination: Encodable {
         )
       #else
         return Destination(
-            target: hostTargetTriple,
+            target: nil,
             sdk: .root,
             binDir: binDir,
             extraCCFlags: ["-fPIC"],
@@ -147,9 +147,6 @@ public struct Destination: Encodable {
     }
     /// Cache storage for sdk platform path.
     private static var _sdkPlatformFrameworkPath: (fwk: AbsolutePath, lib: AbsolutePath)? = nil
-
-    /// Target triple for the host system.
-    private static let hostTargetTriple = Triple.hostTriple
 }
 
 extension Destination {

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -55,6 +55,9 @@ public final class UserToolchain: Toolchain {
     /// The compilation destination object.
     public let destination: Destination
 
+    /// The target triple that should be used for compilation.
+    public let triple: Triple
+
     /// Search paths from the PATH environment variable.
     let envSearchPaths: [AbsolutePath]
 
@@ -221,13 +224,15 @@ public final class UserToolchain: Toolchain {
         self.xctest = nil
       #endif
 
-        self.extraSwiftCFlags = (destination.target.isDarwin()
+        // Use the triple from destination or compute the host triple using swiftc.
+        self.triple = destination.target ?? Triple.getHostTriple(usingSwiftCompiler: swiftCompilers.compile)
+        self.extraSwiftCFlags = (triple.isDarwin()
                                     ? ["-sdk", destination.sdk.pathString]
                                     : [])
                                   + destination.extraSwiftCFlags
 
         self.extraCCFlags = [
-            destination.target.isDarwin() ? "-isysroot" : "--sysroot", destination.sdk.pathString
+            triple.isDarwin() ? "-isysroot" : "--sysroot", destination.sdk.pathString
         ] + destination.extraCCFlags
 
         // Compute the path of directory containing the PackageDescription libraries.

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -18,10 +18,11 @@ import PackageLoading
 
 import Build
 
+let hostTriple = Resources.default.toolchain.triple
 #if os(macOS)
-    let defaultTargetTriple: String = Triple.hostTriple.tripleString(forPlatformVersion: "10.10")
+    let defaultTargetTriple: String = hostTriple.tripleString(forPlatformVersion: "10.10")
 #else
-    let defaultTargetTriple: String = Triple.hostTriple.tripleString
+    let defaultTargetTriple: String = hostTriple.tripleString
 #endif
 
 private struct MockToolchain: Toolchain {
@@ -58,7 +59,7 @@ final class BuildPlanTests: XCTestCase {
         config: BuildConfiguration = .debug,
         flags: BuildFlags = BuildFlags(),
         shouldLinkStaticSwiftStdlib: Bool = false,
-        destinationTriple: Triple = Triple.hostTriple,
+        destinationTriple: Triple = hostTriple,
         indexStoreMode: BuildParameters.IndexStoreMode = .off
     ) -> BuildParameters {
         return BuildParameters(
@@ -2427,4 +2428,11 @@ fileprivate extension TargetBuildDescription {
             throw Error.error("Unexpected \(self) type")
         }
     }
+}
+
+fileprivate extension Triple {
+    static let x86_64Linux = try! Triple("x86_64-unknown-linux-gnu")
+    static let arm64Linux = try! Triple("aarch64-unknown-linux-gnu")
+    static let arm64Android = try! Triple("aarch64-unknown-linux-android")
+    static let windows = try! Triple("x86_64-unknown-windows-msvc")
 }

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -54,7 +54,7 @@ final class BuildToolTests: XCTestCase {
     func testBinPathAndSymlink() throws {
         fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { path in
             let fullPath = resolveSymlinks(path)
-            let targetPath = fullPath.appending(components: ".build", Destination.host.target.tripleString)
+            let targetPath = fullPath.appending(components: ".build", Resources.default.toolchain.triple.tripleString)
             XCTAssertEqual(try execute(["--show-bin-path"], packagePath: fullPath).stdout,
                            "\(targetPath.appending(components: "debug").pathString)\n")
             XCTAssertEqual(try execute(["-c", "release", "--show-bin-path"], packagePath: fullPath).stdout,

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -229,7 +229,7 @@ final class PackageToolTests: XCTestCase {
             _ = try SwiftPMProduct.SwiftPackage.execute(["edit", "baz", "--branch", "bugfix"], packagePath: fooPath)
 
             // Path to the executable.
-            let exec = [fooPath.appending(components: ".build", Destination.host.target.tripleString, "debug", "foo").pathString]
+            let exec = [fooPath.appending(components: ".build", Resources.default.toolchain.triple.tripleString, "debug", "foo").pathString]
 
             // We should see it now in packages directory.
             let editsPath = fooPath.appending(components: "Packages", "bar")
@@ -303,7 +303,7 @@ final class PackageToolTests: XCTestCase {
             // Build it.
             XCTAssertBuilds(packageRoot)
             let buildPath = packageRoot.appending(component: ".build")
-            let binFile = buildPath.appending(components: Destination.host.target.tripleString, "debug", "Bar")
+            let binFile = buildPath.appending(components: Resources.default.toolchain.triple.tripleString, "debug", "Bar")
             XCTAssertFileExists(binFile)
             XCTAssert(localFileSystem.isDirectory(buildPath))
 
@@ -322,7 +322,7 @@ final class PackageToolTests: XCTestCase {
             // Build it.
             XCTAssertBuilds(packageRoot)
             let buildPath = packageRoot.appending(component: ".build")
-            let binFile = buildPath.appending(components: Destination.host.target.tripleString, "debug", "Bar")
+            let binFile = buildPath.appending(components: Resources.default.toolchain.triple.tripleString, "debug", "Bar")
             XCTAssertFileExists(binFile)
             XCTAssert(localFileSystem.isDirectory(buildPath))
             // Clean, and check for removal of the build directory but not Packages.
@@ -390,7 +390,7 @@ final class PackageToolTests: XCTestCase {
             func build() throws -> String {
                 return try SwiftPMProduct.SwiftBuild.execute([], packagePath: fooPath).stdout
             }
-            let exec = [fooPath.appending(components: ".build", Destination.host.target.tripleString, "debug", "foo").pathString]
+            let exec = [fooPath.appending(components: ".build", Resources.default.toolchain.triple.tripleString, "debug", "foo").pathString]
 
             // Build and sanity check.
             _ = try build()

--- a/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
+++ b/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
@@ -46,7 +46,8 @@ class BuildPerfTests: XCTestCasePerf {
     func runFullBuildTest(for name: String, app appString: String? = nil, product productString: String) {
         fixture(name: name) { prefix in
             let app = prefix.appending(components: (appString ?? ""))
-            let product = app.appending(components: ".build", Destination.host.target.tripleString, "debug", productString)
+            let triple = Resources.default.toolchain.triple
+            let product = app.appending(components: ".build", triple.tripleString, "debug", productString)
             try self.execute(packagePath: app)
             measure {
                 try! self.clean(packagePath: app)
@@ -59,7 +60,8 @@ class BuildPerfTests: XCTestCasePerf {
     func runNullBuildTest(for name: String, app appString: String? = nil, product productString: String) {
         fixture(name: name) { prefix in
             let app = prefix.appending(components: (appString ?? ""))
-            let product = app.appending(components: ".build", Destination.host.target.tripleString, "debug", productString)
+            let triple = Resources.default.toolchain.triple
+            let product = app.appending(components: ".build", triple.tripleString, "debug", productString)
             try self.execute(packagePath: app)
             measure {
                 try! self.execute(packagePath: app)

--- a/Tests/FunctionalTests/CFamilyTargetTests.swift
+++ b/Tests/FunctionalTests/CFamilyTargetTests.swift
@@ -36,7 +36,7 @@ class CFamilyTargetTestCase: XCTestCase {
     func testCLibraryWithSpaces() {
         fixture(name: "CFamilyTargets/CLibraryWithSpaces") { prefix in
             XCTAssertBuilds(prefix)
-            let debugPath = prefix.appending(components: ".build", Destination.host.target.tripleString, "debug")
+            let debugPath = prefix.appending(components: ".build", Resources.default.toolchain.triple.tripleString, "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Bar.c.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
         }
@@ -46,7 +46,7 @@ class CFamilyTargetTestCase: XCTestCase {
         fixture(name: "DependencyResolution/External/CUsingCDep") { prefix in
             let packageRoot = prefix.appending(component: "Bar")
             XCTAssertBuilds(packageRoot)
-            let debugPath = prefix.appending(components: "Bar", ".build", Destination.host.target.tripleString, "debug")
+            let debugPath = prefix.appending(components: "Bar", ".build", Resources.default.toolchain.triple.tripleString, "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Sea.c.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
             let path = try SwiftPMProduct.packagePath(for: "Foo", packageRoot: packageRoot)
@@ -57,7 +57,7 @@ class CFamilyTargetTestCase: XCTestCase {
     func testModuleMapGenerationCases() {
         fixture(name: "CFamilyTargets/ModuleMapGenerationCases") { prefix in
             XCTAssertBuilds(prefix)
-            let debugPath = prefix.appending(components: ".build", Destination.host.target.tripleString, "debug")
+            let debugPath = prefix.appending(components: ".build", Resources.default.toolchain.triple.tripleString, "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Jaz.c.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "main.swift.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "FlatInclude.c.o")
@@ -69,7 +69,7 @@ class CFamilyTargetTestCase: XCTestCase {
         // Try building a fixture which needs extra flags to be able to build.
         fixture(name: "CFamilyTargets/CDynamicLookup") { prefix in
             XCTAssertBuilds(prefix, Xld: ["-undefined", "dynamic_lookup"])
-            let debugPath = prefix.appending(components: ".build", Destination.host.target.tripleString, "debug")
+            let debugPath = prefix.appending(components: ".build", Resources.default.toolchain.triple.tripleString, "debug")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
         }
     }
@@ -79,7 +79,7 @@ class CFamilyTargetTestCase: XCTestCase {
         fixture(name: "CFamilyTargets/ObjCmacOSPackage") { prefix in
             // Build the package.
             XCTAssertBuilds(prefix)
-            XCTAssertDirectoryContainsFile(dir: prefix.appending(components: ".build", Destination.host.target.tripleString, "debug"), filename: "HelloWorldExample.m.o")
+            XCTAssertDirectoryContainsFile(dir: prefix.appending(components: ".build", Resources.default.toolchain.triple.tripleString, "debug"), filename: "HelloWorldExample.m.o")
             // Run swift-test on package.
             XCTAssertSwiftTest(prefix)
         }

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -21,7 +21,7 @@ class DependencyResolutionTests: XCTestCase {
         fixture(name: "DependencyResolution/Internal/Simple") { prefix in
             XCTAssertBuilds(prefix)
 
-            let output = try Process.checkNonZeroExit(args: prefix.appending(components: ".build", Destination.host.target.tripleString, "debug", "Foo").pathString)
+            let output = try Process.checkNonZeroExit(args: prefix.appending(components: ".build", Resources.default.toolchain.triple.tripleString, "debug", "Foo").pathString)
             XCTAssertEqual(output, "Foo\nBar\n")
         }
     }
@@ -36,7 +36,7 @@ class DependencyResolutionTests: XCTestCase {
         fixture(name: "DependencyResolution/Internal/Complex") { prefix in
             XCTAssertBuilds(prefix)
 
-            let output = try Process.checkNonZeroExit(args: prefix.appending(components: ".build", Destination.host.target.tripleString, "debug", "Foo").pathString)
+            let output = try Process.checkNonZeroExit(args: prefix.appending(components: ".build", Resources.default.toolchain.triple.tripleString, "debug", "Foo").pathString)
             XCTAssertEqual(output, "meiow Baz\n")
         }
     }
@@ -52,7 +52,7 @@ class DependencyResolutionTests: XCTestCase {
 
             let packageRoot = prefix.appending(component: "Bar")
             XCTAssertBuilds(packageRoot)
-            XCTAssertFileExists(prefix.appending(components: "Bar", ".build", Destination.host.target.tripleString, "debug", "Bar"))
+            XCTAssertFileExists(prefix.appending(components: "Bar", ".build", Resources.default.toolchain.triple.tripleString, "debug", "Bar"))
             let path = try SwiftPMProduct.packagePath(for: "Foo", packageRoot: packageRoot)
             XCTAssert(GitRepository(path: path).tags.contains("1.2.3"))
         }
@@ -61,7 +61,7 @@ class DependencyResolutionTests: XCTestCase {
     func testExternalComplex() {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
             XCTAssertBuilds(prefix.appending(component: "app"))
-            let output = try Process.checkNonZeroExit(args: prefix.appending(components: "app", ".build", Destination.host.target.tripleString, "debug", "Dealer").pathString)
+            let output = try Process.checkNonZeroExit(args: prefix.appending(components: "app", ".build", Resources.default.toolchain.triple.tripleString, "debug", "Dealer").pathString)
             XCTAssertEqual(output, "♣︎K\n♣︎Q\n♣︎J\n♣︎10\n♣︎9\n♣︎8\n♣︎7\n♣︎6\n♣︎5\n♣︎4\n")
         }
     }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -47,7 +47,7 @@ class MiscellaneousTestCase: XCTestCase {
 
         fixture(name: "Miscellaneous/ExactDependencies") { prefix in
             XCTAssertBuilds(prefix.appending(component: "app"))
-            let buildDir = prefix.appending(components: "app", ".build", Destination.host.target.tripleString, "debug")
+            let buildDir = prefix.appending(components: "app", ".build", Resources.default.toolchain.triple.tripleString, "debug")
             XCTAssertFileExists(buildDir.appending(component: "FooExec"))
             XCTAssertFileExists(buildDir.appending(component: "FooLib1.swiftmodule"))
             XCTAssertFileExists(buildDir.appending(component: "FooLib2.swiftmodule"))
@@ -120,7 +120,7 @@ class MiscellaneousTestCase: XCTestCase {
     */
     func testInternalDependencyEdges() {
         fixture(name: "Miscellaneous/DependencyEdges/Internal") { prefix in
-            let execpath = prefix.appending(components: ".build", Destination.host.target.tripleString, "debug", "Foo").pathString
+            let execpath = prefix.appending(components: ".build", Resources.default.toolchain.triple.tripleString, "debug", "Foo").pathString
 
             XCTAssertBuilds(prefix)
             var output = try Process.checkNonZeroExit(args: execpath)
@@ -144,7 +144,7 @@ class MiscellaneousTestCase: XCTestCase {
     */
     func testExternalDependencyEdges1() {
         fixture(name: "DependencyResolution/External/Complex") { prefix in
-            let execpath = prefix.appending(components: "app", ".build", Destination.host.target.tripleString, "debug", "Dealer").pathString
+            let execpath = prefix.appending(components: "app", ".build", Resources.default.toolchain.triple.tripleString, "debug", "Dealer").pathString
 
             let packageRoot = prefix.appending(component: "app")
             XCTAssertBuilds(packageRoot)
@@ -171,7 +171,7 @@ class MiscellaneousTestCase: XCTestCase {
      */
     func testExternalDependencyEdges2() {
         fixture(name: "Miscellaneous/DependencyEdges/External") { prefix in
-            let execpath = [prefix.appending(components: "root", ".build", Destination.host.target.tripleString, "debug", "dep2").pathString]
+            let execpath = [prefix.appending(components: "root", ".build", Resources.default.toolchain.triple.tripleString, "debug", "dep2").pathString]
 
             let packageRoot = prefix.appending(component: "root")
             XCTAssertBuilds(prefix.appending(component: "root"))
@@ -195,7 +195,7 @@ class MiscellaneousTestCase: XCTestCase {
     func testSpaces() {
         fixture(name: "Miscellaneous/Spaces Fixture") { prefix in
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix.appending(components: ".build", Destination.host.target.tripleString, "debug", "Module_Name_1.build", "Foo.swift.o"))
+            XCTAssertFileExists(prefix.appending(components: ".build", Resources.default.toolchain.triple.tripleString, "debug", "Module_Name_1.build", "Foo.swift.o"))
         }
     }
 
@@ -278,7 +278,8 @@ class MiscellaneousTestCase: XCTestCase {
             let systemModule = prefix.appending(component: "SystemModule")
             // Create a shared library.
             let input = systemModule.appending(components: "Sources", "SystemModule.c")
-            let output =  systemModule.appending(component: "libSystemModule\(Destination.host.target.dynamicLibraryExtension)")
+            let triple = Resources.default.toolchain.triple
+            let output =  systemModule.appending(component: "libSystemModule\(triple.dynamicLibraryExtension)")
             try systemQuietly(["clang", "-shared", input.pathString, "-o", output.pathString])
 
             let pcFile = prefix.appending(component: "libSystemModule.pc")
@@ -303,7 +304,7 @@ class MiscellaneousTestCase: XCTestCase {
             let env = ["PKG_CONFIG_PATH": prefix.pathString]
             _ = try executeSwiftBuild(moduleUser, env: env)
 
-            XCTAssertFileExists(moduleUser.appending(components: ".build", Destination.host.target.tripleString, "debug", "SystemModuleUserClang"))
+            XCTAssertFileExists(moduleUser.appending(components: ".build", triple.tripleString, "debug", "SystemModuleUserClang"))
         }
     }
 

--- a/Tests/FunctionalTests/ModuleMapTests.swift
+++ b/Tests/FunctionalTests/ModuleMapTests.swift
@@ -20,9 +20,10 @@ class ModuleMapsTestCase: XCTestCase {
     private func fixture(name: String, cModuleName: String, rootpkg: String, body: @escaping (AbsolutePath, [String]) throws -> Void) {
         SPMTestSupport.fixture(name: name) { prefix in
             let input = prefix.appending(components: cModuleName, "C", "foo.c")
-            let outdir = prefix.appending(components: rootpkg, ".build", Destination.host.target.tripleString, "debug")
+            let triple = Resources.default.toolchain.triple
+            let outdir = prefix.appending(components: rootpkg, ".build", triple.tripleString, "debug")
             try makeDirectories(outdir)
-            let output = outdir.appending(component: "libfoo\(Destination.host.target.dynamicLibraryExtension)")
+            let output = outdir.appending(component: "libfoo\(triple.dynamicLibraryExtension)")
             try systemQuietly(["clang", "-shared", input.pathString, "-o", output.pathString])
 
             var Xld = ["-L", outdir.pathString]
@@ -39,7 +40,8 @@ class ModuleMapsTestCase: XCTestCase {
 
             XCTAssertBuilds(prefix.appending(component: "App"), Xld: Xld)
 
-            let targetPath = prefix.appending(components: "App", ".build", Destination.host.target.tripleString)
+            let triple = Resources.default.toolchain.triple
+            let targetPath = prefix.appending(components: "App", ".build", triple.tripleString)
             let debugout = try Process.checkNonZeroExit(args: targetPath.appending(components: "debug", "App").pathString)
             XCTAssertEqual(debugout, "123\n")
             let releaseout = try Process.checkNonZeroExit(args: targetPath.appending(components: "release", "App").pathString)
@@ -53,7 +55,8 @@ class ModuleMapsTestCase: XCTestCase {
             XCTAssertBuilds(prefix.appending(component: "packageA"), Xld: Xld)
 
             func verify(_ conf: String, file: StaticString = #file, line: UInt = #line) throws {
-                let out = try Process.checkNonZeroExit(args: prefix.appending(components: "packageA", ".build", Destination.host.target.tripleString, conf, "packageA").pathString)
+                let triple = Resources.default.toolchain.triple
+                let out = try Process.checkNonZeroExit(args: prefix.appending(components: "packageA", ".build", triple.tripleString, conf, "packageA").pathString)
                 XCTAssertEqual(out, """
                     calling Y.bar()
                     Y.bar() called

--- a/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
+++ b/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
@@ -21,7 +21,8 @@ class SwiftPMXCTestHelperTests: XCTestCase {
         fixture(name: "Miscellaneous/SwiftPMXCTestHelper") { prefix in
             // Build the package.
             XCTAssertBuilds(prefix)
-            XCTAssertFileExists(prefix.appending(components: ".build", Destination.host.target.tripleString, "debug", "SwiftPMXCTestHelper.swiftmodule"))
+            let triple = Resources.default.toolchain.triple
+            XCTAssertFileExists(prefix.appending(components: ".build", triple.tripleString, "debug", "SwiftPMXCTestHelper.swiftmodule"))
             // Run swift-test on package.
             XCTAssertSwiftTest(prefix)
             // Expected output dictionary.
@@ -38,7 +39,7 @@ class SwiftPMXCTestHelperTests: XCTestCase {
               ] as Array<Dictionary<String, Any>>]] as Array<Dictionary<String, Any>>
             ] as Dictionary<String, Any> as NSDictionary
             // Run the XCTest helper tool and check result.
-            XCTAssertXCTestHelper(prefix.appending(components: ".build", Destination.host.target.tripleString, "debug", "SwiftPMXCTestHelperPackageTests.xctest"), testCases: testCases)
+            XCTAssertXCTestHelper(prefix.appending(components: ".build", Resources.default.toolchain.triple.tripleString, "debug", "SwiftPMXCTestHelperPackageTests.xctest"), testCases: testCases)
         }
       #endif
     }

--- a/Tests/FunctionalTests/ToolsVersionTests.swift
+++ b/Tests/FunctionalTests/ToolsVersionTests.swift
@@ -91,7 +91,7 @@ class ToolsVersionTests: XCTestCase {
 
             // Build the primary package.
             _ = try SwiftPMProduct.SwiftBuild.execute([], packagePath: primaryPath)
-            let exe = primaryPath.appending(components: ".build", Destination.host.target.tripleString, "debug", "Primary").pathString
+            let exe = primaryPath.appending(components: ".build", Resources.default.toolchain.triple.tripleString, "debug", "Primary").pathString
             // v1 should get selected because v1.0.1 depends on a (way) higher set of tools.
             XCTAssertEqual(try Process.checkNonZeroExit(args: exe).spm_chomp(), "foo@1.0")
 

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -88,7 +88,8 @@ class InitTests: XCTestCase {
             
             // Try building it
             XCTAssertBuilds(path)
-            let binPath = path.appending(components: ".build", Destination.host.target.tripleString, "debug")
+            let triple = Resources.default.toolchain.triple
+            let binPath = path.appending(components: ".build", triple.tripleString, "debug")
             XCTAssertFileExists(binPath.appending(component: "Foo"))
             XCTAssertFileExists(binPath.appending(component: "Foo.swiftmodule"))
         }
@@ -131,7 +132,8 @@ class InitTests: XCTestCase {
 
             // Try building it
             XCTAssertBuilds(path)
-            XCTAssertFileExists(path.appending(components: ".build", Destination.host.target.tripleString, "debug", "Foo.swiftmodule"))
+            let triple = Resources.default.toolchain.triple
+            XCTAssertFileExists(path.appending(components: ".build", triple.tripleString, "debug", "Foo.swiftmodule"))
         }
     }
     
@@ -212,7 +214,8 @@ class InitTests: XCTestCase {
 
             // Try building it.
             XCTAssertBuilds(packageRoot)
-            XCTAssertFileExists(packageRoot.appending(components: ".build", Destination.host.target.tripleString, "debug", "some_package.swiftmodule"))
+            let triple = Resources.default.toolchain.triple
+            XCTAssertFileExists(packageRoot.appending(components: ".build", triple.tripleString, "debug", "some_package.swiftmodule"))
         }
     }
     


### PR DESCRIPTION
I'm not extremely happy of this PR. This feature introduces a cyclic dependency in the SwiftPM types: to generate the host `Triple`, we now need the path to the Swift compiler, which is calculated and stored in a `Toolchain`. The `UserToolchain` used in SwiftPM itself requires the host `Destination`, which requires the host `Triple` :)

I resolved this cyclic dependency by introducing a `getHostTriple(usingSwiftCompiler:)` static function on `Triple` and defining a cached `Triple.hostTriple` extension property in `Workspace` that uses the bare minimum information in the `UserToolchain` static functions to get the path to a Swift compiler.

Please let me know if you think there is a better way.