### PR TITLE
[FunctionalTests] Make localization test more robust

### DIFF
--- a/Tests/FunctionalTests/ResourcesTests.swift
+++ b/Tests/FunctionalTests/ResourcesTests.swift
@@ -35,7 +35,8 @@ class ResourcesTests: XCTestCase {
             try executeSwiftBuild(prefix)
 
             let exec = prefix.appending(RelativePath(".build/debug/exe"))
-            let output = try Process.checkNonZeroExit(args: exec.pathString)
+            // Note: <rdar://problem/59738569> Source from LANG and -AppleLanguages on command line for Linux resources
+            let output = try Process.checkNonZeroExit(args: exec.pathString, "-AppleLanguages", "(en_US)")
             XCTAssertEqual(output, """
                 ¡Hola Mundo!
                 Hallo Welt!


### PR DESCRIPTION
This flag allows us to control the language instead of it getting picked
up from the system.