### PR TITLE
[XCBuildSupport] Implement Decodable for PIF types

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -380,7 +380,7 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             let graph = try loadPackageGraph(createMultipleTestProducts: true)
             let parameters = try PIFBuilderParameters(buildParameters())
             let builder = PIFBuilder(graph: graph, parameters: parameters, diagnostics: diagnostics)
-            let pif = try builder.generatePIF()
+            let pif = try builder.generatePIF(preservePIFModelStructure: options.pifDumpOptions.preservePIFModelStructure)
             print(pif)
 
         case .completionTool:
@@ -432,7 +432,12 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             to: { $0.describeMode = $1 })
 
         _ = parser.add(subparser: PackageMode.dumpPackage.rawValue, overview: "Print parsed Package.swift as JSON")
-        _ = parser.add(subparser: PackageMode.dumpPIF.rawValue, overview: "")
+        let dumpPIFParser = parser.add(subparser: PackageMode.dumpPIF.rawValue, overview: "")
+        binder.bind(
+            option: dumpPIFParser.add(
+                option: "--preserve-structure", kind: Bool.self,
+                usage: "Preserve the internal structure of PIF"),
+            to: { $0.pifDumpOptions.preservePIFModelStructure = $1 })
 
         let editParser = parser.add(subparser: PackageMode.edit.rawValue, overview: "Put a package in editable mode")
         binder.bind(
@@ -744,6 +749,11 @@ public class PackageToolOptions: ToolOptions {
     }
 
     var editOptions = EditOptions()
+
+    struct PIFDumpOptions {
+        var preservePIFModelStructure: Bool = false
+    }
+    var pifDumpOptions = PIFDumpOptions()
 
     var outputPath: AbsolutePath?
     var xcodeprojOptions = XcodeprojOptions()

--- a/Sources/SPMTestSupport/PIFTester.swift
+++ b/Sources/SPMTestSupport/PIFTester.swift
@@ -162,18 +162,18 @@ public class PIFBaseTargetTester {
     }
 
     public func checkImpartedBuildSettings(file: StaticString = #file, line: UInt = #line, _ body: (PIFBuildSettingsTester) -> Void) {
-        let buildSettingsTester = PIFBuildSettingsTester(buildSettings: baseTarget.impartedBuildProperties.settings)
+        let buildSettingsTester = PIFBuildSettingsTester(buildSettings: baseTarget.impartedBuildProperties.buildSettings)
         body(buildSettingsTester)
     }
 
     public func checkAllImpartedBuildSettings(file: StaticString = #file, line: UInt = #line, _ body: (PIFBuildSettingsTester) -> Void) {
-        let buildSettingsTester = PIFBuildSettingsTester(buildSettings: baseTarget.impartedBuildProperties.settings)
+        let buildSettingsTester = PIFBuildSettingsTester(buildSettings: baseTarget.impartedBuildProperties.buildSettings)
         body(buildSettingsTester)
         buildSettingsTester.checkUncheckedSettings(file: file, line: line)
     }
 
     public func checkNoImpartedBuildSettings(file: StaticString = #file, line: UInt = #line) {
-        let buildSettingsTester = PIFBuildSettingsTester(buildSettings: baseTarget.impartedBuildProperties.settings)
+        let buildSettingsTester = PIFBuildSettingsTester(buildSettings: baseTarget.impartedBuildProperties.buildSettings)
         buildSettingsTester.checkUncheckedSettings(file: file, line: line)
     }
 }

--- a/Sources/XCBuildSupport/PIF.swift
+++ b/Sources/XCBuildSupport/PIF.swift
@@ -54,17 +54,29 @@ public enum PIF {
         }
     }
 
-    public class TypedObject: Encodable {
+    public class TypedObject: Codable {
         class var type: String {
             fatalError("\(self) missing implementation")
         }
 
+        let type: String?
+
         fileprivate init() {
+            type = Swift.type(of: self).type
+        }
+
+        private enum CodingKeys: CodingKey {
+            case type
         }
 
         public func encode(to encoder: Encoder) throws {
-            var container = encoder.container(keyedBy: StringKey.self)
-            try container.encode(Swift.type(of: self).type, forKey: "type")
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(Swift.type(of: self).type, forKey: .type)
+        }
+
+        required public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            type = try container.decode(String.self, forKey: .type)
         }
     }
 
@@ -95,6 +107,12 @@ public enum PIF {
                 try container.encode(signature, forKey: "signature")
             }
         }
+
+        public required init(from decoder: Decoder) throws {
+            try super.init(from: decoder)
+            let container = try decoder.container(keyedBy: StringKey.self)
+            signature = try container.decode(String.self, forKey: "signature")
+        }
     }
 
     public final class Workspace: SignedObject {
@@ -118,17 +136,37 @@ public enum PIF {
             super.init()
         }
 
+        private enum CodingKeys: CodingKey {
+            case guid, name, path, projects
+        }
+
         public override func encode(to encoder: Encoder) throws {
             try super.encode(to: encoder)
             var container = encoder.container(keyedBy: StringKey.self)
-            var contents = container.nestedContainer(keyedBy: StringKey.self, forKey: "contents")
-            try contents.encode("\(guid)@\(schemaVersion)", forKey: "guid")
-            try contents.encode(name, forKey: "name")
-            try contents.encode(path, forKey: "path")
+            var contents = container.nestedContainer(keyedBy: CodingKeys.self, forKey: "contents")
+            try contents.encode("\(guid)@\(schemaVersion)", forKey: .guid)
+            try contents.encode(name, forKey: .name)
+            try contents.encode(path, forKey: .path)
 
             if encoder.userInfo[.encodingPIFSignature] == nil {
-                try contents.encode(projects.map({ $0.signature }), forKey: "projects")
+                try contents.encode(projects.map({ $0.signature }), forKey: .projects)
             }
+
+            if encoder.userInfo.keys.contains(.preservePIFModelStructure) {
+                try contents.encode(projects, forKey: .projects)
+            }
+        }
+
+        public required init(from decoder: Decoder) throws {
+            let superContainer = try decoder.container(keyedBy: StringKey.self)
+            let container = try superContainer.nestedContainer(keyedBy: CodingKeys.self, forKey: "contents")
+
+            let guidString = try container.decode(GUID.self, forKey: .guid)
+            self.guid = String(guidString.dropLast("\(schemaVersion)".count + 1))
+            self.name = try container.decode(String.self, forKey: .name)
+            self.path = try container.decode(AbsolutePath.self, forKey: .path)
+            self.projects = try container.decode([Project].self, forKey: .projects)
+            try super.init(from: decoder)
         }
     }
 
