### PR TITLE
Resolve Dictionary crashes in Workspace

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1129,8 +1129,9 @@ extension Workspace {
         diagnostics: DiagnosticsEngine
     ) -> DependencyManifests {
 
-        // Remove any managed dependency which has become a root.
+        // Make a copy of dependencies as we might mutate them in the for loop.
         let dependenciesToCheck = Array(state.dependencies)
+        // Remove any managed dependency which has become a root.
         for dependency in dependenciesToCheck {
             if root.packageRefs.contains(dependency.packageRef) {
                 diagnostics.wrap {
@@ -2022,7 +2023,9 @@ extension Workspace {
             try? state.reset()
         }
 
-        for dependency in state.dependencies {
+        // Make a copy of dependencies as we might mutate them in the for loop.
+        let allDependencies = Array(state.dependencies)
+        for dependency in allDependencies {
             diagnostics.wrap {
 
                 // If the dependency is present, we're done.


### PR DESCRIPTION
Now that `ManagedDependencies` is a true collection, this has caused random crashed in `Workspace` where we were mutating managed dependencies while iterating over them. To resolve those crashes, we make a copy of dependencies before iterating over them.