### PR TITLE
WebAssembly Support

### DIFF
--- a/Sources/Build/ManifestBuilder.swift
+++ b/Sources/Build/ManifestBuilder.swift
@@ -339,11 +339,12 @@ extension LLBuildManifestBuilder {
     private func addModuleWrapCmd(_ target: SwiftTargetBuildDescription) {
         // Add commands to perform the module wrapping Swift modules when debugging statergy is `modulewrap`.
         guard buildParameters.debuggingStrategy == .modulewrap else { return }
-        let moduleWrapArgs = [
+        var moduleWrapArgs = [
             target.buildParameters.toolchain.swiftCompiler.pathString,
             "-modulewrap", target.moduleOutputPath.pathString,
             "-o", target.wrappedModuleOutputPath.pathString
         ]
+        moduleWrapArgs += buildParameters.targetTripleArgs(for: target.target)
         manifest.addShellCmd(
             name: target.wrappedModuleOutputPath.pathString,
             description: "Wrapping AST for \(target.target.name) for debugging",

--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -41,6 +41,10 @@ public struct Platform: Encodable {
     /// The Android platform
     @available(_PackageDescription, introduced: 5.2)
     public static let android: Platform = Platform(name: "android")
+
+    /// The WASI platform
+    @available(_PackageDescription, introduced: 5.2)
+    public static let wasi: Platform = Platform(name: "wasi")
 }
 
 /// A platform that the Swift package supports.

--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -43,7 +43,7 @@ public struct Platform: Encodable {
     public static let android: Platform = Platform(name: "android")
 
     /// The WASI platform
-    @available(_PackageDescription, introduced: 5.2)
+    @available(_PackageDescription, introduced: 999.0)
     public static let wasi: Platform = Platform(name: "wasi")
 }
 

--- a/Sources/PackageModel/Platform.swift
+++ b/Sources/PackageModel/Platform.swift
@@ -29,7 +29,7 @@ public final class PlatformRegistry {
 
     /// The static list of known platforms.
     private static var _knownPlatforms: [Platform] {
-        return [.macOS, .iOS, .tvOS, .watchOS, .linux, .android]
+        return [.macOS, .iOS, .tvOS, .watchOS, .linux, .android, .wasi]
     }
 }
 
@@ -57,6 +57,8 @@ public struct Platform: Equatable, Hashable {
     public static let linux: Platform = Platform(name: "linux", oldestSupportedVersion: .unknown)
     public static let android: Platform = Platform(name: "android", oldestSupportedVersion: .unknown)
     public static let windows: Platform = Platform(name: "windows", oldestSupportedVersion: .unknown)
+    public static let wasi: Platform = Platform(name: "wasi", oldestSupportedVersion: .unknown)
+
 }
 
 /// Represents a platform version.

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -99,6 +99,8 @@ public struct BuildParameters: Encodable {
             return .macOS
         } else if self.triple.isAndroid() {
             return .android
+        } else if self.triple.isWASI() {
+            return .wasi
         } else {
             return .linux
         }

--- a/Sources/SPMBuildCore/Triple.swift
+++ b/Sources/SPMBuildCore/Triple.swift
@@ -40,6 +40,7 @@ public struct Triple: Encodable, Equatable {
         case aarch64
         case armv7
         case arm
+        case wasm32
     }
 
     public enum Vendor: String, Encodable {
@@ -52,12 +53,14 @@ public struct Triple: Encodable, Equatable {
         case macOS = "macosx"
         case linux
         case windows
+        case wasi
 
         fileprivate static let allKnown:[OS] = [
             .darwin,
             .macOS,
             .linux,
-            .windows
+            .windows,
+            .wasi,
         ]
     }
 
@@ -125,6 +128,10 @@ public struct Triple: Encodable, Equatable {
         return os == .windows
     }
 
+    public func isWASI() -> Bool {
+        return os == .wasi
+    }
+
     /// Returns the triple string for the given platform version.
     ///
     /// This is currently meant for Apple platforms only.
@@ -165,6 +172,8 @@ extension Triple {
             return ".so"
         case .windows:
             return ".dll"
+        case .wasi:
+            fatalError("WebAssembly/WASI doesn't support dynamic library yet")
         }
     }
 
@@ -173,6 +182,8 @@ extension Triple {
       case .darwin, .macOS:
         return ""
       case .linux:
+        return ""
+      case .wasi:
         return ""
       case .windows:
         return ".exe"

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -2130,14 +2130,14 @@ final class BuildPlanTests: XCTestCase {
                     inputs: ["/path/to/build/debug/exe.swiftmodule"]
                     outputs: ["/path/to/build/debug/exe.build/exe.swiftmodule.o"]
                     description: "Wrapping AST for exe for debugging"
-                    args: ["/fake/path/to/swiftc","-modulewrap","/path/to/build/debug/exe.swiftmodule","-o","/path/to/build/debug/exe.build/exe.swiftmodule.o"]
+                    args: ["/fake/path/to/swiftc","-modulewrap","/path/to/build/debug/exe.swiftmodule","-o","/path/to/build/debug/exe.build/exe.swiftmodule.o","-target","x86_64-unknown-linux-gnu"]
 
                   "/path/to/build/debug/lib.build/lib.swiftmodule.o":
                     tool: shell
                     inputs: ["/path/to/build/debug/lib.swiftmodule"]
                     outputs: ["/path/to/build/debug/lib.build/lib.swiftmodule.o"]
                     description: "Wrapping AST for lib for debugging"
-                    args: ["/fake/path/to/swiftc","-modulewrap","/path/to/build/debug/lib.swiftmodule","-o","/path/to/build/debug/lib.build/lib.swiftmodule.o"]
+                    args: ["/fake/path/to/swiftc","-modulewrap","/path/to/build/debug/lib.swiftmodule","-o","/path/to/build/debug/lib.build/lib.swiftmodule.o","-target","x86_64-unknown-linux-gnu"]
                 """))
         }
     }

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -1524,6 +1524,7 @@ class PackageBuilderTests: XCTestCase {
             "tvos": "9.0",
             "watchos": "2.0",
             "android": "0.0",
+            "wasi": "0.0",
         ]
 
         PackageBuilderTester(manifest, in: fs) { package, _ in
@@ -1560,6 +1561,7 @@ class PackageBuilderTests: XCTestCase {
             "ios": "8.0",
             "watchos": "2.0",
             "android": "0.0",
+            "wasi": "0.0",
         ]
 
         PackageBuilderTester(manifest, in: fs) { package, _ in


### PR DESCRIPTION
- 2548c5e The main change of this PR adds WebAssembly/WASI variant as platform.
- 6d16075 This change is necessary to make swift-autolink-extract work.
For wasm target, swift-autolink-extract try to extract info from swiftmodule. But without target argument, compiler emits module as Mach-O format on macOS which is not supported by swift-autolink-extract. So SwiftPM need to pass target option when emitting swiftmodule.

This is a part of SR-9307 and [#24684](https://github.com/apple/swift/pull/24684).