@@ -174,28 +212,67 @@ public enum PIF {
             super.init()
         }
 
+        private enum CodingKeys: CodingKey {
+            case guid, projectName, projectIsPackage, path, projectDirectory, developmentRegion, defaultConfigurationName, buildConfigurations, targets, groupTree
+        }
+
         public override func encode(to encoder: Encoder) throws {
             try super.encode(to: encoder)
             var container = encoder.container(keyedBy: StringKey.self)
-            var contents = container.nestedContainer(keyedBy: StringKey.self, forKey: "contents")
-            try contents.encode("\(guid)@\(schemaVersion)", forKey: "guid")
-            try contents.encode(name, forKey: "projectName")
-            try contents.encode("true", forKey: "projectIsPackage")
-            try contents.encode(path, forKey: "path")
-            try contents.encode(projectDirectory, forKey: "projectDirectory")
-            try contents.encode(developmentRegion, forKey: "developmentRegion")
-            try contents.encode("Release", forKey: "defaultConfigurationName")
-            try contents.encode(buildConfigurations, forKey: "buildConfigurations")
-            try contents.encode(targets.map({ $0.signature }), forKey: "targets")
-            try contents.encode(groupTree, forKey: "groupTree")
+            var contents = container.nestedContainer(keyedBy: CodingKeys.self, forKey: "contents")
+            try contents.encode("\(guid)@\(schemaVersion)", forKey: .guid)
+            try contents.encode(name, forKey: .projectName)
+            try contents.encode("true", forKey: .projectIsPackage)
+            try contents.encode(path, forKey: .path)
+            try contents.encode(projectDirectory, forKey: .projectDirectory)
+            try contents.encode(developmentRegion, forKey: .developmentRegion)
+            try contents.encode("Release", forKey: .defaultConfigurationName)
+            try contents.encode(buildConfigurations, forKey: .buildConfigurations)
+
+            if encoder.userInfo.keys.contains(.preservePIFModelStructure) {
+                try contents.encode(targets, forKey: .targets)
+            } else {
+                try contents.encode(targets.map{ $0.signature }, forKey: .targets)
+            }
+
+            try contents.encode(groupTree, forKey: .groupTree)
+        }
+
+        public required init(from decoder: Decoder) throws {
+            let superContainer = try decoder.container(keyedBy: StringKey.self)
+            let container = try superContainer.nestedContainer(keyedBy: CodingKeys.self, forKey: "contents")
+
+            let guidString = try container.decode(GUID.self, forKey: .guid)
+            self.guid = String(guidString.dropLast("\(schemaVersion)".count + 1))
+            self.name = try container.decode(String.self, forKey: .projectName)
+            self.path = try container.decode(AbsolutePath.self, forKey: .path)
+            self.projectDirectory = try container.decode(AbsolutePath.self, forKey: .projectDirectory)
+            self.developmentRegion = try container.decode(String.self, forKey: .developmentRegion)
+            self.buildConfigurations = try container.decode([BuildConfiguration].self, forKey: .buildConfigurations)
+
+            let untypedTargets = try container.decode([UntypedTarget].self, forKey: .targets)
+            var targetContainer = try container.nestedUnkeyedContainer(forKey: .targets)
+            self.targets = try untypedTargets.map { target in
+                let type = target.contents.type
+                switch type {
+                case "aggregate":
+                    return try targetContainer.decode(AggregateTarget.self)
+                case "standard", "packageProduct":
+                    return try targetContainer.decode(Target.self)
+                default:
+                    fatalError("unknown target type \(type)")
+                }
+            }
+
+            self.groupTree = try container.decode(Group.self, forKey: .groupTree)
+            try super.init(from: decoder)
         }
     }
 
     /// Abstract base class for all items in the group hierarhcy.
     public class Reference: TypedObject {
-
         /// Determines the base path for a reference's relative path.
-        public enum SourceTree: String, Encodable {
+        public enum SourceTree: String, Codable {
 
             /// Indicates that the path is relative to the source root (i.e. the "project directory").
             case sourceRoot = "SOURCE_ROOT"
@@ -236,15 +313,29 @@ public enum PIF {
             self.path = path
             self.sourceTree = sourceTree
             self.name = name
+            super.init()
+        }
+
+        private enum CodingKeys: CodingKey {
+            case guid, sourceTree, path, name, type
         }
 
         public override func encode(to encoder: Encoder) throws {
             try super.encode(to: encoder)
-            var container = encoder.container(keyedBy: StringKey.self)
-            try container.encode(guid, forKey: "guid")
-            try container.encode(sourceTree, forKey: "sourceTree")
-            try container.encode(path, forKey: "path")
-            try container.encode(name ?? path, forKey: "name")
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(guid, forKey: .guid)
+            try container.encode(sourceTree, forKey: .sourceTree)
+            try container.encode(path, forKey: .path)
+            try container.encode(name ?? path, forKey: .name)
+        }
+
+        public required init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.guid = try container.decode(String.self, forKey: .guid)
+            self.sourceTree = try container.decode(SourceTree.self, forKey: .sourceTree)
+            self.path = try container.decode(String.self, forKey: .path)
+            self.name = try container.decodeIfPresent(String.self, forKey: .name)
+            try super.init(from: decoder)
         }
     }
 
@@ -265,10 +356,20 @@ public enum PIF {
             super.init(guid: guid, path: path, sourceTree: sourceTree, name: name)
         }
 
+        private enum CodingKeys: CodingKey {
+            case fileType
+        }
+
         public override func encode(to encoder: Encoder) throws {
             try super.encode(to: encoder)
-            var container = encoder.container(keyedBy: StringKey.self)
-            try container.encode(fileType, forKey: "fileType")
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(fileType, forKey: .fileType)
+        }
+
+        public required init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.fileType = try container.decode(String.self, forKey: .fileType)
+            try super.init(from: decoder)
         }
     }
 
@@ -296,15 +397,39 @@ public enum PIF {
             super.init(guid: guid, path: path, sourceTree: sourceTree, name: name)
         }
 
