### PR TITLE
Fix an issue and improve diagnostics for target-based dependencies

### DIFF
--- a/Sources/PackageLoading/PackageDescription4Loader.swift
+++ b/Sources/PackageLoading/PackageDescription4Loader.swift
@@ -294,7 +294,7 @@ extension PackageDependencyDescription {
 
         let requirement = try Requirement(v4: json.get("requirement"))
         let url = try fixURL(json.get("url"), requirement: requirement)
-        let name = json.get("name") ?? PackageReference.computeDefaultName(fromURL: url)
+        let name: String? = json.get("name")
         self.init(name: name, url: url, requirement: requirement)
     }
 }

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -255,7 +255,7 @@ extension Manifest {
         for target in targetsRequired(for: products) {
             for targetDependency in target.dependencies {
                 if let dependency = packageDependency(referencedBy: targetDependency) {
-                    requiredDependencyNames.insert(dependency.name!)
+                    requiredDependencyNames.insert(dependency.name)
                 }
             }
         }
@@ -507,8 +507,11 @@ public struct PackageDependencyDescription: Equatable, Codable {
         }
     }
 
-    /// The name of the dependency.
-    public let name: String?
+    /// The name of the dependency explicitly defined in the manifest.
+    public let explicitName: String?
+
+    /// The name of the dependency, either explicitly defined in the manifest, or deduced from the URL.
+    public let name: String
 
     /// The url of the dependency.
     public let url: String
