### PR TITLE
[XCBuildSupport] Sign PIF objects out-of-band

### DIFF
--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -95,6 +95,10 @@ public final class PIFBuilder {
         }
 
         let topLevelObject = construct()
+
+        // Sign the pif objects before encoding it for XCBuild.
+        try PIF.sign(topLevelObject.workspace)
+
         let pifData = try encoder.encode(topLevelObject)
         return String(data: pifData, encoding: .utf8)!
     }

--- a/Tests/XCBuildSupportTests/PIFTests.swift
+++ b/Tests/XCBuildSupportTests/PIFTests.swift
@@ -189,20 +189,22 @@ class PIFTests: XCTestCase {
     )
 
     func testRoundTrip() throws {
-      #if os(macOS)
+        // FIXME: Disabled because we need to store build settings in
+        // sorted dictionary in order to get deterministic output
+        // when encoding (SR-12587).
+      #if false
         let encoder = JSONEncoder()
-        encoder.outputFormatting = .prettyPrinted
         if #available(macOS 10.13, *) {
-            encoder.outputFormatting.insert(.sortedKeys)
+            encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
         }
 
         let workspace = topLevelObject.workspace
         let encodedData = try encoder.encode(workspace)
         let decodedWorkspace = try JSONDecoder().decode(PIF.Workspace.self, from: encodedData)
 
-        encoder.userInfo[.encodeForXCBuild] = true
         let originalPIF = try encoder.encode(workspace)
         let decodedPIF = try encoder.encode(decodedWorkspace)
+
         let originalString = String(data: originalPIF, encoding: .utf8)!
         let decodedString = String(data: decodedPIF, encoding: .utf8)!
 
@@ -213,6 +215,7 @@ class PIFTests: XCTestCase {
     func testEncodable() throws {
         let encoder = JSONEncoder()
         encoder.userInfo[.encodeForXCBuild] = true
+        try PIF.sign(topLevelObject.workspace)
         let data = try encoder.encode(topLevelObject)
         let json = try JSON(data: data)
 


### PR DESCRIPTION
Sign PIF model in a separate step so it can still by modified after it
is constructed by the PIFBuilder.