### PR TITLE
Improve PackageBuilder tests by reusing DiagnosticsEngineTester

### DIFF
--- a/TSC/Sources/TSCTestSupport/AssertMatch.swift
+++ b/TSC/Sources/TSCTestSupport/AssertMatch.swift
@@ -32,7 +32,7 @@ public indirect enum StringPattern {
     case or(StringPattern, StringPattern)
 }
 
-extension StringPattern: ExpressibleByStringLiteral {
+extension StringPattern: ExpressibleByStringInterpolation {
     public typealias UnicodeScalarLiteralType = StringLiteralType
     public typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
     


### PR DESCRIPTION
Improved `PackageBuilderTests` by reusing the `DiagnosticsEngineTester`, which allows us to:
* pattern match diagnostic messages with `StringPattern`
* test the diagnostic's behavior and location