### PR TITLE
Keep swift build from toolchains working on Mojave

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -25,7 +25,7 @@ import shutil
 import subprocess
 from helpers import note, error, symlink_force, mkdir_p, call, call_output
 
-g_macos_deployment_target = '10.15'
+g_macos_deployment_target = '10.14'
 
 if platform.system() == 'Darwin':
     g_shared_lib_ext = ".dylib"


### PR DESCRIPTION
Hi Apple,

would you consider this change please? At the moment `swift build` does not work on Mojave when using an overnight development toolchain from swift.org and the toolchain build fails preventing those of us who can’t upgrade to Catalina from working on the compiler/toolchain.

Cheers

Error is:
```
 johnholdsworth$ ~/Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2020-05-11-a.xctoolchain/usr/bin/swift build
dyld: lazy symbol binding failed: Symbol not found: _objc_opt_self
  Referenced from: /Users/johnholdsworth/Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2020-05-11-a.xctoolchain/usr/bin/swift-build (which was built for Mac OS X 10.15)
  Expected in: /usr/lib/libobjc.A.dylib

dyld: Symbol not found: _objc_opt_self
  Referenced from: /Users/johnholdsworth/Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2020-05-11-a.xctoolchain/usr/bin/swift-build (which was built for Mac OS X 10.15)
  Expected in: /usr/lib/libobjc.A.dylib

Abort trap: 6
```