### PR TITLE
Use LinuxMain on all platforms except Darwin

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1532,7 +1532,7 @@ public class BuildPlan {
             }
         }
 
-        if buildParameters.triple.isLinux() {
+        if !buildParameters.triple.isDarwin() {
             if product.type == .test {
                 linuxMainMap[product].map{ staticTargets.append($0) }
             }

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1207,7 +1207,7 @@ public class BuildPlan {
         _ buildParameters: BuildParameters,
         _ graph: PackageGraph
     ) throws -> [(ResolvedProduct, SwiftTargetBuildDescription)] {
-        guard buildParameters.triple.isLinux() else {
+        guard !buildParameters.triple.isDarwin() else {
             return []
         }
 


### PR DESCRIPTION
LinuxMain is also used to run tests on WebAssembly/WASI (and potentially on Android, Windows etc)