### PR TITLE
[Build] Add support for building with the integrated Swift driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ endif()
 find_package(dispatch QUIET)
 find_package(Foundation QUIET)
 
+find_package(Yams CONFIG REQUIRED)
 find_package(SwiftDriver CONFIG REQUIRED)
 
 add_subdirectory(Sources)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,4 +42,6 @@ endif()
 find_package(dispatch QUIET)
 find_package(Foundation QUIET)
 
+find_package(SwiftDriver CONFIG REQUIRED)
+
 add_subdirectory(Sources)

--- a/Package.swift
+++ b/Package.swift
@@ -127,7 +127,7 @@ let package = Package(
         .target(
             /** Builds Modules and Products */
             name: "Build",
-            dependencies: ["SwiftToolsSupport-auto", "SPMBuildCore", "PackageGraph", "LLBuildManifest"]),
+            dependencies: ["SwiftToolsSupport-auto", "SPMBuildCore", "PackageGraph", "LLBuildManifest", "SwiftDriver"]),
         .target(
             /** Support for building using Xcode's build system */
             name: "XCBuildSupport",
@@ -253,9 +253,11 @@ if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("master")),
+        .package(url: "https://github.com/apple/swift-driver.git", .branch("master")),
     ]
 } else {
     package.dependencies += [
         .package(path: "./swift-tools-support-core"),
+        .package(path: "../swift-driver"),
     ]
 }

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -19,6 +19,8 @@ import SPMBuildCore
 // FIXME: JUST TO MAKE SURE WE CAN
 import SwiftDriver
 
