### PR TITLE
[PackageLoading] Handle header files in TargetSourcesBuilder

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -678,19 +678,12 @@ public final class PackageBuilder {
             throw ModuleError.invalidPublicHeadersDirectory(potentialModule.name)
         }
 
-        // Exclude public headers path directory from source searching if it's not
-        // the target root.
-        // FIXME: This means we'll try to assign rules to header files
-        // which is currently not handled by the sources builder.
-        let extraExcludes = publicHeadersPath != potentialModule.path ? [publicHeadersPath] : []
-
         let sourcesBuilder = TargetSourcesBuilder(
             packageName: manifest.name,
             packagePath: packagePath,
             target: manifestTarget,
             path: potentialModule.path,
             additionalFileRules: additionalFileRules,
-            extraExcludes: extraExcludes,
             toolsVersion: manifest.toolsVersion,
             fs: fileSystem,
             diags: diagnostics

--- a/TSC/Sources/TSCBasic/CollectionExtensions.swift
+++ b/TSC/Sources/TSCBasic/CollectionExtensions.swift
@@ -23,3 +23,20 @@ extension Collection {
         }
     }
 }
+
+extension Collection where Element: Hashable {
+    /// Returns a new list of element removing duplicate elements.
+    ///
+    /// Note: The order of elements is preseved.
+    /// Complexity: O(n)
+    public func spm_uniqueElements() -> [Element] {
+        var set = Set<Element>()
+        var result = [Element]()
+        for element in self {
+            if set.insert(element).inserted {
+                result.append(element)
+            }
+        }
+        return result
+    }
+}

--- a/TSC/Tests/TSCBasicTests/CollectionExtensionsTests.swift
+++ b/TSC/Tests/TSCBasicTests/CollectionExtensionsTests.swift
@@ -17,4 +17,10 @@ class CollectionExtensionsTests: XCTestCase {
         XCTAssertEqual([42].spm_only, 42)
         XCTAssertEqual([42, 24].spm_only, nil)
     }
+
+    func testUniqueElements() {
+        XCTAssertEqual([1, 2, 2, 4, 2, 1, 1, 4].spm_uniqueElements(), [1, 2, 4])
+        XCTAssertEqual([1, 2, 2, 4, 2, 1, 1, 4, 9].spm_uniqueElements(), [1, 2, 4, 9])
+        XCTAssertEqual([3, 2, 1].spm_uniqueElements(), [3, 2, 1])
+    }
 }

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -215,6 +215,37 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
+    func testPublicIncludeDirMixedWithSources() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/clib/nested/nested.h",
+            "/Sources/clib/nested/nested.c",
+            "/Sources/clib/clib.h",
+            "/Sources/clib/clib.c",
+            "/Sources/clib/clib2.h",
+            "/Sources/clib/clib2.c",
+            "/done"
+        )
+
+        let manifest = Manifest.createV4Manifest(
+            name: "MyPackage",
+            targets: [
+                TargetDescription(
+                    name: "clib",
+                    path: "Sources",
+                    sources: ["clib", "clib"],
+                    publicHeadersPath: "."
+                ),
+            ]
+        )
+        PackageBuilderTester(manifest, in: fs) { package, diags in
+            diags.check(diagnostic: "found duplicate sources declaration in the package manifest: /Sources/clib", behavior: .warning)
+            package.checkModule("clib") { module in
+                module.check(c99name: "clib", type: .library)
+                module.checkSources(root: "/Sources", paths: "clib/clib.c", "clib/clib2.c", "clib/nested/nested.c")
+            }
+        }
+    }
+
     func testDeclaredExecutableProducts() {
         // Check that declaring executable product doesn't collide with the
         // inferred products.

--- a/Tests/PackageLoadingTests/XCTestManifests.swift
+++ b/Tests/PackageLoadingTests/XCTestManifests.swift
@@ -50,6 +50,7 @@ extension PackageBuilderTests {
         ("testPlatforms", testPlatforms),
         ("testPredefinedTargetSearchError", testPredefinedTargetSearchError),
         ("testPublicHeadersPath", testPublicHeadersPath),
+        ("testPublicIncludeDirMixedWithSources", testPublicIncludeDirMixedWithSources),
         ("testResolvesSystemModulePackage", testResolvesSystemModulePackage),
         ("testSpecialTargetDir", testSpecialTargetDir),
         ("testSpecifiedCustomPathDoesNotExist", testSpecifiedCustomPathDoesNotExist),


### PR DESCRIPTION
Since header files are allowed to be mixed with sources, it makes sense
to handle them inside the target sources builder. This allow us to not
special case the public headers directory which can lead to weird edge
cases with previously supported layouts. This patch also adds two more
things 1) diagnostics for duplicate declaration in sources parameter 2)
move the explicit resources check to the vNext tools version as
resources isn't a Swift 5.2 feature.

<rdar://problem/56783465>