### PR TITLE
Add swiftpm-xctest-helper rpath on macOS.

### DIFF
--- a/Sources/swiftpm-xctest-helper/CMakeLists.txt
+++ b/Sources/swiftpm-xctest-helper/CMakeLists.txt
@@ -9,5 +9,10 @@
 add_executable(swiftpm-xctest-helper
   main.swift)
 
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
+  target_link_options(swiftpm-xctest-helper PRIVATE
+    "-Xlinker -rpath -Xlinker @executable_path/../../../lib/swift/macosx")
+endif()
+
 install(TARGETS swiftpm-xctest-helper
   RUNTIME DESTINATION bin)


### PR DESCRIPTION
Add an extra rpath for swiftpm-xctest-helper on macOS:
`@executable_path/../../../lib/swift/macosx`.

This should fix SR-12599 and SR-12600, not yet verified:
```
$ swift test --filter foo
error: signalled(6): /Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2020-04-14-a.xctoolchain/usr/libexec/swift/pm/swiftpm-xctest-helper /Users/danielzheng/swift-tf/Package/.build/x86_64-apple-macosx/debug/PackagePackageTests.xctest /var/folders/m_/6f7q8zfs3n9fr0c_4gy8840m00hc_q/T/TemporaryFile.B8gUFG output:
    dyld: Library not loaded: @rpath/XCTest.framework/Versions/A/XCTest
      Referenced from: /Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2020-04-14-a.xctoolchain/usr/libexec/swift/pm/swiftpm-xctest-helper
      Reason: image not found
```

Building Swift toolchains now to verify the fix.
Edit: this patch doesn't fix the issues in its current form.

---

This idea was suggested by @abertelrud in https://github.com/apple/swift-package-manager/pull/2692#issuecomment-614778948 as a more focused fix for SR-12599 and SR-12600.