### PR TITLE
[PackageLoading] Fix a regression in target sources builder

### DIFF
--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -206,13 +206,7 @@ public struct TargetSourcesBuilder {
             }
 
             // At this point, curr can only be a directory.
-
-            // The path is a symlinked directory. Warn and continue.
-            if fs.isSymlink(curr) {
-                // FIXME: Emit warning here.
-                continue
-            }
-
+            //
             // Check if the directory is marked to be copied.
             let directoryMarkedToBeCopied = target.resources.contains{ resource in
                 let resourcePath = self.targetPath.appending(RelativePath(resource.path))

--- a/Tests/PackageLoadingTests/XCTestManifests.swift
+++ b/Tests/PackageLoadingTests/XCTestManifests.swift
@@ -52,6 +52,7 @@ extension PackageBuilderTests {
         ("testResolvesSystemModulePackage", testResolvesSystemModulePackage),
         ("testSpecialTargetDir", testSpecialTargetDir),
         ("testSpecifiedCustomPathDoesNotExist", testSpecifiedCustomPathDoesNotExist),
+        ("testSymlinkedSourcesDirectory", testSymlinkedSourcesDirectory),
         ("testSystemLibraryTarget", testSystemLibraryTarget),
         ("testSystemLibraryTargetDiagnostics", testSystemLibraryTargetDiagnostics),
         ("testSystemPackageDeclaresTargetsDiagnostic", testSystemPackageDeclaresTargetsDiagnostic),


### PR DESCRIPTION
For some reason I thought that we ignored symlinked directories and
baked that logic in the new sources builder. This fixes that regression.

<rdar://problem/58963219>
https://bugs.swift.org/browse/SR-12094

(cherry picked from commit 78e5ee26d6c23174627998488107121f81edab01)