### PR TITLE
[bootstrap] Add swift-argument-parser as a bootstrapped swift-driver dependency

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -507,6 +507,7 @@ def build_swift_driver(args):
         get_llbuild_cmake_arg(args),
         "-DTSC_DIR=" + os.path.join(args.tsc_build_dir, "cmake/modules"),
         "-DYams_DIR=" + os.path.join(args.yams_build_dir, "cmake/modules"),
+        "-DArgumentParser_DIR=" + os.path.join(args.swift_argument_parser_build_dir, "cmake/modules"),
     ]
     if platform.system() == 'Darwin':
         cmake_flags.append("-DCMAKE_C_FLAGS=-target %s%s" % (get_build_target(args), g_macos_deployment_target))


### PR DESCRIPTION
Only the last commit is new, the rest is from #2736 