### PR TITLE
Add zlib to package names

### DIFF
--- a/Utilities/build_ubuntu_cross_compilation_toolchain
+++ b/Utilities/build_ubuntu_cross_compilation_toolchain
@@ -106,7 +106,7 @@ cross_tc_basename="cross-toolchain"
 clang_package_url="http://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-apple-darwin.tar.xz"
 ubuntu_mirror="http://gb.archive.ubuntu.com/ubuntu"
 packages_file="$ubuntu_mirror/dists/xenial/main/binary-amd64/Packages.gz"
-pkg_names=( libc6-dev linux-libc-dev libicu55 libgcc-5-dev libicu-dev libc6 libgcc1 libstdc++-5-dev libstdc++6 )
+pkg_names=( libc6-dev linux-libc-dev libicu55 libgcc-5-dev libicu-dev libc6 libgcc1 libstdc++-5-dev libstdc++6 zlib1g-dev )
 pkgs=()
 
 # url


### PR DESCRIPTION
This PR enables building code for Linux that uses `zlib` (for instance, [swift-nio-zlib-support](https://github.com/apple/swift-nio-zlib-support)). There’s probably a deeper to-do in here, as `libz-dev` is an alias to `zlib1g-dev` for Ubuntu, but for now this gets things building.