### PR TITLE
[Resolver] Don't prefetch overridden packages

### DIFF
--- a/Sources/SPMTestSupport/TestWorkspace.swift
+++ b/Sources/SPMTestSupport/TestWorkspace.swift
@@ -154,6 +154,7 @@ public final class TestWorkspace {
             config: config,
             fileSystem: fs,
             repositoryProvider: repoProvider,
+            isResolverPrefetchingEnabled: true,
             enablePubgrubResolver: enablePubGrub,
             skipUpdate: skipUpdate
         )

--- a/Tests/WorkspaceTests/XCTestManifests.swift
+++ b/Tests/WorkspaceTests/XCTestManifests.swift
@@ -81,6 +81,7 @@ extension WorkspaceTests {
         ("testPrecomputeResolution_requirementChange_versionToBranch", testPrecomputeResolution_requirementChange_versionToBranch),
         ("testPrecomputeResolution_requirementChange_versionToLocal", testPrecomputeResolution_requirementChange_versionToLocal),
         ("testPrecomputeResolution_requirementChange_versionToRevision", testPrecomputeResolution_requirementChange_versionToRevision),
+        ("testPrefetchingWithOverridenPackage", testPrefetchingWithOverridenPackage),
         ("testResolutionFailureWithEditedDependency", testResolutionFailureWithEditedDependency),
         ("testResolve", testResolve),
         ("testResolvedFileUpdate", testResolvedFileUpdate),


### PR DESCRIPTION
Avoid prefetching overriden packages as that will cause us to create and
cache the wrong container kind if an overriden package is present in the
Package.resolved file.

<rdar://problem/59310622>