### PR TITLE
Process any files in .lproj by default

### DIFF
--- a/Fixtures/Resources/Localized/Package.swift
+++ b/Fixtures/Resources/Localized/Package.swift
@@ -5,8 +5,6 @@ let package = Package(
     name: "Localized",
     defaultLocalization: "es",
     targets: [
-        .target(name: "exe", resources: [
-            .process("Resources"),
-        ]),
+        .target(name: "exe"),
     ]
 )

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -200,6 +200,8 @@ public struct TargetSourcesBuilder {
 
             if let needle = effectiveRules.first(where: { $0.match(path: path, toolsVersion: toolsVersion) }) {
                 matchedRule = Rule(rule: needle.rule, localization: nil)
+            } else if path.parentDirectory.extension == Resource.localizationDirectoryExtension {
+                matchedRule = Rule(rule: .processResource, localization: nil)
             }
         }
 

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -406,6 +406,20 @@ class TargetSourcesBuilderTests: XCTestCase {
         }
     }
 
+    func testLocalizedImage() {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Foo/fr.lproj/Image.png",
+            "/Foo/es.lproj/Image.png"
+        )
+
+        build(target: TargetDescription(name: "Foo"), defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, resources, diagnostics in
+            XCTAssertEqual(Set(resources), [
+                Resource(rule: .process, path: AbsolutePath("/Foo/fr.lproj/Image.png"), localization: "fr"),
+                Resource(rule: .process, path: AbsolutePath("/Foo/es.lproj/Image.png"), localization: "es"),
+            ])
+        }
+    }
+
     func testInfoPlistResource() {
         do {
             let target = TargetDescription(name: "Foo", resources: [


### PR DESCRIPTION
So far we have only been processing resources if they are in a folder that has explicitly been declared as a resource, but we should do it by default.

rdar://problem/61957063