### PR TITLE
Emit all diagnostics when parsing manifest in Workspace

### DIFF
--- a/Sources/PackageGraph/PackageGraphLoader.swift
+++ b/Sources/PackageGraph/PackageGraphLoader.swift
@@ -130,15 +130,18 @@ public struct PackageGraphLoader {
                 createREPLProduct: manifest.packageKind == .root ? createREPLProduct : false
             )
 
-            diagnostics.wrap(with: PackageLocation.Local(name: manifest.name, packagePath: packagePath), {
-                let package = try builder.construct()
-                manifestToPackage[manifest] = package
+            let packageLocation = PackageLocation.Local(name: manifest.name, packagePath: packagePath)
+            diagnostics.with(location: packageLocation) { diagnostics in
+                diagnostics.wrap {
+                    let package = try builder.construct()
+                    manifestToPackage[manifest] = package
 
-                // Throw if any of the non-root package is empty.
-                if package.targets.isEmpty && manifest.packageKind != .root {
-                    throw PackageGraphError.noModules(package)
+                    // Throw if any of the non-root package is empty.
+                    if package.targets.isEmpty && manifest.packageKind != .root {
+                        throw PackageGraphError.noModules(package)
+                    }
                 }
-            })
+            }
         }
 
         // Resolve dependencies and create resolved packages.

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -113,7 +113,7 @@ public final class Manifest: ObjectIdentifierProtocol, CustomStringConvertible, 
         self.dependencies = dependencies
         self.products = products
         self.targets = targets
-        self.targetMap = Dictionary(uniqueKeysWithValues: targets.lazy.map({ ($0.name, $0) }))
+        self.targetMap = Dictionary(targets.lazy.map({ ($0.name, $0) }), uniquingKeysWith: { $1 })
     }
 
     public var description: String {

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -29,47 +29,6 @@ public struct ManifestParseDiagnostic: DiagnosticData {
     }
 }
 
