### PR TITLE
Don't generate XCTestManifest and related files by default

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -31,7 +31,7 @@ public final class InitPackage {
 
         public init(
             packageType: PackageType,
-            enableXCTestManifest: Bool = true,
+            enableXCTestManifest: Bool = false,
             platforms: [SupportedPlatform] = []
         ) {
             self.packageType = packageType


### PR DESCRIPTION
More of a discussion this one - I propose that when you run `swift package init` it doesn't generate a `LinuxMain.swift`, `allTests` arrays for test cases and the `XCTestManifest` file. Now that `swift test --enable-test-discovery` replaces those files, they end up being redundant.

(I'm aware that `--enable-test-discovery` may need to be enabled by default before this can be merged and there's the whole `swift build` bug if you don't add `--enable-test-discovery` and have a `LinuxMain.swift`)