### PR TITLE
[5.3] Fix a SwiftPM 5.2 regression that cause it to try to compile unknown files in pre-5.3 manifests

### DIFF
--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -175,7 +175,10 @@ public struct TargetSourcesBuilder {
                     if let ext = path.extension,
                       FileRuleDescription.header.fileTypes.contains(ext) {
                         matchedRule = Rule(rule: .header, localization: nil)
-                    } else {
+                    } else if toolsVersion >= .v5_3 {
+                        matchedRule = Rule(rule: .compile, localization: nil)
+                    } else if let ext = path.extension,
+                      SupportedLanguageExtension.validExtensions(toolsVersion: toolsVersion).contains(ext) {
                         matchedRule = Rule(rule: .compile, localization: nil)
                     }
                     // The source file might have been declared twice so

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -1659,6 +1659,54 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
+    func testUnknownSourceFilesUnderDeclaredSourcesIgnoredInV5_2Manifest() throws {
+        // Files with unknown suffixes under declared sources are not considered valid sources in 5.2 manifest.
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/lib/movie.mkv",
+            "/Sources/lib/lib.c",
+            "/Sources/lib/include/lib.h"
+        )
+
+        let manifest = Manifest.createManifest(
+            name: "pkg",
+            v: .v5_2,
+            targets: [
+                TargetDescription(name: "lib", dependencies: [], path: "./Sources/lib", sources: ["."]),
+            ]
+        )
+
+        PackageBuilderTester(manifest, in: fs) { package, _ in
+            package.checkModule("lib") { module in
+                module.checkSources(root: "/Sources/lib", paths: "lib.c")
+                module.check(includeDir: "/Sources/lib/include")
+            }
+        }
+    }
+
+    func testUnknownSourceFilesUnderDeclaredSourcesCompiledInV5_3Manifest() throws {
+        // Files with unknown suffixes under declared sources are treated as compilable in 5.3 manifest.
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/lib/movie.mkv",
+            "/Sources/lib/lib.c",
+            "/Sources/lib/include/lib.h"
+        )
+
+        let manifest = Manifest.createManifest(
+            name: "pkg",
+            v: .v5_3,
+            targets: [
+                TargetDescription(name: "lib", dependencies: [], path: "./Sources/lib", sources: ["."]),
+            ]
+        )
+
+        PackageBuilderTester(manifest, in: fs) { package, _ in
+            package.checkModule("lib") { module in
+                module.checkSources(root: "/Sources/lib", paths: "movie.mkv", "lib.c")
+                module.check(includeDir: "/Sources/lib/include")
+            }
+        }
+    }
+
     func testBuildSettings() {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/exe/main.swift",


### PR DESCRIPTION
SwiftPM 5.2 introduced a regression that caused a semantic change in how package manifests declaring a tools version earlier than 5.3 were parsed. Specifically, files with an unknown source type are not ignored, as they were in SwiftPM 5.1.x and earlier. This leads to issues such as the one reported here: https://swiftpm.slack.com/archives/C14QU6CUU/p1587442104122300

This is the 5.3 nomination PR.  The original change is already on master

(cherry picked from commit 3f63a2ddef92c7feaa083b9418b59988fb20426b)