+        private enum CodingKeys: CodingKey {
+            case children, type
+        }
+
         public override func encode(to encoder: Encoder) throws {
             try super.encode(to: encoder)
-            var container = encoder.container(keyedBy: StringKey.self)
-            try container.encode(children, forKey: "children")
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(children, forKey: .children)
+        }
+
+        public required init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            let untypedChildren = try container.decode([TypedObject].self, forKey: .children)
+            var childrenContainer = try container.nestedUnkeyedContainer(forKey: .children)
+
+            self.children = try untypedChildren.map { child in
+                switch child.type {
+                case Group.type:
+                    return try childrenContainer.decode(Group.self)
+                case FileReference.type:
+                    return try childrenContainer.decode(FileReference.self)
+                default:
+                    fatalError("unknown reference type \(child.type ?? "<nil>")")
+                }
+            }
+
+            try super.init(from: decoder)
         }
     }
 
     /// Represents a dependency on another target (identified by its PIF GUID).
-    public struct TargetDependency: Encodable {
+    public struct TargetDependency: Codable {
         /// Identifier of depended-upon target.
         public var targetGUID: String
 
@@ -316,19 +441,30 @@ public enum PIF {
             self.platformFilters = platformFilters
         }
 
+        private enum CodingKeys: CodingKey {
+            case guid, platformFilters
+        }
+
         public func encode(to encoder: Encoder) throws {
-            var container = encoder.container(keyedBy: StringKey.self)
-            try container.encode("\(targetGUID)@\(schemaVersion)", forKey: "guid")
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("\(targetGUID)@\(schemaVersion)", forKey: .guid)
 
             if !platformFilters.isEmpty {
-                try container.encode(platformFilters, forKey: "platformFilters")
+                try container.encode(platformFilters, forKey: .platformFilters)
             }
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            let targetGUIDString = try container.decode(String.self, forKey: .guid)
+            self.targetGUID = String(targetGUIDString.dropLast("\(schemaVersion)".count + 1))
+            platformFilters = try container.decodeIfPresent([PlatformFilter].self, forKey: .platformFilters) ?? []
         }
     }
 
     public class BaseTarget: SignedObject {
         class override var type: String { "target" }
-
         public let guid: GUID
         public let name: String
         public let buildConfigurations: [BuildConfiguration]
@@ -350,6 +486,11 @@ public enum PIF {
             self.buildPhases = buildPhases
             self.dependencies = dependencies
             impartedBuildProperties = ImpartedBuildProperties(settings: impartedBuildSettings)
+            super.init()
+        }
+
+        public required init(from decoder: Decoder) throws {
+            fatalError("init(from:) has not been implemented")
         }
     }
 
@@ -372,23 +513,60 @@ public enum PIF {
             )
         }
 
