### PR TITLE
Don't use force unwrap in the generated bundle accessor for resource bundles

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -587,7 +587,11 @@ public final class SwiftTargetBuildDescription {
 
         extension Foundation.Bundle {
             static var module: Bundle = {
-                return Bundle(path: Bundle.main.bundlePath + "/" + "\(bundleBasename)")!
+                let bundlePath = Bundle.main.bundlePath + "/" + "\(bundleBasename)"
+                guard let bundle = Bundle(path: bundlePath) else {
+                    fatalError("could not load resource bundle: \\(bundlePath)")
+                }
+                return bundle
             }()
         }
         """


### PR DESCRIPTION
When the generated code to load a resource bundle can't find the bundle, it should emit a fatal error rather than crashing the process with a force-unwrap.

I don't see any tests that check that we properly have a fatal error when the bundle can't be loaded at runtime.  Perhaps we should add one?