### PR TITLE
[bootstrap] Add RPATH on Darwin.

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -547,27 +547,41 @@ def get_swiftpm_flags(args):
             "-Xlinker", "-rpath",
             "-Xlinker", "@executable_path/../../../../../SharedFrameworks",
 
-            # For TensorFlow.
-            "-Xlinker", "-rpath",
-            "-Xlinker", "@executable_path/../lib/swift/macosx",
-
             # For LLBuild in CLT.
             "-Xlinker", "-rpath",
             "-Xlinker", "@executable_path/../lib/swift/pm/llbuild",
         ])
 
-    # Add a relative rpath to find core Swift libraries on non-Darwin platforms,
-    # where they aren't present as part of the base OS.
-    if platform.system() != 'Darwin':
-        platform_path = None
-        for path in args.target_info["paths"]["runtimeLibraryPaths"]:
-            platform_path = re.search(r'(lib/swift/[^/]+)$', path)
-            if platform_path:
-                build_flags.extend(["-Xlinker", "-rpath=$ORIGIN/../" + platform_path.group(1)])
-                break
+    # Add a relative rpath to find Swift libraries in toolchains.
+    # On non-Darwin platforms, a relative rpath is necessary because Swift
+    # libraries are not part of the OS.
+    # On Darwin platforms, a relative rpath is necessary for experimental
+    # toolchains that include libraries not part of the OS (e.g. PythonKit or
+    # TensorFlow).
+    if platform.system() == "Darwin":
+        swift_library_rpath_prefix = "@executable_path/../"
+    elif platform.system() == 'Linux':
+        # `$ORIGIN` is an ELF construct.
+        swift_library_rpath_prefix = "$ORIGIN/../"
+    platform_path = None
+    for path in args.target_info["paths"]["runtimeLibraryPaths"]:
+        platform_path = re.search(r"(lib/swift/[^/]+)$", path)
+        if platform_path:
+            build_flags.extend(
+                [
+                    "-Xlinker",
+                    "-rpath",
+                    "-Xlinker",
+                    swift_library_rpath_prefix + platform_path.group(1),
+                ]
+            )
+            break
 
-        if not platform_path:
-            error("the command `%s -print-target-info` didn't return a valid runtime library path" % args.swiftc_path)
+    if not platform_path:
+        error(
+            "the command `%s -print-target-info` didn't return a valid runtime library path"
+            % args.swiftc_path
+        )
 
     # Don't use GNU strerror_r on Android.
     if 'ANDROID_DATA' in os.environ:


### PR DESCRIPTION
Add `@executable_path/../lib/swift/<platform>` RPATH on Darwin platforms.
This is necessary for experimental toolchains that include libraries not part of the OS (e.g. `PythonKit` or `TensorFlow`).

Verified to fix SwiftPM command linker issues for Swift for TensorFlow toolchains: https://github.com/tensorflow/swift/issues/347.

Effectively reverts https://github.com/apple/swift-package-manager/pull/2548: an unverified fix for the same issue that did not work.

---

Note: previously, `@executable_path/../lib/swift/macosx` was [actually added as an RPATH in `Utilities/bootstrap`](https://github.com/apple/swift-package-manager/pull/2462/files#diff-296aa080a049a48a75c47e0a2926fde0L1302), but the `Utilities/bootstrap ` revamp in https://github.com/apple/swift-package-manager/pull/2462 removed that logic.

---

Before:
```console
$ swift build
dyld: Library not loaded: @rpath/libswiftCore.dylib
  Referenced from: /Library/Developer/Toolchains/swift-tensorflow-LOCAL-2020-02-05-a.xctoolchain/usr/bin/swift-test
  Reason: image not found
[1]    50469 abort      swift build
```

After:
```console
$ swift build
# No error.
```