### PR TITLE
[SPMLLBuild] Gracefully handle missing data

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -804,8 +804,12 @@ final class ManifestLoadRule: LLBuildRule {
 
     override func isResultValid(_ priorValue: Value) -> Bool {
         // Always rebuild if we had a failure.
-        let value = RuleKey.BuildValue(priorValue)
-        if value.hasErrors { return false }
+        do {
+            let value = try RuleKey.BuildValue(priorValue)
+            if value.hasErrors { return false }
+        } catch {
+            return false
+        }
 
         return super.isResultValid(priorValue)
     }
@@ -869,13 +873,13 @@ final class FileInfoRule: LLBuildRule {
     }
 
     override func isResultValid(_ priorValue: Value) -> Bool {
-        let priorValue = RuleValue(priorValue)
+        let priorValue = try? RuleValue(priorValue)
 
         // Always rebuild if we had a failure.
-        if case .failure = priorValue.result {
+        if case .failure = priorValue?.result {
             return false
         }
-        return getFileInfo(key.path).result == priorValue.result
+        return getFileInfo(key.path).result == priorValue?.result
     }
 
     override func inputsAvailable(_ engine: LLTaskBuildEngine) {

--- a/Sources/SPMLLBuild/llbuild.swift
+++ b/Sources/SPMLLBuild/llbuild.swift
@@ -92,7 +92,7 @@ public final class LLBuildEngine {
             throw Error.failed(errors: delegate.errors)
         }
 
-        return T.BuildValue(value)
+        return try T.BuildValue(value)
     }
 
     public func attachDB(path: String, schemaVersion: Int = 2) throws {
@@ -219,18 +219,8 @@ public extension LLBuildKey {
 }
 
 public extension LLBuildValue {
-    init(_ value: Value) {
-        do {
-            self = try fromBytes(value.data)
-        } catch {
-            let stringValue: String
-            if let str = String(bytes: value.data, encoding: .utf8) {
-                stringValue = str
-            } else {
-                stringValue = String(describing: value.data)
-            }
-            fatalError("Please file a bug at https://bugs.swift.org with this info -- LLBuildValue: ###\(error)### ----- ###\(stringValue)###")
-        }
+    init(_ value: Value) throws {
+        self = try fromBytes(value.data)
     }
 
     func toValue() -> Value {


### PR DESCRIPTION
This will throw instead of crashing if we can't form a build value.
That can happen if we add new properties to the objects that get encoded in
the database but not bump the schema. This change will cause the build
value to be out-of-date and instead force recomputation of the cached
value.

<rdar://problem/51146826>