### PR TITLE
Allow checking diagnostics unordered

### DIFF
--- a/TSC/Sources/TSCTestSupport/DiagnosticsEngine.swift
+++ b/TSC/Sources/TSCTestSupport/DiagnosticsEngine.swift
@@ -61,4 +61,28 @@ final public class DiagnosticsEngineResult {
         XCTAssertEqual(theDiagnostic.message.behavior, behavior, file: file, line: line)
         XCTAssertEqual(theDiagnostic.location.description, location, file: file, line: line)
     }
+
+    public func checkUnordered(
+        diagnostic diagnosticPattern: StringPattern,
+        checkContains: Bool = false,
+        behavior: Diagnostic.Behavior,
+        location: String? = nil,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        guard !uncheckedDiagnostics.isEmpty else {
+            return XCTFail("No diagnostics left to check", file: file, line: line)
+        }
+
+        let locationDescription = location ?? UnknownLocation.location.description
+        let matchIndex = uncheckedDiagnostics.firstIndex(where: { diagnostic in
+            diagnosticPattern ~= diagnostic.description &&
+            diagnostic.message.behavior == behavior &&
+            diagnostic.location.description == locationDescription
+        })
+
+        if let index = matchIndex {
+            uncheckedDiagnostics.remove(at: index)
+        }
+    }
 }

--- a/Tests/PackageLoadingTests/PD4LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4LoadingTests.swift
@@ -382,8 +382,8 @@ class PackageDescription4LoadingTests: PackageDescriptionLoadingTests {
             """
 
         XCTAssertManifestLoadThrows(stream.bytes) { _, diagnotics in
-            diagnotics.check(diagnostic: .regex("duplicate target named '(A|B)'"), behavior: .error)
-            diagnotics.check(diagnostic: .regex("duplicate target named '(A|B)'"), behavior: .error)
+            diagnotics.checkUnordered(diagnostic: "duplicate target named 'A'", behavior: .error)
+            diagnotics.checkUnordered(diagnostic: "duplicate target named 'B'", behavior: .error)
         }
     }
 

--- a/Tests/PackageLoadingTests/PD5_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5_2LoadingTests.swift
@@ -197,8 +197,8 @@ class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
             """
 
         XCTAssertManifestLoadThrows(stream.bytes) { _, diagnostics in
-            diagnostics.check(diagnostic: .regex("duplicate dependency named '(Bar|Biz)'; consider differentiating them using the 'name' argument"), behavior: .error)
-            diagnostics.check(diagnostic: .regex("duplicate dependency named '(Bar|Biz)'; consider differentiating them using the 'name' argument"), behavior: .error)
+            diagnostics.checkUnordered(diagnostic: "duplicate dependency named 'Bar'; consider differentiating them using the 'name' argument", behavior: .error)
+            diagnostics.checkUnordered(diagnostic: "duplicate dependency named 'Biz'; consider differentiating them using the 'name' argument", behavior: .error)
         }
     }
 


### PR DESCRIPTION
In some few tests, we could be receiving diagnostics in slightly different order. To improve tests, I've added a function to `DiagnosticsEngineTester` to allow checking for any diagnostic, not only the next in line.