### PR TITLE
[5.3] [Workspace] Update wording in template for Swift Packages

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -174,7 +174,7 @@ public final class InitPackage {
             if packageType == .library || packageType == .manifest {
                 pkgParams.append("""
                     products: [
-                        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+                        // Products define the executables and libraries a package produces, and make them visible to other packages.
                         .library(
                             name: "\(pkgname)",
                             targets: ["\(pkgname)"]),
@@ -193,7 +193,7 @@ public final class InitPackage {
                 pkgParams.append("""
                     targets: [
                         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-                        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+                        // Targets can depend on other targets in this package, and on products in packages this package depends on.
                         .target(
                             name: "\(pkgname)",
                             dependencies: []),


### PR DESCRIPTION
Minor tweaks to the wording of newly instantiated packages.

This is the 5.3 merge of the already approved master commit with the same content.

rdar://63120125

(cherry picked from commit 4221fdcea2b20e26c78085f0a795c9bc17461e53)