### PR TITLE
[SR-12101] Support migration of old dependencies-state.json

### DIFF
--- a/Sources/Workspace/WorkspaceState.swift
+++ b/Sources/Workspace/WorkspaceState.swift
@@ -259,8 +259,15 @@ public final class WorkspaceState: SimplePersistanceProtocol {
     }
 
     public func restore(from json: JSON) throws {
+        try restore(from: json, supportedSchemaVersion: WorkspaceState.schemaVersion)
+    }
+
+    public func restore(from json: JSON, supportedSchemaVersion: Int) throws {
         dependencies = try ManagedDependencies(json: json.get("dependencies"))
-        artifacts = try ManagedArtifacts(json: json.get("artifacts"))
+
+        if supportedSchemaVersion >= 4 {
+            artifacts = try ManagedArtifacts(json: json.get("artifacts"))
+        }
     }
 
     public func toJSON() -> JSON {


### PR DESCRIPTION
The `public func restore(from json: JSON, supportedSchemaVersion: Int) throws` function has a default implementation that does nothing: and this is why I missed implementing it. This is a bit dangerous, we might want to do something about it.