### PR TITLE
[bootstrap] Add rpath for macOS.

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -558,22 +558,22 @@ def get_swiftpm_flags(args):
     # toolchains that include libraries not part of the OS (e.g. PythonKit or
     # TensorFlow).
     if platform.system() == "Darwin":
-        swift_library_rpath_prefix = "@executable_path/../"
-    elif platform.system() == 'Linux':
-        # `$ORIGIN` is an ELF construct.
-        swift_library_rpath_prefix = "$ORIGIN/../"
+        swift_library_rpath_prefixes = [
+            "@executable_path/../",
+            # Necessary for swiftpm-xctest-helper.
+            "@executable_path/../../../",
+        ]
+    elif platform.system() == "Linux":
+        # `$ORIGIN` is an ELF-specific construct.
+        swift_library_rpath_prefixes = ["$ORIGIN/../"]
     platform_path = None
     for path in args.target_info["paths"]["runtimeLibraryPaths"]:
         platform_path = re.search(r"(lib/swift/[^/]+)$", path)
         if platform_path:
-            build_flags.extend(
-                [
-                    "-Xlinker",
-                    "-rpath",
-                    "-Xlinker",
-                    swift_library_rpath_prefix + platform_path.group(1),
-                ]
-            )
+            for prefix in swift_library_rpath_prefixes:
+                build_flags.extend(
+                    ["-Xlinker", "-rpath", "-Xlinker", prefix + platform_path.group(1)]
+                )
             break
 
     if not platform_path:


### PR DESCRIPTION
Add an extra rpath for macOS: `@executable_path/../../../lib/swift/macosx`.

This rpath is necessary for swiftpm-xctest-helper, which is invoked by
`swift test --filter`.

I believe this resolves SR-12599 and SR-12600:
```
$ swift test --filter blah
error: signalled(6): /Library/Developer/Toolchains/swift-tensorflow-DEVELOPMENT-2020-04-07-a.xctoolchain/usr/libexec/swift/pm/swiftpm-xctest-helper /private/tmp/bug/.build/x86_64-apple-macosx/debug/bugPackageTests.xctest /var/folders/z0/4612twmx5wbfrsp0jxbcvwrm00qbwx/T/TemporaryFile.0ZEehg output:
    dyld: Library not loaded: @rpath/libswiftCore.dylib
      Referenced from: /Library/Developer/Toolchains/swift-tensorflow-DEVELOPMENT-2020-04-07-a.xctoolchain/usr/libexec/swift/pm/swiftpm-xctest-helper
      Reason: image not found
```

I'm verifying the fix via [`build-toolchain`](https://github.com/apple/swift/blob/master/utils/build-toolchain) now.

---

I believe this SwiftPM regression occurred in https://github.com/apple/swift-package-manager/pull/2462, which revamped the `bootstrap` script.
Related issue: https://github.com/tensorflow/swift/issues/347