### PR TITLE
ELF platforms: remove host toolchain rpath from executables and shared libraries

### DIFF
--- a/Sources/PackageDescription/CMakeLists.txt
+++ b/Sources/PackageDescription/CMakeLists.txt
@@ -47,6 +47,8 @@ foreach(PACKAGE_DESCRIPTION_VERSION 4 4_2)
     if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
       target_link_libraries(PD${PACKAGE_DESCRIPTION_VERSION} PRIVATE
         Foundation)
+      target_link_options(PD${PACKAGE_DESCRIPTION_VERSION} PRIVATE
+        "SHELL:-no-toolchain-stdlib-rpath")
       set_target_properties(PD${PACKAGE_DESCRIPTION_VERSION} PROPERTIES
           BUILD_WITH_INSTALL_RPATH TRUE
           INSTALL_RPATH "$ORIGIN/../../$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -589,6 +589,11 @@ def get_swiftpm_flags(args):
     if 'ANDROID_DATA' in os.environ:
         build_flags.extend(["-Xswiftc", "-Xcc", "-Xswiftc", "-U_GNU_SOURCE"])
 
+    # On ELF platforms, remove the host toolchain's stdlib absolute rpath from
+    # installed executables and shared libraries.
+    if platform.system() != "Darwin" and args.command == 'install':
+        build_flags.extend(["-Xswiftc", "-no-toolchain-stdlib-rpath"])
+
     return build_flags
 
 if __name__ == '__main__':


### PR DESCRIPTION
I think this should work, given the relative rpaths that are added, but limited to non-Darwin for the shared libraries as the relative rpath is only added there.