### PR TITLE
Improve output when using XCBuild

### DIFF
--- a/Sources/XCBuildSupport/XCBuildOutputParser.swift
+++ b/Sources/XCBuildSupport/XCBuildOutputParser.swift
@@ -23,9 +23,14 @@ public enum XCBuildMessage {
             case ok
             case failed
             case cancelled
+            case aborted
         }
 
         public let result: Result
+    }
+
+    public struct BuildOutputInfo {
+        let data: String
     }
 
     public struct DidUpdateProgressInfo {
@@ -101,6 +106,7 @@ public enum XCBuildMessage {
     case buildStarted
     case buildDiagnostic(BuildDiagnosticInfo)
     case buildCompleted(BuildCompletedInfo)
+    case buildOutput(BuildOutputInfo)
     case preparationComplete
     case didUpdateProgress(DidUpdateProgressInfo)
     case targetUpToDate(TargetUpToDateInfo)
@@ -187,6 +193,7 @@ extension XCBuildOutputParser: JSONMessageStreamingParserDelegate {
 extension XCBuildMessage.BuildDiagnosticInfo: Decodable, Equatable {}
 extension XCBuildMessage.BuildCompletedInfo.Result: Decodable, Equatable {}
 extension XCBuildMessage.BuildCompletedInfo: Decodable, Equatable {}
+extension XCBuildMessage.BuildOutputInfo: Decodable, Equatable {}
 extension XCBuildMessage.TargetUpToDateInfo: Decodable, Equatable {}
 extension XCBuildMessage.TaskDiagnosticInfo: Decodable, Equatable {}
 extension XCBuildMessage.TargetDiagnosticInfo: Decodable, Equatable {}
@@ -322,6 +329,8 @@ extension XCBuildMessage: Decodable, Equatable {
             self = try .buildDiagnostic(BuildDiagnosticInfo(from: decoder))
         case "buildCompleted":
             self = try .buildCompleted(BuildCompletedInfo(from: decoder))
+        case "buildOutput":
+            self = try .buildOutput(BuildOutputInfo(from: decoder))
         case "preparationComplete":
             self = .preparationComplete
         case "didUpdateProgress":
@@ -345,7 +354,7 @@ extension XCBuildMessage: Decodable, Equatable {
         case "targetDiagnostic":
             self = try .targetDiagnostic(TargetDiagnosticInfo(from: decoder))
         default:
-            throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "invalid kind")
+            throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "invalid kind \(kind)")
         }
     }
 }


### PR DESCRIPTION
- Print build diagnostics and output as they both are used for potential
error message
- If the build failed, was canceled or aborted, log a message.

rdar://problem/60925204