### PR TITLE
bootstrap: add an `LC_RPATH` relative to the executable

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -542,8 +542,12 @@ def get_swiftpm_flags(args):
         build_flags.extend([
             "-Xswiftc", "-F" + args.llbuild_build_dir,
             "-Xlinker", "-F" + args.llbuild_build_dir,
+
             "-Xlinker", "-rpath",
             "-Xlinker", "@executable_path/../../../../../SharedFrameworks",
+
+            "-Xlinker", "-rpath",
+            "-Xlinker", "@executable_path/../lib/swift/macosx",
         ])
 
     # Add a relative rpath to find core Swift libraries on non-Darwin platforms,


### PR DESCRIPTION
This adds the executable relative path to the runtime path selection to
ensure that we use local copies of the libraries to run executables.
Without this, the system libraries would be used which may not have
changes that the tool was built against.