-public struct ManifestDuplicateDependencyURLsDiagnostic: DiagnosticData {
-    public let duplicates: [[PackageDependencyDescription]]
-
-    public var description: String {
-        let stream = BufferedOutputByteStream()
-
-        stream <<< "manifest parse error(s): duplicate dependency URLs\n"
-        let indent = Format.asRepeating(string: " ", count: 4)
-
-        for duplicateGroup in duplicates {
-            for duplicate in duplicateGroup {
-                stream <<< indent <<< duplicate.url <<< " @ " <<< "\(duplicate.requirement)" <<< "\n"
-            }
-            stream <<< "\n"
-        }
-
-        return stream.bytes.description
-    }
-}
-
-public struct ManifestDuplicateDependencyNamesDiagnostic: DiagnosticData {
-    public let duplicates: [[PackageDependencyDescription]]
-
-    public var description: String {
-        let stream = BufferedOutputByteStream()
-
-        stream <<< "manifest parse error(s): duplicate dependency names\n"
-        let indent = Format.asRepeating(string: " ", count: 4)
-
-        for duplicateGroup in duplicates {
-            for duplicate in duplicateGroup {
-                stream <<< indent <<< duplicate.url <<< " @ " <<< "\(duplicate.requirement)" <<< "\n"
-            }
-            stream <<< "\n"
-        }
-
-        stream <<< "consider differentiating them using the 'name' argument.\n"
-        return stream.bytes.description
-    }
-}
-
 extension ManifestParseError: DiagnosticDataConvertible {
     public var diagnosticData: DiagnosticData {
         switch self {
@@ -77,26 +36,6 @@ extension ManifestParseError: DiagnosticDataConvertible {
             return ManifestParseDiagnostic([error], diagnosticFile: diagnisticFile)
         case .runtimeManifestErrors(let errors):
             return ManifestParseDiagnostic(errors, diagnosticFile: nil)
-        case .emptyProductTargets(let productName):
-            return Diagnostic.Message.emptyProductTargets(productName: productName).data
-        case .productTargetNotFound(let productName, let targetName):
-            return Diagnostic.Message.productTargetNotFound(productName: productName, targetName: targetName).data
-        case .invalidBinaryProductType(let productName):
-            return Diagnostic.Message.invalidBinaryProductType(productName: productName).data
-        case .duplicateDependencyURLs(let duplicates):
-            return ManifestDuplicateDependencyURLsDiagnostic(duplicates: duplicates)
-        case .duplicateTargetNames(let targetNames):
-            return Diagnostic.Message.duplicateTargetNames(duplicates: targetNames).data
-        case .unknownTargetDependencyPackage(let targetName, let packageName):
-            return Diagnostic.Message.unknownTargetDependencyPackage(targetName: targetName, packageName: packageName).data
-        case .duplicateDependencyNames(let duplicates):
-            return ManifestDuplicateDependencyNamesDiagnostic(duplicates: duplicates)
-        case .invalidBinaryLocation(let targetName):
-            return Diagnostic.Message.invalidBinaryLocation(targetName: targetName).data
-        case .invalidBinaryURLScheme(let targetName, let validSchemes):
-            return Diagnostic.Message.invalidBinaryURLScheme(targetName: targetName, validSchemes: validSchemes).data
-        case .invalidBinaryLocationExtension(let targetName, let validExtensions):
-            return Diagnostic.Message.invalidBinaryLocationExtension(targetName: targetName, validExtensions: validExtensions).data
         }
     }
 }
@@ -258,37 +197,5 @@ extension Diagnostic.Message {
 
     static func artifactFailedExtraction(targetName: String, reason: String) -> Diagnostic.Message {
         .error("artifact of binary target '\(targetName)' failed extraction: \(reason)")
-    }
-
-    static func productTargetNotFound(productName: String, targetName: String) -> Diagnostic.Message {
-        .error("manifest parse error: target '\(targetName)' referenced in product '\(productName)' could not be found")
-    }
-
-    static func emptyProductTargets(productName: String) -> Diagnostic.Message {
-        .error("manifest parse error: product '\(productName)' doesn't reference any targets")
-    }
-
-    static func invalidBinaryProductType(productName: String) -> Diagnostic.Message {
-        .error("manifest parse error: invalid type for binary product '\(productName)'; a binary product can only be a library with no defined type")
-    }
-
-    static func duplicateTargetNames(duplicates: [String]) -> Diagnostic.Message {
-        .error("manifest parse error: duplicate target names: \(duplicates.joined(separator: ", "))")
-    }
-
-    static func unknownTargetDependencyPackage(targetName: String, packageName: String) -> Diagnostic.Message {
-        .error("manifest parse error: target '\(targetName)' depends on an unknown package '\(packageName)'")
-    }
-
-    static func invalidBinaryLocation(targetName: String) -> Diagnostic.Message {
-        .error("manifest parse error: invalid location of binary target '\(targetName)'")
-    }
-
-    static func invalidBinaryURLScheme(targetName: String, validSchemes: [String]) -> Diagnostic.Message {
-        .error("manifest parse error: invalid URL scheme for binary target '\(targetName)' (valid schemes are \(validSchemes.joined(separator: ", "))")
-    }
-
-    static func invalidBinaryLocationExtension(targetName: String, validExtensions: [String]) -> Diagnostic.Message {
-        .error("manifest parse error: unsupported extension of binary target '\(targetName)' (valid extensions are \(validExtensions.joined(separator: ", "))")
     }
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1242,26 +1242,28 @@ extension Workspace {
         packageKind: PackageReference.Kind,
         diagnostics: DiagnosticsEngine
     ) -> Manifest? {
-        return diagnostics.wrap(with: PackageLocation.Local(packagePath: packagePath), {
-            // Load the tools version for the package.
-            let toolsVersion = try toolsVersionLoader.load(
-                at: packagePath, fileSystem: fileSystem)
+        return diagnostics.with(location: PackageLocation.Local(packagePath: packagePath)) { diagnostics in
+            return diagnostics.wrap {
+                // Load the tools version for the package.
+                let toolsVersion = try toolsVersionLoader.load(
+                    at: packagePath, fileSystem: fileSystem)
 
-            // Validate the tools version.
-            try toolsVersion.validateToolsVersion(
-                currentToolsVersion, packagePath: packagePath.pathString)
+                // Validate the tools version.
+                try toolsVersion.validateToolsVersion(
+                    currentToolsVersion, packagePath: packagePath.pathString)
 
-            // Load the manifest.
-            // FIXME: We should have a cache for this.
-            return try manifestLoader.load(
-                package: packagePath,
-                baseURL: url,
-                version: version,
-                toolsVersion: toolsVersion,
-                packageKind: packageKind,
-                diagnostics: diagnostics
-            )
-        })
+                // Load the manifest.
+                // FIXME: We should have a cache for this.
+                return try manifestLoader.load(
+                    package: packagePath,
+                    baseURL: url,
+                    version: version,
+                    toolsVersion: toolsVersion,
+                    packageKind: packageKind,
+                    diagnostics: diagnostics
+                )
+            }
+        }
     }
 
     fileprivate func updateBinaryArtifacts(

--- a/TSC/Sources/TSCBasic/CollectionAlgorithms.swift
+++ b/TSC/Sources/TSCBasic/CollectionAlgorithms.swift
@@ -8,15 +8,16 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-extension Sequence where Iterator.Element: Hashable {
+extension Sequence where Element: Hashable {
 
     /// Finds duplicates in given sequence of Hashables.
     /// - Returns: duplicated elements in the invoking sequence.
-    public func spm_findDuplicates() -> [Iterator.Element] {
-        var unique: Set<Iterator.Element> = []
-        return filter {
-            !unique.insert($0).inserted
+    public func spm_findDuplicates() -> [Element] {
+        var counts: [Element: Int] = [:]
+        for element in self {
+            counts[element, default: 0] += 1
         }
+        return Array(counts.lazy.filter({ $0.value > 1 }).map({ $0.key }))
     }
 }
 

--- a/TSC/Sources/TSCBasic/DiagnosticsEngine.swift
+++ b/TSC/Sources/TSCBasic/DiagnosticsEngine.swift
@@ -101,23 +101,27 @@ public final class DiagnosticsEngine: CustomStringConvertible {
     /// The handler will be called on an unknown queue.
     private let handlers: [DiagnosticsHandler]
 
+    /// The default location to apply to location-less diagnostics.
+    public let defaultLocation: DiagnosticLocation
+
     /// Returns true if there is an error diagnostics in the engine.
     public var hasErrors: Bool {
         return diagnostics.contains(where: { $0.message.behavior == .error })
     }
 
-    public init(handlers: [DiagnosticsHandler] = []) {
+    public init(handlers: [DiagnosticsHandler] = [], defaultLocation: DiagnosticLocation = UnknownLocation.location) {
         self.handlers = handlers
+        self.defaultLocation = defaultLocation
     }
 
     public func emit(
         _ message: Diagnostic.Message,
-        location: DiagnosticLocation = UnknownLocation.location
+        location: DiagnosticLocation? = nil
     ) {
-        emit(Diagnostic(message: message, location: location))
+        emit(Diagnostic(message: message, location: location ?? defaultLocation))
     }
 
-    private func emit(_ diagnostic: Diagnostic) {
+    public func emit(_ diagnostic: Diagnostic) {
         queue.sync {
             _diagnostics.append(diagnostic)
         }

--- a/TSC/Sources/TSCTestSupport/DiagnosticsEngine.swift
+++ b/TSC/Sources/TSCTestSupport/DiagnosticsEngine.swift
@@ -13,36 +13,6 @@ import TSCUtility
 
 import XCTest
 
-public enum StringCheck: ExpressibleByStringLiteral {
-    case equal(String)
-    case contains(String)
-
-    func check(
-        input: String,
-        file: StaticString = #file,
-        line: UInt = #line
-    ) {
-        switch self {
-        case .equal(let str):
-            XCTAssertEqual(str, input, file: file, line: line)
-        case .contains(let str):
-            XCTAssert(input.contains(str), "\(input) does not contain \(str)", file: file, line: line)
-        }
-    }
-
-    public init(stringLiteral value: String) {
-        self = .equal(value)
-    }
-
-    public init(extendedGraphemeClusterLiteral value: String) {
-        self.init(stringLiteral: value)
-    }
-
-    public init(unicodeScalarLiteral value: String) {
-        self.init(stringLiteral: value)
-    }
-}
-
 public func DiagnosticsEngineTester(
     _ engine: DiagnosticsEngine,
     ignoreNotes: Bool = false,
@@ -73,7 +43,7 @@ final public class DiagnosticsEngineResult {
     }
 
     public func check(
-        diagnostic: StringCheck,
+        diagnostic: StringPattern,
         checkContains: Bool = false,
         behavior: Diagnostic.Behavior,
         location: String? = nil,
@@ -87,7 +57,7 @@ final public class DiagnosticsEngineResult {
         let location = location ?? UnknownLocation.location.description
         let theDiagnostic = uncheckedDiagnostics.removeFirst()
 
-        diagnostic.check(input: theDiagnostic.description, file: file, line: line)
+        XCTAssertMatch(theDiagnostic.description, diagnostic, file: file, line: line)
         XCTAssertEqual(theDiagnostic.message.behavior, behavior, file: file, line: line)
         XCTAssertEqual(theDiagnostic.location.description, location, file: file, line: line)
     }

--- a/TSC/Tests/TSCBasicTests/CollectionAlgorithmsTests.swift
+++ b/TSC/Tests/TSCBasicTests/CollectionAlgorithmsTests.swift
@@ -14,7 +14,8 @@ import TSCBasic
 
 class CollectionAlgorithmsTests: XCTestCase {
     func testFindDuplicates() {
-        XCTAssertEqual([1, 2, 3, 2, 1].spm_findDuplicates(), [2, 1])
+        XCTAssertEqual(Set([1, 2, 3, 2, 1].spm_findDuplicates()), [1, 2])
+        XCTAssertEqual(Set([1, 2, 3, 2, 1, 2].spm_findDuplicates()), [1, 2])
         XCTAssertEqual(["foo", "bar"].spm_findDuplicates(), [])
         XCTAssertEqual(["foo", "Foo"].spm_findDuplicates(), [])
     }

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -411,13 +411,9 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        do {
-            try loadManifestThrowing(stream.bytes) { _ in }
-            XCTFail("Unexpected success")
-        } catch ManifestParseError.duplicateDependencyURLs(let duplicates) {
-            XCTAssertEqual(duplicates.count, 2)
-            let urls = duplicates.flatMap({$0}).map({ $0.url }).sorted()
-            XCTAssertEqual(urls, ["/foo/path/to/foo1", "/foo1", "/foo1.git", "/foo2.git", "/foo2.git"])
+        XCTAssertManifestLoadThrows(stream.bytes) { _, diagnostics in
+            diagnostics.check(diagnostic: .regex("duplicate dependency 'foo(1|2)'"), behavior: .error)
+            diagnostics.check(diagnostic: .regex("duplicate dependency 'foo(1|2)'"), behavior: .error)
         }
     }
 

--- a/Tests/PackageLoadingTests/PDLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDLoadingTests.swift
@@ -61,4 +61,103 @@ class PackageDescriptionLoadingTests: XCTestCase {
             XCTFail("Unexpected error: \(error)", file: #file, line: line)
         }
     }
+
+    func XCTAssertManifestLoadNoThrows(
+        _ contents: ByteString,
+        toolsVersion: ToolsVersion? = nil,
+        file: StaticString = #file,
+        line: UInt = #line,
+        onSuccess: ((Manifest, DiagnosticsEngineResult) -> Void)? = nil
+    ) {
+        let diagnostics = DiagnosticsEngine()
+
+        do {
+            let manifest = try loadManifest(
+                contents,
+                toolsVersion: toolsVersion ?? self.toolsVersion,
+                diagnostics: diagnostics,
+                file: file,
+                line: line)
+
+            if let onSuccess = onSuccess {
+                DiagnosticsEngineTester(diagnostics) { result in
+                    onSuccess(manifest, result)
+                }
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)", file: file, line: line)
+        }
+    }
+
+    func XCTAssertManifestLoadThrows(
+        _ contents: ByteString,
+        toolsVersion: ToolsVersion? = nil,
+        file: StaticString = #file,
+        line: UInt = #line,
+        onCatch: ((Error, DiagnosticsEngineResult) -> Void)? = nil
+    ) {
+        let diagnostics = DiagnosticsEngine()
+
+        do {
+            let manifest = try loadManifest(
+                contents,
+                toolsVersion: toolsVersion ?? self.toolsVersion,
+                diagnostics: diagnostics,
+                file: file,
+                line: line)
+
+            XCTFail("Unexpected success: \(manifest)", file: file, line: line)
+        } catch {
+            if let onCatch = onCatch {
+                DiagnosticsEngineTester(diagnostics, file: file, line: line) { result in
+                    onCatch(error, result)
+                }
+            }
+        }
+    }
+
+    func XCTAssertManifestLoadThrows<E: Error & Equatable>(
+        _ expectedError: E,
+        _ contents: ByteString,
+        toolsVersion: ToolsVersion? = nil,
+        file: StaticString = #file,
+        line: UInt = #line,
+        onCatch: ((DiagnosticsEngineResult) -> Void)? = nil
+    ) {
+        XCTAssertManifestLoadThrows(contents, toolsVersion: toolsVersion, file: file, line: line) { error, result in
+            if let typedError = error as? E, typedError == expectedError {
+                // Everything okay
+            } else {
+                XCTFail("Unexpected error: \(error)", file: file, line: line)
+            }
+
+            onCatch?(result)
+        }
+    }
+
+    private func loadManifest(
+        _ contents: ByteString,
+        toolsVersion: ToolsVersion?,
+        diagnostics: DiagnosticsEngine?,
+        file: StaticString,
+        line: UInt
+    ) throws -> Manifest {
+        let toolsVersion = toolsVersion ?? self.toolsVersion
+        let fileSystem = InMemoryFileSystem()
+        let manifestPath = AbsolutePath.root.appending(component: Manifest.filename)
+        try fileSystem.writeFileContents(manifestPath, bytes: contents)
+        let manifest = try manifestLoader.load(
+            package: AbsolutePath.root,
+            baseURL: "/foo",
+            toolsVersion: toolsVersion,
+            packageKind: .local,
+            fileSystem: fileSystem,
+            diagnostics: diagnostics)
+
+        if manifest.toolsVersion != toolsVersion {
+            XCTFail("Invalid manifest version", file: file, line: line)
+        }
+
+        return manifest
+    }
 }

--- a/Tests/PackageLoadingTests/PDNextLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDNextLoadingTests.swift
@@ -114,18 +114,14 @@ class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
                         .library(name: "FooLibrary", type: .static, targets: ["Foo"]),
                     ],
                     targets: [
-                        .binaryTarget(name: "Foo", path: "Foo.zip"),
+                        .binaryTarget(name: "Foo", path: "Foo.xcframework"),
                     ]
                 )
                 """
 
-            try loadManifestThrowing(stream.bytes) { manifest in
-                return XCTFail("did not generate eror")
+            XCTAssertManifestLoadThrows(stream.bytes) { _, diagnostics in
+                diagnostics.check(diagnostic: "invalid type for binary product 'FooLibrary'; products referencing only binary targets must have a type of 'library'", behavior: .error)
             }
-        } catch ManifestParseError.invalidBinaryProductType(let productName) {
-            XCTAssertEqual(productName, "FooLibrary")
-        } catch {
-            XCTFail(error.localizedDescription)
         }
 
         do {
@@ -138,18 +134,14 @@ class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
                         .executable(name: "FooLibrary", targets: ["Foo"]),
                     ],
                     targets: [
-                        .binaryTarget(name: "Foo", path: "Foo.zip"),
+                        .binaryTarget(name: "Foo", path: "Foo.xcframework"),
                     ]
                 )
                 """
 
-            try loadManifestThrowing(stream.bytes) { manifest in
-                return XCTFail("did not generate eror")
+            XCTAssertManifestLoadThrows(stream.bytes) { _, diagnostics in
+                diagnostics.check(diagnostic: "invalid type for binary product 'FooLibrary'; products referencing only binary targets must have a type of 'library'", behavior: .error)
             }
-        } catch ManifestParseError.invalidBinaryProductType(let productName) {
-            XCTAssertEqual(productName, "FooLibrary")
-        } catch {
-            XCTFail(error.localizedDescription)
         }
 
         do {
@@ -162,13 +154,13 @@ class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
                         .library(name: "FooLibrary", type: .static, targets: ["Foo", "Bar"]),
                     ],
                     targets: [
-                        .binaryTarget(name: "Foo", path: "Foo.zip"),
+                        .binaryTarget(name: "Foo", path: "Foo.xcframework"),
                         .target(name: "Bar"),
                     ]
                 )
                 """
 
-            loadManifest(stream.bytes) { _ in }
+            XCTAssertManifestLoadNoThrows(stream.bytes)
         }
 
         do {
@@ -186,13 +178,29 @@ class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            try loadManifestThrowing(stream.bytes) { manifest in
-                return XCTFail("did not generate eror")
+            XCTAssertManifestLoadThrows(stream.bytes) { _, diagnostics in
+                diagnostics.check(diagnostic: "invalid location for binary target 'Foo'", behavior: .error)
             }
-        } catch ManifestParseError.invalidBinaryLocation(let targetName) {
-            XCTAssertEqual(targetName, "Foo")
-        } catch {
-            XCTFail(error.localizedDescription)
+        }
+
+        do {
+            let stream = BufferedOutputByteStream()
+            stream <<< """
+                import PackageDescription
+                let package = Package(
+                    name: "Foo",
+                    products: [
+                        .library(name: "Foo", targets: ["Foo"]),
+                    ],
+                    targets: [
+                        .binaryTarget(name: "Foo", url: "http://foo.com/foo.zip", checksum: "checksum"),
+                    ]
+                )
+                """
+
+            XCTAssertManifestLoadThrows(stream.bytes) { _, diagnostics in
+                diagnostics.check(diagnostic: "invalid URL scheme for binary target 'Foo'; valid schemes are: https", behavior: .error)
+            }
         }
 
         do {
@@ -210,14 +218,9 @@ class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            try loadManifestThrowing(stream.bytes) { manifest in
-                return XCTFail("did not generate eror")
+            XCTAssertManifestLoadThrows(stream.bytes) { _, diagnostics in
+                diagnostics.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: xcframework", behavior: .error)
             }
-        } catch ManifestParseError.invalidBinaryLocationExtension(let targetName, let validExtensions) {
-            XCTAssertEqual(targetName, "Foo")
-            XCTAssertEqual(Set(validExtensions), ["zip", "xcframework"])
-        } catch {
-            XCTFail(error.localizedDescription)
         }
 
         do {
@@ -238,14 +241,9 @@ class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            try loadManifestThrowing(stream.bytes) { manifest in
-                return XCTFail("did not generate eror")
+            XCTAssertManifestLoadThrows(stream.bytes) { _, diagnostics in
+                diagnostics.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: zip", behavior: .error)
             }
-        } catch ManifestParseError.invalidBinaryLocationExtension(let targetName, let validExtensions) {
-            XCTAssertEqual(targetName, "Foo")
-            XCTAssertEqual(Set(validExtensions), ["zip"])
-        } catch {
-            XCTFail(error.localizedDescription)
         }
 
         do {
@@ -263,14 +261,9 @@ class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            try loadManifestThrowing(stream.bytes) { manifest in
-                return XCTFail("did not generate eror")
+            XCTAssertManifestLoadThrows(stream.bytes) { _, diagnostics in
+                diagnostics.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: xcframework", behavior: .error)
             }
-        } catch ManifestParseError.invalidBinaryLocationExtension(let targetName, let validExtensions) {
-            XCTAssertEqual(targetName, "Foo")
-            XCTAssertEqual(Set(validExtensions), ["zip", "xcframework"])
-        } catch {
-            XCTFail(error.localizedDescription)
         }
 
         do {
@@ -291,14 +284,9 @@ class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            try loadManifestThrowing(stream.bytes) { manifest in
-                return XCTFail("did not generate eror")
+            XCTAssertManifestLoadThrows(stream.bytes) { _, diagnostics in
+                diagnostics.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: zip", behavior: .error)
             }
-        } catch ManifestParseError.invalidBinaryLocationExtension(let targetName, let validExtensions) {
-            XCTAssertEqual(targetName, "Foo")
-            XCTAssertEqual(Set(validExtensions), ["zip"])
-        } catch {
-            XCTFail(error.localizedDescription)
         }
     }
 }


### PR DESCRIPTION
Refactor manifest validation diagnostics to emit all of them when parsing manifests from Workspace, instead of failing on the first one. Also took the opportunity to improve the wording of some of those diagnostics.

For example, the following Package:

```swift
let package = Package(
	name: "Foo",
	products: [
		.library(name: "Product", targets: []),
		.library(name: "Product", targets: ["A", "C"]),
	],
	dependencies: [
		.package(path: "../foo1"),
		.package(url: "/foo1.git", from: "1.0.1"),
		.package(url: "path/to/foo1", from: "3.0.0"),
		.package(url: "/foo2.git", from: "1.0.1"),
		.package(url: "/foo2.git", from: "1.1.1"),
		.package(url: "/foo3.git", from: "1.0.1"),
	],
	targets: [
		.target(name: "A"),
		.target(name: "B"),
		.target(name: "A"),
		.target(name: "B"),
	]
)
```

will now emit the following diagnostics:

```
/path/to/Package: error: duplicate target named 'B'
/path/to/Package: error: duplicate target named 'A'
/path/to/Package: error: product 'Product' doesn't reference any targets
/path/to/Package: error: target 'C' referenced in product 'Product' could not be found
/path/to/Package: error: duplicate dependency 'foo2'
/path/to/Package: error: duplicate dependency 'foo1'
```

### PS

To achieve this while continue to have those diagnostics assigned the right `DiagnosticLocation`, I modified `DiagnosticsEngine` to have a configurable `defaultLocation` (not always `UnknownLocation` anymore), and created a helper function to generate a new `DiagnosticsEngine` with a specific default location that emits back to a parent `DiagnosticsEngine`. The allows to do the following in Workspace:

```swift
return diagnostics.with(location: PackageLocation.Local(packagePath: packagePath)) { diagnostics in
     // Use the new "inner" diagnostics engine.
}
```

Finally, to disambiguate this new functionality from the `wrap` function, which also used to provide a default location, but only for captured errors, I removed the optional location from `wrap`. Now, to both capture errors and provide a default location for them, we can simply surround them in both closures:

```swift
return diagnostics.with(location: PackageLocation.Local(packagePath: packagePath)) { diagnostics in
    diagnostics.wrap {
        try something()
    }
}
```