### PR TITLE
Improve diagnostic for system target with missing modulemap

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -19,6 +19,7 @@ public enum ModuleError: Swift.Error {
     public enum InvalidLayoutType {
         case multipleSourceRoots([AbsolutePath])
         case modulemapInSources(AbsolutePath)
+        case modulemapMissing(AbsolutePath)
     }
 
     /// Indicates two targets with the same name and their corresponding packages.
@@ -120,6 +121,8 @@ extension ModuleError.InvalidLayoutType: CustomStringConvertible {
           return "multiple source roots found: " + paths.map({ $0.description }).sorted().joined(separator: ", ")
         case .modulemapInSources(let path):
             return "modulemap '\(path)' should be inside the 'include' directory"
+        case .modulemapMissing(let path):
+            return "missing system target module map at '\(path)'"
         }
     }
 }
@@ -653,7 +656,7 @@ public final class PackageBuilder {
         if potentialModule.type == .system {
             let moduleMapPath = potentialModule.path.appending(component: moduleMapFilename)
             guard fileSystem.isFile(moduleMapPath) else {
-                return nil
+                throw ModuleError.invalidLayout(.modulemapMissing(moduleMapPath))
             }
 
             return SystemLibraryTarget(

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -1448,6 +1448,22 @@ class PackageBuilderTests: XCTestCase {
                 behavior: .error,
                 location: "'SystemModulePackage' /")
         }
+        
+        manifest = Manifest.createV4Manifest(
+            name: "bar",
+            products: [
+                ProductDescription(name: "bar", type: .library(.automatic), targets: ["bar"])
+            ],
+            targets: [
+                TargetDescription(name: "bar", type: .system)
+            ]
+        )
+        PackageBuilderTester(manifest, in: fs) { _, diagnostics in
+            diagnostics.check(
+                diagnostic: "package has unsupported layout; missing system target module map at '/Sources/bar/module.modulemap'",
+                behavior: .error
+            )
+        }
     }
 
     func testBadExecutableProductDecl() {


### PR DESCRIPTION
## Motivation 

(copied from [SR-12170](https://bugs.swift.org/browse/SR-12170))

> Right now, if SwiftPM doesn't find a system target's module.modulemap at the expected location, it emits the following diagnostic:
>
> `Source files for target SystemLib should be located under 'Sources/SystemLib', or a custom sources path can be set with the 'path' property in Package.swift`
>
> even if there is a module map file in that folder but with the wrong name. Perhaps SwiftPM should generate a more precise diagnostic:
>
> `missing system target module map at 'Sources/SystemLib/module.modulemap'`
>
> Or perhaps SwiftPM could also scan for any modulemap file inside the target folder.

## Whats in this PR

- Addition of a new `ModuleError.InvalidLayoutType` case called `modulemapMissing`.
- Implementation of the new error to be thrown in `PackageBuilder.createTarget` when a module map is not found during system target creation.
- Tests.

I did not add scanning for any module map, like mentioned in the last sentence of the linked Jira, but I would be happy to add that as a follow up improvement (this is my first PR here, 👋).

## Discussion Points

Should this be a `ModuleError` instead of a `ModuleError.InvalidLayoutType`?