### PR TITLE
Restore -sdk Universally

### DIFF
--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -239,10 +239,9 @@ public final class UserToolchain: Toolchain {
 
         // Use the triple from destination or compute the host triple using swiftc.
         self.triple = destination.target ?? Triple.getHostTriple(usingSwiftCompiler: swiftCompilers.compile)
-        self.extraSwiftCFlags = (triple.isDarwin()
-                                    ? ["-sdk", destination.sdk.pathString]
-                                    : [])
-                                  + destination.extraSwiftCFlags
+        self.extraSwiftCFlags = [
+            "-sdk", destination.sdk.pathString
+        ] + destination.extraSwiftCFlags
 
         self.extraCCFlags = [
             triple.isDarwin() ? "-isysroot" : "--sysroot", destination.sdk.pathString


### PR DESCRIPTION
This is a simple revert of [42fc98ec3b5d10328875dc8c1499e4be6d7d2625](https://github.com/apple/swift-package-manager/commit/42fc98ec3b5d10328875dc8c1499e4be6d7d2625) with the conflicts resolved.

It reapplies `-sdk` universally.
See discussion at https://github.com/apple/swift-package-manager/pull/2617.