### PR TITLE
Make sure main and test targets are always created

### DIFF
--- a/Sources/Build/ManifestBuilder.swift
+++ b/Sources/Build/ManifestBuilder.swift
@@ -45,6 +45,8 @@ public class LLBuildManifestBuilder {
 
     /// Generate manifest at the given path.
     public func generateManifest(at path: AbsolutePath) throws {
+        manifest.createTarget(TargetKind.main.targetName)
+        manifest.createTarget(TargetKind.test.targetName)
         manifest.defaultTarget = TargetKind.main.targetName
 
         addPackageStructureCommand()

--- a/Sources/LLBuildManifest/BuildManifest.swift
+++ b/Sources/LLBuildManifest/BuildManifest.swift
@@ -36,12 +36,13 @@ public struct BuildManifest {
         return result
     }
 
-    func createTarget(_ name: TargetName) -> Target {
-        Target(name: name, nodes: [])
+    public mutating func createTarget(_ name: TargetName) {
+        guard !targets.keys.contains(name) else { return }
+        targets[name] = Target(name: name, nodes: [])
     }
 
     public mutating func addNode(_ node: Node, toTarget target: TargetName) {
-        targets[target, default: createTarget(target)].nodes.append(node)
+        targets[target, default: Target(name: target, nodes: [])].nodes.append(node)
     }
 
     public mutating func addPhonyCmd(


### PR DESCRIPTION
If a package contains only test targets (like Integration Tests), SwiftPM currently fails building it because it generates a manifest with a `defaultTarget` of `main`, but no target called `main` exists as they are lazily created. This change makes it so that SwiftPM always creates `main` and `test` targets, even if they end up empty.