### PR TITLE
Cross‐Compilation Overrides

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -50,6 +50,12 @@ public class ToolOptions {
 
     /// Path to the compilation destination describing JSON file.
     public var customCompileDestination: AbsolutePath?
+    /// The compilation destination’s target triple.
+    public var customCompileTriple: Triple?
+    /// Path to the compilation destination’s SDK.
+    public var customCompileSDK: AbsolutePath?
+    /// Path to the `bin` directory of the compilation destination’s toolchain.
+    public var customCompileToolchainBinDir: AbsolutePath?
 
     /// If should link the Swift stdlib statically.
     public var shouldLinkStaticSwiftStdlib = false

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -54,8 +54,8 @@ public class ToolOptions {
     public var customCompileTriple: Triple?
     /// Path to the compilation destination’s SDK.
     public var customCompileSDK: AbsolutePath?
-    /// Path to the `bin` directory of the compilation destination’s toolchain.
-    public var customCompileToolchainBinDir: AbsolutePath?
+    /// Path to the compilation destination’s toolchain.
+    public var customCompileToolchain: AbsolutePath?
 
     /// If should link the Swift stdlib statically.
     public var shouldLinkStaticSwiftStdlib = false

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -386,8 +386,8 @@ public class SwiftTool<Options: ToolOptions> {
             option: parser.add(option: "--sdk", kind: PathArgument.self),
             to: { $0.customCompileSDK = $1.path })
         binder.bind(
-            option: parser.add(option: "--toolchain-bin-dir", kind: PathArgument.self),
-            to: { $0.customCompileToolchainBinDir = $1.path })
+            option: parser.add(option: "--toolchain", kind: PathArgument.self),
+            to: { $0.customCompileToolchain = $1.path })
 
         // FIXME: We need to allow -vv type options for this.
         binder.bind(
@@ -809,8 +809,8 @@ public class SwiftTool<Options: ToolOptions> {
         if let triple = self.options.customCompileTriple {
           destination.target = triple
         }
-        if let binDir = self.options.customCompileToolchainBinDir {
-            destination.binDir = binDir
+        if let binDir = self.options.customCompileToolchain {
+            destination.binDir = binDir.appending(components: "usr", "bin")
         }
         if let sdk = self.options.customCompileSDK {
             destination.sdk = sdk

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -379,6 +379,15 @@ public class SwiftTool<Options: ToolOptions> {
         binder.bind(
             option: parser.add(option: "--destination", kind: PathArgument.self),
             to: { $0.customCompileDestination = $1.path })
+        binder.bind(
+            option: parser.add(option: "--triple", kind: String.self),
+            to: { $0.customCompileTriple = try Triple($1) })
+        binder.bind(
+            option: parser.add(option: "--sdk", kind: PathArgument.self),
+            to: { $0.customCompileSDK = $1.path })
+        binder.bind(
+            option: parser.add(option: "--toolchain-bin-dir", kind: PathArgument.self),
+            to: { $0.customCompileToolchainBinDir = $1.path })
 
         // FIXME: We need to allow -vv type options for this.
         binder.bind(
@@ -782,14 +791,31 @@ public class SwiftTool<Options: ToolOptions> {
 
     /// Lazily compute the destination toolchain.
     private lazy var _destinationToolchain: Result<UserToolchain, Swift.Error> = {
-        // Create custom toolchain if present.
-        if let customDestination = self.options.customCompileDestination {
-            return Result(catching: {
-                try UserToolchain(destination: Destination(fromFile: customDestination))
-            })
+        var destination: Destination
+        do {
+            // Create custom toolchain if present.
+            if let customDestination = self.options.customCompileDestination {
+                destination = try Destination(fromFile: customDestination)
+            } else {
+                // Otherwise use the host toolchain.
+                destination = try Destination.hostDestination(
+                    originalWorkingDirectory: self.originalWorkingDirectory
+                )
+            }
+        } catch {
+            return .failure(error)
         }
-        // Otherwise use the host toolchain.
-        return self._hostToolchain
+        // Apply any manual overrides.
+        if let triple = self.options.customCompileTriple {
+          destination.target = triple
+        }
+        if let binDir = self.options.customCompileToolchainBinDir {
+            destination.binDir = binDir
+        }
+        if let sdk = self.options.customCompileSDK {
+            destination.sdk = sdk
+        }
+        return Result(catching: { try UserToolchain(destination: destination) })
     }()
 
     /// Lazily compute the host toolchain used to compile the package description.

--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -35,13 +35,13 @@ public struct Destination: Encodable {
     ///  - abi = eabi, gnu, android, macho, elf, etc.
     ///
     /// for more information see //https://clang.llvm.org/docs/CrossCompilation.html
-    public let target: Triple?
+    public var target: Triple?
 
     /// The SDK used to compile for the destination.
-    public let sdk: AbsolutePath
+    public var sdk: AbsolutePath
 
     /// The binDir in the containing the compilers/linker to be used for the compilation.
-    public let binDir: AbsolutePath
+    public var binDir: AbsolutePath
 
     /// Additional flags to be passed to the C compiler.
     public let extraCCFlags: [String]


### PR DESCRIPTION
This adds command line options to override individual aspects of the destination.

It enables cross‐compilation to be done without the need to write out a separate JSON file, and it simplifies one‐off experiments during testing. It also paves the way for SwiftPM to start looking for things in standard locations based on the supplied triple (but that is not implemented here).

The new options are just as hidden as the original `--destination` option that served as their inspiration.

The aspects of the JSON file not touched on here were already available through other means anyway. (e.g.`-Xswiftc`, `-Xcc`)

[Here](https://github.com/SDGGiesbrecht/swift-package-manager/compare/sdg%E2%80%90ci...sdg%E2%80%90destination%E2%80%90ci) is a diff that also shows the simplification it allows to an external integration test, which passes [before](https://github.com/SDGGiesbrecht/swift-package-manager/runs/463495624) and [after](https://github.com/SDGGiesbrecht/swift-package-manager/runs/463567441).