### PR TITLE
[bootstrap] Use the right install name for PackageDescription

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -667,7 +667,8 @@ def process_runtime_libraries(build, args, lib_path):
                "-Xlinker", "-all_load",
                input_lib_path,
                "-sdk", args.sysroot,
-               "-target", "x86_64-apple-macosx10.10"]
+               "-target", "x86_64-apple-macosx10.10",
+               "-Xlinker", "-install_name", "-Xlinker", "@rpath/libPackageDescription.dylib"]
     else:
         # We include an RPATH entry so that the Swift libraries can be found
         # relative to where it will be installed (in 'lib/swift/pm/<version>/...').


### PR DESCRIPTION
The install name didn't used to matter when we were evaluating the
manifests through the Swift interpreter.

<rdar://problem/60635550>