### PR TITLE
Improve diagnostic for binary checksum mismatch

### DIFF
--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -137,8 +137,8 @@ extension Diagnostic.Message {
         .error("artifact of binary target '\(targetName)' has changed checksum; this is a potential security risk so the new artifact won't be downloaded")
     }
 
-    static func artifactInvalidChecksum(targetName: String) -> Diagnostic.Message {
-        .error("downloaded artifact of binary target '\(targetName)' has an invalid checksum")
+    static func artifactInvalidChecksum(targetName: String, expectedChecksum: String, actualChecksum: String) -> Diagnostic.Message {
+        .error("checksum of downloaded artifact of binary target '\(targetName)' (\(actualChecksum)) does not match checksum specified by the manifest (\(expectedChecksum))")
     }
 
     static func artifactFailedDownload(targetName: String, reason: String) -> Diagnostic.Message {

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1399,7 +1399,7 @@ extension Workspace {
                             forBinaryArtifactAt: archivePath,
                             diagnostics: tempDiagnostics)
                         guard archiveChecksum == checksum else {
-                            tempDiagnostics.emit(.artifactInvalidChecksum(targetName: artifact.targetName))
+                            tempDiagnostics.emit(.artifactInvalidChecksum(targetName: artifact.targetName, expectedChecksum: checksum, actualChecksum: archiveChecksum))
                             tempDiagnostics.wrap { try self.fileSystem.removeFileTree(archivePath) }
                             group.leave()
                             return

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -4413,7 +4413,7 @@ final class WorkspaceTests: XCTestCase {
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(diagnostic: .contains("artifact of binary target 'A1' failed download: invalid status code 500"), behavior: .error)
                 result.check(diagnostic: .contains("artifact of binary target 'A2' failed extraction: dummy error"), behavior: .error)
-                result.check(diagnostic: .contains("downloaded artifact of binary target 'A3' has an invalid checksum"), behavior: .error)
+                result.check(diagnostic: .contains("checksum of downloaded artifact of binary target 'A3' (6d75736b6365686320746e65726566666964203d2073746e65746e6f6320746e65726566666964) does not match checksum specified by the manifest (a3)"), behavior: .error)
             }
         }
     }


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift-package-manager/pull/2695 to the 5.3 branch.