### PR TITLE
Fix issues with diagnostics emitted during manifest loading

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -320,7 +320,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             }
 
             // Check that products that reference only binary targets don't define a type.
-            let areTargetsBinary = product.targets.allSatisfy({ manifest.targetMap[$0]!.type == .binary })
+            let areTargetsBinary = product.targets.allSatisfy({ manifest.targetMap[$0]?.type == .binary })
             if areTargetsBinary && product.type != .library(.automatic) {
                 try diagnostics.emit(.invalidBinaryProductType(productName: product.name))
             }

--- a/TSC/Sources/TSCUtility/Diagnostics.swift
+++ b/TSC/Sources/TSCUtility/Diagnostics.swift
@@ -109,7 +109,7 @@ extension DiagnosticsEngine {
             return nil
         }
     }
-    
+
     /// Wrap a throwing closure, returning a success boolean and
     /// emitting any thrown errors.
     ///
@@ -139,7 +139,7 @@ extension Optional where Wrapped == DiagnosticsEngine {
         if case let diagnostics? = self {
             diagnostics.emit(.error(error), location: location)
         } else {
-            throw Diagnostics.fatalError
+            throw StringError(error)
         }
     }
 
@@ -150,7 +150,7 @@ extension Optional where Wrapped == DiagnosticsEngine {
         if case let diagnostics? = self {
             diagnostics.emit(error, location: location)
         } else {
-            throw Diagnostics.fatalError
+            throw error
         }
     }
 
@@ -161,7 +161,7 @@ extension Optional where Wrapped == DiagnosticsEngine {
         if case let diagnostics? = self {
             diagnostics.emit(.error(convertible.diagnosticData), location: location)
         } else {
-            throw Diagnostics.fatalError
+            throw StringError(convertible.diagnosticData.description)
         }
     }
 
@@ -172,7 +172,7 @@ extension Optional where Wrapped == DiagnosticsEngine {
         if case let diagnostics? = self {
             diagnostics.emit(message, location: location)
         } else if message.behavior == .error {
-            throw Diagnostics.fatalError
+            throw StringError(message.text)
         }
     }
 }

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -677,6 +677,27 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
         }
     }
 
+    func testProductTargetNotFound() throws {
+        let stream = BufferedOutputByteStream()
+        stream <<< """
+            import PackageDescription
+
+            let package = Package(
+                name: "Foo",
+                products: [
+                    .library(name: "Product", targets: ["B"]),
+                ],
+                targets: [
+                    .target(name: "A"),
+                ]
+            )
+            """
+
+        XCTAssertManifestLoadThrows(stream.bytes) { _, diagnostics in
+            diagnostics.check(diagnostic: "target 'B' referenced in product 'Product' could not be found", behavior: .error)
+        }
+    }
+
     final class ManifestTestDelegate: ManifestLoaderDelegate {
         var loaded: [AbsolutePath] = []
         var parsed: [AbsolutePath] = []


### PR DESCRIPTION
Fixes two issues:

* Crash when a product references an unknown target in the root package
* Missing diagnostic when failing to load a manifest of a dependency package