### PR TITLE
[PackageModel] Add sdk options to platform description

### DIFF
--- a/Sources/PackageLoading/PackageDescription4Loader.swift
+++ b/Sources/PackageLoading/PackageDescription4Loader.swift
@@ -68,12 +68,37 @@ extension ManifestBuilder {
         for platformJSON in declaredPlatforms {
             // Parse the version and validate that it can be used in the current
             // manifest version.
-            let version: String = try platformJSON.get("version")
+            let versionString: String = try platformJSON.get("version")
 
             // Get the platform name.
             let platformName: String = try platformJSON.getJSON("platform").get("name")
 
-            let description = PlatformDescription(name: platformName, version: version)
+            let versionComponents = versionString.split(
+                separator: ".",
+                omittingEmptySubsequences: false
+            )
+            var version: [String.SubSequence] = []
+            var options: [String.SubSequence] = []
+
+            for (idx, component) in versionComponents.enumerated() {
+                if idx < 2 {
+                    version.append(component)
+                    continue
+                }
+
+                if idx == 2, UInt(component) != nil {
+                    version.append(component)
+                    continue
+                }
+
+                options.append(component)
+            }
+
+            let description = PlatformDescription(
+                name: platformName,
+                version: version.joined(separator: "."),
+                options: options.map{ String($0) }
+            )
 
             // Check for duplicates.
             if platforms.map({ $0.platformName }).contains(platformName) {

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -546,10 +546,12 @@ public struct PackageDependencyDescription: Equatable, Codable {
 public struct PlatformDescription: Codable, Equatable {
     public let platformName: String
     public let version: String
+    public let options: [String]
 
-    public init(name: String, version: String) {
+    public init(name: String, version: String, options: [String] = []) {
         self.platformName = name
         self.version = version
+        self.options = options
     }
 }
 

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -115,19 +115,23 @@ final class PackageToolTests: XCTestCase {
             XCTAssertEqual(platforms, [
                 .dictionary([
                     "platformName": .string("macos"),
-                    "version": .string("10.12")
+                    "version": .string("10.12"),
+                    "options": .array([])
                 ]),
                 .dictionary([
                     "platformName": .string("ios"),
-                    "version": .string("10.0")
+                    "version": .string("10.0"),
+                    "options": .array([])
                 ]),
                 .dictionary([
                     "platformName": .string("tvos"),
-                    "version": .string("11.0")
+                    "version": .string("11.0"),
+                    "options": .array([])
                 ]),
                 .dictionary([
                     "platformName": .string("watchos"),
-                    "version": .string("5.0")
+                    "version": .string("5.0"),
+                    "options": .array([])
                 ]),
             ])
         }


### PR DESCRIPTION
This adds a way to express generic "sdk options" in string version of
the platforms API. The idea is that a package might be able to express
some platform-specific options for the underlying build system in
a generic way. Currently, this is just for experimentation purposes and
we might want some other (better, more typesafe) way of allowing
extending the package description language.

<rdar://problem/59788403>