### PR TITLE
-sdk for Android (Take 3)

### DIFF
--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -52,6 +52,23 @@ public struct Destination: Encodable, Equatable {
     /// Additional flags to be passed when compiling with C++.
     public let extraCPPFlags: [String]
 
+    /// Creates a compilation destination with the specified properties.
+    public init(
+      target: Triple? = nil,
+      sdk: AbsolutePath,
+      binDir: AbsolutePath,
+      extraCCFlags: [String] = [],
+      extraSwiftCFlags: [String] = [],
+      extraCPPFlags: [String] = []
+    ) {
+      self.target = target
+      self.sdk = sdk
+      self.binDir = binDir
+      self.extraCCFlags = extraCCFlags
+      self.extraSwiftCFlags = extraSwiftCFlags
+      self.extraCPPFlags = extraCPPFlags
+    }
+
     /// Returns the bin directory for the host.
     ///
     /// - Parameter originalWorkingDirectory: The working directory when the program was launched.

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -248,8 +248,9 @@ public final class UserToolchain: Toolchain {
       #endif
 
         // Use the triple from destination or compute the host triple using swiftc.
-        self.triple = destination.target ?? Triple.getHostTriple(usingSwiftCompiler: swiftCompilers.compile)
-        self.extraSwiftCFlags = (triple.isDarwin()
+        let triple = destination.target ?? Triple.getHostTriple(usingSwiftCompiler: swiftCompilers.compile)
+        self.triple = triple
+        self.extraSwiftCFlags = (triple.isDarwin() || triple.isAndroid()
                                     ? ["-sdk", destination.sdk.pathString]
                                     : [])
                                   + destination.extraSwiftCFlags

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -222,6 +222,13 @@ public final class UserToolchain: Toolchain {
         throw InvalidToolchainDiagnostic("could not find swift-api-digester")
     }
 
+    public static func deriveSwiftCFlags(triple: Triple, destination: Destination) -> [String] {
+      return (triple.isDarwin() || triple.isAndroid()
+        ? ["-sdk", destination.sdk.pathString]
+        : [])
+        + destination.extraSwiftCFlags
+    }
+
     public init(destination: Destination, environment: [String: String] = ProcessEnv.vars) throws {
         self.destination = destination
         self.processEnvironment = environment
@@ -250,10 +257,7 @@ public final class UserToolchain: Toolchain {
         // Use the triple from destination or compute the host triple using swiftc.
         let triple = destination.target ?? Triple.getHostTriple(usingSwiftCompiler: swiftCompilers.compile)
         self.triple = triple
-        self.extraSwiftCFlags = (triple.isDarwin() || triple.isAndroid()
-                                    ? ["-sdk", destination.sdk.pathString]
-                                    : [])
-                                  + destination.extraSwiftCFlags
+        self.extraSwiftCFlags = UserToolchain.deriveSwiftCFlags(triple: triple, destination: destination)
 
         self.extraCCFlags = [
             triple.isDarwin() ? "-isysroot" : "--sysroot", destination.sdk.pathString

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -16,6 +16,7 @@ import PackageModel
 import PackageGraph
 import SourceControl
 import TSCUtility
+import SPMBuildCore
 import Workspace
 
 import SPMTestSupport
@@ -4478,6 +4479,24 @@ final class WorkspaceTests: XCTestCase {
                 result.check(diagnostic: .contains("artifact of binary target 'A' has changed checksum"), behavior: .error)
             }
         }
+    }
+
+    func testAndroidCompilerFlags() throws {
+      let target = try Triple("x86_64-unknown-linux-android")
+      let sdk = AbsolutePath("/some/path/to/an/SDK.sdk")
+      let toolchainPath = AbsolutePath("/some/path/to/a/toolchain.xctoolchain")
+
+      let destination = Destination(
+        target: target,
+        sdk: sdk,
+        binDir: toolchainPath.appending(components: "usr", "bin")
+      )
+      let toolchain = try UserToolchain(destination: destination)
+
+      XCTAssertEqual(toolchain.extraSwiftCFlags, [
+        // Needed when cross‐compiling for Android. 2020‐03‐01
+        "-sdk", sdk.pathString
+      ])
     }
 }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -4484,7 +4484,7 @@ final class WorkspaceTests: XCTestCase {
     func testAndroidCompilerFlags() throws {
       let target = try Triple("x86_64-unknown-linux-android")
       let sdk = AbsolutePath("/some/path/to/an/SDK.sdk")
-      let toolchainPath = AbsolutePath("/some/path/to/a/toolchain.xctoolchain")
+      let toolchainPath = Resources.default.toolchain.destination.binDir.parentDirectory.parentDirectory
 
       let destination = Destination(
         target: target,

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -4484,16 +4484,15 @@ final class WorkspaceTests: XCTestCase {
     func testAndroidCompilerFlags() throws {
       let target = try Triple("x86_64-unknown-linux-android")
       let sdk = AbsolutePath("/some/path/to/an/SDK.sdk")
-      let toolchainPath = Resources.default.toolchain.destination.binDir.parentDirectory.parentDirectory
+      let toolchainPath = AbsolutePath("/some/path/to/a/toolchain.xctoolchain")
 
       let destination = Destination(
         target: target,
         sdk: sdk,
         binDir: toolchainPath.appending(components: "usr", "bin")
       )
-      let toolchain = try UserToolchain(destination: destination)
 
-      XCTAssertEqual(toolchain.extraSwiftCFlags, [
+      XCTAssertEqual(UserToolchain.deriveSwiftCFlags(triple: target, destination: destination), [
         // Needed when cross‐compiling for Android. 2020‐03‐01
         "-sdk", sdk.pathString
       ])


### PR DESCRIPTION
This is a further narrowing of #2620. It now only changes anything when building for Android. It merely adds `|| triple.isAndroid()`.

The local variable of `triple` was necessary because `||` involves an implicit closure and would result in an error if the instance property were used directly:

> 'self' captured by a closure before all members were initialized