### PR TITLE
[NFC] Update #file to #filePath to support SE-0274

### DIFF
--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -54,7 +54,7 @@ public func fixture(
 
             // Construct the expected path of the fixture.
             // FIXME: This seems quite hacky; we should provide some control over where fixtures are found.
-            let fixtureDir = AbsolutePath(#file).appending(RelativePath("../../../Fixtures")).appending(fixtureSubpath)
+            let fixtureDir = AbsolutePath.sourceFile().appending(RelativePath("../../../Fixtures")).appending(fixtureSubpath)
 
             // Check that the fixture is really there.
             guard localFileSystem.isDirectory(fixtureDir) else {

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -451,7 +451,7 @@ class MiscellaneousTestCase: XCTestCase {
 
             // ••••• Set up dependency.
             let dependencyName = "UnicodeDependency‐\(complicatedString)"
-            let dependencyOrigin = AbsolutePath(#file).parentDirectory.parentDirectory.parentDirectory
+            let dependencyOrigin = AbsolutePath.sourceFile().parentDirectory.parentDirectory.parentDirectory
                 .appending(component: "Fixtures")
                 .appending(component: "Miscellaneous")
                 .appending(component: dependencyName)

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -76,7 +76,7 @@ class DependencyResolverRealWorldPerfTests: XCTestCasePerf {
     }
 
     func mockGraph(for name: String) throws -> MockGraph {
-        let input = AbsolutePath(#file).parentDirectory.appending(component: "Inputs").appending(component: name)
+        let input = AbsolutePath.sourceFile().parentDirectory.appending(component: "Inputs").appending(component: name)
         let jsonString = try localFileSystem.readFileContents(input)
         let json = try JSON(bytes: jsonString)
         return MockGraph(json)

--- a/Tests/PackageLoadingTests/PkgConfigTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigTests.swift
@@ -28,7 +28,7 @@ extension SystemLibraryTarget {
 
 class PkgConfigTests: XCTestCase {
 
-    let inputsDir = AbsolutePath(#file).parentDirectory.appending(components: "Inputs")
+    let inputsDir = AbsolutePath.sourceFile().parentDirectory.appending(components: "Inputs")
     let diagnostics = DiagnosticsEngine()
 
     func testBasics() throws {

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -96,7 +96,7 @@ class GitRepositoryTests: XCTestCase {
     func testRawRepository() throws {
         mktmpdir { path in
             // Unarchive the static test repository.
-            let inputArchivePath = AbsolutePath(#file).parentDirectory.appending(components: "Inputs", "TestRepo.tgz")
+            let inputArchivePath = AbsolutePath.sourceFile().parentDirectory.appending(components: "Inputs", "TestRepo.tgz")
             try systemQuietly(["tar", "-x", "-v", "-C", path.pathString, "-f", inputArchivePath.pathString])
             let testRepoPath = path.appending(component: "TestRepo")
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3657,7 +3657,7 @@ final class WorkspaceTests: XCTestCase {
         // This verifies that the simplest possible loading APIs are available for package clients.
 
         // This checkout of the SwiftPM package.
-        let package = AbsolutePath(#file).parentDirectory.parentDirectory.parentDirectory
+        let package = AbsolutePath.sourceFile().parentDirectory.parentDirectory.parentDirectory
 
         // Clients must locate the corresponding “swiftc” exectuable themselves for now.
         // (This just uses the same one used by all the other tests.)

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -18,7 +18,7 @@ import XCBuildSupport
 import SPMTestSupport
 
 class PIFBuilderTests: XCTestCase {
-    let inputsDir = AbsolutePath(#file).parentDirectory.appending(components: "Inputs")
+    let inputsDir = AbsolutePath.sourceFile().parentDirectory.appending(components: "Inputs")
 
   #if os(macOS)
     func testOrdering() {

--- a/swift-tools-support-core/Sources/TSCBasic/Path.swift
+++ b/swift-tools-support-core/Sources/TSCBasic/Path.swift
@@ -92,6 +92,18 @@ public struct AbsolutePath: Hashable {
         try self.init(PathImpl(validatingAbsolutePath: path))
     }
 
+    #if compiler(>=5.3)
+    /// Returns the AbsolutePath of the source file that called it.
+    public static func sourceFile(at path: String = #filePath) -> AbsolutePath {
+        return AbsolutePath(path)
+    }
+    #else
+    /// Returns the AbsolutePath of the source file that called it.
+    public static func sourceFile(at path: String = #file) -> AbsolutePath {
+        return AbsolutePath(path)
+    }
+    #endif
+
     /// Directory component.  An absolute path always has a non-empty directory
     /// component (the directory component of the root path is the root itself).
     public var dirname: String {

--- a/swift-tools-support-core/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/swift-tools-support-core/Tests/TSCBasicTests/FileSystemTests.swift
@@ -76,10 +76,10 @@ class FileSystemTests: XCTestCase {
                     XCTAssertEqual(error.localizedDescription, "The folder “does-not-exist” doesn’t exist.")
                 }
 
-                let thisDirectoryContents = try! fs.getDirectoryContents(AbsolutePath(#file).parentDirectory)
+                let thisDirectoryContents = try! fs.getDirectoryContents(AbsolutePath.sourceFile().parentDirectory)
                 XCTAssertTrue(!thisDirectoryContents.contains(where: { $0 == "." }))
                 XCTAssertTrue(!thisDirectoryContents.contains(where: { $0 == ".." }))
-                XCTAssertTrue(thisDirectoryContents.contains(where: { $0 == AbsolutePath(#file).basename }))
+                XCTAssertTrue(thisDirectoryContents.contains(where: { $0 == AbsolutePath.sourceFile().basename }))
             }
         }
     }

--- a/swift-tools-support-core/Tests/TSCBasicTests/PathShimTests.swift
+++ b/swift-tools-support-core/Tests/TSCBasicTests/PathShimTests.swift
@@ -93,7 +93,7 @@ class WalkTests : XCTestCase {
     }
 
     func testRecursive() {
-        let root = AbsolutePath(#file).parentDirectory.parentDirectory.parentDirectory.appending(component: "Sources")
+        let root = AbsolutePath.sourceFile().parentDirectory.parentDirectory.parentDirectory.appending(component: "Sources")
         var expected = [
             root.appending(component: "TSCBasic"),
             root.appending(component: "TSCUtility")

--- a/swift-tools-support-core/Tests/TSCBasicTests/PathTests.swift
+++ b/swift-tools-support-core/Tests/TSCBasicTests/PathTests.swift
@@ -338,6 +338,15 @@ class PathTests: XCTestCase {
         }
     }
 
+    func testAbsolutePathSourceFile() {
+        #sourceLocation(file: "/a/b/c.swift", line: 10000)
+
+        let path = AbsolutePath.sourceFile()
+        XCTAssertEqual(path.pathString, "/a/b/c.swift")
+
+        #sourceLocation()
+    }
+
     // FIXME: We also need tests for join() operations.
 
     // FIXME: We also need tests for dirname, basename, suffix, etc.

--- a/swift-tools-support-core/Tests/TSCBasicTests/ProcessSetTests.swift
+++ b/swift-tools-support-core/Tests/TSCBasicTests/ProcessSetTests.swift
@@ -16,7 +16,7 @@ import TSCTestSupport
 
 class ProcessSetTests: XCTestCase {
     func script(_ name: String) -> String {
-        return AbsolutePath(#file).parentDirectory.appending(components: "processInputs", name).pathString
+        return AbsolutePath.sourceFile().parentDirectory.appending(components: "processInputs", name).pathString
     }
 
     func testSigInt() throws {

--- a/swift-tools-support-core/Tests/TSCBasicTests/ProcessTests.swift
+++ b/swift-tools-support-core/Tests/TSCBasicTests/ProcessTests.swift
@@ -19,7 +19,7 @@ typealias Process = TSCBasic.Process
 
 class ProcessTests: XCTestCase {
     func script(_ name: String) -> String {
-        return AbsolutePath(#file).parentDirectory.appending(components: "processInputs", name).pathString
+        return AbsolutePath.sourceFile().parentDirectory.appending(components: "processInputs", name).pathString
     }
 
     func testBasics() throws {

--- a/swift-tools-support-core/Tests/TSCUtilityTests/ArchiverTests.swift
+++ b/swift-tools-support-core/Tests/TSCUtilityTests/ArchiverTests.swift
@@ -21,7 +21,7 @@ class ArchiverTests: XCTestCase {
             let expectation = XCTestExpectation(description: "success")
 
             let archiver = ZipArchiver()
-            let inputArchivePath = AbsolutePath(#file).parentDirectory.appending(components: "Inputs", "archive.zip")
+            let inputArchivePath = AbsolutePath.sourceFile().parentDirectory.appending(components: "Inputs", "archive.zip")
             archiver.extract(from: inputArchivePath, to: tmpdir, completion: { result in
                 XCTAssertResultSuccess(result) { _ in
                     let content = tmpdir.appending(component: "file")
@@ -79,7 +79,7 @@ class ArchiverTests: XCTestCase {
             let expectation = XCTestExpectation(description: "failure")
 
             let archiver = ZipArchiver()
-            let inputArchivePath = AbsolutePath(#file).parentDirectory
+            let inputArchivePath = AbsolutePath.sourceFile().parentDirectory
                 .appending(components: "Inputs", "invalid_archive.zip")
             archiver.extract(from: inputArchivePath, to: tmpdir, completion: { result in
                 XCTAssertResultFailure(result) { error in

--- a/swift-tools-support-core/Tests/TSCUtilityTests/PkgConfigParserTests.swift
+++ b/swift-tools-support-core/Tests/TSCUtilityTests/PkgConfigParserTests.swift
@@ -139,7 +139,7 @@ final class PkgConfigParserTests: XCTestCase {
     }
 
     private func loadPCFile(_ inputName: String, body: ((PkgConfigParser) -> Void)? = nil) throws {
-        let input = AbsolutePath(#file).parentDirectory.appending(components: "pkgconfigInputs", inputName)
+        let input = AbsolutePath.sourceFile().parentDirectory.appending(components: "pkgconfigInputs", inputName)
         var parser = PkgConfigParser(pcFile: input, fileSystem: localFileSystem)
         try parser.parse()
         body?(parser)


### PR DESCRIPTION
This change updates many tests which use `#file` to find fixtures to use `#filePath` instead.

NFC until `#file` changes behavior when SE-0274 lands.