### PR TITLE
Unify binary path extension logic to `Triple`

### DIFF
--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -210,13 +210,9 @@ public struct BuildParameters: Encodable {
     public func binaryRelativePath(for product: ResolvedProduct) -> RelativePath {
         switch product.type {
         case .executable:
-            if triple.isWindows() {
-                return RelativePath("\(product.name).exe")
-            } else {
-                return RelativePath(product.name)
-            }
+            return RelativePath("\(product.name)\(triple.executableExtension)")
         case .library(.static):
-            return RelativePath("lib\(product.name).a")
+            return RelativePath("lib\(product.name)\(triple.staticLibraryExtension)")
         case .library(.dynamic):
             return RelativePath("lib\(product.name)\(triple.dynamicLibraryExtension)")
         case .library(.automatic):

--- a/Sources/SPMBuildCore/Triple.swift
+++ b/Sources/SPMBuildCore/Triple.swift
@@ -189,6 +189,11 @@ extension Triple {
         return ".exe"
       }
     }
+    
+    /// The file extension for static libraries.
+    public var staticLibraryExtension: String {
+        return ".a"
+    }
 
     /// The file extension for Foundation-style bundle.
     public var nsbundleExtension: String {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1505,6 +1505,9 @@ final class BuildPlanTests: XCTestCase {
             "@/path/to/build/debug/exe.product/Objects.LinkFileList",
              "-target", "x86_64-unknown-windows-msvc",
             ])
+        
+        let executablePathExtension = try result.buildProduct(for: "exe").binary.extension
+        XCTAssertMatch(executablePathExtension, "exe")
     }
 
     func testIndexStore() throws {
@@ -2340,6 +2343,12 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(clibraryLinkArguments, [.anySequence, "-F", "/path/to/build/debug", .anySequence])
         XCTAssertMatch(clibraryLinkArguments, [.anySequence, "-L", "/path/to/build/debug", .anySequence])
         XCTAssertMatch(clibraryLinkArguments, ["-lStaticLibrary"])
+        
+        let executablePathExtension = try result.buildProduct(for: "exe").binary.extension ?? ""
+        XCTAssertMatch(executablePathExtension, "")
+        
+        let dynamicLibraryPathExtension = try result.buildProduct(for: "Library").binary.extension
+        XCTAssertMatch(dynamicLibraryPathExtension, "dylib")
     }
 }
 


### PR DESCRIPTION
- Unify the binary path extension logic to `Triple` and reuse the existing `Triple.executableExtension` method.
- Add tests.