### PR TITLE
[test] Update PD5LoadingTests.swift for an upcoming parser fix that suppressed a diagnostic it was checking for.

### DIFF
--- a/Tests/PackageLoadingTests/PD5LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5LoadingTests.swift
@@ -328,7 +328,7 @@ class PackageDescription5LoadingTests: PackageDescriptionLoadingTests {
                     packageKind: .local
                 )
             } catch ManifestParseError.invalidManifestFormat(let error, let diagnosticFile) {
-                XCTAssertMatch(error, .contains("expected \')\' in expression list"))
+                XCTAssertMatch(error, .contains("expected expression in container literal"))
                 let contents = try localFileSystem.readFileContents(diagnosticFile!)
                 XCTAssertNotNil(contents)
             }


### PR DESCRIPTION
The test parses the code below and checks for a `expected ')' in expression list` diagnostic:

```
import PackageDescription

let package = Package(
    name: "Trivial",
    targets: [
        .target(
            name: "foo",
            dependencies: []),
)
```
Prior to the parser fix the invalid targets array literal failed to parse but the error status wasn't propagated up to the containing argument list parsing code, so it produced an additional (and undesirable) missing right token diagnostic that this test was checking for.
```
/tmp/t.swift:9:1: error: expected expression in container literal
)
^
/tmp/t.swift:9:2: error: expected ')' in expression list
)
 ^
/tmp/t.swift:2:22: note: to match this opening '('
let package = Package(
                     ^
```
After the parser fix in https://github.com/apple/swift/pull/30187 lands, we will only report the first error and suppress the rest:
```
/tmp/t.swift:9:1: error: expected expression in container literal
)
^
```
So this PR changes the test to check for that diagnostic instead.