### PR TITLE
Update In-Source Documentation

### DIFF
--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -133,14 +133,14 @@ public struct CSetting: Encodable {
 
     /// Sets unsafe flags to pass arbitrary command-line flags to the corresponding build tool.
     ///
-    /// As the usage of the word "unsafe" implies, the Swift package manager
+    /// As the usage of the word "unsafe" implies, the Swift Package Manager
     /// can't safely determine if the build flags have any negative
     /// side effect on the build since certain flags can change the behavior of
-    /// how a build is performed.
+    /// how it performs a build.
     ///
     /// As some build flags can be exploited for unsupported or malicious
     /// behavior, the use of unsafe flags make the products containing this
-    /// target ineligible to be used by other packages.
+    /// target ineligible for use by other packages.
     ///
     /// - Since: First available in PackageDescription 5.0
     ///
@@ -197,7 +197,7 @@ public struct CXXSetting: Encodable {
 
     /// Sets unsafe flags to pass arbitrary command-line flags to the corresponding build tool.
     ///
-    /// As the usage of the word "unsafe" implies, the Swift package manager
+    /// As the usage of the word "unsafe" implies, the Swift Package Manager
     /// can't safely determine if the build flags have any negative
     /// side effect on the build since certain flags can change the behavior of
     /// how a build is performed.
@@ -247,7 +247,7 @@ public struct SwiftSetting: Encodable {
 
     /// Sets unsafe flags to pass arbitrary command-line flags to the corresponding build tool.
     ///
-    /// As the usage of the word "unsafe" implies, the Swift package manager
+    /// As the usage of the word "unsafe" implies, the Swift Package Manager
     /// can't safely determine if the build flags have any negative
     /// side effect on the build since certain flags can change the behavior of
     /// how a build is performed.
@@ -305,7 +305,7 @@ public struct LinkerSetting: Encodable {
 
     /// Sets unsafe flags to pass arbitrary command-line flags to the corresponding build tool.
     ///
-    /// As the usage of the word "unsafe" implies, the Swift package manager
+    /// As the usage of the word "unsafe" implies, the Swift Package Manager
     /// can't safely determine if the build flags have any negative
     /// side effect on the build since certain flags can change the behavior of
     /// how a build is performed.

--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -58,7 +58,7 @@ public struct BuildSettingCondition: Encodable {
         self.config = config
     }
 
-    /// Create a build setting condition.
+    /// Creates a build setting condition.
     ///
     /// At least one parameter is mandatory.
     ///
@@ -96,7 +96,7 @@ public struct CSetting: Encodable {
         self.data = BuildSettingData(name: name, value: value, condition: condition)
     }
 
-    /// Provide a header search path relative to the target's directory.
+    /// Provides a header search path relative to the target's directory.
     ///
     /// Use this setting to add a search path for headers within your target.
     /// You can't use absolute paths and you can't use this setting to provide
@@ -131,9 +131,9 @@ public struct CSetting: Encodable {
         return CSetting(name: "define", value: [settingValue], condition: condition)
     }
 
-    /// Set unsafe flags to pass arbitrary command-line flags to the corresponding build tool.
+    /// Sets unsafe flags to pass arbitrary command-line flags to the corresponding build tool.
     ///
-    /// As the usage of the word "unsafe" implies, the Swift Package Manager
+    /// As the usage of the word "unsafe" implies, the Swift package manager
     /// can't safely determine if the build flags have any negative
     /// side effect on the build since certain flags can change the behavior of
     /// how a build is performed.
@@ -160,7 +160,7 @@ public struct CXXSetting: Encodable {
         self.data = BuildSettingData(name: name, value: value, condition: condition)
     }
 
-    /// Provide a header search path relative to the target's directory.
+    /// Provides a header search path relative to the target's directory.
     ///
     /// Use this setting to add a search path for headers within your target.
     /// You can't use absolute paths and you can't use this setting to provide
@@ -195,9 +195,9 @@ public struct CXXSetting: Encodable {
         return CXXSetting(name: "define", value: [settingValue], condition: condition)
     }
 
-    /// Set unsafe flags to pass arbitrary command-line flags to the corresponding build tool.
+    /// Sets unsafe flags to pass arbitrary command-line flags to the corresponding build tool.
     ///
-    /// As the usage of the word "unsafe" implies, the Swift Package Manager
+    /// As the usage of the word "unsafe" implies, the Swift package manager
     /// can't safely determine if the build flags have any negative
     /// side effect on the build since certain flags can change the behavior of
     /// how a build is performed.
@@ -223,7 +223,7 @@ public struct SwiftSetting: Encodable {
         self.data = BuildSettingData(name: name, value: value, condition: condition)
     }
 
-    /// Define a compilation condition.
+    /// Defines a compilation condition.
     ///
     /// Use compilation conditions to only compile statements if a certain condition is true.
     /// For example, the Swift compiler will only compile the
@@ -245,9 +245,9 @@ public struct SwiftSetting: Encodable {
         return SwiftSetting(name: "define", value: [name], condition: condition)
     }
 
-    /// Set unsafe flags to pass arbitrary command-line flags to the corresponding build tool.
+    /// Sets unsafe flags to pass arbitrary command-line flags to the corresponding build tool.
     ///
-    /// As the usage of the word "unsafe" implies, the Swift Package Manager
+    /// As the usage of the word "unsafe" implies, the Swift package manager
     /// can't safely determine if the build flags have any negative
     /// side effect on the build since certain flags can change the behavior of
     /// how a build is performed.
@@ -273,7 +273,7 @@ public struct LinkerSetting: Encodable {
         self.data = BuildSettingData(name: name, value: value, condition: condition)
     }
 
-    /// Declare linkage to a system library.
+    /// Declares linkage to a system library.
     ///
     /// This setting is most useful when the library can't be linked
     /// automatically, such as C++ based libraries and non-modular
@@ -288,7 +288,7 @@ public struct LinkerSetting: Encodable {
         return LinkerSetting(name: "linkedLibrary", value: [library], condition: condition)
     }
 
-    /// Declare linkage to a system framework.
+    /// Declares linkage to a system framework.
     ///
     /// This setting is most useful when the framework can't be linked
     /// automatically, such as C++ based frameworks and non-modular
@@ -303,9 +303,9 @@ public struct LinkerSetting: Encodable {
         return LinkerSetting(name: "linkedFramework", value: [framework], condition: condition)
     }
 
-    /// Set unsafe flags to pass arbitrary command-line flags to the corresponding build tool.
+    /// Sets unsafe flags to pass arbitrary command-line flags to the corresponding build tool.
     ///
-    /// As the usage of the word "unsafe" implies, the Swift Package Manager
+    /// As the usage of the word "unsafe" implies, the Swift package manager
     /// can't safely determine if the build flags have any negative
     /// side effect on the build since certain flags can change the behavior of
     /// how a build is performed.

--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -10,7 +10,7 @@
 
 extension Package.Dependency {
 
-    /// Create a package dependency that uses the version requirement, starting with the given minimum version,
+    /// Creates a package dependency that uses the version requirement, starting with the given minimum version,
     /// going up to the next major version.
     ///
     /// This is the recommended way to specify a remote package dependency.

--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -37,7 +37,7 @@ extension Package.Dependency {
         return .init(name: nil, url: url, requirement: .upToNextMajor(from: version))
     }
 
-    /// Create a package dependency that uses the version requirement, starting with the given minimum version,
+    /// Creates a package dependency that uses the version requirement, starting with the given minimum version,
     /// going up to the next major version.
     ///
     /// This is the recommended way to specify a remote package dependency.
@@ -65,7 +65,7 @@ extension Package.Dependency {
         return .init(name: name, url: url, requirement: .upToNextMajor(from: version))
     }
 
-    /// Add a remote package dependency given a version requirement.
+    /// Adds a remote package dependency given a version requirement.
     ///
     /// - Parameters:
     ///     - name: The name of the package, or nil to deduce it from the URL.
@@ -80,10 +80,10 @@ extension Package.Dependency {
         return .init(name: nil, url: url, requirement: requirement)
     }
 
-    /// Add a remote package dependency given a version requirement.
+    /// Adds a remote package dependency with a given version requirement.
     ///
     /// - Parameters:
-    ///     - name: The name of the package, or nil to deduce it from the URL.
+    ///     - name: The name of the package, or `nil` to deduce it from the URL.
     ///     - url: The valid Git URL of the package.
     ///     - requirement: A dependency requirement. See static methods on `Package.Dependency.Requirement` for available options.
     @available(_PackageDescription, introduced: 5.2)
@@ -96,7 +96,7 @@ extension Package.Dependency {
         return .init(name: name, url: url, requirement: requirement)
     }
 
-    /// Add a package dependency starting with a specific minimum version, up to
+    /// Adds a package dependency starting with a specific minimum version, up to
     /// but not including a specified maximum version.
     ///
     /// The following example allows the Swift package manager to pick
@@ -120,7 +120,7 @@ extension Package.Dependency {
       #endif
     }
 
-    /// Add a package dependency starting with a specific minimum version, up to
+    /// Adds a package dependency starting with a specific minimum version, up to
     /// but not including a specified maximum version.
     ///
     /// The following example allows the Swift package manager to pick
@@ -129,7 +129,7 @@ extension Package.Dependency {
     ///     .package(url: "https://example.com/example-package.git", "1.2.3"..<"1.2.6"),
     ///
     /// - Parameters:
-    ///     - name: The name of the package, or nil to deduce it from the URL.
+    ///     - name: The name of the package, or `nil` to deduce it from the URL.
     ///     - url: The valid Git URL of the package.
     ///     - range: The custom version range requirement.
     @available(_PackageDescription, introduced: 5.2)
@@ -145,7 +145,7 @@ extension Package.Dependency {
       #endif
     }
 
-    /// Add a package dependency starting with a specific minimum version, going
+    /// Adds a package dependency starting with a specific minimum version, going
     /// up to and including a specific maximum version.
     ///
     /// The following example allows the Swift package manager to pick
@@ -154,7 +154,7 @@ extension Package.Dependency {
     ///     .package(url: "https://example.com/example-package.git", "1.2.3"..."1.2.6"),
     ///
     /// - Parameters:
-    ///     - name: The name of the package, or nil to deduce it from the URL.
+    ///     - name: The name of the package, or `nil` to deduce it from the URL.
     ///     - url: The valid Git URL of the package.
     ///     - range: The closed version range requirement.
     @available(_PackageDescription, obsoleted: 5.2)
@@ -175,7 +175,7 @@ extension Package.Dependency {
       #endif
     }
 
-    /// Add a package dependency starting with a specific minimum version, going
+    /// Adds a package dependency starting with a specific minimum version, going
     /// up to and including a specific maximum version.
     ///
     /// The following example allows the Swift package manager to pick
@@ -184,7 +184,7 @@ extension Package.Dependency {
     ///     .package(url: "https://example.com/example-package.git", "1.2.3"..."1.2.6"),
     ///
     /// - Parameters:
-    ///     - name: The name of the package, or nil to deduce it from the URL.
+    ///     - name: The name of the package, or `nil` to deduce it from the URL.
     ///     - url: The valid Git URL of the package.
     ///     - range: The closed version range requirement.
     @available(_PackageDescription, introduced: 5.2)
@@ -207,9 +207,9 @@ extension Package.Dependency {
     }
 
   #if !PACKAGE_DESCRIPTION_4
-    /// Add a dependency to a local package on the filesystem.
+    /// Adds a package dependency to a local package on the filesystem.
     ///
-    /// The Swift Package Manager uses the package dependency as-is
+    /// The Swift package manager uses the package dependency as-is
     /// and does not perform any source control access. Local package dependencies
     /// are especially useful during development of a new package or when working
     /// on multiple tightly coupled packages.
@@ -222,14 +222,16 @@ extension Package.Dependency {
         return .init(name: nil, url: path, requirement: ._localPackageItem)
     }
 
-    /// Add a dependency to a local package on the filesystem.
+    /// Adds a package dependency to a local package on the filesystem.
     ///
-    /// The Swift Package Manager uses the package dependency as-is
-    /// and does not perform any source control access. Local package dependencies
+    /// The Swift package manager uses the package dependency as-is
+    /// and doesn't perform any source control access. Local package dependencies
     /// are especially useful during development of a new package or when working
     /// on multiple tightly coupled packages.
     ///
-    /// - Parameter path: The path of the package.
+    /// - Parameters
+    ///   - name: The name of the Swift package or `nil` to deduce the name from path.
+    ///   - path: The local path to the package.
     @available(_PackageDescription, introduced: 5.2)
     public static func package(
         name: String? = nil,

--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -10,7 +10,7 @@
 
 extension Package.Dependency {
 
-    /// Creates a package dependency that uses the version requirement, starting with the given minimum version,
+    /// Adds a package dependency that uses the version requirement, starting with the given minimum version,
     /// going up to the next major version.
     ///
     /// This is the recommended way to specify a remote package dependency.
@@ -20,7 +20,7 @@ extension Package.Dependency {
     /// while making sure you don't update to a version with breaking changes,
     /// and helps to prevent conflicts in your dependency graph.
     ///
-    /// The following example allows the Swift package manager to select a version
+    /// The following example allows the Swift Package Manager to select a version
     /// like a  `1.2.3`, `1.2.4`, or `1.3.0`, but not `2.0.0`.
     ///
     ///    .package(url: "https://example.com/example-package.git", from: "1.2.3"),
@@ -37,7 +37,7 @@ extension Package.Dependency {
         return .init(name: nil, url: url, requirement: .upToNextMajor(from: version))
     }
 
-    /// Creates a package dependency that uses the version requirement, starting with the given minimum version,
+    /// Adds a package dependency that uses the version requirement, starting with the given minimum version,
     /// going up to the next major version.
     ///
     /// This is the recommended way to specify a remote package dependency.
@@ -47,7 +47,7 @@ extension Package.Dependency {
     /// while making sure you don't update to a version with breaking changes,
     /// and helps to prevent conflicts in your dependency graph.
     ///
-    /// The following example allows the Swift package manager to select a version
+    /// The following example allows the Swift Package Manager to select a version
     /// like a  `1.2.3`, `1.2.4`, or `1.3.0`, but not `2.0.0`.
     ///
     ///    .package(url: "https://example.com/example-package.git", from: "1.2.3"),
@@ -99,7 +99,7 @@ extension Package.Dependency {
     /// Adds a package dependency starting with a specific minimum version, up to
     /// but not including a specified maximum version.
     ///
-    /// The following example allows the Swift package manager to pick
+    /// The following example allows the Swift Package Manager to pick
     /// versions `1.2.3`, `1.2.4`, `1.2.5`, but not `1.2.6`.
     ///
     ///     .package(url: "https://example.com/example-package.git", "1.2.3"..<"1.2.6"),
@@ -123,7 +123,7 @@ extension Package.Dependency {
     /// Adds a package dependency starting with a specific minimum version, up to
     /// but not including a specified maximum version.
     ///
-    /// The following example allows the Swift package manager to pick
+    /// The following example allows the Swift Package Manager to pick
     /// versions `1.2.3`, `1.2.4`, `1.2.5`, but not `1.2.6`.
     ///
     ///     .package(url: "https://example.com/example-package.git", "1.2.3"..<"1.2.6"),
@@ -148,7 +148,7 @@ extension Package.Dependency {
     /// Adds a package dependency starting with a specific minimum version, going
     /// up to and including a specific maximum version.
     ///
-    /// The following example allows the Swift package manager to pick
+    /// The following example allows the Swift Package Manager to pick
     /// versions 1.2.3, 1.2.4, 1.2.5, as well as 1.2.6.
     ///
     ///     .package(url: "https://example.com/example-package.git", "1.2.3"..."1.2.6"),
@@ -178,7 +178,7 @@ extension Package.Dependency {
     /// Adds a package dependency starting with a specific minimum version, going
     /// up to and including a specific maximum version.
     ///
-    /// The following example allows the Swift package manager to pick
+    /// The following example allows the Swift Package Manager to pick
     /// versions 1.2.3, 1.2.4, 1.2.5, as well as 1.2.6.
     ///
     ///     .package(url: "https://example.com/example-package.git", "1.2.3"..."1.2.6"),
@@ -209,7 +209,7 @@ extension Package.Dependency {
   #if !PACKAGE_DESCRIPTION_4
     /// Adds a package dependency to a local package on the filesystem.
     ///
-    /// The Swift package manager uses the package dependency as-is
+    /// The Swift Package Manager uses the package dependency as-is
     /// and does not perform any source control access. Local package dependencies
     /// are especially useful during development of a new package or when working
     /// on multiple tightly coupled packages.
@@ -224,7 +224,7 @@ extension Package.Dependency {
 
     /// Adds a package dependency to a local package on the filesystem.
     ///
-    /// The Swift package manager uses the package dependency as-is
+    /// The Swift Package Manager uses the package dependency as-is
     /// and doesn't perform any source control access. Local package dependencies
     /// are especially useful during development of a new package or when working
     /// on multiple tightly coupled packages.

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -451,8 +451,8 @@ public enum SystemPackageProvider {
     case _yumItem([String])
   #endif
 
-    /// Declares the list of installable packages using the homebrew package
-    /// manager on macOS to create a system package provider instance.
+    /// Creates a system package provider with a list of installable packages
+    /// for users of the homebrew package manager on macOS.
     ///
     /// - Parameters:
     ///     - packages: The list of package names.
@@ -464,8 +464,8 @@ public enum SystemPackageProvider {
       #endif
     }
 
-    /// Declares the list of installable packages using the apt-get package
-    /// manager on Ubuntu to create a system package provider instance.
+    /// Creates a system package provider with a list of installable packages
+    /// for users of the apt-get package manager on Ubuntu Linux.
     ///
     /// - Parameters:
     ///     - packages: The list of package names.
@@ -480,8 +480,8 @@ public enum SystemPackageProvider {
 #if PACKAGE_DESCRIPTION_4
 // yum is not supported
 #else
-    /// Declares the list of installable packages using the yum package
-    /// manager on Red Hat Enterprise Linux/CentOS to create a system package provider instance.
+    /// Creates a system package provider with a list of installable packages
+    /// for users of the yum package manager on Red Hat Enterprise Linux or CentOS.
     ///
     /// - Parameters:
     ///     - packages: The list of package names.

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -23,7 +23,7 @@ import Foundation
 /// statement to provide the name of the package, its targets, products,
 /// dependencies, and other configuration options.
 ///
-/// By convention, you need to define the properties of a Package in a single
+/// By convention, you need to define the properties of a package in a single
 /// nested initializer statement. Don’t modify it after initialization. The
 /// following package manifest shows the initialization of a simple package
 /// object for the MyLibrary Swift package:
@@ -53,7 +53,7 @@ import Foundation
 ///
 /// The Swift tools version declares:
 ///
-///     - The version of the PackageDescription library
+///     - The version of the PackageDescription framework
 ///     - The Swift language compatibility version to process the manifest
 ///     - The required minimum version of the Swift tools to use the package
 ///
@@ -196,7 +196,7 @@ public final class Package {
     /// The list of targets that are part of this package.
     public var targets: [Target]
 
-    /// The list of products that this package vends and that clients can run or use.
+    /// The list of products that this package vends and that clients can use.
     public var products: [Product]
 
     /// The list of package dependencies.
@@ -225,7 +225,7 @@ public final class Package {
     ///           Package Manager searches for a <name>.pc file to get the
     ///           required additional flags for a system target.
     ///     - providers: The package providers for a system package.
-    ///     - products: The list of products that this package vends and that clients can run or use.
+    ///     - products: The list of products that this package vends and that clients can use.
     ///     - dependencies: The list of package dependencies.
     ///     - targets: The list of targets that are part of this package.
     ///     - swiftLanguageVersions: The list of Swift versions that this package is compatible with.
@@ -261,7 +261,7 @@ public final class Package {
     ///     - pkgConfig: The name to use for C modules. If present, the Swift 
     ///           Package Manager searches for a <name>.pc file to get the
     ///           required additional flags for a system target.
-    ///     - products: The list of products that this package vends and that clients can run or use.
+    ///     - products: The list of products that this package vends and that clients can use.
     ///     - dependencies: The list of package dependencies.
     ///     - targets: The list of targets that are part of this package.
     ///     - swiftLanguageVersions: The list of Swift versions that this package is compatible with.
@@ -299,7 +299,7 @@ public final class Package {
     ///     - pkgConfig: The name to use for C modules. If present, the Swift 
     ///           Package Manager searches for a <name>.pc file to get the
     ///           required additional flags for a system target.
-    ///     - products: The list of products that this package vends and that clients can run or use.
+    ///     - products: The list of products that this package vends and that clients can use.
     ///     - dependencies: The list of package dependencies.
     ///     - targets: The list of targets that are part of this package.
     ///     - swiftLanguageVersions: The list of Swift versions that this package is compatible with.
@@ -340,7 +340,7 @@ public final class Package {
     ///     - pkgConfig: The name to use for C modules. If present, the Swift 
     ///           Package Manager searches for a <name>.pc file to get the
     ///           required additional flags for a system target.
-    ///     - products: The list of products that this package vends and that clients can run or use.
+    ///     - products: The list of products that this package vends and that clients can use.
     ///     - dependencies: The list of package dependencies.
     ///     - targets: The list of targets that are part of this package.
     ///     - swiftLanguageVersions: The list of Swift versions that this package is compatible with.

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -70,7 +70,7 @@ public final class Package {
       /// A package dependency consists of a Git URL to the source of the package,
       /// and a requirement for the version of the package.
       ///
-      /// The Swift package manager performs a process called *dependency resolution* to
+      /// The Swift Package Manager performs a process called *dependency resolution* to
       /// figure out the exact version of the package dependencies that an app or other
       /// Swift package can use. The `Package.resolved` file records the results of the
       /// dependency resolution and lives in the top-level directory of a Swift package.
@@ -186,7 +186,7 @@ public final class Package {
 
     /// The name to use for C modules.
     ///
-    /// If present, the Swift package manager searches for a `<name>.pc` file
+    /// If present, the Swift Package Manager searches for a `<name>.pc` file
     /// to get the required additional flags for a system target.
     public var pkgConfig: String?
 

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -53,9 +53,9 @@ import Foundation
 ///
 /// The Swift tools version declares:
 ///
-///     * The version of the PackageDescription library
-///     * The Swift language compatibility version to process the manifest
-///     * The required minimum version of the Swift tools to use the package
+///     - The version of the PackageDescription library
+///     - The Swift language compatibility version to process the manifest
+///     - The required minimum version of the Swift tools to use the package
 ///
 /// Each version of Swift can introduce updates to the PackageDescription
 /// library, but the previous API version is available to packages that declare
@@ -331,7 +331,7 @@ public final class Package {
         registerExitHandler()
     }
 
-    /// Initializes and returns a newly allocated package object with the specified parameters
+    /// Initializes a Swift package with the provided configuration options.
     ///
     /// - Parameters:
     ///     - name: The name of the Swift package or `nil` to deduce the name from the package’s Git URL.

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -23,11 +23,12 @@ import Foundation
 /// statement to provide the name of the package, its targets, products,
 /// dependencies, and other configuration options.
 ///
-/// By convention, the properties of a `Package` are defined in a single nested
-/// initializer statement, and not modified after initialization. The following package manifest shows the initialization
-/// of a simple package object for the MyLibrary Swift package:
+/// By convention, you need to define the properties of a Package in a single
+/// nested initializer statement. Don’t modify it after initialization. The
+/// following package manifest shows the initialization of a simple package
+/// object for the MyLibrary Swift package:
 ///
-///     // swift-tools-version:5.1
+///     // swift-tools-version:5.3
 ///     import PackageDescription
 ///
 ///     let package = Package(
@@ -47,24 +48,21 @@ import Foundation
 ///         ]
 ///     )
 ///
-/// A `Package.swift` manifest file must begin with the string `//
-/// swift-tools-version:` followed by a version number specifier. The following code listing shows a few examples of valid declarations of the Swift tools version:
+/// The package manifest must begin with the string `// swift-tools-version:``,
+/// followed by a version number such as `// swift-tools-version:5.3.
 ///
-///     // swift-tools-version:3.0.2
-///     // swift-tools-version:3.1
-///     // swift-tools-version:4.0
-///     // swift-tools-version:5.0
-///     // swift-tools-version:5.1
+/// The Swift tools version declares:
 ///
-/// The Swift tools version declares the version of the `PackageDescription`
-/// library, the minimum version of the Swift tools and Swift language
-/// compatibility version to process the manifest, and the minimum version of the
-/// Swift tools that are needed to use the Swift package. Each version of Swift
-/// can introduce updates to the `PackageDescription` framework, but the previous
-/// API version will continue to be available to packages which declare a prior
-/// tools version. This behavior lets you take advantage of new releases of
-/// Swift, the Swift tools, and the `PackageDescription` library, without having
-/// to update your package's manifest or losing access to existing packages.
+///     * The version of the PackageDescription library
+///     * The Swift language compatibility version to process the manifest
+///     * The required minimum version of the Swift tools to use the package
+///
+/// Each version of Swift can introduce updates to the PackageDescription
+/// library, but the previous API version is available to packages that declare
+/// a prior tools version. This behavior allows you take advantage of new
+/// releases of Swift, the Swift tools, and the PackageDescription framework,
+/// without having to update your package manifest and without losing access to
+/// existing packages.
 public final class Package {
 
       /// A package dependency of a Swift package.
@@ -72,7 +70,7 @@ public final class Package {
       /// A package dependency consists of a Git URL to the source of the package,
       /// and a requirement for the version of the package.
       ///
-      /// The Swift Package Manager performs a process called *dependency resolution* to
+      /// The Swift package manager performs a process called *dependency resolution* to
       /// figure out the exact version of the package dependencies that an app or other
       /// Swift package can use. The `Package.resolved` file records the results of the
       /// dependency resolution and lives in the top-level directory of a Swift package.
@@ -147,10 +145,11 @@ public final class Package {
             }
         }
 
-        /// The name of the package, or nil to deduce it from the URL.
+        /// The name of the package, or `nil` to deduce the name using the
+        /// package's Git URL.
         public let name: String?
 
-        /// The Git url of the package dependency.
+        /// The Git URL of the package dependency.
         public let url: String
 
         /// The dependency requirement of the package dependency.
@@ -185,19 +184,19 @@ public final class Package {
     }
     private var _defaultLocalization: LanguageTag?
 
-    /// The name to use for C Modules.
+    /// The name to use for C modules.
     ///
-    /// If present, the Swift Package Manager searches for a `<name>.pc` file
+    /// If present, the Swift package manager searches for a `<name>.pc` file
     /// to get the required additional flags for a system target.
     public var pkgConfig: String?
 
-    /// An array of providers for the system target.
+    /// An array of providers for a system target.
     public var providers: [SystemPackageProvider]?
 
-    /// The list of targets.
+    /// The list of targets that are part of this package.
     public var targets: [Target]
 
-    /// The list of products that this package vends and that can be run or used by its clients.
+    /// The list of products that this package vends and that clients can run or use.
     public var products: [Product]
 
     /// The list of package dependencies.
@@ -218,13 +217,15 @@ public final class Package {
     public var cxxLanguageStandard: CXXLanguageStandard?
 
   #if PACKAGE_DESCRIPTION_4
-    /// Initializes and returns a newly allocated package object with the provided configuration options.
+    /// Initializes a Swift package with the provided configuration options.
     ///
     /// - Parameters:
-    ///     - name: The name of the Swift package.
-    ///     - pkgConfig: Additional flags for a system package.
+    ///     - name: The name of the Swift package or `nil` to deduce the name from the package’s Git URL.
+    ///     - pkgConfig: The name to use for C modules. If present, the Swift 
+    ///           Package Manager searches for a <name>.pc file to get the
+    ///           required additional flags for a system target.
     ///     - providers: The package providers for a system package.
-    ///     - products: The list of products that this package vends and that can be run or used by its clients.
+    ///     - products: The list of products that this package vends and that clients can run or use.
     ///     - dependencies: The list of package dependencies.
     ///     - targets: The list of targets that are part of this package.
     ///     - swiftLanguageVersions: The list of Swift versions that this package is compatible with.
@@ -253,11 +254,14 @@ public final class Package {
         registerExitHandler()
     }
   #else
-    /// Initializes and returns a newly allocated package object with the provided configuration options.
+    /// Initializes a Swift package with the provided configuration options.
     ///
     /// - Parameters:
-    ///     - name: The name of the Swift package.
-    ///     - products: The list of products that this package vends and that can be run or used by its clients.
+    ///     - name: The name of the Swift package or `nil` to deduce the name from the package’s Git URL.
+    ///     - pkgConfig: The name to use for C modules. If present, the Swift 
+    ///           Package Manager searches for a <name>.pc file to get the
+    ///           required additional flags for a system target.
+    ///     - products: The list of products that this package vends and that clients can run or use.
     ///     - dependencies: The list of package dependencies.
     ///     - targets: The list of targets that are part of this package.
     ///     - swiftLanguageVersions: The list of Swift versions that this package is compatible with.
@@ -287,12 +291,15 @@ public final class Package {
         registerExitHandler()
     }
 
-    /// Initializes and returns a newly allocated package object with the specified parameters
+    /// Initializes a Swift package with the provided configuration options.
     ///
     /// - Parameters:
-    ///     - name: The name of the Swift package.
-    ///     - platforms: The list of minimum deployment targets per platform.
-    ///     - products: The list of products that this package vends and that can be run or used by its clients.
+    ///     - name: The name of the Swift package or `nil` to deduce the name from the package’s Git URL.
+    ///     - platforms: The list of supported platforms with a custom deployment target.
+    ///     - pkgConfig: The name to use for C modules. If present, the Swift 
+    ///           Package Manager searches for a <name>.pc file to get the
+    ///           required additional flags for a system target.
+    ///     - products: The list of products that this package vends and that clients can run or use.
     ///     - dependencies: The list of package dependencies.
     ///     - targets: The list of targets that are part of this package.
     ///     - swiftLanguageVersions: The list of Swift versions that this package is compatible with.
@@ -327,10 +334,13 @@ public final class Package {
     /// Initializes and returns a newly allocated package object with the specified parameters
     ///
     /// - Parameters:
-    ///     - name: The name of the Swift package.
+    ///     - name: The name of the Swift package or `nil` to deduce the name from the package’s Git URL.
     ///     - defaultLocalization: The default localization for resources.
-    ///     - platforms: The list of minimum deployment targets per platform.
-    ///     - products: The list of products that this package vends and that can be run or used by its clients.
+    ///     - platforms: The list of supported platforms with a custom deployment target.
+    ///     - pkgConfig: The name to use for C modules. If present, the Swift 
+    ///           Package Manager searches for a <name>.pc file to get the
+    ///           required additional flags for a system target.
+    ///     - products: The list of products that this package vends and that clients can run or use.
     ///     - dependencies: The list of package dependencies.
     ///     - targets: The list of targets that are part of this package.
     ///     - swiftLanguageVersions: The list of Swift versions that this package is compatible with.
@@ -386,13 +396,16 @@ public final class Package {
     }
 }
 
-/// A wrapper around a [IETF Language Tag](https://en.wikipedia.org/wiki/IETF_language_tag).
+/// A wrapper around an IETF language tag.
+///
+/// To learn more about IETF language tags, a worldwide standard for language
+/// tags, visit [the IEFT website for RFC5646](https://tools.ietf.org/html/rfc5646).
 public struct LanguageTag: Hashable {
 
-    /// A IETF language tag.
+    /// An IETF language tag.
     public let tag: String
 
-    /// Creates a `LanguageTag` from its IETF string representation.
+    /// Creates a language tag from its IETF string representation.
     public init(_ tag: String) {
         self.tag = tag
     }
@@ -438,7 +451,7 @@ public enum SystemPackageProvider {
     case _yumItem([String])
   #endif
 
-    /// Declare the list of installable packages using the homebrew package
+    /// Declares the list of installable packages using the homebrew package
     /// manager on macOS to create a system package provider instance.
     ///
     /// - Parameters:
@@ -451,7 +464,7 @@ public enum SystemPackageProvider {
       #endif
     }
 
-    /// Declare the list of installable packages using the apt-get package
+    /// Declares the list of installable packages using the apt-get package
     /// manager on Ubuntu to create a system package provider instance.
     ///
     /// - Parameters:
@@ -467,8 +480,8 @@ public enum SystemPackageProvider {
 #if PACKAGE_DESCRIPTION_4
 // yum is not supported
 #else
-    /// Declare the list of installable packages using the yum package
-    /// manager on RHEL/CentOS to create a system package provider instance.
+    /// Declares the list of installable packages using the yum package
+    /// manager on Red Hat Enterprise Linux/CentOS to create a system package provider instance.
     ///
     /// - Parameters:
     ///     - packages: The list of package names.

--- a/Sources/PackageDescription/Product.swift
+++ b/Sources/PackageDescription/Product.swift
@@ -150,7 +150,7 @@ public class Product: Encodable {
         return Library(name: name, type: type, targets: targets)
     }
 
-    /// Creates an executable package product that clients can run.
+    /// Creates an executable package product.
     ///
     /// - Parameters:
     ///     - name: The name of the executable product.

--- a/Sources/PackageDescription/Product.swift
+++ b/Sources/PackageDescription/Product.swift
@@ -128,7 +128,7 @@ public class Product: Encodable {
         }
     }
 
-    /// Create a library product to allow clients that declare a dependency on this package
+    /// Creates a library product to allow clients that declare a dependency on this package
     /// to use the package's functionality.
     ///
     /// A library's product can either be statically or dynamically linked.
@@ -150,7 +150,7 @@ public class Product: Encodable {
         return Library(name: name, type: type, targets: targets)
     }
 
-    /// Create an executable package product that clients can run.
+    /// Creates an executable package product that clients can run.
     ///
     /// - Parameters:
     ///     - name: The name of the executable product.

--- a/Sources/PackageDescription/Product.swift
+++ b/Sources/PackageDescription/Product.swift
@@ -108,7 +108,7 @@ public class Product: Encodable {
 
         /// The type of the library.
         ///
-        /// If the type is unspecified, the Swift Package Manager automatically
+        /// If the type is unspecified, the Swift package manager automatically
         /// chooses a type based on the client's preference.
         public let type: LibraryType?
 
@@ -133,13 +133,13 @@ public class Product: Encodable {
     ///
     /// A library's product can either be statically or dynamically linked.
     /// If possible, don't declare the type of library explicitly to let 
-    /// the Swift Package Manager choose between static or dynamic linking based
+    /// the Swift package manager choose between static or dynamic linking based
     /// on the preference of the package's consumer.
     ///
     /// - Parameters:
     ///     - name: The name of the library product.
     ///     - type: The optional type of the library that is used to determine how to link to the library.
-    ///         Leave this parameter unspecified to let to let the Swift Package Manager choose between static or dynamic linking (recommended).
+    ///         Leave this parameter unspecified to let to let the Swift package manager choose between static or dynamic linking (recommended).
     ///         If you do not support both linkage types, use `.static` or `.dynamic` for this parameter. 
     ///     - targets: The targets that are bundled into a library product.
     public static func library(

--- a/Sources/PackageDescription/Product.swift
+++ b/Sources/PackageDescription/Product.swift
@@ -108,7 +108,7 @@ public class Product: Encodable {
 
         /// The type of the library.
         ///
-        /// If the type is unspecified, the Swift package manager automatically
+        /// If the type is unspecified, the Swift Package Manager automatically
         /// chooses a type based on the client's preference.
         public let type: LibraryType?
 
@@ -133,14 +133,14 @@ public class Product: Encodable {
     ///
     /// A library's product can either be statically or dynamically linked.
     /// If possible, don't declare the type of library explicitly to let 
-    /// the Swift package manager choose between static or dynamic linking based
+    /// the Swift Package Manager choose between static or dynamic linking based
     /// on the preference of the package's consumer.
     ///
     /// - Parameters:
     ///     - name: The name of the library product.
-    ///     - type: The optional type of the library that is used to determine how to link to the library.
-    ///         Leave this parameter unspecified to let to let the Swift package manager choose between static or dynamic linking (recommended).
-    ///         If you do not support both linkage types, use `.static` or `.dynamic` for this parameter. 
+    ///     - type: The optional type of the library that's used to determine how to link to the library.
+    ///         Leave this parameter unspecified to let to let the Swift Package Manager choose between static or dynamic linking (recommended).
+    ///         If you don't support both linkage types, use `.static` or `.dynamic` for this parameter. 
     ///     - targets: The targets that are bundled into a library product.
     public static func library(
         name: String,

--- a/Sources/PackageDescription/Resource.swift
+++ b/Sources/PackageDescription/Resource.swift
@@ -20,9 +20,11 @@
 ///
 /// Per default, Xcode handles common resources types for Apple platforms automatically.
 /// You don’t need to declare XIB files, storyboards, CoreData file types, and asset catalogs
-/// as resources in your package manifest. However, you must declare other file types as resources,
-/// for example, image files, explicitly using the `process(_:localization:)` or `copy(_:) rules`.
-/// Alternatively, you can exclude resource files from a target by using `exclude`.
+/// as resources in your package manifest.
+/// However, you must declare other file types, for example image files, as resources explicitly
+/// using the `process(_:localization:)` or `copy(_:)` rules.
+/// Alternatively, exclude resource files from a target by passing them to the
+/// package initializer’s `exclude` parameter. 
 public struct Resource: Encodable {
 
     /// Defines the explicit type of localization for resources.

--- a/Sources/PackageDescription/Resource.swift
+++ b/Sources/PackageDescription/Resource.swift
@@ -8,12 +8,29 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+/// A resource to bundle with the Swift package.
+///
+/// If a Swift package declares a Swift tools version of 5.3 or later, it can
+/// include resource files. Similar to source code, the Swift package manager
+/// scopes resources to a target. As a result, you need to put your resources
+/// into the subfolder for the target they belong to. For example, any resources
+/// for the `MyLibrary` target need to reside in `Sources/MyLibrary`. Use
+/// subdirectories to organize your resource files in a way that makes it easy
+/// to identify and manage them.
+///
+/// Per default, the Swift package manager handles common resources types for
+/// Apple platforms automatically. You don’t need to declare Interface Builder
+/// files, for example, XIB and storyboards, CoreData file types, and asset
+/// catalogs as resources in your package manifest. However, you must declare
+/// other file types as resources, for example, image files, explicitly using
+/// the `copy(_:)` or `process(_:localization:)`` rule. Alternatively, you can
+/// exclude resource files from a target by using `exclude(_:)``.
 public struct Resource: Encodable {
 
     /// Defines the explicit type of localization for resources.
     public enum Localization: String, Encodable {
 
-        /// The Package's default localization.
+        /// The package's default localization.
         case `default`
 
         /// Localization for base internationalization.
@@ -35,25 +52,32 @@ public struct Resource: Encodable {
         self.localization = localization
     }
 
-    /// Apply the platform-specific rule to the given path.
+    /// Apply the platform-specific rule to a resource at the given path.
     ///
-    /// Matching paths will be processed according to the platform for which this
-    /// target is being built. For example, image files might get optimized when
-    /// building for platforms that support such optimizations.
+    /// Use the process rule to process resources at the given path
+    /// according to the platform it builds the target for. For example, the
+    /// Swift package manager may optimize image files for platforms that
+    /// support such optimizations. If no optimization is available for a file
+    /// type, the Swift package manager copies the file.
     ///
-    /// By default, a file will be copied if there is no specialized processing
-    /// for its file type.
+    /// If the given path represents a directory, the Swift package manager
+    /// applies the process rule recursively to each file in the directory.
     ///
-    /// If path is a directory, the rule is applied recursively to each file in the
-    /// directory.
+    /// - Parameters:
+    ///     - path: The path for a resource.
+    ///     - localization: The explicit type for the resource.
     public static func process(_ path: String, localization: Localization? = nil) -> Resource {
         return Resource(rule: "process", path: path, localization: localization)
     }
 
-    /// Apply the copy rule to the given path.
+    /// Apply the copy rule to a resource at the given path.
     ///
-    /// Matching paths will be copied as-is and will be at the top-level
-    /// in the bundle. The structure is retained if path is a directory.
+    /// Use the copy rule to copy resources at the given path as is to the
+    /// top-level in the package’s resource bundle. If the path represents a
+    /// directory, Xcode preserves its structure.
+    ///
+    /// - Parameters:
+    ///     - path: The path for a resource.
     public static func copy(_ path: String) -> Resource {
         return Resource(rule: "copy", path: path, localization: nil)
     }

--- a/Sources/PackageDescription/Resource.swift
+++ b/Sources/PackageDescription/Resource.swift
@@ -50,7 +50,7 @@ public struct Resource: Encodable {
         self.localization = localization
     }
 
-    /// Applies the platform-specific rule to a resource at the given path.
+    /// Applies a platform-specific rule to the resource at the given path.
     ///
     /// Use the process rule to process resources at the given path
     /// according to the platform it builds the target for. For example, the

--- a/Sources/PackageDescription/Resource.swift
+++ b/Sources/PackageDescription/Resource.swift
@@ -16,24 +16,24 @@
 /// For example, any resources for the `MyLibrary` target need to reside in `Sources/MyLibrary`.
 /// Use subdirectories to organize your resource files in a way that makes it easy to identify and manage them.
 /// For example, put all resource files into a directory named `Resources`,
-/// resulting in all of your resource files residing at `Sources/MyLibrary/Resources`.
+/// so your resource files reside at `Sources/MyLibrary/Resources`.
 ///
 /// Per default, Xcode handles common resources types for Apple platforms automatically.
-/// You don’t need to declare XIB files, storyboards, CoreData file types, and asset catalogs
+/// For example, you don’t need to declare XIB files, storyboards, CoreData file types, and asset catalogs
 /// as resources in your package manifest.
 /// However, you must declare other file types, for example image files, as resources explicitly
 /// using the `process(_:localization:)` or `copy(_:)` rules.
 /// Alternatively, exclude resource files from a target by passing them to the
-/// package initializer’s `exclude` parameter. 
+/// target initializer’s `exclude` parameter. 
 public struct Resource: Encodable {
 
     /// Defines the explicit type of localization for resources.
     public enum Localization: String, Encodable {
 
-        /// The package's default localization.
+        /// A constant that represents default internationalization.
         case `default`
 
-        /// Localization for base internationalization.
+        /// A constant that represents base internationalization.
         case base
     }
 
@@ -75,12 +75,12 @@ public struct Resource: Encodable {
     /// Applies the copy rule to a resource at the given path.
     ///
     /// If possible, use `process(_:localization:)`` to automatically apply optimizations
-    /// to resources if applicable for the platform that you’re building the package for.
+    /// to resources.
     ///
-    /// However, you may need resources to remain untouched or retain to a specific folder structure.
-    /// In this case, use the copy rule to copy resources at the given path as
-    /// is to the top-level in the package’s resource bundle.
-    /// If the path represents a directory, the Swift Package Manager preserves its structure.
+    /// If you need resources to remain untouched or retain a specific folder structure,
+    /// use the copy rule. It copies resources at the given path as is to the top-level
+    /// in the package’s resource bundle.
+    /// If the given path represents a directory, the Swift Package Manager preserves its structure.
     ///
     /// - Parameters:
     ///     - path: The path for a resource.

--- a/Sources/PackageDescription/Resource.swift
+++ b/Sources/PackageDescription/Resource.swift
@@ -10,21 +10,19 @@
 
 /// A resource to bundle with the Swift package.
 ///
-/// If a Swift package declares a Swift tools version of 5.3 or later, it can
-/// include resource files. Similar to source code, the Swift package manager
-/// scopes resources to a target. As a result, you need to put your resources
-/// into the subfolder for the target they belong to. For example, any resources
-/// for the `MyLibrary` target need to reside in `Sources/MyLibrary`. Use
-/// subdirectories to organize your resource files in a way that makes it easy
-/// to identify and manage them.
+/// If a Swift package declares a Swift tools version of 5.3 or later, it can include resource files.
+/// Similar to source code, Xcode scopes resources to a target. As a result,
+/// you need to put them into the folder that corresponds to the target they belong to.
+/// For example, any resources for the `MyLibrary` target need to reside in `Sources/MyLibrary`.
+/// Use subdirectories to organize your resource files in a way that makes it easy to identify and manage them.
+/// For example, put all resource files into a directory named `Resources`,
+/// resulting in all of your resource files residing at `Sources/MyLibrary/Resources`.
 ///
-/// Per default, the Swift package manager handles common resources types for
-/// Apple platforms automatically. You don’t need to declare Interface Builder
-/// files, for example, XIB and storyboards, CoreData file types, and asset
-/// catalogs as resources in your package manifest. However, you must declare
-/// other file types as resources, for example, image files, explicitly using
-/// the `copy(_:)` or `process(_:localization:)`` rule. Alternatively, you can
-/// exclude resource files from a target by using `exclude(_:)``.
+/// Per default, Xcode handles common resources types for Apple platforms automatically.
+/// You don’t need to declare XIB files, storyboards, CoreData file types, and asset catalogs
+/// as resources in your package manifest. However, you must declare other file types as resources,
+/// for example, image files, explicitly using the `process(_:localization:)` or `copy(_:) rules`.
+/// Alternatively, you can exclude resource files from a target by using `exclude`.
 public struct Resource: Encodable {
 
     /// Defines the explicit type of localization for resources.
@@ -52,7 +50,7 @@ public struct Resource: Encodable {
         self.localization = localization
     }
 
-    /// Apply the platform-specific rule to a resource at the given path.
+    /// Applies the platform-specific rule to a resource at the given path.
     ///
     /// Use the process rule to process resources at the given path
     /// according to the platform it builds the target for. For example, the
@@ -63,18 +61,24 @@ public struct Resource: Encodable {
     /// If the given path represents a directory, the Swift package manager
     /// applies the process rule recursively to each file in the directory.
     ///
+    /// If possible use this rule instead of `copy(_:)`.
+    ///
     /// - Parameters:
     ///     - path: The path for a resource.
-    ///     - localization: The explicit type for the resource.
+    ///     - localization: The explicit localization type for the resource.
     public static func process(_ path: String, localization: Localization? = nil) -> Resource {
         return Resource(rule: "process", path: path, localization: localization)
     }
 
-    /// Apply the copy rule to a resource at the given path.
+    /// Applies the copy rule to a resource at the given path.
     ///
-    /// Use the copy rule to copy resources at the given path as is to the
-    /// top-level in the package’s resource bundle. If the path represents a
-    /// directory, Xcode preserves its structure.
+    /// If possible, use `process(_:localization:)`` to automatically apply optimizations
+    /// to resources if applicable for the platform that you’re building the package for.
+    ///
+    /// However, you may need resources to remain untouched or retain to a specific folder structure.
+    /// In this case, use the copy rule to copy resources at the given path as
+    /// is to the top-level in the package’s resource bundle.
+    /// If the path represents a directory, the Swift package manager preserves its structure.
     ///
     /// - Parameters:
     ///     - path: The path for a resource.

--- a/Sources/PackageDescription/Resource.swift
+++ b/Sources/PackageDescription/Resource.swift
@@ -54,11 +54,11 @@ public struct Resource: Encodable {
     ///
     /// Use the process rule to process resources at the given path
     /// according to the platform it builds the target for. For example, the
-    /// Swift package manager may optimize image files for platforms that
+    /// Swift Package Manager may optimize image files for platforms that
     /// support such optimizations. If no optimization is available for a file
-    /// type, the Swift package manager copies the file.
+    /// type, the Swift Package Manager copies the file.
     ///
-    /// If the given path represents a directory, the Swift package manager
+    /// If the given path represents a directory, the Swift Package Manager
     /// applies the process rule recursively to each file in the directory.
     ///
     /// If possible use this rule instead of `copy(_:)`.
@@ -78,7 +78,7 @@ public struct Resource: Encodable {
     /// However, you may need resources to remain untouched or retain to a specific folder structure.
     /// In this case, use the copy rule to copy resources at the given path as
     /// is to the top-level in the package’s resource bundle.
-    /// If the path represents a directory, the Swift package manager preserves its structure.
+    /// If the path represents a directory, the Swift Package Manager preserves its structure.
     ///
     /// - Parameters:
     ///     - path: The path for a resource.

--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -60,8 +60,8 @@ public struct Platform: Encodable {
 /// provided for supported platforms, such as an empty array, multiple declarations
 /// for the same platform, or an invalid version specification.
 ///
-/// The Swift Package Manager will emit an error if a dependency is not
-/// compatible with the top-level package's deployment version. The deployment
+/// The Swift Package Manager emits an error if a dependency isn’t compatible
+/// with the top-level package’s deployment version. The deployment
 /// target of a package's dependencies must be lower than or equal to the top-level package's
 /// deployment target version for a particular platform.
 public struct SupportedPlatform: Encodable {

--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -34,33 +34,33 @@ public struct Platform: Encodable {
     /// The Linux platform.
     public static let linux: Platform = Platform(name: "linux")
 
-    /// The Windows platform
+    /// The Windows platform.
     @available(_PackageDescription, introduced: 5.2)
     public static let windows: Platform = Platform(name: "windows")
 
-    /// The Android platform
+    /// The Android platform.
     @available(_PackageDescription, introduced: 5.2)
     public static let android: Platform = Platform(name: "android")
 
-    /// The WASI platform
+    /// The WebAssembly System Interface platform.
     @available(_PackageDescription, introduced: 5.3)
     public static let wasi: Platform = Platform(name: "wasi")
 }
 
 /// A platform that the Swift package supports.
 ///
-/// By default, the Swift Package Manager assigns a predefined minimum deployment
+/// By default, the Swift package manager assigns a predefined minimum deployment
 /// version for each supported platforms unless you configure supported platforms using the `platforms`
 /// API. This predefined deployment version is the oldest deployment target
 /// version that the installed SDK supports for a given platform. One exception
 /// to this rule is macOS, for which the minimum deployment target version
 /// starts from 10.10. Packages can choose to configure the minimum deployment
 /// target version for a platform by using the APIs defined in this struct. The
-/// Swift Package Manager emits appropriate errors when an invalid value is
+/// Swift package manager emits appropriate errors when an invalid value is
 /// provided for supported platforms, such as an empty array, multiple declarations
 /// for the same platform, or an invalid version specification.
 ///
-/// The Swift Package Manager will emit an error if a dependency is not
+/// The Swift package manager will emit an error if a dependency is not
 /// compatible with the top-level package's deployment version. The deployment
 /// target of a package's dependencies must be lower than or equal to the top-level package's
 /// deployment target version for a particular platform.

--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -78,7 +78,7 @@ public struct SupportedPlatform: Encodable {
         self.version = version
     }
 
-    /// Configure the minimum deployment target version for the macOS platform.
+    /// Configures the minimum deployment target version for the macOS platform.
     ///
     /// - Since: First available in PackageDescription 5.0
     ///
@@ -87,7 +87,7 @@ public struct SupportedPlatform: Encodable {
         return SupportedPlatform(platform: .macOS, version: version.version)
     }
 
-    /// Configure the minimum deployment target version for the macOS platform
+    /// Configures the minimum deployment target version for the macOS platform
     /// using a version string.
     ///
     /// The version string must be a series of two or three dot-separated integers, such as `10.10` or `10.10.1`.
@@ -99,7 +99,7 @@ public struct SupportedPlatform: Encodable {
         return SupportedPlatform(platform: .macOS, version: SupportedPlatform.MacOSVersion(string: versionString).version)
     }
 
-    /// Configure the minimum deployment target version for the iOS platform.
+    /// Configures the minimum deployment target version for the iOS platform.
     ///
     /// - Since: First available in PackageDescription 5.0
     ///
@@ -108,7 +108,7 @@ public struct SupportedPlatform: Encodable {
         return SupportedPlatform(platform: .iOS, version: version.version)
     }
 
-    /// Configure the minimum deployment target version for the iOS platform
+    /// Configures the minimum deployment target version for the iOS platform
     /// using a custom version string.
     ///
     /// The version string must be a series of two or three dot-separated integers, such as `8.0` or `8.0.1`.
@@ -120,7 +120,7 @@ public struct SupportedPlatform: Encodable {
         return SupportedPlatform(platform: .iOS, version: SupportedPlatform.IOSVersion(string: versionString).version)
     }
 
-    /// Configure the minimum deployment target version for the tvOS platform.
+    /// Configures the minimum deployment target version for the tvOS platform.
     ///
     /// - Since: First available in PackageDescription 5.0
     ///
@@ -129,7 +129,7 @@ public struct SupportedPlatform: Encodable {
         return SupportedPlatform(platform: .tvOS, version: version.version)
     }
 
-    /// Configure the minimum deployment target version for the tvOS platform
+    /// Configures the minimum deployment target version for the tvOS platform
     /// using a custom version string.
     ///
     /// The version string must be a series of two or three dot-separated integers,such as `9.0` or `9.0.1`.
@@ -141,7 +141,7 @@ public struct SupportedPlatform: Encodable {
         return SupportedPlatform(platform: .tvOS, version: SupportedPlatform.TVOSVersion(string: versionString).version)
     }
 
-    /// Configure the minimum deployment target version for the watchOS platform.
+    /// Configures the minimum deployment target version for the watchOS platform.
     ///
     /// - Since: First available in PackageDescription 5.0
     ///
@@ -150,7 +150,7 @@ public struct SupportedPlatform: Encodable {
         return SupportedPlatform(platform: .watchOS, version: version.version)
     }
 
-    /// Configure the minimum deployment target version for the watchOS platform
+    /// Configures the minimum deployment target version for the watchOS platform
     /// using a custom version string.
     ///
     /// The version string must be a series of two or three dot-separated integers, such as `2.0` or `2.0.1`.

--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -49,18 +49,18 @@ public struct Platform: Encodable {
 
 /// A platform that the Swift package supports.
 ///
-/// By default, the Swift package manager assigns a predefined minimum deployment
+/// By default, the Swift Package Manager assigns a predefined minimum deployment
 /// version for each supported platforms unless you configure supported platforms using the `platforms`
 /// API. This predefined deployment version is the oldest deployment target
 /// version that the installed SDK supports for a given platform. One exception
 /// to this rule is macOS, for which the minimum deployment target version
 /// starts from 10.10. Packages can choose to configure the minimum deployment
 /// target version for a platform by using the APIs defined in this struct. The
-/// Swift package manager emits appropriate errors when an invalid value is
+/// Swift Package Manager emits appropriate errors when an invalid value is
 /// provided for supported platforms, such as an empty array, multiple declarations
 /// for the same platform, or an invalid version specification.
 ///
-/// The Swift package manager will emit an error if a dependency is not
+/// The Swift Package Manager will emit an error if a dependency is not
 /// compatible with the top-level package's deployment version. The deployment
 /// target of a package's dependencies must be lower than or equal to the top-level package's
 /// deployment target version for a particular platform.

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -102,7 +102,7 @@ public final class Target {
 
     /// The path to the directory containing public headers of a C-family target.
     ///
-    /// If this is `nil`, the directory will be set to `include`.
+    /// If this is `nil`, the directory is set to `include`.
     public var publicHeadersPath: String?
 
     /// The type of the target.

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -52,8 +52,8 @@ public final class Target {
     /// and in a subdirectory with the target's name.
     ///
     /// The predefined search paths are the following directories under the package root:
-    ///   - For regular targets: `Sources`, `Source`, `src`, and `srcs`
-    ///   - For test targets: `Tests`, `Sources`, `Source`, `src`, `srcs`
+    ///   - `Sources`, `Source`, `src`, and `srcs` for regular targets
+    ///   - `Tests`, `Sources`, `Source`, `src`, and `srcs` for test targets
     ///
     /// For example, the Swift Package Manager looks for source files inside the `[PackageRoot]/Sources/[TargetName]` directory.
     ///

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -48,14 +48,14 @@ public final class Target {
 
     /// The path of the target, relative to the package root.
     ///
-    /// If the path is `nil`, the Swift package manager looks for a target's source files at predefined search paths
+    /// If the path is `nil`, the Swift Package Manager looks for a target's source files at predefined search paths
     /// and in a subdirectory with the target's name.
     ///
     /// The predefined search paths are the following directories under the package root:
     ///   - For regular targets: `Sources`, `Source`, `src`, and `srcs`
     ///   - For test targets: `Tests`, `Sources`, `Source`, `src`, `srcs`
     ///
-    /// For example, the Swift package manager looks for source files inside the `[PackageRoot]/Sources/[TargetName]` directory.
+    /// For example, the Swift Package Manager looks for source files inside the `[PackageRoot]/Sources/[TargetName]` directory.
     ///
     /// Don't escape the package root; that is, values like `../Foo` or `/Foo` are invalid.
     public var path: String?
@@ -72,9 +72,9 @@ public final class Target {
 
     /// The source files in this target.
     ///
-    /// If this property is `nil`, the Swift package manager includes all valid source files in the target's path and treats specified paths as relative to the target’s path.
+    /// If this property is `nil`, the Swift Package Manager includes all valid source files in the target's path and treats specified paths as relative to the target’s path.
     ///
-    /// A path can be a path to a directory or an individual source file. In case of a directory, the Swift package manager searches for valid source files
+    /// A path can be a path to a directory or an individual source file. In case of a directory, the Swift Package Manager searches for valid source files
     /// recursively inside it.
     public var sources: [String]?
 
@@ -110,7 +110,7 @@ public final class Target {
 
     /// The `pkgconfig` name to use for a system library target.
     ///
-    /// If present, the Swift package manager tries to
+    /// If present, the Swift Package Manager tries to
     /// search for the `<name>.pc` file to get the additional flags needed for the
     /// system target.
     public let pkgConfig: String?
@@ -236,7 +236,7 @@ public final class Target {
     /// Creates a library or executable target.
     ///
     /// A target can either contain Swift or C-family source files. You can't
-    /// mix Swift and C-family source files within a target. The Swift package manager
+    /// mix Swift and C-family source files within a target. The Swift Package Manager
     /// considers a target to be an executable target if there's a `main.swift`,
     /// `main.m`, `main.c`, or `main.cpp` file in the target's directory. It considers
     /// all other targets to be library targets.
@@ -244,14 +244,14 @@ public final class Target {
     /// - Parameters:
     ///   - name: The name of the target.
     ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
-    ///   - path: The custom path for the target. By default, the Swift package manager expects a target's sources to reside at predefined search paths,
+    ///   - path: The custom path for the target. By default, the Swift Package Manager expects a target's sources to reside at predefined search paths,
     ///       for example, `[PackageRoot]/Sources/[TargetName]`.
     ///       Don't escape the package root; that is, values like `../Foo` or `/Foo` are invalid.
-    ///   - exclude: A list of paths to files or directories that the Swift package manager shouldn't consider to be source or resource files.
+    ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
     ///       This path is relative to the target's directory.
     ///       This parameter has precedence over the `sources` parameter.
     ///   - sources: An explicit list of source files. In case you provide a path to a directory,
-    ///       the Swift package manager searches for valid source files recursively.
+    ///       the Swift Package Manager searches for valid source files recursively.
     ///   - publicHeadersPath: The directory containing public headers of a C-family family library target.
     @available(_PackageDescription, introduced: 4, obsoleted: 5)
     public static func target(
@@ -276,7 +276,7 @@ public final class Target {
     /// Creates a library or executable target.
     ///
     /// A target can either contain Swift or C-family source files. You can't
-    /// mix Swift and C-family source files within a target. The Swift package manager
+    /// mix Swift and C-family source files within a target. The Swift Package Manager
     /// considers a target to be an executable target if there's a `main.swift`,
     /// `main.m`, `main.c`, or `main.cpp` file in the target's directory. It considers
     /// all other targets to be library targets.
@@ -284,14 +284,14 @@ public final class Target {
     /// - Parameters:
     ///   - name: The name of the target.
     ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
-    ///   - path: The custom path for the target. By default, the Swift package manager expects a target's sources to reside at predefined search paths,
+    ///   - path: The custom path for the target. By default, the Swift Package Manager expects a target's sources to reside at predefined search paths,
     ///       for example, `[PackageRoot]/Sources/[TargetName]`.
     ///       Don't escape the package root; that is, values like `../Foo` or `/Foo` are invalid.
-    ///   - exclude: A list of paths to files or directories that the Swift package manager shouldn't consider to be source or resource files.
+    ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
     ///       This path is relative to the target's directory.
     ///       This parameter has precedence over the `sources` parameter.
     ///   - sources: An explicit list of source files. In case you provide a path to a directory,
-    ///       the Swift package manager searches for valid source files recursively.
+    ///       the Swift Package Manager searches for valid source files recursively.
     ///   - publicHeadersPath: The directory containing public headers of a C-family family library target.
     ///   - cSettings: The C settings for this target.
     ///   - cxxSettings: The C++ settings for this target.
@@ -328,7 +328,7 @@ public final class Target {
     /// Creates a library or executable target.
     ///
     /// A target can either contain Swift or C-family source files. You can't
-    /// mix Swift and C-family source files within a target. The Swift package manager
+    /// mix Swift and C-family source files within a target. The Swift Package Manager
     /// considers a target to be an executable target if there's a `main.swift`,
     /// `main.m`, `main.c`, or `main.cpp` file in the target's directory. It considers
     /// all other targets to be library targets.
@@ -336,14 +336,14 @@ public final class Target {
     /// - Parameters:
     ///   - name: The name of the target.
     ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
-    ///   - path: The custom path for the target. By default, the Swift package manager expects a target's sources to reside at predefined search paths,
+    ///   - path: The custom path for the target. By default, the Swift Package Manager expects a target's sources to reside at predefined search paths,
     ///       for example, `[PackageRoot]/Sources/[TargetName]`.
     ///       Don't escape the package root; that is, values like `../Foo` or `/Foo` are invalid.
-    ///   - exclude: A list of paths to files or directories that the Swift package manager shouldn't consider to be source or resource files.
+    ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
     ///       This path is relative to the target's directory.
     ///       This parameter has precedence over the `sources` parameter.
     ///   - sources: An explicit list of source files. In case you provide a path to a directory,
-    ///       the Swift package manager searches for valid source files recursively.
+    ///       the Swift Package Manager searches for valid source files recursively.
     ///   - resources: An explicit list of resources files.
     ///   - publicHeadersPath: The directory containing public headers of a C-family family library target.
     ///   - cSettings: The C settings for this target.
@@ -388,14 +388,14 @@ public final class Target {
     /// - Parameters:
     ///   - name: The name of the target.
     ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
-    ///   - path: The custom path for the target. By default, the Swift package manager expects a target's sources to reside at predefined search paths,
+    ///   - path: The custom path for the target. By default, the Swift Package Manager expects a target's sources to reside at predefined search paths,
     ///       for example, `[PackageRoot]/Sources/[TargetName]`.
     ///       Don't escape the package root; that is, values like `../Foo` or `/Foo` are invalid.
-    ///   - exclude: A list of paths to files or directories that the Swift package manager shouldn't consider to be source or resource files.
+    ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
     ///       This path is relative to the target's directory.
     ///       This parameter has precedence over the `sources` parameter.
     ///   - sources: An explicit list of source files. In case you provide a path to a directory,
-    ///       the Swift package manager searches for valid source files recursively.
+    ///       the Swift Package Manager searches for valid source files recursively.
     @available(_PackageDescription, introduced: 4, obsoleted: 5)
     public static func testTarget(
         name: String,
@@ -423,14 +423,14 @@ public final class Target {
     /// - Parameters:
     ///   - name: The name of the target.
     ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
-    ///   - path: The custom path for the target. By default, the Swift package manager expects a target's sources to reside at predefined search paths,
+    ///   - path: The custom path for the target. By default, the Swift Package Manager expects a target's sources to reside at predefined search paths,
     ///       for example, `[PackageRoot]/Sources/[TargetName]`.
     ///       Don't escape the package root; that is, values like `../Foo` or `/Foo` are invalid.
-    ///   - exclude: A list of paths to files or directories that the Swift package manager shouldn't consider to be source or resource files.
+    ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
     ///       This path is relative to the target's directory.
     ///       This parameter has precedence over the `sources` parameter.
     ///   - sources: An explicit list of source files. In case you provide a path to a directory,
-    ///       the Swift package manager searches for valid source files recursively.
+    ///       the Swift Package Manager searches for valid source files recursively.
     ///   - cSettings: The C settings for this target.
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
@@ -470,14 +470,14 @@ public final class Target {
     /// - Parameters:
     ///   - name: The name of the target.
     ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
-    ///   - path: The custom path for the target. By default, the Swift package manager expects a target's sources to reside at predefined search paths,
+    ///   - path: The custom path for the target. By default, the Swift Package Manager expects a target's sources to reside at predefined search paths,
     ///       for example, `[PackageRoot]/Sources/[TargetName]`.
     ///       Don't escape the package root; that is, values like `../Foo` or `/Foo` are invalid.
-    ///   - exclude: A list of paths to files or directories that the Swift package manager shouldn't consider to be source or resource files.
+    ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
     ///       This path is relative to the target's directory.
     ///       This parameter has precedence over the `sources` parameter.
     ///   - sources: An explicit list of source files. In case you provide a path to a directory,
-    ///       the Swift package manager searches for valid source files recursively.
+    ///       the Swift Package Manager searches for valid source files recursively.
     ///   - resources: An explicit list of resources files.
     ///   - cSettings: The C settings for this target.
     ///   - cxxSettings: The C++ settings for this target.
@@ -575,7 +575,7 @@ public final class Target {
     /// Creates a binary target that references an artifact on disk.
     ///
     /// A binary target provides the path to a pre-built binary artifact for the target.
-    /// The Swift package manager only supports binary targets for Apple platforms.
+    /// The Swift Package Manager only supports binary targets for Apple platforms.
     ///
     /// - Parameters:
     ///   - name: The name of the target.
@@ -734,7 +734,7 @@ extension Target.Dependency {
         return ._productItem(name: name, package: package, condition: condition)
     }
 
-    /// Creates a by-name dependency that resolves to either a target or a product but after the Swift package manager
+    /// Creates a by-name dependency that resolves to either a target or a product but after the Swift Package Manager
     /// has loaded the package graph.
     ///
     /// - parameters:

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -60,7 +60,10 @@ public final class Target {
     /// Do not escape the package root; that is, values like `../Foo` or `/Foo` are invalid.
     public var path: String?
 
-    /// The url of the binary target.
+    /// The URL of a binary target.
+    ///
+    /// The URL points to a ZIP file that contains an XCFramework at its root.
+    /// Binary targets are only available on Apple Platforms.
     public var url: String? {
         get { _url }
         set { _url = newValue }

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -48,16 +48,16 @@ public final class Target {
 
     /// The path of the target, relative to the package root.
     ///
-    /// If the path is `nil`, the Swift Package Manager looks for a targets source files at predefined search paths
+    /// If the path is `nil`, the Swift package manager looks for a target's source files at predefined search paths
     /// and in a subdirectory with the target's name.
     ///
     /// The predefined search paths are the following directories under the package root:
     ///   - For regular targets: `Sources`, `Source`, `src`, and `srcs`
     ///   - For test targets: `Tests`, `Sources`, `Source`, `src`, `srcs`
     ///
-    /// For example, the Swift Package Manager will look for source files inside the `[PackageRoot]/Sources/[TargetName]` directory.
+    /// For example, the Swift package manager looks for source files inside the `[PackageRoot]/Sources/[TargetName]` directory.
     ///
-    /// Do not escape the package root; that is, values like `../Foo` or `/Foo` are invalid.
+    /// Don't escape the package root; that is, values like `../Foo` or `/Foo` are invalid.
     public var path: String?
 
     /// The URL of a binary target.
@@ -72,9 +72,9 @@ public final class Target {
 
     /// The source files in this target.
     ///
-    /// If this property is `nil`, all valid source files in the target's path will be included and specified paths are relative to the target path.
+    /// If this property is `nil`, the Swift package manager includes all valid source files in the target's path and treats specified paths as relative to the target’s path.
     ///
-    /// A path can be a path to a directory or an individual source file. In case of a directory, the Swift Package Manager searches for valid source files
+    /// A path can be a path to a directory or an individual source file. In case of a directory, the Swift package manager searches for valid source files
     /// recursively inside it.
     public var sources: [String]?
 
@@ -86,10 +86,10 @@ public final class Target {
     }
     private var _resources: [Resource]?
 
-    /// The paths you want to exclude from source inference.
+    /// The paths to source and resource files you don’t want to include in the target.
     ///
     /// Excluded paths are relative to the target path.
-    /// This property has precedence over the `sources` property.
+    /// This property has precedence over the `sources` and `resources` properties.
     public var exclude: [String]
 
     /// A boolean value that indicates if this is a test target.
@@ -110,7 +110,7 @@ public final class Target {
 
     /// The `pkgconfig` name to use for a system library target.
     ///
-    /// If present, the Swift Package Manager tries to
+    /// If present, the Swift package manager tries to
     /// search for the `<name>.pc` file to get the additional flags needed for the
     /// system target.
     public let pkgConfig: String?
@@ -150,7 +150,7 @@ public final class Target {
     }
     private var _linkerSettings: [LinkerSetting]?
 
-    /// The binary target's checksum.
+    /// The checksum for the ZIP file that contains the referenced XCFramework.
     @available(_PackageDescription, introduced: 5.3)
     public var checksum: String? {
         get { _checksum }
@@ -233,25 +233,26 @@ public final class Target {
         }
     }
 
-    /// Create a library or executable target.
+    /// Creates a library or executable target.
     ///
-    /// A target can either contain Swift or C-family source files and you can't
-    /// mix Swift and C-family source files within a target. A target is
-    /// considered to be an executable target if there is a `main.swift`,
-    /// `main.m`, `main.c`, or `main.cpp` file in the target's directory. All
-    /// other targets are considered to be library targets.
+    /// A target can either contain Swift or C-family source files. You can't
+    /// mix Swift and C-family source files within a target. The Swift package manager
+    /// considers a target to be an executable target if there's a `main.swift`,
+    /// `main.m`, `main.c`, or `main.cpp` file in the target's directory. It considers
+    /// all other targets to be library targets.
     ///
     /// - Parameters:
     ///   - name: The name of the target.
     ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
-    ///   - path: The custom path for the target. By default, a targets sources are expected to be located in the predefined search paths,
-    ///       such as `[PackageRoot]/Sources/[TargetName]`.
-    ///       Do not escape the package root; that is, values like `../Foo` or `/Foo` are invalid.
-    ///   - exclude: A list of paths to files or directories that should not be considered source files. This path is relative to the target's directory.
+    ///   - path: The custom path for the target. By default, the Swift package manager expects a target's sources to reside at predefined search paths,
+    ///       for example, `[PackageRoot]/Sources/[TargetName]`.
+    ///       Don't escape the package root; that is, values like `../Foo` or `/Foo` are invalid.
+    ///   - exclude: A list of paths to files or directories that the Swift package manager shouldn't consider to be source or resource files.
+    ///       This path is relative to the target's directory.
     ///       This parameter has precedence over the `sources` parameter.
-    ///   - sources: An explicit list of source files. In case of a directory, the Swift Package Manager searches for valid source files
-    ///       recursively.
-    ///   - publicHeadersPath: The path to the directory containing public headers of a C-family target.
+    ///   - sources: An explicit list of source files. In case you provide a path to a directory,
+    ///       the Swift package manager searches for valid source files recursively.
+    ///   - publicHeadersPath: The directory containing public headers of a C-family family library target.
     @available(_PackageDescription, introduced: 4, obsoleted: 5)
     public static func target(
         name: String,
@@ -272,24 +273,25 @@ public final class Target {
         )
     }
 
-    /// Create a library or executable target.
+    /// Creates a library or executable target.
     ///
     /// A target can either contain Swift or C-family source files. You can't
-    /// mix Swift and C-family source files within a target. A target is
-    /// considered to be an executable target if there is a `main.swift`,
-    /// `main.m`, `main.c`, or `main.cpp` file in the target's directory. All
-    /// other targets are considered to be library targets.
+    /// mix Swift and C-family source files within a target. The Swift package manager
+    /// considers a target to be an executable target if there's a `main.swift`,
+    /// `main.m`, `main.c`, or `main.cpp` file in the target's directory. It considers
+    /// all other targets to be library targets.
     ///
     /// - Parameters:
     ///   - name: The name of the target.
     ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
-    ///   - path: The custom path for the target. By default, a targets sources are expected to be located in the predefined search paths,
-    ///       such as `[PackageRoot]/Sources/[TargetName]`.
-    ///       Do not escape the package root; that is, values like `../Foo` or `/Foo` are invalid..
-    ///   - exclude: A list of paths to files or directories that should not be considered source files. This path is relative to the target's directory.
+    ///   - path: The custom path for the target. By default, the Swift package manager expects a target's sources to reside at predefined search paths,
+    ///       for example, `[PackageRoot]/Sources/[TargetName]`.
+    ///       Don't escape the package root; that is, values like `../Foo` or `/Foo` are invalid.
+    ///   - exclude: A list of paths to files or directories that the Swift package manager shouldn't consider to be source or resource files.
+    ///       This path is relative to the target's directory.
     ///       This parameter has precedence over the `sources` parameter.
-    ///   - sources: An explicit list of source files. In case of a directory, the Swift Package Manager searches for valid source files
-    ///       recursively.
+    ///   - sources: An explicit list of source files. In case you provide a path to a directory,
+    ///       the Swift package manager searches for valid source files recursively.
     ///   - publicHeadersPath: The directory containing public headers of a C-family family library target.
     ///   - cSettings: The C settings for this target.
     ///   - cxxSettings: The C++ settings for this target.
@@ -323,24 +325,25 @@ public final class Target {
         )
     }
 
-    /// Create a library or executable target.
+    /// Creates a library or executable target.
     ///
     /// A target can either contain Swift or C-family source files. You can't
-    /// mix Swift and C-family source files within a target. A target is
-    /// considered to be an executable target if there is a `main.swift`,
-    /// `main.m`, `main.c`, or `main.cpp` file in the target's directory. All
-    /// other targets are considered to be library targets.
+    /// mix Swift and C-family source files within a target. The Swift package manager
+    /// considers a target to be an executable target if there's a `main.swift`,
+    /// `main.m`, `main.c`, or `main.cpp` file in the target's directory. It considers
+    /// all other targets to be library targets.
     ///
     /// - Parameters:
     ///   - name: The name of the target.
     ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
-    ///   - path: The custom path for the target. By default, a targets sources are expected to be located in the predefined search paths,
-    ///       such as `[PackageRoot]/Sources/[TargetName]`.
-    ///       Do not escape the package root; that is, values like `../Foo` or `/Foo` are invalid..
-    ///   - exclude: A list of paths to files or directories that should not be considered source files. This path is relative to the target's directory.
+    ///   - path: The custom path for the target. By default, the Swift package manager expects a target's sources to reside at predefined search paths,
+    ///       for example, `[PackageRoot]/Sources/[TargetName]`.
+    ///       Don't escape the package root; that is, values like `../Foo` or `/Foo` are invalid.
+    ///   - exclude: A list of paths to files or directories that the Swift package manager shouldn't consider to be source or resource files.
+    ///       This path is relative to the target's directory.
     ///       This parameter has precedence over the `sources` parameter.
-    ///   - sources: An explicit list of source files. In case of a directory, the Swift Package Manager searches for valid source files
-    ///       recursively.
+    ///   - sources: An explicit list of source files. In case you provide a path to a directory,
+    ///       the Swift package manager searches for valid source files recursively.
     ///   - resources: An explicit list of resources files.
     ///   - publicHeadersPath: The directory containing public headers of a C-family family library target.
     ///   - cSettings: The C settings for this target.
@@ -377,7 +380,7 @@ public final class Target {
         )
     }
 
-    /// Create a test target.
+    /// Creates a test target.
     ///
     /// Write test targets using the XCTest testing framework.
     /// Test targets generally declare a dependency on the targets they test.
@@ -385,13 +388,14 @@ public final class Target {
     /// - Parameters:
     ///   - name: The name of the target.
     ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
-    ///   - path: The custom path for the target. By default, a targets sources are expected to be located in the predefined search paths,
-    ///       such as `[PackageRoot]/Sources/[TargetName]`.
-    ///       Do not escape the package root; that is, values like `../Foo` or `/Foo` are invalid.
-    ///   - exclude: A list of paths to files or directories that should not be considered source files. This path is relative to the target's directory.
+    ///   - path: The custom path for the target. By default, the Swift package manager expects a target's sources to reside at predefined search paths,
+    ///       for example, `[PackageRoot]/Sources/[TargetName]`.
+    ///       Don't escape the package root; that is, values like `../Foo` or `/Foo` are invalid.
+    ///   - exclude: A list of paths to files or directories that the Swift package manager shouldn't consider to be source or resource files.
+    ///       This path is relative to the target's directory.
     ///       This parameter has precedence over the `sources` parameter.
-    ///   - sources: An explicit list of source files. In case of a directory, the Swift Package Manager searches for valid source files
-    ///       recursively.
+    ///   - sources: An explicit list of source files. In case you provide a path to a directory,
+    ///       the Swift package manager searches for valid source files recursively.
     @available(_PackageDescription, introduced: 4, obsoleted: 5)
     public static func testTarget(
         name: String,
@@ -411,7 +415,7 @@ public final class Target {
         )
     }
 
-    /// Create a test target.
+    /// Creates a test target.
     ///
     /// Write test targets using the XCTest testing framework.
     /// Test targets generally declare a dependency on the targets they test.
@@ -419,13 +423,14 @@ public final class Target {
     /// - Parameters:
     ///   - name: The name of the target.
     ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
-    ///   - path: The custom path for the target. By default, a targets sources are expected to be located in the predefined search paths,
-    ///       such as `[PackageRoot]/Sources/[TargetName]`.
-    ///       Do not escape the package root; that is, values like `../Foo` or `/Foo` are invalid.
-    ///   - exclude: A list of paths to files or directories that should not be considered source files. This path is relative to the target's directory.
+    ///   - path: The custom path for the target. By default, the Swift package manager expects a target's sources to reside at predefined search paths,
+    ///       for example, `[PackageRoot]/Sources/[TargetName]`.
+    ///       Don't escape the package root; that is, values like `../Foo` or `/Foo` are invalid.
+    ///   - exclude: A list of paths to files or directories that the Swift package manager shouldn't consider to be source or resource files.
+    ///       This path is relative to the target's directory.
     ///       This parameter has precedence over the `sources` parameter.
-    ///   - sources: An explicit list of source files. In case of a directory, the Swift Package Manager searches for valid source files
-    ///       recursively.
+    ///   - sources: An explicit list of source files. In case you provide a path to a directory,
+    ///       the Swift package manager searches for valid source files recursively.
     ///   - cSettings: The C settings for this target.
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
@@ -457,7 +462,7 @@ public final class Target {
         )
     }
 
-    /// Create a test target.
+    /// Creates a test target.
     ///
     /// Write test targets using the XCTest testing framework.
     /// Test targets generally declare a dependency on the targets they test.
@@ -465,13 +470,14 @@ public final class Target {
     /// - Parameters:
     ///   - name: The name of the target.
     ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
-    ///   - path: The custom path for the target. By default, a targets sources are expected to be located in the predefined search paths,
-    ///       such as `[PackageRoot]/Sources/[TargetName]`.
-    ///       Do not escape the package root; that is, values like `../Foo` or `/Foo` are invalid.
-    ///   - exclude: A list of paths to files or directories that should not be considered source files. This path is relative to the target's directory.
+    ///   - path: The custom path for the target. By default, the Swift package manager expects a target's sources to reside at predefined search paths,
+    ///       for example, `[PackageRoot]/Sources/[TargetName]`.
+    ///       Don't escape the package root; that is, values like `../Foo` or `/Foo` are invalid.
+    ///   - exclude: A list of paths to files or directories that the Swift package manager shouldn't consider to be source or resource files.
+    ///       This path is relative to the target's directory.
     ///       This parameter has precedence over the `sources` parameter.
-    ///   - sources: An explicit list of source files. In case of a directory, the Swift Package Manager searches for valid source files
-    ///       recursively.
+    ///   - sources: An explicit list of source files. In case you provide a path to a directory,
+    ///       the Swift package manager searches for valid source files recursively.
     ///   - resources: An explicit list of resources files.
     ///   - cSettings: The C settings for this target.
     ///   - cxxSettings: The C++ settings for this target.
@@ -507,7 +513,7 @@ public final class Target {
     }
 
   #if !PACKAGE_DESCRIPTION_4
-    /// Create a system library target.
+    /// Creates a system library target.
     ///
     /// Use system library targets to adapt a library installed on the system to work with Swift packages.
     /// Such libraries are generally installed by system package managers (such as Homebrew and apt-get)
@@ -538,15 +544,16 @@ public final class Target {
             providers: providers)
     }
 
-    /// Create a binary target referencing a remote artifact.
+    /// Creates a binary target that references a remote artifact.
     ///
     /// A binary target provides the url to a pre-built binary artifact for the target. Currently only supports
     /// artifacts for Apple platforms.
     ///
     /// - Parameters:
     ///   - name: The name of the target.
-    ///   - url: The URL to the binary artifact. Should point to a `zip` archive containing a `XCFramework`.
-    ///   - checksum: The checksum of the artifact archive for validation.
+    ///   - url: The URL to the binary artifact. It needs to point to a ZIP archive
+    ///       that contains an XCFramework in its root directory.
+    ///   - checksum: The checksum of the ZIP file that contains the XCFramework.
     @available(_PackageDescription, introduced: 5.3)
     public static func binaryTarget(
         name: String,
@@ -565,15 +572,14 @@ public final class Target {
             checksum: checksum)
     }
 
-    /// Create a binary target referencing an artifact on disk.
+    /// Creates a binary target that references an artifact on disk.
     ///
-    /// A binary target provides the path to a pre-built binary artifact for the target. Currently only supports
-    /// artifacts for Apple platforms.
+    /// A binary target provides the path to a pre-built binary artifact for the target.
+    /// The Swift package manager only supports binary targets for Apple platforms.
     ///
     /// - Parameters:
     ///   - name: The name of the target.
-    ///   - path: The path to the binary artifact. Can point directly to a `XCFramework` or a zip containing the
-    ///       `XCFramework`.
+    ///   - path: The path to the binary artifact. It can point directly to an XCFramework or a ZIP file that contains the XCFramework at its root.
     @available(_PackageDescription, introduced: 5.3)
     public static func binaryTarget(
         name: String,
@@ -705,18 +711,20 @@ extension Target.Dependency {
     ///
     /// - parameters:
     ///   - name: The name of the target.
-    ///   - condition: The condition under which the dependency is exercised.
+    ///   - condition: A condition that limits the application of the target dependency. For example, only apply a
+    ///       dependency for a specific platform.
     @available(_PackageDescription, introduced: 5.3)
     public static func target(name: String, condition: TargetDependencyCondition? = nil) -> Target.Dependency {
         return ._targetItem(name: name, condition: condition)
     }
 
-    /// Creates a dependency on a product from a package dependency.
+    /// Creates a target dependency on a product from a package dependency.
     ///
     /// - parameters:
     ///   - name: The name of the product.
     ///   - package: The name of the package.
-    ///   - condition: The condition under which the dependency is exercised.
+    ///   - condition: A condition that limits the application of the target dependency. For example, only apply a
+    ///       dependency for a specific platform.
     @available(_PackageDescription, introduced: 5.3)
     public static func product(
         name: String,
@@ -726,12 +734,13 @@ extension Target.Dependency {
         return ._productItem(name: name, package: package, condition: condition)
     }
 
-    /// Creates a by-name dependency that resolves to either a target or a product but
-    /// after the package graph has been loaded.
+    /// Creates a by-name dependency that resolves to either a target or a product but after the Swift package manager
+    /// has loaded the package graph.
     ///
     /// - parameters:
     ///   - name: The name of the dependency, either a target or a product.
-    ///   - condition: The condition under which the dependency is exercised.
+    ///   - condition: A condition that limits the application of the target dependency. For example, only apply a
+    ///       dependency for a specific platform.
     @available(_PackageDescription, introduced: 5.3)
     public static func byName(name: String, condition: TargetDependencyCondition? = nil) -> Target.Dependency {
         return ._byNameItem(name: name, condition: condition)
@@ -765,7 +774,7 @@ public struct TargetDependencyCondition: Encodable {
         self.platforms = platforms
     }
 
-    /// Create a target dependency condition.
+    /// Creates a target dependency condition.
     ///
     /// - Parameters:
     ///   - platforms: The applicable platforms for this target dependency condition.

--- a/Sources/PackageDescription/Version+StringLiteralConvertible.swift
+++ b/Sources/PackageDescription/Version+StringLiteralConvertible.swift
@@ -10,10 +10,10 @@
 
 extension Version: ExpressibleByStringLiteral {
 
-    /// Initializes and returns a newly allocated version struct for the provided string literal.
+    /// Initializes a version struct with the provided string literal.
     ///
     /// - Parameters:
-    ///     - version: A string literal to use for creating a new version object.
+    ///     - version: A string literal to use for creating a new version struct.
     public init(stringLiteral value: String) {
         if let version = Version(value) {
             self.init(version)
@@ -27,18 +27,18 @@ extension Version: ExpressibleByStringLiteral {
         }
     }
 
-    /// Initializes and returns a newly allocated version struct for the provided extended grapheme cluster.
+    /// Initializes a version struct with the provided extended grapheme cluster.
     ///
     /// - Parameters:
-    ///     - version: An extended grapheme cluster to use for creating a new version object.
+    ///     - version: An extended grapheme cluster to use for creating a new version struct.
     public init(extendedGraphemeClusterLiteral value: String) {
         self.init(stringLiteral: value)
     }
 
-    /// Initializes and returns a newly allocated version struct for the provided Unicode string.
+    /// Initializes a version struct with the provided Unicode string.
     ///
     /// - Parameters:
-    ///     - version: A Unicode string to use for creating a new version object.
+    ///     - version: A Unicode string to use for creating a new version struct.
     public init(unicodeScalarLiteral value: String) {
         self.init(stringLiteral: value)
     }
@@ -46,10 +46,10 @@ extension Version: ExpressibleByStringLiteral {
 
 extension Version {
 
-    /// Initializes and returns a newly allocated version struct for the provided version.
+    /// Initializes a version struct with the provided version.
     ///
     /// - Parameters:
-    ///     - version: A version object to use for creating a new version object.
+    ///     - version: A version object to use for creating a new version struct.
     public init(_ version: Version) {
         major = version.major
         minor = version.minor
@@ -58,10 +58,10 @@ extension Version {
         buildMetadataIdentifiers = version.buildMetadataIdentifiers
     }
 
-    /// Initializes and returns a newly allocated version struct for the provided version string.
+    /// Initializes a version struct with the provided version string.
     ///
     /// - Parameters:
-    ///     - version: A version string to use for creating a new version object.
+    ///     - version: A version string to use for creating a new version struct.
     public init?(_ versionString: String) {
         let prereleaseStartIndex = versionString.firstIndex(of: "-")
         let metadataStartIndex = versionString.firstIndex(of: "+")

--- a/Sources/PackageDescription/Version.swift
+++ b/Sources/PackageDescription/Version.swift
@@ -35,8 +35,6 @@
 /// Increase the third digit of a version, or *patch version*, if you are making a backward-compatible bug fix.
 /// This allows clients to benefit from bugfixes to your package without incurring
 /// any maintenance burden.
-///
-
 public struct Version {
 
     /// The major version according to the semantic versioning standard.
@@ -54,8 +52,7 @@ public struct Version {
     /// The build metadata of this version according to the semantic versioning standard, such as a commit hash.
     public let buildMetadataIdentifiers: [String]
 
-    /// Initializes and returns a newly allocated version struct
-    /// for the provided components of a semantic version.
+    /// Initializes a version struct with the provided components of a semantic version.
     ///
     /// - Parameters:
     ///     - major: The major version numner.


### PR DESCRIPTION
This PR includes the following updates:
- Fix a few typos.
- ~Don't use title case for "Swift package manager".~
- Use Apple-style docs for abstracts, e.g. use 3rd person for verb phrases ("Creates..." instead of "Create").
- Add source docs for package resources, localized resources, and binary packages.
