### PR TITLE
Pass sdk option to Swift compiler for WASI triples

### DIFF
--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -223,7 +223,7 @@ public final class UserToolchain: Toolchain {
     }
 
     public static func deriveSwiftCFlags(triple: Triple, destination: Destination) -> [String] {
-      return (triple.isDarwin() || triple.isAndroid()
+      return (triple.isDarwin() || triple.isAndroid() || triple.isWASI()
         ? ["-sdk", destination.sdk.pathString]
         : [])
         + destination.extraSwiftCFlags


### PR DESCRIPTION
When building for WebAssembly/WASI `swiftc` needs the `-sdk` option passed to it with the sdk path.