### PR TITLE
[PackageLoading] Better handling for directories with extension

### DIFF
--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -187,6 +187,10 @@ public struct TargetSourcesBuilder {
                     } else {
                         matchedRule = .compile
                     }
+                    // The source file might have been declared twice so
+                    // exit on first match.
+                    // FIXME: We should emitting warnings for duplicate// declarations.
+                    break
                 }
             }
         }

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -293,6 +293,32 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
+    func testOverlappingDeclaredSources() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/clib/subfolder/foo.h",
+            "/Sources/clib/subfolder/foo.c",
+            "/Sources/clib/bar.h",
+            "/Sources/clib/bar.c",
+            "/done"
+        )
+
+        let manifest = Manifest.createV4Manifest(
+            name: "MyPackage",
+            targets: [
+                TargetDescription(
+                    name: "clib",
+                    path: "Sources",
+                    sources: ["clib", "clib/subfolder"]
+                ),
+            ]
+        )
+        PackageBuilderTester(manifest, in: fs) { result, _ in
+            result.checkModule("clib") { module in
+                module.checkSources(sources: ["clib/bar.c", "clib/subfolder/foo.c"])
+            }
+        }
+    }
+
     func testDeclaredExecutableProducts() {
         // Check that declaring executable product doesn't collide with the
         // inferred products.

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -246,6 +246,53 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
+    func testDeclaredSourcesWithDot() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/swift.lib/foo.swift",
+            "/Sources/swiftlib1/swift.lib/foo.swift",
+            "/Sources/swiftlib2/swift.lib/foo.swift",
+            "/Sources/swiftlib3/swift.lib/foo.swift",
+            "/Sources/swiftlib3/swift.lib/foo.bar/bar.swift",
+            "/done"
+        )
+
+        let manifest = Manifest.createV4Manifest(
+            name: "MyPackage",
+            targets: [
+                TargetDescription(
+                    name: "swift.lib"
+                ),
+                TargetDescription(
+                    name: "swiftlib1",
+                    path: "Sources/swiftlib1",
+                    sources: ["swift.lib"]
+                ),
+                TargetDescription(
+                    name: "swiftlib2",
+                    path: "Sources/swiftlib2/swift.lib"
+                ),
+                TargetDescription(
+                    name: "swiftlib3",
+                    path: "Sources/swiftlib3/swift.lib"
+                ),
+            ]
+        )
+        PackageBuilderTester(manifest, in: fs) { result, _ in
+            result.checkModule("swift.lib") { module in
+                module.checkSources(sources: ["foo.swift"])
+            }
+            result.checkModule("swiftlib1") { module in
+                module.checkSources(sources: ["swift.lib/foo.swift"])
+            }
+            result.checkModule("swiftlib2") { module in
+                module.checkSources(sources: ["foo.swift"])
+            }
+            result.checkModule("swiftlib3") { module in
+                module.checkSources(sources: ["foo.bar/bar.swift", "foo.swift"])
+            }
+        }
+    }
+
     func testDeclaredExecutableProducts() {
         // Check that declaring executable product doesn't collide with the
         // inferred products.

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -60,11 +60,48 @@ class TargetSourcesBuilderTests: XCTestCase {
         XCTAssertEqual(contents, [
             "/Bar.swift",
             "/Foo.swift",
-            "/Hello.something",
+            "/Hello.something/hello.txt",
             "/file",
             "/path/to/somefile.txt",
             "/some/path.swift",
             "/some/path/toBeCopied",
+        ])
+
+        XCTAssertNoDiagnostics(diags)
+    }
+
+    func testDirectoryWithExt() throws {
+        let target = TargetDescription(
+            name: "Foo",
+            path: nil,
+            exclude: ["some2"],
+            sources: nil,
+            publicHeadersPath: nil,
+            type: .regular
+        )
+
+        let fs = InMemoryFileSystem()
+        fs.createEmptyFiles(at: .root, files: [
+            "/.some2/hello.swift",
+            "/Hello.something/hello.txt",
+        ])
+
+        let diags = DiagnosticsEngine()
+
+        let builder = TargetSourcesBuilder(
+            packageName: "",
+            packagePath: .root,
+            target: target,
+            path: .root,
+            toolsVersion: .vNext,
+            fs: fs,
+            diags: diags
+        )
+
+        let contents = builder.computeContents().map{ $0.pathString }.sorted()
+
+        XCTAssertEqual(contents, [
+            "/Hello.something",
         ])
 
         XCTAssertNoDiagnostics(diags)


### PR DESCRIPTION
Package builder started considering directories inside a target as
a file that can have a rule. However, this wasn't gated behind the tools
version check and we were not handling directories that are explicitly
declared as sources in the package manifest.

<rdar://problem/59243977>
https://bugs.swift.org/browse/SR-12158