### PR TITLE
Fix incorrect assertion in `ManifestParserResult`

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -489,7 +489,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         /// For e.g., we could have failed to spawn the process or create temporary file.
         var errorOutput: String? {
             didSet {
-                assert(parsedManifest == nil && compilerOutput == nil)
+                assert(parsedManifest == nil)
             }
         }
     }

--- a/Tests/PackageLoadingTests/PD5_3LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5_3LoadingTests.swift
@@ -385,4 +385,25 @@ class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
             }
         }
     }
+
+    func testNonZeroExitStatusDoesNotAssert() throws {
+        let stream = BufferedOutputByteStream()
+        stream <<< """
+            #if canImport(Glibc)
+            import Glibc
+            #elseif os(Windows)
+            import MSVCRT
+            import WinSDK
+            #else
+            import Darwin.C
+            #endif
+
+            print("crash")
+            exit(1)
+            """
+
+        XCTAssertManifestLoadThrows(stream.bytes) { error, _ in
+            XCTAssertTrue(error is ManifestParseError, "unexpected error: \(error)")
+        }
+    }
 }


### PR DESCRIPTION
This assertion in `ManifestParseResult` would always be triggered if parsing the manifest returns non-zero and produced output. One case where that happens is if running the manifest crashes, e.g. due to a force unwrap.

rdar://problem/63040735