### PR TITLE
XCBuild output parsing

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -732,7 +732,8 @@ public class SwiftTool<Options: ToolOptions> {
             buildSystem = try XcodeBuildSystem(
                 buildParameters: buildParameters(),
                 packageGraphLoader: graphLoader,
-                diagnostics: diagnostics
+                diagnostics: diagnostics,
+                stdoutStream: stdoutStream
             )
         }
 

--- a/Sources/XCBuildSupport/CMakeLists.txt
+++ b/Sources/XCBuildSupport/CMakeLists.txt
@@ -9,6 +9,8 @@
 add_library(XCBuildSupport
   PIF.swift
   PIFBuilder.swift
+  XCBuildDelegate.swift
+  XCBuildOutputParser.swift
 )
 target_link_libraries(XCBuildSupport PUBLIC
   Build

--- a/Sources/XCBuildSupport/XCBuildDelegate.swift
+++ b/Sources/XCBuildSupport/XCBuildDelegate.swift
@@ -1,0 +1,74 @@
+/*
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2020 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See http://swift.org/LICENSE.txt for license information
+See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import TSCBasic
+import TSCUtility
+
+public class XCBuildDelegate {
+    private var parser: XCBuildOutputParser!
+    private let diagnostics: DiagnosticsEngine
+    private let outputStream: ThreadSafeOutputByteStream
+    private let progressAnimation: ProgressAnimationProtocol
+    private var step: Int = 0
+    private let queue = DispatchQueue(label: "org.swift.swiftpm.xcbuild-delegate")
+
+    /// Whether to print more informationr regarding the build.
+    public var isVerbose: Bool = false
+
+    public init(
+        diagnostics: DiagnosticsEngine,
+        outputStream: OutputByteStream,
+        progressAnimation: ProgressAnimationProtocol
+    ) {
+        self.diagnostics = diagnostics
+        // FIXME: Implement a class convenience initializer that does this once they are supported
+        // https://forums.swift.org/t/allow-self-x-in-class-convenience-initializers/15924
+        self.outputStream = outputStream as? ThreadSafeOutputByteStream ?? ThreadSafeOutputByteStream(outputStream)
+        self.progressAnimation = progressAnimation
+        parser = XCBuildOutputParser(delegate: self)
+    }
+
+    public func parse(bytes: [UInt8]) {
+        parser.parse(bytes: bytes)
+    }
+}
+
+extension XCBuildDelegate: XCBuildOutputParserDelegate {
+    public func xcBuildOutputParser(_ parser: XCBuildOutputParser, didParse message: XCBuildMessage) {
+        switch message {
+        case .taskStarted(let info):
+            queue.async {
+                self.step += 1
+                let text = self.isVerbose ? info.commandLineDisplayString : info.executionDescription
+                self.progressAnimation.update(step: self.step, total: self.step, text: text)
+            }
+        case .taskOutput(let info):
+            queue.async {
+                self.progressAnimation.clear()
+                self.outputStream <<< info.data
+                self.outputStream.flush()
+            }
+        default:
+            break
+        }
+    }
+
+    public func xcBuildOutputParser(_ parser: XCBuildOutputParser, didFailWith error: Error) {
+        let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        diagnostics.emit(.xcbuildOutputParsingError(message))
+    }
+}
+
+private extension Diagnostic.Message {
+    static func xcbuildOutputParsingError(_ error: String) -> Diagnostic.Message {
+        .error("failed parsing XCBuild output: \(error)")
+    }
+}

--- a/Sources/XCBuildSupport/XCBuildOutputParser.swift
+++ b/Sources/XCBuildSupport/XCBuildOutputParser.swift
@@ -1,0 +1,338 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Foundation
+import TSCBasic
+import TSCUtility
+
+/// Represents a message output by xcbuild.
+public enum XCBuildMessage {
+    public struct BuildDiagnosticInfo {
+        public let message: String
+    }
+
+    public struct BuildCompletedInfo {
+        public enum Result: String {
+            case ok
+        }
+
+        public let result: Result
+    }
+
+    public struct DidUpdateProgressInfo {
+        public let message: String
+        public let percentComplete: Double
+        public let showInLog: Bool
+    }
+
+    public struct TargetUpToDateInfo {
+        public let guid: PIF.GUID
+    }
+
+    public struct TargetStartedInfo {
+        public enum Kind: String {
+            case native = "Native"
+        }
+
+        public let targetID: Int
+        public let targetGUID: PIF.GUID
+        public let targetName: String
+        public let type: Kind
+    }
+
+    public struct TargetCompleteInfo {
+        public let targetID: Int
+    }
+
+    public struct TaskUpToDateInfo {
+        let targetID: Int
+        let targetSignature: String
+        let parentTaskID: Int?
+    }
+
+    public struct TaskStartedInfo {
+        let taskID: Int
+        let targetID: Int
+        let targetSignature: String
+        let parentTaskID: Int?
+        let ruleInfo: String
+        let interestingPath: AbsolutePath?
+        let commandLineDisplayString: String
+        let executionDescription: String
+    }
+
+    public struct TaskDiagnosticInfo {
+        let taskID: Int
+        let targetID: Int
+        let message: String
+    }
+
+    public struct TaskOutputInfo {
+        let taskID: Int
+        let data: String
+    }
+
+    public struct TaskCompleteInfo {
+        public enum Result: String {
+            case success
+        }
+
+        let taskID: Int
+        let result: Result
+        let signalled: Bool
+    }
+
+    case buildStarted
+    case buildDiagnostic(BuildDiagnosticInfo)
+    case buildCompleted(BuildCompletedInfo)
+    case preparationComplete
+    case didUpdateProgress(DidUpdateProgressInfo)
+    case targetUpToDate(TargetUpToDateInfo)
+    case targetStarted(TargetStartedInfo)
+    case targetComplete(TargetCompleteInfo)
+    case taskUpToDate(TaskUpToDateInfo)
+    case taskStarted(TaskStartedInfo)
+    case taskDiagnostic(TaskDiagnosticInfo)
+    case taskOutput(TaskOutputInfo)
+    case taskComplete(TaskCompleteInfo)
+}
+
+/// Protocol for the parser delegate to get notified of parsing events.
+public protocol XCBuildOutputParserDelegate: class {
+
+    /// Called for each message parsed.
+    func xcBuildOutputParser(_ parser: XCBuildOutputParser, didParse message: XCBuildMessage)
+
+    /// Called on an un-expected parsing error. No more events will be received after that.
+    func xcBuildOutputParser(_ parser: XCBuildOutputParser, didFailWith error: Error)
+}
+
+/// Parser for XCBuild output.
+public final class XCBuildOutputParser {
+
+    /// The underlying JSON message parser.
+    private var jsonParser: JSONMessageStreamingParser<XCBuildOutputParser>!
+
+    /// Whether the parser is in a failing state.
+    private var hasFailed: Bool
+
+    /// Delegate to notify of parsing events.
+    public weak var delegate: XCBuildOutputParserDelegate? = nil
+
+    /// Initializes the parser with a delegate to notify of parsing events.
+    /// - Parameters:
+    ///     - delegate: Delegate to notify of parsing events.
+    public init(delegate: XCBuildOutputParserDelegate) {
+        self.hasFailed = false
+        self.delegate = delegate
+        self.jsonParser = JSONMessageStreamingParser<XCBuildOutputParser>(delegate: self)
+    }
+
+    /// Parse the next bytes of the Swift compiler JSON output.
+    /// - Note: If a parsing error is encountered, the delegate will be notified and the parser won't accept any further
+    ///   input.
+    public func parse<C>(bytes: C) where C: Collection, C.Element == UInt8 {
+        guard !hasFailed else {
+            return
+        }
+
+        jsonParser.parse(bytes: bytes)
+    }
+}
+
+extension XCBuildOutputParser: JSONMessageStreamingParserDelegate {
+    public func jsonMessageStreamingParser(
+        _ parser: JSONMessageStreamingParser<XCBuildOutputParser>,
+        didParse message: XCBuildMessage
+    ) {
+        guard !hasFailed else {
+            return
+        }
+
+        delegate?.xcBuildOutputParser(self, didParse: message)
+    }
+
+    public func jsonMessageStreamingParser(
+        _ parser: JSONMessageStreamingParser<XCBuildOutputParser>,
+        didParseRawText text: String
+    ) {
+        // Don't do anything with raw text.
+    }
+
+    public func jsonMessageStreamingParser(
+        _ parser: JSONMessageStreamingParser<XCBuildOutputParser>,
+        didFailWith error: Error
+    ) {
+        delegate?.xcBuildOutputParser(self, didFailWith: error)
+    }
+}
+
+extension XCBuildMessage.BuildDiagnosticInfo: Decodable, Equatable {}
+extension XCBuildMessage.BuildCompletedInfo.Result: Decodable, Equatable {}
+extension XCBuildMessage.BuildCompletedInfo: Decodable, Equatable {}
+extension XCBuildMessage.TargetUpToDateInfo: Decodable, Equatable {}
+extension XCBuildMessage.TaskDiagnosticInfo: Decodable, Equatable {}
+
+extension XCBuildMessage.DidUpdateProgressInfo: Decodable, Equatable {
+    enum CodingKeys: String, CodingKey {
+        case message
+        case percentComplete
+        case showInLog
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        message = try container.decode(String.self, forKey: .message)
+        percentComplete = try Double(container.decode(String.self, forKey: .percentComplete))!
+        showInLog = try Bool(container.decode(String.self, forKey: .showInLog))!
+    }
+}
+
+extension XCBuildMessage.TargetStartedInfo.Kind: Decodable, Equatable {}
+extension XCBuildMessage.TargetStartedInfo: Decodable, Equatable {
+    enum CodingKeys: String, CodingKey {
+        case targetID = "id"
+        case targetGUID = "guid"
+        case targetName = "name"
+        case type
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        targetID = try Int(container.decode(String.self, forKey: .targetID))!
+        targetGUID = try container.decode(PIF.GUID.self, forKey: .targetGUID)
+        targetName = try container.decode(String.self, forKey: .targetName)
+        type = try container.decode(Kind.self, forKey: .type)
+    }
+}
+
+extension XCBuildMessage.TargetCompleteInfo: Decodable, Equatable {
+    enum CodingKeys: String, CodingKey {
+        case targetID = "id"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        targetID = try Int(container.decode(String.self, forKey: .targetID))!
+    }
+}
+
+extension XCBuildMessage.TaskUpToDateInfo: Decodable, Equatable {
+    enum CodingKeys: String, CodingKey {
+        case targetID
+        case targetSignature = "signature"
+        case parentTaskID = "parentID"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        targetID = try Int(container.decode(String.self, forKey: .targetID))!
+        targetSignature = try container.decode(String.self, forKey: .targetSignature)
+        let parentTaskIDString = try container.decode(String.self, forKey: .parentTaskID)
+        parentTaskID = !parentTaskIDString.isEmpty ? Int(parentTaskIDString)! : nil
+    }
+}
+
+extension XCBuildMessage.TaskStartedInfo: Decodable, Equatable {
+    enum CodingKeys: String, CodingKey {
+        case taskID = "id"
+        case targetID
+        case targetSignature = "signature"
+        case parentTaskID = "parentID"
+        case ruleInfo
+        case interestingPath
+        case commandLineDisplayString
+        case executionDescription
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        taskID = try Int(container.decode(String.self, forKey: .taskID))!
+        targetID = try Int(container.decode(String.self, forKey: .targetID))!
+        targetSignature = try container.decode(String.self, forKey: .targetSignature)
+        let parentTaskIDString = try container.decode(String.self, forKey: .parentTaskID)
+        parentTaskID = !parentTaskIDString.isEmpty ? Int(parentTaskIDString)! : nil
+        ruleInfo = try container.decode(String.self, forKey: .ruleInfo)
+        let interestingPathString = try container.decode(String.self, forKey: .interestingPath)
+        interestingPath = !interestingPathString.isEmpty ? AbsolutePath(interestingPathString) : nil
+        commandLineDisplayString = try container.decode(String.self, forKey: .commandLineDisplayString)
+        executionDescription = try container.decode(String.self, forKey: .executionDescription)
+    }
+}
+
+extension XCBuildMessage.TaskOutputInfo: Decodable, Equatable {
+    enum CodingKeys: String, CodingKey {
+        case taskID
+        case data
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        taskID = try Int(container.decode(String.self, forKey: .taskID))!
+        data = try container.decode(String.self, forKey: .data)
+    }
+}
+
+extension XCBuildMessage.TaskCompleteInfo.Result: Decodable, Equatable {}
+extension XCBuildMessage.TaskCompleteInfo: Decodable, Equatable {
+    enum CodingKeys: String, CodingKey {
+        case taskID = "id"
+        case result
+        case signalled
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        taskID = try Int(container.decode(String.self, forKey: .taskID))!
+        result = try container.decode(Result.self, forKey: .result)
+        signalled = try container.decode(Bool.self, forKey: .signalled)
+    }
+}
+
+extension XCBuildMessage: Decodable, Equatable {
+    enum CodingKeys: CodingKey {
+        case kind
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(String.self, forKey: .kind)
+        switch kind {
+        case "buildStarted":
+            self = .buildStarted
+        case "buildDiagnostic":
+            self = try .buildDiagnostic(BuildDiagnosticInfo(from: decoder))
+        case "buildCompleted":
+            self = try .buildCompleted(BuildCompletedInfo(from: decoder))
+        case "preparationComplete":
+            self = .preparationComplete
+        case "didUpdateProgress":
+            self = try .didUpdateProgress(DidUpdateProgressInfo(from: decoder))
+        case "targetUpToDate":
+            self = try .targetUpToDate(TargetUpToDateInfo(from: decoder))
+        case "targetStarted":
+            self = try .targetStarted(TargetStartedInfo(from: decoder))
+        case "targetComplete":
+            self = try .targetComplete(TargetCompleteInfo(from: decoder))
+        case "taskUpToDate":
+            self = try .taskUpToDate(TaskUpToDateInfo(from: decoder))
+        case "taskStarted":
+            self = try .taskStarted(TaskStartedInfo(from: decoder))
+        case "taskDiagnostic":
+            self = try .taskDiagnostic(TaskDiagnosticInfo(from: decoder))
+        case "taskOutput":
+            self = try .taskOutput(TaskOutputInfo(from: decoder))
+        case "taskComplete":
+            self = try .taskComplete(TaskCompleteInfo(from: decoder))
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "invalid kind")
+        }
+    }
+}

--- a/TSC/Sources/TSCUtility/CMakeLists.txt
+++ b/TSC/Sources/TSCUtility/CMakeLists.txt
@@ -13,12 +13,15 @@ add_library(TSCUtility
   BuildFlags.swift
   CollectionExtensions.swift
   Diagnostics.swift
+  dlopen.swift
   Downloader.swift
-  FSWatch.swift
   FloatingPointExtensions.swift
+  FSWatch.swift
   Git.swift
   IndexStore.swift
   InterruptHandler.swift
+  JSONMessageStreamingParser.swift
+  misc.swift
   OSLog.swift
   PkgConfig.swift
   Platform.swift
@@ -30,8 +33,7 @@ add_library(TSCUtility
   Verbosity.swift
   Version.swift
   Versioning.swift
-  dlopen.swift
-  misc.swift)
+)
 target_link_libraries(TSCUtility PUBLIC
   TSCBasic)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet

--- a/TSC/Sources/TSCUtility/JSONMessageStreamingParser.swift
+++ b/TSC/Sources/TSCUtility/JSONMessageStreamingParser.swift
@@ -1,0 +1,167 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Foundation
+
+/// Protocol for the parser delegate to get notified of parsing events.
+public protocol JSONMessageStreamingParserDelegate: class {
+
+    /// A decodable type representing the JSON messages being parsed.
+    associatedtype Message: Decodable
+
+    /// Called for each message parsed.
+    func jsonMessageStreamingParser(_ parser: JSONMessageStreamingParser<Self>, didParse message: Message)
+
+    /// Called when parsing raw text instead of message size.
+    func jsonMessageStreamingParser(_ parser: JSONMessageStreamingParser<Self>, didParseRawText text: String)
+
+    /// Called on an un-expected parsing error. No more events will be received after that.
+    func jsonMessageStreamingParser(_ parser: JSONMessageStreamingParser<Self>, didFailWith error: Error)
+}
+
+/// Streaming parser for JSON messages seperated by integers to represent size of message. Used by the Swift compiler
+/// and XCBuild to share progess information: https://github.com/apple/swift/blob/master/docs/DriverParseableOutput.rst.
+public final class JSONMessageStreamingParser<Delegate: JSONMessageStreamingParserDelegate> {
+
+    /// The object representing the JSON message being parsed.
+    public typealias Message = Delegate.Message
+
+    /// State of the parser state machine.
+    private enum State {
+        case parsingMessageSize
+        case parsingMessage(size: Int)
+        case parsingNewlineAfterMessage
+        case failed
+    }
+
+    /// Delegate to notify of parsing events.
+    public weak var delegate: Delegate?
+
+    /// Buffer containing the bytes until a full message can be parsed.
+    private var buffer: [UInt8] = []
+
+    /// The parser's state machine current state.
+    private var state: State = .parsingMessageSize
+
+    /// The JSON decoder to parse messages.
+    private let decoder: JSONDecoder
+
+    /// Initializes the parser.
+    /// - Parameters:
+    ///   - delegate: The `JSONMessageStreamingParserDelegate` that will receive parsing event callbacks.
+    ///   - decoder: The `JSONDecoder` to use for decoding JSON messages.
+    public init(delegate: Delegate, decoder: JSONDecoder = JSONDecoder())
+    {
+        self.delegate = delegate
+        self.decoder = decoder
+    }
+
+    /// Parse the next bytes of the stream.
+    /// - Note: If a parsing error is encountered, the delegate will be notified and the parser won't accept any further
+    ///   input.
+    public func parse<C>(bytes: C) where C: Collection, C.Element == UInt8 {
+        if case .failed = state { return }
+
+        do {
+            try parseImpl(bytes: bytes)
+        } catch {
+            state = .failed
+            delegate?.jsonMessageStreamingParser(self, didFailWith: error)
+        }
+    }
+}
+
+private extension JSONMessageStreamingParser {
+
+    /// Error corresponding to invalid Swift compiler output.
+    struct ParsingError: LocalizedError {
+
+        /// Text describing the specific reason for the parsing failure.
+        let reason: String
+
+        /// The underlying error, if there is one.
+        let underlyingError: Error?
+
+        var errorDescription: String? {
+            if let error = underlyingError {
+                return "\(reason): \(error)"
+            } else {
+                return reason
+            }
+        }
+    }
+
+    /// Throwing implementation of the parse function.
+    func parseImpl<C>(bytes: C) throws where C: Collection, C.Element == UInt8 {
+        switch state {
+        case .parsingMessageSize:
+            if let newlineIndex = bytes.firstIndex(of: newline) {
+                buffer.append(contentsOf: bytes[..<newlineIndex])
+                try parseMessageSize()
+
+                let nextIndex = bytes.index(after: newlineIndex)
+                try parseImpl(bytes: bytes[nextIndex...])
+            } else {
+                buffer.append(contentsOf: bytes)
+            }
+        case .parsingMessage(size: let size):
+            let remainingBytes = size - buffer.count
+            if remainingBytes <= bytes.count {
+                buffer.append(contentsOf: bytes.prefix(remainingBytes))
+
+                let message = try parseMessage()
+                delegate?.jsonMessageStreamingParser(self, didParse: message)
+
+                try parseImpl(bytes: bytes.dropFirst(remainingBytes))
+            } else {
+                buffer.append(contentsOf: bytes)
+            }
+        case .parsingNewlineAfterMessage:
+            if let firstByte = bytes.first {
+                precondition(firstByte == newline)
+                state = .parsingMessageSize
+                try parseImpl(bytes: bytes.dropFirst())
+            }
+        case .failed:
+            return
+        }
+    }
+
+    /// Parse the next message size from the buffer and update the state machine.
+    func parseMessageSize() throws {
+        guard let string = String(bytes: buffer, encoding: .utf8) else {
+            throw ParsingError(reason: "invalid UTF8 bytes", underlyingError: nil)
+        }
+
+        guard let messageSize = Int(string) else {
+            delegate?.jsonMessageStreamingParser(self, didParseRawText: string)
+            buffer.removeAll()
+            return
+        }
+
+        buffer.removeAll()
+        state = .parsingMessage(size: messageSize)
+    }
+
+    /// Parse the message in the buffer and update the state machine.
+    func parseMessage() throws -> Message {
+        let data = Data(buffer)
+        buffer.removeAll()
+        state = .parsingNewlineAfterMessage
+
+        do {
+            return try decoder.decode(Message.self, from: data)
+        } catch {
+            throw ParsingError(reason: "unexpected JSON message", underlyingError: error)
+        }
+    }
+}
+
+private let newline = UInt8(ascii: "\n")

--- a/TSC/Tests/TSCUtilityTests/JSONMessageStreamingParserTests.swift
+++ b/TSC/Tests/TSCUtilityTests/JSONMessageStreamingParserTests.swift
@@ -1,0 +1,279 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import XCTest
+import TSCTestSupport
+import TSCUtility
+
+class JSONMessageStreamingParserTests: XCTestCase {
+    func testParse() throws {
+        let delegate = MockParserDelegate()
+        let parser = JSONMessageStreamingParser(delegate: delegate)
+
+        parser.parse(bytes: "7".utf8)
+        delegate.assert(messages: [], rawTexts: [], errorDescription: nil)
+
+        parser.parse(bytes: "".utf8)
+        delegate.assert(messages: [], rawTexts: [], errorDescription: nil)
+
+        parser.parse(bytes: """
+            3
+            {
+              "id": 123456,
+              "type": "error",
+
+            """.utf8)
+        delegate.assert(messages: [], rawTexts: [], errorDescription: nil)
+
+        parser.parse(bytes: "".utf8)
+        delegate.assert(messages: [], rawTexts: [], errorDescription: nil)
+
+        parser.parse(bytes: """
+              "message": "This is outrageous!"
+            }
+            78
+
+            """.utf8)
+        delegate.assert(
+            messages: [MockParserDelegate.Message(id: 123456, type: "error", message: "This is outrageous!")],
+            rawTexts: [],
+            errorDescription: nil
+        )
+
+        parser.parse(bytes: """
+            {
+              "id": 456798,
+              "type": "warning",
+              "message": "You should be careful."
+            }
+            """.utf8)
+            delegate.assert(
+                messages: [MockParserDelegate.Message(id: 456798, type: "warning", message: "You should be careful.")],
+                rawTexts: [],
+                errorDescription: nil
+            )
+
+        parser.parse(bytes: """
+
+            76
+            {
+              "id": 789123,
+              "type": "note",
+              "message": "Note to self: buy milk."
+            }
+            64
+            {
+              "id": 456123,
+              "type": "note",
+              "message": "...and eggs"
+            }
+            63
+            """.utf8)
+        delegate.assert(
+            messages: [
+                MockParserDelegate.Message(id: 789123, type: "note", message: "Note to self: buy milk."),
+                MockParserDelegate.Message(id: 456123, type: "note", message: "...and eggs"),
+            ],
+            rawTexts: [],
+            errorDescription: nil
+        )
+
+        parser.parse(bytes: """
+
+            {
+              "id": 753869,
+              "type": "error",
+              "message": "Pancakes!"
+            }
+
+            """.utf8)
+        delegate.assert(
+            messages: [
+                MockParserDelegate.Message(id: 753869, type: "error", message: "Pancakes!"),
+            ],
+            rawTexts: [],
+            errorDescription: nil
+        )
+    }
+
+    func testInvalidMessageSizeBytes() {
+        let delegate = MockParserDelegate()
+        let parser = JSONMessageStreamingParser(delegate: delegate)
+
+        parser.parse(bytes: [65, 66, 200, 67, UInt8(ascii: "\n")])
+        delegate.assert(messages: [], rawTexts: [], errorDescription: "invalid UTF8 bytes")
+
+        parser.parse(bytes: """
+            76
+            {
+              "id": 789123,
+              "type": "note",
+              "message": "Note to self: buy milk."
+            }
+            """.utf8)
+        delegate.assert(messages: [], rawTexts: [], errorDescription: nil)
+    }
+
+    func testInvalidMessageSizeValue() {
+        let delegate = MockParserDelegate()
+        let parser = JSONMessageStreamingParser(delegate: delegate)
+
+        parser.parse(bytes: """
+            2A
+
+            """.utf8)
+        delegate.assert(messages: [], rawTexts: ["2A"], errorDescription: nil)
+
+        parser.parse(bytes: """
+            76
+            {
+              "id": 789123,
+              "type": "note",
+              "message": "Note to self: buy milk."
+            }
+            """.utf8)
+        delegate.assert(
+            messages: [MockParserDelegate.Message(id: 789123, type: "note", message: "Note to self: buy milk.")],
+            rawTexts: [],
+            errorDescription: nil
+        )
+    }
+
+    func testInvalidMessageBytes() {
+        let delegate = MockParserDelegate()
+        let parser = JSONMessageStreamingParser(delegate: delegate)
+
+        parser.parse(bytes: """
+            4
+
+            """.utf8)
+        delegate.assert(messages: [], rawTexts: [], errorDescription: nil)
+        parser.parse(bytes: [65, 66, 200, 67, UInt8(ascii: "\n")])
+        delegate.assert(messages: [], rawTexts: [], errorDescription: .contains("unexpected JSON message"))
+
+        parser.parse(bytes: """
+            76
+            {
+              "id": 789123,
+              "type": "note",
+              "message": "Note to self: buy milk."
+            }
+            """.utf8)
+        delegate.assert(messages: [], rawTexts: [], errorDescription: nil)
+    }
+
+    func testInvalidMessageMissingField() {
+        let delegate = MockParserDelegate()
+        let parser = JSONMessageStreamingParser(delegate: delegate)
+
+        parser.parse(bytes: """
+            23
+            {
+              "invalid": "json"
+            }
+            """.utf8)
+        delegate.assert(messages: [], rawTexts: [], errorDescription: .contains("unexpected JSON message"))
+
+        parser.parse(bytes: """
+            76
+            {
+              "id": 789123,
+              "type": "note",
+              "message": "Note to self: buy milk."
+            }
+            """.utf8)
+        delegate.assert(messages: [], rawTexts: [], errorDescription: nil)
+    }
+
+    func testInvalidMessageInvalidValue() {
+        let delegate = MockParserDelegate()
+        let parser = JSONMessageStreamingParser(delegate: delegate)
+
+        parser.parse(bytes: """
+            5
+            {
+              "id": 789123,
+              "type": "note",
+              "message": "Note to self: buy milk."
+            }
+            """.utf8)
+        delegate.assert(messages: [], rawTexts: [], errorDescription: .contains("unexpected JSON message"))
+
+        parser.parse(bytes: """
+            76
+            {
+              "id": 789123,
+              "type": "note",
+              "message": "Note to self: buy milk."
+            }
+            """.utf8)
+        delegate.assert(messages: [], rawTexts: [], errorDescription: nil)
+    }
+}
+
+private final class MockParserDelegate: JSONMessageStreamingParserDelegate {
+    struct Message: Equatable, Decodable {
+        let id: Int
+        let type: String
+        let message: String
+    }
+
+    private var messages: [Message] = []
+    private var rawTexts: [String] = []
+    private var error: Error? = nil
+
+    func jsonMessageStreamingParser(
+        _ parser: JSONMessageStreamingParser<MockParserDelegate>,
+        didParse message: Message
+    ) {
+        messages.append(message)
+    }
+
+    func jsonMessageStreamingParser(
+        _ parser: JSONMessageStreamingParser<MockParserDelegate>,
+        didParseRawText text: String
+    ) {
+        rawTexts.append(text)
+    }
+
+    func jsonMessageStreamingParser(
+        _ parser: JSONMessageStreamingParser<MockParserDelegate>,
+        didFailWith error: Error
+    ) {
+        self.error = error
+    }
+
+    func assert(
+        messages: [Message],
+        rawTexts: [String],
+        errorDescription: StringPattern?,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(messages, self.messages, file: file, line: line)
+        XCTAssertEqual(rawTexts, self.rawTexts, file: file, line: line)
+
+        let errorReason = (self.error as? LocalizedError)?.errorDescription ?? error?.localizedDescription
+        switch (errorReason, errorDescription) {
+        case (let errorReason?, let errorDescription?):
+            XCTAssertMatch(errorReason, errorDescription, file: file, line: line)
+        case (nil, nil):
+            break
+        case (let errorReason?, nil):
+            XCTFail("unexpected error: \(errorReason)")
+        case (nil, .some):
+            XCTFail("unexpected success")
+        }
+
+        self.messages.removeAll()
+        self.rawTexts.removeAll()
+        self.error = nil
+    }
+}


### PR DESCRIPTION
Added an initial simple implementation for parsing XCBuild output and used it to prettify the `swift build --enable-xcbuild` output.

This builds on top of https://github.com/apple/swift-package-manager/pull/2585, so check the second commit to see the real changes.