+public typealias FileSystem = TSCBasic.FileSystem
+
 extension BuildParameters {
     /// Returns the directory to be used for module cache.
     public var moduleCache: AbsolutePath {
@@ -1720,7 +1722,7 @@ public class BuildPlan {
 
             // Check that it supports macOS.
             guard let library = info.libraries.first(where: {
-                $0.platform == "macos" && $0.architectures.contains(Triple.Arch.x86_64.rawValue)
+                $0.platform == "macos" && $0.architectures.contains(SPMBuildCore.Triple.Arch.x86_64.rawValue)
             }) else {
                 diagnostics.emit(error: """
                     artifact '\(target.name)' does not support the target platform and architecture \

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -16,6 +16,9 @@ import PackageLoading
 import Foundation
 import SPMBuildCore
 
+// FIXME: JUST TO MAKE SURE WE CAN
+import SwiftDriver
+
 extension BuildParameters {
     /// Returns the directory to be used for module cache.
     public var moduleCache: AbsolutePath {

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -678,7 +678,7 @@ public final class SwiftTargetBuildDescription {
 
         result.append("-module-name")
         result.append(target.c99name)
-//        result.append("-incremental")
+        result.append("-incremental")
         result.append("-emit-dependencies")
         result.append("-emit-module")
         result.append("-emit-module-path")

--- a/Sources/Build/CMakeLists.txt
+++ b/Sources/Build/CMakeLists.txt
@@ -17,7 +17,8 @@ target_link_libraries(Build PUBLIC
   TSCBasic
   PackageGraph
   LLBuildManifest
-  SPMBuildCore)
+  SPMBuildCore
+  SwiftDriver)
 
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(Build PROPERTIES

--- a/Sources/Build/CMakeLists.txt
+++ b/Sources/Build/CMakeLists.txt
@@ -18,6 +18,8 @@ target_link_libraries(Build PUBLIC
   PackageGraph
   LLBuildManifest
   SPMBuildCore
+  CYaml
+  Yams
   SwiftDriver)
 
 # NOTE(compnerd) workaround for CMake not setting up include flags yet

--- a/Sources/Build/ManifestBuilder.swift
+++ b/Sources/Build/ManifestBuilder.swift
@@ -205,7 +205,19 @@ extension LLBuildManifestBuilder {
             let resolver = try ArgsResolver()
 
             for job in jobs {
-                let datool = try resolver.resolve(.path(job.tool))
+                // Figure out which tool we are using.
+                // FIXME: This feels like a hack.
+                var datool: String
+                switch job.kind {
+                case .compile, .mergeModule, .emitModule, .generatePCH,
+                    .generatePCM, .interpret, .repl, .printTargetInfo,
+                    .versionRequest:
+                    datool = buildParameters.toolchain.swiftCompiler.pathString
+
+                case .autolinkExtract, .generateDSYM, .help, .link, .verifyDebugInfo:
+                    datool = try resolver.resolve(.path(job.tool))
+                }
+
                 let commandLine = try job.commandLine.map{ try resolver.resolve($0) }
                 let arguments = [datool] + commandLine
 

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -93,6 +93,10 @@ public class ToolOptions {
     /// Emit the Swift module separately from the object files.
     public var emitSwiftModuleSeparately: Bool = false
 
+    /// Whether to use the integrated Swift driver rather than shelling out
+    /// to a separate process.
+    public var useIntegratedSwiftDriver: Bool = false
+
     /// The build system to use.
     public var buildSystem: BuildSystemKind = .native
 

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -451,6 +451,10 @@ public class SwiftTool<Options: ToolOptions> {
             to: { $0.emitSwiftModuleSeparately = $1 })
 
         binder.bind(
+            option: parser.add(option: "--use-integrated-swift-driver", kind: Bool.self, usage: nil),
+            to: { $0.useIntegratedSwiftDriver = $1 })
+
+        binder.bind(
             option: parser.add(option: "--build-system", kind: BuildSystemKind.self, usage: nil),
             to: { $0.buildSystem = $1 })
 
@@ -791,6 +795,7 @@ public class SwiftTool<Options: ToolOptions> {
                 enableParseableModuleInterfaces: options.shouldEnableParseableModuleInterfaces,
                 enableTestDiscovery: options.enableTestDiscovery,
                 emitSwiftModuleSeparately: options.emitSwiftModuleSeparately,
+                useIntegratedSwiftDriver: options.useIntegratedSwiftDriver,
                 isXcodeBuildSystemEnabled: options.buildSystem == .xcode
             )
         })

--- a/Sources/LLBuildManifest/BuildManifest.swift
+++ b/Sources/LLBuildManifest/BuildManifest.swift
@@ -155,6 +155,7 @@ public struct BuildManifest {
             isLibrary: isLibrary,
             WMO: WMO
         )
+      
         commands[name] = Command(name: name, tool: tool)
     }
 }

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -85,6 +85,10 @@ public struct BuildParameters: Encodable {
     /// module to finish building.
     public var emitSwiftModuleSeparately: Bool
 
+    /// Whether to use the integrated Swift driver rather than shelling out
+    /// to a separate process.
+    public var useIntegratedSwiftDriver: Bool
+
     /// Whether to create dylibs for dynamic library products.
     public var shouldCreateDylibForDynamicProducts: Bool
 
@@ -130,6 +134,7 @@ public struct BuildParameters: Encodable {
         enableParseableModuleInterfaces: Bool = false,
         enableTestDiscovery: Bool = false,
         emitSwiftModuleSeparately: Bool = false,
+        useIntegratedSwiftDriver: Bool = false,
         isXcodeBuildSystemEnabled: Bool = false
     ) {
         self.dataPath = dataPath
@@ -149,6 +154,7 @@ public struct BuildParameters: Encodable {
         self.enableParseableModuleInterfaces = enableParseableModuleInterfaces
         self.enableTestDiscovery = enableTestDiscovery
         self.emitSwiftModuleSeparately = emitSwiftModuleSeparately
+        self.useIntegratedSwiftDriver = useIntegratedSwiftDriver
         self.isXcodeBuildSystemEnabled = isXcodeBuildSystemEnabled
     }
 

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -298,12 +298,6 @@ def test(args):
     # Test TSC.
     call_swiftpm(args, cmd, args.tsc_source_dir)
 
-    # Test Yams.
-    call_swiftpm(args, cmd, args.yams_source_dir)
-
-    # Test swift-driver.
-    call_swiftpm(args, cmd, args.swift_driver_source_dir)
-
     # Test SwiftPM.
     call_swiftpm(args, cmd)
 

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -452,6 +452,11 @@ def build_yams(args):
     if platform.system() == 'Darwin':
         cmake_flags.append("-DCMAKE_C_FLAGS=-target x86_64-apple-macosx%s" % g_macos_deployment_target)
         cmake_flags.append("-DCMAKE_OSX_DEPLOYMENT_TARGET=%s" % g_macos_deployment_target)
+    else:
+        cmake_flags += [
+            get_dispatch_cmake_arg(args),
+            get_foundation_cmake_arg(args),
+        ]
 
     build_with_cmake(args, cmake_flags, args.yams_source_dir, args.yams_build_dir)
 
@@ -497,9 +502,9 @@ def build_swiftpm_with_cmake(args):
     if args.llbuild_link_framework:
         add_rpath_for_cmake_build(args, args.llbuild_build_dir)
 
-    add_rpath_for_cmake_build(args, os.path.join(args.yams_build_dir, "Sources", "Yams"))
-    add_rpath_for_cmake_build(args, os.path.join(args.yams_build_dir, "Sources", "CYaml"))
-    add_rpath_for_cmake_build(args, os.path.join(args.swift_driver_build_dir, "lib"))
+    if platform.system() == "Darwin":
+        add_rpath_for_cmake_build(args, os.path.join(args.yams_build_dir, "lib"))
+        add_rpath_for_cmake_build(args, os.path.join(args.swift_driver_build_dir, "lib"))
 
 def build_swiftpm_with_swiftpm(args):
     """Builds SwiftPM using the version of SwiftPM built with CMake."""

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -476,6 +476,13 @@ def build_swift_driver(args):
 
     build_with_cmake(args, cmake_flags, args.swift_driver_source_dir, args.swift_driver_build_dir)
 
+def add_rpath_for_cmake_build(args, rpath):
+    "Adds the given rpath to the CMake-built swift-build"
+    swift_build = os.path.join(args.bootstrap_dir, "bin/swift-build")
+    add_rpath_cmd = ["install_name_tool", "-add_rpath", rpath, swift_build]
+    note(' '.join(add_rpath_cmd))
+    subprocess.call(add_rpath_cmd, stderr=subprocess.PIPE)
+
 def build_swiftpm_with_cmake(args):
     """Builds SwiftPM using CMake."""
     note("Building SwiftPM (with CMake)")
@@ -494,10 +501,11 @@ def build_swiftpm_with_cmake(args):
     build_with_cmake(args, cmake_flags, args.project_root, args.bootstrap_dir)
 
     if args.llbuild_link_framework:
-        swift_build = os.path.join(args.bootstrap_dir, "bin/swift-build")
-        add_rpath_cmd = ["install_name_tool", "-add_rpath", args.llbuild_build_dir, swift_build]
-        note(' '.join(add_rpath_cmd))
-        subprocess.call(add_rpath_cmd, stderr=subprocess.PIPE)
+        add_rpath_for_cmake_build(args, args.llbuild_build_dir)
+
+    add_rpath_for_cmake_build(args, os.path.join(args.yams_build_dir, "Sources", "Yams"))
+    add_rpath_for_cmake_build(args, os.path.join(args.yams_build_dir, "Sources", "CYaml"))
+    add_rpath_for_cmake_build(args, os.path.join(args.swift_driver_build_dir, "lib"))
 
 def build_swiftpm_with_swiftpm(args):
     """Builds SwiftPM using the version of SwiftPM built with CMake."""

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -150,6 +150,8 @@ def parse_global_args(args):
     args.build_dir = os.path.abspath(args.build_dir)
     args.project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     args.tsc_source_dir = os.path.join(args.project_root, "swift-tools-support-core")
+    args.yams_source_dir = os.path.join(args.project_root, "..", "yams")
+    args.swift_driver_source_dir = os.path.join(args.project_root, "..", "swift-driver")
     args.source_root = os.path.join(args.project_root, "Sources")
 
     if platform.system() == 'Darwin':
@@ -275,6 +277,8 @@ def build(args):
         build_llbuild(args)
 
     build_tsc(args)
+    build_yams(args)
+    build_swift_driver(args)
     build_swiftpm_with_cmake(args)
     build_swiftpm_with_swiftpm(args)
 
@@ -293,6 +297,12 @@ def test(args):
 
     # Test TSC.
     call_swiftpm(args, cmd, args.tsc_source_dir)
+
+    # Test Yams.
+    call_swiftpm(args, cmd, args.yams_source_dir)
+
+    # Test swift-driver.
+    call_swiftpm(args, cmd, args.swift_driver_source_dir)
 
     # Test SwiftPM.
     call_swiftpm(args, cmd)
@@ -440,6 +450,32 @@ def build_tsc(args):
 
     build_with_cmake(args, cmake_flags, args.tsc_source_dir, args.tsc_build_dir)
 
+def build_yams(args):
+    note("Building Yams")
+    args.yams_build_dir = os.path.join(args.target_dir, "yams")
+
+    cmake_flags = []
+    if platform.system() == 'Darwin':
+        cmake_flags.append("-DCMAKE_C_FLAGS=-target x86_64-apple-macosx%s" % g_macos_deployment_target)
+        cmake_flags.append("-DCMAKE_OSX_DEPLOYMENT_TARGET=%s" % g_macos_deployment_target)
+
+    build_with_cmake(args, cmake_flags, args.yams_source_dir, args.yams_build_dir)
+
+def build_swift_driver(args):
+    note("Building SwiftDriver")
+    args.swift_driver_build_dir = os.path.join(args.target_dir, "swift-driver")
+
+    cmake_flags = [
+        get_llbuild_cmake_arg(args),
+        "-DTSC_DIR=" + os.path.join(args.tsc_build_dir, "cmake/modules"),
+        "-DYams_DIR=" + os.path.join(args.yams_build_dir, "cmake/modules"),
+    ]
+    if platform.system() == 'Darwin':
+        cmake_flags.append("-DCMAKE_C_FLAGS=-target x86_64-apple-macosx%s" % g_macos_deployment_target)
+        cmake_flags.append("-DCMAKE_OSX_DEPLOYMENT_TARGET=%s" % g_macos_deployment_target)
+
+    build_with_cmake(args, cmake_flags, args.swift_driver_source_dir, args.swift_driver_build_dir)
+
 def build_swiftpm_with_cmake(args):
     """Builds SwiftPM using CMake."""
     note("Building SwiftPM (with CMake)")
@@ -447,6 +483,8 @@ def build_swiftpm_with_cmake(args):
     cmake_flags = [
         get_llbuild_cmake_arg(args),
         "-DTSC_DIR=" + os.path.join(args.tsc_build_dir, "cmake/modules"),
+        "-DYams_DIR=" + os.path.join(args.yams_build_dir, "cmake/modules"),
+        "-DSwiftDriver_DIR=" + os.path.join(args.swift_driver_build_dir, "cmake/modules"),
     ]
 
     if platform.system() == 'Darwin':
@@ -539,6 +577,8 @@ def get_swiftpm_env_cmd(args):
         os.path.join(args.bootstrap_dir, "lib"),
         os.path.join(args.tsc_build_dir, "lib"),
         os.path.join(args.llbuild_build_dir, "lib"),
+        os.path.join(args.yams_build_dir, "lib"),
+        os.path.join(args.swift_driver_build_dir, "lib"),
     ])
 
     if platform.system() == 'Darwin':


### PR DESCRIPTION
Add bootstrap and build support for building the new Swift driver
and importing it (as a library) into SwiftPM. Then introduce the new
SwiftPM flag `--use-integrated-swift-driver` to enable use of the
integrated Swift driver rather than shelling out to a separate
Swift driver binary. The jobs created by the integrated Swift driver
will be merged into SwiftPM's build graph.