### PR TITLE
[5.2] [SR-12667] Fix a SwiftPM 5.2 regression that causes non-source files under declared source directories to be treated as source files

### DIFF
--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -155,7 +155,8 @@ public struct TargetSourcesBuilder {
                     if let ext = path.extension,
                       FileRuleDescription.header.fileTypes.contains(ext) {
                         matchedRule = .header
-                    } else {
+                    } else if let ext = path.extension,
+                      SupportedLanguageExtension.validExtensions(toolsVersion: toolsVersion).contains(ext) {
                         matchedRule = .compile
                     }
                     // The source file might have been declared twice so

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -1585,6 +1585,30 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
+    func testUnknownSourceFilesUnderDeclaredSourcesIgnoredInV5_2Manifest() throws {
+        // Files with unknown suffixes under declared sources are not considered valid sources in 5.2 manifest.
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/lib/movie.mkv",
+            "/Sources/lib/lib.c",
+            "/Sources/lib/include/lib.h"
+        )
+
+        let manifest = Manifest.createManifest(
+            name: "pkg",
+            v: .v5_2,
+            targets: [
+                TargetDescription(name: "lib", dependencies: [], path: "./Sources/lib", sources: ["."]),
+            ]
+        )
+
+        PackageBuilderTester(manifest, in: fs) { package in
+            package.checkModule("lib") { module in
+                module.checkSources(root: "/Sources/lib", paths: "lib.c")
+                module.check(includeDir: "/Sources/lib/include")
+            }
+        }
+    }
+
     func testBuildSettings() {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/exe/main.swift",


### PR DESCRIPTION
When the source scanning logic was reworked in preparation for support of resources, there was an unintentional change to the semantics of how files with unrecognized filename suffixes under declared source directories were treated.  This caused some existing packages to fail to build, if they use the `sources:` parameter when declaring a target and include at least one file that isn't a recognized source file.

This fix restores the previous semantics of only treating files with recognized source file suffixes as sources.

This fix is already in master as well as in the 5.3 branch, and this is a nomination for fixing it in the 5.2 branch as well, for inclusion in any future 5.2.x release.  This PR should be reviewed and tested, but held pending further discussion and approval.