### PR TITLE
[bootstrap] Reconfigure cmake when swiftc path changes

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -364,7 +364,7 @@ def install_binary(args, binary, dest_dir):
 def build_with_cmake(args, cmake_args, source_path, build_dir):
     """Runs CMake if needed, then builds with Ninja."""
     cache_path = os.path.join(build_dir, "CMakeCache.txt")
-    if not os.path.isfile(cache_path) or args.reconfigure:
+    if args.reconfigure or not os.path.isfile(cache_path) or not args.swiftc_path in open(cache_path).read():
         swift_flags = ""
         if args.sysroot:
             swift_flags = "-sdk %s" % args.sysroot


### PR DESCRIPTION
Previously, we would only care if "CMakeCache.txt" exists, this adds a
check for whether we are using the correct `swiftc`. This resolves an
issue when switching between different versions of Xcode.

<rdar://problem/58680012>