### PR TITLE
[Build plan] Use the provided file system consistently 

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -689,8 +689,13 @@ public final class SwiftTargetBuildDescription {
         result.append("-output-file-map")
         // FIXME: Eliminate side effect.
         result.append(try! writeOutputFileMap().pathString)
-        if target.type == .library || target.type == .test {
+
+        switch target.type {
+        case .library, .test:
             result.append("-parse-as-library")
+
+        case .executable, .systemModule, .binary:
+            do { }
         }
 
         if buildParameters.useWholeModuleOptimization {
@@ -702,9 +707,7 @@ public final class SwiftTargetBuildDescription {
         }
 
         result.append("-c")
-        for source in target.sources.paths {
-            result.append(source.pathString)
-        }
+        result.append(contentsOf: target.sources.paths.map { $0.pathString })
 
         result.append("-I")
         result.append(buildParameters.buildPath.pathString)

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -693,7 +693,7 @@ public final class SwiftTargetBuildDescription {
             result.append("-parse-as-library")
         }
 
-        if (buildParameters.configuration == .release) {
+        if buildParameters.useWholeModuleOptimization {
             result.append("-whole-module-optimization")
             result.append("-num-threads")
             result.append(String(ProcessInfo.processInfo.activeProcessorCount))
@@ -821,11 +821,16 @@ public final class SwiftTargetBuildDescription {
         stream <<< "{\n"
 
         let masterDepsPath = tempsPath.appending(component: "master.swiftdeps")
+        stream <<< "  \"\": {\n"
+        if buildParameters.useWholeModuleOptimization {
+            let moduleName = target.c99name
+            stream <<< "    \"dependencies\": \"" <<< tempsPath.appending(component: moduleName + ".d") <<< "\",\n"
+            // FIXME: Need to record this deps file for processing it later.
+            stream <<< "    \"object\": \"" <<< tempsPath.appending(component: moduleName + ".o") <<< "\",\n"
+        }
+        stream <<< "    \"swift-dependencies\": \"" <<< masterDepsPath.pathString <<< "\"\n"
 
-        stream <<< "  \"\": {\n";
-        // FIXME: Handle WMO
-        stream <<< "    \"swift-dependencies\": \"" <<< masterDepsPath.pathString <<< "\"\n";
-        stream <<< "  },\n";
+        stream <<< "  },\n"
 
         // Write out the entries for each source file.
         let sources = target.sources.paths
@@ -834,19 +839,22 @@ public final class SwiftTargetBuildDescription {
             let objectDir = object.parentDirectory
 
             let sourceFileName = source.basenameWithoutExt
-            let partialModulePath = objectDir.appending(component: sourceFileName + "~partial.swiftmodule")
 
             let swiftDepsPath = objectDir.appending(component: sourceFileName + ".swiftdeps")
 
             stream <<< "  \"" <<< source.pathString <<< "\": {\n"
-            // FIXME: Handle WMO
-            let depsPath = objectDir.appending(component: sourceFileName + ".d")
-            stream <<< "    \"dependencies\": \"" <<< depsPath.pathString <<< "\",\n"
-            // FIXME: Need to record this deps file for processing it later.
+
+            if (!buildParameters.useWholeModuleOptimization) {
+                let depsPath = objectDir.appending(component: sourceFileName + ".d")
+                stream <<< "    \"dependencies\": \"" <<< depsPath.pathString <<< "\",\n"
+                // FIXME: Need to record this deps file for processing it later.
+            }
 
             stream <<< "    \"object\": \"" <<< object.pathString <<< "\",\n"
-            stream <<< "    \"swiftmodule\": \"" <<< partialModulePath.pathString <<< "\",\n";
-            stream <<< "    \"swift-dependencies\": \"" <<< swiftDepsPath.pathString <<< "\"\n";
+
+            let partialModulePath = objectDir.appending(component: sourceFileName + "~partial.swiftmodule")
+            stream <<< "    \"swiftmodule\": \"" <<< partialModulePath.pathString <<< "\",\n"
+            stream <<< "    \"swift-dependencies\": \"" <<< swiftDepsPath.pathString <<< "\"\n"
             stream <<< "  }" <<< ((idx + 1) < sources.count ? "," : "") <<< "\n"
         }
 

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -863,8 +863,8 @@ public final class SwiftTargetBuildDescription {
 
         stream <<< "}\n"
 
-        try localFileSystem.createDirectory(path.parentDirectory, recursive: true)
-        try localFileSystem.writeFileContents(path, bytes: stream.bytes)
+        try fs.createDirectory(path.parentDirectory, recursive: true)
+        try fs.writeFileContents(path, bytes: stream.bytes)
         return path
     }
 

--- a/Sources/Build/ManifestBuilder.swift
+++ b/Sources/Build/ManifestBuilder.swift
@@ -232,7 +232,7 @@ extension LLBuildManifestBuilder {
                 let description: String
                 switch job.kind {
                 case .compile:
-                    description = "Compiling \(moduleName) \(job.displayInputs.first!.file.name)"
+                    description = "Compiling \(moduleName) \(job.displayInputs.first?.file.name ?? "")"
 
                 case .mergeModule:
                     description = "Merging module \(moduleName)"

--- a/Sources/Build/ManifestBuilder.swift
+++ b/Sources/Build/ManifestBuilder.swift
@@ -17,7 +17,7 @@ import PackageModel
 import PackageGraph
 import SPMBuildCore
 
-import SwiftDriver
+@_implementationOnly import SwiftDriver
 
 public class LLBuildManifestBuilder {
     public enum TargetKind {
@@ -200,9 +200,9 @@ extension LLBuildManifestBuilder {
         do {
             // Use the integrated Swift driver to compute the set of frontend
             // jobs needed to build this Swift target.
-            var driver = try Driver(args: target.emitCommandLine())
+            var driver = try Driver(args: target.emitCommandLine(), fileSystem: target.fs)
             let jobs = try driver.planBuild()
-            let resolver = try ArgsResolver()
+            let resolver = try ArgsResolver(fileSystem: target.fs)
 
             for job in jobs {
                 // Figure out which tool we are using.

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -258,3 +258,17 @@ private struct _Toolchain: Encodable {
         try container.encode(toolchain.swiftCompiler, forKey: .swiftCompiler)
     }
 }
+
+extension BuildParameters {
+    /// Whether to build Swift code with whole module optimization (WMO)
+    /// enabled.
+    public var useWholeModuleOptimization: Bool {
+        switch configuration {
+        case .debug:
+            return false
+
+        case .release:
+            return true
+        }
+    }
+}

--- a/swift-tools-support-core/Sources/TSCBasic/FileSystem.swift
+++ b/swift-tools-support-core/Sources/TSCBasic/FileSystem.swift
@@ -238,7 +238,7 @@ public extension FileSystem {
     }
 
     func getFileInfo(_ path: AbsolutePath) throws -> FileInfo {
-        fatalError("This file system currently doesn't support this method")
+        throw FileSystemError.unsupported
     }
 }
 
@@ -578,7 +578,7 @@ public class InMemoryFileSystem: FileSystem {
     }
 
     public func changeCurrentWorkingDirectory(to path: AbsolutePath) throws {
-        fatalError("Unsupported")
+        throw FileSystemError.unsupported
     }
 
     public var homeDirectory: AbsolutePath {
@@ -812,7 +812,7 @@ public class RerootedFileSystemView: FileSystem {
     }
 
     public func changeCurrentWorkingDirectory(to path: AbsolutePath) throws {
-        fatalError("Unsupported")
+        throw FileSystemError.unsupported
     }
 
     public var homeDirectory: AbsolutePath {


### PR DESCRIPTION
When writing an output file map and using the integrated Swift
driver, use the provided file system rather than the local file
system.