### PR TITLE
[PackageLoading] Better handling for directories with extension

### DIFF
--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -182,6 +182,11 @@ public struct TargetSourcesBuilder {
         return matchedRule
     }
 
+    /// Returns true if the given path is a declared source.
+    func isDeclaredSource(_ path: AbsolutePath) -> Bool {
+        return path == targetPath || declaredSources?.contains(path) == true
+    }
+
     /// Compute the contents of the files in a target.
     ///
     /// This avoids recursing into certain directories like exclude or the
@@ -219,14 +224,22 @@ public struct TargetSourcesBuilder {
                 continue
             }
 
-            // Append and continue if the path doesn't have an extension or is not a directory.
-            if curr.extension != nil || !fs.isDirectory(curr) {
+            // Consider non-directories as source files.
+            if !fs.isDirectory(curr) {
                 contents.append(curr)
                 continue
             }
 
             // At this point, curr can only be a directory.
             //
+            // Starting tools version with resources, pick directories as
+            // sources that have an extension but are not explicitly
+            // declared as sources in the manifest.
+            if toolsVersion >= .vNext && curr.extension != nil && !isDeclaredSource(curr) {
+                contents.append(curr)
+                continue
+            }
+
             // Check if the directory is marked to be copied.
             let directoryMarkedToBeCopied = target.resources.contains{ resource in
                 let resourcePath = self.targetPath.appending(RelativePath(resource.path))

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -60,7 +60,7 @@ class TargetSourcesBuilderTests: XCTestCase {
         XCTAssertEqual(contents, [
             "/Bar.swift",
             "/Foo.swift",
-            "/Hello.something",
+            "/Hello.something/hello.txt",
             "/file",
             "/path/to/somefile.txt",
             "/some/path.swift",


### PR DESCRIPTION
Package builder started considering directories inside a target as
a file that can have a rule. However, this wasn't gated behind the tools
version check and we were not handling directories that are explicitly
declared as sources in the package manifest.

<rdar://problem/59243977>
https://bugs.swift.org/browse/SR-12158

(cherry picked from commit 1e15bbb4d399d28ed7d03b4e11cc4c1a720ca2fa)