### PR TITLE
Android: Handle flags derived from SDK

### DIFF
--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -223,10 +223,14 @@ public final class UserToolchain: Toolchain {
     }
 
     public static func deriveSwiftCFlags(triple: Triple, destination: Destination) -> [String] {
-      return (triple.isDarwin() || triple.isAndroid()
+      var flags = (triple.isDarwin() || triple.isAndroid()
         ? ["-sdk", destination.sdk.pathString]
         : [])
-        + destination.extraSwiftCFlags
+      if triple.isAndroid() {
+        let resourceDirectory = destination.sdk.appending(components: "usr", "lib", "swift")
+        flags += ["-resource-dir", resourceDirectory.pathString]
+      }
+      return flags + destination.extraSwiftCFlags
     }
 
     public init(destination: Destination, environment: [String: String] = ProcessEnv.vars) throws {

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -4493,8 +4493,10 @@ final class WorkspaceTests: XCTestCase {
       )
 
       XCTAssertEqual(UserToolchain.deriveSwiftCFlags(triple: target, destination: destination), [
-        // Needed when cross‐compiling for Android. 2020‐03‐01
-        "-sdk", sdk.pathString
+        // Needed when cross‐compiling for Android.
+        // Dates indicate when it was last verified that a flag was needed.
+        "-sdk", sdk.pathString, // 2020‐03‐01
+        "-resource-dir", "\(sdk.pathString)/usr/lib/swift" // 2020‐03‐05
       ])
     }
 }


### PR DESCRIPTION
This handles those of Android’s extra compiler flags that can be derived solely from the location of the SDK.

- [Usage difference](https://github.com/SDGGiesbrecht/swift-package-manager/commit/1cc55693c5e24a98982bf26aa42f27ce1a3010e7)
- [Success with](https://github.com/SDGGiesbrecht/swift-package-manager/runs/488624339) and [failure without](https://github.com/SDGGiesbrecht/swift-package-manager/runs/488622691) this commit.

(In my fork I have now set up the self‐hosted tests (`swift test`) on both macOS and Linux, so I can better guage what the official CI is likely to do. Both are passing.)