+        private enum CodingKeys: CodingKey {
+            case type, guid, name, buildConfigurations, buildPhases, dependencies, impartedBuildProperties
+        }
+
         public override func encode(to encoder: Encoder) throws {
             try super.encode(to: encoder)
             var container = encoder.container(keyedBy: StringKey.self)
-            var contents = container.nestedContainer(keyedBy: StringKey.self, forKey: "contents")
-            try contents.encode("aggregate", forKey: "type")
-            try contents.encode("\(guid)@\(schemaVersion)", forKey: "guid")
-            try contents.encode(name, forKey: "name")
-            try contents.encode(buildConfigurations, forKey: "buildConfigurations")
-            try contents.encode(buildPhases, forKey: "buildPhases")
-            try contents.encode(dependencies, forKey: "dependencies")
-            try contents.encode(impartedBuildProperties, forKey: "impartedBuildProperties")
+            var contents = container.nestedContainer(keyedBy: CodingKeys.self, forKey: "contents")
+            try contents.encode("aggregate", forKey: .type)
+            try contents.encode("\(guid)@\(schemaVersion)", forKey: .guid)
+            try contents.encode(name, forKey: .name)
+            try contents.encode(buildConfigurations, forKey: .buildConfigurations)
+            try contents.encode(buildPhases, forKey: .buildPhases)
+            try contents.encode(dependencies, forKey: .dependencies)
+            try contents.encode(impartedBuildProperties, forKey: .impartedBuildProperties)
+        }
+
+        public required init(from decoder: Decoder) throws {
+            let superContainer = try decoder.container(keyedBy: StringKey.self)
+            let container = try superContainer.nestedContainer(keyedBy: CodingKeys.self, forKey: "contents")
+
+            let guidString = try container.decode(GUID.self, forKey: .guid)
+            let guid = String(guidString.dropLast("\(schemaVersion)".count + 1))
+
+            let name = try container.decode(String.self, forKey: .name)
+            let buildConfigurations = try container.decode([BuildConfiguration].self, forKey: .buildConfigurations)
+
+            let untypedBuildPhases = try container.decode([TypedObject].self, forKey: .buildPhases)
+            var buildPhasesContainer = try container.nestedUnkeyedContainer(forKey: .buildPhases)
+
+            let buildPhases: [BuildPhase] = try untypedBuildPhases.map {
+                guard let type = $0.type else {
+                    fatalError("Expected type in build phase \($0)")
+                }
+                return try BuildPhase.decode(container: &buildPhasesContainer, type: type)
+            }
+
+            let dependencies = try container.decode([TargetDependency].self, forKey: .dependencies)
+            let impartedBuildProperties = try container.decode(BuildSettings.self, forKey: .impartedBuildProperties)
+
+            super.init(
+                guid: guid,
+                name: name,
+                buildConfigurations: buildConfigurations,
+                buildPhases: buildPhases,
+                dependencies: dependencies,
+                impartedBuildSettings: impartedBuildProperties
+            )
         }
     }
 
     /// An Xcode target, representing a single entity to build.
     public final class Target: BaseTarget {
-        public enum ProductType: String, Encodable {
+        public enum ProductType: String, Codable {
             case application = "com.apple.product-type.application"
             case staticArchive = "com.apple.product-type.library.static"
             case objectFile = "com.apple.product-type.objfile"
@@ -402,7 +580,6 @@ public enum PIF {
 
         public let productName: String
         public let productType: ProductType
-        public let productReference: FileReference?
 
         public init(
             guid: GUID,
@@ -416,7 +593,6 @@ public enum PIF {
         ) {
             self.productType = productType
             self.productName = productName
-            self.productReference = nil
 
             super.init(
                 guid: guid,
@@ -428,57 +604,140 @@ public enum PIF {
             )
         }
 
+        private enum CodingKeys: CodingKey {
+            case guid, name, dependencies, buildConfigurations, type, frameworksBuildPhase, productTypeIdentifier, productReference, buildRules, buildPhases, impartedBuildProperties
+        }
+
         override public func encode(to encoder: Encoder) throws {
             try super.encode(to: encoder)
             var container = encoder.container(keyedBy: StringKey.self)
-            var contents = container.nestedContainer(keyedBy: StringKey.self, forKey: "contents")
-            try contents.encode("\(guid)@\(schemaVersion)", forKey: "guid")
-            try contents.encode(name, forKey: "name")
-            try contents.encode(dependencies, forKey: "dependencies")
-            try contents.encode(buildConfigurations, forKey: "buildConfigurations")
+            var contents = container.nestedContainer(keyedBy: CodingKeys.self, forKey: "contents")
+            try contents.encode("\(guid)@\(schemaVersion)", forKey: .guid)
+            try contents.encode(name, forKey: .name)
+            try contents.encode(dependencies, forKey: .dependencies)
+            try contents.encode(buildConfigurations, forKey: .buildConfigurations)
 
             if productType == .packageProduct {
-                try contents.encode("packageProduct", forKey: "type")
+                try contents.encode("packageProduct", forKey: .type)
 
                 // Add the framework build phase, if present.
                 if let phase = buildPhases.first as? PIF.FrameworksBuildPhase {
-                    try contents.encode(phase, forKey: "frameworksBuildPhase")
+                    try contents.encode(phase, forKey: .frameworksBuildPhase)
                 }
             } else {
-                try contents.encode("standard", forKey: "type")
-                try contents.encode(productType, forKey: "productTypeIdentifier")
+                try contents.encode("standard", forKey: .type)
+                try contents.encode(productType, forKey: .productTypeIdentifier)
 
                 let productReference = [
                     "type": "file",
                     "guid": "PRODUCTREF-\(guid)",
                     "name": productName,
                 ]
-                try contents.encode(productReference, forKey: "productReference")
+                try contents.encode(productReference, forKey: .productReference)
 
-                try contents.encode([String](), forKey: "buildRules")
-                try contents.encode(buildPhases, forKey: "buildPhases")
-                try contents.encode(impartedBuildProperties, forKey: "impartedBuildProperties")
+                try contents.encode([String](), forKey: .buildRules)
+                try contents.encode(buildPhases, forKey: .buildPhases)
+                try contents.encode(impartedBuildProperties, forKey: .impartedBuildProperties)
             }
+        }
+
+        public required init(from decoder: Decoder) throws {
+            let superContainer = try decoder.container(keyedBy: StringKey.self)
+            let container = try superContainer.nestedContainer(keyedBy: CodingKeys.self, forKey: "contents")
+
+            let guidString = try container.decode(GUID.self, forKey: .guid)
+            let guid = String(guidString.dropLast("\(schemaVersion)".count + 1))
+            let name = try container.decode(String.self, forKey: .name)
+            let buildConfigurations = try container.decode([BuildConfiguration].self, forKey: .buildConfigurations)
+            let dependencies = try container.decode([TargetDependency].self, forKey: .dependencies)
+
+            let type = try container.decode(String.self, forKey: .type)
+
+            let buildPhases: [BuildPhase]
+            let impartedBuildProperties: BuildSettings
+
+            if type == "packageProduct" {
+                self.productType = .packageProduct
+                self.productName = ""
+                let fwkBuildPhase = try container.decodeIfPresent(FrameworksBuildPhase.self, forKey: .frameworksBuildPhase)
+                buildPhases = fwkBuildPhase.map{ [$0] } ?? []
+                impartedBuildProperties = BuildSettings()
+            } else if type == "standard" {
+                self.productType = try container.decode(ProductType.self, forKey: .productTypeIdentifier)
+
+                let productReference = try container.decode([String: String].self, forKey: .productReference)
+                self.productName = productReference["name"]!
+
+                let untypedBuildPhases = try container.decodeIfPresent([TypedObject].self, forKey: .buildPhases) ?? []
+                var buildPhasesContainer = try container.nestedUnkeyedContainer(forKey: .buildPhases)
+
+                buildPhases = try untypedBuildPhases.map {
+                    guard let type = $0.type else {
+                        fatalError("Expected type in build phase \($0)")
+                    }
+                    return try BuildPhase.decode(container: &buildPhasesContainer, type: type)
+                }
+
+                impartedBuildProperties = try container.decode(BuildSettings.self, forKey: .impartedBuildProperties)
+            } else {
+                fatalError("Unhandled target type \(type)")
+            }
+
+            super.init(
+                guid: guid,
+                name: name,
+                buildConfigurations: buildConfigurations,
+                buildPhases: buildPhases,
+                dependencies: dependencies,
+                impartedBuildSettings: impartedBuildProperties
+            )
         }
     }
 
     /// Abstract base class for all build phases in a target.
     public class BuildPhase: TypedObject {
+        static func decode(container: inout UnkeyedDecodingContainer, type: String) throws -> BuildPhase {
+            switch type {
+            case HeadersBuildPhase.type:
+                return try container.decode(HeadersBuildPhase.self)
+            case SourcesBuildPhase.type:
+                return try container.decode(SourcesBuildPhase.self)
+            case FrameworksBuildPhase.type:
+                return try container.decode(FrameworksBuildPhase.self)
+            case ResourcesBuildPhase.type:
+                return try container.decode(ResourcesBuildPhase.self)
+            default:
+                fatalError("unknown build phase \(type)")
+            }
+        }
+
         public let guid: GUID
         public let buildFiles: [BuildFile]
 
-        internal init(guid: GUID, buildFiles: [BuildFile]) {
+        public init(guid: GUID, buildFiles: [BuildFile]) {
             precondition(!guid.isEmpty)
 
             self.guid = guid
             self.buildFiles = buildFiles
+            super.init()
+        }
+
+        private enum CodingKeys: CodingKey {
+            case guid, buildFiles
         }
 
         public override func encode(to encoder: Encoder) throws {
             try super.encode(to: encoder)
-            var container = encoder.container(keyedBy: StringKey.self)
-            try container.encode(guid, forKey: "guid")
-            try container.encode(buildFiles, forKey: "buildFiles")
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(guid, forKey: .guid)
+            try container.encode(buildFiles, forKey: .buildFiles)
+        }
+
+        public required init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.guid = try container.decode(GUID.self, forKey: .guid)
+            self.buildFiles = try container.decode([BuildFile].self, forKey: .buildFiles)
+            try super.init(from: decoder)
         }
     }
 
@@ -486,53 +745,37 @@ public enum PIF {
     /// processing.
     public final class HeadersBuildPhase: BuildPhase {
         override class var type: String { "com.apple.buildphase.headers" }
-
-        public override init(guid: GUID, buildFiles: [BuildFile]) {
-            super.init(guid: guid, buildFiles: buildFiles)
-        }
     }
 
     /// A "sources" build phase, i.e. one that compiles sources and provides them to be linked into the executable code
     /// of the product.
     public final class SourcesBuildPhase: BuildPhase {
         override class var type: String { "com.apple.buildphase.sources" }
-
-        public override init(guid: GUID, buildFiles: [BuildFile]) {
-            super.init(guid: guid, buildFiles: buildFiles)
-        }
     }
 
     /// A "frameworks" build phase, i.e. one that links compiled code and libraries into the executable of the product.
     public final class FrameworksBuildPhase: BuildPhase {
         override class var type: String { "com.apple.buildphase.frameworks" }
-
-        public override init(guid: String, buildFiles: [BuildFile]) {
-            super.init(guid: guid, buildFiles: buildFiles)
-        }
     }
 
     public final class ResourcesBuildPhase: BuildPhase {
         override class var type: String { "com.apple.buildphase.resources" }
-
-        public override init(guid: GUID, buildFiles: [BuildFile]) {
-            super.init(guid: guid, buildFiles: buildFiles)
-        }
     }
 
     /// A build file, representing the membership of either a file or target product reference in a build phase.
-    public struct BuildFile: Encodable {
+    public struct BuildFile: Codable {
         public enum Reference {
             case file(guid: PIF.GUID)
             case target(guid: PIF.GUID)
         }
 
-        public enum HeaderVisibility: String {
+        public enum HeaderVisibility: String, Codable {
             case `public` = "public"
             case `private` = "private"
         }
 
         public let guid: GUID
-        public let reference: Reference
+        public var reference: Reference
         public let headerVisibility: HeaderVisibility? = nil
         public let platformFilters: [PlatformFilter]
 
@@ -566,22 +809,42 @@ public enum PIF {
             self.platformFilters = platformFilters
         }
 
+        private enum CodingKeys: CodingKey {
+            case guid, platformFilters, fileReference, targetReference
+        }
+
         public func encode(to encoder: Encoder) throws {
-            var container = encoder.container(keyedBy: StringKey.self)
-            try container.encode(guid, forKey: "guid")
-            try container.encode(platformFilters, forKey: "platformFilters")
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(guid, forKey: .guid)
+            try container.encode(platformFilters, forKey: .platformFilters)
 
             switch self.reference {
             case .file(let fileGUID):
-                try container.encode(fileGUID, forKey: "fileReference")
+                try container.encode(fileGUID, forKey: .fileReference)
             case .target(let targetGUID):
-                try container.encode("\(targetGUID)@\(schemaVersion)", forKey: "targetReference")
+                try container.encode("\(targetGUID)@\(schemaVersion)", forKey: .targetReference)
+            }
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            guid = try container.decode(GUID.self, forKey: .guid)
+            platformFilters = try container.decode([PlatformFilter].self, forKey: .platformFilters)
+
+            if container.allKeys.contains(.fileReference) {
+                reference = try .file(guid: container.decode(GUID.self, forKey: .fileReference))
+            } else if container.allKeys.contains(.targetReference) {
+                let targetGUIDString = try container.decode(GUID.self, forKey: .targetReference)
+                let targetGUID = String(targetGUIDString.dropLast("\(schemaVersion)".count + 1))
+                reference = .file(guid: targetGUID)
+            } else {
+                fatalError("Expected \(CodingKeys.fileReference) or \(CodingKeys.targetReference) in the keys")
             }
         }
     }
 
     /// Represents a generic platform filter.
-    public struct PlatformFilter: Encodable, Equatable {
+    public struct PlatformFilter: Codable, Equatable {
         /// The name of the platform (`LC_BUILD_VERSION`).
         ///
         /// Example: macos, ios, watchos, tvos.
@@ -599,7 +862,7 @@ public enum PIF {
     }
 
     /// A build configuration, which is a named collection of build settings.
-    public struct BuildConfiguration: Encodable {
+    public struct BuildConfiguration: Codable {
         public let guid: GUID
         public let name: String
         public let buildSettings: BuildSettings
@@ -612,32 +875,20 @@ public enum PIF {
             self.name = name
             self.buildSettings = buildSettings
         }
-
-        public func encode(to encoder: Encoder) throws {
-            var container = encoder.container(keyedBy: StringKey.self)
-            try container.encode(guid, forKey: "guid")
-            try container.encode(name, forKey: "name")
-            try container.encode(buildSettings, forKey: "buildSettings")
-        }
     }
 
-    public struct ImpartedBuildProperties: Encodable {
-        public let settings: BuildSettings
+    public struct ImpartedBuildProperties: Codable {
+        public let buildSettings: BuildSettings
 
         public init(settings: BuildSettings) {
-            self.settings = settings
-        }
-
-        public func encode(to encoder: Encoder) throws {
-            var container = encoder.container(keyedBy: StringKey.self)
-            try container.encode(settings, forKey: "buildSettings")
+            self.buildSettings = settings
         }
     }
 
     /// A set of build settings, which is represented as a struct of optional build settings. This is not optimally
     /// efficient, but it is great for code completion and type-checking.
-    public struct BuildSettings: Encodable {
-        public enum SingleValueSetting: String {
+    public struct BuildSettings: Codable {
+        public enum SingleValueSetting: String, Codable {
             case APPLICATION_EXTENSION_API_ONLY
             case BUILT_PRODUCTS_DIR
             case CLANG_CXX_LANGUAGE_STANDARD
@@ -698,7 +949,7 @@ public enum PIF {
             case CURRENT_PROJECT_VERSION
         }
 
-        public enum MultipleValueSetting: String {
+        public enum MultipleValueSetting: String, Codable {
             case EMBED_PACKAGE_RESOURCE_BUNDLE_NAMES
             case FRAMEWORK_SEARCH_PATHS
             case GCC_PREPROCESSOR_DEFINITIONS
@@ -716,7 +967,7 @@ public enum PIF {
             case SWIFT_ACTIVE_COMPILATION_CONDITIONS
         }
 
-        public enum Platform: String, CaseIterable {
+        public enum Platform: String, CaseIterable, Codable {
             case macOS = "macos"
             case iOS = "ios"
             case tvOS = "tvos"
@@ -778,7 +1029,19 @@ public enum PIF {
         public init() {
         }
 
+        private enum CodingKeys: CodingKey {
+            case platformSpecificSettings, singleValueSettings, multipleValueSettings
+        }
+
         public func encode(to encoder: Encoder) throws {
+            if encoder.userInfo.keys.contains(.preservePIFModelStructure) {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(platformSpecificSettings, forKey: .platformSpecificSettings)
+                try container.encode(singleValueSettings, forKey: .singleValueSettings)
+                try container.encode(multipleValueSettings, forKey: .multipleValueSettings)
+                return
+            }
+
             var container = encoder.container(keyedBy: StringKey.self)
 
             for (key, value) in singleValueSettings {
@@ -796,6 +1059,14 @@ public enum PIF {
                     }
                 }
             }
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            platformSpecificSettings = try container.decodeIfPresent([Platform: [MultipleValueSetting: [String]]].self, forKey: .platformSpecificSettings) ?? .init()
+            singleValueSettings = try container.decodeIfPresent([SingleValueSetting: String].self, forKey: .singleValueSettings) ?? [:]
+            multipleValueSettings = try container.decodeIfPresent([MultipleValueSetting: [String]] .self, forKey: .multipleValueSettings) ?? [:]
         }
     }
 }
@@ -916,4 +1187,14 @@ extension PIF.FileReference {
 
 extension CodingUserInfoKey {
     public static let encodingPIFSignature: CodingUserInfoKey = CodingUserInfoKey(rawValue: "encodingPIFSignature")!
+
+    /// Preserve the internal structure of the PIF types which enables decoding.
+    public static let preservePIFModelStructure: CodingUserInfoKey = CodingUserInfoKey(rawValue: "preserveInternalStructure")!
+}
+
+private struct UntypedTarget: Decodable {
+    struct TargetContents: Decodable {
+        let type: String
+    }
+    let contents: TargetContents
 }

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -76,7 +76,10 @@ public final class PIFBuilder {
     /// - Parameters:
     ///   - prettyPrint: Whether to return a formatted JSON.
     /// - Returns: The package graph in the JSON PIF format.
-    public func generatePIF(prettyPrint: Bool = true) throws -> String {
+    public func generatePIF(
+        prettyPrint: Bool = true,
+        preservePIFModelStructure: Bool = false
+    ) throws -> String {
         let encoder = JSONEncoder()
         if prettyPrint {
             encoder.outputFormatting = .prettyPrinted
@@ -85,6 +88,10 @@ public final class PIFBuilder {
                 encoder.outputFormatting.insert(.sortedKeys)
             }
           #endif
+        }
+
+        if preservePIFModelStructure {
+            encoder.userInfo[.preservePIFModelStructure] = true
         }
 
         let topLevelObject = construct()
@@ -273,7 +280,9 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         PlatformRegistry.default.knownPlatforms.forEach {
             guard let platform = PIF.BuildSettings.Platform.from(platform: $0) else { return }
             guard let supportedPlatform = firstTarget?.getSupportedPlatform(for: $0) else { return }
-            settings[.SPECIALIZATION_SDK_OPTIONS, for: platform] = supportedPlatform.options
+            if !supportedPlatform.options.isEmpty {
+                settings[.SPECIALIZATION_SDK_OPTIONS, for: platform] = supportedPlatform.options
+            }
         }
 
         // Disable signing for all the things since there is no way to configure

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -193,7 +193,7 @@ class PIFBuilderTests: XCTestCase {
                         }
 
                         for platform in PIF.BuildSettings.Platform.allCases {
-                            XCTAssertEqual(settings[.SPECIALIZATION_SDK_OPTIONS, for: platform], [])
+                            XCTAssertEqual(settings[.SPECIALIZATION_SDK_OPTIONS, for: platform], nil)
                         }
                     }
                 }
@@ -236,7 +236,7 @@ class PIFBuilderTests: XCTestCase {
                         }
 
                         for platform in PIF.BuildSettings.Platform.allCases {
-                            XCTAssertEqual(settings[.SPECIALIZATION_SDK_OPTIONS, for: platform], [])
+                            XCTAssertEqual(settings[.SPECIALIZATION_SDK_OPTIONS, for: platform], nil)
                         }
                     }
                 }
@@ -291,7 +291,7 @@ class PIFBuilderTests: XCTestCase {
                         }
 
                         for platform in PIF.BuildSettings.Platform.allCases {
-                            XCTAssertEqual(settings[.SPECIALIZATION_SDK_OPTIONS, for: platform], [])
+                            XCTAssertEqual(settings[.SPECIALIZATION_SDK_OPTIONS, for: platform], nil)
                         }
                     }
                 }
@@ -334,7 +334,7 @@ class PIFBuilderTests: XCTestCase {
                         }
 
                         for platform in PIF.BuildSettings.Platform.allCases {
-                            XCTAssertEqual(settings[.SPECIALIZATION_SDK_OPTIONS, for: platform], [])
+                            XCTAssertEqual(settings[.SPECIALIZATION_SDK_OPTIONS, for: platform], nil)
                         }
                     }
                 }

--- a/Tests/XCBuildSupportTests/PIFTests.swift
+++ b/Tests/XCBuildSupportTests/PIFTests.swift
@@ -17,178 +17,202 @@ import XCBuildSupport
 import SPMTestSupport
 
 class PIFTests: XCTestCase {
-    func testEncodable() throws {
-        let topLevelObject = PIF.TopLevelObject(workspace:
-            PIF.Workspace(
-                guid: "workspace",
-                name: "MyWorkspace",
-                path: AbsolutePath("/path/to/workspace"),
-                projects: [
-                    PIF.Project(
-                        guid: "project",
-                        name: "MyProject",
-                        path: AbsolutePath("/path/to/workspace/project"),
-                        projectDirectory: AbsolutePath("/path/to/workspace/project"),
-                        developmentRegion: "fr",
-                        buildConfigurations: [
-                            PIF.BuildConfiguration(
-                                guid: "project-config-debug-guid",
-                                name: "Debug",
-                                buildSettings: {
-                                    var settings = PIF.BuildSettings()
-                                    settings[.PRODUCT_NAME] = "$(TARGET_NAME)"
-                                    settings[.SUPPORTED_PLATFORMS] = ["$(AVAILABLE_PLATFORMS)"]
-                                    return settings
-                                }()
-                            ),
-                            PIF.BuildConfiguration(
-                                guid: "project-config-release-guid",
-                                name: "Release",
-                                buildSettings: {
-                                    var settings = PIF.BuildSettings()
-                                    settings[.PRODUCT_NAME] = "$(TARGET_NAME)"
-                                    settings[.SUPPORTED_PLATFORMS] = ["$(AVAILABLE_PLATFORMS)"]
-                                    settings[.GCC_OPTIMIZATION_LEVEL] = "s"
-                                    return settings
-                                }()
-                            ),
-                        ],
-                        targets: [
-                            PIF.Target(
-                                guid: "target-exe-guid",
-                                name: "MyExecutable",
-                                productType: .executable,
-                                productName: "MyExecutable",
-                                buildConfigurations: [
-                                    PIF.BuildConfiguration(
-                                        guid: "target-exe-config-debug-guid",
-                                        name: "Debug",
-                                        buildSettings: {
-                                            var settings = PIF.BuildSettings()
-                                            settings[.TARGET_NAME] = "MyExecutable"
-                                            settings[.EXECUTABLE_NAME] = "my-exe"
-                                            return settings
-                                        }()
-                                    ),
-                                    PIF.BuildConfiguration(
-                                        guid: "target-exe-config-release-guid",
-                                        name: "Release",
-                                        buildSettings: {
-                                            var settings = PIF.BuildSettings()
-                                            settings[.TARGET_NAME] = "MyExecutable"
-                                            settings[.EXECUTABLE_NAME] = "my-exe"
-                                            settings[.SKIP_INSTALL] = "NO"
-                                            return settings
-                                        }()
-                                    ),
-                                ],
-                                buildPhases: [
-                                    PIF.SourcesBuildPhase(
-                                        guid: "target-exe-sources-build-phase-guid",
-                                        buildFiles: [
-                                            PIF.BuildFile(
-                                                guid: "target-exe-sources-build-file-guid",
-                                                fileGUID: "exe-file-guid",
-                                                platformFilters: []
-                                            )
-                                        ]
-                                    ),
-                                    PIF.FrameworksBuildPhase(
-                                        guid: "target-exe-frameworks-build-phase-guid",
-                                        buildFiles: [
-                                            PIF.BuildFile(
-                                                guid: "target-exe-frameworks-build-file-guid",
-                                                targetGUID: "target-lib-guid",
-                                                platformFilters: []
-                                            )
-                                        ]
-                                    )
-                                ],
-                                dependencies: [
-                                    .init(targetGUID: "target-lib-guid")
-                                ],
-                                impartedBuildSettings: PIF.BuildSettings()
-                            ),
-                            PIF.Target(
-                                guid: "target-lib-guid",
-                                name: "MyLibrary",
-                                productType: .objectFile,
-                                productName: "MyLibrary",
-                                buildConfigurations: [
-                                    PIF.BuildConfiguration(
-                                        guid: "target-lib-config-debug-guid",
-                                        name: "Debug",
-                                        buildSettings: {
-                                            var settings = PIF.BuildSettings()
-                                            settings[.TARGET_NAME] = "MyLibrary-Debug"
-                                            return settings
-                                        }()
-                                    ),
-                                    PIF.BuildConfiguration(
-                                        guid: "target-lib-config-release-guid",
-                                        name: "Release",
-                                        buildSettings: {
-                                            var settings = PIF.BuildSettings()
-                                            settings[.TARGET_NAME] = "MyLibrary"
-                                            return settings
-                                        }()
-                                    ),
-                                ],
-                                buildPhases: [
-                                    PIF.SourcesBuildPhase(
-                                        guid: "target-lib-sources-build-phase-guid",
-                                        buildFiles: [
-                                            PIF.BuildFile(
-                                                guid: "target-lib-sources-build-file-guid",
-                                                fileGUID: "lib-file-guid",
-                                                platformFilters: []
-                                            )
-                                        ]
-                                    )
-                                ],
-                                dependencies: [],
-                                impartedBuildSettings: {
-                                    var settings = PIF.BuildSettings()
-                                    settings[.OTHER_CFLAGS] = ["-fmodule-map-file=modulemap", "$(inherited)"]
-                                    return settings
-                                }()
-                            ),
-                            PIF.AggregateTarget(
-                                guid: "aggregate-target-guid",
-                                name: "AggregateLibrary",
-                                buildConfigurations: [
-                                    PIF.BuildConfiguration(
-                                        guid: "aggregate-target-config-debug-guid",
-                                        name: "Debug",
-                                        buildSettings: PIF.BuildSettings()
-                                    ),
-                                    PIF.BuildConfiguration(
-                                        guid: "aggregate-target-config-release-guid",
-                                        name: "Release",
-                                        buildSettings: PIF.BuildSettings()
-                                    ),
-                                ],
-                                buildPhases: [],
-                                dependencies: [
-                                    .init(targetGUID: "target-lib-guid"),
-                                    .init(targetGUID: "target-exe-guid"),
-                                ],
-                                impartedBuildSettings: {
-                                    var settings = PIF.BuildSettings()
-                                    settings[.OTHER_CFLAGS] = ["-fmodule-map-file=modulemap", "$(inherited)"]
-                                    return settings
-                                }()
-                            )
-                        ],
-                        groupTree: PIF.Group(guid: "main-group-guid", path: "", children: [
-                            PIF.FileReference(guid: "exe-file-guid", path: "main.swift"),
-                            PIF.FileReference(guid: "lib-file-guid", path: "lib.swift"),
-                        ])
-                    )
-                ]
-            )
+    let topLevelObject = PIF.TopLevelObject(workspace:
+        PIF.Workspace(
+            guid: "workspace",
+            name: "MyWorkspace",
+            path: AbsolutePath("/path/to/workspace"),
+            projects: [
+                PIF.Project(
+                    guid: "project",
+                    name: "MyProject",
+                    path: AbsolutePath("/path/to/workspace/project"),
+                    projectDirectory: AbsolutePath("/path/to/workspace/project"),
+                    developmentRegion: "fr",
+                    buildConfigurations: [
+                        PIF.BuildConfiguration(
+                            guid: "project-config-debug-guid",
+                            name: "Debug",
+                            buildSettings: {
+                                var settings = PIF.BuildSettings()
+                                settings[.PRODUCT_NAME] = "$(TARGET_NAME)"
+                                settings[.SUPPORTED_PLATFORMS] = ["$(AVAILABLE_PLATFORMS)"]
+                                return settings
+                            }()
+                        ),
+                        PIF.BuildConfiguration(
+                            guid: "project-config-release-guid",
+                            name: "Release",
+                            buildSettings: {
+                                var settings = PIF.BuildSettings()
+                                settings[.PRODUCT_NAME] = "$(TARGET_NAME)"
+                                settings[.SUPPORTED_PLATFORMS] = ["$(AVAILABLE_PLATFORMS)"]
+                                settings[.GCC_OPTIMIZATION_LEVEL] = "s"
+                                return settings
+                            }()
+                        ),
+                    ],
+                    targets: [
+                        PIF.Target(
+                            guid: "target-exe-guid",
+                            name: "MyExecutable",
+                            productType: .executable,
+                            productName: "MyExecutable",
+                            buildConfigurations: [
+                                PIF.BuildConfiguration(
+                                    guid: "target-exe-config-debug-guid",
+                                    name: "Debug",
+                                    buildSettings: {
+                                        var settings = PIF.BuildSettings()
+                                        settings[.TARGET_NAME] = "MyExecutable"
+                                        settings[.EXECUTABLE_NAME] = "my-exe"
+                                        return settings
+                                    }()
+                                ),
+                                PIF.BuildConfiguration(
+                                    guid: "target-exe-config-release-guid",
+                                    name: "Release",
+                                    buildSettings: {
+                                        var settings = PIF.BuildSettings()
+                                        settings[.TARGET_NAME] = "MyExecutable"
+                                        settings[.EXECUTABLE_NAME] = "my-exe"
+                                        settings[.SKIP_INSTALL] = "NO"
+                                        return settings
+                                    }()
+                                ),
+                            ],
+                            buildPhases: [
+                                PIF.SourcesBuildPhase(
+                                    guid: "target-exe-sources-build-phase-guid",
+                                    buildFiles: [
+                                        PIF.BuildFile(
+                                            guid: "target-exe-sources-build-file-guid",
+                                            fileGUID: "exe-file-guid",
+                                            platformFilters: []
+                                        )
+                                    ]
+                                ),
+                                PIF.FrameworksBuildPhase(
+                                    guid: "target-exe-frameworks-build-phase-guid",
+                                    buildFiles: [
+                                        PIF.BuildFile(
+                                            guid: "target-exe-frameworks-build-file-guid",
+                                            targetGUID: "target-lib-guid",
+                                            platformFilters: []
+                                        )
+                                    ]
+                                )
+                            ],
+                            dependencies: [
+                                .init(targetGUID: "target-lib-guid")
+                            ],
+                            impartedBuildSettings: PIF.BuildSettings()
+                        ),
+                        PIF.Target(
+                            guid: "target-lib-guid",
+                            name: "MyLibrary",
+                            productType: .objectFile,
+                            productName: "MyLibrary",
+                            buildConfigurations: [
+                                PIF.BuildConfiguration(
+                                    guid: "target-lib-config-debug-guid",
+                                    name: "Debug",
+                                    buildSettings: {
+                                        var settings = PIF.BuildSettings()
+                                        settings[.TARGET_NAME] = "MyLibrary-Debug"
+                                        return settings
+                                    }()
+                                ),
+                                PIF.BuildConfiguration(
+                                    guid: "target-lib-config-release-guid",
+                                    name: "Release",
+                                    buildSettings: {
+                                        var settings = PIF.BuildSettings()
+                                        settings[.TARGET_NAME] = "MyLibrary"
+                                        return settings
+                                    }()
+                                ),
+                            ],
+                            buildPhases: [
+                                PIF.SourcesBuildPhase(
+                                    guid: "target-lib-sources-build-phase-guid",
+                                    buildFiles: [
+                                        PIF.BuildFile(
+                                            guid: "target-lib-sources-build-file-guid",
+                                            fileGUID: "lib-file-guid",
+                                            platformFilters: []
+                                        )
+                                    ]
+                                )
+                            ],
+                            dependencies: [],
+                            impartedBuildSettings: {
+                                var settings = PIF.BuildSettings()
+                                settings[.OTHER_CFLAGS] = ["-fmodule-map-file=modulemap", "$(inherited)"]
+                                return settings
+                            }()
+                        ),
+                        PIF.AggregateTarget(
+                            guid: "aggregate-target-guid",
+                            name: "AggregateLibrary",
+                            buildConfigurations: [
+                                PIF.BuildConfiguration(
+                                    guid: "aggregate-target-config-debug-guid",
+                                    name: "Debug",
+                                    buildSettings: PIF.BuildSettings()
+                                ),
+                                PIF.BuildConfiguration(
+                                    guid: "aggregate-target-config-release-guid",
+                                    name: "Release",
+                                    buildSettings: PIF.BuildSettings()
+                                ),
+                            ],
+                            buildPhases: [],
+                            dependencies: [
+                                .init(targetGUID: "target-lib-guid"),
+                                .init(targetGUID: "target-exe-guid"),
+                            ],
+                            impartedBuildSettings: {
+                                var settings = PIF.BuildSettings()
+                                settings[.OTHER_CFLAGS] = ["-fmodule-map-file=modulemap", "$(inherited)"]
+                                return settings
+                            }()
+                        )
+                    ],
+                    groupTree: PIF.Group(guid: "main-group-guid", path: "", children: [
+                        PIF.FileReference(guid: "exe-file-guid", path: "main.swift"),
+                        PIF.FileReference(guid: "lib-file-guid", path: "lib.swift"),
+                    ])
+                )
+            ]
         )
+    )
 
+    func testRoundTrip() throws {
+      #if os(macOS)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        if #available(macOS 10.13, *) {
+            encoder.outputFormatting.insert(.sortedKeys)
+        }
+
+        encoder.userInfo[.preservePIFModelStructure] = true
+
+        let workspace = topLevelObject.workspace
+        let encodedData = try encoder.encode(workspace)
+        let decodedWorkspace = try JSONDecoder().decode(PIF.Workspace.self, from: encodedData)
+
+        encoder.userInfo = [:]
+        let originalPIF = try encoder.encode(workspace)
+        let decodedPIF = try encoder.encode(decodedWorkspace)
+        let originalString = String(data: originalPIF, encoding: .utf8)!
+        let decodedString = String(data: decodedPIF, encoding: .utf8)!
+
+        XCTAssertEqual(originalString, decodedString)
+      #endif
+    }
+
+    func testEncodable() throws {
         let data = try JSONEncoder().encode(topLevelObject)
         let json = try JSON(data: data)
 


### PR DESCRIPTION
This adds support for Decoding PIF types. The encoder uses
a CodingUserInfoKey named `preservePIFModelStructure` to preseve the
structure that makes it easier to decode the model vs encoding it for
xcbuild consumption.