### PR TITLE
[5.3] [SR-12553] [ManifestLoader] Capture JSON output from a manifest separately from the stdout

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -566,8 +566,8 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
             try withTemporaryDirectory(removeTreeOnDeinit: true) { tmpDir in
                 // Set path to compiled manifest executable.
-                let file = tmpDir.appending(components: "\(packageIdentity)-manifest")
-                cmd += ["-o", file.pathString]
+                let compiledManifestFile = tmpDir.appending(component: "\(packageIdentity)-manifest")
+                cmd += ["-o", compiledManifestFile.pathString]
 
                 // Compile the manifest.
                 let compilerResult = try Process.popen(arguments: cmd)
@@ -578,9 +578,10 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                 if compilerResult.exitStatus != .terminated(code: 0) {
                     return
                 }
-
-                // Pass the fd in arguments.
-                cmd = [file.pathString, "-fileno", "1"]
+                
+                // Pass the path of a file to which the JSON representation of the manifest will be written.
+                let jsonOutputFile = tmpDir.appending(component: "\(packageIdentity)-output.json")
+                cmd = [compiledManifestFile.pathString, "-json-output-file", jsonOutputFile.pathString]
 
               #if os(macOS)
                 // If enabled, use sandbox-exec on macOS. This provides some safety against
@@ -596,9 +597,13 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                 }
               #endif
 
-                // Run the command.
+                // Run the compiled manifest.
                 let runResult = try Process.popen(arguments: cmd)
                 let runOutput = try (runResult.utf8Output() + runResult.utf8stderrOutput()).spm_chuzzle()
+                if let runOutput = runOutput {
+                    // Append the runtime output to any compiler output we've received.
+                    manifestParseResult.compilerOutput = (manifestParseResult.compilerOutput ?? "") + runOutput
+                }
 
                 // Return now if there was an error.
                 if runResult.exitStatus != .terminated(code: 0) {
@@ -606,7 +611,11 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                     return
                 }
 
-                manifestParseResult.parsedManifest = runOutput
+                // Read the JSON output that was emitted by libPackageDescription.
+                guard let jsonOutput = try localFileSystem.readFileContents(jsonOutputFile).validDescription else {
+                    throw StringError("the manifest's JSON output has invalid encoding")
+                }
+                manifestParseResult.parsedManifest = jsonOutput
             }
         }
 

--- a/Tests/PackageLoadingTests/PD5LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5LoadingTests.swift
@@ -487,4 +487,21 @@ class PackageDescription5LoadingTests: PackageDescriptionLoadingTests {
             XCTAssertMatch(message, .contains("was introduced in PackageDescription 5.2"))
         }
     }
+
+    func testManifestWithPrintStatements() {
+        let stream = BufferedOutputByteStream()
+        stream <<< """
+            import PackageDescription
+            print(String(repeating: "Hello manifest... ", count: 65536))
+            let package = Package(
+                name: "PackageWithChattyManifest"
+            )
+            """
+        loadManifest(stream.bytes) { manifest in
+            XCTAssertEqual(manifest.name, "PackageWithChattyManifest")
+            XCTAssertEqual(manifest.toolsVersion, .v5)
+            XCTAssertEqual(manifest.targets, [])
+            XCTAssertEqual(manifest.dependencies, [])
+        }
+    }
 }


### PR DESCRIPTION
Manifests can emit output to stdout (useful for debugging purposes).  The earlier switch from an interpreted to a compiled manifest caused this output to no longer be captured; and more seriously, if enough stdout output was emitted to fill the stdout buffer (or if buffering was disabled), then the stdout output would interfere with the emitted JSON description of the package manifest.

This change causes the JSON to again be emitted to a separate file so that there is no interference with stdout output, restoring the behavior of when the manifest was interpreted.

There are possible various error conditions that the existing code doesn't handle, and this change doesn't improve on that (it also doesn't make it worse).  A future change should consider making those cases more robust, although it may be of limited practical use, since this is an internal contract between two pieces of code.  However, it would be good to have better diagnostics in the case of I/O errors or other environmental problems.

(cherry picked from commit ab8d72c2ebe887baaf29d0e3115e45a02c8359bc)