### PR TITLE
Add link to PackageDescription API to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For extensive documentation on using Swift Package Manager, creating packages, a
 
 For additional documentation on developing the Swift Package Manager itself, see [Documentation/Development](Documentation/Development.md).
 
-For detailed documentation on the package manifest API, see [PackageDescription API](https://docs.swift.org/package-manager/PackageDescription/index.html)
+For detailed documentation on the package manifest API, see [PackageDescription API](https://docs.swift.org/package-manager/PackageDescription/index.html).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ For extensive documentation on using Swift Package Manager, creating packages, a
 
 For additional documentation on developing the Swift Package Manager itself, see [Documentation/Development](Documentation/Development.md).
 
+For detailed documentation on the package manifest API, see [PackageDescription API](https://docs.swift.org/package-manager/PackageDescription/index.html)
+
 ---
 
 ## System Requirements


### PR DESCRIPTION
I don't think this link is present anywhere else in the repository, but it can be tremendously useful to users when working with Package.swift files.