### PR TITLE
[5.3] Don't use force unwrap in the code generated for looking up the module resource bundle

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -587,7 +587,11 @@ public final class SwiftTargetBuildDescription {
 
         extension Foundation.Bundle {
             static var module: Bundle = {
-                return Bundle(path: Bundle.main.bundlePath + "/" + "\(bundleBasename)")!
+                let bundlePath = Bundle.main.bundlePath + "/" + "\(bundleBasename)"
+                guard let bundle = Bundle(path: bundlePath) else {
+                    fatalError("could not load resource bundle: \\(bundlePath)")
+                }
+                return bundle
             }()
         }
         """


### PR DESCRIPTION
When the generated code to load a resource bundle can't find the bundle, it should emit a fatal error rather than crashing the process with a force-unwrap

(cherry picked from commit 33d4375442f67d254c49b0529e2d0f28a430af73)