### PR TITLE
[XCBuildSupport] Preserve PIF structure in default encoding

### DIFF
--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -90,8 +90,8 @@ public final class PIFBuilder {
           #endif
         }
 
-        if preservePIFModelStructure {
-            encoder.userInfo[.preservePIFModelStructure] = true
+        if !preservePIFModelStructure {
+            encoder.userInfo[.encodeForXCBuild] = true
         }
 
         let topLevelObject = construct()

--- a/Tests/XCBuildSupportTests/PIFTests.swift
+++ b/Tests/XCBuildSupportTests/PIFTests.swift
@@ -196,13 +196,11 @@ class PIFTests: XCTestCase {
             encoder.outputFormatting.insert(.sortedKeys)
         }
 
-        encoder.userInfo[.preservePIFModelStructure] = true
-
         let workspace = topLevelObject.workspace
         let encodedData = try encoder.encode(workspace)
         let decodedWorkspace = try JSONDecoder().decode(PIF.Workspace.self, from: encodedData)
 
-        encoder.userInfo = [:]
+        encoder.userInfo[.encodeForXCBuild] = true
         let originalPIF = try encoder.encode(workspace)
         let decodedPIF = try encoder.encode(decodedWorkspace)
         let originalString = String(data: originalPIF, encoding: .utf8)!
@@ -213,7 +211,9 @@ class PIFTests: XCTestCase {
     }
 
     func testEncodable() throws {
-        let data = try JSONEncoder().encode(topLevelObject)
+        let encoder = JSONEncoder()
+        encoder.userInfo[.encodeForXCBuild] = true
+        let data = try encoder.encode(topLevelObject)
         let json = try JSON(data: data)
 
         guard case .array(let objects) = json else {


### PR DESCRIPTION
This just flips the encoding from encoding for XCBuild consumption by
default to encoding the internal structure by default. This is a little
better as clients don't need to worry about providing the right user
info in the normal case of preserving the internal model.