### PR TITLE
[SR-12016] show-dependencies: Don't emit duplicate lines in dot format.

### DIFF
--- a/Sources/Commands/show-dependencies.swift
+++ b/Sources/Commands/show-dependencies.swift
@@ -11,7 +11,7 @@
 import TSCBasic
 import PackageModel
 
-func dumpDependenciesOf(rootPackage: ResolvedPackage, mode: ShowDependenciesMode) {
+public func dumpDependenciesOf(rootPackage: ResolvedPackage, mode: ShowDependenciesMode, on stream: OutputByteStream = stdoutStream) {
     let dumper: DependenciesDumper
     switch mode {
     case .text:
@@ -23,15 +23,16 @@ func dumpDependenciesOf(rootPackage: ResolvedPackage, mode: ShowDependenciesMode
     case .flatlist:
         dumper = FlatListDumper()
     }
-    dumper.dump(dependenciesOf: rootPackage)
+    dumper.dump(dependenciesOf: rootPackage, on: stream)
+    stream.flush()
 }
 
 private protocol DependenciesDumper {
-    func dump(dependenciesOf: ResolvedPackage)
+    func dump(dependenciesOf: ResolvedPackage, on: OutputByteStream)
 }
 
 private final class PlainTextDumper: DependenciesDumper {
-    func dump(dependenciesOf rootpkg: ResolvedPackage) {
+    func dump(dependenciesOf rootpkg: ResolvedPackage, on stream: OutputByteStream) {
         func recursiveWalk(packages: [ResolvedPackage], prefix: String = "") {
             var hanger = prefix + "├── "
 
@@ -42,7 +43,7 @@ private final class PlainTextDumper: DependenciesDumper {
 
                 let pkgVersion = package.manifest.version?.description ?? "unspecified"
 
-                print("\(hanger)\(package.name)<\(package.manifest.url)@\(pkgVersion)>")
+                stream <<< "\(hanger)\(package.name)<\(package.manifest.url)@\(pkgVersion)>\n"
 
                 if !package.dependencies.isEmpty {
                     let replacement = (index == packages.count - 1) ?  "    " : "│   "
@@ -55,19 +56,19 @@ private final class PlainTextDumper: DependenciesDumper {
         }
 
         if !rootpkg.dependencies.isEmpty {
-            print(".")
+            stream <<< (".\n")
             recursiveWalk(packages: rootpkg.dependencies)
         } else {
-            print("No external dependencies found")
+            stream <<< "No external dependencies found\n"
         }
     }
 }
 
 private final class FlatListDumper: DependenciesDumper {
-    func dump(dependenciesOf rootpkg: ResolvedPackage) {
+    func dump(dependenciesOf rootpkg: ResolvedPackage, on stream: OutputByteStream) {
         func recursiveWalk(packages: [ResolvedPackage]) {
             for package in packages {
-                print(package.name)
+                stream <<< package.name <<< "\n"
                 if !package.dependencies.isEmpty {
                     recursiveWalk(packages: package.dependencies)
                 }
@@ -80,15 +81,13 @@ private final class FlatListDumper: DependenciesDumper {
 }
 
 private final class DotDumper: DependenciesDumper {
-    func dump(dependenciesOf rootpkg: ResolvedPackage) {
+    func dump(dependenciesOf rootpkg: ResolvedPackage, on stream: OutputByteStream) {
         var nodesAlreadyPrinted: Set<String> = []
         func printNode(_ package: ResolvedPackage) {
             let url = package.manifest.url
             if nodesAlreadyPrinted.contains(url) { return }
             let pkgVersion = package.manifest.version?.description ?? "unspecified"
-            print("""
-                "\(url)" [label="\(package.name)\\n\(url)\\n\(pkgVersion)"]
-                """)
+            stream <<< #""\#(url)" [label="\#(package.name)\n\#(url)\n\#(pkgVersion)"]"# <<< "\n"
             nodesAlreadyPrinted.insert(url)
         }
         
@@ -106,9 +105,7 @@ private final class DotDumper: DependenciesDumper {
                 if dependenciesAlreadyPrinted.contains(urlPair) { continue }
                 
                 printNode(dependency)
-                print("""
-                    "\(rootURL)" -> "\(dependencyURL)"
-                    """)
+                stream <<< #""\#(rootURL)" -> "\#(dependencyURL)""# <<< "\n"
                 dependenciesAlreadyPrinted.insert(urlPair)
 
                 if !dependency.dependencies.isEmpty {
@@ -118,18 +115,18 @@ private final class DotDumper: DependenciesDumper {
         }
 
         if !rootpkg.dependencies.isEmpty {
-            print("digraph DependenciesGraph {")
-            print("node [shape = box]")
+            stream <<< "digraph DependenciesGraph {\n"
+            stream <<< "node [shape = box]\n"
             recursiveWalk(rootpkg: rootpkg)
-            print("}")
+            stream <<< "}\n"
         } else {
-            print("No external dependencies found")
+            stream <<< "No external dependencies found\n"
         }
     }
 }
 
 private final class JSONDumper: DependenciesDumper {
-    func dump(dependenciesOf rootpkg: ResolvedPackage) {
+    func dump(dependenciesOf rootpkg: ResolvedPackage, on stream: OutputByteStream) {
         func convert(_ package: ResolvedPackage) -> JSON {
             return .orderedDictionary([
                 "name": .string(package.name),
@@ -140,14 +137,14 @@ private final class JSONDumper: DependenciesDumper {
             ])
         }
 
-        print(convert(rootpkg).toString(prettyPrint: true))
+        stream <<< convert(rootpkg).toString(prettyPrint: true) <<< "\n"
     }
 }
 
-enum ShowDependenciesMode: CustomStringConvertible {
+public enum ShowDependenciesMode: CustomStringConvertible {
     case text, dot, json, flatlist
 
-    init?(rawValue: String) {
+    public init?(rawValue: String) {
         switch rawValue.lowercased() {
         case "text":
            self = .text
@@ -162,7 +159,7 @@ enum ShowDependenciesMode: CustomStringConvertible {
         }
     }
 
-    var description: String {
+    public var description: String {
         switch self {
         case .text: return "text"
         case .dot: return "dot"


### PR DESCRIPTION
`show-dependencies` emits duplicate lines in dot format in some cases. This behavior, for example,  causes wasteful arrows when converted image is drawn.
This PR will fix the issue.

Resolves [SR-12016](https://bugs.swift.org/browse/SR-12016).