@@ -518,7 +521,8 @@ public struct PackageDependencyDescription: Equatable, Codable {
 
     /// Create a dependency.
     public init(name: String?, url: String, requirement: Requirement) {
-        self.name = name
+        self.explicitName = name
+        self.name = name ?? PackageReference.computeDefaultName(fromURL: url)
         self.url = url
         self.requirement = requirement
     }

--- a/Sources/SPMTestSupport/TestWorkspace.swift
+++ b/Sources/SPMTestSupport/TestWorkspace.swift
@@ -557,7 +557,7 @@ public struct TestTarget {
     }
 
     public let name: String
-    public let dependencies: [String]
+    public let dependencies: [TargetDescription.Dependency]
     public let path: String?
     public let url: String?
     public let checksum: String?
@@ -566,7 +566,7 @@ public struct TestTarget {
 
     public init(
         name: String,
-        dependencies: [String] = [],
+        dependencies: [TargetDescription.Dependency] = [],
         type: Type = .regular,
         path: String? = nil,
         url: String? = nil,
@@ -587,7 +587,7 @@ public struct TestTarget {
         case .regular:
             return TargetDescription(
                 name: name,
-                dependencies: dependencies.map { .byName(name: $0, condition: nil) },
+                dependencies: dependencies,
                 path: path,
                 exclude: [],
                 sources: nil,
@@ -597,7 +597,7 @@ public struct TestTarget {
         case .test:
             return TargetDescription(
                 name: name,
-                dependencies: dependencies.map { .byName(name: $0, condition: nil) },
+                dependencies: dependencies,
                 path: path,
                 exclude: [],
                 sources: nil,
@@ -607,7 +607,7 @@ public struct TestTarget {
         case .binary:
             return TargetDescription(
                 name: name,
-                dependencies: dependencies.map { .byName(name: $0, condition: nil) },
+                dependencies: dependencies,
                 path: path,
                 url: url,
                 exclude: [],
@@ -632,19 +632,27 @@ public struct TestProduct {
 }
 
 public struct TestDependency {
-    public let name: String
+    public let name: String?
+    public let path: String
     public let requirement: Requirement
     public typealias Requirement = PackageDependencyDescription.Requirement
 
     public init(name: String, requirement: Requirement) {
         self.name = name
+        self.path = name
+        self.requirement = requirement
+    }
+
+    public init(name: String?, path: String, requirement: Requirement) {
+        self.name = name
+        self.path = path
         self.requirement = requirement
     }
 
     public func convert(baseURL: AbsolutePath) -> PackageDependencyDescription {
         return PackageDependencyDescription(
             name: name,
-            url: baseURL.appending(RelativePath(name)).pathString,
+            url: baseURL.appending(RelativePath(path)).pathString,
             requirement: requirement
         )
     }

--- a/Tests/PackageLoadingTests/PD4LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4LoadingTests.swift
@@ -142,12 +142,12 @@ class PackageDescription4LoadingTests: PackageDescriptionLoadingTests {
             """
        loadManifest(stream.bytes) { manifest in
             let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.url, $0) })
-            XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(name: "foo1", url: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
-            XCTAssertEqual(deps["/foo2"], PackageDependencyDescription(name: "foo2", url: "/foo2", requirement: .upToNextMajor(from: "1.0.0")))
-            XCTAssertEqual(deps["/foo3"], PackageDependencyDescription(name: "foo3", url: "/foo3", requirement: .upToNextMinor(from: "1.0.0")))
-            XCTAssertEqual(deps["/foo4"], PackageDependencyDescription(name: "foo4", url: "/foo4", requirement: .exact("1.0.0")))
-            XCTAssertEqual(deps["/foo5"], PackageDependencyDescription(name: "foo5", url: "/foo5", requirement: .branch("master")))
-            XCTAssertEqual(deps["/foo6"], PackageDependencyDescription(name: "foo6", url: "/foo6", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
+            XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(name: nil, url: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
+            XCTAssertEqual(deps["/foo2"], PackageDependencyDescription(name: nil, url: "/foo2", requirement: .upToNextMajor(from: "1.0.0")))
+            XCTAssertEqual(deps["/foo3"], PackageDependencyDescription(name: nil, url: "/foo3", requirement: .upToNextMinor(from: "1.0.0")))
+            XCTAssertEqual(deps["/foo4"], PackageDependencyDescription(name: nil, url: "/foo4", requirement: .exact("1.0.0")))
+            XCTAssertEqual(deps["/foo5"], PackageDependencyDescription(name: nil, url: "/foo5", requirement: .branch("master")))
+            XCTAssertEqual(deps["/foo6"], PackageDependencyDescription(name: nil, url: "/foo6", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
         }
     }
 

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -63,7 +63,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             // Check dependencies.
             let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.url, $0) })
-            XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(name: "foo1", url: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
+            XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(name: nil, url: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
 
             // Check products.
             let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })
@@ -253,8 +253,8 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             """
        loadManifest(stream.bytes) { manifest in
             let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.url, $0) })
-            XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(name: "foo1", url: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
-            XCTAssertEqual(deps["/foo2"], PackageDependencyDescription(name: "foo2", url: "/foo2", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
+            XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(name: nil, url: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
+            XCTAssertEqual(deps["/foo2"], PackageDependencyDescription(name: nil, url: "/foo2", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
 
             XCTAssertEqual(deps["/foo3"]?.url, "/foo3")
             XCTAssertEqual(deps["/foo3"]?.requirement, .localPackage)
@@ -262,11 +262,11 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             XCTAssertEqual(deps["/path/to/foo4"]?.url, "/path/to/foo4")
             XCTAssertEqual(deps["/path/to/foo4"]?.requirement, .localPackage)
 
-            XCTAssertEqual(deps["/foo5"], PackageDependencyDescription(name: "foo5", url: "/foo5", requirement: .exact("1.2.3")))
-            XCTAssertEqual(deps["/foo6"], PackageDependencyDescription(name: "foo6", url: "/foo6", requirement: .range("1.2.3"..<"2.0.0")))
-            XCTAssertEqual(deps["/foo7"], PackageDependencyDescription(name: "foo7", url: "/foo7", requirement: .branch("master")))
-            XCTAssertEqual(deps["/foo8"], PackageDependencyDescription(name: "foo8", url: "/foo8", requirement: .upToNextMinor(from: "1.3.4")))
-            XCTAssertEqual(deps["/foo9"], PackageDependencyDescription(name: "foo9", url: "/foo9", requirement: .upToNextMajor(from: "1.3.4")))
+            XCTAssertEqual(deps["/foo5"], PackageDependencyDescription(name: nil, url: "/foo5", requirement: .exact("1.2.3")))
+            XCTAssertEqual(deps["/foo6"], PackageDependencyDescription(name: nil, url: "/foo6", requirement: .range("1.2.3"..<"2.0.0")))
+            XCTAssertEqual(deps["/foo7"], PackageDependencyDescription(name: nil, url: "/foo7", requirement: .branch("master")))
+            XCTAssertEqual(deps["/foo8"], PackageDependencyDescription(name: nil, url: "/foo8", requirement: .upToNextMinor(from: "1.3.4")))
+            XCTAssertEqual(deps["/foo9"], PackageDependencyDescription(name: nil, url: "/foo9", requirement: .upToNextMajor(from: "1.3.4")))
 
             let homeDir = "/home/user"
             XCTAssertEqual(deps["\(homeDir)/path/to/foo10"]?.url, "\(homeDir)/path/to/foo10")

--- a/Tests/PackageLoadingTests/PD5LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5LoadingTests.swift
@@ -63,7 +63,7 @@ class PackageDescription5LoadingTests: PackageDescriptionLoadingTests {
 
             // Check dependencies.
             let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.url, $0) })
-            XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(name: "foo1", url: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
+            XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(name: nil, url: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
 
             // Check products.
             let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })

--- a/Tests/PackageLoadingTests/PDLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDLoadingTests.swift
@@ -26,6 +26,7 @@ class PackageDescriptionLoadingTests: XCTestCase {
     func loadManifestThrowing(
         _ contents: ByteString,
         toolsVersion: ToolsVersion? = nil,
+        packageKind: PackageReference.Kind = .local,
         line: UInt = #line,
         body: (Manifest) -> Void
     ) throws {
@@ -37,7 +38,7 @@ class PackageDescriptionLoadingTests: XCTestCase {
             package: AbsolutePath.root,
             baseURL: "/foo",
             toolsVersion: toolsVersion,
-            packageKind: .local,
+            packageKind: packageKind,
             fileSystem: fs)
         guard m.toolsVersion == toolsVersion else {
             return XCTFail("Invalid manfiest version")
@@ -48,12 +49,19 @@ class PackageDescriptionLoadingTests: XCTestCase {
     func loadManifest(
         _ contents: ByteString,
         toolsVersion: ToolsVersion? = nil,
+        packageKind: PackageReference.Kind = .local,
         line: UInt = #line,
         body: (Manifest) -> Void
     ) {
         do {
             let toolsVersion = toolsVersion ?? self.toolsVersion
-            try loadManifestThrowing(contents, toolsVersion: toolsVersion, line: line, body: body)
+            try loadManifestThrowing(
+                contents,
+                toolsVersion: toolsVersion,
+                packageKind: packageKind,
+                line: line,
+                body: body
+            )
         } catch ManifestParseError.invalidManifestFormat(let error, _) {
             print(error)
             XCTFail(file: #file, line: line)
@@ -65,6 +73,7 @@ class PackageDescriptionLoadingTests: XCTestCase {
     func XCTAssertManifestLoadNoThrows(
         _ contents: ByteString,
         toolsVersion: ToolsVersion? = nil,
+        packageKind: PackageReference.Kind = .local,
         file: StaticString = #file,
         line: UInt = #line,
         onSuccess: ((Manifest, DiagnosticsEngineResult) -> Void)? = nil
@@ -75,6 +84,7 @@ class PackageDescriptionLoadingTests: XCTestCase {
             let manifest = try loadManifest(
                 contents,
                 toolsVersion: toolsVersion ?? self.toolsVersion,
+                packageKind: packageKind,
                 diagnostics: diagnostics,
                 file: file,
                 line: line)
@@ -92,6 +102,7 @@ class PackageDescriptionLoadingTests: XCTestCase {
     func XCTAssertManifestLoadThrows(
         _ contents: ByteString,
         toolsVersion: ToolsVersion? = nil,
+        packageKind: PackageReference.Kind = .local,
         file: StaticString = #file,
         line: UInt = #line,
         onCatch: ((Error, DiagnosticsEngineResult) -> Void)? = nil
@@ -102,6 +113,7 @@ class PackageDescriptionLoadingTests: XCTestCase {
             let manifest = try loadManifest(
                 contents,
                 toolsVersion: toolsVersion ?? self.toolsVersion,
+                packageKind: packageKind,
                 diagnostics: diagnostics,
                 file: file,
                 line: line)
@@ -120,6 +132,7 @@ class PackageDescriptionLoadingTests: XCTestCase {
         _ expectedError: E,
         _ contents: ByteString,
         toolsVersion: ToolsVersion? = nil,
+        packageKind: PackageReference.Kind = .local,
         file: StaticString = #file,
         line: UInt = #line,
         onCatch: ((DiagnosticsEngineResult) -> Void)? = nil
@@ -138,6 +151,7 @@ class PackageDescriptionLoadingTests: XCTestCase {
     private func loadManifest(
         _ contents: ByteString,
         toolsVersion: ToolsVersion?,
+        packageKind: PackageReference.Kind,
         diagnostics: DiagnosticsEngine?,
         file: StaticString,
         line: UInt
@@ -150,7 +164,7 @@ class PackageDescriptionLoadingTests: XCTestCase {
             package: AbsolutePath.root,
             baseURL: "/foo",
             toolsVersion: toolsVersion,
-            packageKind: .local,
+            packageKind: packageKind,
             fileSystem: fileSystem,
             diagnostics: diagnostics)
 

--- a/Tests/PackageModelTests/ManifestTests.swift
+++ b/Tests/PackageModelTests/ManifestTests.swift
@@ -93,7 +93,7 @@ class ManifestTests: XCTestCase {
                 targets: targets
             )
 
-            XCTAssertEqual(manifest.allRequiredDependencies.map({ $0.name! }).sorted(), [
+            XCTAssertEqual(manifest.allRequiredDependencies.map({ $0.name }).sorted(), [
                 "Bar1",
                 "Bar2",
                 "Bar3",
@@ -112,7 +112,7 @@ class ManifestTests: XCTestCase {
                 targets: targets
             )
 
-            XCTAssertEqual(manifest.allRequiredDependencies.map({ $0.name! }).sorted(), [
+            XCTAssertEqual(manifest.allRequiredDependencies.map({ $0.name }).sorted(), [
                 "Bar1",
                 "Bar2",
                 "Bar3",
@@ -131,7 +131,7 @@ class ManifestTests: XCTestCase {
                 targets: targets
             )
 
-            XCTAssertEqual(manifest.allRequiredDependencies.map({ $0.name! }).sorted(), [
+            XCTAssertEqual(manifest.allRequiredDependencies.map({ $0.name }).sorted(), [
                 "Bar1",
                 "Bar2",
                 "Bar3",
@@ -150,7 +150,7 @@ class ManifestTests: XCTestCase {
                 targets: targets
             )
 
-            XCTAssertEqual(manifest.allRequiredDependencies.map({ $0.name! }).sorted(), [
+            XCTAssertEqual(manifest.allRequiredDependencies.map({ $0.name }).sorted(), [
                 "Bar1",
                 "Bar2",
             ])

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -238,8 +238,9 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        TestDependency(name: "bazzz", requirement: .upToNextMajor(from: "1.0.0")),
-                    ]
+                        TestDependency(name: nil, path: "bazzz", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    toolsVersion: .v5
                 ),
                 TestPackage(
                     name: "Bar",
@@ -415,7 +416,8 @@ final class WorkspaceTests: XCTestCase {
                     products: [],
                     dependencies: [
                         TestDependency(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
-                    ]
+                    ],
+                    toolsVersion: .v5
                 ),
                 TestPackage(
                     name: "Baz",
@@ -3189,7 +3191,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     dependencies: [
                         TestDependency(name: "Dep", requirement: .upToNextMajor(from: "1.0.0")),
-                    ]
+                    ],
+                    toolsVersion: .v5
                 ),
             ],
             packages: [
@@ -3202,9 +3205,10 @@ final class WorkspaceTests: XCTestCase {
                         TestProduct(name: "Dep", targets: ["Dep"]),
                     ],
                     dependencies: [
-                        TestDependency(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        TestDependency(name: nil, path: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
-                    versions: ["1.0.0", "1.5.0"]
+                    versions: ["1.0.0", "1.5.0"],
+                    toolsVersion: .v5
                 ),
                 TestPackage(
                     name: "Bar",
@@ -3318,9 +3322,10 @@ final class WorkspaceTests: XCTestCase {
                          TestProduct(name: "Bar", targets: ["Bar"]),
                      ],
                      dependencies: [
-                        TestDependency(name: "Nested/Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        TestDependency(name: nil, path: "Nested/Foo", requirement: .upToNextMajor(from: "1.0.0")),
                      ],
-                     versions: ["1.1.0"]
+                     versions: ["1.1.0"],
+                     toolsVersion: .v5
                  ),
                  TestPackage(
                      name: "Foo",
@@ -4025,7 +4030,7 @@ final class WorkspaceTests: XCTestCase {
                 TestPackage(
                     name: "Foo",
                     targets: [
-                        TestTarget(name: "Foo", dependencies: ["A1", "B"]),
+                        TestTarget(name: "Foo", dependencies: [.product(name: "A1", package: "A"), "B"]),
                     ],
                     products: [],
                     dependencies: [
@@ -4248,7 +4253,10 @@ final class WorkspaceTests: XCTestCase {
                 TestPackage(
                     name: "Foo",
                     targets: [
-                        TestTarget(name: "Foo", dependencies: ["A1", "A2"]),
+                        TestTarget(name: "Foo", dependencies: [
+                            .product(name: "A1", package: "A"),
+                            .product(name: "A2", package: "A"),
+                        ]),
                     ],
                     products: [],
                     dependencies: [


### PR DESCRIPTION
Added a missing diagnostic to check that explicit dependency names match the package name and improve the diagnostic for invalid product target dependency references.