### PR TITLE
Finish SE‐0226 (Ignore Unused Products)

### DIFF
--- a/Fixtures/ModuleMaps/Transitive/packageC/Package.swift
+++ b/Fixtures/ModuleMaps/Transitive/packageC/Package.swift
@@ -10,6 +10,6 @@ let package = Package(
         .package(url: "../packageD", from: "1.0.0"),
     ],
     targets: [
-        .target(name: "x", dependencies: []),
+        .target(name: "x", dependencies: ["CFoo"]),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -221,6 +221,13 @@ let package = Package(
         .testTarget(
             name: "XCBuildSupportTests",
             dependencies: ["XCBuildSupport", "SPMTestSupport"]),
+
+        // Examples (These are built to ensure they stay up to date with the API.)
+        .target(
+          name: "package-info",
+          dependencies: ["PackageModel", "PackageLoading", "PackageGraph", "Workspace"],
+          path: "Examples/package-info/Sources/package-info"
+        )
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -224,9 +224,9 @@ let package = Package(
 
         // Examples (These are built to ensure they stay up to date with the API.)
         .target(
-          name: "package-info",
-          dependencies: ["PackageModel", "PackageLoading", "PackageGraph", "Workspace"],
-          path: "Examples/package-info/Sources/package-info"
+            name: "package-info",
+            dependencies: ["PackageModel", "PackageLoading", "PackageGraph", "Workspace"],
+            path: "Examples/package-info/Sources/package-info"
         )
     ],
     swiftLanguageVersions: [.v5]

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -37,7 +37,7 @@ public class SwiftBuildTool: SwiftTool<BuildToolOptions> {
           #endif
 
             guard let subset = options.buildSubset(diagnostics: diagnostics) else { return }
-            let buildSystem = try createBuildSystem()
+            let buildSystem = try createBuildSystem(explicitProduct: options.product)
             try buildSystem.build(subset: subset)
 
         case .binPath:

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -938,7 +938,7 @@ fileprivate extension SwiftPackageTool {
             case let .added(state):
                 stream <<< "+ \(package.name) \(state.requirement.prettyPrinted)"
             case let .updated(state):
-              stream <<< "~ \(package.name) \(currentVersion) -> \(package.name) \(state.requirement.prettyPrinted)"
+                stream <<< "~ \(package.name) \(currentVersion) -> \(package.name) \(state.requirement.prettyPrinted)"
             case .removed:
                 stream <<< "- \(package.name) \(currentVersion)"
             case .unchanged:

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -114,6 +114,7 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
 
             let builder = PackageBuilder(
                 manifest: manifest,
+                productFilter: .everything,
                 path: try getPackageRoot(),
                 xcTestMinimumDeploymentTargets: [:], // Minimum deployment target does not matter for this operation.
                 diagnostics: diagnostics
@@ -354,6 +355,7 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
 
             let builder = PackageBuilder(
                 manifest: manifest,
+                productFilter: .everything,
                 path: try getPackageRoot(),
                 xcTestMinimumDeploymentTargets: MinimumDeploymentTarget.default.xcTestMinimumDeploymentTargets,
                 diagnostics: diagnostics
@@ -933,10 +935,10 @@ fileprivate extension SwiftPackageTool {
         for (package, change) in changes {
             let currentVersion = pins.pinsMap[package.identity]?.state.description ?? ""
             switch change {
-            case let .added(requirement):
-                stream <<< "+ \(package.name) \(requirement.prettyPrinted)"
-            case let .updated(requirement):
-                stream <<< "~ \(package.name) \(currentVersion) -> \(package.name) \(requirement.prettyPrinted)"
+            case let .added(state):
+                stream <<< "+ \(package.name) \(state.requirement.prettyPrinted)"
+            case let .updated(state):
+              stream <<< "~ \(package.name) \(currentVersion) -> \(package.name) \(state.requirement.prettyPrinted)"
             case .removed:
                 stream <<< "- \(package.name) \(currentVersion)"
             case .unchanged:

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -96,9 +96,9 @@ public class SwiftRunTool: SwiftTool<RunToolOptions> {
         case .repl:
             // Load a custom package graph which has a special product for REPL.
             let graphLoader = {
-              try self.loadPackageGraph(
-                explicitProduct: self.options.executable,
-                createREPLProduct: self.options.shouldLaunchREPL)
+                try self.loadPackageGraph(
+                    explicitProduct: self.options.executable,
+                    createREPLProduct: self.options.shouldLaunchREPL)
             }
             let buildParameters = try self.buildParameters()
 

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -95,7 +95,11 @@ public class SwiftRunTool: SwiftTool<RunToolOptions> {
 
         case .repl:
             // Load a custom package graph which has a special product for REPL.
-            let graphLoader = { try self.loadPackageGraph(createREPLProduct: self.options.shouldLaunchREPL) }
+            let graphLoader = {
+              try self.loadPackageGraph(
+                explicitProduct: self.options.executable,
+                createREPLProduct: self.options.shouldLaunchREPL)
+            }
             let buildParameters = try self.buildParameters()
 
             // Construct the build operation.
@@ -140,7 +144,7 @@ public class SwiftRunTool: SwiftTool<RunToolOptions> {
                 return
             }
 
-            let buildSystem = try createBuildSystem()
+            let buildSystem = try createBuildSystem(explicitProduct: options.executable)
             let productName = try findProductName(in: buildSystem.getPackageGraph())
 
             if options.shouldBuildTests {

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -667,8 +667,12 @@ public class SwiftTool<Options: ToolOptions> {
     }
 
     /// Fetch and load the complete package graph.
+    ///
+    /// - Parameters:
+    ///   - explicitProduct: The product specified on the command line to a “swift run” or “swift build” command. This allows executables from dependencies to be run directly without having to hook them up to any particular target.
     @discardableResult
     func loadPackageGraph(
+        explicitProduct: String? = nil,
         createMultipleTestProducts: Bool = false,
         createREPLProduct: Bool = false
     ) throws -> PackageGraph {
@@ -678,6 +682,7 @@ public class SwiftTool<Options: ToolOptions> {
             // Fetch and load the package graph.
             let graph = try workspace.loadPackageGraph(
                 root: getWorkspaceRoot(),
+                explicitProduct: explicitProduct,
                 createMultipleTestProducts: createMultipleTestProducts,
                 createREPLProduct: createREPLProduct,
                 forceResolvedVersions: options.forceResolvedVersions,
@@ -720,9 +725,9 @@ public class SwiftTool<Options: ToolOptions> {
         return enableBuildManifestCaching && haveBuildManifestAndDescription && !hasEditedPackages
     }
 
-    func createBuildOperation(useBuildManifestCaching: Bool = true) throws -> BuildOperation {
+    func createBuildOperation(explicitProduct: String? = nil, useBuildManifestCaching: Bool = true) throws -> BuildOperation {
         // Load a custom package graph which has a special product for REPL.
-        let graphLoader = { try self.loadPackageGraph() }
+        let graphLoader = { try self.loadPackageGraph(explicitProduct: explicitProduct) }
 
         // Construct the build operation.
         let buildOp = try BuildOperation(
@@ -738,11 +743,11 @@ public class SwiftTool<Options: ToolOptions> {
         return buildOp
     }
 
-    func createBuildSystem(useBuildManifestCaching: Bool = true) throws -> BuildSystem {
+    func createBuildSystem(explicitProduct: String? = nil, useBuildManifestCaching: Bool = true) throws -> BuildSystem {
         let buildSystem: BuildSystem
         switch options.buildSystem {
         case .native:
-            let graphLoader = { try self.loadPackageGraph() }
+            let graphLoader = { try self.loadPackageGraph(explicitProduct: explicitProduct) }
             buildSystem = try BuildOperation(
                 buildParameters: buildParameters(),
                 useBuildManifestCaching: useBuildManifestCaching && canUseBuildManifestCaching(),
@@ -751,7 +756,7 @@ public class SwiftTool<Options: ToolOptions> {
                 stdoutStream: stdoutStream
             )
         case .xcode:
-            let graphLoader = { try self.loadPackageGraph(createMultipleTestProducts: true) }
+            let graphLoader = { try self.loadPackageGraph(explicitProduct: explicitProduct, createMultipleTestProducts: true) }
             buildSystem = try XcodeBuildSystem(
                 buildParameters: buildParameters(),
                 packageGraphLoader: graphLoader,

--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -239,7 +239,7 @@ public class DependencyResolver {
 ///     - indicate that a particular product in a particular package is required.
 ///     - always have dependencies. A product node has...
 ///         - one implicit dependency on its own package at an exact version (as an empty package node).
-///           This dependency is what ensures the resolve does not select two products from the same package at different versions.
+///           This dependency is what ensures the resolver does not select two products from the same package at different versions.
 ///         - zero or more dependencies on the product nodes of other packages.
 ///           These are all the external products required to build all of the targets vended by this product.
 ///           They derive from the manifest.

--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -355,30 +355,3 @@ public enum DependencyResolutionNode: Equatable, Hashable, CustomStringConvertib
         }
     }
 }
-
-extension ProductFilter {
-
-    /// Returns each product, or an array containing `nil` if the filter is empty.
-    ///
-    /// This method is of narrow use. It is is intended to centralize functionality used by dependency resolution nodes, so that in conjunction with `map`, such nodes can easily assemble their successors.
-    ///
-    /// If:
-    ///   - `.everything`, this method produces a fatal error.
-    ///   - `.specific`, then:
-    ///     - if the set is empty, an array containing `nil` will be returned.
-    ///     - if the set is non‐empty, it will be sorted and returned.
-    ///
-    /// - Precondition: The set is not `.everything`.
-    internal func enumerated() -> [String?] {
-        switch self {
-        case .everything:
-            fatalError("Attempted to enumerate a root package’s product filter; root packages have no filter.")
-        case .specific(let set):
-            if set.isEmpty { // Pointing at the package without a particular product.
-                return [Optional<String>.none]
-            } else {
-                return set.sorted()
-            }
-        }
-    }
-}

--- a/Sources/PackageGraph/PackageGraphLoader.swift
+++ b/Sources/PackageGraph/PackageGraphLoader.swift
@@ -132,10 +132,12 @@ public struct PackageGraphLoader {
         // API to specify identity in the manifest file
         let manifestMapSequence = (root.manifests + externalManifests).map({ (PackageReference.computeIdentity(packageURL: $0.url), $0) })
         let manifestMap = Dictionary(uniqueKeysWithValues: manifestMapSequence)
-        let successors: (Manifest) -> [Manifest] = { manifest in
-            manifest.allRequiredDependencies.compactMap({
-                let url = config.mirroredURL(forURL: $0.url)
-                return manifestMap[PackageReference.computeIdentity(packageURL: url)]
+        let successors: (GraphLoadingNode) -> [GraphLoadingNode] = { node in
+            node.requiredDependencies().compactMap({ dependency in
+                let url = config.mirroredURL(forURL: dependency.declaration.url)
+                return manifestMap[PackageReference.computeIdentity(packageURL: url)].map { manifest in
+                  GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
+                }
             })
         }
 
@@ -144,24 +146,44 @@ public struct PackageGraphLoader {
         let rootDependencies = Set(root.dependencies.compactMap({
             manifestMap[PackageReference.computeIdentity(packageURL: $0.url)]
         }))
-        let inputManifests = root.manifests + rootDependencies
+        let rootManifestNodes = root.manifests.map { GraphLoadingNode(manifest: $0, productFilter: .everything) }
+        let rootDependencyNodes = root.dependencies.lazy.compactMap { (dependency: PackageGraphRoot.PackageDependency) -> GraphLoadingNode? in
+          guard let manifest = manifestMap[PackageReference.computeIdentity(packageURL: dependency.url)] else { return nil }
+          return GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
+        }
+        let inputManifests = rootManifestNodes + rootDependencyNodes
 
         // Collect the manifests for which we are going to build packages.
-        let allManifests: [Manifest]
+        var allManifests: [GraphLoadingNode]
 
         // Detect cycles in manifest dependencies.
         if let cycle = findCycle(inputManifests, successors: successors) {
             diagnostics.emit(PackageGraphError.cycleDetected(cycle))
             // Break the cycle so we can build a partial package graph.
-            allManifests = inputManifests.filter({ $0 != cycle.cycle[0] })
+            allManifests = inputManifests.filter({ $0.manifest != cycle.cycle[0] })
         } else {
             // Sort all manifests toplogically.
             allManifests = try! topologicalSort(inputManifests, successors: successors)
         }
+        var flattenedManifests: [String: GraphLoadingNode] = [:]
+        for node in allManifests {
+          if let existing = flattenedManifests[node.manifest.name] {
+            let merged = GraphLoadingNode(
+              manifest: node.manifest,
+              productFilter: existing.productFilter.union(node.productFilter)
+            )
+            flattenedManifests[node.manifest.name] = merged
+          } else {
+            flattenedManifests[node.manifest.name] = node
+          }
+        }
+        allManifests = flattenedManifests.values.sorted(by: { $0.manifest.name < $1.manifest.name })
 
         // Create the packages.
         var manifestToPackage: [Manifest: Package] = [:]
-        for manifest in allManifests {
+        for node in allManifests {
+            let manifest = node.manifest
+
             // Derive the path to the package.
             //
             // FIXME: Lift this out of the manifest.
@@ -170,6 +192,7 @@ public struct PackageGraphLoader {
             // Create a package from the manifest and sources.
             let builder = PackageBuilder(
                 manifest: manifest,
+                productFilter: node.productFilter,
                 path: packagePath,
                 additionalFileRules: additionalFileRules,
                 remoteArtifacts: remoteArtifacts,
@@ -187,7 +210,9 @@ public struct PackageGraphLoader {
                     manifestToPackage[manifest] = package
 
                     // Throw if any of the non-root package is empty.
-                    if package.targets.isEmpty && manifest.packageKind != .root {
+                    if package.targets.isEmpty // System packages have targets in the package but not the manifest.
+                      && package.manifest.targets.isEmpty // An unneeded dependency will not have loaded anything from the manifest.
+                      && manifest.packageKind != .root {
                         throw PackageGraphError.noModules(package)
                     }
                 }
@@ -254,7 +279,7 @@ private func checkAllDependenciesAreUsed(_ rootPackages: [ResolvedPackage], _ di
 
 /// Create resolved packages from the loaded packages.
 private func createResolvedPackages(
-    allManifests: [Manifest],
+    allManifests: [GraphLoadingNode],
     config: SwiftPMConfig,
     manifestToPackage: [Manifest: Package],
     // FIXME: This shouldn't be needed once <rdar://problem/33693433> is fixed.
@@ -264,12 +289,16 @@ private func createResolvedPackages(
 ) -> [ResolvedPackage] {
 
     // Create package builder objects from the input manifests.
-    let packageBuilders: [ResolvedPackageBuilder] = allManifests.compactMap({
-        guard let package = manifestToPackage[$0] else {
+    let packageBuilders: [ResolvedPackageBuilder] = allManifests.compactMap({ node in
+        guard let package = manifestToPackage[node.manifest] else {
             return nil
         }
         let isAllowedToVendUnsafeProducts = unsafeAllowedPackages.contains{ $0.path == package.manifest.url }
-        return ResolvedPackageBuilder(package, isAllowedToVendUnsafeProducts: isAllowedToVendUnsafeProducts)
+        return ResolvedPackageBuilder(
+          package,
+          productFilter: node.productFilter,
+          isAllowedToVendUnsafeProducts: isAllowedToVendUnsafeProducts
+        )
     })
 
     // Create a map of package builders keyed by the package identity.
@@ -284,24 +313,25 @@ private func createResolvedPackages(
         let package = packageBuilder.package
 
         // Establish the manifest-declared package dependencies.
-        packageBuilder.dependencies = package.manifest.allRequiredDependencies.compactMap { dependency in
+        packageBuilder.dependencies = package.manifest.dependenciesRequired(for: packageBuilder.productFilter)
+          .compactMap { dependency in
             // Use the package name to lookup the dependency. The package name will be present in packages with tools version >= 5.2.
-            if let dependencyName = dependency.explicitName, let resolvedPackage = packageMapByName[dependencyName] {
+            if let dependencyName = dependency.declaration.explicitName, let resolvedPackage = packageMapByName[dependencyName] {
                 return resolvedPackage
             }
 
             // Otherwise, look it up by its identity.
-            let url = config.mirroredURL(forURL: dependency.url)
+            let url = config.mirroredURL(forURL: dependency.declaration.url)
             let resolvedPackage = packageMapByIdentity[PackageReference.computeIdentity(packageURL: url)]
 
             // We check that the explicit package dependency name matches the package name.
             if let resolvedPackage = resolvedPackage,
-                let explicitDependencyName = dependency.explicitName,
-                resolvedPackage.package.name != dependency.explicitName
+                let explicitDependencyName = dependency.declaration.explicitName,
+                resolvedPackage.package.name != dependency.declaration.explicitName
             {
                 let error = PackageGraphError.incorrectPackageDependencyName(
                     dependencyName: explicitDependencyName,
-                    dependencyURL: dependency.url,
+                    dependencyURL: dependency.declaration.url,
                     packageName: resolvedPackage.package.name)
                 let diagnosticLocation = PackageLocation.Local(name: package.name, packagePath: package.path)
                 diagnostics.emit(error, location: diagnosticLocation)
@@ -576,6 +606,9 @@ private final class ResolvedPackageBuilder: ResolvedBuilder<ResolvedPackage> {
     /// The package reference.
     let package: Package
 
+    /// The product filter applied to the package.
+    let productFilter: ProductFilter
+
     /// The targets in the package.
     var targets: [ResolvedTargetBuilder] = []
 
@@ -587,8 +620,9 @@ private final class ResolvedPackageBuilder: ResolvedBuilder<ResolvedPackage> {
 
     let isAllowedToVendUnsafeProducts: Bool
 
-    init(_ package: Package, isAllowedToVendUnsafeProducts: Bool) {
+    init(_ package: Package, productFilter: ProductFilter, isAllowedToVendUnsafeProducts: Bool) {
         self.package = package
+        self.productFilter = productFilter
         self.isAllowedToVendUnsafeProducts = isAllowedToVendUnsafeProducts
     }
 
@@ -648,4 +682,79 @@ private extension Diagnostic.Message {
     static func productUsesUnsafeFlags(product: String, target: String) -> Diagnostic.Message {
         .error("the target '\(target)' in product '\(product)' contains unsafe build flags")
     }
+}
+
+/// A node used while loading the packages in a resolved graph.
+///
+/// This node uses the product filter that was already finalized during resolution.
+///
+/// - SeeAlso: DependencyResolutionNode
+public struct GraphLoadingNode: Equatable, Hashable, CustomStringConvertible {
+
+  /// The package manifest.
+  public let manifest: Manifest
+
+  /// The product filter applied to the package.
+  public let productFilter: ProductFilter
+
+  public init(manifest: Manifest, productFilter: ProductFilter) {
+    self.manifest = manifest
+    self.productFilter = productFilter
+  }
+
+  /// Returns the dependencies required by this node.
+  internal func requiredDependencies() -> [FilteredDependencyDescription] {
+    return manifest.dependenciesRequired(for: productFilter)
+  }
+
+  public var description: String {
+    switch productFilter {
+    case .everything:
+      return manifest.name
+    case .specific(let set):
+      return "\(manifest.name)[\(set.sorted().joined(separator: ", "))]"
+    }
+  }
+}
+
+/// Finds the first cycle encountered in a graph.
+///
+/// This is different from the one in tools support core, in that it handles equality separately from node traversal. Nodes traverse product filters, but only the manifests must be equal for there to be a cycle.
+internal func findCycle(
+    _ nodes: [GraphLoadingNode],
+    successors: (GraphLoadingNode) throws -> [GraphLoadingNode]
+) rethrows -> (path: [Manifest], cycle: [Manifest])? {
+    // Ordered set to hold the current traversed path.
+    var path = OrderedSet<Manifest>()
+
+    // Function to visit nodes recursively.
+    // FIXME: Convert to stack.
+    func visit(
+      _ node: GraphLoadingNode,
+      _ successors: (GraphLoadingNode) throws -> [GraphLoadingNode]
+    ) rethrows -> (path: [Manifest], cycle: [Manifest])? {
+        // If this node is already in the current path then we have found a cycle.
+        if !path.append(node.manifest) {
+            let index = path.firstIndex(of: node.manifest)!
+            return (Array(path[path.startIndex..<index]), Array(path[index..<path.endIndex]))
+        }
+
+        for succ in try successors(node) {
+            if let cycle = try visit(succ, successors) {
+                return cycle
+            }
+        }
+        // No cycle found for this node, remove it from the path.
+        let item = path.removeLast()
+        assert(item == node.manifest)
+        return nil
+    }
+
+    for node in nodes {
+        if let cycle = try visit(node, successors) {
+            return cycle
+        }
+    }
+    // Couldn't find any cycle in the graph.
+    return nil
 }

--- a/Sources/PackageGraph/PackageGraphLoader.swift
+++ b/Sources/PackageGraph/PackageGraphLoader.swift
@@ -136,7 +136,7 @@ public struct PackageGraphLoader {
             node.requiredDependencies().compactMap({ dependency in
                 let url = config.mirroredURL(forURL: dependency.declaration.url)
                 return manifestMap[PackageReference.computeIdentity(packageURL: url)].map { manifest in
-                  GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
+                    GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
                 }
             })
         }
@@ -148,8 +148,8 @@ public struct PackageGraphLoader {
         }))
         let rootManifestNodes = root.manifests.map { GraphLoadingNode(manifest: $0, productFilter: .everything) }
         let rootDependencyNodes = root.dependencies.lazy.compactMap { (dependency: PackageGraphRoot.PackageDependency) -> GraphLoadingNode? in
-          guard let manifest = manifestMap[PackageReference.computeIdentity(packageURL: dependency.url)] else { return nil }
-          return GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
+            guard let manifest = manifestMap[PackageReference.computeIdentity(packageURL: dependency.url)] else { return nil }
+            return GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
         }
         let inputManifests = rootManifestNodes + rootDependencyNodes
 
@@ -167,15 +167,15 @@ public struct PackageGraphLoader {
         }
         var flattenedManifests: [String: GraphLoadingNode] = [:]
         for node in allManifests {
-          if let existing = flattenedManifests[node.manifest.name] {
-            let merged = GraphLoadingNode(
-              manifest: node.manifest,
-              productFilter: existing.productFilter.union(node.productFilter)
-            )
-            flattenedManifests[node.manifest.name] = merged
-          } else {
-            flattenedManifests[node.manifest.name] = node
-          }
+            if let existing = flattenedManifests[node.manifest.name] {
+                let merged = GraphLoadingNode(
+                    manifest: node.manifest,
+                    productFilter: existing.productFilter.union(node.productFilter)
+                )
+                flattenedManifests[node.manifest.name] = merged
+            } else {
+                flattenedManifests[node.manifest.name] = node
+            }
         }
         allManifests = flattenedManifests.values.sorted(by: { $0.manifest.name < $1.manifest.name })
 
@@ -211,9 +211,9 @@ public struct PackageGraphLoader {
 
                     // Throw if any of the non-root package is empty.
                     if package.targets.isEmpty // System packages have targets in the package but not the manifest.
-                      && package.manifest.targets.isEmpty // An unneeded dependency will not have loaded anything from the manifest.
-                      && manifest.packageKind != .root {
-                        throw PackageGraphError.noModules(package)
+                        && package.manifest.targets.isEmpty // An unneeded dependency will not have loaded anything from the manifest.
+                        && manifest.packageKind != .root {
+                            throw PackageGraphError.noModules(package)
                     }
                 }
             }
@@ -295,9 +295,9 @@ private func createResolvedPackages(
         }
         let isAllowedToVendUnsafeProducts = unsafeAllowedPackages.contains{ $0.path == package.manifest.url }
         return ResolvedPackageBuilder(
-          package,
-          productFilter: node.productFilter,
-          isAllowedToVendUnsafeProducts: isAllowedToVendUnsafeProducts
+            package,
+            productFilter: node.productFilter,
+            isAllowedToVendUnsafeProducts: isAllowedToVendUnsafeProducts
         )
     })
 
@@ -314,31 +314,31 @@ private func createResolvedPackages(
 
         // Establish the manifest-declared package dependencies.
         packageBuilder.dependencies = package.manifest.dependenciesRequired(for: packageBuilder.productFilter)
-          .compactMap { dependency in
-            // Use the package name to lookup the dependency. The package name will be present in packages with tools version >= 5.2.
-            if let dependencyName = dependency.declaration.explicitName, let resolvedPackage = packageMapByName[dependencyName] {
+            .compactMap { dependency in
+                // Use the package name to lookup the dependency. The package name will be present in packages with tools version >= 5.2.
+                if let dependencyName = dependency.declaration.explicitName, let resolvedPackage = packageMapByName[dependencyName] {
+                    return resolvedPackage
+                }
+
+                // Otherwise, look it up by its identity.
+                let url = config.mirroredURL(forURL: dependency.declaration.url)
+                let resolvedPackage = packageMapByIdentity[PackageReference.computeIdentity(packageURL: url)]
+
+                // We check that the explicit package dependency name matches the package name.
+                if let resolvedPackage = resolvedPackage,
+                    let explicitDependencyName = dependency.declaration.explicitName,
+                    resolvedPackage.package.name != dependency.declaration.explicitName
+                {
+                    let error = PackageGraphError.incorrectPackageDependencyName(
+                        dependencyName: explicitDependencyName,
+                        dependencyURL: dependency.declaration.url,
+                        packageName: resolvedPackage.package.name)
+                    let diagnosticLocation = PackageLocation.Local(name: package.name, packagePath: package.path)
+                    diagnostics.emit(error, location: diagnosticLocation)
+                }
+
                 return resolvedPackage
             }
-
-            // Otherwise, look it up by its identity.
-            let url = config.mirroredURL(forURL: dependency.declaration.url)
-            let resolvedPackage = packageMapByIdentity[PackageReference.computeIdentity(packageURL: url)]
-
-            // We check that the explicit package dependency name matches the package name.
-            if let resolvedPackage = resolvedPackage,
-                let explicitDependencyName = dependency.declaration.explicitName,
-                resolvedPackage.package.name != dependency.declaration.explicitName
-            {
-                let error = PackageGraphError.incorrectPackageDependencyName(
-                    dependencyName: explicitDependencyName,
-                    dependencyURL: dependency.declaration.url,
-                    packageName: resolvedPackage.package.name)
-                let diagnosticLocation = PackageLocation.Local(name: package.name, packagePath: package.path)
-                diagnostics.emit(error, location: diagnosticLocation)
-            }
-
-            return resolvedPackage
-        }
 
         // Create target builders for each target in the package.
         let targetBuilders = package.targets.map({ ResolvedTargetBuilder(target: $0, diagnostics: diagnostics) })
@@ -691,30 +691,30 @@ private extension Diagnostic.Message {
 /// - SeeAlso: DependencyResolutionNode
 public struct GraphLoadingNode: Equatable, Hashable, CustomStringConvertible {
 
-  /// The package manifest.
-  public let manifest: Manifest
+    /// The package manifest.
+    public let manifest: Manifest
 
-  /// The product filter applied to the package.
-  public let productFilter: ProductFilter
+    /// The product filter applied to the package.
+    public let productFilter: ProductFilter
 
-  public init(manifest: Manifest, productFilter: ProductFilter) {
-    self.manifest = manifest
-    self.productFilter = productFilter
-  }
-
-  /// Returns the dependencies required by this node.
-  internal func requiredDependencies() -> [FilteredDependencyDescription] {
-    return manifest.dependenciesRequired(for: productFilter)
-  }
-
-  public var description: String {
-    switch productFilter {
-    case .everything:
-      return manifest.name
-    case .specific(let set):
-      return "\(manifest.name)[\(set.sorted().joined(separator: ", "))]"
+    public init(manifest: Manifest, productFilter: ProductFilter) {
+        self.manifest = manifest
+        self.productFilter = productFilter
     }
-  }
+
+    /// Returns the dependencies required by this node.
+    internal func requiredDependencies() -> [FilteredDependencyDescription] {
+        return manifest.dependenciesRequired(for: productFilter)
+    }
+
+    public var description: String {
+        switch productFilter {
+        case .everything:
+            return manifest.name
+        case .specific(let set):
+            return "\(manifest.name)[\(set.sorted().joined(separator: ", "))]"
+        }
+    }
 }
 
 /// Finds the first cycle encountered in a graph.

--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -105,7 +105,13 @@ public struct PackageGraphRoot {
         }
         self.manifests = manifests
 
-        // FIXME: Special casing explicit products like this is necessary to pass the test suite and satisfy backwards compatibility. However, changing the dependencies based on the command line arguments may force pins to temporarily change, which can become a nuissance. Such pin switching can currently be worked around by declaring the executable product as a dependency of a dummy target. But in the future it might be worth providing a way of declaring them in the manifest without a dummy target, at which time the current special casing can be deprecated.
+        // FIXME: Deprecate special casing once the manifest supports declaring used executable products.
+        // Special casing explicit products like this is necessary to pass the test suite and satisfy backwards compatibility.
+        // However, changing the dependencies based on the command line arguments may force pins to temporarily change,
+        // which can become a nuissance.
+        // Such pin switching can currently be worked around by declaring the executable product as a dependency of a dummy target.
+        // But in the future it might be worth providing a way of declaring them in the manifest without a dummy target,
+        // at which time the current special casing can be deprecated.
         var adjustedDependencies = input.dependencies
         if let product = explicitProduct {
             for dependency in manifests.lazy

--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -108,14 +108,14 @@ public struct PackageGraphRoot {
         // FIXME: Special casing explicit products like this is necessary to pass the test suite and satisfy backwards compatibility. However, changing the dependencies based on the command line arguments may force pins to temporarily change, which can become a nuissance. Such pin switching can currently be worked around by declaring the executable product as a dependency of a dummy target. But in the future it might be worth providing a way of declaring them in the manifest without a dummy target, at which time the current special casing can be deprecated.
         var adjustedDependencies = input.dependencies
         if let product = explicitProduct {
-          for dependency in manifests.lazy
-            .map({ $0.dependenciesRequired(for: .everything) }).joined() {
-              adjustedDependencies.append(PackageDependency(
-                url: dependency.declaration.url,
-                requirement: dependency.declaration.requirement,
-                productFilter: .specific([product]),
-                location: ""))
-          }
+            for dependency in manifests.lazy
+                .map({ $0.dependenciesRequired(for: .everything) }).joined() {
+                    adjustedDependencies.append(PackageDependency(
+                        url: dependency.declaration.url,
+                        requirement: dependency.declaration.requirement,
+                        productFilter: .specific([product]),
+                        location: ""))
+            }
         }
 
         self.dependencies = adjustedDependencies

--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -55,6 +55,9 @@ public struct PackageGraphRoot {
         /// The requirement of the package.
         public let requirement: Requirement
 
+        /// The product filter to apply to the package.
+        public let productFilter: ProductFilter
+
         /// Create the package reference object for the dependency.
         public func createPackageRef(config: SwiftPMConfig) -> PackageReference {
             let effectiveURL = config.mirroredURL(forURL: self.url)
@@ -68,6 +71,7 @@ public struct PackageGraphRoot {
         public init(
             url: String,
             requirement: Requirement,
+            productFilter: ProductFilter,
             location: String
         ) {
             // FIXME: SwiftPM can't handle file URLs with file:// scheme so we need to
@@ -79,6 +83,7 @@ public struct PackageGraphRoot {
                 self.url = url
             }
             self.requirement = requirement
+            self.productFilter = productFilter
             self.location = location
         }
     }
@@ -93,24 +98,39 @@ public struct PackageGraphRoot {
     public let dependencies: [PackageDependency]
 
     /// Create a package graph root.
-    public init(input: PackageGraphRootInput, manifests: [Manifest]) {
+    public init(input: PackageGraphRootInput, manifests: [Manifest], explicitProduct: String? = nil) {
         self.packageRefs = zip(input.packages, manifests).map { (path, manifest) in
             let identity = PackageReference.computeIdentity(packageURL: manifest.url)
             return PackageReference(identity: identity, path: path.pathString, kind: .root)
         }
         self.manifests = manifests
-        self.dependencies = input.dependencies
+
+        // FIXME: Special casing explicit products like this is necessary to pass the test suite and satisfy backwards compatibility. However, changing the dependencies based on the command line arguments may force pins to temporarily change, which can become a nuissance. Such pin switching can currently be worked around by declaring the executable product as a dependency of a dummy target. But in the future it might be worth providing a way of declaring them in the manifest without a dummy target, at which time the current special casing can be deprecated.
+        var adjustedDependencies = input.dependencies
+        if let product = explicitProduct {
+          for dependency in manifests.lazy
+            .map({ $0.dependenciesRequired(for: .everything) }).joined() {
+              adjustedDependencies.append(PackageDependency(
+                url: dependency.declaration.url,
+                requirement: dependency.declaration.requirement,
+                productFilter: .specific([product]),
+                location: ""))
+          }
+        }
+
+        self.dependencies = adjustedDependencies
     }
 
     /// Returns the constraints imposed by root manifests + dependencies.
     public func constraints(config: SwiftPMConfig) -> [RepositoryPackageConstraint] {
         let constraints = packageRefs.map({
-            RepositoryPackageConstraint(container: $0, requirement: .unversioned)
+            RepositoryPackageConstraint(container: $0, requirement: .unversioned, products: .everything)
         })
         return constraints + dependencies.map({
             RepositoryPackageConstraint(
                 container: $0.createPackageRef(config: config),
-                requirement: $0.requirement.toConstraintRequirement()
+                requirement: $0.requirement.toConstraintRequirement(),
+                products: $0.productFilter
             )
         })
     }

--- a/Sources/PackageGraph/PinsStore.swift
+++ b/Sources/PackageGraph/PinsStore.swift
@@ -23,12 +23,17 @@ public final class PinsStore {
         /// The pinned state.
         public let state: CheckoutState
 
+        /// The product filter applied by the pin.
+        public let productFilter: ProductFilter
+
         public init(
             packageRef: PackageReference,
-            state: CheckoutState
+            state: CheckoutState,
+            productFilter: ProductFilter
         ) {
             self.packageRef = packageRef
             self.state = state
+            self.productFilter = productFilter
         }
     }
 
@@ -83,11 +88,13 @@ public final class PinsStore {
     ///   - state: The state to pin at.
     public func pin(
         packageRef: PackageReference,
-        state: CheckoutState
+        state: CheckoutState,
+        productFilter: ProductFilter
     ) {
         pinsMap[packageRef.identity] = Pin(
             packageRef: packageRef,
-            state: state
+            state: state,
+            productFilter: productFilter
         )
     }
 
@@ -110,7 +117,7 @@ public final class PinsStore {
     public func createConstraints() -> [RepositoryPackageConstraint] {
         return pins.map({ pin in
             return RepositoryPackageConstraint(
-                container: pin.packageRef, requirement: pin.state.requirement())
+                container: pin.packageRef, requirement: pin.state.requirement(), products: pin.productFilter)
         })
     }
 }
@@ -152,6 +159,7 @@ extension PinsStore.Pin: JSONMappable, JSONSerializable, Equatable {
         let ref = PackageReference(identity: identity, path: url)
         self.packageRef = name.flatMap(ref.with(newName:)) ?? ref
         self.state = try json.get("state")
+        self.productFilter = try json.get("products")
     }
 
     /// Convert the pin to JSON.
@@ -160,6 +168,7 @@ extension PinsStore.Pin: JSONMappable, JSONSerializable, Equatable {
             "package": packageRef.name.toJSON(),
             "repositoryURL": packageRef.path,
             "state": state,
+            "products": productFilter,
         ])
     }
 }

--- a/Sources/PackageGraph/Pubgrub.swift
+++ b/Sources/PackageGraph/Pubgrub.swift
@@ -990,11 +990,8 @@ public final class PubgrubDependencyResolver {
                 flattenedAssignments[identifier] = (binding: boundVersion, products: products)
             }
         }
-        var finalAssignments: [(
-            container: PackageReference,
-            binding: BoundVersion,
-            products: ProductFilter
-            )] = flattenedAssignments.keys.sorted(by: { $0.name < $1.name }).map { package in
+        var finalAssignments: [DependencyResolver.Binding]
+            = flattenedAssignments.keys.sorted(by: { $0.name < $1.name }).map { package in
                 let details = flattenedAssignments[package]!
                 return (container: package, binding: details.binding, products: details.products)
         }

--- a/Sources/PackageGraph/Pubgrub.swift
+++ b/Sources/PackageGraph/Pubgrub.swift
@@ -741,9 +741,9 @@ public final class PubgrubDependencyResolver {
     private func processInputs(
         with constraints: [Constraint]
     ) throws -> (
-      overriddenPackages: [PackageReference: (version: BoundVersion, products: ProductFilter)],
-      rootIncompatibilities: [Incompatibility]
-      ) {
+        overriddenPackages: [PackageReference: (version: BoundVersion, products: ProductFilter)],
+        rootIncompatibilities: [Incompatibility]
+    ) {
         let root = self.root!
 
         // The list of constraints that we'll be working with. We start with the input constraints
@@ -770,33 +770,33 @@ public final class PubgrubDependencyResolver {
 
             // Mark the package as overridden.
             if var existing = overriddenPackages[constraint.identifier] {
-              assert(existing.version == .unversioned, "Overridden package is not unversioned: \(constraint.identifier)@\(existing.version)")
-              existing.products.formUnion(constraint.products)
-              overriddenPackages[constraint.identifier] = existing
+                assert(existing.version == .unversioned, "Overridden package is not unversioned: \(constraint.identifier)@\(existing.version)")
+                existing.products.formUnion(constraint.products)
+                overriddenPackages[constraint.identifier] = existing
             } else {
-              overriddenPackages[constraint.identifier] = (version: .unversioned, products: constraint.products)
+                overriddenPackages[constraint.identifier] = (version: .unversioned, products: constraint.products)
             }
 
             for node in constraint.nodes() {
-              // Process dependencies of this package.
-              //
-              // We collect all version-based dependencies in a separate structure so they can
-              // be process at the end. This allows us to override them when there is a non-version
-              // based (unversioned/branch-based) constraint present in the graph.
-              let container = try provider.getContainer(for: node.package)
-              for dependency in try container.packageContainer.getUnversionedDependencies(
-                productFilter: node.productFilter()
-              ) {
-                if let versionedBasedConstraints = VersionBasedConstraint.constraints(dependency) {
-                  for constraint in versionedBasedConstraints {
-                    versionBasedDependencies[node, default: []].append(constraint)
-                  }
-                } else if !overriddenPackages.keys.contains(dependency.identifier) {
-                  // Add the constraint if its not already present. This will ensure we don't
-                  // end up looping infinitely due to a cycle (which are diagnosed seperately).
-                  constraints.append(dependency)
+                // Process dependencies of this package.
+                //
+                // We collect all version-based dependencies in a separate structure so they can
+                // be process at the end. This allows us to override them when there is a non-version
+                // based (unversioned/branch-based) constraint present in the graph.
+                let container = try provider.getContainer(for: node.package)
+                for dependency in try container.packageContainer.getUnversionedDependencies(
+                    productFilter: node.productFilter()
+                ) {
+                    if let versionedBasedConstraints = VersionBasedConstraint.constraints(dependency) {
+                        for constraint in versionedBasedConstraints {
+                            versionBasedDependencies[node, default: []].append(constraint)
+                        }
+                    } else if !overriddenPackages.keys.contains(dependency.identifier) {
+                        // Add the constraint if its not already present. This will ensure we don't
+                        // end up looping infinitely due to a cycle (which are diagnosed seperately).
+                        constraints.append(dependency)
+                    }
                 }
-              }
             }
         }
 
@@ -848,29 +848,29 @@ public final class PubgrubDependencyResolver {
             }
 
             for node in constraint.nodes() {
-              var unprocessedDependencies = try container.packageContainer.getDependencies(
-                at: revisionForDependencies,
-                productFilter: constraint.products
-              )
-              if let sharedRevision = node.revisionLock(revision: revision) {
-                unprocessedDependencies.append(sharedRevision)
-              }
-              for dependency in unprocessedDependencies {
-                switch dependency.requirement {
-                case .versionSet(let req):
-                    for node in dependency.nodes() {
-                      let versionedBasedConstraint = VersionBasedConstraint(node: node, req: req)
-                      versionBasedDependencies[node, default: []].append(versionedBasedConstraint)
-                    }
-                case .revision:
-                    constraints.append(dependency)
-                case .unversioned:
-                    throw DependencyResolverError.revisionDependencyContainsLocalPackage(
-                        dependency: package.name,
-                        localPackage: dependency.identifier.name
-                    )
+                var unprocessedDependencies = try container.packageContainer.getDependencies(
+                    at: revisionForDependencies,
+                    productFilter: constraint.products
+                )
+                if let sharedRevision = node.revisionLock(revision: revision) {
+                    unprocessedDependencies.append(sharedRevision)
                 }
-              }
+                for dependency in unprocessedDependencies {
+                    switch dependency.requirement {
+                    case .versionSet(let req):
+                        for node in dependency.nodes() {
+                            let versionedBasedConstraint = VersionBasedConstraint(node: node, req: req)
+                            versionBasedDependencies[node, default: []].append(versionedBasedConstraint)
+                        }
+                    case .revision:
+                        constraints.append(dependency)
+                    case .unversioned:
+                        throw DependencyResolverError.revisionDependencyContainsLocalPackage(
+                            dependency: package.name,
+                            localPackage: dependency.identifier.name
+                        )
+                    }
+                }
             }
         }
 
@@ -880,10 +880,10 @@ public final class PubgrubDependencyResolver {
             switch dependency.requirement {
             case .versionSet(let req):
                 for node in dependency.nodes() {
-                  let versionedBasedConstraint = VersionBasedConstraint(node: node, req: req)
-                  // FIXME: It would be better to record where this constraint came from, instead of just
-                  // using root.
-                  versionBasedDependencies[root, default: []].append(versionedBasedConstraint)
+                    let versionedBasedConstraint = VersionBasedConstraint(node: node, req: req)
+                    // FIXME: It would be better to record where this constraint came from, instead of just
+                    // using root.
+                    versionBasedDependencies[root, default: []].append(versionedBasedConstraint)
                 }
             case .revision, .unversioned:
                 fatalError("Unexpected revision/unversioned requirement in the constraints list: \(constraints)")
@@ -983,20 +983,20 @@ public final class PubgrubDependencyResolver {
             let identifier = try container.packageContainer.getUpdatedIdentifier(at: boundVersion)
 
             if var existing = flattenedAssignments[identifier] {
-              assert(existing.binding == boundVersion, "Two products in one package resolved to different versions: \(existing.products)@\(existing.binding) vs \(products)@\(boundVersion)")
-              existing.products.formUnion(products)
-              flattenedAssignments[identifier] = existing
+                assert(existing.binding == boundVersion, "Two products in one package resolved to different versions: \(existing.products)@\(existing.binding) vs \(products)@\(boundVersion)")
+                existing.products.formUnion(products)
+                flattenedAssignments[identifier] = existing
             } else {
-              flattenedAssignments[identifier] = (binding: boundVersion, products: products)
+                flattenedAssignments[identifier] = (binding: boundVersion, products: products)
             }
         }
         var finalAssignments: [(
-          container: PackageReference,
-          binding: BoundVersion,
-          products: ProductFilter
-          )] = flattenedAssignments.keys.sorted(by: { $0.name < $1.name }).map { package in
-            let details = flattenedAssignments[package]!
-            return (container: package, binding: details.binding, products: details.products)
+            container: PackageReference,
+            binding: BoundVersion,
+            products: ProductFilter
+            )] = flattenedAssignments.keys.sorted(by: { $0.name < $1.name }).map { package in
+                let details = flattenedAssignments[package]!
+                return (container: package, binding: details.binding, products: details.products)
         }
 
         // Add overriden packages to the result.
@@ -1207,10 +1207,10 @@ public final class PubgrubDependencyResolver {
 
         // Add all of this version's dependencies as incompatibilities.
         let depIncompatibilities = try container.incompatibilites(
-          at: version,
-          node: pkgTerm.node,
-          overriddenPackages: overriddenPackages,
-          root: root!)
+            at: version,
+            node: pkgTerm.node,
+            overriddenPackages: overriddenPackages,
+            root: root!)
 
         var haveConflict = false
         for incompatibility in depIncompatibilities {
@@ -1702,7 +1702,7 @@ private final class PubGrubPackageContainer {
 
         var unprocessedDependencies = try packageContainer.getDependencies(at: version, productFilter: node.productFilter())
         if let sharedVersion = node.versionLock(version: version) {
-          unprocessedDependencies.append(sharedVersion)
+            unprocessedDependencies.append(sharedVersion)
         }
         var dependencies: [PackageContainerConstraint] = []
         for dep in unprocessedDependencies {
@@ -1739,10 +1739,10 @@ private final class PubGrubPackageContainer {
             return Array(dependencies.map({ (constraint: PackageContainerConstraint) -> [Incompatibility] in
                 guard case .versionSet(let vs) = constraint.requirement else { fatalError("Unexpected unversioned requirement: \(constraint)") }
                 return constraint.nodes().map { dependencyNode in
-                  var terms: OrderedSet<Term> = []
-                  terms.append(Term(node, .exact(version)))
-                  terms.append(Term(not: dependencyNode, vs))
-                  return Incompatibility(terms, root: root, cause: .dependency(node: node))
+                    var terms: OrderedSet<Term> = []
+                    terms.append(Term(node, .exact(version)))
+                    terms.append(Term(not: dependencyNode, vs))
+                    return Incompatibility(terms, root: root, cause: .dependency(node: node))
                 }
             }).joined())
         }

--- a/Sources/PackageGraph/Pubgrub.swift
+++ b/Sources/PackageGraph/Pubgrub.swift
@@ -10,34 +10,34 @@
 
 import struct TSCUtility.Version
 import TSCBasic
-import struct PackageModel.PackageReference
+import PackageModel
 import Dispatch
 
 /// A term represents a statement about a package that may be true or false.
 public struct Term: Equatable, Hashable {
-    public let package: PackageReference
+    public let node: DependencyResolutionNode
     public let requirement: VersionSetSpecifier
     public let isPositive: Bool
 
-    public init(package: PackageReference, requirement: VersionSetSpecifier, isPositive: Bool) {
-        self.package = package
+    public init(node: DependencyResolutionNode, requirement: VersionSetSpecifier, isPositive: Bool) {
+        self.node = node
         self.requirement = requirement
         self.isPositive = isPositive
     }
 
-    public init(_ package: PackageReference, _ requirement: VersionSetSpecifier) {
-        self.init(package: package, requirement: requirement, isPositive: true)
+    public init(_ node: DependencyResolutionNode, _ requirement: VersionSetSpecifier) {
+        self.init(node: node, requirement: requirement, isPositive: true)
     }
 
     /// Create a new negative term.
-    public init(not package: PackageReference, _ requirement: VersionSetSpecifier) {
-        self.init(package: package, requirement: requirement, isPositive: false)
+    public init(not node: DependencyResolutionNode, _ requirement: VersionSetSpecifier) {
+        self.init(node: node, requirement: requirement, isPositive: false)
     }
 
     /// The same term with an inversed `isPositive` value.
     public var inverse: Term {
         return Term(
-            package: package,
+            node: node,
             requirement: requirement,
             isPositive: !isPositive)
     }
@@ -46,13 +46,13 @@ public struct Term: Equatable, Hashable {
     /// `other` must also be true.
     public func satisfies(_ other: Term) -> Bool {
         // TODO: This probably makes more sense as isSatisfied(by:) instead.
-        guard self.package == other.package else { return false }
+        guard self.node == other.node else { return false }
         return self.relation(with: other) == .subset
     }
 
     /// Create an intersection with another term.
     public func intersect(with other: Term) -> Term? {
-        guard self.package == other.package else { return nil }
+        guard self.node == other.node else { return nil }
         return intersect(withRequirement: other.requirement, andPolarity: other.isPositive)
     }
 
@@ -89,7 +89,7 @@ public struct Term: Equatable, Hashable {
             return nil
         }
 
-        return Term(package: package, requirement: versionIntersection, isPositive: isPositive)
+        return Term(node: node, requirement: versionIntersection, isPositive: isPositive)
     }
 
     public func difference(with other: Term) -> Term? {
@@ -102,7 +102,7 @@ public struct Term: Equatable, Hashable {
     /// - There has to be no decision for it.
     /// - The package version has to match all assignments.
     public func isValidDecision(for solution: PartialSolution) -> Bool {
-        for assignment in solution.assignments where assignment.term.package == package {
+        for assignment in solution.assignments where assignment.term.node == node {
             assert(!assignment.isDecision, "Expected assignment to be a derivation.")
             guard satisfies(assignment.term) else { return false }
         }
@@ -112,7 +112,7 @@ public struct Term: Equatable, Hashable {
     public func relation(with other: Term) -> SetRelation {
         // From: https://github.com/dart-lang/pub/blob/master/lib/src/solver/term.dart
 
-        if self.package != other.package {
+        if self.node != other.node {
             fatalError("attempting to compute relation between different packages \(self) \(other)")
         }
 
@@ -178,7 +178,7 @@ extension VersionSetSpecifier {
 
 extension Term: CustomStringConvertible {
     public var description: String {
-        let pkg = "\(package)"
+        let pkg = "\(node)"
         let req = requirement.description
 
         if !isPositive {
@@ -200,12 +200,12 @@ public struct Incompatibility: Equatable, Hashable {
         self.cause = cause
     }
 
-    public init(_ terms: Term..., root: PackageReference, cause: Cause = .root) {
+    public init(_ terms: Term..., root: DependencyResolutionNode, cause: Cause = .root) {
         let termSet = OrderedSet(terms)
         self.init(termSet, root: root, cause: cause)
     }
 
-    public init(_ terms: OrderedSet<Term>, root: PackageReference, cause: Cause) {
+    public init(_ terms: OrderedSet<Term>, root: DependencyResolutionNode, cause: Cause) {
         if terms.isEmpty {
             self.init(terms: terms, cause: cause)
             return
@@ -215,8 +215,8 @@ public struct Incompatibility: Equatable, Hashable {
         // always be selected.
         var terms = terms
         if terms.count > 1, cause.isConflict,
-            terms.contains(where: { $0.isPositive && $0.package == root }) {
-            terms = OrderedSet(terms.filter { !$0.isPositive || $0.package != root })
+            terms.contains(where: { $0.isPositive && $0.node == root }) {
+            terms = OrderedSet(terms.filter { !$0.isPositive || $0.node != root })
         }
 
         let normalizedTerms = normalize(terms: terms.contents)
@@ -272,7 +272,7 @@ extension Incompatibility {
 
         /// The incompatibility represents a package's dependency on another
         /// package.
-        case dependency(package: PackageReference)
+        case dependency(node: DependencyResolutionNode)
 
         /// The incompatibility was derived from two others during conflict
         /// resolution.
@@ -370,22 +370,22 @@ extension Assignment: CustomStringConvertible {
 /// The partial solution is a constantly updated solution used throughout the
 /// dependency resolution process, tracking know assignments.
 public final class PartialSolution {
-    var root: PackageReference?
+    var root: DependencyResolutionNode?
 
     /// All known assigments.
     public private(set) var assignments: [Assignment]
 
     /// All known decisions.
-    public private(set) var decisions: [PackageReference: Version] = [:]
+    public private(set) var decisions: [DependencyResolutionNode: Version] = [:]
 
     /// The intersection of all positive assignments for each package, minus any
     /// negative assignments that refer to that package.
-    public private(set) var _positive: OrderedDictionary<PackageReference, Term> = [:]
+    public private(set) var _positive: OrderedDictionary<DependencyResolutionNode, Term> = [:]
 
     /// Union of all negative assignments for a package.
     ///
     /// Only present if a package has no postive assignment.
-    public private(set) var _negative: [PackageReference: Term] = [:]
+    public private(set) var _negative: [DependencyResolutionNode: Term] = [:]
 
     /// The current decision level.
     public var decisionLevel: Int {
@@ -401,7 +401,7 @@ public final class PartialSolution {
 
     /// A list of all packages that have been assigned, but are not yet satisfied.
     public var undecided: [Term] {
-        return _positive.values.filter { !decisions.keys.contains($0.package) }
+        return _positive.values.filter { !decisions.keys.contains($0.node) }
     }
 
     /// Create a new derivation assignment and add it to the partial solution's
@@ -414,9 +414,9 @@ public final class PartialSolution {
 
     /// Create a new decision assignment and add it to the partial solution's
     /// list of known assignments.
-    public func decide(_ package: PackageReference, at version: Version) {
-        decisions[package] = version
-        let term = Term(package, .exact(version))
+    public func decide(_ node: DependencyResolutionNode, at version: Version) {
+        decisions[node] = version
+        let term = Term(node, .exact(version))
         let decision = Assignment.decision(term, decisionLevel: decisionLevel)
         self.assignments.append(decision)
         register(decision)
@@ -425,10 +425,10 @@ public final class PartialSolution {
     /// Populates the _positive and _negative poperties with the assignment.
     private func register(_ assignment: Assignment) {
         let term = assignment.term
-        let pkg = term.package
+        let pkg = term.node
 
         if let positive = _positive[pkg] {
-            _positive[term.package] = positive.intersect(with: term)
+            _positive[term.node] = positive.intersect(with: term)
             return
         }
 
@@ -448,7 +448,7 @@ public final class PartialSolution {
         var assignedTerm: Term?
 
         for assignment in assignments {
-            guard assignment.term.package == term.package else {
+            guard assignment.term.node == term.node else {
                 continue
             }
             assignedTerm = assignedTerm.flatMap{ $0.intersect(with: assignment.term) } ?? assignment.term
@@ -475,7 +475,7 @@ public final class PartialSolution {
         for (idx, remove) in toBeRemoved.reversed() {
             let assignment = assignments.remove(at: idx)
             if assignment.isDecision {
-                decisions.removeValue(forKey: remove.term.package)
+                decisions.removeValue(forKey: remove.term.node)
             }
         }
 
@@ -494,7 +494,7 @@ public final class PartialSolution {
 
     /// Returns the set relation of the partial solution with the given term.
     func relation(with term: Term) -> Term.SetRelation {
-        let pkg = term.package
+        let pkg = term.node
         if let positive = _positive[pkg] {
             return positive.relation(with: term)
         } else if let negative = _negative[pkg] {
@@ -511,25 +511,25 @@ public final class PartialSolution {
 fileprivate func normalize(
     terms: [Term]) -> [Term] {
 
-    let dict = terms.reduce(into: OrderedDictionary<PackageReference, (req: VersionSetSpecifier, polarity: Bool)>()) {
+    let dict = terms.reduce(into: OrderedDictionary<DependencyResolutionNode, (req: VersionSetSpecifier, polarity: Bool)>()) {
         res, term in
         // Don't try to intersect if this is the first time we're seeing this package.
-        guard let previous = res[term.package] else {
-            res[term.package] = (term.requirement, term.isPositive)
+        guard let previous = res[term.node] else {
+            res[term.node] = (term.requirement, term.isPositive)
             return
         }
 
         guard let intersection = term.intersect(withRequirement: previous.req, andPolarity: previous.polarity) else {
             fatalError("""
-                Attempting to create an incompatibility with terms for \(term.package) \
+                Attempting to create an incompatibility with terms for \(term.node) \
                 intersecting versions \(previous) and \(term.requirement). These are \
                 mutually exclusive and can't be intersected, making this incompatibility \
                 irrelevant.
                 """)
         }
-        res[term.package] = (intersection.requirement, intersection.isPositive)
+        res[term.node] = (intersection.requirement, intersection.isPositive)
     }
-    return dict.map { Term(package: $0, requirement: $1.req, isPositive: $1.polarity) }
+    return dict.map { Term(node: $0, requirement: $1.req, isPositive: $1.polarity) }
 }
 
 /// The solver that is able to transitively resolve a set of package constraints
@@ -544,20 +544,20 @@ public final class PubgrubDependencyResolver {
 
     /// A collection of all known incompatibilities matched to the packages they
     /// refer to. This means an incompatibility can occur several times.
-    public var incompatibilities: [PackageReference: [Incompatibility]] = [:]
+    public var incompatibilities: [DependencyResolutionNode: [Incompatibility]] = [:]
 
     /// Find all incompatibilities containing a positive term for a given package.
-    public func positiveIncompatibilities(for package: PackageReference) -> [Incompatibility]? {
-        guard let all = incompatibilities[package] else {
+    public func positiveIncompatibilities(for node: DependencyResolutionNode) -> [Incompatibility]? {
+        guard let all = incompatibilities[node] else {
             return nil
         }
         return all.filter {
-            $0.terms.first { $0.package == package }!.isPositive
+            $0.terms.first { $0.node == node }!.isPositive
         }
     }
 
     /// The root package reference.
-    private(set) var root: PackageReference?
+    private(set) var root: DependencyResolutionNode?
 
     /// Reference to the pins store, if provided.
     private var pinsMap: PinsStore.PinsMap = [:]
@@ -591,7 +591,7 @@ public final class PubgrubDependencyResolver {
     private var _traceStream: OutputByteStream?
 
     /// Set the package root.
-    public func set(_ root: PackageReference) {
+    public func set(_ root: DependencyResolutionNode) {
         self.root = root
         self.solution.root = root
     }
@@ -603,9 +603,9 @@ public final class PubgrubDependencyResolver {
         case conflictResolution = "conflict resolution"
     }
 
-    private func log(_ assignments: [(container: PackageReference, binding: BoundVersion)]) {
+    private func log(_ assignments: [(container: PackageReference, binding: BoundVersion, products: ProductFilter)]) {
         log("solved:")
-        for (container, binding) in assignments {
+        for (container, binding, _) in assignments {
             log("\(container) \(binding)")
         }
     }
@@ -617,12 +617,12 @@ public final class PubgrubDependencyResolver {
         }
     }
 
-    public func decide(_ package: PackageReference, version: Version) {
-        let term = Term(package, .exact(version))
+    public func decide(_ node: DependencyResolutionNode, version: Version) {
+        let term = Term(node, .exact(version))
         // FIXME: Shouldn't we check this _before_ making a decision?
         assert(term.isValidDecision(for: solution))
 
-        solution.decide(package, at: version)
+        solution.decide(node, at: version)
     }
 
     func derive(_ term: Term, cause: Incompatibility) {
@@ -658,7 +658,7 @@ public final class PubgrubDependencyResolver {
     /// Add a new incompatibility to the list of known incompatibilities.
     public func add(_ incompatibility: Incompatibility, location: LogLocation) {
         log("incompat: \(incompatibility) \(location)")
-        for package in incompatibility.terms.map({ $0.package }) {
+        for package in incompatibility.terms.map({ $0.node }) {
             if let incompats = incompatibilities[package] {
                 if !incompats.contains(incompatibility) {
                     incompatibilities[package]!.append(incompatibility)
@@ -718,19 +718,18 @@ public final class PubgrubDependencyResolver {
     }
 
     struct VersionBasedConstraint {
-        let package: PackageReference
+        let node: DependencyResolutionNode
         let requirement: VersionSetSpecifier
 
-        init(package: PackageReference, req: VersionSetSpecifier) {
-            self.package = package
+        init(node: DependencyResolutionNode, req: VersionSetSpecifier) {
+            self.node = node
             self.requirement = req
         }
 
-        init?(_ constaint: Constraint) {
-            switch constaint.requirement {
+        internal static func constraints(_ constraint: Constraint) -> [VersionBasedConstraint]? {
+            switch constraint.requirement {
             case .versionSet(let req):
-                self.package = constaint.identifier
-                self.requirement = req
+              return constraint.nodes().map { VersionBasedConstraint(node: $0, req: req) }
             case .revision:
                 return nil
             case .unversioned:
@@ -741,7 +740,10 @@ public final class PubgrubDependencyResolver {
 
     private func processInputs(
         with constraints: [Constraint]
-    ) throws -> (overriddenPackages: [PackageReference: BoundVersion], rootIncompatibilities: [Incompatibility]) {
+    ) throws -> (
+      overriddenPackages: [PackageReference: (version: BoundVersion, products: ProductFilter)],
+      rootIncompatibilities: [Incompatibility]
+      ) {
         let root = self.root!
 
         // The list of constraints that we'll be working with. We start with the input constraints
@@ -752,12 +754,12 @@ public final class PubgrubDependencyResolver {
         // The list of packages that are overridden in the graph. A local package reference will
         // always override any other kind of package reference and branch-based reference will override
         // version-based reference.
-        var overridenPackages: [PackageReference: BoundVersion] = [:]
+        var overriddenPackages: [PackageReference: (version: BoundVersion, products: ProductFilter)] = [:]
 
         // The list of version-based references reachable via local and branch-based references.
         // These are added as top-level incompatibilities since they always need to be statisfied.
         // Some of these might be overridden as we discover local and branch-based references.
-        var versionBasedDependencies: [PackageReference: [VersionBasedConstraint]] = [:]
+        var versionBasedDependencies: [DependencyResolutionNode: [VersionBasedConstraint]] = [:]
 
         // Process unversioned constraints in first phase. We go through all of the unversioned packages
         // and collect them and their dependencies. This gives us the complete list of unversioned
@@ -767,23 +769,34 @@ public final class PubgrubDependencyResolver {
             constraints.remove(constraint)
 
             // Mark the package as overridden.
-            let package = constraint.identifier
-            overridenPackages[package] = .unversioned
+            if var existing = overriddenPackages[constraint.identifier] {
+              assert(existing.version == .unversioned, "Overridden package is not unversioned: \(constraint.identifier)@\(existing.version)")
+              existing.products.formUnion(constraint.products)
+              overriddenPackages[constraint.identifier] = existing
+            } else {
+              overriddenPackages[constraint.identifier] = (version: .unversioned, products: constraint.products)
+            }
 
-            // Process dependencies of this package.
-            //
-            // We collect all version-based dependencies in a separate structure so they can
-            // be process at the end. This allows us to override them when there is a non-version
-            // based (unversioned/branch-based) constraint present in the graph.
-            let container = try provider.getContainer(for: package)
-            for dependency in try container.packageContainer.getUnversionedDependencies() {
-                if let versionedBasedConstraint = VersionBasedConstraint(dependency) {
-                    versionBasedDependencies[package, default: []].append(versionedBasedConstraint)
-                } else if !overridenPackages.keys.contains(dependency.identifier) {
-                    // Add the constraint if its not already present. This will ensure we don't
-                    // end up looping infinitely due to a cycle (which are diagnosed seperately).
-                    constraints.append(dependency)
+            for node in constraint.nodes() {
+              // Process dependencies of this package.
+              //
+              // We collect all version-based dependencies in a separate structure so they can
+              // be process at the end. This allows us to override them when there is a non-version
+              // based (unversioned/branch-based) constraint present in the graph.
+              let container = try provider.getContainer(for: node.package)
+              for dependency in try container.packageContainer.getUnversionedDependencies(
+                productFilter: node.productFilter()
+              ) {
+                if let versionedBasedConstraints = VersionBasedConstraint.constraints(dependency) {
+                  for constraint in versionedBasedConstraints {
+                    versionBasedDependencies[node, default: []].append(constraint)
+                  }
+                } else if !overriddenPackages.keys.contains(dependency.identifier) {
+                  // Add the constraint if its not already present. This will ensure we don't
+                  // end up looping infinitely due to a cycle (which are diagnosed seperately).
+                  constraints.append(dependency)
                 }
+              }
             }
         }
 
@@ -796,10 +809,10 @@ public final class PubgrubDependencyResolver {
             let package = constraint.identifier
 
             // Check if there is an existing value for this package in the overridden packages.
-            switch overridenPackages[package] {
+            switch overriddenPackages[package]?.version {
                 case .excluded?, .version?:
                     // These values are not possible.
-                    fatalError("Unexpected value for overriden package \(package) in \(overridenPackages)")
+                    fatalError("Unexpected value for overriden package \(package) in \(overriddenPackages)")
                 case .unversioned?:
                     // This package is overridden by an unversioned package so we can ignore this constraint.
                     continue
@@ -817,7 +830,7 @@ public final class PubgrubDependencyResolver {
             }
 
             // Mark the package as overridden.
-            overridenPackages[package] = .revision(revision)
+            overriddenPackages[package] = (version: .revision(revision), products: constraint.products)
 
             // Process dependencies of this package, similar to the first phase but branch-based dependencies
             // are not allowed to contain local/unversioned packages.
@@ -834,11 +847,21 @@ public final class PubgrubDependencyResolver {
                 revisionForDependencies = revision
             }
 
-            for dependency in try container.packageContainer.getDependencies(at: revisionForDependencies) {
+            for node in constraint.nodes() {
+              var unprocessedDependencies = try container.packageContainer.getDependencies(
+                at: revisionForDependencies,
+                productFilter: constraint.products
+              )
+              if let sharedRevision = node.revisionLock(revision: revision) {
+                unprocessedDependencies.append(sharedRevision)
+              }
+              for dependency in unprocessedDependencies {
                 switch dependency.requirement {
                 case .versionSet(let req):
-                    let versionedBasedConstraint = VersionBasedConstraint(package: dependency.identifier, req: req)
-                    versionBasedDependencies[package, default: []].append(versionedBasedConstraint)
+                    for node in dependency.nodes() {
+                      let versionedBasedConstraint = VersionBasedConstraint(node: node, req: req)
+                      versionBasedDependencies[node, default: []].append(versionedBasedConstraint)
+                    }
                 case .revision:
                     constraints.append(dependency)
                 case .unversioned:
@@ -847,6 +870,7 @@ public final class PubgrubDependencyResolver {
                         localPackage: dependency.identifier.name
                     )
                 }
+              }
             }
         }
 
@@ -855,10 +879,12 @@ public final class PubgrubDependencyResolver {
         for dependency in constraints {
             switch dependency.requirement {
             case .versionSet(let req):
-                let versionedBasedConstraint = VersionBasedConstraint(package: dependency.identifier, req: req)
-                // FIXME: It would be better to record where this constraint came from, instead of just
-                // using root.
-                versionBasedDependencies[root, default: []].append(versionedBasedConstraint)
+                for node in dependency.nodes() {
+                  let versionedBasedConstraint = VersionBasedConstraint(node: node, req: req)
+                  // FIXME: It would be better to record where this constraint came from, instead of just
+                  // using root.
+                  versionBasedDependencies[root, default: []].append(versionedBasedConstraint)
+                }
             case .revision, .unversioned:
                 fatalError("Unexpected revision/unversioned requirement in the constraints list: \(constraints)")
             }
@@ -866,26 +892,26 @@ public final class PubgrubDependencyResolver {
 
         // Finally, compute the root incompatibilities (which will be all version-based).
         var rootIncompatibilities: [Incompatibility] = []
-        for (package, constraints) in versionBasedDependencies {
+        for (node, constraints) in versionBasedDependencies {
             for constraint in constraints {
-                if overridenPackages.keys.contains(constraint.package) { continue }
+                if overriddenPackages.keys.contains(constraint.node.package) { continue }
 
                 let incompat = Incompatibility(
                     Term(root, .exact("1.0.0")),
-                    Term(not: constraint.package, constraint.requirement),
+                    Term(not: constraint.node, constraint.requirement),
                     root: root,
-                    cause: .dependency(package: package))
+                    cause: .dependency(node: node))
                 rootIncompatibilities.append(incompat)
             }
         }
 
-        return (overridenPackages, rootIncompatibilities)
+        return (overriddenPackages, rootIncompatibilities)
     }
 
     /// The list of packages that are overridden in the graph. A local package reference will
     /// always override any other kind of package reference and branch-based reference will override
     /// version-based reference.
-    private var overriddenPackages: [PackageReference: BoundVersion] = [:]
+    private var overriddenPackages: [PackageReference: (version: BoundVersion, products: ProductFilter)] = [:]
 
     /// Find a set of dependencies that fit the given constraints. If dependency
     /// resolution is unable to provide a result, an error is thrown.
@@ -894,13 +920,13 @@ public final class PubgrubDependencyResolver {
     private func solve(
         constraints: [Constraint],
         pinsMap: PinsStore.PinsMap = [:]
-    ) throws -> [(container: PackageReference, binding: BoundVersion)] {
-        let root = PackageReference(
+    ) throws -> [(container: PackageReference, binding: BoundVersion, products: ProductFilter)] {
+        let root = DependencyResolutionNode.root(package: PackageReference(
             identity: "<synthesized-root>",
             path: "<synthesized-root-path>",
             name: nil,
             kind: .root
-        )
+        ))
 
         self.root = root
         self.pinsMap = pinsMap
@@ -937,12 +963,13 @@ public final class PubgrubDependencyResolver {
         try run()
 
         let decisions = solution.assignments.filter { $0.isDecision }
-        var finalAssignments: [(container: PackageReference, binding: BoundVersion)] = try decisions.compactMap { assignment in
-            guard assignment.term.package != root else {
-                return nil
+        var flattenedAssignments: [PackageReference: (binding: BoundVersion, products: ProductFilter)] = [:]
+        for assignment in decisions {
+            if assignment.term.node == root {
+                continue
             }
 
-            var boundVersion: BoundVersion
+            let boundVersion: BoundVersion
             switch assignment.term.requirement {
             case .exact(let version):
                 boundVersion = .version(version)
@@ -950,17 +977,33 @@ public final class PubgrubDependencyResolver {
                 fatalError("unexpected requirement value for assignment \(assignment.term)")
             }
 
-            let container = try provider.getContainer(for: assignment.term.package)
+            let products = assignment.term.node.productFilter()
+
+            let container = try provider.getContainer(for: assignment.term.node.package)
             let identifier = try container.packageContainer.getUpdatedIdentifier(at: boundVersion)
 
-            return (identifier, boundVersion)
+            if var existing = flattenedAssignments[identifier] {
+              assert(existing.binding == boundVersion, "Two products in one package resolved to different versions: \(existing.products)@\(existing.binding) vs \(products)@\(boundVersion)")
+              existing.products.formUnion(products)
+              flattenedAssignments[identifier] = existing
+            } else {
+              flattenedAssignments[identifier] = (binding: boundVersion, products: products)
+            }
+        }
+        var finalAssignments: [(
+          container: PackageReference,
+          binding: BoundVersion,
+          products: ProductFilter
+          )] = flattenedAssignments.keys.sorted(by: { $0.name < $1.name }).map { package in
+            let details = flattenedAssignments[package]!
+            return (container: package, binding: details.binding, products: details.products)
         }
 
         // Add overriden packages to the result.
-        for (package, boundVersion) in overriddenPackages {
+        for (package, override) in overriddenPackages {
             let container = try provider.getContainer(for: package)
-            let identifier = try container.packageContainer.getUpdatedIdentifier(at: boundVersion)
-            finalAssignments.append((identifier, boundVersion))
+            let identifier = try container.packageContainer.getUpdatedIdentifier(at: override.version)
+            finalAssignments.append((identifier, override.version, override.products))
         }
 
         log(finalAssignments)
@@ -973,7 +1016,7 @@ public final class PubgrubDependencyResolver {
     /// After this method returns `solution` is either populated with a list of
     /// final version assignments or an error is thrown.
     func run() throws {
-        var next: PackageReference? = root
+        var next: DependencyResolutionNode? = root
         while let nxt = next {
             try propagate(nxt)
 
@@ -987,8 +1030,8 @@ public final class PubgrubDependencyResolver {
     /// partial solution.
     /// If a conflict is found, the conflicting incompatibility is returned to
     /// resolve the conflict on.
-    public func propagate(_ package: PackageReference) throws {
-        var changed: OrderedSet<PackageReference> = [package]
+    public func propagate(_ node: DependencyResolutionNode) throws {
+        var changed: OrderedSet<DependencyResolutionNode> = [node]
 
         while !changed.isEmpty {
             let package = changed.removeFirst()
@@ -1045,12 +1088,12 @@ public final class PubgrubDependencyResolver {
         log("derived: \(unsatisfiedTerm.inverse)")
         derive(unsatisfiedTerm.inverse, cause: incompatibility)
 
-        return .almostSatisfied(package: unsatisfiedTerm.package)
+        return .almostSatisfied(node: unsatisfiedTerm.node)
     }
 
     enum PropagationResult {
         case conflict
-        case almostSatisfied(package: PackageReference)
+        case almostSatisfied(node: DependencyResolutionNode)
         case none
     }
 
@@ -1111,7 +1154,7 @@ public final class PubgrubDependencyResolver {
             let priorCause = _mostRecentSatisfier.cause!
 
             var newTerms = incompatibility.terms.filter{ $0 != mostRecentTerm }
-            newTerms += priorCause.terms.filter({ $0.package != _mostRecentSatisfier.term.package })
+            newTerms += priorCause.terms.filter({ $0.node != _mostRecentSatisfier.term.node })
 
             if let _difference = difference {
                 newTerms.append(_difference.inverse)
@@ -1136,10 +1179,10 @@ public final class PubgrubDependencyResolver {
     /// failed, meaning this incompatibility is either empty or only for the root
     /// package.
     private func isCompleteFailure(_ incompatibility: Incompatibility) -> Bool {
-        return incompatibility.terms.isEmpty || (incompatibility.terms.count == 1 && incompatibility.terms.first?.package == root)
+        return incompatibility.terms.isEmpty || (incompatibility.terms.count == 1 && incompatibility.terms.first?.node == root)
     }
 
-    public func makeDecision() throws -> PackageReference? {
+    public func makeDecision() throws -> DependencyResolutionNode? {
         let undecided = solution.undecided
 
         // If there are no more undecided terms, version solving is complete.
@@ -1150,20 +1193,24 @@ public final class PubgrubDependencyResolver {
         // Prefer packages with least number of versions that fit the current requirements so we
         // get conflicts (if any) sooner.
         let pkgTerm = try undecided.min {
-            let count1 = try provider.getContainer(for: $0.package).versionCount($0.requirement)
-            let count2 = try provider.getContainer(for: $1.package).versionCount($1.requirement)
+            let count1 = try provider.getContainer(for: $0.node.package).versionCount($0.requirement)
+            let count2 = try provider.getContainer(for: $1.node.package).versionCount($1.requirement)
             return count1 < count2
         }!
 
-        let container = try provider.getContainer(for: pkgTerm.package)
+        let container = try provider.getContainer(for: pkgTerm.node.package)
         // Get the best available version for this package.
         guard let version = try container.getBestAvailableVersion(for: pkgTerm) else {
             add(Incompatibility(pkgTerm, root: root!, cause: .noAvailableVersion), location: .decisionMaking)
-            return pkgTerm.package
+            return pkgTerm.node
         }
 
         // Add all of this version's dependencies as incompatibilities.
-        let depIncompatibilities = try container.incompatibilites(at: version, overriddenPackages: overriddenPackages, root: root!)
+        let depIncompatibilities = try container.incompatibilites(
+          at: version,
+          node: pkgTerm.node,
+          overriddenPackages: overriddenPackages,
+          root: root!)
 
         var haveConflict = false
         for incompatibility in depIncompatibilities {
@@ -1176,31 +1223,31 @@ public final class PubgrubDependencyResolver {
                 // are satisfied because we _know_ that the terms matching
                 // this package will be satisfied if we make this version
                 // as a decision.
-                $0.package == pkgTerm.package || solution.satisfies($0)
+                $0.node == pkgTerm.node || solution.satisfies($0)
             }
         }
 
         // Decide this version if there was no conflict with its dependencies.
         if !haveConflict {
-            log("decision: \(pkgTerm.package)@\(version)")
-            decide(pkgTerm.package, version: version)
+            log("decision: \(pkgTerm.node.package)@\(version)")
+            decide(pkgTerm.node, version: version)
         }
 
-        return pkgTerm.package
+        return pkgTerm.node
     }
 }
 
 private final class DiagnosticReportBuilder {
-    let rootPackage: PackageReference
-    let incompatibilities: [PackageReference: [Incompatibility]]
+    let rootNode: DependencyResolutionNode
+    let incompatibilities: [DependencyResolutionNode: [Incompatibility]]
 
     private var lines: [(String, Int)] = []
     private var derivations: [Incompatibility: Int] = [:]
     private var lineNumbers: [Incompatibility: Int] = [:]
     private let provider: ContainerProvider
 
-    init(root: PackageReference, incompatibilities: [PackageReference: [Incompatibility]], provider: ContainerProvider) {
-        self.rootPackage = root
+    init(root: DependencyResolutionNode, incompatibilities: [DependencyResolutionNode: [Incompatibility]], provider: ContainerProvider) {
+        self.rootNode = root
         self.incompatibilities = incompatibilities
         self.provider = provider
     }
@@ -1353,7 +1400,7 @@ private final class DiagnosticReportBuilder {
 
     private func description(for incompatibility: Incompatibility) -> String {
         switch incompatibility.cause {
-        case .dependency(package: _):
+        case .dependency(node: _):
             assert(incompatibility.terms.count == 2)
             let depender = incompatibility.terms.first!
             let dependee = incompatibility.terms.last!
@@ -1365,15 +1412,15 @@ private final class DiagnosticReportBuilder {
             return "\(dependerDesc) depends on \(dependeeDesc)"
         case .noAvailableVersion:
             assert(incompatibility.terms.count == 1)
-            let package = incompatibility.terms.first!
-            assert(package.isPositive)
-            return "no versions of \(package.package.lastPathComponent) match the requirement \(package.requirement)"
+            let term = incompatibility.terms.first!
+            assert(term.isPositive)
+            return "no versions of \(term.node.nameForDiagnostics()) match the requirement \(term.requirement)"
         case .root:
             // FIXME: This will never happen I think.
             assert(incompatibility.terms.count == 1)
-            let package = incompatibility.terms.first!
-            assert(package.isPositive)
-            return "\(package.package.lastPathComponent) is \(package.requirement)"
+            let term = incompatibility.terms.first!
+            assert(term.isPositive)
+            return "\(term.node.nameForDiagnostics()) is \(term.requirement)"
         case .conflict:
             break
         case .versionBasedDependencyContainsUnversionedDependency(let versionedDependency, let unversionedDependency):
@@ -1390,16 +1437,16 @@ private final class DiagnosticReportBuilder {
         let terms = incompatibility.terms
         if terms.count == 1 {
             let term = terms.first!
-            let prefix = hasEffectivelyAnyRequirement(term) ? term.package.lastPathComponent : description(for: term, normalizeRange: true)
+            let prefix = hasEffectivelyAnyRequirement(term) ? term.node.nameForDiagnostics() : description(for: term, normalizeRange: true)
             return "\(prefix) is " + (term.isPositive ? "forbidden" : "required")
         } else if terms.count == 2 {
             let term1 = terms.first!
             let term2 = terms.last!
             if term1.isPositive == term2.isPositive {
                 if term1.isPositive {
-                    return "\(term1.package.lastPathComponent) is incompatible with \(term2.package.lastPathComponent)";
+                    return "\(term1.node.nameForDiagnostics()) is incompatible with \(term2.node.nameForDiagnostics())";
                 } else {
-                    return "either \(term1.package.lastPathComponent) or \(term2)"
+                    return "either \(term1.node.nameForDiagnostics()) or \(term2)"
                 }
             }
         }
@@ -1429,7 +1476,7 @@ private final class DiagnosticReportBuilder {
         case .empty, .exact, .ranges:
             return false
         case .range(let range):
-            guard let container = try? provider.getContainer(for: term.package) else {
+            guard let container = try? provider.getContainer(for: term.node.package) else {
                 return false
             }
             let bounds = container.computeBounds(for: range)
@@ -1461,23 +1508,23 @@ private final class DiagnosticReportBuilder {
 
     // FIXME: This is duplicated and wrong.
     private func isFailure(_ incompatibility: Incompatibility) -> Bool {
-        return incompatibility.terms.count == 1 && incompatibility.terms.first?.package.identity == "<synthesized-root>"
+        return incompatibility.terms.count == 1 && incompatibility.terms.first?.node.package.identity == "<synthesized-root>"
     }
 
     private func description(for term: Term, normalizeRange: Bool = false) -> String {
-        let name = term.package.name
+        let name = term.node.nameForDiagnostics()
 
         switch term.requirement {
         case .any: return "every version of \(name)"
         case .empty: return "no version of \(name)"
         case .exact(let version):
             // For the root package, don't output the useless version 1.0.0.
-            if term.package == rootPackage {
+            if term.node == rootNode {
                 return "root"
             }
             return "\(name) \(version)"
         case .range(let range):
-            guard normalizeRange, let container = try? provider.getContainer(for: term.package) else {
+            guard normalizeRange, let container = try? provider.getContainer(for: term.node.package) else {
                 return "\(name) \(range.description)"
             }
 
@@ -1643,23 +1690,28 @@ private final class PubGrubPackageContainer {
     /// Returns the incompatibilities of a package at the given version.
     func incompatibilites(
         at version: Version,
-        overriddenPackages: [PackageReference: BoundVersion],
-        root: PackageReference
+        node: DependencyResolutionNode,
+        overriddenPackages: [PackageReference: (version: BoundVersion, products: ProductFilter)],
+        root: DependencyResolutionNode
     ) throws -> [Incompatibility] {
         // FIXME: It would be nice to compute bounds for this as well.
         if !packageContainer.isToolsVersionCompatible(at: version) {
             let requirement = computeIncompatibleToolsVersionBounds(fromVersion: version)
-            return [Incompatibility(Term(package, requirement), root: root, cause: .incompatibleToolsVersion)]
+            return [Incompatibility(Term(node, requirement), root: root, cause: .incompatibleToolsVersion)]
         }
 
+        var unprocessedDependencies = try packageContainer.getDependencies(at: version, productFilter: node.productFilter())
+        if let sharedVersion = node.versionLock(version: version) {
+          unprocessedDependencies.append(sharedVersion)
+        }
         var dependencies: [PackageContainerConstraint] = []
-        for dep in try packageContainer.getDependencies(at: version) {
+        for dep in unprocessedDependencies {
             // Version-based packages are not allowed to contain unversioned dependencies.
             guard case .versionSet = dep.requirement else {
                 let cause: Incompatibility.Cause = .versionBasedDependencyContainsUnversionedDependency(
                     versionedDependency: package.identity,
                     unversionedDependency: dep.identifier.identity)
-                return [Incompatibility(Term(package, .exact(version)), root: root, cause: cause)]
+                return [Incompatibility(Term(node, .exact(version)), root: root, cause: cause)]
             }
 
             // Skip if this package is overriden.
@@ -1684,34 +1736,38 @@ private final class PubGrubPackageContainer {
 
             // Since the pinned version is most likely to succeed, we don't compute bounds for its
             // incompatibilities.
-            return dependencies.map {
-                guard case .versionSet(let vs) = $0.requirement else { fatalError("Unexpected unversioned requirement: \($0)") }
-                var terms: OrderedSet<Term> = []
-                terms.append(Term(packageContainer.identifier, .exact(version)))
-                terms.append(Term(not: $0.identifier, vs))
-                return Incompatibility(terms, root: root, cause: .dependency(package: packageContainer.identifier))
-            }
+            return Array(dependencies.map({ (constraint: PackageContainerConstraint) -> [Incompatibility] in
+                guard case .versionSet(let vs) = constraint.requirement else { fatalError("Unexpected unversioned requirement: \(constraint)") }
+                return constraint.nodes().map { dependencyNode in
+                  var terms: OrderedSet<Term> = []
+                  terms.append(Term(node, .exact(version)))
+                  terms.append(Term(not: dependencyNode, vs))
+                  return Incompatibility(terms, root: root, cause: .dependency(node: node))
+                }
+            }).joined())
         }
 
-        let (lowerBounds, upperBounds) = computeBounds(dependencies, from: version)
+        let (lowerBounds, upperBounds) = computeBounds(dependencies, from: version, products: node.productFilter())
 
-        return dependencies.map {
+        return dependencies.map { dependency in
             var terms: OrderedSet<Term> = []
-            let lowerBound = lowerBounds[$0.identifier] ?? "0.0.0"
-            let upperBound = upperBounds[$0.identifier] ?? Version(version.major + 1, 0, 0)
+            let lowerBound = lowerBounds[dependency.identifier] ?? "0.0.0"
+            let upperBound = upperBounds[dependency.identifier] ?? Version(version.major + 1, 0, 0)
             assert(lowerBound < upperBound)
 
             // We only have version-based requirements at this point.
-            guard case .versionSet(let vs) = $0.requirement else { fatalError("Unexpected unversioned requirement: \($0)") }
+            guard case .versionSet(let vs) = dependency.requirement else { fatalError("Unexpected unversioned requirement: \(dependency)") }
 
-            let requirement: VersionSetSpecifier = .range(lowerBound..<upperBound)
-            terms.append(Term(packageContainer.identifier, requirement))
-            terms.append(Term(not: $0.identifier, vs))
+            for dependencyNode in dependency.nodes() {
+              let requirement: VersionSetSpecifier = .range(lowerBound..<upperBound)
+              terms.append(Term(node, requirement))
+              terms.append(Term(not: dependencyNode, vs))
 
-            // Make a record for this dependency so we don't have to recompute the bounds when the selected version falls within the bounds.
-            emittedIncompatibilities[$0.identifier] = requirement.union(emittedIncompatibilities[$0.identifier] ?? .empty)
+              // Make a record for this dependency so we don't have to recompute the bounds when the selected version falls within the bounds.
+              emittedIncompatibilities[dependency.identifier] = requirement.union(emittedIncompatibilities[dependency.identifier] ?? .empty)
+            }
 
-            return Incompatibility(terms, root: root, cause: .dependency(package: packageContainer.identifier))
+            return Incompatibility(terms, root: root, cause: .dependency(node: node))
         }
     }
 
@@ -1730,7 +1786,8 @@ private final class PubGrubPackageContainer {
     /// inclusive and the upper bound is exclusive.
     private func computeBounds(
         _ dependencies: [PackageContainerConstraint],
-        from fromVersion: Version
+        from fromVersion: Version,
+        products: ProductFilter
     ) -> (lowerBounds: [PackageReference: Version], upperBounds: [PackageReference: Version]) {
         func computeBounds(with versionsToIterate: AnyCollection<Version>, upperBound: Bool) -> [PackageReference: Version] {
             var result: [PackageReference: Version] = [:]
@@ -1743,7 +1800,7 @@ private final class PubGrubPackageContainer {
                 let isToolsVersionCompatible = packageContainer.isToolsVersionCompatible(at: version)
 
                 // Get the dependencies at this version.
-                let currentDependencies = (try? packageContainer.getDependencies(at: version)) ?? []
+                let currentDependencies = (try? packageContainer.getDependencies(at: version, productFilter: products)) ?? []
 
                 // Record this version as the bound for our list of dependencies, if appropriate.
                 for dependency in dependencies where !result.keys.contains(dependency.identifier) {

--- a/Sources/PackageGraph/RawPackageConstraints.swift
+++ b/Sources/PackageGraph/RawPackageConstraints.swift
@@ -43,12 +43,14 @@ extension RepositoryPackageConstraint {
         case .everything:
             return [.root(package: identifier)]
         case .specific:
-            return products.enumerated().map { node in
-                switch node {
-                case .none:
-                    return .empty(package: identifier)
-                case .some(let product):
-                    return .product(product, package: identifier)
+            switch products {
+            case .everything:
+                fatalError("Attempted to enumerate a root package’s product filter; root packages have no filter.")
+            case .specific(let set):
+                if set.isEmpty { // Pointing at the package without a particular product.
+                    return [.empty(package: identifier)]
+                } else {
+                    return set.sorted().map { .product($0, package: identifier) }
                 }
             }
         }

--- a/Sources/PackageGraph/RawPackageConstraints.swift
+++ b/Sources/PackageGraph/RawPackageConstraints.swift
@@ -38,19 +38,19 @@ extension Manifest {
 
 extension RepositoryPackageConstraint {
 
-  internal func nodes() -> [DependencyResolutionNode] {
-    switch products {
-    case .everything:
-      return [.root(package: identifier)]
-    case .specific:
-      return products.enumerated().map { node in
-        switch node {
-        case .none:
-          return .empty(package: identifier)
-        case .some(let product):
-          return .product(product, package: identifier)
+    internal func nodes() -> [DependencyResolutionNode] {
+        switch products {
+        case .everything:
+            return [.root(package: identifier)]
+        case .specific:
+            return products.enumerated().map { node in
+                switch node {
+                case .none:
+                    return .empty(package: identifier)
+                case .some(let product):
+                    return .product(product, package: identifier)
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -270,19 +270,19 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         var products =  manifestBuilder.products
         var targets = manifestBuilder.targets
         if products.isEmpty, targets.isEmpty,
-          (fileSystem ?? localFileSystem).isFile(inputPath.parentDirectory.appending(component: moduleMapFilename)) {
-          products.append(ProductDescription(
-            name: manifestBuilder.name,
-            type: .library(.automatic),
-            targets: [manifestBuilder.name])
-          )
-          targets.append(TargetDescription(
-            name: manifestBuilder.name,
-            path: "",
-            type: .system,
-            pkgConfig: manifestBuilder.pkgConfig,
-            providers: manifestBuilder.providers
-          ))
+            (fileSystem ?? localFileSystem).isFile(inputPath.parentDirectory.appending(component: moduleMapFilename)) {
+                products.append(ProductDescription(
+                name: manifestBuilder.name,
+                type: .library(.automatic),
+                targets: [manifestBuilder.name])
+            )
+            targets.append(TargetDescription(
+                name: manifestBuilder.name,
+                path: "",
+                type: .system,
+                pkgConfig: manifestBuilder.pkgConfig,
+                providers: manifestBuilder.providers
+            ))
         }
 
         let manifest = Manifest(

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -63,6 +63,7 @@ public protocol ManifestLoaderProtocol {
     ///   - path: The root path of the package.
     ///   - baseURL: The URL the manifest was loaded from.
     ///   - version: The version the manifest is from, if known.
+    ///   - revision: The revision the manifest is from, if known.
     ///   - toolsVersion: The version of the tools the manifest supports.
     ///   - kind: The kind of package the manifest is from.
     ///   - fileSystem: If given, the file system to load from (otherwise load from the local file system).
@@ -71,6 +72,7 @@ public protocol ManifestLoaderProtocol {
         packagePath path: AbsolutePath,
         baseURL: String,
         version: Version?,
+        revision: String?,
         toolsVersion: ToolsVersion,
         packageKind: PackageReference.Kind,
         fileSystem: FileSystem?,
@@ -85,6 +87,7 @@ extension ManifestLoaderProtocol {
     ///   - path: The root path of the package.
     ///   - baseURL: The URL the manifest was loaded from.
     ///   - version: The version the manifest is from, if known.
+    ///   - revision: The revision the manifest is from, if known.
     ///   - toolsVersion: The version of the tools the manifest supports.
     ///   - kind: The kind of package the manifest is from.
     ///   - fileSystem: If given, the file system to load from (otherwise load from the local file system).
@@ -93,6 +96,7 @@ extension ManifestLoaderProtocol {
         package path: AbsolutePath,
         baseURL: String,
         version: Version? = nil,
+        revision: String? = nil,
         toolsVersion: ToolsVersion,
         packageKind: PackageReference.Kind,
         fileSystem: FileSystem? = nil,
@@ -102,6 +106,7 @@ extension ManifestLoaderProtocol {
             packagePath: path,
             baseURL: baseURL,
             version: version,
+            revision: revision,
             toolsVersion: toolsVersion,
             packageKind: packageKind,
             fileSystem: fileSystem,
@@ -190,6 +195,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         packagePath path: AbsolutePath,
         baseURL: String,
         version: Version?,
+        revision: String?,
         toolsVersion: ToolsVersion,
         packageKind: PackageReference.Kind,
         fileSystem: FileSystem? = nil,
@@ -199,6 +205,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             path: Manifest.path(atPackagePath: path, fileSystem: fileSystem ?? localFileSystem),
             baseURL: baseURL,
             version: version,
+            revision: revision,
             toolsVersion: toolsVersion,
             packageKind: packageKind,
             fileSystem: fileSystem,
@@ -212,12 +219,14 @@ public final class ManifestLoader: ManifestLoaderProtocol {
     ///   - path: The path to the manifest file (or a package root).
     ///   - baseURL: The URL the manifest was loaded from.
     ///   - version: The version the manifest is from, if known.
+    ///   - revision: The revision the manifest is from, if known.
     ///   - kind: The kind of package the manifest is from.
     ///   - fileSystem: If given, the file system to load from (otherwise load from the local file system).
     func loadFile(
         path inputPath: AbsolutePath,
         baseURL: String,
         version: Version?,
+        revision: String?,
         toolsVersion: ToolsVersion,
         packageKind: PackageReference.Kind,
         fileSystem: FileSystem? = nil,
@@ -257,6 +266,25 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             throw ManifestParseError.runtimeManifestErrors(manifestBuilder.errors)
         }
 
+        // Convert legacy system packages to the current target‐based model.
+        var products =  manifestBuilder.products
+        var targets = manifestBuilder.targets
+        if products.isEmpty, targets.isEmpty,
+          (fileSystem ?? localFileSystem).isFile(inputPath.parentDirectory.appending(component: moduleMapFilename)) {
+          products.append(ProductDescription(
+            name: manifestBuilder.name,
+            type: .library(.automatic),
+            targets: [manifestBuilder.name])
+          )
+          targets.append(TargetDescription(
+            name: manifestBuilder.name,
+            path: "",
+            type: .system,
+            pkgConfig: manifestBuilder.pkgConfig,
+            providers: manifestBuilder.providers
+          ))
+        }
+
         let manifest = Manifest(
             name: manifestBuilder.name,
             defaultLocalization: manifestBuilder.defaultLocalization,
@@ -264,6 +292,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             path: inputPath,
             url: baseURL,
             version: version,
+            revision: revision,
             toolsVersion: toolsVersion,
             packageKind: packageKind,
             pkgConfig: manifestBuilder.pkgConfig,
@@ -272,8 +301,8 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             cxxLanguageStandard: manifestBuilder.cxxLanguageStandard,
             swiftLanguageVersions: manifestBuilder.swiftLanguageVersions,
             dependencies: manifestBuilder.dependencies,
-            products: manifestBuilder.products,
-            targets: manifestBuilder.targets
+            products: products,
+            targets: targets
         )
 
         try validate(manifest, toolsVersion: toolsVersion, diagnostics: diagnostics)

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -276,7 +276,8 @@ public final class PackageBuilder {
     public static func loadPackage(
         packagePath: AbsolutePath,
         swiftCompiler: AbsolutePath,
-        xcTestMinimumDeploymentTargets: [PackageModel.Platform:PlatformVersion] = [:],
+        xcTestMinimumDeploymentTargets: [PackageModel.Platform:PlatformVersion]
+          = MinimumDeploymentTarget.default.xcTestMinimumDeploymentTargets,
         diagnostics: DiagnosticsEngine,
         kind: PackageReference.Kind = .root
     ) throws -> Package {

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -203,6 +203,9 @@ public final class PackageBuilder {
     /// The manifest for the package being constructed.
     private let manifest: Manifest
 
+    /// The product filter to apply to the package.
+    private let productFilter: ProductFilter
+
     /// The path of the package.
     private let packagePath: AbsolutePath
 
@@ -241,6 +244,7 @@ public final class PackageBuilder {
     ///     each test target.
     public init(
         manifest: Manifest,
+        productFilter: ProductFilter,
         path: AbsolutePath,
         additionalFileRules: [FileRuleDescription] = [],
         remoteArtifacts: [RemoteArtifact] = [],
@@ -251,6 +255,7 @@ public final class PackageBuilder {
         createREPLProduct: Bool = false
     ) {
         self.manifest = manifest
+        self.productFilter = productFilter
         self.packagePath = path
         self.additionalFileRules = additionalFileRules
         self.remoteArtifacts = remoteArtifacts
@@ -271,7 +276,7 @@ public final class PackageBuilder {
     public static func loadPackage(
         packagePath: AbsolutePath,
         swiftCompiler: AbsolutePath,
-        xcTestMinimumDeploymentTargets: [PackageModel.Platform:PlatformVersion],
+        xcTestMinimumDeploymentTargets: [PackageModel.Platform:PlatformVersion] = [:],
         diagnostics: DiagnosticsEngine,
         kind: PackageReference.Kind = .root
     ) throws -> Package {
@@ -281,6 +286,7 @@ public final class PackageBuilder {
             packageKind: kind)
         let builder = PackageBuilder(
             manifest: manifest,
+            productFilter: .everything,
             path: packagePath,
             xcTestMinimumDeploymentTargets: xcTestMinimumDeploymentTargets,
             diagnostics: diagnostics)
@@ -527,7 +533,7 @@ public final class PackageBuilder {
 
         // Create potential targets.
         let potentialTargets: [PotentialModule]
-        potentialTargets = try manifest.allRequiredTargets.map({ target in
+        potentialTargets = try manifest.targetsRequired(for: productFilter).map({ target in
             let path = try findPath(for: target)
             return PotentialModule(name: target.name, path: path, type: target.type)
         })
@@ -537,7 +543,7 @@ public final class PackageBuilder {
     // Create targets from the provided potential targets.
     private func createModules(_ potentialModules: [PotentialModule]) throws -> [Target] {
         // Find if manifest references a target which isn't present on disk.
-        let allVisibleModuleNames = manifest.allVisibleModuleNames()
+        let allVisibleModuleNames = manifest.visibleModuleNames(for: productFilter)
         let potentialModulesName = Set(potentialModules.map({ $0.name }))
         let missingModuleNames = allVisibleModuleNames.subtracting(potentialModulesName)
         if let missingModuleName = missingModuleNames.first {
@@ -1080,7 +1086,14 @@ public final class PackageBuilder {
             }
         }
 
-        for product in manifest.products {
+        let filteredProducts: [ProductDescription]
+        switch productFilter {
+        case .everything:
+          filteredProducts = manifest.products
+        case .specific(let set):
+          filteredProducts = manifest.products.filter { set.contains($0.name) }
+        }
+        for product in filteredProducts {
             let targets = try modulesFrom(targetNames: product.targets, product: product.name)
             // Peform special validations if this product is exporting
             // a system library target.
@@ -1187,8 +1200,8 @@ private struct PotentialModule: Hashable {
 
 private extension Manifest {
     /// Returns the names of all the visible targets in the manifest.
-    func allVisibleModuleNames() -> Set<String> {
-        let names = allRequiredTargets.flatMap({ target in
+    func visibleModuleNames(for productFilter: ProductFilter) -> Set<String> {
+        let names = targetsRequired(for: productFilter).flatMap({ target in
             [target.name] + target.dependencies.compactMap({
                 switch $0 {
                 case .target(let name, _):

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -277,7 +277,7 @@ public final class PackageBuilder {
         packagePath: AbsolutePath,
         swiftCompiler: AbsolutePath,
         xcTestMinimumDeploymentTargets: [PackageModel.Platform:PlatformVersion]
-          = MinimumDeploymentTarget.default.xcTestMinimumDeploymentTargets,
+            = MinimumDeploymentTarget.default.xcTestMinimumDeploymentTargets,
         diagnostics: DiagnosticsEngine,
         kind: PackageReference.Kind = .root
     ) throws -> Package {
@@ -1090,9 +1090,9 @@ public final class PackageBuilder {
         let filteredProducts: [ProductDescription]
         switch productFilter {
         case .everything:
-          filteredProducts = manifest.products
+            filteredProducts = manifest.products
         case .specific(let set):
-          filteredProducts = manifest.products.filter { set.contains($0.name) }
+            filteredProducts = manifest.products.filter { set.contains($0.name) }
         }
         for product in filteredProducts {
             let targets = try modulesFrom(targetNames: product.targets, product: product.name)

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -177,10 +177,10 @@ extension Manifest {
             let targets: [TargetDescription]
             switch productFilter {
             case .everything:
-              return self.targets
+                return self.targets
             case .specific(let productFilter):
-              let products = self.products.filter { productFilter.contains($0.name) }
-              targets = targetsRequired(for: products)
+                let products = self.products.filter { productFilter.contains($0.name) }
+                targets = targetsRequired(for: products)
             }
 
             _requiredTargets[productFilter] = targets
@@ -253,8 +253,8 @@ extension Manifest {
     ///
     /// The returned dependencies have their particular product filters registered. (To determine product filters without removing any dependencies from the list, specify `keepUnused: true`.)
     public func dependenciesRequired(
-      for targets: [TargetDescription],
-      keepUnused: Bool = false
+        for targets: [TargetDescription],
+        keepUnused: Bool = false
     ) -> [FilteredDependencyDescription] {
 
         var registry: (known: [String: ProductFilter], unknown: Set<String>) = ([:], [])
@@ -262,7 +262,7 @@ extension Manifest {
 
         for target in targets {
             for targetDependency in target.dependencies {
-              register(targetDependency: targetDependency, registry: &registry, availablePackages: availablePackages)
+                register(targetDependency: targetDependency, registry: &registry, availablePackages: availablePackages)
             }
         }
 
@@ -271,21 +271,21 @@ extension Manifest {
         var associations = registry.known
         let unknown = registry.unknown
         if !registry.unknown.isEmpty {
-          for package in availablePackages {
-            associations[package, default: .specific([])].formUnion(.specific(unknown))
-          }
+            for package in availablePackages {
+                associations[package, default: .specific([])].formUnion(.specific(unknown))
+            }
         }
 
         return dependencies.compactMap { dependency in
-          if let filter = associations[dependency.name] {
-            return FilteredDependencyDescription(declaration: dependency, productFilter: filter)
-          } else if keepUnused {
-            // Register that while the dependency was kept, no products are needed.
-            return FilteredDependencyDescription(declaration: dependency, productFilter: .specific([]))
-          } else {
-            // Dependencies known to not have any relevant products are discarded.
-            return nil
-          }
+            if let filter = associations[dependency.name] {
+                return FilteredDependencyDescription(declaration: dependency, productFilter: filter)
+            } else if keepUnused {
+                // Register that while the dependency was kept, no products are needed.
+                return FilteredDependencyDescription(declaration: dependency, productFilter: .specific([]))
+            } else {
+                // Dependencies known to not have any relevant products are discarded.
+                return nil
+            }
         }
     }
 
@@ -315,56 +315,56 @@ extension Manifest {
     ///   - registry: The registry in which to record the assocation.
     ///   - availablePackages: The set of available packages.
     private func register(
-      targetDependency: TargetDescription.Dependency,
-      registry: inout (known: [String: ProductFilter], unknown: Set<String>),
-      availablePackages: Set<String>
+        targetDependency: TargetDescription.Dependency,
+        registry: inout (known: [String: ProductFilter], unknown: Set<String>),
+        availablePackages: Set<String>
     ) {
-      switch targetDependency {
-      case .target:
-        break
-      case .product(let product, let package, _):
-        if let package = package { // ≥ 5.2
-          if !register(
-            product: product,
-            inPackage: package,
-            registry: &registry.known,
-            availablePackages: availablePackages) {
-            // This is an invalid manifest condition diagnosed later. (No such package.)
-            // Treating it as unknown gracefully allows resolution to continue for now.
-            registry.unknown.insert(product)
-          }
-        } else { // < 5.2
-          registry.unknown.insert(product)
-        }
-      case .byName(let product, _):
-        if toolsVersion < .v5_2 {
-          // A by‐name entry might be a product from anywhere.
-          if targets.contains(where: { $0.name == product }) {
-            // Save the resolver some effort if it is known to only be a target anyway.
+        switch targetDependency {
+        case .target:
             break
-          } else {
-            registry.unknown.insert(product)
-          }
-        } else { // ≥ 5.2
-          // If a by‐name entry is a product, it must be in a package of the same name.
-          if !register(
-            product: product,
-            inPackage: product,
-            registry: &registry.known,
-            availablePackages: availablePackages) {
-            // If it doesn’t match a package, it should be a target, not a product.
-            if targets.contains(where: { $0.name == product }) {
-              break
-            } else {
-              // But in case the user is trying to reference a product,
-              // we still need to pass on the invalid reference
-              // so that the resolver fetches all dependencies
-              // in order to provide the diagnostic pass with the information it needs.
-              registry.unknown.insert(product)
+        case .product(let product, let package, _):
+            if let package = package { // ≥ 5.2
+                if !register(
+                    product: product,
+                    inPackage: package,
+                    registry: &registry.known,
+                    availablePackages: availablePackages) {
+                        // This is an invalid manifest condition diagnosed later. (No such package.)
+                        // Treating it as unknown gracefully allows resolution to continue for now.
+                    registry.unknown.insert(product)
+                }
+            } else { // < 5.2
+                registry.unknown.insert(product)
             }
-          }
+        case .byName(let product, _):
+            if toolsVersion < .v5_2 {
+                // A by‐name entry might be a product from anywhere.
+                if targets.contains(where: { $0.name == product }) {
+                    // Save the resolver some effort if it is known to only be a target anyway.
+                    break
+                } else {
+                    registry.unknown.insert(product)
+                }
+            } else { // ≥ 5.2
+                // If a by‐name entry is a product, it must be in a package of the same name.
+                if !register(
+                    product: product,
+                    inPackage: product,
+                    registry: &registry.known,
+                    availablePackages: availablePackages) {
+                        // If it doesn’t match a package, it should be a target, not a product.
+                        if targets.contains(where: { $0.name == product }) {
+                            break
+                        } else {
+                            // But in case the user is trying to reference a product,
+                            // we still need to pass on the invalid reference
+                            // so that the resolver fetches all dependencies
+                            // in order to provide the diagnostic pass with the information it needs.
+                            registry.unknown.insert(product)
+                        }
+                }
+            }
         }
-      }
     }
 
     /// Registers a required product with a particular dependency if possible.
@@ -377,20 +377,20 @@ extension Manifest {
     ///
     /// - Returns: `true` if the particular dependency was found and the product was registered; `false` if no matching dependency was found and the product has not yet been handled.
     private func register(
-      product: String,
-      inPackage package: String,
-      registry: inout [String: ProductFilter],
-      availablePackages: Set<String>
+        product: String,
+        inPackage package: String,
+        registry: inout [String: ProductFilter],
+        availablePackages: Set<String>
     ) -> Bool {
-      if let existing = registry[package] {
-        registry[package] = existing.union(.specific([product]))
-        return true
-      } else if availablePackages.contains(package) {
-        registry[package] = .specific([product])
-        return true
-      } else {
-        return false
-      }
+        if let existing = registry[package] {
+            registry[package] = existing.union(.specific([product]))
+            return true
+        } else if availablePackages.contains(package) {
+            registry[package] = .specific([product])
+            return true
+        } else {
+            return false
+        }
     }
 }
 
@@ -655,105 +655,105 @@ public struct PackageDependencyDescription: Equatable, Codable {
 /// Requested products need not actually exist in the package. Under certain circumstances, the resolver may request names whose package of origin are unknown. The intended package will recognize and fullfill the request; packages that do not know what it is will simply ignore it.
 public enum ProductFilter: Equatable, Hashable, Codable, JSONMappable, JSONSerializable, CustomStringConvertible {
 
-  /// All products, targets, and tests are requested.
-  ///
-  /// This is used for root packages.
-  case everything
+    /// All products, targets, and tests are requested.
+    ///
+    /// This is used for root packages.
+    case everything
 
-  /// A set of specific products requested by one or more client packages.
-  case specific(Set<String>)
+    /// A set of specific products requested by one or more client packages.
+    case specific(Set<String>)
 
-  public func union(_ other: ProductFilter) -> ProductFilter {
-    switch self {
-    case .everything:
-      return .everything
-    case .specific(let set):
-      switch other {
-      case .everything:
-        return .everything
-      case .specific(let otherSet):
-        return .specific(set.union(otherSet))
-      }
+    public func union(_ other: ProductFilter) -> ProductFilter {
+        switch self {
+        case .everything:
+            return .everything
+        case .specific(let set):
+            switch other {
+            case .everything:
+                return .everything
+            case .specific(let otherSet):
+                return .specific(set.union(otherSet))
+            }
+        }
     }
-  }
-  public mutating func formUnion(_ other: ProductFilter) {
-    self = self.union(other)
-  }
+    public mutating func formUnion(_ other: ProductFilter) {
+        self = self.union(other)
+    }
 
-  public func contains(_ product: String) -> Bool {
-    switch self {
-    case .everything:
-      return true
-    case .specific(let set):
-      return set.contains(product)
+    public func contains(_ product: String) -> Bool {
+        switch self {
+        case .everything:
+            return true
+        case .specific(let set):
+            return set.contains(product)
+        }
     }
-  }
 
-  public func encode(to encoder: Encoder) throws {
-    let optionalSet: Set<String>?
-    switch self {
-    case .everything:
-      optionalSet = nil
-    case .specific(let set):
-      optionalSet = set
+    public func encode(to encoder: Encoder) throws {
+        let optionalSet: Set<String>?
+        switch self {
+        case .everything:
+            optionalSet = nil
+        case .specific(let set):
+            optionalSet = set
+        }
+        var container = encoder.singleValueContainer()
+        try container.encode(optionalSet?.sorted())
     }
-    var container = encoder.singleValueContainer()
-    try container.encode(optionalSet?.sorted())
-  }
-  public init(from decoder: Decoder) throws {
-    let container = try decoder.singleValueContainer()
-    let optionalSet: Set<String>? = try container.decode([String]?.self).map { Set($0) }
-    if let set = optionalSet {
-      self = .specific(set)
-    } else {
-      self = .everything
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let optionalSet: Set<String>? = try container.decode([String]?.self).map { Set($0) }
+        if let set = optionalSet {
+            self = .specific(set)
+        } else {
+            self = .everything
+        }
     }
-  }
 
-  public func toJSON() -> JSON {
-    switch self {
-    case .everything:
-      return "all".toJSON()
-    case .specific(let products):
-      return products.sorted().toJSON()
+    public func toJSON() -> JSON {
+        switch self {
+        case .everything:
+            return "all".toJSON()
+        case .specific(let products):
+            return products.sorted().toJSON()
+        }
     }
-  }
-  public init(json: JSON) throws {
-    if let products = try? [String](json: json) {
-      self = .specific(Set(products))
-    } else {
-      self = .everything
+    public init(json: JSON) throws {
+        if let products = try? [String](json: json) {
+            self = .specific(Set(products))
+        } else {
+            self = .everything
+        }
     }
-  }
 
-  public var description: String {
-    switch self {
-    case .everything:
-      return "[everything]"
-    case .specific(let set):
-      return "[\(set.sorted().joined(separator: ", "))]"
+    public var description: String {
+        switch self {
+        case .everything:
+            return "[everything]"
+        case .specific(let set):
+            return "[\(set.sorted().joined(separator: ", "))]"
+        }
     }
-  }
 }
 
 /// A dependency description along with its associated product filter.
 public struct FilteredDependencyDescription: Codable {
 
-  /// Creates a filtered dependency.
-  ///
-  /// - Parameters:
-  ///   - declaration: The raw dependency.
-  ///   - productFilter: The product filter to apply.
-  public init(declaration: PackageDependencyDescription, productFilter: ProductFilter) {
-    self.declaration = declaration
-    self.productFilter = productFilter
-  }
+    /// Creates a filtered dependency.
+    ///
+    /// - Parameters:
+    ///   - declaration: The raw dependency.
+    ///   - productFilter: The product filter to apply.
+    public init(declaration: PackageDependencyDescription, productFilter: ProductFilter) {
+        self.declaration = declaration
+        self.productFilter = productFilter
+    }
 
-  /// The loaded dependency declaration.
-  public let declaration: PackageDependencyDescription
+    /// The loaded dependency declaration.
+    public let declaration: PackageDependencyDescription
 
-  /// The resolved product filter.
-  public let productFilter: ProductFilter
+    /// The resolved product filter.
+    public let productFilter: ProductFilter
 }
 
 public struct PlatformDescription: Codable, Equatable {

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -37,6 +37,9 @@ public final class Manifest: ObjectIdentifierProtocol, CustomStringConvertible, 
     /// The version this package was loaded from, if known.
     public let version: Version?
 
+    /// The revision this package was loaded from, if known.
+    public let revision: String?
+
     /// The tools version declared in the manifest.
     public let toolsVersion: ToolsVersion
 
@@ -79,11 +82,11 @@ public final class Manifest: ObjectIdentifierProtocol, CustomStringConvertible, 
     /// The system package providers of a system package.
     public let providers: [SystemPackageProviderDescription]?
 
-    /// Targets required for building all the products.
-    private var _allRequiredTargets: [TargetDescription]?
+    /// Targets required for building particular product filters.
+    private var _requiredTargets: [ProductFilter: [TargetDescription]]
 
-    /// Dependencies required for building all the products.
-    private var _allRequiredDependencies: [PackageDependencyDescription]?
+    /// Dependencies required for building particular product filters.
+    private var _requiredDependencies: [ProductFilter: [FilteredDependencyDescription]]
 
     public init(
         name: String,
@@ -92,6 +95,7 @@ public final class Manifest: ObjectIdentifierProtocol, CustomStringConvertible, 
         path: AbsolutePath,
         url: String,
         version: TSCUtility.Version? = nil,
+        revision: String? = nil,
         toolsVersion: ToolsVersion,
         packageKind: PackageReference.Kind,
         pkgConfig: String? = nil,
@@ -109,6 +113,7 @@ public final class Manifest: ObjectIdentifierProtocol, CustomStringConvertible, 
         self.path = path
         self.url = url
         self.version = version
+        self.revision = revision
         self.toolsVersion = toolsVersion
         self.packageKind = packageKind
         self.pkgConfig = pkgConfig
@@ -120,6 +125,8 @@ public final class Manifest: ObjectIdentifierProtocol, CustomStringConvertible, 
         self.products = products
         self.targets = targets
         self.targetMap = Dictionary(targets.lazy.map({ ($0.name, $0) }), uniquingKeysWith: { $1 })
+        self._requiredTargets = [:]
+        self._requiredDependencies = [:]
     }
 
     public var description: String {
@@ -161,43 +168,35 @@ extension ToolsVersion {
 }
 
 extension Manifest {
-    /// Targets required for building all the products. If this manifest is a root manifest, it returns all targets.
-    public var allRequiredTargets: [TargetDescription] {
-        // Special case root packages to return all targets.
-        switch packageKind {
-        case .root:
-            return targets
-        case .local, .remote:
-            break
-        }
-
-        // If we have already calcualted allRequiredTargets, returned the cached value.
-        if let targets = _allRequiredTargets {
+    /// Returns the targets required for a particular product filter.
+    public func targetsRequired(for productFilter: ProductFilter) -> [TargetDescription] {
+        // If we have already calcualted it, returned the cached value.
+        if let targets = _requiredTargets[productFilter] {
             return targets
         } else {
-            let targets = targetsRequired(for: products)
-            _allRequiredTargets = targets
+            let targets: [TargetDescription]
+            switch productFilter {
+            case .everything:
+              return self.targets
+            case .specific(let productFilter):
+              let products = self.products.filter { productFilter.contains($0.name) }
+              targets = targetsRequired(for: products)
+            }
+
+            _requiredTargets[productFilter] = targets
             return targets
         }
     }
 
-    /// The package dependencies required for building all the products.  If this manifest is a root manifest, it
-    /// returns all dependencies.
-    public var allRequiredDependencies: [PackageDependencyDescription] {
-        // Special case root packages to return all depdendencies.
-        switch packageKind {
-        case .root:
-            return dependencies
-        case .local, .remote:
-            break
-        }
-
-        // If we have already calcualted allRequiredDependencies, returned the cached value.
-        if let dependencies = _allRequiredDependencies {
+    /// Returns the package dependencies required for a particular products filter.
+    public func dependenciesRequired(for productFilter: ProductFilter) -> [FilteredDependencyDescription] {
+        // If we have already calcualted it, returned the cached value.
+        if let dependencies = _requiredDependencies[productFilter] {
             return dependencies
         } else {
-            let dependencies = dependenciesRequired(for: products)
-            _allRequiredDependencies = dependencies
+            let targets = targetsRequired(for: productFilter)
+            let dependencies = dependenciesRequired(for: targets, keepUnused: productFilter == .everything)
+            _requiredDependencies[productFilter] = dependencies
             return dependencies
         }
     }
@@ -250,26 +249,44 @@ extension Manifest {
         return requiredTargets
     }
 
-    /// Returns the package dependencies required for building the provided products. If the tools version is less than
-    /// 5.2, this function returns all dependencies as we can't link target dependencies with package dependencies.
-    public func dependenciesRequired(for products: [ProductDescription]) -> [PackageDependencyDescription] {
-        guard toolsVersion >= .v5_2 else {
-            return dependencies
-        }
+    /// Returns the package dependencies required for building the provided targets.
+    ///
+    /// The returned dependencies have their particular product filters registered. (To determine product filters without removing any dependencies from the list, specify `keepUnused: true`.)
+    public func dependenciesRequired(
+      for targets: [TargetDescription],
+      keepUnused: Bool = false
+    ) -> [FilteredDependencyDescription] {
 
-        var requiredDependencyNames: Set<String> = []
+        var registry: (known: [String: ProductFilter], unknown: Set<String>) = ([:], [])
+        let availablePackages = Set(dependencies.lazy.map({ $0.name }))
 
-        for target in targetsRequired(for: products) {
+        for target in targets {
             for targetDependency in target.dependencies {
-                if let dependency = packageDependency(referencedBy: targetDependency) {
-                    requiredDependencyNames.insert(dependency.name)
-                }
+              register(targetDependency: targetDependency, registry: &registry, availablePackages: availablePackages)
             }
         }
 
-        let dependenciesByName = Dictionary(dependencies.map({ ($0.name, $0) }), uniquingKeysWith: { $1 })
-        let requiredDependencies = requiredDependencyNames.compactMap({ dependenciesByName[$0] })
-        return requiredDependencies
+        // Products whose package could not be determined are marked as needed on every dependency.
+        // (This way none of them filters such a product out.)
+        var associations = registry.known
+        let unknown = registry.unknown
+        if !registry.unknown.isEmpty {
+          for package in availablePackages {
+            associations[package, default: .specific([])].formUnion(.specific(unknown))
+          }
+        }
+
+        return dependencies.compactMap { dependency in
+          if let filter = associations[dependency.name] {
+            return FilteredDependencyDescription(declaration: dependency, productFilter: filter)
+          } else if keepUnused {
+            // Register that while the dependency was kept, no products are needed.
+            return FilteredDependencyDescription(declaration: dependency, productFilter: .specific([]))
+          } else {
+            // Dependencies known to not have any relevant products are discarded.
+            return nil
+          }
+        }
     }
 
     /// Finds the package dependency referenced by the specified target dependency.
@@ -289,6 +306,91 @@ extension Manifest {
         }
 
         return dependencies.first(where: { $0.name == packageName })
+    }
+
+    /// Registers a required product with a particular dependency if possible, or registers it as unknown.
+    ///
+    /// - Parameters:
+    ///   - targetDependency: The target dependency to register.
+    ///   - registry: The registry in which to record the assocation.
+    ///   - availablePackages: The set of available packages.
+    private func register(
+      targetDependency: TargetDescription.Dependency,
+      registry: inout (known: [String: ProductFilter], unknown: Set<String>),
+      availablePackages: Set<String>
+    ) {
+      switch targetDependency {
+      case .target:
+        break
+      case .product(let product, let package, _):
+        if let package = package { // ≥ 5.2
+          if !register(
+            product: product,
+            inPackage: package,
+            registry: &registry.known,
+            availablePackages: availablePackages) {
+            // This is an invalid manifest condition diagnosed later. (No such package.)
+            // Treating it as unknown gracefully allows resolution to continue for now.
+            registry.unknown.insert(product)
+          }
+        } else { // < 5.2
+          registry.unknown.insert(product)
+        }
+      case .byName(let product, _):
+        if toolsVersion < .v5_2 {
+          // A by‐name entry might be a product from anywhere.
+          if targets.contains(where: { $0.name == product }) {
+            // Save the resolver some effort if it is known to only be a target anyway.
+            break
+          } else {
+            registry.unknown.insert(product)
+          }
+        } else { // ≥ 5.2
+          // If a by‐name entry is a product, it must be in a package of the same name.
+          if !register(
+            product: product,
+            inPackage: product,
+            registry: &registry.known,
+            availablePackages: availablePackages) {
+            // If it doesn’t match a package, it should be a target, not a product.
+            if targets.contains(where: { $0.name == product }) {
+              break
+            } else {
+              // But in case the user is trying to reference a product,
+              // we still need to pass on the invalid reference
+              // so that the resolver fetches all dependencies
+              // in order to provide the diagnostic pass with the information it needs.
+              registry.unknown.insert(product)
+            }
+          }
+        }
+      }
+    }
+
+    /// Registers a required product with a particular dependency if possible.
+    ///
+    /// - Parameters:
+    ///   - product: The product to try registering.
+    ///   - package: The package to try associating it with.
+    ///   - registry: The registry in which to record the assocation.
+    ///   - availablePackages: The set of available packages.
+    ///
+    /// - Returns: `true` if the particular dependency was found and the product was registered; `false` if no matching dependency was found and the product has not yet been handled.
+    private func register(
+      product: String,
+      inPackage package: String,
+      registry: inout [String: ProductFilter],
+      availablePackages: Set<String>
+    ) -> Bool {
+      if let existing = registry[package] {
+        registry[package] = existing.union(.specific([product]))
+        return true
+      } else if availablePackages.contains(package) {
+        registry[package] = .specific([product])
+        return true
+      } else {
+        return false
+      }
     }
 }
 
@@ -544,6 +646,114 @@ public struct PackageDependencyDescription: Equatable, Codable {
         self.url = url
         self.requirement = requirement
     }
+}
+
+/// The products requested of a package.
+///
+/// Any product which matches the filter will be used for dependency resolution, whereas unrequested products will be ingored.
+///
+/// Requested products need not actually exist in the package. Under certain circumstances, the resolver may request names whose package of origin are unknown. The intended package will recognize and fullfill the request; packages that do not know what it is will simply ignore it.
+public enum ProductFilter: Equatable, Hashable, Codable, JSONMappable, JSONSerializable, CustomStringConvertible {
+
+  /// All products, targets, and tests are requested.
+  ///
+  /// This is used for root packages.
+  case everything
+
+  /// A set of specific products requested by one or more client packages.
+  case specific(Set<String>)
+
+  public func union(_ other: ProductFilter) -> ProductFilter {
+    switch self {
+    case .everything:
+      return .everything
+    case .specific(let set):
+      switch other {
+      case .everything:
+        return .everything
+      case .specific(let otherSet):
+        return .specific(set.union(otherSet))
+      }
+    }
+  }
+  public mutating func formUnion(_ other: ProductFilter) {
+    self = self.union(other)
+  }
+
+  public func contains(_ product: String) -> Bool {
+    switch self {
+    case .everything:
+      return true
+    case .specific(let set):
+      return set.contains(product)
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    let optionalSet: Set<String>?
+    switch self {
+    case .everything:
+      optionalSet = nil
+    case .specific(let set):
+      optionalSet = set
+    }
+    var container = encoder.singleValueContainer()
+    try container.encode(optionalSet?.sorted())
+  }
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let optionalSet: Set<String>? = try container.decode([String]?.self).map { Set($0) }
+    if let set = optionalSet {
+      self = .specific(set)
+    } else {
+      self = .everything
+    }
+  }
+
+  public func toJSON() -> JSON {
+    switch self {
+    case .everything:
+      return "all".toJSON()
+    case .specific(let products):
+      return products.sorted().toJSON()
+    }
+  }
+  public init(json: JSON) throws {
+    if let products = try? [String](json: json) {
+      self = .specific(Set(products))
+    } else {
+      self = .everything
+    }
+  }
+
+  public var description: String {
+    switch self {
+    case .everything:
+      return "[everything]"
+    case .specific(let set):
+      return "[\(set.sorted().joined(separator: ", "))]"
+    }
+  }
+}
+
+/// A dependency description along with its associated product filter.
+public struct FilteredDependencyDescription: Codable {
+
+  /// Creates a filtered dependency.
+  ///
+  /// - Parameters:
+  ///   - declaration: The raw dependency.
+  ///   - productFilter: The product filter to apply.
+  public init(declaration: PackageDependencyDescription, productFilter: ProductFilter) {
+    self.declaration = declaration
+    self.productFilter = productFilter
+  }
+
+  /// The loaded dependency declaration.
+  public let declaration: PackageDependencyDescription
+
+  /// The resolved product filter.
+  public let productFilter: ProductFilter
 }
 
 public struct PlatformDescription: Codable, Equatable {

--- a/Sources/SPMTestSupport/MockManifestLoader.swift
+++ b/Sources/SPMTestSupport/MockManifestLoader.swift
@@ -50,6 +50,7 @@ public final class MockManifestLoader: ManifestLoaderProtocol {
         packagePath path: TSCBasic.AbsolutePath,
         baseURL: String,
         version: Version?,
+        revision: String?,
         toolsVersion: ToolsVersion,
         packageKind: PackageReference.Kind,
         fileSystem: FileSystem?,

--- a/Sources/SPMTestSupport/TestWorkspace.swift
+++ b/Sources/SPMTestSupport/TestWorkspace.swift
@@ -192,16 +192,19 @@ public final class TestWorkspace {
 
         public let name: String
         public let requirement: Requirement
+        public let products: ProductFilter
 
-        public init(name: String, requirement: Requirement) {
+        public init(name: String, requirement: Requirement, products: ProductFilter) {
             self.name = name
             self.requirement = requirement
+            self.products = products
         }
 
         fileprivate func convert(_ packagesDir: AbsolutePath, url: String) -> PackageGraphRootInput.PackageDependency {
             return PackageGraphRootInput.PackageDependency(
                 url: url,
                 requirement: requirement,
+                productFilter: products,
                 location: name
             )
         }
@@ -343,7 +346,7 @@ public final class TestWorkspace {
     }
 
     public func set(
-        pins: [PackageReference: CheckoutState] = [:],
+        pins: [PackageReference: (version: CheckoutState, products: ProductFilter)] = [:],
         managedDependencies: [ManagedDependency] = [],
         managedArtifacts: [ManagedArtifact] = []
     ) throws {
@@ -351,7 +354,7 @@ public final class TestWorkspace {
         let pinsStore = try workspace.pinsStore.load()
 
         for (ref, state) in pins {
-            pinsStore.pin(packageRef: ref, state: state)
+            pinsStore.pin(packageRef: ref, state: state.version, productFilter: state.products)
         }
 
         for dependency in managedDependencies {

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -193,6 +193,7 @@ public func loadPackageGraph(
     fs: FileSystem,
     diagnostics: DiagnosticsEngine = DiagnosticsEngine(),
     manifests: [Manifest],
+    explicitProduct: String? = nil,
     shouldCreateMultipleTestProducts: Bool = false,
     createREPLProduct: Bool = false
 ) -> PackageGraph {
@@ -200,7 +201,7 @@ public func loadPackageGraph(
     let externalManifests = manifests.filter({ $0.packageKind != .root })
     let packages = rootManifests.map({ $0.path })
     let input = PackageGraphRootInput(packages: packages)
-    let graphRoot = PackageGraphRoot(input: input, manifests: rootManifests)
+    let graphRoot = PackageGraphRoot(input: input, manifests: rootManifests, explicitProduct: explicitProduct)
 
     return PackageGraphLoader().load(
         root: graphRoot,

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -135,18 +135,18 @@ private struct LocalPackageContainer: PackageContainer {
         return AnySequence(reversedVersions)
     }
 
-    func getDependencies(at version: Version) throws -> [PackageContainerConstraint] {
+    func getDependencies(at version: Version, productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
         // Because of the implementation of `reversedVersions`, we should only get the exact same version.
         precondition(dependency?.checkoutState?.version == version)
-        return manifest.dependencyConstraints(config: config)
+        return manifest.dependencyConstraints(productFilter: productFilter, config: config)
     }
 
-    func getDependencies(at revision: String) throws -> [PackageContainerConstraint] {
+    func getDependencies(at revision: String, productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
         // Return the dependencies if the checkout state matches the revision.
         if let checkoutState = dependency?.checkoutState,
             checkoutState.version == nil,
             checkoutState.revision.identifier == revision {
-            return manifest.dependencyConstraints(config: config)
+            return manifest.dependencyConstraints(productFilter: productFilter, config: config)
         }
 
         throw ResolverPrecomputationError.differentRequirement(
@@ -156,7 +156,7 @@ private struct LocalPackageContainer: PackageContainer {
         )
     }
 
-    func getUnversionedDependencies() throws -> [PackageContainerConstraint] {
+    func getUnversionedDependencies(productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
         // Throw an error when the dependency is not unversioned to fail resolution.
         guard dependency?.state.isCheckout != true else {
             throw ResolverPrecomputationError.differentRequirement(
@@ -166,7 +166,7 @@ private struct LocalPackageContainer: PackageContainer {
             )
         }
 
-        return manifest.dependencyConstraints(config: config)
+        return manifest.dependencyConstraints(productFilter: productFilter, config: config)
     }
 
     func getUpdatedIdentifier(at boundVersion: BoundVersion) throws -> PackageReference {

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -143,7 +143,11 @@ public class Workspace {
 
         let workspace: Workspace
 
-        fileprivate init(root: PackageGraphRoot, dependencies: [(Manifest, ManagedDependency)], workspace: Workspace) {
+        fileprivate init(
+          root: PackageGraphRoot,
+          dependencies: [(Manifest, ManagedDependency)],
+          workspace: Workspace
+        ) {
             self.root = root
             self.dependencies = dependencies
             self.workspace = workspace
@@ -193,25 +197,36 @@ public class Workspace {
                 root.manifests.map({ (PackageReference.computeIdentity(packageURL: $0.url), $0) }) +
                 dependencies.map({ (PackageReference.computeIdentity(packageURL: $0.manifest.url), $0.manifest) }))
 
-            let inputIdentities: [PackageReference] = root.manifests.map({
-                let identity = PackageReference.computeIdentity(packageURL: $0.url)
-                return PackageReference(identity: identity, path: $0.url, kind: $0.packageKind)
-            }) + root.dependencies.map({
-                let url = workspace.config.mirroredURL(forURL: $0.url)
+            var inputIdentities: Set<PackageReference> = []
+            let inputNodes: [GraphLoadingNode] = root.manifests.map({ manifest in
+                let identity = PackageReference.computeIdentity(packageURL: manifest.url)
+                let package = PackageReference(identity: identity, path: manifest.url, kind: manifest.packageKind)
+                inputIdentities.insert(package)
+                let node = GraphLoadingNode(manifest: manifest, productFilter: .everything)
+                return node
+            }) + root.dependencies.compactMap({ dependency in
+                let url = workspace.config.mirroredURL(forURL: dependency.url)
                 let identity = PackageReference.computeIdentity(packageURL: url)
-                return PackageReference(identity: identity, path: url)
+                let package = PackageReference(identity: identity, path: url)
+                inputIdentities.insert(package)
+                guard let manifest = manifestsMap[identity] else { return nil }
+                let node = GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
+                return node
             })
 
-            var requiredIdentities = transitiveClosure(inputIdentities) { identity in
-                guard let manifest = manifestsMap[identity.identity] else { return [] }
-                return manifest.allRequiredDependencies.map({
-                    let url = workspace.config.mirroredURL(forURL: $0.url)
+            var requiredIdentities: Set<PackageReference> = []
+            _ = transitiveClosure(inputNodes) { node in
+                return node.manifest.dependenciesRequired(for: node.productFilter).compactMap({ dependency in
+                    let url = workspace.config.mirroredURL(forURL: dependency.declaration.url)
                     let identity = PackageReference.computeIdentity(packageURL: url)
-                    return PackageReference(identity: identity, path: url)
+                    let package = PackageReference(identity: identity, path: url)
+                    requiredIdentities.insert(package)
+                    guard let manifest = manifestsMap[identity] else { return nil }
+                    return GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
                 })
             }
             // FIXME: This should be an ordered set.
-            requiredIdentities = Set(inputIdentities).union(requiredIdentities)
+            requiredIdentities = inputIdentities.union(requiredIdentities)
 
             let availableIdentities: Set<PackageReference> = Set(manifestsMap.map({
                 let url = workspace.config.mirroredURL(forURL: $0.1.url)
@@ -243,12 +258,16 @@ public class Workspace {
                     )
                     let constraint = RepositoryPackageConstraint(
                         container: ref,
-                        requirement: .unversioned)
+                        requirement: .unversioned,
+                        products: managedDependency.productFilter)
                     allConstraints.append(constraint)
                 case .checkout, .local:
                     break
                 }
-                allConstraints += externalManifest.dependencyConstraints(config: workspace.config)
+                allConstraints += externalManifest.dependencyConstraints(
+                  productFilter: managedDependency.productFilter,
+                  config: workspace.config
+                )
             }
             return allConstraints
         }
@@ -272,7 +291,8 @@ public class Workspace {
                 )
                 let constraint = RepositoryPackageConstraint(
                     container: ref,
-                    requirement: .unversioned)
+                    requirement: .unversioned,
+                    products: managedDependency.productFilter)
                 constraints.append(constraint)
             }
             return constraints
@@ -548,7 +568,7 @@ extension Workspace {
             requirement = currentState.requirement()
         }
         let constraint = RepositoryPackageConstraint(
-                container: dependency.packageRef, requirement: requirement)
+                container: dependency.packageRef, requirement: requirement, products: dependency.productFilter)
 
         // Run the resolution.
         _resolve(root: root, forceResolution: false, extraConstraints: [constraint], diagnostics: diagnostics)
@@ -727,6 +747,7 @@ extension Workspace {
     @discardableResult
     public func loadPackageGraph(
         root: PackageGraphRootInput,
+        explicitProduct: String? = nil,
         createMultipleTestProducts: Bool = false,
         createREPLProduct: Bool = false,
         forceResolvedVersions: Bool = false,
@@ -737,9 +758,18 @@ extension Workspace {
         // Perform dependency resolution, if required.
         let manifests: DependencyManifests
         if forceResolvedVersions {
-            manifests = self._resolveToResolvedVersion(root: root, diagnostics: diagnostics)
+            manifests = self._resolveToResolvedVersion(
+              root: root,
+              explicitProduct: explicitProduct,
+              diagnostics: diagnostics
+            )
         } else {
-            manifests = self._resolve(root: root, forceResolution: false, diagnostics: diagnostics)
+            manifests = self._resolve(
+              root: root,
+              explicitProduct: explicitProduct,
+              forceResolution: false,
+              diagnostics: diagnostics
+            )
         }
 
         let remoteArtifacts = state.artifacts.compactMap({ artifact -> RemoteArtifact? in
@@ -770,10 +800,12 @@ extension Workspace {
     @discardableResult
     public func loadPackageGraph(
         root: AbsolutePath,
+        explicitProduct: String? = nil,
         diagnostics: DiagnosticsEngine
     ) -> PackageGraph {
         return self.loadPackageGraph(
             root: PackageGraphRootInput(packages: [root]),
+            explicitProduct: explicitProduct,
             diagnostics: diagnostics
         )
     }
@@ -1007,11 +1039,12 @@ extension Workspace {
             try fileSystem.removeFileTree(editablesPath)
         }
 
-        if let checkoutState = dependency.basedOn?.checkoutState {
+        if let checkoutState = dependency.basedOn?.checkoutState,
+          let productFilter = dependency.basedOn?.productFilter {
             // Restore the original checkout.
             //
             // The clone method will automatically update the managed dependency state.
-            _ = try clone(package: dependency.packageRef, at: checkoutState)
+            _ = try clone(package: dependency.packageRef, at: checkoutState, productFilter: productFilter)
         } else {
             // The original dependency was removed, update the managed dependency state.
             state.dependencies.remove(forURL: dependency.packageRef.path)
@@ -1461,6 +1494,7 @@ extension Workspace {
     @discardableResult
     fileprivate func _resolveToResolvedVersion(
         root: PackageGraphRootInput,
+        explicitProduct: String? = nil,
         diagnostics: DiagnosticsEngine
     ) -> DependencyManifests {
         // Ensure the cache path exists.
@@ -1470,7 +1504,7 @@ extension Workspace {
         diagnostics.wrap { try config.load() }
 
         let rootManifests = loadRootManifests(packages: root.packages, diagnostics: diagnostics)
-        let graphRoot = PackageGraphRoot(input: root, manifests: rootManifests)
+        let graphRoot = PackageGraphRoot(input: root, manifests: rootManifests, explicitProduct: explicitProduct)
 
         // Load the pins store or abort now.
         guard let pinsStore = diagnostics.wrap({ try self.pinsStore.load() }), !diagnostics.hasErrors else {
@@ -1507,7 +1541,7 @@ extension Workspace {
         // Clone the required pins.
         for pin in requiredPins {
             diagnostics.wrap {
-                _ = try self.clone(package: pin.packageRef, at: pin.state)
+                _ = try self.clone(package: pin.packageRef, at: pin.state, productFilter: pin.productFilter)
             }
         }
 
@@ -1518,7 +1552,7 @@ extension Workspace {
             let dependencies = rootManifest.dependencies.filter{ $0.requirement == .localPackage }
             for localPackage in dependencies {
                 let package = localPackage.createPackageRef(config: self.config)
-                state.dependencies.add(ManagedDependency.local(packageRef: package))
+                state.dependencies.add(ManagedDependency.local(packageRef: package, productFilter: .everything))
             }
         }
         diagnostics.wrap { try state.saveState() }
@@ -1549,6 +1583,7 @@ extension Workspace {
     @discardableResult
     fileprivate func _resolve(
         root: PackageGraphRootInput,
+        explicitProduct: String? = nil,
         forceResolution: Bool,
         extraConstraints: [RepositoryPackageConstraint] = [],
         diagnostics: DiagnosticsEngine,
@@ -1565,7 +1600,7 @@ extension Workspace {
         let rootManifests = loadRootManifests(packages: root.packages, diagnostics: diagnostics)
 
         // Load the current manifests.
-        let graphRoot = PackageGraphRoot(input: root, manifests: rootManifests)
+        let graphRoot = PackageGraphRoot(input: root, manifests: rootManifests, explicitProduct: explicitProduct)
         let currentManifests = loadDependencyManifests(root: graphRoot, diagnostics: diagnostics)
         guard !diagnostics.hasErrors else {
             return currentManifests
@@ -1657,6 +1692,7 @@ extension Workspace {
                 // we have the manifest files of all the dependencies.
                 return self._resolve(
                     root: root,
+                    explicitProduct: explicitProduct,
                     forceResolution: forceResolution,
                     extraConstraints: extraConstraints,
                     diagnostics: diagnostics,
@@ -1730,7 +1766,7 @@ extension Workspace {
         let constraints =
             root.constraints(config: config) +
             // Include constraints from the manifests in the graph root.
-            root.manifests.flatMap({ $0.dependencyConstraints(config: config) }) +
+            root.manifests.flatMap({ $0.dependencyConstraints(productFilter: .everything, config: config) }) +
             dependencyManifests.dependencyConstraints() +
             extraConstraints
 
@@ -1825,9 +1861,17 @@ extension Workspace {
                 }
             }
         }
+        public struct State: Equatable {
+          public let requirement: Requirement
+          public let products: ProductFilter
+          public init(requirement: Requirement, products: ProductFilter) {
+            self.requirement = requirement
+            self.products = products
+          }
+        }
 
         /// The package is added.
-        case added(Requirement)
+        case added(State)
 
         /// The package is removed.
         case removed
@@ -1836,7 +1880,7 @@ extension Workspace {
         case unchanged
 
         /// The package is updated.
-        case updated(Requirement)
+        case updated(State)
 
         public var description: String {
             switch self {
@@ -1864,7 +1908,7 @@ extension Workspace {
     /// Computes states of the packages based on last stored state.
     fileprivate func computePackageStateChanges(
         root: PackageGraphRoot,
-        resolvedDependencies: [(PackageReference, BoundVersion)],
+        resolvedDependencies: [(PackageReference, BoundVersion, ProductFilter)],
         updateBranches: Bool
     ) throws -> [(PackageReference, PackageStateChange)] {
         // Load pins store and managed dependendencies.
@@ -1872,7 +1916,7 @@ extension Workspace {
         var packageStateChanges: [String: (PackageReference, PackageStateChange)] = [:]
 
         // Set the states from resolved dependencies results.
-        for (packageRef, binding) in resolvedDependencies {
+        for (packageRef, binding, products) in resolvedDependencies {
             // Get the existing managed dependency for this package ref, if any.
             let currentDependency: ManagedDependency?
             if let existingDependency = state.dependencies[forURL: packageRef.path] {
@@ -1913,10 +1957,12 @@ extension Workspace {
                     case .local, .edited:
                         packageStateChanges[packageRef.path] = (packageRef, .unchanged)
                     case .checkout:
-                        packageStateChanges[packageRef.path] = (packageRef, .updated(.unversioned))
+                        let newState = PackageStateChange.State(requirement: .unversioned, products: products)
+                        packageStateChanges[packageRef.path] = (packageRef, .updated(newState))
                     }
                 } else {
-                    packageStateChanges[packageRef.path] = (packageRef, .added(.unversioned))
+                    let newState = PackageStateChange.State(requirement: .unversioned, products: products)
+                    packageStateChanges[packageRef.path] = (packageRef, .added(newState))
                 }
 
             case .revision(let identifier):
@@ -1946,10 +1992,12 @@ extension Workspace {
                         packageStateChanges[packageRef.path] = (packageRef, .unchanged)
                     } else {
                         // Otherwise, we need to update this dependency to this revision.
-                        packageStateChanges[packageRef.path] = (packageRef, .updated(.revision(revision, branch: branch)))
+                        let newState = PackageStateChange.State(requirement: .revision(revision, branch: branch), products: products)
+                        packageStateChanges[packageRef.path] = (packageRef, .updated(newState))
                     }
                 } else {
-                    packageStateChanges[packageRef.path] = (packageRef, .added(.revision(revision, branch: branch)))
+                    let newState = PackageStateChange.State(requirement: .revision(revision, branch: branch), products: products)
+                    packageStateChanges[packageRef.path] = (packageRef, .added(newState))
                 }
 
             case .version(let version):
@@ -1957,10 +2005,12 @@ extension Workspace {
                     if case .checkout(let checkoutState) = currentDependency.state, checkoutState.version == version {
                         packageStateChanges[packageRef.path] = (packageRef, .unchanged)
                     } else {
-                        packageStateChanges[packageRef.path] = (packageRef, .updated(.version(version)))
+                        let newState = PackageStateChange.State(requirement: .version(version), products: products)
+                        packageStateChanges[packageRef.path] = (packageRef, .updated(newState))
                     }
                 } else {
-                    packageStateChanges[packageRef.path] = (packageRef, .added(.version(version)))
+                    let newState = PackageStateChange.State(requirement: .version(version), products: products)
+                    packageStateChanges[packageRef.path] = (packageRef, .added(newState))
                 }
             }
         }
@@ -1991,7 +2041,7 @@ extension Workspace {
         pins: [RepositoryPackageConstraint] = [],
         pinsMap: PinsStore.PinsMap,
         diagnostics: DiagnosticsEngine
-    ) -> [(container: PackageReference, binding: BoundVersion)] {
+    ) -> [(container: PackageReference, binding: BoundVersion, products: ProductFilter)] {
 
         os_signpost(.begin, log: .swiftpm, name: SignpostName.resolution)
         let result = resolver.solve(dependencies: dependencies, pinsMap: pinsMap)
@@ -2040,7 +2090,7 @@ extension Workspace {
                 switch dependency.state {
                 case .checkout(let checkoutState):
                     // If some checkout dependency has been removed, clone it again.
-                    _ = try clone(package: dependency.packageRef, at: checkoutState)
+                    _ = try clone(package: dependency.packageRef, at: checkoutState, productFilter: dependency.productFilter)
                     diagnostics.emit(.checkedOutDependencyMissing(packageName: dependency.packageRef.name))
 
                 case .edited:
@@ -2077,7 +2127,7 @@ extension Workspace {
     @discardableResult
     fileprivate func updateCheckouts(
         root: PackageGraphRoot,
-        updateResults: [(PackageReference, BoundVersion)],
+        updateResults: [(PackageReference, BoundVersion, ProductFilter)],
         updateBranches: Bool = false,
         diagnostics: DiagnosticsEngine
     ) -> [(PackageReference, PackageStateChange)] {
@@ -2103,10 +2153,10 @@ extension Workspace {
         for (packageRef, state) in packageStateChanges {
             diagnostics.wrap {
                 switch state {
-                case .added(let requirement):
-                    _ = try clone(package: packageRef, requirement: requirement)
-                case .updated(let requirement):
-                    _ = try clone(package: packageRef, requirement: requirement)
+                case .added(let state):
+                    _ = try clone(package: packageRef, requirement: state.requirement, productFilter: state.products)
+                case .updated(let state):
+                    _ = try clone(package: packageRef, requirement: state.requirement, productFilter: state.products)
                 case .removed, .unchanged: break
                 }
             }
@@ -2185,7 +2235,8 @@ extension Workspace {
     /// - Throws: If the operation could not be satisfied.
     func clone(
         package: PackageReference,
-        at checkoutState: CheckoutState
+        at checkoutState: CheckoutState,
+        productFilter: ProductFilter
     ) throws -> AbsolutePath {
         // Get the repository.
         let path = try fetch(package: package)
@@ -2205,7 +2256,8 @@ extension Workspace {
         state.dependencies.add(ManagedDependency(
             packageRef: package,
             subpath: path.relative(to: checkoutsPath),
-            checkoutState: checkoutState))
+            checkoutState: checkoutState,
+            productFilter: productFilter))
         try state.saveState()
 
         return path
@@ -2213,7 +2265,8 @@ extension Workspace {
 
     private func clone(
         package: PackageReference,
-        requirement: PackageStateChange.Requirement
+        requirement: PackageStateChange.Requirement,
+        productFilter: ProductFilter
     ) throws -> AbsolutePath {
         let checkoutState: CheckoutState
 
@@ -2234,12 +2287,12 @@ extension Workspace {
             checkoutState = CheckoutState(revision: revision, branch: branch)
 
         case .unversioned:
-            state.dependencies.add(ManagedDependency.local(packageRef: package))
+            state.dependencies.add(ManagedDependency.local(packageRef: package, productFilter: productFilter))
             try state.saveState()
             return AbsolutePath(package.path)
         }
 
-        return try self.clone(package: package, at: checkoutState)
+        return try self.clone(package: package, at: checkoutState, productFilter: productFilter)
     }
 
     /// Removes the clone and checkout of the provided specifier.

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -144,9 +144,9 @@ public class Workspace {
         let workspace: Workspace
 
         fileprivate init(
-          root: PackageGraphRoot,
-          dependencies: [(Manifest, ManagedDependency)],
-          workspace: Workspace
+            root: PackageGraphRoot,
+            dependencies: [(Manifest, ManagedDependency)],
+            workspace: Workspace
         ) {
             self.root = root
             self.dependencies = dependencies
@@ -265,8 +265,8 @@ public class Workspace {
                     break
                 }
                 allConstraints += externalManifest.dependencyConstraints(
-                  productFilter: managedDependency.productFilter,
-                  config: workspace.config
+                    productFilter: managedDependency.productFilter,
+                    config: workspace.config
                 )
             }
             return allConstraints
@@ -759,16 +759,16 @@ extension Workspace {
         let manifests: DependencyManifests
         if forceResolvedVersions {
             manifests = self._resolveToResolvedVersion(
-              root: root,
-              explicitProduct: explicitProduct,
-              diagnostics: diagnostics
+                root: root,
+                explicitProduct: explicitProduct,
+                diagnostics: diagnostics
             )
         } else {
             manifests = self._resolve(
-              root: root,
-              explicitProduct: explicitProduct,
-              forceResolution: false,
-              diagnostics: diagnostics
+                root: root,
+                explicitProduct: explicitProduct,
+                forceResolution: false,
+                diagnostics: diagnostics
             )
         }
 
@@ -1040,11 +1040,11 @@ extension Workspace {
         }
 
         if let checkoutState = dependency.basedOn?.checkoutState,
-          let productFilter = dependency.basedOn?.productFilter {
-            // Restore the original checkout.
-            //
-            // The clone method will automatically update the managed dependency state.
-            _ = try clone(package: dependency.packageRef, at: checkoutState, productFilter: productFilter)
+            let productFilter = dependency.basedOn?.productFilter {
+                // Restore the original checkout.
+                //
+                // The clone method will automatically update the managed dependency state.
+                _ = try clone(package: dependency.packageRef, at: checkoutState, productFilter: productFilter)
         } else {
             // The original dependency was removed, update the managed dependency state.
             state.dependencies.remove(forURL: dependency.packageRef.path)
@@ -1862,12 +1862,12 @@ extension Workspace {
             }
         }
         public struct State: Equatable {
-          public let requirement: Requirement
-          public let products: ProductFilter
-          public init(requirement: Requirement, products: ProductFilter) {
-            self.requirement = requirement
-            self.products = products
-          }
+            public let requirement: Requirement
+            public let products: ProductFilter
+            public init(requirement: Requirement, products: ProductFilter) {
+                self.requirement = requirement
+                self.products = products
+            }
         }
 
         /// The package is added.

--- a/Sources/Workspace/WorkspaceState.swift
+++ b/Sources/Workspace/WorkspaceState.swift
@@ -49,6 +49,9 @@ public final class ManagedDependency {
     /// The state of the managed dependency.
     public let state: State
 
+    /// The product filter applied to the package.
+    public let productFilter: ProductFilter
+
     /// The checked out path of the dependency on disk, relative to the workspace checkouts path.
     public let subpath: RelativePath
 
@@ -62,21 +65,25 @@ public final class ManagedDependency {
     public init(
         packageRef: PackageReference,
         subpath: RelativePath,
-        checkoutState: CheckoutState
+        checkoutState: CheckoutState,
+        productFilter: ProductFilter
     ) {
         self.packageRef = packageRef
         self.state = .checkout(checkoutState)
+        self.productFilter = productFilter
         self.basedOn = nil
         self.subpath = subpath
     }
 
     /// Create a dependency present locally on the filesystem.
     public static func local(
-        packageRef: PackageReference
+        packageRef: PackageReference,
+        productFilter: ProductFilter
     ) -> ManagedDependency {
         return ManagedDependency(
             packageRef: packageRef,
             state: .local,
+            productFilter: productFilter,
             // FIXME: This is just a fake entry, we should fix it.
             subpath: RelativePath(packageRef.identity),
             basedOn: nil
@@ -86,6 +93,7 @@ public final class ManagedDependency {
     private init(
         packageRef: PackageReference,
         state: State,
+        productFilter: ProductFilter,
         subpath: RelativePath,
         basedOn: ManagedDependency?
     ) {
@@ -93,6 +101,7 @@ public final class ManagedDependency {
         self.subpath = subpath
         self.basedOn = basedOn
         self.state = state
+        self.productFilter = productFilter
     }
 
     private init(
@@ -105,6 +114,7 @@ public final class ManagedDependency {
         self.packageRef = dependency.packageRef
         self.subpath = subpath
         self.state = .edited(unmanagedPath)
+        self.productFilter = dependency.productFilter
     }
 
     /// Create an editable managed dependency based on a dependency which
@@ -348,6 +358,7 @@ extension ManagedDependency: JSONMappable, JSONSerializable, CustomStringConvert
         try self.init(
             packageRef: json.get("packageRef"),
             state: json.get("state"),
+            productFilter: json.get("products"),
             subpath: RelativePath(json.get("subpath")),
             basedOn: json.get("basedOn")
         )
@@ -359,11 +370,12 @@ extension ManagedDependency: JSONMappable, JSONSerializable, CustomStringConvert
             "subpath": subpath,
             "basedOn": basedOn.toJSON(),
             "state": state,
+            "products": productFilter
         ])
     }
 
     public var description: String {
-        return "<ManagedDependency: \(packageRef.name) \(state)>"
+        return "<ManagedDependency: \(packageRef.name) \(state) \(productFilter)>"
     }
 }
 

--- a/Sources/Workspace/misc.swift
+++ b/Sources/Workspace/misc.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import PackageModel
 import PackageGraph
 
 extension ManagedDependency {
@@ -36,7 +37,8 @@ extension PinsStore {
 
         self.pin(
             packageRef: dependency.packageRef,
-            state: checkoutState)
+            state: checkoutState,
+            productFilter: dependency.productFilter)
     }
 }
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1221,12 +1221,19 @@ final class BuildPlanTests: XCTestCase {
                     ]),
             ]
         )
-        XCTAssertNoDiagnostics(diagnostics)
+
+        XCTAssertEqual(diagnostics.diagnostics.count, 1)
+        let firstDiagnostic = diagnostics.diagnostics.first.map({ $0.message.text })
+        XCTAssert(
+          firstDiagnostic == "dependency 'C' is not used by any target",
+          "Unexpected diagnostic: " + (firstDiagnostic ?? "[none]")
+        )
+
         let graphResult = PackageGraphResult(graph)
         graphResult.check(reachableProducts: "aexec", "BLibrary")
         graphResult.check(reachableTargets: "ATarget", "BTarget1")
-        graphResult.check(products: "aexec", "BLibrary", "bexec", "cexec")
-        graphResult.check(targets: "ATarget", "BTarget1", "BTarget2", "CTarget")
+        graphResult.check(products: "aexec", "BLibrary")
+        graphResult.check(targets: "ATarget", "BTarget1")
 
         let planResult = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
@@ -1235,8 +1242,8 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fileSystem
         ))
 
-        planResult.checkProductsCount(4)
-        planResult.checkTargetsCount(4)
+        planResult.checkProductsCount(2)
+        planResult.checkTargetsCount(2)
     }
 
     func testReachableBuildProductsAndTargets() throws {
@@ -1882,7 +1889,8 @@ final class BuildPlanTests: XCTestCase {
                     targets: [
                         TargetDescription(name: "PkgB", dependencies: ["swiftlib"]),
                     ]),
-            ]
+            ],
+            explicitProduct: "exe"
         )
         XCTAssertNoDiagnostics(diagnostics)
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1225,8 +1225,8 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(diagnostics.diagnostics.count, 1)
         let firstDiagnostic = diagnostics.diagnostics.first.map({ $0.message.text })
         XCTAssert(
-          firstDiagnostic == "dependency 'C' is not used by any target",
-          "Unexpected diagnostic: " + (firstDiagnostic ?? "[none]")
+            firstDiagnostic == "dependency 'C' is not used by any target",
+            "Unexpected diagnostic: " + (firstDiagnostic ?? "[none]")
         )
 
         let graphResult = PackageGraphResult(graph)

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -192,26 +192,6 @@ final class BuildToolTests: XCTestCase {
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
                 XCTFail(stderr)
             }
-
-            // Dependency does not contain a dependent product
-
-            do {
-                let result = try build(["--target", "CTarget"], packagePath: aPath)
-                XCTAssert(result.binContents.contains("CTarget.build"))
-                XCTAssert(!result.binContents.contains("aexec"))
-                XCTAssert(!result.binContents.contains("ATarget.build"))
-                XCTAssert(!result.binContents.contains("BLibrary.a"))
-                XCTAssert(!result.binContents.contains("bexec"))
-
-                // FIXME: We create the modulemap during build planning, hence this uglyness.
-                let bTargetBuildDir = ((try? localFileSystem.getDirectoryContents(result.binPath.appending(component: "BTarget1.build"))) ?? []).filter{ $0 != moduleMapFilename }
-                XCTAssertEqual(bTargetBuildDir, [])
-
-                XCTAssert(!result.binContents.contains("BTarget2.build"))
-                XCTAssert(!result.binContents.contains("cexec"))
-            } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-                XCTFail(stderr)
-            }
         }
     }
 

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -1069,91 +1069,91 @@ class PackageGraphTests: XCTestCase {
     }
 
     func testUnreachableProductsSkipped() {
-      let fs = InMemoryFileSystem(emptyFiles:
-          "/Root/Sources/Root/Root.swift",
-          "/Immediate/Sources/ImmediateUsed/ImmediateUsed.swift",
-          "/Immediate/Sources/ImmediateUnused/ImmediateUnused.swift",
-          "/Transitive/Sources/TransitiveUsed/TransitiveUsed.swift",
-          "/Transitive/Sources/TransitiveUnused/TransitiveUnused.swift"
-      )
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Root/Sources/Root/Root.swift",
+            "/Immediate/Sources/ImmediateUsed/ImmediateUsed.swift",
+            "/Immediate/Sources/ImmediateUnused/ImmediateUnused.swift",
+            "/Transitive/Sources/TransitiveUsed/TransitiveUsed.swift",
+            "/Transitive/Sources/TransitiveUnused/TransitiveUnused.swift"
+        )
 
-      let diagnostics = DiagnosticsEngine()
-      _ = loadPackageGraph(
-        fs: fs,
-        diagnostics: diagnostics,
-        manifests: [
-          Manifest.createManifest(
-            name: "Root",
-            path: "/Root",
-            url: "/Root",
-            v: .v5_2,
-            packageKind: .root,
-            dependencies: [
-              PackageDependencyDescription(name: "Immediate", url: "/Immediate", requirement: .upToNextMajor(from: "1.0.0")),
-            ],
-            targets: [
-              TargetDescription(name: "Root", dependencies: [
-                .product(name: "ImmediateUsed", package: "Immediate")
-              ]),
+        let diagnostics = DiagnosticsEngine()
+        _ = loadPackageGraph(
+            fs: fs,
+            diagnostics: diagnostics,
+            manifests: [
+                Manifest.createManifest(
+                    name: "Root",
+                    path: "/Root",
+                    url: "/Root",
+                    v: .v5_2,
+                    packageKind: .root,
+                    dependencies: [
+                        PackageDependencyDescription(name: "Immediate", url: "/Immediate", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    targets: [
+                        TargetDescription(name: "Root", dependencies: [
+                            .product(name: "ImmediateUsed", package: "Immediate")
+                        ]),
+                    ]
+                ),
+                Manifest.createManifest(
+                    name: "Immediate",
+                    path: "/Immediate",
+                    url: "/Immediate",
+                    v: .v5_2,
+                    packageKind: .local,
+                    dependencies: [
+                        PackageDependencyDescription(
+                            name: "Transitive",
+                            url: "/Transitive",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        ),
+                        PackageDependencyDescription(
+                            name: "Nonexistent",
+                            url: "/Nonexistent",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        )
+                    ],
+                    products: [
+                        ProductDescription(name: "ImmediateUsed", targets: ["ImmediateUsed"]),
+                        ProductDescription(name: "ImmediateUnused", targets: ["ImmediateUnused"])
+                    ],
+                    targets: [
+                        TargetDescription(name: "ImmediateUsed", dependencies: [
+                            .product(name: "TransitiveUsed", package: "Transitive")
+                        ]),
+                        TargetDescription(name: "ImmediateUnused", dependencies: [
+                            .product(name: "TransitiveUnused", package: "Transitive"),
+                            .product(name: "Nonexistent", package: "Nonexistent")
+                        ]),
+                    ]
+                ),
+                Manifest.createManifest(
+                    name: "Transitive",
+                    path: "/Transitive",
+                    url: "/Transitive",
+                    v: .v5_2,
+                    packageKind: .local,
+                    dependencies: [
+                        PackageDependencyDescription(
+                            name: "Nonexistent",
+                            url: "/Nonexistent",
+                            requirement: .upToNextMajor(from: "1.0.0")
+                        )
+                    ],
+                    products: [
+                        ProductDescription(name: "TransitiveUsed", targets: ["TransitiveUsed"])
+                    ],
+                    targets: [
+                        TargetDescription(name: "TransitiveUsed"),
+                        TargetDescription(name: "TransitiveUnused", dependencies: [
+                            .product(name: "Nonexistent", package: "Nonexistent")
+                        ])
+                ]),
             ]
-          ),
-          Manifest.createManifest(
-            name: "Immediate",
-            path: "/Immediate",
-            url: "/Immediate",
-            v: .v5_2,
-            packageKind: .local,
-            dependencies: [
-              PackageDependencyDescription(
-                name: "Transitive",
-                url: "/Transitive",
-                requirement: .upToNextMajor(from: "1.0.0")
-              ),
-              PackageDependencyDescription(
-                name: "Nonexistent",
-                url: "/Nonexistent",
-                requirement: .upToNextMajor(from: "1.0.0")
-              )
-            ],
-            products: [
-              ProductDescription(name: "ImmediateUsed", targets: ["ImmediateUsed"]),
-              ProductDescription(name: "ImmediateUnused", targets: ["ImmediateUnused"])
-            ],
-            targets: [
-              TargetDescription(name: "ImmediateUsed", dependencies: [
-                .product(name: "TransitiveUsed", package: "Transitive")
-              ]),
-              TargetDescription(name: "ImmediateUnused", dependencies: [
-                .product(name: "TransitiveUnused", package: "Transitive"),
-                .product(name: "Nonexistent", package: "Nonexistent")
-              ]),
-            ]
-          ),
-          Manifest.createManifest(
-            name: "Transitive",
-            path: "/Transitive",
-            url: "/Transitive",
-            v: .v5_2,
-            packageKind: .local,
-            dependencies: [
-              PackageDependencyDescription(
-                name: "Nonexistent",
-                url: "/Nonexistent",
-                requirement: .upToNextMajor(from: "1.0.0")
-              )
-            ],
-            products: [
-              ProductDescription(name: "TransitiveUsed", targets: ["TransitiveUsed"])
-            ],
-            targets: [
-              TargetDescription(name: "TransitiveUsed"),
-              TargetDescription(name: "TransitiveUnused", dependencies: [
-                .product(name: "Nonexistent", package: "Nonexistent")
-              ])
-          ]),
-        ]
-      )
+        )
 
-      XCTAssert(diagnostics.diagnostics.isEmpty, "\(diagnostics.diagnostics)")
+        XCTAssert(diagnostics.diagnostics.isEmpty, "\(diagnostics.diagnostics)")
     }
 }

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -146,7 +146,7 @@ class PackageGraphTests: XCTestCase {
                         PackageDependencyDescription(name: nil, url: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
-                        TargetDescription(name: "Foo"),
+                        TargetDescription(name: "Foo", dependencies: ["Bar"]),
                     ]),
                 Manifest.createV4Manifest(
                     name: "Bar",
@@ -156,8 +156,11 @@ class PackageGraphTests: XCTestCase {
                     dependencies: [
                         PackageDependencyDescription(name: nil, url: "/Baz", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
+                    products: [
+                        ProductDescription(name: "Bar", targets: ["Bar"])
+                    ],
                     targets: [
-                        TargetDescription(name: "Bar"),
+                        TargetDescription(name: "Bar", dependencies: ["Baz"]),
                     ]),
                 Manifest.createV4Manifest(
                     name: "Baz",
@@ -167,8 +170,11 @@ class PackageGraphTests: XCTestCase {
                     dependencies: [
                         PackageDependencyDescription(name: nil, url: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
+                    products: [
+                        ProductDescription(name: "Baz", targets: ["Baz"])
+                    ],
                     targets: [
-                        TargetDescription(name: "Baz"),
+                        TargetDescription(name: "Baz", dependencies: ["Bar"]),
                     ]),
             ]
         )
@@ -733,6 +739,7 @@ class PackageGraphTests: XCTestCase {
 
         DiagnosticsEngineTester(diagnostics) { result in
             result.check(diagnostic: "dependency 'Baz' is not used by any target", behavior: .warning)
+            result.check(diagnostic: "dependency 'Biz' is not used by any target", behavior: .warning)
         }
     }
 
@@ -1059,5 +1066,94 @@ class PackageGraphTests: XCTestCase {
                 }
             }
         }
+    }
+
+    func testUnreachableProductsSkipped() {
+      let fs = InMemoryFileSystem(emptyFiles:
+          "/Root/Sources/Root/Root.swift",
+          "/Immediate/Sources/ImmediateUsed/ImmediateUsed.swift",
+          "/Immediate/Sources/ImmediateUnused/ImmediateUnused.swift",
+          "/Transitive/Sources/TransitiveUsed/TransitiveUsed.swift",
+          "/Transitive/Sources/TransitiveUnused/TransitiveUnused.swift"
+      )
+
+      let diagnostics = DiagnosticsEngine()
+      _ = loadPackageGraph(
+        fs: fs,
+        diagnostics: diagnostics,
+        manifests: [
+          Manifest.createManifest(
+            name: "Root",
+            path: "/Root",
+            url: "/Root",
+            v: .v5_2,
+            packageKind: .root,
+            dependencies: [
+              PackageDependencyDescription(name: "Immediate", url: "/Immediate", requirement: .upToNextMajor(from: "1.0.0")),
+            ],
+            targets: [
+              TargetDescription(name: "Root", dependencies: [
+                .product(name: "ImmediateUsed", package: "Immediate")
+              ]),
+            ]
+          ),
+          Manifest.createManifest(
+            name: "Immediate",
+            path: "/Immediate",
+            url: "/Immediate",
+            v: .v5_2,
+            packageKind: .local,
+            dependencies: [
+              PackageDependencyDescription(
+                name: "Transitive",
+                url: "/Transitive",
+                requirement: .upToNextMajor(from: "1.0.0")
+              ),
+              PackageDependencyDescription(
+                name: "Nonexistent",
+                url: "/Nonexistent",
+                requirement: .upToNextMajor(from: "1.0.0")
+              )
+            ],
+            products: [
+              ProductDescription(name: "ImmediateUsed", targets: ["ImmediateUsed"]),
+              ProductDescription(name: "ImmediateUnused", targets: ["ImmediateUnused"])
+            ],
+            targets: [
+              TargetDescription(name: "ImmediateUsed", dependencies: [
+                .product(name: "TransitiveUsed", package: "Transitive")
+              ]),
+              TargetDescription(name: "ImmediateUnused", dependencies: [
+                .product(name: "TransitiveUnused", package: "Transitive"),
+                .product(name: "Nonexistent", package: "Nonexistent")
+              ]),
+            ]
+          ),
+          Manifest.createManifest(
+            name: "Transitive",
+            path: "/Transitive",
+            url: "/Transitive",
+            v: .v5_2,
+            packageKind: .local,
+            dependencies: [
+              PackageDependencyDescription(
+                name: "Nonexistent",
+                url: "/Nonexistent",
+                requirement: .upToNextMajor(from: "1.0.0")
+              )
+            ],
+            products: [
+              ProductDescription(name: "TransitiveUsed", targets: ["TransitiveUsed"])
+            ],
+            targets: [
+              TargetDescription(name: "TransitiveUsed"),
+              TargetDescription(name: "TransitiveUnused", dependencies: [
+                .product(name: "Nonexistent", package: "Nonexistent")
+              ])
+          ]),
+        ]
+      )
+
+      XCTAssert(diagnostics.diagnostics.isEmpty, "\(diagnostics.diagnostics)")
     }
 }

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -708,10 +708,10 @@ final class PubgrubTests: XCTestCase {
 
     func testUnversioned8() {
         builder.serve("entry", at: .unversioned, with: [
-          "entry": [
-            "remote": (.versionSet(v1Range), .specific(["remote"])),
-            "local": (.unversioned, .specific(["local"])),
-          ]
+            "entry": [
+                "remote": (.versionSet(v1Range), .specific(["remote"])),
+                "local": (.unversioned, .specific(["local"])),
+            ]
         ])
         builder.serve("local", at: .unversioned, with: [
             "local": ["remote": (.unversioned, .specific(["remote"]))]
@@ -734,10 +734,10 @@ final class PubgrubTests: XCTestCase {
 
     func testUnversioned9() {
         builder.serve("entry", at: .unversioned, with: [
-          "entry": [
-            "local": (.unversioned, .specific(["local"])),
-            "remote": (.versionSet(v1Range), .specific(["remote"])),
-          ]
+            "entry": [
+                "local": (.unversioned, .specific(["local"])),
+                "remote": (.versionSet(v1Range), .specific(["remote"])),
+            ]
         ])
         builder.serve("local", at: .unversioned, with: [
             "local": ["remote": (.unversioned, .specific(["remote"]))]
@@ -910,16 +910,16 @@ final class PubgrubTests: XCTestCase {
             "swift-nio-ssl": ["swift-nio": (.versionSet(v2Range), .specific(["swift-nio"]))],
         ])
         builder.serve("nio-postgres", at: .revision("master"), with: [
-          "nio-postgres": [
-            "swift-nio": (.revision("master"), .specific(["swift-nio"])),
-            "swift-nio-ssl": (.revision("master"), .specific(["swift-nio-ssl"])),
-          ]
+            "nio-postgres": [
+                "swift-nio": (.revision("master"), .specific(["swift-nio"])),
+                "swift-nio-ssl": (.revision("master"), .specific(["swift-nio-ssl"])),
+            ]
         ])
         builder.serve("http-client", at: v1, with: [
-          "http-client": [
-            "swift-nio": (.versionSet(v1Range), .specific(["swift-nio"])),
-            "boring-ssl": (.versionSet(v1Range), .specific(["boring-ssl"])),
-          ]
+            "http-client": [
+                "swift-nio": (.versionSet(v1Range), .specific(["swift-nio"])),
+                "boring-ssl": (.versionSet(v1Range), .specific(["boring-ssl"])),
+            ]
         ])
         builder.serve("boring-ssl", at: v1, with: [
             "boring-ssl": ["swift-nio": (.versionSet(v1Range), .specific(["swift-nio"]))],
@@ -1060,52 +1060,52 @@ final class PubgrubTests: XCTestCase {
     }
 
     func testUnreachableProductsSkipped() {
-      builder.serve("root", at: .unversioned, with: [
-        "root": ["immediate": (.versionSet(v1Range), .specific(["ImmediateUsed"]))]
-      ])
-      builder.serve("immediate", at: v1, with: [
-        "ImmediateUsed": ["transitive": (.versionSet(v1Range), .specific(["TransitiveUsed"]))],
-        "ImmediateUnused": [
-          "transitive": (.versionSet(v1Range), .specific(["TransitiveUnused"])),
-          "nonexistent": (.versionSet(v1Range), .specific(["Nonexistent"]))
-        ]
-      ])
-      builder.serve("transitive", at: v1, with: [
-        "TransitiveUsed": [:],
-        "TransitiveUnused": [
-          "nonexistent": (.versionSet(v1Range), .specific(["Nonexistent"]))
-        ]
-      ])
+        builder.serve("root", at: .unversioned, with: [
+            "root": ["immediate": (.versionSet(v1Range), .specific(["ImmediateUsed"]))]
+        ])
+        builder.serve("immediate", at: v1, with: [
+            "ImmediateUsed": ["transitive": (.versionSet(v1Range), .specific(["TransitiveUsed"]))],
+            "ImmediateUnused": [
+                "transitive": (.versionSet(v1Range), .specific(["TransitiveUnused"])),
+                "nonexistent": (.versionSet(v1Range), .specific(["Nonexistent"]))
+            ]
+        ])
+        builder.serve("transitive", at: v1, with: [
+            "TransitiveUsed": [:],
+            "TransitiveUnused": [
+                "nonexistent": (.versionSet(v1Range), .specific(["Nonexistent"]))
+            ]
+        ])
 
-      let resolver = builder.create()
-      let dependencies = builder.create(dependencies: [
-        "root": (.unversioned, .everything)
-      ])
-      let result = resolver.solve(dependencies: dependencies)
+        let resolver = builder.create()
+        let dependencies = builder.create(dependencies: [
+            "root": (.unversioned, .everything)
+        ])
+        let result = resolver.solve(dependencies: dependencies)
 
-      AssertResult(result, [
-        ("root", .unversioned),
-        ("immediate", .version(v1)),
-        ("transitive", .version(v1))
-      ])
+        AssertResult(result, [
+            ("root", .unversioned),
+            ("immediate", .version(v1)),
+            ("transitive", .version(v1))
+        ])
     }
 }
 
 final class PubGrubTestsBasicGraphs: XCTestCase {
     func testSimple1() {
         builder.serve("a", at: v1, with: [
-          "a": [
-            "aa": (.versionSet(.exact("1.0.0")), .specific(["aa"])),
-            "ab": (.versionSet(.exact("1.0.0")), .specific(["ab"])),
-          ]
+            "a": [
+                "aa": (.versionSet(.exact("1.0.0")), .specific(["aa"])),
+                "ab": (.versionSet(.exact("1.0.0")), .specific(["ab"])),
+            ]
         ])
         builder.serve("aa", at: v1)
         builder.serve("ab", at: v1)
         builder.serve("b", at: v1, with: [
-          "b": [
-            "ba": (.versionSet(.exact("1.0.0")), .specific(["ba"])),
-            "bb": (.versionSet(.exact("1.0.0")), .specific(["bb"])),
-          ]
+            "b": [
+                "ba": (.versionSet(.exact("1.0.0")), .specific(["ba"])),
+                "bb": (.versionSet(.exact("1.0.0")), .specific(["bb"])),
+            ]
         ])
         builder.serve("ba", at: v1)
         builder.serve("bb", at: v1)
@@ -1261,16 +1261,16 @@ final class PubGrubDiagnosticsTests: XCTestCase {
 
     func testResolutionBranchingErrorReporting() {
         builder.serve("foo", at: v1, with: [
-          "foo": [
-            "a": (.versionSet(v1Range), .specific(["a"])),
-            "b": (.versionSet(v1Range), .specific(["b"]))
-          ]
+            "foo": [
+                "a": (.versionSet(v1Range), .specific(["a"])),
+                "b": (.versionSet(v1Range), .specific(["b"]))
+            ]
         ])
         builder.serve("foo", at: v1_1, with: [
-          "foo": [
-            "x": (.versionSet(v1Range), .specific(["x"])),
-            "y": (.versionSet(v1Range), .specific(["y"]))
-          ]
+            "foo": [
+                "x": (.versionSet(v1Range), .specific(["x"])),
+                "y": (.versionSet(v1Range), .specific(["y"]))
+            ]
         ])
         builder.serve("a", at: v1, with: ["a": ["b": (.versionSet(v2Range), .specific(["b"]))]])
         builder.serve("b", at: v1)
@@ -1578,45 +1578,45 @@ final class PubGrubDiagnosticsTests: XCTestCase {
     }
 
     func testProductsCannotResolveToDifferentVersions() {
-      builder.serve("root", at: .unversioned, with: [
-        "root": [
-          "intermediate_a": (.versionSet(v1Range), .specific(["Intermediate A"])),
-          "intermediate_b": (.versionSet(v1Range), .specific(["Intermediate B"]))
-        ]
-      ])
-      builder.serve("intermediate_a", at: v1, with: [
-        "Intermediate A": [
-          "transitive": (.versionSet(.exact(v1)), .specific(["Product A"]))
-        ]
-      ])
-      builder.serve("intermediate_b", at: v1, with: [
-        "Intermediate B": [
-          "transitive": (.versionSet(.exact(v1_1)), .specific(["Product B"]))
-        ]
-      ])
-      builder.serve("transitive", at: v1, with: [
-        "Product A": [:],
-        "Product B": [:]
-      ])
-      builder.serve("transitive", at: v1_1, with: [
-        "Product A": [:],
-        "Product B": [:]
-      ])
+        builder.serve("root", at: .unversioned, with: [
+            "root": [
+                "intermediate_a": (.versionSet(v1Range), .specific(["Intermediate A"])),
+                "intermediate_b": (.versionSet(v1Range), .specific(["Intermediate B"]))
+            ]
+        ])
+        builder.serve("intermediate_a", at: v1, with: [
+            "Intermediate A": [
+                "transitive": (.versionSet(.exact(v1)), .specific(["Product A"]))
+            ]
+        ])
+        builder.serve("intermediate_b", at: v1, with: [
+            "Intermediate B": [
+                "transitive": (.versionSet(.exact(v1_1)), .specific(["Product B"]))
+            ]
+        ])
+        builder.serve("transitive", at: v1, with: [
+            "Product A": [:],
+            "Product B": [:]
+        ])
+        builder.serve("transitive", at: v1_1, with: [
+            "Product A": [:],
+            "Product B": [:]
+        ])
 
-      let resolver = builder.create()
-      let dependencies = builder.create(dependencies: [
-        "root": (.unversioned, .everything)
-      ])
-      let result = resolver.solve(dependencies: dependencies)
+        let resolver = builder.create()
+        let dependencies = builder.create(dependencies: [
+            "root": (.unversioned, .everything)
+        ])
+        let result = resolver.solve(dependencies: dependencies)
 
-      XCTAssertEqual(
-        result.errorMsg,
-        """
-        because every version of intermediate_b[Intermediate B] depends on transitive[Product B] 1.1.0 and transitive[Product B] >=1.1.0 depends on transitive 1.1.0, every version of intermediate_b[Intermediate B] requires transitive 1.1.0.
-        And because transitive[Product A] <1.1.0 depends on transitive 1.0.0 and every version of intermediate_a[Intermediate A] depends on transitive[Product A] 1.0.0, intermediate_b[Intermediate B] is incompatible with intermediate_a[Intermediate A].
-        And because root depends on intermediate_a[Intermediate A] 1.0.0..<2.0.0 and root depends on intermediate_b[Intermediate B] 1.0.0..<2.0.0, version solving failed.
-        """
-      )
+        XCTAssertEqual(
+            result.errorMsg,
+            """
+            because every version of intermediate_b[Intermediate B] depends on transitive[Product B] 1.1.0 and transitive[Product B] >=1.1.0 depends on transitive 1.1.0, every version of intermediate_b[Intermediate B] requires transitive 1.1.0.
+            And because transitive[Product A] <1.1.0 depends on transitive 1.0.0 and every version of intermediate_a[Intermediate A] depends on transitive[Product A] 1.0.0, intermediate_b[Intermediate B] is incompatible with intermediate_a[Intermediate A].
+            And because root depends on intermediate_a[Intermediate A] 1.0.0..<2.0.0 and root depends on intermediate_b[Intermediate B] 1.0.0..<2.0.0, version solving failed.
+            """
+        )
     }
 }
 
@@ -1684,10 +1684,10 @@ final class PubGrubBacktrackTests: XCTestCase {
 
         builder.serve("c", at: "1.0.0")
         builder.serve("c", at: "2.0.0", with: [
-          "c": [
-            "a": (.versionSet(.range("0.0.0"..<"5.0.0")), .specific(["a"])),
-            "b": (.versionSet(.range("0.0.0"..<"5.0.0")), .specific(["b"])),
-          ]
+            "c": [
+                "a": (.versionSet(.range("0.0.0"..<"5.0.0")), .specific(["a"])),
+                "b": (.versionSet(.range("0.0.0"..<"5.0.0")), .specific(["b"])),
+            ]
         ])
 
         builder.serve("x", at: "0.0.0")
@@ -1723,10 +1723,10 @@ final class PubGrubBacktrackTests: XCTestCase {
 
         builder.serve("c", at: "1.0.0")
         builder.serve("c", at: "2.0.0", with: [
-          "c": [
-            "a": (.versionSet(.range("0.0.0"..<"5.0.0")), .specific(["a"])),
-            "b": (.versionSet(.range("0.0.0"..<"5.0.0")), .specific(["b"])),
-          ]
+            "c": [
+                "a": (.versionSet(.range("0.0.0"..<"5.0.0")), .specific(["a"])),
+                "b": (.versionSet(.range("0.0.0"..<"5.0.0")), .specific(["b"])),
+            ]
         ])
 
         builder.serve("x", at: "0.0.0")
@@ -1949,7 +1949,7 @@ public class MockContainer: PackageContainer {
         }
         var filteredDependencies: [MockContainer.Dependency] = []
         for (product, productDependencies) in revisionDependencies where productFilter.contains(product) {
-          filteredDependencies.append(contentsOf: productDependencies)
+            filteredDependencies.append(contentsOf: productDependencies)
         }
         return filteredDependencies.map({ value in
             let (name, requirement, filter) = value
@@ -1984,20 +1984,20 @@ public class MockContainer: PackageContainer {
     public convenience init(
         name: PackageReference,
         dependenciesByVersion: [Version: [String: [(
-          package: PackageReference,
-          requirement: VersionSetSpecifier,
-          productFilter: ProductFilter
+            package: PackageReference,
+            requirement: VersionSetSpecifier,
+            productFilter: ProductFilter
         )]]]) {
         var dependencies: [String: [String: [Dependency]]] = [:]
         for (version, productDependencies) in dependenciesByVersion {
-          if dependencies[version.description] == nil {
-            dependencies[version.description] = [:]
-          }
-          for (product, deps) in productDependencies {
-            dependencies[version.description, default: [:]][product] = deps.map({
-                ($0.package, .versionSet($0.requirement), $0.productFilter)
-            })
-          }
+            if dependencies[version.description] == nil {
+                dependencies[version.description] = [:]
+            }
+            for (product, deps) in productDependencies {
+                dependencies[version.description, default: [:]][product] = deps.map({
+                    ($0.package, .versionSet($0.requirement), $0.productFilter)
+                })
+            }
         }
         self.init(name: name, dependencies: dependencies)
     }
@@ -2103,13 +2103,13 @@ class DependencyGraphBuilder {
             .reversed()
 
         if container.dependencies[version.description] == nil {
-          container.dependencies[version.description] = [:]
+            container.dependencies[version.description] = [:]
         }
         for (product, filteredDependencies) in dependencies {
-          let packageDependencies: [MockContainer.Dependency] = filteredDependencies.map {
-            (container: reference(for: $0), requirement: $1.0, products: $1.1)
-          }
-          container.dependencies[version.description, default: [:]][product] = packageDependencies
+            let packageDependencies: [MockContainer.Dependency] = filteredDependencies.map {
+                (container: reference(for: $0), requirement: $1.0, products: $1.1)
+            }
+            container.dependencies[version.description, default: [:]][product] = packageDependencies
         }
         self.containers[package] = container
     }

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -59,8 +59,9 @@ let bRef = PackageReference(identity: "b", path: "")
 let cRef = PackageReference(identity: "c", path: "")
 
 let rootRef = PackageReference(identity: "root", path: "", kind: .root)
-let rootCause = Incompatibility(Term(rootRef, .exact(v1)), root: rootRef)
-let _cause = Incompatibility("cause@0.0.0", root: rootRef)
+let rootNode = DependencyResolutionNode.root(package: rootRef)
+let rootCause = Incompatibility(Term(rootNode, .exact(v1)), root: rootNode)
+let _cause = Incompatibility("cause@0.0.0", root: rootNode)
 
 final class PubgrubTests: XCTestCase {
     func testTermInverse() {
@@ -135,10 +136,10 @@ final class PubgrubTests: XCTestCase {
             Term("¬a@1.0.0"))
 
         // Check difference.
-        let anyA = Term("a", .any)
+        let anyA = Term(.empty(package: "a"), .any)
         XCTAssertNil(Term("a^1.0.0").difference(with: anyA))
 
-        let notEmptyA = Term(not: "a", .empty)
+        let notEmptyA = Term(not: .empty(package: "a"), .empty)
         XCTAssertNil(Term("a^1.0.0").difference(with: notEmptyA))
     }
 
@@ -188,15 +189,15 @@ final class PubgrubTests: XCTestCase {
 
     func testIncompatibilityNormalizeTermsOnInit() {
         let i1 = Incompatibility(Term("a^1.0.0"), Term("a^1.5.0"), Term("¬b@1.0.0"),
-                                 root: rootRef)
+                                 root: rootNode)
         XCTAssertEqual(i1.terms.count, 2)
-        let a1 = i1.terms.first { $0.package == "a" }
-        let b1 = i1.terms.first { $0.package == "b" }
+        let a1 = i1.terms.first { $0.node.package == "a" }
+        let b1 = i1.terms.first { $0.node.package == "b" }
         XCTAssertEqual(a1?.requirement, v1_5Range)
         XCTAssertEqual(b1?.requirement, .exact(v1))
 
         let i2 = Incompatibility(Term("¬a^1.0.0"), Term("a^2.0.0"),
-                                 root: rootRef)
+                                 root: rootNode)
         XCTAssertEqual(i2.terms.count, 1)
         let a2 = i2.terms.first
         XCTAssertEqual(a2?.requirement, v2Range)
@@ -208,40 +209,40 @@ final class PubgrubTests: XCTestCase {
             .derivation("b@2.0.0", cause: _cause, decisionLevel: 0),
             .derivation("a^1.0.0", cause: _cause, decisionLevel: 0)
         ])
-        let a1 = s1._positive.first { $0.key.identity == "a" }?.value
+        let a1 = s1._positive.first { $0.key.package.identity == "a" }?.value
         XCTAssertEqual(a1?.requirement, v1_5Range)
-        let b1 = s1._positive.first { $0.key.identity == "b" }?.value
+        let b1 = s1._positive.first { $0.key.package.identity == "b" }?.value
         XCTAssertEqual(b1?.requirement, .exact(v2))
 
         let s2 = PartialSolution(assignments: [
             .derivation("¬a^1.5.0", cause: _cause, decisionLevel: 0),
             .derivation("a^1.0.0", cause: _cause, decisionLevel: 0)
         ])
-        let a2 = s2._positive.first { $0.key.identity == "a" }?.value
+        let a2 = s2._positive.first { $0.key.package.identity == "a" }?.value
         XCTAssertEqual(a2?.requirement, .range(v1..<v1_5))
     }
 
     func testSolutionUndecided() {
         let solution = PartialSolution()
         solution.derive("a^1.0.0", cause: rootCause)
-        solution.decide("b", at: v2)
+        solution.decide(.empty(package: "b"), at: v2)
         solution.derive("a^1.5.0", cause: rootCause)
         solution.derive("¬c^1.5.0", cause: rootCause)
         solution.derive("d^1.9.0", cause: rootCause)
         solution.derive("d^1.9.9", cause: rootCause)
 
-        let undecided = solution.undecided.sorted{ $0.package.identity < $1.package.identity }
+        let undecided = solution.undecided.sorted{ $0.node.package.identity < $1.node.package.identity }
         XCTAssertEqual(undecided, [Term("a^1.5.0"), Term("d^1.9.9")])
     }
 
     func testSolutionAddAssignments() {
-        let root = Term("root@1.0.0")
+        let root = Term(rootNode, .exact("1.0.0"))
         let a = Term("a@1.0.0")
         let b = Term("b@2.0.0")
 
         let solution = PartialSolution(assignments: [])
-        solution.decide(rootRef, at: v1)
-        solution.decide(aRef, at: v1)
+        solution.decide(rootNode, at: v1)
+        solution.decide(.product("a", package: aRef), at: v1)
         solution.derive(b, cause: _cause)
         XCTAssertEqual(solution.decisionLevel, 1)
 
@@ -251,17 +252,17 @@ final class PubgrubTests: XCTestCase {
             .derivation(b, cause: _cause, decisionLevel: 1)
         ])
         XCTAssertEqual(solution.decisions, [
-            rootRef: v1,
-            aRef: v1,
+            rootNode: v1,
+            .product("a", package: aRef): v1,
         ])
     }
 
     func testSolutionBacktrack() {
         // TODO: This should probably add derivations to cover that logic as well.
         let solution = PartialSolution()
-        solution.decide(aRef, at: v1)
-        solution.decide(bRef, at: v1)
-        solution.decide(cRef, at: v1)
+        solution.decide(.empty(package: aRef), at: v1)
+        solution.decide(.empty(package: bRef), at: v1)
+        solution.decide(.empty(package: cRef), at: v1)
 
         XCTAssertEqual(solution.decisionLevel, 2)
         solution.backtrack(toDecisionLevel: 1)
@@ -273,47 +274,47 @@ final class PubgrubTests: XCTestCase {
         let s1 = PartialSolution(assignments: [
             .derivation("a^1.0.0", cause: _cause, decisionLevel: 0),
         ])
-        XCTAssertEqual(s1._positive["a"]?.requirement,
+        XCTAssertEqual(s1._positive[.product("a", package: "a")]?.requirement,
                        v1Range)
 
         let s2 = PartialSolution(assignments: [
             .derivation("a^1.0.0", cause: _cause, decisionLevel: 0),
             .derivation("a^1.5.0", cause: _cause, decisionLevel: 0)
         ])
-        XCTAssertEqual(s2._positive["a"]?.requirement,
+        XCTAssertEqual(s2._positive[.product("a", package: "a")]?.requirement,
                        v1_5Range)
     }
 
     func testResolverAddIncompatibility() {
         let solver = PubgrubDependencyResolver(emptyProvider, delegate)
 
-        let a = Incompatibility(Term("a@1.0.0"), root: rootRef)
+        let a = Incompatibility(Term("a@1.0.0"), root: rootNode)
         solver.add(a, location: .topLevel)
-        let ab = Incompatibility(Term("a@1.0.0"), Term("b@2.0.0"), root: rootRef)
+        let ab = Incompatibility(Term("a@1.0.0"), Term("b@2.0.0"), root: rootNode)
         solver.add(ab, location: .topLevel)
 
         XCTAssertEqual(solver.incompatibilities, [
-            "a": [a, ab],
-            "b": [ab],
+            .product("a", package: "a"): [a, ab],
+            .product("b", package: "b"): [ab],
         ])
     }
 
     func testUpdatePackageIdentifierAfterResolution() {
         let fooRef = PackageReference(identity: "foo", path: "https://some.url/FooBar")
-        let foo = MockContainer(name: fooRef, dependenciesByVersion: [v1: []])
+        let foo = MockContainer(name: fooRef, dependenciesByVersion: [v1: [:]])
         foo.manifestName = "bar"
 
         let provider = MockProvider(containers: [foo])
 
         let resolver = PubgrubDependencyResolver(provider, delegate)
         let deps = builder.create(dependencies: [
-            "foo": .versionSet(v1Range)
+            "foo": (.versionSet(v1Range), .specific(["foo"]))
         ])
         let result = resolver.solve(dependencies: deps)
 
         switch result {
-        case .error:
-            XCTFail("Unexpected error")
+        case .error(let error):
+            XCTFail("Unexpected error: \(error)")
         case .success(let bindings):
             XCTAssertEqual(bindings.count, 1)
             let foo = bindings.first { $0.container.identity == "foo" }
@@ -323,10 +324,10 @@ final class PubgrubTests: XCTestCase {
 
     func testResolverConflictResolution() {
         let solver1 = PubgrubDependencyResolver(emptyProvider, delegate)
-        solver1.set(rootRef)
+        solver1.set(rootNode)
 
-        let notRoot = Incompatibility(Term(not: rootRef, .any),
-                                      root: rootRef,
+        let notRoot = Incompatibility(Term(not: rootNode, .any),
+                                      root: rootNode,
                                       cause: .root)
         solver1.add(notRoot, location: .topLevel)
         XCTAssertThrowsError(try solver1._resolve(conflict: notRoot))
@@ -334,14 +335,14 @@ final class PubgrubTests: XCTestCase {
 
     func testResolverDecisionMaking() {
         let solver1 = PubgrubDependencyResolver(emptyProvider, delegate)
-        solver1.set(rootRef)
+        solver1.set(rootNode)
 
         // No decision can be made if no unsatisfied terms are available.
         XCTAssertNil(try solver1.makeDecision())
 
         let a = MockContainer(name: aRef, dependenciesByVersion: [
-            "0.0.0": [],
-            v1: [(package: bRef, requirement: v1Range)]
+            "0.0.0": [:],
+            v1: ["a": [(package: bRef, requirement: v1Range, productFilter: .specific(["b"]))]]
         ])
 
         let provider = MockProvider(containers: [a])
@@ -350,18 +351,21 @@ final class PubgrubTests: XCTestCase {
             .derivation("a^1.0.0", cause: rootCause, decisionLevel: 0)
         ])
         solver2.solution = solution
-        solver2.set(rootRef)
+        solver2.set(rootNode)
 
         XCTAssertEqual(solver2.incompatibilities.count, 0)
 
         let decision = try! solver2.makeDecision()
-        XCTAssertEqual(decision, "a")
+        XCTAssertEqual(decision, .product("a", package: "a"))
 
-        XCTAssertEqual(solver2.incompatibilities.count, 2)
-        XCTAssertEqual(solver2.incompatibilities["a"], [
-            Incompatibility("a^1.0.0", "¬b^1.0.0",
-                                              root: rootRef,
-                                              cause: .dependency(package: "a"))
+        XCTAssertEqual(solver2.incompatibilities.count, 3)
+        XCTAssertEqual(solver2.incompatibilities[.product("a", package: "a")], [
+            Incompatibility("a^1.0.0", Term(not: .product("b", package: "b"), v1Range),
+                                              root: rootNode,
+                                              cause: .dependency(node: .product("a", package: "a"))),
+            Incompatibility("a^1.0.0", Term(not: .empty(package: "a"), .exact("1.0.0")),
+                                              root: rootNode,
+                                              cause: .dependency(node: .product("a", package: "a"))),
         ])
     }
 
@@ -369,35 +373,35 @@ final class PubgrubTests: XCTestCase {
         let solver1 = PubgrubDependencyResolver(emptyProvider, delegate)
 
         // no known incompatibilities should result in no satisfaction checks
-        try solver1.propagate("root")
+        try solver1.propagate(.root(package: "root"))
 
         // even if incompatibilities are present
-        solver1.add(Incompatibility(Term("a@1.0.0"), root: rootRef), location: .topLevel)
-        try solver1.propagate("a")
-        try solver1.propagate("a")
-        try solver1.propagate("a")
+        solver1.add(Incompatibility(Term("a@1.0.0"), root: rootNode), location: .topLevel)
+        try solver1.propagate(.empty(package: "a"))
+        try solver1.propagate(.empty(package: "a"))
+        try solver1.propagate(.empty(package: "a"))
 
         // adding a satisfying term should result in a conflict
-        solver1.solution.decide(aRef, at: v1)
+        solver1.solution.decide(.empty(package: aRef), at: v1)
         // FIXME: This leads to fatal error.
         // try solver1.propagate(aRef)
 
         // Unit propagation should derive a new assignment from almost satisfied incompatibilities.
         let solver2 = PubgrubDependencyResolver(emptyProvider, delegate)
-        solver2.add(Incompatibility(Term("root", .any),
+        solver2.add(Incompatibility(Term(.root(package: "root"), .any),
                                     Term("¬a@1.0.0"),
-                                    root: rootRef), location: .topLevel)
-        solver2.solution.decide(rootRef, at: v1)
+                                    root: rootNode), location: .topLevel)
+        solver2.solution.decide(rootNode, at: v1)
         XCTAssertEqual(solver2.solution.assignments.count, 1)
-        try solver2.propagate(PackageReference(identity: "root", path: ""))
+        try solver2.propagate(.root(package: PackageReference(identity: "root", path: "")))
         XCTAssertEqual(solver2.solution.assignments.count, 2)
     }
 
     func testSolutionFindSatisfiers() {
         let solution = PartialSolution()
-        solution.decide(rootRef, at: v1) // ← previous, but actually nil because this is the root decision
-        solution.derive(Term(aRef, .any), cause: _cause) // ← satisfier
-        solution.decide(aRef, at: v2)
+        solution.decide(rootNode, at: v1) // ← previous, but actually nil because this is the root decision
+        solution.derive(Term(.product("a", package: aRef), .any), cause: _cause) // ← satisfier
+        solution.decide(.product("a", package: aRef), at: v2)
         solution.derive("b^1.0.0", cause: _cause)
 
         XCTAssertEqual(solution.satisfier(for: Term("b^1.0.0")) .term, "b^1.0.0")
@@ -406,13 +410,13 @@ final class PubgrubTests: XCTestCase {
     }
 
     func testResolutionNoConflicts() {
-        builder.serve("a", at: v1, with: ["b": .versionSet(v1Range)])
+        builder.serve("a", at: v1, with: ["a": ["b": (.versionSet(v1Range), .specific(["b"]))]])
         builder.serve("b", at: v1)
         builder.serve("b", at: v2)
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "a": .versionSet(v1Range),
+            "a": (.versionSet(v1Range), .specific(["a"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -424,15 +428,15 @@ final class PubgrubTests: XCTestCase {
 
     func testResolutionAvoidingConflictResolutionDuringDecisionMaking() {
         builder.serve("a", at: v1)
-        builder.serve("a", at: v1_1, with: ["b": .versionSet(v2Range)])
+        builder.serve("a", at: v1_1, with: ["a": ["b": (.versionSet(v2Range), .specific(["b"]))]])
         builder.serve("b", at: v1)
         builder.serve("b", at: v1_1)
         builder.serve("b", at: v2)
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "a": .versionSet(v1Range),
-            "b": .versionSet(v1Range),
+            "a": (.versionSet(v1Range), .specific(["a"])),
+            "b": (.versionSet(v1Range), .specific(["b"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -447,12 +451,12 @@ final class PubgrubTests: XCTestCase {
         // It's either .any or 1.0.0..<n.0.0 with n>2. Both should have the same
         // effect though.
         builder.serve("a", at: v1)
-        builder.serve("a", at: v2, with: ["b": .versionSet(v1Range)])
-        builder.serve("b", at: v1, with: ["a": .versionSet(v1Range)])
+        builder.serve("a", at: v2, with: ["a": ["b": (.versionSet(v1Range), .specific(["b"]))]])
+        builder.serve("b", at: v1, with: ["b": ["a": (.versionSet(v1Range), .specific(["a"]))]])
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "a": .versionSet(v1to3Range),
+            "a": (.versionSet(v1to3Range), .specific(["a"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -464,12 +468,12 @@ final class PubgrubTests: XCTestCase {
     func testResolutionConflictResolutionWithAPartialSatisfier() {
         builder.serve("foo", at: v1)
         builder.serve("foo", at: v1_1, with: [
-            "left": .versionSet(v1Range),
-            "right": .versionSet(v1Range)
+            "foo": ["left": (.versionSet(v1Range), .specific(["left"]))],
+            "foo": ["right": (.versionSet(v1Range), .specific(["right"]))]
         ])
-        builder.serve("left", at: v1, with: ["shared": .versionSet(v1Range)])
-        builder.serve("right", at: v1, with: ["shared": .versionSet(v1Range)])
-        builder.serve("shared", at: v1, with: ["target": .versionSet(v1Range)])
+        builder.serve("left", at: v1, with: ["left": ["shared": (.versionSet(v1Range), .specific(["shared"]))]])
+        builder.serve("right", at: v1, with: ["right": ["shared": (.versionSet(v1Range), .specific(["shared"]))]])
+        builder.serve("shared", at: v1, with: ["shared": ["target": (.versionSet(v1Range), .specific(["target"]))]])
         builder.serve("shared", at: v2)
         builder.serve("target", at: v1)
         builder.serve("target", at: v2)
@@ -480,8 +484,8 @@ final class PubgrubTests: XCTestCase {
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .versionSet(v1Range),
-            "target": .versionSet(v2Range),
+            "foo": (.versionSet(v1Range), .specific(["foo"])),
+            "target": (.versionSet(v2Range), .specific(["target"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -492,11 +496,11 @@ final class PubgrubTests: XCTestCase {
     }
 
     func testCycle1() {
-        builder.serve("foo", at: v1_1, with: ["foo": .versionSet(v1Range)])
+        builder.serve("foo", at: v1_1, with: ["foo": ["foo": (.versionSet(v1Range), .specific(["foo"]))]])
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .versionSet(v1Range)
+            "foo": (.versionSet(v1Range), .specific(["foo"]))
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -506,14 +510,14 @@ final class PubgrubTests: XCTestCase {
     }
 
     func testCycle2() {
-        builder.serve("foo", at: v1_1, with: ["bar": .versionSet(v1Range)])
-        builder.serve("bar", at: v1, with: ["baz": .versionSet(v1Range)])
-        builder.serve("baz", at: v1, with: ["bam": .versionSet(v1Range)])
-        builder.serve("bam", at: v1, with: ["baz": .versionSet(v1Range)])
+        builder.serve("foo", at: v1_1, with: ["foo": ["bar": (.versionSet(v1Range), .specific(["bar"]))]])
+        builder.serve("bar", at: v1, with: ["bar": ["baz": (.versionSet(v1Range), .specific(["baz"]))]])
+        builder.serve("baz", at: v1, with: ["baz": ["bam": (.versionSet(v1Range), .specific(["bam"]))]])
+        builder.serve("bam", at: v1, with: ["bam": ["baz": (.versionSet(v1Range), .specific(["baz"]))]])
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .versionSet(v1Range),
+            "foo": (.versionSet(v1Range), .specific(["foo"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -527,18 +531,18 @@ final class PubgrubTests: XCTestCase {
 
     func testLocalPackageCycle() {
         builder.serve("foo", at: .unversioned, with: [
-            "bar": .unversioned,
+            "foo": ["bar": (.unversioned, .specific(["bar"]))],
         ])
         builder.serve("bar", at: .unversioned, with: [
-            "baz": .unversioned,
+            "bar": ["baz": (.unversioned, .specific(["baz"]))],
         ])
         builder.serve("baz", at: .unversioned, with: [
-            "foo": .unversioned,
+            "baz": ["foo": (.unversioned, .specific(["foo"]))],
         ])
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .unversioned,
+            "foo": (.unversioned, .specific(["foo"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -551,18 +555,18 @@ final class PubgrubTests: XCTestCase {
 
     func testBranchBasedPackageCycle() {
         builder.serve("foo", at: .revision("develop"), with: [
-            "bar": .revision("develop"),
+            "foo": ["bar": (.revision("develop"), .specific(["bar"]))],
         ])
         builder.serve("bar", at: .revision("develop"), with: [
-            "baz": .revision("develop"),
+            "bar": ["baz": (.revision("develop"), .specific(["baz"]))],
         ])
         builder.serve("baz", at: .revision("develop"), with: [
-            "foo": .revision("develop"),
+            "baz": ["foo": (.revision("develop"), .specific(["foo"]))],
         ])
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .revision("develop"),
+            "foo": (.revision("develop"), .specific(["foo"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -576,7 +580,7 @@ final class PubgrubTests: XCTestCase {
     func testNonExistentPackage() {
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "package": .versionSet(.exact(v1)),
+            "package": (.versionSet(.exact(v1)), .specific(["package"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -590,8 +594,8 @@ final class PubgrubTests: XCTestCase {
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .unversioned,
-            "bar": .versionSet(v1Range)
+            "foo": (.unversioned, .specific(["foo"])),
+            "bar": (.versionSet(v1Range), .specific(["bar"]))
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -603,7 +607,7 @@ final class PubgrubTests: XCTestCase {
 
     func testUnversioned2() {
         builder.serve("foo", at: .unversioned, with: [
-            "bar": .versionSet(.range(v1..<"1.2.0"))
+            "foo": ["bar": (.versionSet(.range(v1..<"1.2.0")), .specific(["bar"]))]
         ])
         builder.serve("bar", at: v1)
         builder.serve("bar", at: v1_1)
@@ -613,8 +617,8 @@ final class PubgrubTests: XCTestCase {
         let resolver = builder.create()
 
         let dependencies = builder.create(dependencies: [
-            "foo": .unversioned,
-            "bar": .versionSet(v1Range)
+            "foo": (.unversioned, .specific(["foo"])),
+            "bar": (.versionSet(v1Range), .specific(["bar"]))
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -627,13 +631,13 @@ final class PubgrubTests: XCTestCase {
     func testUnversioned3() {
         builder.serve("foo", at: .unversioned)
         builder.serve("bar", at: v1, with: [
-            "foo": .versionSet(.exact(v1))
+            "bar": ["foo": (.versionSet(.exact(v1)), .specific(["foo"]))]
         ])
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .unversioned,
-            "bar": .versionSet(v1Range)
+            "foo": (.unversioned, .specific(["foo"])),
+            "bar": (.versionSet(v1Range), .specific(["bar"]))
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -646,13 +650,13 @@ final class PubgrubTests: XCTestCase {
     func testUnversioned4() {
         builder.serve("foo", at: .unversioned)
         builder.serve("bar", at: .revision("master"), with: [
-            "foo": .versionSet(v1Range)
+            "bar": ["foo": (.versionSet(v1Range), .specific(["foo"]))]
         ])
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .unversioned,
-            "bar": .revision("master")
+            "foo": (.unversioned, .specific(["foo"])),
+            "bar": (.revision("master"), .specific(["bar"]))
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -666,13 +670,13 @@ final class PubgrubTests: XCTestCase {
         builder.serve("foo", at: .unversioned)
         builder.serve("foo", at: .revision("master"))
         builder.serve("bar", at: .revision("master"), with: [
-            "foo": .revision("master")
+            "bar": ["foo": (.revision("master"), .specific(["foo"]))]
         ])
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .unversioned,
-            "bar": .revision("master")
+            "foo": (.unversioned, .specific(["foo"])),
+            "bar": (.revision("master"), .specific(["bar"]))
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -684,15 +688,15 @@ final class PubgrubTests: XCTestCase {
 
     func testUnversioned7() {
         builder.serve("local", at: .unversioned, with: [
-            "remote": .unversioned
+            "local": ["remote": (.unversioned, .specific(["remote"]))]
         ])
         builder.serve("remote", at: .unversioned)
         builder.serve("remote", at: v1)
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "local": .unversioned,
-            "remote": .versionSet(v1Range),
+            "local": (.unversioned, .specific(["local"])),
+            "remote": (.versionSet(v1Range), .specific(["remote"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -704,18 +708,20 @@ final class PubgrubTests: XCTestCase {
 
     func testUnversioned8() {
         builder.serve("entry", at: .unversioned, with: [
-            "remote": .versionSet(v1Range),
-            "local": .unversioned,
+          "entry": [
+            "remote": (.versionSet(v1Range), .specific(["remote"])),
+            "local": (.unversioned, .specific(["local"])),
+          ]
         ])
         builder.serve("local", at: .unversioned, with: [
-            "remote": .unversioned
+            "local": ["remote": (.unversioned, .specific(["remote"]))]
         ])
         builder.serve("remote", at: .unversioned)
         builder.serve("remote", at: v1)
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "entry": .unversioned,
+            "entry": (.unversioned, .specific(["entry"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -728,18 +734,20 @@ final class PubgrubTests: XCTestCase {
 
     func testUnversioned9() {
         builder.serve("entry", at: .unversioned, with: [
-            "local": .unversioned,
-            "remote": .versionSet(v1Range),
+          "entry": [
+            "local": (.unversioned, .specific(["local"])),
+            "remote": (.versionSet(v1Range), .specific(["remote"])),
+          ]
         ])
         builder.serve("local", at: .unversioned, with: [
-            "remote": .unversioned
+            "local": ["remote": (.unversioned, .specific(["remote"]))]
         ])
         builder.serve("remote", at: .unversioned)
         builder.serve("remote", at: v1)
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "entry": .unversioned,
+            "entry": (.unversioned, .specific(["entry"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -751,13 +759,13 @@ final class PubgrubTests: XCTestCase {
     }
 
     func testResolutionWithSimpleBranchBasedDependency() {
-        builder.serve("foo", at: .revision("master"), with: ["bar": .versionSet(v1Range)])
+        builder.serve("foo", at: .revision("master"), with: ["foo": ["bar": (.versionSet(v1Range), .specific(["bar"]))]])
         builder.serve("bar", at: v1)
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .revision("master"),
-            "bar": .versionSet(v1Range)
+            "foo": (.revision("master"), .specific(["foo"])),
+            "bar": (.versionSet(v1Range), .specific(["bar"]))
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -768,12 +776,12 @@ final class PubgrubTests: XCTestCase {
     }
 
     func testResolutionWithSimpleBranchBasedDependency2() {
-        builder.serve("foo", at: .revision("master"), with: ["bar": .versionSet(v1Range)])
+        builder.serve("foo", at: .revision("master"), with: ["foo": ["bar": (.versionSet(v1Range), .specific(["bar"]))]])
         builder.serve("bar", at: v1)
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .revision("master"),
+            "foo": (.revision("master"), .specific(["foo"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -785,12 +793,12 @@ final class PubgrubTests: XCTestCase {
 
     func testResolutionWithOverridingBranchBasedDependency() {
         builder.serve("foo", at: .revision("master"))
-        builder.serve("bar", at: v1, with: ["foo": .versionSet(v1Range)])
+        builder.serve("bar", at: v1, with: ["bar": ["foo": (.versionSet(v1Range), .specific(["foo"]))]])
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .revision("master"),
-            "bar": .versionSet(.exact(v1)),
+            "foo": (.revision("master"), .specific(["foo"])),
+            "bar": (.versionSet(.exact(v1)), .specific(["bar"])),
 
         ])
         let result = resolver.solve(dependencies: dependencies)
@@ -803,12 +811,12 @@ final class PubgrubTests: XCTestCase {
 
     func testResolutionWithOverridingBranchBasedDependency2() {
         builder.serve("foo", at: .revision("master"))
-        builder.serve("bar", at: v1, with: ["foo": .versionSet(v1Range)])
+        builder.serve("bar", at: v1, with: ["bar": ["foo": (.versionSet(v1Range), .specific(["foo"]))]])
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "bar": .versionSet(.exact(v1)),
-            "foo": .revision("master"),
+            "bar": (.versionSet(.exact(v1)), .specific(["bar"])),
+            "foo": (.revision("master"), .specific(["foo"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -819,17 +827,17 @@ final class PubgrubTests: XCTestCase {
     }
 
     func testResolutionWithOverridingBranchBasedDependency3() {
-        builder.serve("foo", at: .revision("master"), with: ["bar": .revision("master")])
+        builder.serve("foo", at: .revision("master"), with: ["foo": ["bar": (.revision("master"), .specific(["bar"]))]])
 
         builder.serve("bar", at: .revision("master"))
         builder.serve("bar", at: v1)
 
-        builder.serve("baz", at: .revision("master"), with: ["bar": .versionSet(v1Range)])
+        builder.serve("baz", at: .revision("master"), with: ["baz": ["bar": (.versionSet(v1Range), .specific(["bar"]))]])
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .revision("master"),
-            "baz": .revision("master"),
+            "foo": (.revision("master"), .specific(["foo"])),
+            "baz": (.revision("master"), .specific(["baz"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -845,7 +853,7 @@ final class PubgrubTests: XCTestCase {
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .revision("master")
+            "foo": (.revision("master"), .specific(["foo"]))
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -853,14 +861,14 @@ final class PubgrubTests: XCTestCase {
     }
 
     func testResolutionWithRevisionConflict() {
-        builder.serve("foo", at: .revision("master"), with: ["bar": .revision("master")])
+        builder.serve("foo", at: .revision("master"), with: ["foo": ["bar": (.revision("master"), .specific(["bar"]))]])
         builder.serve("bar", at: .version(v1))
         builder.serve("bar", at: .revision("master"))
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "bar": .versionSet(v1Range),
-            "foo": .revision("master"),
+            "bar": (.versionSet(v1Range), .specific(["bar"])),
+            "foo": (.revision("master"), .specific(["foo"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -874,17 +882,17 @@ final class PubgrubTests: XCTestCase {
         builder.serve("swift-nio", at: v1)
         builder.serve("swift-nio", at: .revision("master"))
         builder.serve("swift-nio-ssl", at: .revision("master"), with: [
-            "swift-nio": .versionSet(v2Range),
+            "swift-nio-ssl": ["swift-nio": (.versionSet(v2Range), .specific(["swift-nio"]))],
         ])
         builder.serve("foo", at: "1.0.0", with: [
-            "swift-nio": .versionSet(v1Range),
+            "foo": ["swift-nio": (.versionSet(v1Range), .specific(["swift-nio"]))],
         ])
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .versionSet(v1Range),
-            "swift-nio": .revision("master"),
-            "swift-nio-ssl": .revision("master"),
+            "foo": (.versionSet(v1Range), .specific(["foo"])),
+            "swift-nio": (.revision("master"), .specific(["swift-nio"])),
+            "swift-nio-ssl": (.revision("master"), .specific(["swift-nio-ssl"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -899,25 +907,29 @@ final class PubgrubTests: XCTestCase {
         builder.serve("swift-nio", at: v1)
         builder.serve("swift-nio", at: .revision("master"))
         builder.serve("swift-nio-ssl", at: .revision("master"), with: [
-            "swift-nio": .versionSet(v2Range),
+            "swift-nio-ssl": ["swift-nio": (.versionSet(v2Range), .specific(["swift-nio"]))],
         ])
         builder.serve("nio-postgres", at: .revision("master"), with: [
-            "swift-nio": .revision("master"),
-            "swift-nio-ssl": .revision("master"),
+          "nio-postgres": [
+            "swift-nio": (.revision("master"), .specific(["swift-nio"])),
+            "swift-nio-ssl": (.revision("master"), .specific(["swift-nio-ssl"])),
+          ]
         ])
         builder.serve("http-client", at: v1, with: [
-            "swift-nio": .versionSet(v1Range),
-            "boring-ssl": .versionSet(v1Range),
+          "http-client": [
+            "swift-nio": (.versionSet(v1Range), .specific(["swift-nio"])),
+            "boring-ssl": (.versionSet(v1Range), .specific(["boring-ssl"])),
+          ]
         ])
         builder.serve("boring-ssl", at: v1, with: [
-            "swift-nio": .versionSet(v1Range),
+            "boring-ssl": ["swift-nio": (.versionSet(v1Range), .specific(["swift-nio"]))],
         ])
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "nio-postgres": .revision("master"),
-            "http-client": .versionSet(v1Range),
-            "boring-ssl": .versionSet(v1Range),
+            "nio-postgres": (.revision("master"), .specific(["nio-postgres"])),
+            "http-client": (.versionSet(v1Range), .specific(["https-client"])),
+            "boring-ssl": (.versionSet(v1Range), .specific(["boring-ssl"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -932,12 +944,12 @@ final class PubgrubTests: XCTestCase {
 
     func testNonVersionDependencyInVersionDependency2() {
         builder.serve("foo", at: v1_1, with: [
-            "bar": .revision("master")
+            "foo": ["bar": (.revision("master"), .specific(["bar"]))]
         ])
         builder.serve("foo", at: v1)
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .versionSet(v1Range),
+            "foo": (.versionSet(v1Range), .specific(["foo"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -947,7 +959,7 @@ final class PubgrubTests: XCTestCase {
     }
 
     func testTrivialPinStore() {
-        builder.serve("a", at: v1, with: ["b": .versionSet(v1Range)])
+        builder.serve("a", at: v1, with: ["a": ["b": (.versionSet(v1Range), .specific(["b"]))]])
         builder.serve("a", at: v1_1)
         builder.serve("b", at: v1)
         builder.serve("b", at: v1_1)
@@ -955,18 +967,18 @@ final class PubgrubTests: XCTestCase {
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "a": .versionSet(v1Range),
+            "a": (.versionSet(v1Range), .specific(["a"])),
         ])
 
         let pinsStore = builder.create(pinsStore: [
-            "a": .version(v1),
-            "b": .version(v1),
+            "a": (.version(v1), .specific(["a"])),
+            "b": (.version(v1), .specific(["b"])),
         ])
 
         let result = resolver.solve(dependencies: dependencies, pinsMap: pinsStore.pinsMap)
 
         // Since a was pinned, we shouldn't have computed bounds for its incomaptibilities.
-        let aIncompat = resolver.positiveIncompatibilities(for: builder.reference(for: "a"))![0]
+        let aIncompat = resolver.positiveIncompatibilities(for: .product("a", package: builder.reference(for: "a")))![0]
         XCTAssertEqual(aIncompat.terms[0].requirement, .exact("1.0.0"))
 
         AssertResult(result, [
@@ -978,23 +990,23 @@ final class PubgrubTests: XCTestCase {
     func testPartialPins() {
         // This checks that we can drop pins that are not valid anymore but still keep the ones
         // which fit the constraints.
-        builder.serve("a", at: v1, with: ["b": .versionSet(v1Range)])
+        builder.serve("a", at: v1, with: ["a": ["b": (.versionSet(v1Range), .specific(["b"]))]])
         builder.serve("a", at: v1_1)
         builder.serve("b", at: v1)
         builder.serve("b", at: v1_1)
-        builder.serve("c", at: v1, with: ["b": .versionSet(.range(v1_1..<v2))])
+        builder.serve("c", at: v1, with: ["c": ["b": (.versionSet(.range(v1_1..<v2)), .specific(["b"]))]])
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "c": .versionSet(v1Range),
-            "a": .versionSet(v1Range),
+            "c": (.versionSet(v1Range), .specific(["c"])),
+            "a": (.versionSet(v1Range), .specific(["a"])),
         ])
 
         // Here b is pinned to v1 but its requirement is now 1.1.0..<2.0.0 in the graph
         // due to addition of a new dependency.
         let pinsStore = builder.create(pinsStore: [
-            "a": .version(v1),
-            "b": .version(v1),
+            "a": (.version(v1), .specific(["a"])),
+            "b": (.version(v1), .specific(["b"])),
         ])
 
         let result = resolver.solve(dependencies: dependencies, pinsMap: pinsStore.pinsMap)
@@ -1014,13 +1026,13 @@ final class PubgrubTests: XCTestCase {
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "a": .revision("develop"),
-            "b": .revision("master"),
+            "a": (.revision("develop"), .specific(["a"])),
+            "b": (.revision("master"), .specific(["b"])),
         ])
 
         let pinsStore = builder.create(pinsStore: [
-            "a": .branch("develop", revision: "develop-sha-1"),
-            "b": .branch("master", revision: "master-sha-2"),
+            "a": (.branch("develop", revision: "develop-sha-1"), .specific(["a"])),
+            "b": (.branch("master", revision: "master-sha-2"), .specific(["b"])),
         ])
 
         let result = resolver.solve(dependencies: dependencies, pinsMap: pinsStore.pinsMap)
@@ -1037,7 +1049,7 @@ final class PubgrubTests: XCTestCase {
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "a": .versionSet(v1Range),
+            "a": (.versionSet(v1Range), .specific(["a"])),
         ])
 
         let result = resolver.solve(dependencies: dependencies)
@@ -1046,27 +1058,62 @@ final class PubgrubTests: XCTestCase {
             ("a", .version(v1)),
         ])
     }
+
+    func testUnreachableProductsSkipped() {
+      builder.serve("root", at: .unversioned, with: [
+        "root": ["immediate": (.versionSet(v1Range), .specific(["ImmediateUsed"]))]
+      ])
+      builder.serve("immediate", at: v1, with: [
+        "ImmediateUsed": ["transitive": (.versionSet(v1Range), .specific(["TransitiveUsed"]))],
+        "ImmediateUnused": [
+          "transitive": (.versionSet(v1Range), .specific(["TransitiveUnused"])),
+          "nonexistent": (.versionSet(v1Range), .specific(["Nonexistent"]))
+        ]
+      ])
+      builder.serve("transitive", at: v1, with: [
+        "TransitiveUsed": [:],
+        "TransitiveUnused": [
+          "nonexistent": (.versionSet(v1Range), .specific(["Nonexistent"]))
+        ]
+      ])
+
+      let resolver = builder.create()
+      let dependencies = builder.create(dependencies: [
+        "root": (.unversioned, .everything)
+      ])
+      let result = resolver.solve(dependencies: dependencies)
+
+      AssertResult(result, [
+        ("root", .unversioned),
+        ("immediate", .version(v1)),
+        ("transitive", .version(v1))
+      ])
+    }
 }
 
 final class PubGrubTestsBasicGraphs: XCTestCase {
     func testSimple1() {
         builder.serve("a", at: v1, with: [
-            "aa": .versionSet(.exact("1.0.0")),
-            "ab": .versionSet(.exact("1.0.0")),
+          "a": [
+            "aa": (.versionSet(.exact("1.0.0")), .specific(["aa"])),
+            "ab": (.versionSet(.exact("1.0.0")), .specific(["ab"])),
+          ]
         ])
         builder.serve("aa", at: v1)
         builder.serve("ab", at: v1)
         builder.serve("b", at: v1, with: [
-            "ba": .versionSet(.exact("1.0.0")),
-            "bb": .versionSet(.exact("1.0.0")),
+          "b": [
+            "ba": (.versionSet(.exact("1.0.0")), .specific(["ba"])),
+            "bb": (.versionSet(.exact("1.0.0")), .specific(["bb"])),
+          ]
         ])
         builder.serve("ba", at: v1)
         builder.serve("bb", at: v1)
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "a": .versionSet(.exact("1.0.0")),
-            "b": .versionSet(.exact("1.0.0")),
+            "a": (.versionSet(.exact("1.0.0")), .specific(["a"])),
+            "b": (.versionSet(.exact("1.0.0")), .specific(["b"])),
         ])
 
         let result = resolver.solve(dependencies: dependencies)
@@ -1082,10 +1129,10 @@ final class PubGrubTestsBasicGraphs: XCTestCase {
 
     func testSharedDependency1() {
         builder.serve("a", at: v1, with: [
-            "shared": .versionSet(.range("2.0.0"..<"4.0.0")),
+            "a": ["shared": (.versionSet(.range("2.0.0"..<"4.0.0")), .specific(["shared"]))],
         ])
         builder.serve("b", at: v1, with: [
-            "shared": .versionSet(.range("3.0.0"..<"5.0.0")),
+            "b": ["shared": (.versionSet(.range("3.0.0"..<"5.0.0")), .specific(["shared"]))],
         ])
         builder.serve("shared", at: "2.0.0")
         builder.serve("shared", at: "3.0.0")
@@ -1095,8 +1142,8 @@ final class PubGrubTestsBasicGraphs: XCTestCase {
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "a": .versionSet(.exact("1.0.0")),
-            "b": .versionSet(.exact("1.0.0")),
+            "a": (.versionSet(.exact("1.0.0")), .specific(["a"])),
+            "b": (.versionSet(.exact("1.0.0")), .specific(["b"])),
         ])
 
         let result = resolver.solve(dependencies: dependencies)
@@ -1110,16 +1157,16 @@ final class PubGrubTestsBasicGraphs: XCTestCase {
     func testSharedDependency2() {
         builder.serve("foo", at: "1.0.0")
         builder.serve("foo", at: "1.0.1", with: [
-            "bang": .versionSet(.exact("1.0.0")),
+            "foo": ["bang": (.versionSet(.exact("1.0.0")), .specific(["bang"]))],
         ])
         builder.serve("foo", at: "1.0.2", with: [
-            "whoop": .versionSet(.exact("1.0.0")),
+            "foo": ["whoop": (.versionSet(.exact("1.0.0")), .specific(["whoop"]))],
         ])
         builder.serve("foo", at: "1.0.3", with: [
-            "zoop": .versionSet(.exact("1.0.0")),
+            "foo": ["zoop": (.versionSet(.exact("1.0.0")), .specific(["zoop"]))],
         ])
         builder.serve("bar", at: "1.0.0", with: [
-            "foo": .versionSet(.range("0.0.0"..<"1.0.2")),
+            "bar": ["foo": (.versionSet(.range("0.0.0"..<"1.0.2")), .specific(["foo"]))],
         ])
         builder.serve("bang", at: "1.0.0")
         builder.serve("whoop", at: "1.0.0")
@@ -1127,8 +1174,8 @@ final class PubGrubTestsBasicGraphs: XCTestCase {
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .versionSet(.range("0.0.0"..<"1.0.3")),
-            "bar": .versionSet(.exact("1.0.0")),
+            "foo": (.versionSet(.range("0.0.0"..<"1.0.3")), .specific(["foo"])),
+            "bar": (.versionSet(.exact("1.0.0")), .specific(["bar"])),
         ])
 
         let result = resolver.solve(dependencies: dependencies)
@@ -1144,16 +1191,16 @@ final class PubGrubTestsBasicGraphs: XCTestCase {
         builder.serve("foo", at: "2.0.0")
         builder.serve("bar", at: "1.0.0")
         builder.serve("bar", at: "2.0.0", with: [
-            "baz": .versionSet(.exact("1.0.0")),
+            "bar": ["baz": (.versionSet(.exact("1.0.0")), .specific(["baz"]))],
         ])
         builder.serve("baz", at: "1.0.0", with: [
-            "foo": .versionSet(.exact("2.0.0")),
+            "baz": ["foo": (.versionSet(.exact("2.0.0")), .specific(["foo"]))],
         ])
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "bar": .versionSet(.range("0.0.0"..<"5.0.0")),
-            "foo": .versionSet(.exact("1.0.0")),
+            "bar": (.versionSet(.range("0.0.0"..<"5.0.0")), .specific(["bar"])),
+            "foo": (.versionSet(.exact("1.0.0")), .specific(["foo"])),
         ])
 
         let result = resolver.solve(dependencies: dependencies)
@@ -1171,11 +1218,11 @@ final class PubGrubDiagnosticsTests: XCTestCase {
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foopkg": .versionSet(v2Range),
+            "foopkg": (.versionSet(v2Range), .specific(["foopkg"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
-        XCTAssertEqual(result.errorMsg, "because no versions of foopkg match the requirement 2.0.0..<3.0.0 and root depends on foopkg 2.0.0..<3.0.0, version solving failed.")
+        XCTAssertEqual(result.errorMsg, "because no versions of foopkg[foopkg] match the requirement 2.0.0..<3.0.0 and root depends on foopkg[foopkg] 2.0.0..<3.0.0, version solving failed.")
     }
 
     func testResolutionNonExistentVersion() {
@@ -1183,16 +1230,16 @@ final class PubGrubDiagnosticsTests: XCTestCase {
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "package": .versionSet(.exact(v1))
+            "package": (.versionSet(.exact(v1)), .specific(["package"]))
         ])
         let result = resolver.solve(dependencies: dependencies)
 
-        XCTAssertEqual(result.errorMsg, "because no versions of package match the requirement 1.0.0 and root depends on package 1.0.0, version solving failed.")
+        XCTAssertEqual(result.errorMsg, "because no versions of package[package] match the requirement 1.0.0 and root depends on package[package] 1.0.0, version solving failed.")
     }
 
     func testResolutionLinearErrorReporting() {
-        builder.serve("foo", at: v1, with: ["bar": .versionSet(v2Range)])
-        builder.serve("bar", at: v2, with: ["baz": .versionSet(.range("3.0.0"..<"4.0.0"))])
+        builder.serve("foo", at: v1, with: ["foo": ["bar": (.versionSet(v2Range), .specific(["bar"]))]])
+        builder.serve("bar", at: v2, with: ["bar": ["baz": (.versionSet(.range("3.0.0"..<"4.0.0")), .specific(["baz"]))]])
         builder.serve("baz", at: v1)
         builder.serve("baz", at: "3.0.0")
 
@@ -1201,126 +1248,130 @@ final class PubGrubDiagnosticsTests: XCTestCase {
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .versionSet(v1Range),
-            "baz": .versionSet(v1Range),
+            "foo": (.versionSet(v1Range), .specific(["foo"])),
+            "baz": (.versionSet(v1Range), .specific(["baz"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
         XCTAssertEqual(result.errorMsg, """
-            because every version of foo depends on bar 2.0.0..<3.0.0 and every version of bar depends on baz 3.0.0..<4.0.0, every version of foo requires baz 3.0.0..<4.0.0.
-            And because root depends on foo 1.0.0..<2.0.0 and root depends on baz 1.0.0..<2.0.0, version solving failed.
+            because every version of foo[foo] depends on bar[bar] 2.0.0..<3.0.0 and every version of bar[bar] depends on baz[baz] 3.0.0..<4.0.0, every version of foo[foo] requires baz[baz] 3.0.0..<4.0.0.
+            And because root depends on foo[foo] 1.0.0..<2.0.0 and root depends on baz[baz] 1.0.0..<2.0.0, version solving failed.
             """)
     }
 
     func testResolutionBranchingErrorReporting() {
         builder.serve("foo", at: v1, with: [
-            "a": .versionSet(v1Range),
-            "b": .versionSet(v1Range)
+          "foo": [
+            "a": (.versionSet(v1Range), .specific(["a"])),
+            "b": (.versionSet(v1Range), .specific(["b"]))
+          ]
         ])
         builder.serve("foo", at: v1_1, with: [
-            "x": .versionSet(v1Range),
-            "y": .versionSet(v1Range)
+          "foo": [
+            "x": (.versionSet(v1Range), .specific(["x"])),
+            "y": (.versionSet(v1Range), .specific(["y"]))
+          ]
         ])
-        builder.serve("a", at: v1, with: ["b": .versionSet(v2Range)])
+        builder.serve("a", at: v1, with: ["a": ["b": (.versionSet(v2Range), .specific(["b"]))]])
         builder.serve("b", at: v1)
         builder.serve("b", at: v2)
-        builder.serve("x", at: v1, with: ["y": .versionSet(v2Range)])
+        builder.serve("x", at: v1, with: ["x": ["y": (.versionSet(v2Range), .specific(["y"]))]])
         builder.serve("y", at: v1)
         builder.serve("y", at: v2)
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .versionSet(v1Range),
+            "foo": (.versionSet(v1Range), .specific(["foo"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
         XCTAssertEqual(result.errorMsg, """
-          because every version of a depends on b 2.0.0..<3.0.0 and foo <1.1.0 depends on a 1.0.0..<2.0.0, foo <1.1.0 requires b 2.0.0..<3.0.0.
-             (1) So, because foo <1.1.0 depends on b 1.0.0..<2.0.0, foo <1.1.0 is forbidden.
-          because every version of x depends on y 2.0.0..<3.0.0 and foo >=1.1.0 depends on x 1.0.0..<2.0.0, foo >=1.1.0 requires y 2.0.0..<3.0.0.
-          And because foo >=1.1.0 depends on y 1.0.0..<2.0.0, foo >=1.1.0 is forbidden.
-          And because foo <1.1.0 is forbidden (1), foo is forbidden.
-          And because root depends on foo 1.0.0..<2.0.0, version solving failed.
+          because every version of a[a] depends on b[b] 2.0.0..<3.0.0 and foo[foo] <1.1.0 depends on a[a] 1.0.0..<2.0.0, foo[foo] <1.1.0 requires b[b] 2.0.0..<3.0.0.
+             (1) So, because foo[foo] <1.1.0 depends on b[b] 1.0.0..<2.0.0, foo[foo] <1.1.0 is forbidden.
+          because every version of x[x] depends on y[y] 2.0.0..<3.0.0 and foo[foo] >=1.1.0 depends on x[x] 1.0.0..<2.0.0, foo[foo] >=1.1.0 requires y[y] 2.0.0..<3.0.0.
+          And because foo[foo] >=1.1.0 depends on y[y] 1.0.0..<2.0.0, foo[foo] >=1.1.0 is forbidden.
+          And because foo[foo] <1.1.0 is forbidden (1), foo[foo] is forbidden.
+          And because root depends on foo[foo] 1.0.0..<2.0.0, version solving failed.
         """)
     }
 
     func testConflict1() {
-        builder.serve("foo", at: v1, with: ["config": .versionSet(v1Range)])
-        builder.serve("bar", at: v1, with: ["config": .versionSet(v2Range)])
+        builder.serve("foo", at: v1, with: ["foo": ["config": (.versionSet(v1Range), .specific(["config"]))]])
+        builder.serve("bar", at: v1, with: ["bar": ["config": (.versionSet(v2Range), .specific(["config"]))]])
         builder.serve("config", at: v1)
         builder.serve("config", at: v2)
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .versionSet(v1Range),
-            "bar": .versionSet(v1Range)
+            "foo": (.versionSet(v1Range), .specific(["foo"])),
+            "bar": (.versionSet(v1Range), .specific(["bar"]))
         ])
         let result = resolver.solve(dependencies: dependencies)
 
         XCTAssertEqual(result.errorMsg, """
-            because every version of bar depends on config 2.0.0..<3.0.0 and every version of foo depends on config 1.0.0..<2.0.0, bar is incompatible with foo.
-            And because root depends on foo 1.0.0..<2.0.0 and root depends on bar 1.0.0..<2.0.0, version solving failed.
+            because every version of bar[bar] depends on config[config] 2.0.0..<3.0.0 and every version of foo[foo] depends on config[config] 1.0.0..<2.0.0, bar[bar] is incompatible with foo[foo].
+            And because root depends on foo[foo] 1.0.0..<2.0.0 and root depends on bar[bar] 1.0.0..<2.0.0, version solving failed.
             """)
     }
 
     func testConflict2() {
         func addDeps() {
-            builder.serve("foo", at: v1, with: ["config": .versionSet(v1Range)])
+            builder.serve("foo", at: v1, with: ["foo": ["config": (.versionSet(v1Range), .specific(["config"]))]])
             builder.serve("config", at: v1)
             builder.serve("config", at: v2)
         }
 
         let dependencies1 = builder.create(dependencies: [
-            "config": .versionSet(v2Range),
-            "foo": .versionSet(v1Range),
+            "config": (.versionSet(v2Range), .specific(["config"])),
+            "foo": (.versionSet(v1Range), .specific(["foo"])),
         ])
         addDeps()
         let resolver1 = builder.create()
         let result1 = resolver1.solve(dependencies: dependencies1)
 
         XCTAssertEqual(result1.errorMsg, """
-            because every version of foo depends on config 1.0.0..<2.0.0 and root depends on config 2.0.0..<3.0.0, foo is forbidden.
-            And because root depends on foo 1.0.0..<2.0.0, version solving failed.
+            because every version of foo[foo] depends on config[config] 1.0.0..<2.0.0 and root depends on config[config] 2.0.0..<3.0.0, foo[foo] is forbidden.
+            And because root depends on foo[foo] 1.0.0..<2.0.0, version solving failed.
             """)
 
         let dependencies2 = builder.create(dependencies: [
-            "foo": .versionSet(v1Range),
-            "config": .versionSet(v2Range),
+            "foo": (.versionSet(v1Range), .specific(["foo"])),
+            "config": (.versionSet(v2Range), .specific(["config"])),
         ])
         addDeps()
         let resolver2 = builder.create()
         let result2 = resolver2.solve(dependencies: dependencies2)
 
         XCTAssertEqual(result2.errorMsg, """
-            because every version of foo depends on config 1.0.0..<2.0.0 and root depends on foo 1.0.0..<2.0.0, config 1.0.0..<2.0.0 is required.
-            And because root depends on config 2.0.0..<3.0.0, version solving failed.
+            because every version of foo[foo] depends on config[config] 1.0.0..<2.0.0 and root depends on foo[foo] 1.0.0..<2.0.0, config[config] 1.0.0..<2.0.0 is required.
+            And because root depends on config[config] 2.0.0..<3.0.0, version solving failed.
             """)
     }
 
     func testConflict3() {
-        builder.serve("foo", at: v1, with: ["config": .versionSet(v1Range)])
+        builder.serve("foo", at: v1, with: ["foo": ["config": (.versionSet(v1Range), .specific(["config"]))]])
         builder.serve("config", at: v1)
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "config": .versionSet(v2Range),
-            "foo": .versionSet(v1Range),
+            "config": (.versionSet(v2Range), .specific(["config"])),
+            "foo": (.versionSet(v1Range), .specific(["foo"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
-        XCTAssertEqual(result.errorMsg, "because no versions of config match the requirement 2.0.0..<3.0.0 and root depends on config 2.0.0..<3.0.0, version solving failed.")
+        XCTAssertEqual(result.errorMsg, "because no versions of config[config] match the requirement 2.0.0..<3.0.0 and root depends on config[config] 2.0.0..<3.0.0, version solving failed.")
     }
 
     func testUnversioned6() {
         builder.serve("foo", at: .unversioned)
         builder.serve("bar", at: .revision("master"), with: [
-            "foo": .unversioned
+            "bar": ["foo": (.unversioned, .specific(["foo"]))]
         ])
 
         let resolver = builder.create()
 
         let dependencies = builder.create(dependencies: [
-            "bar": .revision("master")
+            "bar": (.revision("master"), .specific(["bar"]))
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -1328,17 +1379,17 @@ final class PubGrubDiagnosticsTests: XCTestCase {
     }
 
     func testResolutionWithOverridingBranchBasedDependency4() {
-        builder.serve("foo", at: .revision("master"), with: ["bar": .revision("master")])
+        builder.serve("foo", at: .revision("master"), with: ["foo": ["bar": (.revision("master"), .specific(["bar"]))]])
 
         builder.serve("bar", at: .revision("master"))
         builder.serve("bar", at: v1)
 
-        builder.serve("baz", at: .revision("master"), with: ["bar": .revision("develop")])
+        builder.serve("baz", at: .revision("master"), with: ["baz": ["bar": (.revision("develop"), .specific(["baz"]))]])
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .revision("master"),
-            "baz": .revision("master"),
+            "foo": (.revision("master"), .specific(["foo"])),
+            "baz": (.revision("master"), .specific(["baz"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
@@ -1347,31 +1398,31 @@ final class PubGrubDiagnosticsTests: XCTestCase {
 
     func testNonVersionDependencyInVersionDependency1() {
         builder.serve("foo", at: v1_1, with: [
-            "bar": .revision("master")
+            "foo": ["bar": (.revision("master"), .specific(["bar"]))]
         ])
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .versionSet(v1Range),
+            "foo": (.versionSet(v1Range), .specific(["foo"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
         XCTAssertEqual(result.errorMsg, """
-            because no versions of foo match the requirement {1.0.0..<1.1.0, 1.1.1..<2.0.0} and package foo is required using a version-based requirement and it depends on unversion package bar, foo is forbidden.
-            And because root depends on foo 1.0.0..<2.0.0, version solving failed.
+            because no versions of foo[foo] match the requirement {1.0.0..<1.1.0, 1.1.1..<2.0.0} and package foo is required using a version-based requirement and it depends on unversion package bar, foo[foo] is forbidden.
+            And because root depends on foo[foo] 1.0.0..<2.0.0, version solving failed.
             """)
     }
 
     func testNonVersionDependencyInVersionDependency3() {
         builder.serve("foo", at: v1, with: [
-            "bar": .unversioned
+            "foo": ["bar": (.unversioned, .specific(["bar"]))]
         ])
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .versionSet(.exact(v1)),
+            "foo": (.versionSet(.exact(v1)), .specific(["foo"])),
         ])
         let result = resolver.solve(dependencies: dependencies)
 
-        XCTAssertEqual(result.errorMsg, "because package foo is required using a version-based requirement and it depends on unversion package bar and root depends on foo 1.0.0, version solving failed.")
+        XCTAssertEqual(result.errorMsg, "because package foo is required using a version-based requirement and it depends on unversion package bar and root depends on foo[foo] 1.0.0, version solving failed.")
     }
 
     func testIncompatibleToolsVersion1() {
@@ -1379,20 +1430,20 @@ final class PubGrubDiagnosticsTests: XCTestCase {
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "a": .versionSet(v1Range),
+            "a": (.versionSet(v1Range), .specific(["a"])),
         ])
 
         let result = resolver.solve(dependencies: dependencies)
 
         XCTAssertEqual(result.errorMsg, """
-            because no versions of a match the requirement 1.0.1..<2.0.0 and a 1.0.0 contains incompatible tools version, a >=1.0.0 is forbidden.
-            And because root depends on a 1.0.0..<2.0.0, version solving failed.
+            because no versions of a[a] match the requirement 1.0.1..<2.0.0 and a[a] 1.0.0 contains incompatible tools version, a[a] >=1.0.0 is forbidden.
+            And because root depends on a[a] 1.0.0..<2.0.0, version solving failed.
             """)
     }
 
     func testIncompatibleToolsVersion3() {
         builder.serve("a", at: v1_1, with: [
-            "b": .versionSet(v1Range)
+            "a": ["b": (.versionSet(v1Range), .specific(["b"]))]
         ])
         builder.serve("a", at: v1, isToolsVersionCompatible: false)
 
@@ -1401,16 +1452,16 @@ final class PubGrubDiagnosticsTests: XCTestCase {
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "a": .versionSet(v1Range),
-            "b": .versionSet(v2Range),
+            "a": (.versionSet(v1Range), .specific(["a"])),
+            "b": (.versionSet(v2Range), .specific(["b"])),
         ])
 
         let result = resolver.solve(dependencies: dependencies)
 
         XCTAssertEqual(result.errorMsg, """
-            because no versions of a match the requirement 1.0.1..<1.1.0 and a 1.0.0 contains incompatible tools version, a 1.0.0..<1.1.0 is forbidden.
-            And because a >=1.1.0 depends on b 1.0.0..<2.0.0, a >=1.0.0 requires b 1.0.0..<2.0.0.
-            And because root depends on a 1.0.0..<2.0.0 and root depends on b 2.0.0..<3.0.0, version solving failed.
+            because no versions of a[a] match the requirement 1.0.1..<1.1.0 and a[a] 1.0.0 contains incompatible tools version, a[a] 1.0.0..<1.1.0 is forbidden.
+            And because a[a] >=1.1.0 depends on b[b] 1.0.0..<2.0.0, a[a] >=1.0.0 requires b[b] 1.0.0..<2.0.0.
+            And because root depends on a[a] 1.0.0..<2.0.0 and root depends on b[b] 2.0.0..<3.0.0, version solving failed.
             """)
     }
 
@@ -1421,13 +1472,13 @@ final class PubGrubDiagnosticsTests: XCTestCase {
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "a": .versionSet(.range("3.2.0"..<"4.0.0")),
+            "a": (.versionSet(.range("3.2.0"..<"4.0.0")), .specific(["a"])),
         ])
 
         let result = resolver.solve(dependencies: dependencies)
 
         XCTAssertEqual(result.errorMsg, """
-            because every version of a contains incompatible tools version and root depends on a 3.2.0..<4.0.0, version solving failed.
+            because every version of a[a] contains incompatible tools version and root depends on a[a] 3.2.0..<4.0.0, version solving failed.
             """)
     }
 
@@ -1438,92 +1489,134 @@ final class PubGrubDiagnosticsTests: XCTestCase {
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "a": .versionSet(.range("3.2.0"..<"4.0.0")),
+            "a": (.versionSet(.range("3.2.0"..<"4.0.0")), .specific(["a"])),
         ])
 
         let result = resolver.solve(dependencies: dependencies)
 
         XCTAssertEqual(result.errorMsg, """
-            because every version of a contains incompatible tools version and root depends on a 3.2.0..<4.0.0, version solving failed.
+            because every version of a[a] contains incompatible tools version and root depends on a[a] 3.2.0..<4.0.0, version solving failed.
             """)
     }
 
     func testIncompatibleToolsVersion6() {
         builder.serve("a", at: "3.2.1", isToolsVersionCompatible: false)
         builder.serve("a", at: "3.2.0", with: [
-            "b": .versionSet(v1Range),
+            "a": ["b": (.versionSet(v1Range), .specific(["b"]))],
         ])
         builder.serve("a", at: "3.2.2", isToolsVersionCompatible: false)
         builder.serve("b", at: "1.0.0", isToolsVersionCompatible: false)
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "a": .versionSet(.range("3.2.0"..<"4.0.0")),
+            "a": (.versionSet(.range("3.2.0"..<"4.0.0")), .specific(["a"])),
         ])
 
         let result = resolver.solve(dependencies: dependencies)
 
         XCTAssertEqual(result.errorMsg, """
-            because no versions of b match the requirement 1.0.1..<2.0.0 and b 1.0.0 contains incompatible tools version, b >=1.0.0 is forbidden.
-            And because a <3.2.1 depends on b 1.0.0..<2.0.0, a <3.2.1 is forbidden.
-            And because a >=3.2.1 contains incompatible tools version and root depends on a 3.2.0..<4.0.0, version solving failed.
+            because b[b] 1.0.0 contains incompatible tools version and no versions of b[b] match the requirement 1.0.1..<2.0.0, b[b] >=1.0.0 is forbidden.
+            And because a[a] <3.2.1 depends on b[b] 1.0.0..<2.0.0, a[a] <3.2.1 is forbidden.
+            And because a[a] >=3.2.1 contains incompatible tools version and root depends on a[a] 3.2.0..<4.0.0, version solving failed.
             """)
     }
 
     func testConflict4() {
         builder.serve("foo", at: v1, with: [
-            "shared": .versionSet(.range("2.0.0"..<"3.0.0")),
+            "foo": ["shared": (.versionSet(.range("2.0.0"..<"3.0.0")), .specific(["shared"]))],
         ])
         builder.serve("bar", at: v1, with: [
-            "shared": .versionSet(.range("2.9.0"..<"4.0.0")),
+            "bar": ["shared": (.versionSet(.range("2.9.0"..<"4.0.0")), .specific(["shared"]))],
         ])
         builder.serve("shared", at: "2.5.0")
         builder.serve("shared", at: "3.5.0")
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "bar": .versionSet(.exact(v1)),
-            "foo": .versionSet(.exact(v1)),
+            "bar": (.versionSet(.exact(v1)), .specific(["bar"])),
+            "foo": (.versionSet(.exact(v1)), .specific(["foo"])),
         ])
 
         let result = resolver.solve(dependencies: dependencies)
 
         XCTAssertEqual(result.errorMsg, """
-            because every version of bar depends on shared 2.9.0..<4.0.0 and no versions of shared match the requirement 2.9.0..<3.0.0, every version of bar requires shared 3.0.0..<4.0.0.
-            And because every version of foo depends on shared 2.0.0..<3.0.0, foo is incompatible with bar.
-            And because root depends on bar 1.0.0 and root depends on foo 1.0.0, version solving failed.
+            because every version of bar[bar] depends on shared[shared] 2.9.0..<4.0.0 and no versions of shared[shared] match the requirement 2.9.0..<3.0.0, every version of bar[bar] requires shared[shared] 3.0.0..<4.0.0.
+            And because every version of foo[foo] depends on shared[shared] 2.0.0..<3.0.0, foo[foo] is incompatible with bar[bar].
+            And because root depends on bar[bar] 1.0.0 and root depends on foo[foo] 1.0.0, version solving failed.
             """)
     }
 
     func testConflict5() {
         builder.serve("a", at: v1, with: [
-            "b": .versionSet(.exact("1.0.0")),
+            "a": ["b": (.versionSet(.exact("1.0.0")), .specific(["b"]))],
         ])
         builder.serve("a", at: "2.0.0", with: [
-            "b": .versionSet(.exact("2.0.0")),
+            "a": ["b": (.versionSet(.exact("2.0.0")), .specific(["b"]))],
         ])
         builder.serve("b", at: "1.0.0", with: [
-            "a": .versionSet(.exact("2.0.0")),
+            "b": ["a": (.versionSet(.exact("2.0.0")), .specific(["a"]))],
         ])
         builder.serve("b", at: "2.0.0", with: [
-            "a": .versionSet(.exact("1.0.0")),
+            "b": ["a": (.versionSet(.exact("1.0.0")), .specific(["a"]))],
         ])
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "b": .versionSet(.range("0.0.0"..<"5.0.0")),
-            "a": .versionSet(.range("0.0.0"..<"5.0.0")),
+            "b": (.versionSet(.range("0.0.0"..<"5.0.0")), .specific(["b"])),
+            "a": (.versionSet(.range("0.0.0"..<"5.0.0")), .specific(["a"])),
         ])
 
         let result = resolver.solve(dependencies: dependencies)
 
         XCTAssertEqual(result.errorMsg, """
-            because no versions of a match the requirement 3.0.0..<5.0.0 and a <2.0.0 depends on b 1.0.0, a {0.0.0..<2.0.0, 3.0.0..<5.0.0} requires b 1.0.0.
-            And because b <2.0.0 depends on a 2.0.0, a {0.0.0..<2.0.0, 3.0.0..<5.0.0} is forbidden.
-            because b >=2.0.0 depends on a 1.0.0 and a >=2.0.0 depends on b 2.0.0, a >=2.0.0 is forbidden.
-            Thus, a is forbidden.
-            And because root depends on a 0.0.0..<5.0.0, version solving failed.
+            because no versions of a[a] match the requirement 3.0.0..<5.0.0 and a[a] <2.0.0 depends on b[b] 1.0.0, a[a] {0.0.0..<2.0.0, 3.0.0..<5.0.0} requires b[b] 1.0.0.
+            And because b[b] <2.0.0 depends on a[a] 2.0.0, a[a] {0.0.0..<2.0.0, 3.0.0..<5.0.0} is forbidden.
+            because b[b] >=2.0.0 depends on a[a] 1.0.0 and a[a] >=2.0.0 depends on b[b] 2.0.0, a[a] >=2.0.0 is forbidden.
+            Thus, a[a] is forbidden.
+            And because root depends on a[a] 0.0.0..<5.0.0, version solving failed.
             """)
+    }
+
+    func testProductsCannotResolveToDifferentVersions() {
+      builder.serve("root", at: .unversioned, with: [
+        "root": [
+          "intermediate_a": (.versionSet(v1Range), .specific(["Intermediate A"])),
+          "intermediate_b": (.versionSet(v1Range), .specific(["Intermediate B"]))
+        ]
+      ])
+      builder.serve("intermediate_a", at: v1, with: [
+        "Intermediate A": [
+          "transitive": (.versionSet(.exact(v1)), .specific(["Product A"]))
+        ]
+      ])
+      builder.serve("intermediate_b", at: v1, with: [
+        "Intermediate B": [
+          "transitive": (.versionSet(.exact(v1_1)), .specific(["Product B"]))
+        ]
+      ])
+      builder.serve("transitive", at: v1, with: [
+        "Product A": [:],
+        "Product B": [:]
+      ])
+      builder.serve("transitive", at: v1_1, with: [
+        "Product A": [:],
+        "Product B": [:]
+      ])
+
+      let resolver = builder.create()
+      let dependencies = builder.create(dependencies: [
+        "root": (.unversioned, .everything)
+      ])
+      let result = resolver.solve(dependencies: dependencies)
+
+      XCTAssertEqual(
+        result.errorMsg,
+        """
+        because every version of intermediate_b[Intermediate B] depends on transitive[Product B] 1.1.0 and transitive[Product B] >=1.1.0 depends on transitive 1.1.0, every version of intermediate_b[Intermediate B] requires transitive 1.1.0.
+        And because transitive[Product A] <1.1.0 depends on transitive 1.0.0 and every version of intermediate_a[Intermediate A] depends on transitive[Product A] 1.0.0, intermediate_b[Intermediate B] is incompatible with intermediate_a[Intermediate A].
+        And because root depends on intermediate_a[Intermediate A] 1.0.0..<2.0.0 and root depends on intermediate_b[Intermediate B] 1.0.0..<2.0.0, version solving failed.
+        """
+      )
     }
 }
 
@@ -1531,15 +1624,15 @@ final class PubGrubBacktrackTests: XCTestCase {
     func testBacktrack1() {
         builder.serve("a", at: v1)
         builder.serve("a", at: "2.0.0", with: [
-            "b": .versionSet(.exact("1.0.0")),
+            "a": ["b": (.versionSet(.exact("1.0.0")), .specific(["b"]))],
         ])
         builder.serve("b", at: "1.0.0", with: [
-            "a": .versionSet(.exact("1.0.0")),
+            "b": ["a": (.versionSet(.exact("1.0.0")), .specific(["a"]))],
         ])
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "a": .versionSet(.range("1.0.0"..<"3.0.0")),
+            "a": (.versionSet(.range("1.0.0"..<"3.0.0")), .specific(["a"])),
         ])
 
         let result = resolver.solve(dependencies: dependencies)
@@ -1552,14 +1645,14 @@ final class PubGrubBacktrackTests: XCTestCase {
     func testBacktrack2() {
         builder.serve("a", at: v1)
         builder.serve("a", at: "2.0.0", with: [
-            "c": .versionSet(.range("1.0.0"..<"2.0.0")),
+            "a": ["c": (.versionSet(.range("1.0.0"..<"2.0.0")), .specific(["c"]))],
         ])
 
         builder.serve("b", at: "1.0.0", with: [
-            "c": .versionSet(.range("2.0.0"..<"3.0.0")),
+            "b": ["c": (.versionSet(.range("2.0.0"..<"3.0.0")), .specific(["c"]))],
         ])
         builder.serve("b", at: "2.0.0", with: [
-            "c": .versionSet(.range("3.0.0"..<"4.0.0")),
+            "b": ["c": (.versionSet(.range("3.0.0"..<"4.0.0")), .specific(["c"]))],
         ])
 
         builder.serve("c", at: "1.0.0")
@@ -1568,8 +1661,8 @@ final class PubGrubBacktrackTests: XCTestCase {
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "a": .versionSet(.range("1.0.0"..<"3.0.0")),
-            "b": .versionSet(.range("1.0.0"..<"3.0.0")),
+            "a": (.versionSet(.range("1.0.0"..<"3.0.0")), .specific(["a"])),
+            "b": (.versionSet(.range("1.0.0"..<"3.0.0")), .specific(["b"])),
         ])
 
         let result = resolver.solve(dependencies: dependencies)
@@ -1583,22 +1676,24 @@ final class PubGrubBacktrackTests: XCTestCase {
 
     func testBacktrack3() {
         builder.serve("a", at: "1.0.0", with: [
-            "x": .versionSet(.range("1.0.0"..<"5.0.0")),
+            "a": ["x": (.versionSet(.range("1.0.0"..<"5.0.0")), .specific(["x"]))],
         ])
         builder.serve("b", at: "1.0.0", with: [
-            "x": .versionSet(.range("0.0.0"..<"2.0.0")),
+            "b": ["x": (.versionSet(.range("0.0.0"..<"2.0.0")), .specific(["x"]))],
         ])
 
         builder.serve("c", at: "1.0.0")
         builder.serve("c", at: "2.0.0", with: [
-            "a": .versionSet(.range("0.0.0"..<"5.0.0")),
-            "b": .versionSet(.range("0.0.0"..<"5.0.0")),
+          "c": [
+            "a": (.versionSet(.range("0.0.0"..<"5.0.0")), .specific(["a"])),
+            "b": (.versionSet(.range("0.0.0"..<"5.0.0")), .specific(["b"])),
+          ]
         ])
 
         builder.serve("x", at: "0.0.0")
         builder.serve("x", at: "2.0.0")
         builder.serve("x", at: "1.0.0", with: [
-            "y": .versionSet(.exact(v1)),
+            "x": ["y": (.versionSet(.exact(v1)), .specific(["y"]))],
         ])
 
         builder.serve("y", at: "1.0.0")
@@ -1606,8 +1701,8 @@ final class PubGrubBacktrackTests: XCTestCase {
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "c": .versionSet(.range("1.0.0"..<"3.0.0")),
-            "y": .versionSet(.range("2.0.0"..<"3.0.0")),
+            "c": (.versionSet(.range("1.0.0"..<"3.0.0")), .specific(["c"])),
+            "y": (.versionSet(.range("2.0.0"..<"3.0.0")), .specific(["y"])),
         ])
 
         let result = resolver.solve(dependencies: dependencies)
@@ -1620,22 +1715,24 @@ final class PubGrubBacktrackTests: XCTestCase {
 
     func testBacktrack4() {
         builder.serve("a", at: "1.0.0", with: [
-            "x": .versionSet(.range("1.0.0"..<"5.0.0")),
+            "a": ["x": (.versionSet(.range("1.0.0"..<"5.0.0")), .specific(["x"]))],
         ])
         builder.serve("b", at: "1.0.0", with: [
-            "x": .versionSet(.range("0.0.0"..<"2.0.0")),
+            "b": ["x": (.versionSet(.range("0.0.0"..<"2.0.0")), .specific(["x"]))],
         ])
 
         builder.serve("c", at: "1.0.0")
         builder.serve("c", at: "2.0.0", with: [
-            "a": .versionSet(.range("0.0.0"..<"5.0.0")),
-            "b": .versionSet(.range("0.0.0"..<"5.0.0")),
+          "c": [
+            "a": (.versionSet(.range("0.0.0"..<"5.0.0")), .specific(["a"])),
+            "b": (.versionSet(.range("0.0.0"..<"5.0.0")), .specific(["b"])),
+          ]
         ])
 
         builder.serve("x", at: "0.0.0")
         builder.serve("x", at: "2.0.0")
         builder.serve("x", at: "1.0.0", with: [
-            "y": .versionSet(.exact(v1)),
+            "x": ["y": (.versionSet(.exact(v1)), .specific(["y"]))],
         ])
 
         builder.serve("y", at: "1.0.0")
@@ -1643,8 +1740,8 @@ final class PubGrubBacktrackTests: XCTestCase {
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "c": .versionSet(.range("1.0.0"..<"3.0.0")),
-            "y": .versionSet(.range("2.0.0"..<"3.0.0")),
+            "c": (.versionSet(.range("1.0.0"..<"3.0.0")), .specific(["c"])),
+            "y": (.versionSet(.range("2.0.0"..<"3.0.0")), .specific(["y"])),
         ])
 
         let result = resolver.solve(dependencies: dependencies)
@@ -1657,30 +1754,30 @@ final class PubGrubBacktrackTests: XCTestCase {
 
     func testBacktrack5() {
         builder.serve("foo", at: "1.0.0", with: [
-            "bar": .versionSet(.exact("1.0.0")),
+            "foo": ["bar": (.versionSet(.exact("1.0.0")), .specific(["bar"]))],
         ])
         builder.serve("foo", at: "2.0.0", with: [
-            "bar": .versionSet(.exact("2.0.0")),
+            "foo": ["bar": (.versionSet(.exact("2.0.0")), .specific(["bar"]))],
         ])
         builder.serve("foo", at: "3.0.0", with: [
-            "bar": .versionSet(.exact("3.0.0")),
+            "foo": ["bar": (.versionSet(.exact("3.0.0")), .specific(["bar"]))],
         ])
 
         builder.serve("bar", at: "1.0.0", with: [
-            "baz": .versionSet(.range("0.0.0"..<"3.0.0")),
+            "bar": ["baz": (.versionSet(.range("0.0.0"..<"3.0.0")), .specific(["baz"]))],
         ])
         builder.serve("bar", at: "2.0.0", with: [
-            "baz": .versionSet(.exact("3.0.0")),
+            "bar": ["baz": (.versionSet(.exact("3.0.0")), .specific(["baz"]))],
         ])
         builder.serve("bar", at: "3.0.0", with: [
-            "baz": .versionSet(.exact("3.0.0")),
+            "bar": ["baz": (.versionSet(.exact("3.0.0")), .specific(["baz"]))],
         ])
 
         builder.serve("baz", at: "1.0.0")
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "foo": .versionSet(.range("1.0.0"..<"4.0.0")),
+            "foo": (.versionSet(.range("1.0.0"..<"4.0.0")), .specific(["foo"])),
         ])
 
         let result = resolver.solve(dependencies: dependencies)
@@ -1696,19 +1793,19 @@ final class PubGrubBacktrackTests: XCTestCase {
         builder.serve("a", at: "1.0.0")
         builder.serve("a", at: "2.0.0")
         builder.serve("b", at: "1.0.0", with: [
-            "a": .versionSet(.exact("1.0.0")),
+            "b": ["a": (.versionSet(.exact("1.0.0")), .specific(["a"]))],
         ])
         builder.serve("c", at: "1.0.0", with: [
-            "b": .versionSet(.range("0.0.0"..<"3.0.0")),
+            "c": ["b": (.versionSet(.range("0.0.0"..<"3.0.0")), .specific(["b"]))],
         ])
         builder.serve("d", at: "1.0.0")
         builder.serve("d", at: "2.0.0")
 
         let resolver = builder.create()
         let dependencies = builder.create(dependencies: [
-            "a": .versionSet(.range("1.0.0"..<"4.0.0")),
-            "c": .versionSet(.range("1.0.0"..<"4.0.0")),
-            "d": .versionSet(.range("1.0.0"..<"4.0.0")),
+            "a": (.versionSet(.range("1.0.0"..<"4.0.0")), .specific(["a"])),
+            "c": (.versionSet(.range("1.0.0"..<"4.0.0")), .specific(["c"])),
+            "d": (.versionSet(.range("1.0.0"..<"4.0.0")), .specific(["d"])),
         ])
 
         let result = resolver.solve(dependencies: dependencies)
@@ -1796,12 +1893,12 @@ private func AssertError(
 }
 
 public class MockContainer: PackageContainer {
-    public typealias Dependency = (container: PackageReference, requirement: PackageRequirement)
+    public typealias Dependency = (container: PackageReference, requirement: PackageRequirement, productFilter: ProductFilter)
 
     var name: PackageReference
     var manifestName: PackageReference?
 
-    var dependencies: [String: [Dependency]]
+    var dependencies: [String: [String: [Dependency]]]
 
     public var unversionedDeps: [PackageContainerConstraint] = []
 
@@ -1841,27 +1938,31 @@ public class MockContainer: PackageContainer {
         return !incompatibleToolsVersions.contains(version)
     }
 
-    public func getDependencies(at version: Version) throws -> [PackageContainerConstraint] {
+    public func getDependencies(at version: Version, productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
         requestedVersions.insert(version)
-        return try getDependencies(at: version.description)
+        return try getDependencies(at: version.description, productFilter: productFilter)
     }
 
-    public func getDependencies(at revision: String) throws -> [PackageContainerConstraint] {
+    public func getDependencies(at revision: String, productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
         guard let revisionDependencies = dependencies[revision] else {
             throw _MockLoadingError.unknownRevision
         }
-        return revisionDependencies.map({ value in
-            let (name, requirement) = value
-            return PackageContainerConstraint(container: name, requirement: requirement)
+        var filteredDependencies: [MockContainer.Dependency] = []
+        for (product, productDependencies) in revisionDependencies where productFilter.contains(product) {
+          filteredDependencies.append(contentsOf: productDependencies)
+        }
+        return filteredDependencies.map({ value in
+            let (name, requirement, filter) = value
+            return PackageContainerConstraint(container: name, requirement: requirement, products: filter)
         })
     }
 
-    public func getUnversionedDependencies() throws -> [PackageContainerConstraint] {
+    public func getUnversionedDependencies(productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
         // FIXME: This is messy, remove unversionedDeps property.
         if !unversionedDeps.isEmpty {
             return unversionedDeps
         }
-        return try getDependencies(at: PackageRequirement.unversioned.description)
+        return try getDependencies(at: PackageRequirement.unversioned.description, productFilter: productFilter)
     }
 
     public func getUpdatedIdentifier(at boundVersion: BoundVersion) throws -> PackageReference {
@@ -1873,29 +1974,37 @@ public class MockContainer: PackageContainer {
 
     public convenience init(
         name: PackageReference,
-        unversionedDependencies: [(package: PackageReference, requirement: PackageRequirement)]
+        unversionedDependencies: [(package: PackageReference, requirement: PackageRequirement, productFilter: ProductFilter)]
         ) {
         self.init(name: name)
         self.unversionedDeps = unversionedDependencies
-            .map { PackageContainerConstraint(container: $0.package, requirement: $0.requirement) }
+            .map { PackageContainerConstraint(container: $0.package, requirement: $0.requirement, products: $0.productFilter) }
     }
 
     public convenience init(
         name: PackageReference,
-        dependenciesByVersion: [Version: [(package: PackageReference, requirement: VersionSetSpecifier)]]
-        ) {
-        var dependencies: [String: [Dependency]] = [:]
-        for (version, deps) in dependenciesByVersion {
-            dependencies[version.description] = deps.map({
-                ($0.package, .versionSet($0.requirement))
+        dependenciesByVersion: [Version: [String: [(
+          package: PackageReference,
+          requirement: VersionSetSpecifier,
+          productFilter: ProductFilter
+        )]]]) {
+        var dependencies: [String: [String: [Dependency]]] = [:]
+        for (version, productDependencies) in dependenciesByVersion {
+          if dependencies[version.description] == nil {
+            dependencies[version.description] = [:]
+          }
+          for (product, deps) in productDependencies {
+            dependencies[version.description, default: [:]][product] = deps.map({
+                ($0.package, .versionSet($0.requirement), $0.productFilter)
             })
+          }
         }
         self.init(name: name, dependencies: dependencies)
     }
 
     public init(
         name: PackageReference,
-        dependencies: [String: [Dependency]] = [:]
+        dependencies: [String: [String: [Dependency]]] = [:]
         ) {
         self.name = name
         self.dependencies = dependencies
@@ -1950,10 +2059,10 @@ class DependencyGraphBuilder {
     }
 
     func create(
-        dependencies: OrderedDictionary<String, PackageRequirement>
+        dependencies: OrderedDictionary<String, (PackageRequirement, ProductFilter)>
     ) -> [PackageContainerConstraint] {
         return dependencies.map {
-            PackageContainerConstraint(container: reference(for: $0), requirement: $1)
+            PackageContainerConstraint(container: reference(for: $0), requirement: $1.0, products: $1.1)
         }
     }
 
@@ -1961,7 +2070,7 @@ class DependencyGraphBuilder {
         _ package: String,
         at version: Version,
         isToolsVersionCompatible: Bool = true,
-        with dependencies: OrderedDictionary<String, PackageRequirement> = [:]
+        with dependencies: OrderedDictionary<String, OrderedDictionary<String, (PackageRequirement, ProductFilter)>> = [:]
     ) {
         serve(package, at: .version(version), isToolsVersionCompatible: isToolsVersionCompatible, with: dependencies)
     }
@@ -1970,7 +2079,7 @@ class DependencyGraphBuilder {
         _ package: String,
         at version: BoundVersion,
         isToolsVersionCompatible: Bool = true,
-        with dependencies: OrderedDictionary<String, PackageRequirement> = [:]
+        with dependencies: OrderedDictionary<String, OrderedDictionary<String, (PackageRequirement, ProductFilter)>> = [:]
     ) {
         let packageReference = reference(for: package)
         let container = self.containers[package] ?? MockContainer(name: packageReference)
@@ -1993,20 +2102,25 @@ class DependencyGraphBuilder {
             })
             .reversed()
 
-        let packageDependencies = dependencies.map {
-            (container: reference(for: $0), requirement: $1)
+        if container.dependencies[version.description] == nil {
+          container.dependencies[version.description] = [:]
         }
-        container.dependencies[version.description] = packageDependencies
+        for (product, filteredDependencies) in dependencies {
+          let packageDependencies: [MockContainer.Dependency] = filteredDependencies.map {
+            (container: reference(for: $0), requirement: $1.0, products: $1.1)
+          }
+          container.dependencies[version.description, default: [:]][product] = packageDependencies
+        }
         self.containers[package] = container
     }
 
     /// Creates a pins store with the given pins.
-    func create(pinsStore pins: [String: CheckoutState]) -> PinsStore {
+    func create(pinsStore pins: [String: (CheckoutState, ProductFilter)]) -> PinsStore {
         let fs = InMemoryFileSystem()
         let store = try! PinsStore(pinsFile: AbsolutePath("/tmp/Package.resolved"), fileSystem: fs)
 
-        for (package, state) in pins {
-            store.pin(packageRef: reference(for: package), state: state)
+        for (package, pin) in pins {
+            store.pin(packageRef: reference(for: package), state: pin.0, productFilter: pin.1)
         }
 
         try! store.saveState()
@@ -2056,12 +2170,12 @@ extension Term: ExpressibleByStringLiteral {
             requirement = .versionSet(.range(Version(stringLiteral: lowerBound)..<Version(stringLiteral: upperBound)))
         }
 
-        let packageReference = PackageReference(identity: components[0], path: "")
+        let packageReference = PackageReference(identity: components[0], path: "", name: components[0])
 
         guard case let .versionSet(vs) = requirement! else {
             fatalError()
         }
-        self.init(package: packageReference,
+        self.init(node: .product(packageReference.name, package: packageReference),
                   requirement: vs,
                   isPositive: isPositive)
     }

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -273,7 +273,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             let container = try await { provider.getContainer(for: ref, completion: $0) } as! RepositoryPackageContainer
             let revision = try container.getRevision(forTag: "1.0.0")
             do {
-                _ = try container.getDependencies(at: revision.identifier)
+                _ = try container.getDependencies(at: revision.identifier, productFilter: .specific([]))
             } catch let error as RepositoryPackageContainer.GetDependenciesErrorWrapper {
                 let error = error.underlyingError as! UnsupportedToolsVersion
                 XCTAssertMatch(error.description, .and(.prefix("package at '/' @"), .suffix("is using Swift tools version 3.1.0 which is no longer supported; consider using '// swift-tools-version:4.0' to specify the current tools version")))
@@ -377,10 +377,27 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
 
         let config = SwiftPMConfig()
 
-        let constraints = dependencies.map({
+        let v5ProductMapping: [String: ProductFilter] = [
+          "Bar1": .specific(["Bar1", "Bar3"]),
+          "Bar2": .specific(["B2", "Bar1", "Bar3"]),
+          "Bar3": .specific(["Bar1", "Bar3"])
+        ]
+        let v5Constraints = dependencies.map({
             RepositoryPackageConstraint(
                 container: $0.createPackageRef(config: config),
-                requirement: $0.requirement.toConstraintRequirement())
+                requirement: $0.requirement.toConstraintRequirement(),
+                products: v5ProductMapping[$0.name]!)
+        })
+        let v5_2ProductMapping: [String: ProductFilter] = [
+          "Bar1": .specific(["Bar1"]),
+          "Bar2": .specific(["B2"]),
+          "Bar3": .specific(["Bar3"])
+        ]
+        let v5_2Constraints = dependencies.map({
+          RepositoryPackageConstraint(
+            container: $0.createPackageRef(config: config),
+            requirement: $0.requirement.toConstraintRequirement(),
+            products: v5_2ProductMapping[$0.name]!)
         })
 
         do {
@@ -397,12 +414,12 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
 
             XCTAssertEqual(
                 manifest
-                    .dependencyConstraints(config: config)
+                    .dependencyConstraints(productFilter: .everything, config: config)
                     .sorted(by: { $0.identifier.identity < $1.identifier.identity }),
                 [
-                    constraints[0],
-                    constraints[1],
-                    constraints[2],
+                    v5Constraints[0],
+                    v5Constraints[1],
+                    v5Constraints[2],
                 ]
             )
         }
@@ -421,12 +438,12 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
 
             XCTAssertEqual(
                 manifest
-                    .dependencyConstraints(config: config)
+                    .dependencyConstraints(productFilter: .everything, config: config)
                     .sorted(by: { $0.identifier.identity < $1.identifier.identity }),
                 [
-                    constraints[0],
-                    constraints[1],
-                    constraints[2],
+                    v5Constraints[0],
+                    v5Constraints[1],
+                    v5Constraints[2],
                 ]
             )
         }
@@ -445,12 +462,12 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
 
             XCTAssertEqual(
                 manifest
-                    .dependencyConstraints(config: config)
+                    .dependencyConstraints(productFilter: .everything, config: config)
                     .sorted(by: { $0.identifier.identity < $1.identifier.identity }),
                 [
-                    constraints[0],
-                    constraints[1],
-                    constraints[2],
+                    v5_2Constraints[0],
+                    v5_2Constraints[1],
+                    v5_2Constraints[2],
                 ]
             )
         }
@@ -469,11 +486,11 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
 
             XCTAssertEqual(
                 manifest
-                    .dependencyConstraints(config: config)
+                    .dependencyConstraints(productFilter: .specific(Set(products.map({ $0.name }))), config: config)
                     .sorted(by: { $0.identifier.identity < $1.identifier.identity }),
                 [
-                    constraints[0],
-                    constraints[1],
+                    v5_2Constraints[0],
+                    v5_2Constraints[1],
                 ]
             )
         }

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -378,9 +378,9 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         let config = SwiftPMConfig()
 
         let v5ProductMapping: [String: ProductFilter] = [
-          "Bar1": .specific(["Bar1", "Bar3"]),
-          "Bar2": .specific(["B2", "Bar1", "Bar3"]),
-          "Bar3": .specific(["Bar1", "Bar3"])
+            "Bar1": .specific(["Bar1", "Bar3"]),
+            "Bar2": .specific(["B2", "Bar1", "Bar3"]),
+            "Bar3": .specific(["Bar1", "Bar3"])
         ]
         let v5Constraints = dependencies.map({
             RepositoryPackageConstraint(
@@ -389,15 +389,15 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
                 products: v5ProductMapping[$0.name]!)
         })
         let v5_2ProductMapping: [String: ProductFilter] = [
-          "Bar1": .specific(["Bar1"]),
-          "Bar2": .specific(["B2"]),
-          "Bar3": .specific(["Bar3"])
+            "Bar1": .specific(["Bar1"]),
+            "Bar2": .specific(["B2"]),
+            "Bar3": .specific(["Bar3"])
         ]
         let v5_2Constraints = dependencies.map({
-          RepositoryPackageConstraint(
-            container: $0.createPackageRef(config: config),
-            requirement: $0.requirement.toConstraintRequirement(),
-            products: v5_2ProductMapping[$0.name]!)
+            RepositoryPackageConstraint(
+                container: $0.createPackageRef(config: config),
+                requirement: $0.requirement.toConstraintRequirement(),
+                products: v5_2ProductMapping[$0.name]!)
         })
 
         do {

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -2079,6 +2079,7 @@ final class PackageBuilderTester {
             // FIXME: We should allow customizing root package boolean.
             let builder = PackageBuilder(
                 manifest: manifest,
+                productFilter: .everything,
                 path: path,
                 remoteArtifacts: remoteArtifacts,
                 xcTestMinimumDeploymentTargets: Self.xcTestMinimumDeploymentTargets,

--- a/Tests/PackageModelTests/ManifestTests.swift
+++ b/Tests/PackageModelTests/ManifestTests.swift
@@ -37,7 +37,7 @@ class ManifestTests: XCTestCase {
                 targets: targets
             )
 
-            XCTAssertEqual(manifest.allRequiredTargets.map({ $0.name }).sorted(), [
+            XCTAssertEqual(manifest.targetsRequired(for: .everything).map({ $0.name }).sorted(), [
                 "Bar",
                 "Baz",
                 "Foo",
@@ -56,7 +56,7 @@ class ManifestTests: XCTestCase {
                 targets: targets
             )
 
-            XCTAssertEqual(manifest.allRequiredTargets.map({ $0.name }).sorted(), [
+            XCTAssertEqual(manifest.targetsRequired(for: .specific(["Foo", "Bar"])).map({ $0.name }).sorted(), [
                 "Bar",
                 "Baz",
                 "Foo",
@@ -93,7 +93,7 @@ class ManifestTests: XCTestCase {
                 targets: targets
             )
 
-            XCTAssertEqual(manifest.allRequiredDependencies.map({ $0.name }).sorted(), [
+            XCTAssertEqual(manifest.dependenciesRequired(for: .everything).map({ $0.declaration.name }).sorted(), [
                 "Bar1",
                 "Bar2",
                 "Bar3",
@@ -112,10 +112,10 @@ class ManifestTests: XCTestCase {
                 targets: targets
             )
 
-            XCTAssertEqual(manifest.allRequiredDependencies.map({ $0.name }).sorted(), [
-                "Bar1",
-                "Bar2",
-                "Bar3",
+            XCTAssertEqual(manifest.dependenciesRequired(for: .specific(["Foo"])).map({ $0.declaration.name }).sorted(), [
+                "Bar1", // Foo → Foo1 → Bar1
+                "Bar2", // Foo → Foo1 → Foo2 → Bar2
+                "Bar3", // Foo → Foo1 → Bar1 → could be from any package due to pre‐5.2 tools version.
             ])
         }
 
@@ -131,7 +131,7 @@ class ManifestTests: XCTestCase {
                 targets: targets
             )
 
-            XCTAssertEqual(manifest.allRequiredDependencies.map({ $0.name }).sorted(), [
+            XCTAssertEqual(manifest.dependenciesRequired(for: .everything).map({ $0.declaration.name }).sorted(), [
                 "Bar1",
                 "Bar2",
                 "Bar3",
@@ -150,9 +150,10 @@ class ManifestTests: XCTestCase {
                 targets: targets
             )
 
-            XCTAssertEqual(manifest.allRequiredDependencies.map({ $0.name }).sorted(), [
-                "Bar1",
-                "Bar2",
+            XCTAssertEqual(manifest.dependenciesRequired(for: .specific(["Foo"])).map({ $0.declaration.name }).sorted(), [
+                "Bar1", // Foo → Foo1 → Bar1
+                "Bar2", // Foo → Foo1 → Foo2 → Bar2
+                // (Bar3 is unreachable.)
             ])
         }
     }

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -65,9 +65,9 @@ final class PinsStoreTests: XCTestCase {
         // We should be able to pin again.
         store.pin(packageRef: fooRef, state: state, productFilter: products)
         store.pin(
-          packageRef: fooRef,
-          state: CheckoutState(revision: revision, version: "1.0.2"),
-          productFilter: .specific(["some", "products"])
+            packageRef: fooRef,
+            state: CheckoutState(revision: revision, version: "1.0.2"),
+            productFilter: .specific(["some", "products"])
         )
         store.pin(packageRef: barRef, state: state, productFilter: products)
         try store.saveState()
@@ -78,9 +78,9 @@ final class PinsStoreTests: XCTestCase {
         // Test branch pin.
         do {
             store.pin(
-              packageRef: barRef,
-              state: CheckoutState(revision: revision, branch: "develop"),
-              productFilter: .specific(["a", "product"])
+                packageRef: barRef,
+                state: CheckoutState(revision: revision, branch: "develop"),
+                productFilter: .specific(["a", "product"])
             )
             try store.saveState()
             store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -32,7 +32,8 @@ final class PinsStoreTests: XCTestCase {
         let barRef = PackageReference(identity: bar, path: barRepo.url)
 
         let state = CheckoutState(revision: revision, version: v1)
-        let pin = PinsStore.Pin(packageRef: fooRef, state: state)
+        let products: ProductFilter = .everything
+        let pin = PinsStore.Pin(packageRef: fooRef, state: state, productFilter: products)
         // We should be able to round trip from JSON.
         XCTAssertEqual(try PinsStore.Pin(json: pin.toJSON()), pin)
 
@@ -43,7 +44,7 @@ final class PinsStoreTests: XCTestCase {
         XCTAssert(!fs.exists(pinsFile))
         XCTAssert(store.pins.map{$0}.isEmpty)
 
-        store.pin(packageRef: fooRef, state: state)
+        store.pin(packageRef: fooRef, state: state, productFilter: products)
         try store.saveState()
 
         XCTAssert(fs.exists(pinsFile))
@@ -62,9 +63,13 @@ final class PinsStoreTests: XCTestCase {
         }
 
         // We should be able to pin again.
-        store.pin(packageRef: fooRef, state: state)
-        store.pin(packageRef: fooRef, state: CheckoutState(revision: revision, version: "1.0.2"))
-        store.pin(packageRef: barRef, state: state)
+        store.pin(packageRef: fooRef, state: state, productFilter: products)
+        store.pin(
+          packageRef: fooRef,
+          state: CheckoutState(revision: revision, version: "1.0.2"),
+          productFilter: .specific(["some", "products"])
+        )
+        store.pin(packageRef: barRef, state: state, productFilter: products)
         try store.saveState()
 
         store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
@@ -72,7 +77,11 @@ final class PinsStoreTests: XCTestCase {
 
         // Test branch pin.
         do {
-            store.pin(packageRef: barRef, state: CheckoutState(revision: revision, branch: "develop"))
+            store.pin(
+              packageRef: barRef,
+              state: CheckoutState(revision: revision, branch: "develop"),
+              productFilter: .specific(["a", "product"])
+            )
             try store.saveState()
             store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
 
@@ -85,7 +94,7 @@ final class PinsStoreTests: XCTestCase {
 
         // Test revision pin.
         do {
-            store.pin(packageRef: barRef, state: CheckoutState(revision: revision))
+            store.pin(packageRef: barRef, state: CheckoutState(revision: revision), productFilter: .specific(["other", "product"]))
             try store.saveState()
             store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
 
@@ -112,8 +121,9 @@ final class PinsStoreTests: XCTestCase {
                         "state": {
                           "branch": null,
                           "revision": "90a9574276f0fd17f02f58979423c3fd4d73b59e",
-                          "version": "1.0.2"
-                        }
+                          "version": "1.0.2",
+                        },
+                        "products": ["a", "b"]
                       },
                       {
                         "package": "Commandant",
@@ -122,7 +132,8 @@ final class PinsStoreTests: XCTestCase {
                           "branch": null,
                           "revision": "c281992c31c3f41c48b5036c5a38185eaec32626",
                           "version": "0.12.0"
-                        }
+                        },
+                        "products": "all"
                       }
                     ]
                   },
@@ -145,7 +156,7 @@ final class PinsStoreTests: XCTestCase {
 
         let fooRef = PackageReference(identity: "foo", path: "/foo")
         let revision = Revision(identifier: "81513c8fd220cf1ed1452b98060cd80d3725c5b7")
-        store.pin(packageRef: fooRef, state: CheckoutState(revision: revision, version: v1))
+        store.pin(packageRef: fooRef, state: CheckoutState(revision: revision, version: v1), productFilter: .specific([]))
 
         XCTAssert(!fs.exists(pinsFile))
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -70,8 +70,8 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let deps: [TestWorkspace.PackageDependency] = [
-            .init(name: "Quix", requirement: .upToNextMajor(from: "1.0.0")),
-            .init(name: "Baz", requirement: .exact("1.0.0")),
+            .init(name: "Quix", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Quix"])),
+            .init(name: "Baz", requirement: .exact("1.0.0"), products: .specific(["Baz"])),
         ]
         workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
@@ -328,11 +328,13 @@ final class WorkspaceTests: XCTestCase {
             .init(
                 url: workspace.packagesDir.appending(component: "Foo").pathString,
                 requirement: .upToNextMajor(from: "1.0.0"),
+                productFilter: .specific(["Foo"]),
                 location: ""
             ),
             .init(
                 url: workspace.packagesDir.appending(component: "Bar").pathString + ".git",
                 requirement: .upToNextMajor(from: "1.0.0"),
+                productFilter: .specific(["Bar"]),
                 location: ""
             ),
         ]
@@ -579,11 +581,13 @@ final class WorkspaceTests: XCTestCase {
             .init(
                 url: workspace.packagesDir.appending(component: "Bar").pathString,
                 requirement: .upToNextMajor(from: "1.0.0"),
+                productFilter: .specific(["Bar"]),
                 location: ""
             ),
             .init(
                 url: "file://\(workspace.packagesDir.appending(component: "Foo").pathString)/",
                 requirement: .upToNextMajor(from: "1.0.0"),
+                productFilter: .specific(["Foo"]),
                 location: ""
             ),
         ]
@@ -653,7 +657,7 @@ final class WorkspaceTests: XCTestCase {
         // Resolve when A = 1.0.0.
         do {
             let deps: [TestWorkspace.PackageDependency] = [
-                .init(name: "A", requirement: .exact("1.0.0"))
+                .init(name: "A", requirement: .exact("1.0.0"), products: .specific(["A"]))
             ]
             workspace.checkPackageGraph(deps: deps) { (graph, diagnostics) in
                 PackageGraphTester(graph) { result in
@@ -676,7 +680,7 @@ final class WorkspaceTests: XCTestCase {
         // Resolve when A = 1.0.1.
         do {
             let deps: [TestWorkspace.PackageDependency] = [
-                .init(name: "A", requirement: .exact("1.0.1"))
+                .init(name: "A", requirement: .exact("1.0.1"), products: .specific(["A"]))
             ]
             workspace.checkPackageGraph(deps: deps) { (graph, diagnostics) in
                 PackageGraphTester(graph) { result in
@@ -747,8 +751,8 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let deps: [TestWorkspace.PackageDependency] = [
-            .init(name: "A", requirement: .exact("1.0.0")),
-            .init(name: "B", requirement: .exact("1.0.0")),
+            .init(name: "A", requirement: .exact("1.0.0"), products: .specific(["A"])),
+            .init(name: "B", requirement: .exact("1.0.0"), products: .specific(["B"])),
         ]
         workspace.checkPackageGraph(deps: deps) { (_, diagnostics) in
             DiagnosticsEngineTester(diagnostics) { result in
@@ -763,8 +767,14 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
-        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
-        let v2 = CheckoutState(revision: Revision(identifier: "hello"), version: "2.0.0")
+        let v1_5 = (
+          version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
+          products: ProductFilter.specific([])
+        )
+        let v2 = (
+          CheckoutState(revision: Revision(identifier: "hello"), version: "2.0.0"),
+          products: ProductFilter.specific([])
+        )
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -787,7 +797,7 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1_5, cRef: v2],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5)
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5.version, productFilter: v1_5.products)
                     .editedDependency(subpath: bPath, unmanagedPath: nil)
             ]
         )
@@ -803,7 +813,10 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
-        let v1 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.0")
+        let v1 = (
+          version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.0"),
+          products: ProductFilter.everything
+        )
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -843,7 +856,7 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1)
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1.version, productFilter: v1.products)
             ]
         )
 
@@ -860,7 +873,10 @@ final class WorkspaceTests: XCTestCase {
         let cPath = RelativePath("C")
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let branchRequirement: TestDependency.Requirement = .branch("master")
-        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
+        let v1_5 = (
+          version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
+          products: ProductFilter.everything
+        )
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -900,8 +916,8 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1_5, cRef: v1_5],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5),
-                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5),
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5.version, productFilter: v1_5.products),
+                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5.version, productFilter: v1_5.products),
             ]
         )
 
@@ -909,7 +925,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.diagnostics.hasErrors, false)
             XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
                 package: cRef,
-                state: .checkout(v1_5),
+                state: .checkout(v1_5.version),
                 requirement: .revision("master")
             )))
         }
@@ -919,7 +935,10 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let cPath = RelativePath("C")
-        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
+        let v1_5 = (
+          version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
+          products: ProductFilter.everything
+        )
 
         let testWorkspace = try TestWorkspace(
             sandbox: sandbox,
@@ -950,7 +969,7 @@ final class WorkspaceTests: XCTestCase {
         try testWorkspace.set(
             pins: [cRef: v1_5],
             managedDependencies: [
-                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5),
+                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5.version, productFilter: v1_5.products),
             ]
         )
 
@@ -958,7 +977,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.diagnostics.hasErrors, false)
             XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
                 package: cRef,
-                state: .checkout(v1_5),
+                state: .checkout(v1_5.version),
                 requirement: .revision("hello")
             )))
         }
@@ -971,7 +990,10 @@ final class WorkspaceTests: XCTestCase {
         let bPath = RelativePath("B")
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let masterRequirement: TestDependency.Requirement = .branch("master")
-        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
+        let v1_5 = (
+          version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
+          products: ProductFilter.everything
+        )
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -1011,8 +1033,8 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1_5],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5),
-                ManagedDependency.local(packageRef: cRef)
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5.version, productFilter: v1_5.products),
+                ManagedDependency.local(packageRef: cRef, productFilter: .specific(["C"]))
             ]
         )
 
@@ -1033,7 +1055,10 @@ final class WorkspaceTests: XCTestCase {
         let cPath = RelativePath("C")
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let localRequirement: TestDependency.Requirement = .localPackage
-        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
+        let v1_5 = (
+          version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
+          products: ProductFilter.everything
+        )
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -1073,8 +1098,8 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1_5, cRef: v1_5],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5),
-                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5),
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5.version, productFilter: v1_5.products),
+                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5.version, productFilter: v1_5.products),
             ]
         )
 
@@ -1082,7 +1107,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.diagnostics.hasErrors, false)
             XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
                 package: cRef,
-                state: .checkout(v1_5),
+                state: .checkout(v1_5.version),
                 requirement: .unversioned
             )))
         }
@@ -1095,8 +1120,14 @@ final class WorkspaceTests: XCTestCase {
         let cPath = RelativePath("C")
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let localRequirement: TestDependency.Requirement = .localPackage
-        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
-        let master = CheckoutState(revision: Revision(identifier: "master"), branch: "master")
+        let v1_5 = (
+          version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
+          products: ProductFilter.everything
+        )
+        let master = (
+          version: CheckoutState(revision: Revision(identifier: "master"), branch: "master"),
+          products: ProductFilter.everything
+        )
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -1136,8 +1167,8 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1_5, cRef: master],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5),
-                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: master),
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5.version, productFilter: v1_5.products),
+                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: master.version, productFilter: master.products),
             ]
         )
 
@@ -1145,7 +1176,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.diagnostics.hasErrors, false)
             XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
                 package: cRef,
-                state: .checkout(master),
+                state: .checkout(master.version),
                 requirement: .unversioned
             )))
         }
@@ -1158,7 +1189,10 @@ final class WorkspaceTests: XCTestCase {
         let cPath = RelativePath("C")
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let v2Requirement: TestDependency.Requirement = .range("2.0.0" ..< "3.0.0")
-        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
+        let v1_5 = (
+          version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
+          products: ProductFilter.everything
+        )
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -1198,8 +1232,8 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1_5, cRef: v1_5],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5),
-                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5),
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5.version, productFilter: v1_5.products),
+                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5.version, productFilter: v1_5.products),
             ]
         )
 
@@ -1216,8 +1250,14 @@ final class WorkspaceTests: XCTestCase {
         let cPath = RelativePath("C")
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let v2Requirement: TestDependency.Requirement = .range("2.0.0" ..< "3.0.0")
-        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
-        let v2 = CheckoutState(revision: Revision(identifier: "hello"), version: "2.0.0")
+        let v1_5 = (
+          version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
+          products: ProductFilter.everything
+        )
+        let v2 = (
+          version: CheckoutState(revision: Revision(identifier: "hello"), version: "2.0.0"),
+          products: ProductFilter.everything
+        )
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -1257,8 +1297,8 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1_5, cRef: v2],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5),
-                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v2),
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5.version, productFilter: v1_5.products),
+                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v2.version, productFilter: v2.products),
             ]
         )
 
@@ -1352,7 +1392,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Do an intial run, capping at Foo at 1.0.0.
         let deps: [TestWorkspace.PackageDependency] = [
-            .init(name: "Foo", requirement: .exact("1.0.0")),
+            .init(name: "Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
@@ -1437,7 +1477,7 @@ final class WorkspaceTests: XCTestCase {
         
         // Do an intial run, capping at Foo at 1.0.0.
         let deps: [TestWorkspace.PackageDependency] = [
-            .init(name: "Foo", requirement: .exact("1.0.0")),
+            .init(name: "Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
         ]
 
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
@@ -1454,8 +1494,12 @@ final class WorkspaceTests: XCTestCase {
         // Run update.
         workspace.checkUpdateDryRun(roots: ["Root"]) { changes, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            let expectedChange = (PackageReference(identity: "foo", path: "/tmp/ws/pkgs/Foo"),
-                Workspace.PackageStateChange.updated(.version(Version("1.5.0"))))
+            let expectedChange = (
+              PackageReference(identity: "foo", path: "/tmp/ws/pkgs/Foo"),
+              Workspace.PackageStateChange.updated(
+                .init(requirement: .version(Version("1.5.0")), products: .specific(["Foo"]))
+              )
+            )
             guard let change = changes?.first, changes?.count == 1 else {
                 XCTFail()
                 return
@@ -1537,7 +1581,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Do an intial run, capping at Foo at 1.0.0.
         let deps: [TestWorkspace.PackageDependency] = [
-            .init(name: "Foo", requirement: .exact("1.0.0")),
+            .init(name: "Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
@@ -1842,7 +1886,7 @@ final class WorkspaceTests: XCTestCase {
 
         // We request Bar via revision.
         let deps: [TestWorkspace.PackageDependency] = [
-            .init(name: "Bar", requirement: .revision(barRevision))
+            .init(name: "Bar", requirement: .revision(barRevision), products: .specific(["Bar"]))
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
@@ -1919,7 +1963,7 @@ final class WorkspaceTests: XCTestCase {
         // Check failure.
         workspace.checkResolve(pkg: "Foo", roots: ["Root"], version: "1.3.0") { diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("Foo 1.3.0"), behavior: .error)
+                result.check(diagnostic: .contains("Foo[Foo] 1.3.0"), behavior: .error)
             }
         }
         workspace.checkManagedDependencies() { result in
@@ -2012,7 +2056,7 @@ final class WorkspaceTests: XCTestCase {
 
         workspace.checkPackageGraph(roots: ["Root"]) { (graph, diagnostics) in
             DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("Foo 1.0.0..<2.0.0"), behavior: .error)
+                result.check(diagnostic: .contains("Foo[Foo] 1.0.0..<2.0.0"), behavior: .error)
             }
         }
     }
@@ -2266,7 +2310,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let deps: [TestWorkspace.PackageDependency] = [
-            .init(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+            .init(name: "Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
         ]
         let ws = workspace.createWorkspace()
 
@@ -2354,7 +2398,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let deps: [TestWorkspace.PackageDependency] = [
-            .init(name: "Foo", requirement: .exact("1.0.0")),
+            .init(name: "Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
         ]
         // Load the graph.
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
@@ -2499,7 +2543,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         let deps: [TestWorkspace.PackageDependency] = [
-            .init(name: "Foo", requirement: .localPackage),
+            .init(name: "Foo", requirement: .localPackage, products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
@@ -2658,11 +2702,11 @@ final class WorkspaceTests: XCTestCase {
 
         // Try resolving a bad graph.
         let deps: [TestWorkspace.PackageDependency] = [
-            .init(name: "Bar", requirement: .exact("1.1.0")),
+            .init(name: "Bar", requirement: .exact("1.1.0"), products: .specific(["Bar"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
             DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("Bar 1.1.0"), behavior: .error)
+                result.check(diagnostic: .contains("Bar[Bar] 1.1.0"), behavior: .error)
             }
         }
     }
@@ -2848,7 +2892,7 @@ final class WorkspaceTests: XCTestCase {
                 result.check(targets: "Foo")
             }
             DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("Bar {1.0.0..<1.5.0, 1.5.1..<2.0.0} is forbidden"), behavior: .error)
+                result.check(diagnostic: .contains("Bar[Bar] {1.0.0..<1.5.0, 1.5.1..<2.0.0} is forbidden"), behavior: .error)
             }
         }
     }
@@ -2899,7 +2943,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Override with local package and run update.
         let deps: [TestWorkspace.PackageDependency] = [
-            .init(name: "Bar", requirement: .localPackage),
+            .init(name: "Bar", requirement: .localPackage, products: .specific(["Bar"])),
         ]
         workspace.checkUpdate(roots: ["Foo"], deps: deps) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -2952,7 +2996,7 @@ final class WorkspaceTests: XCTestCase {
         // without running swift package update.
 
         var deps: [TestWorkspace.PackageDependency] = [
-            .init(name: "Foo", requirement: .branch("develop"))
+            .init(name: "Foo", requirement: .branch("develop"), products: .specific(["Foo"]))
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
@@ -2966,7 +3010,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         deps = [
-            .init(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+            .init(name: "Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
@@ -2976,7 +3020,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         deps = [
-            .init(name: "Foo", requirement: .branch("develop"))
+            .init(name: "Foo", requirement: .branch("develop"), products: .specific(["Foo"]))
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3021,7 +3065,7 @@ final class WorkspaceTests: XCTestCase {
         // without running swift package update.
 
         var deps: [TestWorkspace.PackageDependency] = [
-            .init(name: "Foo", requirement: .localPackage),
+            .init(name: "Foo", requirement: .localPackage, products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
@@ -3035,7 +3079,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         deps = [
-            .init(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+            .init(name: "Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3045,7 +3089,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         deps = [
-            .init(name: "Foo", requirement: .localPackage),
+            .init(name: "Foo", requirement: .localPackage, products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3101,7 +3145,7 @@ final class WorkspaceTests: XCTestCase {
         // different locations works correctly.
 
         var deps: [TestWorkspace.PackageDependency] = [
-            .init(name: "Foo", requirement: .localPackage),
+            .init(name: "Foo", requirement: .localPackage, products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
             PackageGraphTester(graph) { result in
@@ -3115,7 +3159,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         deps = [
-            .init(name: "Foo2", requirement: .localPackage),
+            .init(name: "Foo2", requirement: .localPackage, products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3171,7 +3215,7 @@ final class WorkspaceTests: XCTestCase {
          // different locations works correctly.
 
          var deps: [TestWorkspace.PackageDependency] = [
-             .init(name: "Foo", requirement: .localPackage),
+             .init(name: "Foo", requirement: .localPackage, products: .specific(["Foo"])),
          ]
          workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
              PackageGraphTester(graph) { result in
@@ -3189,7 +3233,7 @@ final class WorkspaceTests: XCTestCase {
          }
 
          deps = [
-             .init(name: "Nested/Foo", requirement: .localPackage),
+             .init(name: "Nested/Foo", requirement: .localPackage, products: .specific(["Foo"])),
          ]
          workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
              XCTAssertNoDiagnostics(diagnostics)
@@ -3235,7 +3279,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let deps: [TestWorkspace.PackageDependency] = [
-            .init(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+            .init(name: "Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (_, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3346,7 +3390,7 @@ final class WorkspaceTests: XCTestCase {
         try workspace.config.set(mirrorURL: workspace.packagesDir.appending(component: "Baz").pathString, forURL: workspace.packagesDir.appending(component: "Bam").pathString)
 
         let deps: [TestWorkspace.PackageDependency] = [
-            .init(name: "Bam", requirement: .upToNextMajor(from: "1.0.0")),
+            .init(name: "Bam", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Bar"])),
         ]
 
         workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { (graph, diagnostics) in
@@ -3450,7 +3494,7 @@ final class WorkspaceTests: XCTestCase {
          // dependencies.
 
          var deps: [TestWorkspace.PackageDependency] = [
-             .init(name: "Bar", requirement: .exact("1.0.0")),
+             .init(name: "Bar", requirement: .exact("1.0.0"), products: .specific(["Bar"])),
          ]
          workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
              PackageGraphTester(graph) { result in
@@ -3474,7 +3518,7 @@ final class WorkspaceTests: XCTestCase {
          }
 
          deps = [
-             .init(name: "Bar", requirement: .exact("1.1.0")),
+             .init(name: "Bar", requirement: .exact("1.1.0"), products: .specific(["Bar"])),
          ]
          workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
              PackageGraphTester(graph) { result in
@@ -3540,7 +3584,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Load the initial graph.
         let deps: [TestWorkspace.PackageDependency] = [
-            .init(name: "Bar", requirement: .revision("develop")),
+            .init(name: "Bar", requirement: .revision("develop"), products: .specific(["Bar"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { (graph, diagnostics) in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3564,7 +3608,7 @@ final class WorkspaceTests: XCTestCase {
             let revision = try fooRepo.resolveRevision(tag: "1.0.0")
             let newState = CheckoutState(revision: revision, version: "1.0.0")
 
-            pinsStore.pin(packageRef: fooPin.packageRef, state: newState)
+            pinsStore.pin(packageRef: fooPin.packageRef, state: newState, productFilter: .specific(["Foo"]))
             try pinsStore.saveState()
         }
 
@@ -3765,7 +3809,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let deps: [TestWorkspace.PackageDependency] = [
-            .init(name: "bazzz", requirement: .exact("1.0.0")),
+            .init(name: "bazzz", requirement: .exact("1.0.0"), products: .specific(["Baz"])),
         ]
 
         workspace.checkPackageGraph(roots: ["Overridden/bazzz-master"], deps: deps) { (graph, diagnostics) in
@@ -3986,10 +4030,12 @@ final class WorkspaceTests: XCTestCase {
                     name: "Bar",
                     targets: [
                         TestTarget(name: "Bar"),
+                        TestTarget(name: "BarUnused", dependencies: ["Biz"]),
                         TestTarget(name: "BarTests", dependencies: ["TestHelper2"], type: .test),
                     ],
                     products: [
                         TestProduct(name: "Bar", targets: ["Bar"]),
+                        TestProduct(name: "BarUnused", targets: ["BarUnused"])
                     ],
                     dependencies: [
                         TestDependency(name: "TestHelper2", requirement: .upToNextMajor(from: "1.0.0")),
@@ -4144,7 +4190,13 @@ final class WorkspaceTests: XCTestCase {
                 TestPackage(
                     name: "Foo",
                     targets: [
-                        TestTarget(name: "Foo", dependencies: [.product(name: "A1", package: "A"), "B"]),
+                        TestTarget(name: "Foo", dependencies: [
+                          "B",
+                          .product(name: "A1", package: "A"),
+                          .product(name: "A2", package: "A"),
+                          .product(name: "A3", package: "A"),
+                          .product(name: "A4", package: "A"),
+                        ]),
                     ],
                     products: [],
                     dependencies: [
@@ -4215,7 +4267,10 @@ final class WorkspaceTests: XCTestCase {
         let aRef = PackageReference(identity: "a", path: aPath)
         let aRepo = workspace.repoProvider.specifierMap[RepositorySpecifier(url: aPath)]!
         let aRevision = try aRepo.resolveRevision(tag: "1.0.0")
-        let aState = CheckoutState(revision: aRevision, version: "1.0.0")
+        let aState = (
+          version: CheckoutState(revision: aRevision, version: "1.0.0"),
+          products: ProductFilter.everything
+        )
 
         try workspace.set(
             pins: [aRef: aState],
@@ -4461,8 +4516,11 @@ final class WorkspaceTests: XCTestCase {
         let aRef = PackageReference(identity: "a", path: aPath)
         let aRepo = workspace.repoProvider.specifierMap[RepositorySpecifier(url: aPath)]!
         let aRevision = try aRepo.resolveRevision(tag: "1.0.0")
-        let aState = CheckoutState(revision: aRevision, version: "1.0.0")
-        let aDependency = ManagedDependency(packageRef: aRef, subpath: RelativePath("A"), checkoutState: aState)
+        let aState = (
+          version: CheckoutState(revision: aRevision, version: "1.0.0"),
+          products: ProductFilter.everything
+        )
+        let aDependency = ManagedDependency(packageRef: aRef, subpath: RelativePath("A"), checkoutState: aState.version, productFilter: aState.products)
 
         try workspace.set(
             pins: [aRef: aState],

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -768,12 +768,12 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let v1_5 = (
-          version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-          products: ProductFilter.specific([])
+            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
+            products: ProductFilter.specific([])
         )
         let v2 = (
-          CheckoutState(revision: Revision(identifier: "hello"), version: "2.0.0"),
-          products: ProductFilter.specific([])
+            CheckoutState(revision: Revision(identifier: "hello"), version: "2.0.0"),
+            products: ProductFilter.specific([])
         )
 
         let workspace = try TestWorkspace(
@@ -814,8 +814,8 @@ final class WorkspaceTests: XCTestCase {
         let bPath = RelativePath("B")
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let v1 = (
-          version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.0"),
-          products: ProductFilter.everything
+            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.0"),
+            products: ProductFilter.everything
         )
 
         let workspace = try TestWorkspace(
@@ -874,8 +874,8 @@ final class WorkspaceTests: XCTestCase {
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let branchRequirement: TestDependency.Requirement = .branch("master")
         let v1_5 = (
-          version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-          products: ProductFilter.everything
+            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
+            products: ProductFilter.everything
         )
 
         let workspace = try TestWorkspace(
@@ -936,8 +936,8 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
         let cPath = RelativePath("C")
         let v1_5 = (
-          version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-          products: ProductFilter.everything
+            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
+            products: ProductFilter.everything
         )
 
         let testWorkspace = try TestWorkspace(
@@ -991,8 +991,8 @@ final class WorkspaceTests: XCTestCase {
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let masterRequirement: TestDependency.Requirement = .branch("master")
         let v1_5 = (
-          version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-          products: ProductFilter.everything
+            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
+            products: ProductFilter.everything
         )
 
         let workspace = try TestWorkspace(
@@ -1056,8 +1056,8 @@ final class WorkspaceTests: XCTestCase {
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let localRequirement: TestDependency.Requirement = .localPackage
         let v1_5 = (
-          version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-          products: ProductFilter.everything
+            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
+            products: ProductFilter.everything
         )
 
         let workspace = try TestWorkspace(
@@ -1121,12 +1121,12 @@ final class WorkspaceTests: XCTestCase {
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let localRequirement: TestDependency.Requirement = .localPackage
         let v1_5 = (
-          version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-          products: ProductFilter.everything
+            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
+            products: ProductFilter.everything
         )
         let master = (
-          version: CheckoutState(revision: Revision(identifier: "master"), branch: "master"),
-          products: ProductFilter.everything
+            version: CheckoutState(revision: Revision(identifier: "master"), branch: "master"),
+            products: ProductFilter.everything
         )
 
         let workspace = try TestWorkspace(
@@ -1190,8 +1190,8 @@ final class WorkspaceTests: XCTestCase {
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let v2Requirement: TestDependency.Requirement = .range("2.0.0" ..< "3.0.0")
         let v1_5 = (
-          version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-          products: ProductFilter.everything
+            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
+            products: ProductFilter.everything
         )
 
         let workspace = try TestWorkspace(
@@ -1251,12 +1251,12 @@ final class WorkspaceTests: XCTestCase {
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let v2Requirement: TestDependency.Requirement = .range("2.0.0" ..< "3.0.0")
         let v1_5 = (
-          version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-          products: ProductFilter.everything
+            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
+            products: ProductFilter.everything
         )
         let v2 = (
-          version: CheckoutState(revision: Revision(identifier: "hello"), version: "2.0.0"),
-          products: ProductFilter.everything
+            version: CheckoutState(revision: Revision(identifier: "hello"), version: "2.0.0"),
+            products: ProductFilter.everything
         )
 
         let workspace = try TestWorkspace(
@@ -1495,10 +1495,10 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkUpdateDryRun(roots: ["Root"]) { changes, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
             let expectedChange = (
-              PackageReference(identity: "foo", path: "/tmp/ws/pkgs/Foo"),
-              Workspace.PackageStateChange.updated(
-                .init(requirement: .version(Version("1.5.0")), products: .specific(["Foo"]))
-              )
+                PackageReference(identity: "foo", path: "/tmp/ws/pkgs/Foo"),
+                Workspace.PackageStateChange.updated(
+                    .init(requirement: .version(Version("1.5.0")), products: .specific(["Foo"]))
+                )
             )
             guard let change = changes?.first, changes?.count == 1 else {
                 XCTFail()
@@ -4191,11 +4191,11 @@ final class WorkspaceTests: XCTestCase {
                     name: "Foo",
                     targets: [
                         TestTarget(name: "Foo", dependencies: [
-                          "B",
-                          .product(name: "A1", package: "A"),
-                          .product(name: "A2", package: "A"),
-                          .product(name: "A3", package: "A"),
-                          .product(name: "A4", package: "A"),
+                            "B",
+                            .product(name: "A1", package: "A"),
+                            .product(name: "A2", package: "A"),
+                            .product(name: "A3", package: "A"),
+                            .product(name: "A4", package: "A"),
                         ]),
                     ],
                     products: [],
@@ -4268,8 +4268,8 @@ final class WorkspaceTests: XCTestCase {
         let aRepo = workspace.repoProvider.specifierMap[RepositorySpecifier(url: aPath)]!
         let aRevision = try aRepo.resolveRevision(tag: "1.0.0")
         let aState = (
-          version: CheckoutState(revision: aRevision, version: "1.0.0"),
-          products: ProductFilter.everything
+            version: CheckoutState(revision: aRevision, version: "1.0.0"),
+            products: ProductFilter.everything
         )
 
         try workspace.set(
@@ -4517,8 +4517,8 @@ final class WorkspaceTests: XCTestCase {
         let aRepo = workspace.repoProvider.specifierMap[RepositorySpecifier(url: aPath)]!
         let aRevision = try aRepo.resolveRevision(tag: "1.0.0")
         let aState = (
-          version: CheckoutState(revision: aRevision, version: "1.0.0"),
-          products: ProductFilter.everything
+            version: CheckoutState(revision: aRevision, version: "1.0.0"),
+            products: ProductFilter.everything
         )
         let aDependency = ManagedDependency(packageRef: aRef, subpath: RelativePath("A"), checkoutState: aState.version, productFilter: aState.products)
 

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -86,7 +86,7 @@ class PIFBuilderTests: XCTestCase {
             let targetAExeDependencies = pif.workspace.projects[0].targets[0].dependencies
             XCTAssertEqual(targetAExeDependencies.map{ $0.targetGUID }, ["PACKAGE-PRODUCT:blib", "PACKAGE-TARGET:A2", "PACKAGE-TARGET:A3"])
             let projectBTargetNames = pif.workspace.projects[1].targets.map({ $0.name })
-            XCTAssertEqual(projectBTargetNames, ["bexe", "blib", "B2"])
+            XCTAssertEqual(projectBTargetNames, ["blib", "B2"])
         }
     }
 
@@ -388,6 +388,7 @@ class PIFBuilderTests: XCTestCase {
                             "SystemLib",
                             "cfoo",
                             .product(name: "bar", package: "Bar"),
+                            .product(name: "cbar", package: "Bar")
                         ]),
                         .init(name: "cfoo"),
                         .init(name: "SystemLib", type: .system, pkgConfig: "Foo"),
@@ -438,6 +439,7 @@ class PIFBuilderTests: XCTestCase {
                         "PACKAGE-PRODUCT:cfoo",
                         "PACKAGE-PRODUCT:bar",
                         "PACKAGE-PRODUCT:BarLib",
+                        "PACKAGE-PRODUCT:cbar",
                         "PACKAGE-TARGET:FooLib",
                         "PACKAGE-TARGET:SystemLib"
                     ])
@@ -445,6 +447,7 @@ class PIFBuilderTests: XCTestCase {
                     XCTAssertEqual(target.frameworks, [
                         "PACKAGE-TARGET:FooLib",
                         "PACKAGE-PRODUCT:BarLib",
+                        "PACKAGE-PRODUCT:cbar",
                         "PACKAGE-PRODUCT:bar",
                     ])
 


### PR DESCRIPTION
This pull request should complete the implementation of [SE‐0226: Package Manager Target Based Dependency Resolution](https://github.com/apple/swift-evolution/blob/master/proposals/0226-package-manager-target-based-dep-resolution.md). @hartbit already taught the resolver to only care about products in #2424. This takes that work further so that the resolver only cares about products that are actually used.

This pull request is sizeable, so I’ll elaborate the main points here.

The changes broadly fall into four groups:

1. The manifest is now able to compute the downward‐facing products required for any upward‐facing product set. This is [mostly housed in `PackageModel/Manifest.swift`](https://github.com/apple/swift-package-manager/blob/4f434c0f5405e45033c36bcfb389c798ac0dd004/Sources/PackageModel/Manifest.swift#L171-L394), and boils down to turning @hartbit’s `allRequiredDependencies` into [`dependenciesRequired(for:)`](https://github.com/apple/swift-package-manager/blob/4f434c0f5405e45033c36bcfb389c798ac0dd004/Sources/PackageModel/Manifest.swift#L191-L202), along with the input type [`ProductFilter`](https://github.com/apple/swift-package-manager/blob/4f434c0f5405e45033c36bcfb389c798ac0dd004/Sources/PackageModel/Manifest.swift#L651-L737).

2. The resolver now operates on abstract nodes. See [`DependencyResolutionNode`](https://github.com/apple/swift-package-manager/blob/4f434c0f5405e45033c36bcfb389c798ac0dd004/Sources/PackageGraph/DependencyResolver.swift#L228-L264) for the nitty‐gritty details. Essentially, it resolves individual products instead of whole packages. The new node type has simply been slotted in to replace the `PackageReference`s that were in use before. None of @kiliankoe’s Pubgrub decision making processes has been changed in any way. The diagnostics have also been left alone except for the inclusion of the specific product alongside the package name where relevant.

3. Dozens of new method parameters and instance properties have been added to various types and methods in order to pass the new information along from where it originates to where it is needed. Unfortunately, this affects a whole swath of things across the `PackageModel`, `PackageLoading`, `PackageGraph`, `Workspace`, `Commands` and `SPMTestSupport` modules, but all of these changes are straightforward.

4. Many tests required fixing. Most of them merely needed to provide the new parameters required in order to satisfy the new API. Several were expecting failures that were no longer reachable, and needed dependencies to be made explicit so that the resolver would even enter the code branch in question. All but three are straightforward. (See below.)

***

While I was working through the tests, three things came up which need a closer look. They are tests that expected behaviour at least partially at odds with [SE‐0226](https://github.com/apple/swift-evolution/blob/master/proposals/0226-package-manager-target-based-dep-resolution.md).

1. The test suite [expected unreachable executable products to be available](https://github.com/apple/swift-package-manager/blob/4f434c0f5405e45033c36bcfb389c798ac0dd004/Tests/CommandsTests/BuildToolTests.swift#L169-L194). `swift run dependency‐executable` is apparently supposed to work, even if no dependency is declared on that product. I can see how that could be useful, and it wouldn’t surprise me if users are taking advantage of it in their workflows. But SE‐0226 says this:

    > Another example of packages requiring additional dependencies is for sample code targets. A library package may want to create an executable target which demonstrates some functionality of the library. This executable may require other dependencies such as a command-line argument parser.

    So including such executables would undermine one of the motivating use cases for SE‐0226. As such, what I have implemented right now does not resolve such executables by default.

    However, as a compromise to maintain backwards compatibility, I have channeled the argument provided to any `swift run` invocation through to the resolver, so that if you explicitly ask to run an executable of an immediate dependency, you will still be able to. Since it has some minor drawbacks, I consider this an interim solution. This implementation will suffice for now, but a separate evolution proposal should probably be made to design something better if we want to continue supporting this long‐term. See [the Fix‐Me in the initializer for `PackageGraphRoot`](https://github.com/apple/swift-package-manager/blob/4f434c0f5405e45033c36bcfb389c798ac0dd004/Sources/PackageGraph/PackageGraphRoot.swift#L108-L119) for more details.

2. The test suite [expected unreachable targets to be available to a `swift build --target dependency‐target` invocation](https://github.com/apple/swift-package-manager/blob/ae19f036c4ff45d6a8799db1daf29ebc90f18134/Tests/CommandsTests/BuildToolTests.swift#L196-L214). Since there is no infrastructure in the resolver to handle targets, there is no easy way to locate or load such a target. Since it seems backwards to SE‐0226 and has no practical use I can think of, I simply removed the test.

3. The test suite [expected legacy system packages to work without an explicit target dependency declaration](https://github.com/apple/swift-package-manager/blob/ae19f036c4ff45d6a8799db1daf29ebc90f18134/Tests/FunctionalTests/ModuleMapTests.swift#L53-L71). Such packages have been triggering a deprecation warning since Swift 4.2. Continuing to support them implicitly is problematic, because there is no way to know if that’s what a package is until after fetching and loading it, so it would defeat the whole of SE‐0226.

    As a compromise to maintain as much backwards compatibility as possible, I have [taught the manifest loader to internally convert such a package](https://github.com/apple/swift-package-manager/blob/4f434c0f5405e45033c36bcfb389c798ac0dd004/Sources/PackageLoading/ManifestLoader.swift#L269-L286) into a modern‐style one with a system _target_ and product, which inherit the package’s name and details. This allows the current toolchain to still use such dependencies by referencing the synthesized product. However, if the client package wants to support both old and new toolchains at once (such as 5.1 and 5.4), it will have to make use of `#if compiler`, because the old toolchain will be unable to locate the declared product, whereas the new toolchain will not resolve an undeclared product.