### PR TITLE
Support cross-compile for iOS

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -104,10 +104,18 @@ extension BuildParameters {
         var args = ["-target"]
         // Compute the triple string for Darwin platform using the platform version.
         if triple.isDarwin() {
-            guard let macOSSupportedPlatform = target.underlyingTarget.getSupportedPlatform(for: .macOS) else {
-                fatalError("the target \(target) doesn't support building for macOS")
+            switch triple.os {
+            case .iOS:
+                guard let iOSSupportedPlatform = target.underlyingTarget.getSupportedPlatform(for: .iOS) else {
+                    fatalError("the target \(target) doesn't support building for iOS")
+                }
+                args += [triple.tripleString(forPlatformVersion: iOSSupportedPlatform.version.versionString)]
+            default:
+                guard let macOSSupportedPlatform = target.underlyingTarget.getSupportedPlatform(for: .macOS) else {
+                    fatalError("the target \(target) doesn't support building for macOS")
+                }
+                args += [triple.tripleString(forPlatformVersion: macOSSupportedPlatform.version.versionString)]
             }
-            args += [triple.tripleString(forPlatformVersion: macOSSupportedPlatform.version.versionString)]
         } else {
             args += [triple.tripleString]
         }

--- a/Sources/SPMBuildCore/Triple.swift
+++ b/Sources/SPMBuildCore/Triple.swift
@@ -41,6 +41,7 @@ public struct Triple: Encodable, Equatable {
         case armv7
         case arm
         case wasm32
+        case arm64
     }
 
     public enum Vendor: String, Encodable {
@@ -54,6 +55,7 @@ public struct Triple: Encodable, Equatable {
         case linux
         case windows
         case wasi
+        case iOS = "ios"
 
         fileprivate static let allKnown:[OS] = [
             .darwin,
@@ -61,6 +63,7 @@ public struct Triple: Encodable, Equatable {
             .linux,
             .windows,
             .wasi,
+            .iOS
         ]
     }
 
@@ -117,7 +120,7 @@ public struct Triple: Encodable, Equatable {
     }
 
     public func isDarwin() -> Bool {
-        return vendor == .apple || os == .macOS || os == .darwin
+        return vendor == .apple || os == .macOS || os == .darwin || os == .iOS
     }
 
     public func isLinux() -> Bool {
@@ -166,7 +169,7 @@ extension Triple {
     /// The file extension for dynamic libraries (eg. `.dll`, `.so`, or `.dylib`)
     public var dynamicLibraryExtension: String {
         switch os {
-        case .darwin, .macOS:
+        case .darwin, .macOS, .iOS:
             return ".dylib"
         case .linux:
             return ".so"
@@ -179,7 +182,7 @@ extension Triple {
 
     public var executableExtension: String {
       switch os {
-      case .darwin, .macOS:
+      case .darwin, .macOS, .iOS:
         return ""
       case .linux:
         return ""
@@ -193,7 +196,7 @@ extension Triple {
     /// The file extension for Foundation-style bundle.
     public var nsbundleExtension: String {
         switch os {
-        case .darwin, .macOS:
+        case .darwin, .macOS, .iOS:
             return ".bundle"
         default:
             // See: https://github.com/apple/swift-corelibs-foundation/blob/master/Docs/FHS%20Bundles.md


### PR DESCRIPTION
## Abstract

This PR adds the support for cross-compile to iOS using `swift build --destination  iOS.json`
with an `iOS.json` file like this:
```
{
    "version": 1,
    "sdk": "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS13.2.sdk",
    "toolchain-bin-dir": "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin",
    "target": "arm64-apple-ios",
    "extra-cc-flags": [],
    "extra-swiftc-flags": [],
    "extra-cpp-flags": ["-lc++"]
}
```

Not sure if this is a proper way to build for iOS.  It seems there are alternative methods:

1. Use `swift package generate-xcodeproj` to generate a Xcode project then run `xcodebuild -sdk iphoneos -scheme 'PackageName-Package' -project PackageName.xcodeproj`. 

    I cannot get this working with Objective-C targets with user defined modulemap. The linker reports missing symbols of system libraries. Looks like the auto-linking is broken. Seems to be related to the `CLANG_ENABLE_MODULES` setting to be `NO`. https://github.com/apple/swift-package-manager/blob/afc7bd9efb0f0a0e53b060d30e47a876a888cc86/Sources/Xcodeproj/pbxproj.swift#L574-L589

2. Pass a set of parameters (`-sdk`,`-target`,`-isysroot`) to the C/C++/Swift compilers using `-Xswiftc` `-Xcc` `-Xcxx`.
    ```
    swift build -Xswiftc -sdk -Xswiftc $(xcrun --sdk iphoneos --show-sdk-path) -Xswiftc -target -Xswiftc arm64-apple-ios10.0  -Xcc -isysroot -Xcc $(xcrun --sdk iphoneos --show-sdk-path) -Xcc -target -Xcc arm64-apple-ios10.0 -Xcxx -target -Xcxx arm64-apple-ios10.0
    ```
    Seems to work, but the build artifacts still live in `.build/x86_64-apple-macosx/`. I can verify the output is indeed arm64 binary by running `file` command.

## Detail

- Added `arm64` to `Triple.Arch`
- Added `iOS` to `Triple.OS`
- Updated the `-target` generation method to cover iOS platform.
