### PR TITLE
Fail early if expected XCFramework is not present

### DIFF
--- a/Sources/SPMTestSupport/TestWorkspace.swift
+++ b/Sources/SPMTestSupport/TestWorkspace.swift
@@ -72,6 +72,10 @@ public final class TestWorkspace {
         return sandbox.appending(component: "pkgs")
     }
 
+    public var artifactsDir: AbsolutePath {
+        return sandbox.appending(components: ".build", "artifacts")
+    }
+
     public func urlForPackage(withName name: String) -> String {
         return packagesDir.appending(RelativePath(name)).pathString
     }

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -148,4 +148,8 @@ extension Diagnostic.Message {
     static func artifactFailedExtraction(targetName: String, reason: String) -> Diagnostic.Message {
         .error("artifact of binary target '\(targetName)' failed extraction: \(reason)")
     }
+
+    static func artifactNotFound(targetName: String, artifactName: String) -> Diagnostic.Message {
+        .error("downloaded archive of binary target '\(targetName)' does not contain expected binary artifact '\(artifactName)'")
+    }
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1408,6 +1408,9 @@ extension Workspace {
                         self.archiver.extract(from: archivePath, to: parentDirectory, completion: { extractResult in
                             switch extractResult {
                             case .success:
+                                if let expectedPath = self.path(for: artifact), !self.fileSystem.isDirectory(expectedPath) {
+                                    tempDiagnostics.emit(.artifactNotFound(targetName: artifact.targetName, artifactName: expectedPath.basename))
+                                }
                                 break
                             case .failure(let error):
                                 let reason = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -4205,6 +4205,11 @@ final class WorkspaceTests: XCTestCase {
         let a4FrameworkPath = workspace.packagesDir.appending(components: "A", "A4.xcframework")
         try fs.createDirectory(a4FrameworkPath, recursive: true)
 
+        try [("A", "A1.xcframework"), ("A", "A2.xcframework"), ("B", "B.xcframework")].forEach {
+            let frameworkPath = workspace.artifactsDir.appending(components: $0.0, $0.1)
+            try fs.createDirectory(frameworkPath, recursive: true)
+        }
+
         // Pin A to 1.0.0, Checkout B to 1.0.0
         let aPath = workspace.urlForPackage(withName: "A")
         let aRef = PackageReference(identity: "a", path: aPath)
@@ -4252,7 +4257,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
-            XCTAssert(!diagnostics.hasErrors, "\(diagnostics.diagnostics)")
+            XCTAssertEqual(diagnostics.diagnostics.map { $0.message.text }, ["downloaded archive of binary target 'A3' does not contain expected binary artifact 'A3.xcframework'"])
             XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/B")))
             XCTAssert(!fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/A/A3.xcframework")))
             XCTAssert(!fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/A/A4.xcframework")))


### PR DESCRIPTION
Currently, we rely on a build failure if an expected XCFramework isn't
present in a downloaded ZIP. We should instead check if the expected
XCFramework is present while extracting the ZIP so that we can surface
this error already during package loading.

rdar://problem/60619547