### PR TITLE
Fix InMemoryGitRepository by expecting its contents to present at root

### DIFF
--- a/Sources/SPMTestSupport/TestWorkspace.swift
+++ b/Sources/SPMTestSupport/TestWorkspace.swift
@@ -94,24 +94,25 @@ public final class TestWorkspace {
         func create(package: TestPackage, basePath: AbsolutePath, packageKind: PackageReference.Kind) throws {
             let packagePath = basePath.appending(RelativePath(package.path ?? package.name))
 
-            let sourcesDir = packagePath.appending(component: "Sources")
             let url = (packageKind == .root ? packagePath : packagesDir.appending(RelativePath(package.path ?? package.name))).pathString
             let specifier = RepositorySpecifier(url: url)
-            let manifestPath = packagePath.appending(component: Manifest.filename)
 
             // Create targets on disk.
             let repo = repoProvider.specifierMap[specifier] ?? InMemoryGitRepository(path: packagePath, fs: fs as! InMemoryFileSystem)
+            let repoSourcesDir = AbsolutePath("/Sources")
             for target in package.targets {
-                let targetDir = sourcesDir.appending(component: target.name)
-                try repo.createDirectory(targetDir, recursive: true)
-                try repo.writeFileContents(targetDir.appending(component: "file.swift"), bytes: "")
+                let repoTargetDir = repoSourcesDir.appending(component: target.name)
+                try repo.createDirectory(repoTargetDir, recursive: true)
+                try repo.writeFileContents(repoTargetDir.appending(component: "file.swift"), bytes: "")
             }
             let toolsVersion = package.toolsVersion ?? .currentToolsVersion
-            try repo.writeFileContents(manifestPath, bytes: "")
-            try writeToolsVersion(at: packagePath, version: toolsVersion, fs: repo)
+            let repoManifestPath = AbsolutePath.root.appending(component: Manifest.filename)
+            try repo.writeFileContents(repoManifestPath, bytes: "")
+            try writeToolsVersion(at: .root, version: toolsVersion, fs: repo)
             repo.commit()
 
             let versions: [String?] = packageKind == .remote ? package.versions : [nil]
+            let manifestPath = packagePath.appending(component: Manifest.filename)
             for version in versions {
                 let v = version.flatMap(Version.init(string:))
                 manifests[.init(url: url, version: v)] = Manifest(

--- a/Sources/SourceControl/InMemoryGitRepository.swift
+++ b/Sources/SourceControl/InMemoryGitRepository.swift
@@ -145,23 +145,25 @@ public final class InMemoryGitRepository {
         let headFs = head.fileSystem
 
         /// Recursively copies the content at HEAD to fs.
-        func install(at path: AbsolutePath) throws {
-            guard headFs.isDirectory(path) else { return }
-            for entry in try headFs.getDirectoryContents(path) {
+        func install(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
+            assert(headFs.isDirectory(sourcePath))
+            for entry in try headFs.getDirectoryContents(sourcePath) {
                 // The full path of the entry.
-                let entryPath = path.appending(component: entry)
-                if headFs.isFile(entryPath) {
+                let sourceEntryPath = sourcePath.appending(component: entry)
+                let destinationEntryPath = destinationPath.appending(component: entry)
+                if headFs.isFile(sourceEntryPath) {
                     // If we have a file just write the file.
-                    try fs.writeFileContents(entryPath, bytes: try headFs.readFileContents(entryPath))
-                } else if headFs.isDirectory(entryPath) {
+                    let bytes = try headFs.readFileContents(sourceEntryPath)
+                    try fs.writeFileContents(destinationEntryPath, bytes: bytes)
+                } else if headFs.isDirectory(sourceEntryPath) {
                     // If we have a directory, create that directory and copy its contents.
-                    try fs.createDirectory(entryPath, recursive: false)
-                    try install(at: entryPath)
+                    try fs.createDirectory(destinationEntryPath, recursive: false)
+                    try install(from: sourceEntryPath, to: destinationEntryPath)
                 }
             }
         }
         // Install at the repository path.
-        try install(at: path)
+        try install(from: .root, to: path)
     }
 
     /// Tag the current HEAD with the given name.
@@ -263,8 +265,7 @@ extension InMemoryGitRepository: Repository {
     }
 
     public func openFileView(revision: Revision) throws -> FileSystem {
-        let fs: FileSystem = history[revision.identifier]!.fileSystem
-        return RerootedFileSystemView(fs, rootedAt: path)
+        return history[revision.identifier]!.fileSystem
     }
 }
 

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -161,7 +161,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
     func testVprefixVersions() throws {
         let fs = InMemoryFileSystem()
 
-        let repoPath = AbsolutePath.root.appending(component: "some-repo")
+        let repoPath = AbsolutePath.root
         let filePath = repoPath.appending(component: "Package.swift")
 
         let specifier = RepositorySpecifier(url: repoPath.pathString)
@@ -198,7 +198,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
     func testVersions() throws {
         let fs = InMemoryFileSystem()
 
-        let repoPath = AbsolutePath.root.appending(component: "some-repo")
+        let repoPath = AbsolutePath.root
         let filePath = repoPath.appending(component: "Package.swift")
 
         let specifier = RepositorySpecifier(url: repoPath.pathString)
@@ -276,7 +276,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
                 _ = try container.getDependencies(at: revision.identifier)
             } catch let error as RepositoryPackageContainer.GetDependenciesErrorWrapper {
                 let error = error.underlyingError as! UnsupportedToolsVersion
-                XCTAssertMatch(error.description, .and(.prefix("package at '/some-repo' @"), .suffix("is using Swift tools version 3.1.0 which is no longer supported; consider using '// swift-tools-version:4.0' to specify the current tools version")))
+                XCTAssertMatch(error.description, .and(.prefix("package at '/' @"), .suffix("is using Swift tools version 3.1.0 which is no longer supported; consider using '// swift-tools-version:4.0' to specify the current tools version")))
             }
         }
     }
@@ -284,7 +284,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
     func testPrereleaseVersions() throws {
         let fs = InMemoryFileSystem()
 
-        let repoPath = AbsolutePath.root.appending(component: "some-repo")
+        let repoPath = AbsolutePath.root
         let filePath = repoPath.appending(component: "Package.swift")
 
         let specifier = RepositorySpecifier(url: repoPath.pathString)
@@ -323,7 +323,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
     func testSimultaneousVersions() throws {
         let fs = InMemoryFileSystem()
 
-        let repoPath = AbsolutePath.root.appending(component: "some-repo")
+        let repoPath = AbsolutePath.root
         let filePath = repoPath.appending(component: "Package.swift")
 
         let specifier = RepositorySpecifier(url: repoPath.pathString)


### PR DESCRIPTION
`InMemoryGitRepository` is initialized with a path and an in-memory file system where it belongs. It then creates seperate in-memory file systems for each of its commits.

Previously, the contents of the repository in the commit file systems was at the same location as in the working directory file system, which caused issues when cloning the repository to a different location on the file system (in `installHead`).

Now, the contents of the repository in the commit file systems is located at root.