### PR TITLE
[Resources] CoreML model support

### DIFF
--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -550,6 +550,13 @@ public struct FileRuleDescription {
             fileTypes: ["metal"]
         )
     }()
+    
+    /// File types related to CoreML.
+    public static let coreml: FileRuleDescription = {
+        .init(rule: .processResource,
+              toolsVersion: .vNext,
+              fileTypes: ["mlmodel"])
+    }()
 
     /// List of all the builtin rules.
     public static let builtinRules: [FileRuleDescription] = [
@@ -566,6 +573,7 @@ public struct FileRuleDescription {
         assetCatalog,
         coredata,
         metal,
+        coreml,
     ]
 }
 

--- a/Sources/XCBuildSupport/PIF.swift
+++ b/Sources/XCBuildSupport/PIF.swift
@@ -696,6 +696,7 @@ public enum PIF {
             case WATCHOS_DEPLOYMENT_TARGET
             case MARKETING_VERSION
             case CURRENT_PROJECT_VERSION
+            case COREML_CODEGEN_LANGUAGE
         }
 
         public enum MultipleValueSetting: String {
@@ -902,6 +903,9 @@ extension PIF.FileReference {
             return "file.storyboard"
         case "xib":
             return "file.xib"
+            
+        case "mlmodel":
+            return "file.mlmodel"
 
         case "xcframework":
             return "wrapper.xcframework"

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -737,6 +737,9 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         settings[.PRODUCT_BUNDLE_IDENTIFIER] = bundleIdentifier
         settings[.GENERATE_INFOPLIST_FILE] = "YES"
         settings[.PACKAGE_RESOURCE_TARGET_KIND] = "resource"
+        
+        // Do not generate code for mlmodel files in resources target.
+        settings[.COREML_CODEGEN_LANGUAGE] = "None"
 
         resourcesTarget.addBuildConfiguration(name: "Debug", settings: settings)
         resourcesTarget.addBuildConfiguration(name: "Release", settings: settings)

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -1912,7 +1912,8 @@ class PackageBuilderTests: XCTestCase {
             "/Foo/Sources/Foo/Foo.xcassets",
             "/Foo/Sources/Foo/Foo.xib",
             "/Foo/Sources/Foo/Foo.xcdatamodel",
-            "/Foo/Sources/Foo/Foo.metal"
+            "/Foo/Sources/Foo/Foo.metal",
+            "/Foo/Sources/Foo/Foo.mlmodel"
         )
 
         let manifest = Manifest.createManifest(
@@ -1930,7 +1931,8 @@ class PackageBuilderTests: XCTestCase {
                     "/Foo/Sources/Foo/Foo.xib",
                     "/Foo/Sources/Foo/Foo.xcdatamodel",
                     "/Foo/Sources/Foo/Foo.xcassets",
-                    "/Foo/Sources/Foo/Foo.metal"
+                    "/Foo/Sources/Foo/Foo.metal",
+                    "/Foo/Sources/Foo/Foo.mlmodel"
                 ])
             }
         }

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -1550,12 +1550,15 @@ class PIFBuilderTests: XCTestCase {
             "/Foo/Sources/foo/main.swift",
             "/Foo/Sources/foo/Resources/Data.plist",
             "/Foo/Sources/foo/Resources/Database.xcdatamodel",
+            "/Foo/Sources/foo/Resources/Model.mlmodel",
             "/Foo/Sources/FooLib/lib.swift",
             "/Foo/Sources/FooLib/Resources/Data.plist",
             "/Foo/Sources/FooLib/Resources/Database.xcdatamodel",
+            "/Foo/Sources/FooLib/Resources/Model.mlmodel",
             "/Foo/Sources/FooTests/FooTests.swift",
             "/Foo/Sources/FooTests/Resources/Data.plist",
-            "/Foo/Sources/FooTests/Resources/Database.xcdatamodel"
+            "/Foo/Sources/FooTests/Resources/Database.xcdatamodel",
+            "/Foo/Sources/FooTests/Resources/Model.mlmodel"
         )
 
         let diagnostics = DiagnosticsEngine()
@@ -1625,6 +1628,7 @@ class PIFBuilderTests: XCTestCase {
                     XCTAssertEqual(target.resources, [
                         "/Foo/Sources/foo/Resources/Data.plist",
                         "/Foo/Sources/foo/Resources/Database.xcdatamodel",
+                        "/Foo/Sources/foo/Resources/Model.mlmodel",
                     ])
 
                     target.checkBuildConfiguration("Debug") { configuration in
@@ -1637,6 +1641,7 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "Foo.foo.resources")
                             XCTAssertEqual(settings[.GENERATE_INFOPLIST_FILE], "YES")
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "resource")
+                            XCTAssertEqual(settings[.COREML_CODEGEN_LANGUAGE], "None")
                         }
                     }
 
@@ -1650,6 +1655,7 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "Foo.foo.resources")
                             XCTAssertEqual(settings[.GENERATE_INFOPLIST_FILE], "YES")
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "resource")
+                            XCTAssertEqual(settings[.COREML_CODEGEN_LANGUAGE], "None")
                         }
                     }
                 }
@@ -1727,6 +1733,7 @@ class PIFBuilderTests: XCTestCase {
                     XCTAssertEqual(target.resources, [
                         "/Foo/Sources/FooTests/Resources/Data.plist",
                         "/Foo/Sources/FooTests/Resources/Database.xcdatamodel",
+                        "/Foo/Sources/FooTests/Resources/Model.mlmodel",
                     ])
 
                     target.checkBuildConfiguration("Debug") { configuration in
@@ -1739,6 +1746,7 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "Foo.FooTests.resources")
                             XCTAssertEqual(settings[.GENERATE_INFOPLIST_FILE], "YES")
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "resource")
+                            XCTAssertEqual(settings[.COREML_CODEGEN_LANGUAGE], "None")
                         }
                     }
 
@@ -1752,6 +1760,7 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "Foo.FooTests.resources")
                             XCTAssertEqual(settings[.GENERATE_INFOPLIST_FILE], "YES")
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "resource")
+                            XCTAssertEqual(settings[.COREML_CODEGEN_LANGUAGE], "None")
                         }
                     }
                 }


### PR DESCRIPTION
This PR aims to add the support for `.mlmodel` files. It contains two parts:

- Modifications to the PackageLoading system: Recognize `.mlmodel` files as part of the package resources.

- Modifications to the XCBuildSupport system: Generate the appropriate PIF to compile `.mlmodel` files.
    
    A `COREML_CODEGEN_LANGUAGE` setting is added to control the code generation for `.mlmodel` files. 

   Currently `.mlmodel` files are only added to the resources target. The build system should not generate code for resources target, so the `COREML_CODEGEN_LANGUAGE` for the resources target is set to `None`.

    I'm not sure whether we should let the build system automatically generate a custom programmatic interface to the model in the main target. You **can** use a CoreML model without the generated custom programmatic interface, it's not a requirement. You can use a CoreML model directly with frameworks like `Visions` or `CoreImage` as well.