### PR TITLE
[Swift driver] Process the parseable output from Swift frontend jobs.

### DIFF
--- a/Sources/Build/BuildDelegate.swift
+++ b/Sources/Build/BuildDelegate.swift
@@ -192,8 +192,6 @@ public struct BuildDescription: Codable {
         testDiscoveryCommands: [BuildManifest.CmdName: LLBuildManifest.TestDiscoveryTool],
         copyCommands: [BuildManifest.CmdName: LLBuildManifest.CopyTool]
     ) {
-        let buildConfig = plan.buildParameters.configuration.dirname
-
         self.swiftCommands = swiftCommands
         self.testDiscoveryCommands = testDiscoveryCommands
         self.copyCommands = copyCommands

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -236,6 +236,7 @@ extension BuildDescription {
         try llbuild.generateManifest(at: plan.buildParameters.llbuildManifest)
 
         let swiftCommands = llbuild.manifest.getCmdToolMap(kind: SwiftCompilerTool.self)
+        let swiftFrontendCommands = llbuild.manifest.getCmdToolMap(kind: SwiftFrontendTool.self)
         let testDiscoveryCommands = llbuild.manifest.getCmdToolMap(kind: TestDiscoveryTool.self)
         let copyCommands = llbuild.manifest.getCmdToolMap(kind: CopyTool.self)
 
@@ -243,6 +244,7 @@ extension BuildDescription {
         let buildDescription = BuildDescription(
             plan: plan,
             swiftCommands: swiftCommands,
+            swiftFrontendCommands: swiftFrontendCommands,
             testDiscoveryCommands: testDiscoveryCommands,
             copyCommands: copyCommands
         )

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -235,12 +235,14 @@ extension BuildDescription {
         let llbuild = LLBuildManifestBuilder(plan)
         try llbuild.generateManifest(at: plan.buildParameters.llbuildManifest)
 
+        let swiftCommands = llbuild.manifest.getCmdToolMap(kind: SwiftCompilerTool.self)
         let testDiscoveryCommands = llbuild.manifest.getCmdToolMap(kind: TestDiscoveryTool.self)
         let copyCommands = llbuild.manifest.getCmdToolMap(kind: CopyTool.self)
 
         // Create the build description.
         let buildDescription = BuildDescription(
             plan: plan,
+            swiftCommands: swiftCommands,
             testDiscoveryCommands: testDiscoveryCommands,
             copyCommands: copyCommands
         )

--- a/Sources/LLBuildManifest/BuildManifest.swift
+++ b/Sources/LLBuildManifest/BuildManifest.swift
@@ -108,6 +108,24 @@ public struct BuildManifest {
         commands[name] = Command(name: name, tool: tool)
     }
 
+    public mutating func addSwiftFrontendCmd(
+        name: String,
+        moduleName: String,
+        description: String,
+        inputs: [Node],
+        outputs: [Node],
+        args: [String]
+    ) {
+        let tool = SwiftFrontendTool(
+                moduleName: moduleName,
+                description: description,
+                inputs: inputs,
+                outputs: outputs,
+                args: args
+        )
+        commands[name] = Command(name: name, tool: tool)
+    }
+
     public mutating func addClangCmd(
         name: String,
         description: String,

--- a/Sources/LLBuildManifest/Tools.swift
+++ b/Sources/LLBuildManifest/Tools.swift
@@ -166,6 +166,36 @@ public struct ArchiveTool: ToolProtocol {
     }
 }
 
+/// Swift frontend tool, which maps down to a shell tool.
+struct SwiftFrontendTool: ToolProtocol {
+    static let name: String = "shell"
+
+    let moduleName: String
+    var description: String
+    var inputs: [Node]
+    var outputs: [Node]
+    var args: [String]
+
+    init(
+        moduleName: String,
+        description: String,
+        inputs: [Node],
+        outputs: [Node],
+        args: [String]
+    ) {
+        self.moduleName = moduleName
+        self.description = description
+        self.inputs = inputs
+        self.outputs = outputs
+        self.args = args
+    }
+
+    public func write(to stream: ManifestToolStream) {
+      ShellTool(description: description, inputs: inputs, outputs: outputs, args: args)
+        .write(to: stream)
+    }
+}
+
 /// Swift compiler llbuild tool.
 public struct SwiftCompilerTool: ToolProtocol {
     public static let name: String = "swift-compiler"

--- a/Sources/LLBuildManifest/Tools.swift
+++ b/Sources/LLBuildManifest/Tools.swift
@@ -167,14 +167,14 @@ public struct ArchiveTool: ToolProtocol {
 }
 
 /// Swift frontend tool, which maps down to a shell tool.
-struct SwiftFrontendTool: ToolProtocol {
-    static let name: String = "shell"
+public struct SwiftFrontendTool: ToolProtocol {
+    public static let name: String = "shell"
 
-    let moduleName: String
-    var description: String
-    var inputs: [Node]
-    var outputs: [Node]
-    var args: [String]
+    public let moduleName: String
+    public var description: String
+    public var inputs: [Node]
+    public var outputs: [Node]
+    public var args: [String]
 
     init(
         moduleName: String,


### PR DESCRIPTION
Create Swift compiler output parser instances for Swift frontend jobs,
too. This provides better feedback for (e.g.) batch mode, where there
are multiple source files processed in a single frontend invocation,
and also helps line up the "Compiling" output from SwiftPM between
the integrated and non-integrated Swift drivers.