### PR TITLE
Pass SDK to Compiler when Cross‐Compiling

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -169,7 +169,7 @@ let package = Package(
             dependencies: ["swift-build", "swift-package", "swift-test", "swift-run", "Commands", "Workspace", "SPMTestSupport"]),
         .testTarget(
             name: "WorkspaceTests",
-            dependencies: ["Workspace", "SPMTestSupport"]),
+            dependencies: ["Workspace", "SPMTestSupport", "SPMBuildCore"]),
         .testTarget(
             name: "FunctionalTests",
             dependencies: ["swift-build", "swift-package", "swift-test", "PackageModel", "SPMTestSupport"]),

--- a/Sources/SPMBuildCore/Triple.swift
+++ b/Sources/SPMBuildCore/Triple.swift
@@ -18,7 +18,7 @@ import TSCBasic
 /// @see Destination.target
 /// @see https://github.com/apple/swift-llvm/blob/stable/include/llvm/ADT/Triple.h
 ///
-public struct Triple: Encodable {
+public struct Triple: Encodable, Equatable {
     public let tripleString: String
 
     public let arch: Arch

--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -52,6 +52,23 @@ public struct Destination: Encodable {
     /// Additional flags to be passed when compiling with C++.
     public let extraCPPFlags: [String]
 
+    /// Creates a compilation destination with the specified properties.
+    public init(
+      target: Triple? = nil,
+      sdk: AbsolutePath,
+      binDir: AbsolutePath,
+      extraCCFlags: [String] = [],
+      extraSwiftCFlags: [String] = [],
+      extraCPPFlags: [String] = []
+    ) {
+      self.target = target
+      self.sdk = sdk
+      self.binDir = binDir
+      self.extraCCFlags = extraCCFlags
+      self.extraSwiftCFlags = extraSwiftCFlags
+      self.extraCPPFlags = extraCPPFlags
+    }
+
     /// Returns the bin directory for the host.
     ///
     /// - Parameter originalWorkingDirectory: The working directory when the program was launched.

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -16,6 +16,7 @@ import PackageModel
 import PackageGraph
 import SourceControl
 import TSCUtility
+import SPMBuildCore
 import Workspace
 
 import SPMTestSupport
@@ -4478,6 +4479,25 @@ final class WorkspaceTests: XCTestCase {
                 result.check(diagnostic: .contains("artifact of binary target 'A' has changed checksum"), behavior: .error)
             }
         }
+    }
+
+    func testCrossCompilationDefaults() throws {
+      let target = try Triple("x86_64-unknown-linux-android")
+      let sdk = AbsolutePath("/some/path/to/an/SDK.sdk")
+      let toolchainPath = AbsolutePath("/some/path/to/a/toolchain.xctoolchain")
+
+      let destination = Destination(
+        target: target,
+        sdk: sdk,
+        binDir: toolchainPath.appending(components: "usr", "bin")
+      )
+      let toolchain = try UserToolchain(destination: destination)
+
+      #if !(os(Android) && arch(x86_64))  // ← Wouldn’t be cross‐compiling.
+        XCTAssertEqual(toolchain.extraSwiftCFlags, [
+          "-sdk", sdk.pathString
+        ])
+      #endif
     }
 }
 


### PR DESCRIPTION
This pull request makes SwiftPM pass `-sdk [wherever]` to `swiftc` when cross‐compiling. This used to be the case, but regressed since 5.1.3, breaking Android builds.

The implementation here makes two assumptions that I would like confirmation on:

1. `-sdk` is necessary for _all_ cross‐compilation, not just for Android. @compnerd
2. `-sdk` is _not_ necessary for Android to build itself. @buttaface

If either turns out to be incorrect, the precise conditions can be adjusted accordingly.

[Here](https://github.com/SDGGiesbrecht/swift-package-manager/commit/0b10f25eaf2c8f8df2ed315b09d57e87d71762e9) is the diff this enables to the Android build script. Notice how without this, the SDK must be specified double, once for SwiftPM and once for `swiftc`.

You can also see the results of compiling without the redundant flag [before](https://github.com/SDGGiesbrecht/swift-package-manager/runs/468250913) and [after](https://github.com/SDGGiesbrecht/swift-package-manager/runs/468405336) this change.