### PR TITLE
[SR-12553] [ManifestLoader] Capture JSON output from a manifest on a separate pipe than stdout

### DIFF
--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -368,16 +368,14 @@ public final class Package {
     private func registerExitHandler() {
         // Add a custom exit handler to cause the package's JSON representation
         // to be dumped at exit, if requested.  Emitting it to a separate file
-        // descriptor keeps any of the manifest's stdout output from interfering
-        // with it.
+        // keeps any of the manifest's stdout output from interfering with it.
         //
         // FIXME: This doesn't belong here, but for now is the mechanism we use
         // to get the interpreter to dump the package when attempting to load a
         // manifest.
-        if CommandLine.argc > 0,
-            let fileNoOptIndex = CommandLine.arguments.firstIndex(of: "-fileno"),
-           let fileNo = Int32(CommandLine.arguments[fileNoOptIndex + 1]) {
-            dumpPackageAtExit(self, fileNo: fileNo)
+        if let optIdx = CommandLine.arguments.firstIndex(of: "-json-output-file") {
+            let jsonOutputFilePath = CommandLine.arguments[optIdx + 1]
+            dumpPackageAtExit(self, to: jsonOutputFilePath)
         }
     }
 }
@@ -623,14 +621,14 @@ func manifestToJSON(_ package: Package) -> String {
 }
 
 var errors: [String] = []
-private var dumpInfo: (package: Package, fileNo: Int32)?
-private func dumpPackageAtExit(_ package: Package, fileNo: Int32) {
+private var dumpInfo: (package: Package, path: String)?
+private func dumpPackageAtExit(_ package: Package, to path: String) {
     func dump() {
         guard let dumpInfo = dumpInfo else { return }
-        guard let fd = fdopen(dumpInfo.fileNo, "w") else { return }
+        guard let fd = fopen(dumpInfo.path, "w") else { return }
         fputs(manifestToJSON(dumpInfo.package), fd)
         fclose(fd)
     }
-    dumpInfo = (package, fileNo)
+    dumpInfo = (package, path)
     atexit(dump)
 }

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -366,8 +366,10 @@ public final class Package {
   #endif
 
     private func registerExitHandler() {
-        // Add a custom exit handler to cause the package to be dumped at exit, if
-        // requested.
+        // Add a custom exit handler to cause the package's JSON representation
+        // to be dumped at exit, if requested.  Emitting it to a separate file
+        // descriptor keeps any of the manifest's stdout output from interfering
+        // with it.
         //
         // FIXME: This doesn't belong here, but for now is the mechanism we use
         // to get the interpreter to dump the package when attempting to load a

--- a/Tests/PackageLoadingTests/PD5LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5LoadingTests.swift
@@ -487,4 +487,21 @@ class PackageDescription5LoadingTests: PackageDescriptionLoadingTests {
             XCTAssertMatch(message, .contains("was introduced in PackageDescription 5.2"))
         }
     }
+
+    func testManifestWithPrintStatements() {
+        let stream = BufferedOutputByteStream()
+        stream <<< """
+            import PackageDescription
+            print(String(repeating: "Hello manifest... ", count: 65536))
+            let package = Package(
+                name: "PackageWithChattyManifest"
+            )
+            """
+        loadManifest(stream.bytes) { manifest in
+            XCTAssertEqual(manifest.name, "PackageWithChattyManifest")
+            XCTAssertEqual(manifest.toolsVersion, .v5)
+            XCTAssertEqual(manifest.targets, [])
+            XCTAssertEqual(manifest.dependencies, [])
+        }
+    }
 }


### PR DESCRIPTION
Manifests can emit output to stdout (useful for debugging purposes).  When switching from an interpreted to a compiled manifest, this output was no longer captured; and more seriously, if enough stdout output was emitted to fill the stdout buffer (or if buffering was disabled), the stdout output would interfere with the emitted JSON.

This change causes the JSON to again be emitted on a separate channel from the stdout, as it was when the manifest was interpreted.