### PR TITLE
[PackageLoading] Fix a regression in target sources builder

### DIFF
--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -231,13 +231,7 @@ public struct TargetSourcesBuilder {
             }
 
             // At this point, curr can only be a directory.
-
-            // The path is a symlinked directory. Warn and continue.
-            if fs.isSymlink(curr) {
-                // FIXME: Emit warning here.
-                continue
-            }
-
+            //
             // Check if the directory is marked to be copied.
             let directoryMarkedToBeCopied = target.resources.contains{ resource in
                 let resourcePath = self.targetPath.appending(RelativePath(resource.path))

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -87,6 +87,32 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
+    func testSymlinkedSourcesDirectory() throws {
+        mktmpdir { path in
+            let fs = localFileSystem
+
+            let sources = path.appending(components: "Sources")
+            let foo = sources.appending(components: "foo")
+            let bar = sources.appending(components: "bar")
+            try fs.createDirectory(foo, recursive: true)
+            try fs.writeFileContents(foo.appending(components: "foo.swift"), bytes: "")
+
+            // Create a symlink to foo.
+            try createSymlink(bar, pointingAt: foo)
+
+            let manifest = Manifest.createV4Manifest(
+                name: "pkg",
+                targets: [
+                    TargetDescription(name: "bar"),
+                ]
+            )
+
+            PackageBuilderTester(manifest, path: path, in: fs) { package, _ in
+                package.checkModule("bar")
+            }
+        }
+    }
+
     func testCInTests() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/MyPackage/main.swift",

--- a/Tests/PackageLoadingTests/XCTestManifests.swift
+++ b/Tests/PackageLoadingTests/XCTestManifests.swift
@@ -52,6 +52,7 @@ extension PackageBuilderTests {
         ("testResolvesSystemModulePackage", testResolvesSystemModulePackage),
         ("testSpecialTargetDir", testSpecialTargetDir),
         ("testSpecifiedCustomPathDoesNotExist", testSpecifiedCustomPathDoesNotExist),
+        ("testSymlinkedSourcesDirectory", testSymlinkedSourcesDirectory),
         ("testSystemLibraryTarget", testSystemLibraryTarget),
         ("testSystemLibraryTargetDiagnostics", testSystemLibraryTargetDiagnostics),
         ("testSystemPackageDeclaresTargetsDiagnostic", testSystemPackageDeclaresTargetsDiagnostic),


### PR DESCRIPTION
For some reason I thought that we ignored symlinked directories and
baked that logic in the new sources builder. This fixes that regression.

<rdar://problem/58963219>
https://bugs.swift.org/browse/SR-12094