### PR TITLE
Pass XCTest minimum deployment target in Workspace

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -730,7 +730,8 @@ extension Workspace {
         createMultipleTestProducts: Bool = false,
         createREPLProduct: Bool = false,
         forceResolvedVersions: Bool = false,
-        diagnostics: DiagnosticsEngine
+        diagnostics: DiagnosticsEngine,
+        xcTestMinimumDeploymentTargets: [PackageModel.Platform:PlatformVersion]? = nil
     ) -> PackageGraph {
 
         // Perform dependency resolution, if required.
@@ -758,6 +759,7 @@ extension Workspace {
             requiredDependencies: manifests.computePackageURLs().required,
             unsafeAllowedPackages: manifests.unsafeAllowedPackages(),
             remoteArtifacts: remoteArtifacts,
+            xcTestMinimumDeploymentTargets: xcTestMinimumDeploymentTargets ?? MinimumDeploymentTarget.default.xcTestMinimumDeploymentTargets,
             diagnostics: diagnostics,
             fileSystem: fileSystem,
             shouldCreateMultipleTestProducts: createMultipleTestProducts,


### PR DESCRIPTION
This will allow clients of libSwiftPM to provide custom values for
XCTest minimum deployment target instead of the defaults.

rdar://problem/62858732