### PR TITLE
[Integrated Swift driver] Minor fixes to get a clean test run

### DIFF
--- a/Sources/Build/ManifestBuilder.swift
+++ b/Sources/Build/ManifestBuilder.swift
@@ -282,7 +282,7 @@ extension LLBuildManifestBuilder {
                         name: jobOutputs.first!.name,
                         moduleName: moduleName,
                         description: description,
-                        inputs: inputs + jobInputs,
+                        inputs: (inputs + jobInputs).uniqued(),
                         outputs: jobOutputs,
                         args: arguments
                     )
@@ -290,7 +290,7 @@ extension LLBuildManifestBuilder {
                     manifest.addShellCmd(
                         name: jobOutputs.first!.name,
                         description: description,
-                        inputs: inputs + jobInputs,
+                        inputs: (inputs + jobInputs).uniqued(),
                         outputs: jobOutputs,
                         args: arguments
                     )
@@ -724,5 +724,13 @@ extension TypedVirtualPath {
         case .standardInput, .standardOutput:
             fatalError("Cannot handle standard input or output")
         }
+    }
+}
+
+extension Sequence where Element: Hashable {
+    /// Unique the elements in a sequence.
+    func uniqued() -> [Element] {
+        var seen: Set<Element> = []
+        return filter { seen.insert($0).inserted }
     }
 }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -232,8 +232,6 @@ final class BuildPlanTests: XCTestCase {
                 try llbuild.generateManifest(at: yaml)
                 let contents = try localFileSystem.readFileContents(yaml).description
                 XCTAssertMatch(contents, .contains("""
-                      "C.exe-release.module":
-                        tool: swift-compiler
                         inputs: ["/Pkg/Sources/exe/main.swift","/path/to/build/release/PkgLib.swiftmodule"]
                     """))
             }
@@ -260,8 +258,6 @@ final class BuildPlanTests: XCTestCase {
                 try llbuild.generateManifest(at: yaml)
                 let contents = try localFileSystem.readFileContents(yaml).description
                 XCTAssertMatch(contents, .contains("""
-                      "C.exe-debug.module":
-                        tool: swift-compiler
                         inputs: ["/Pkg/Sources/exe/main.swift"]
                     """))
             }
@@ -1895,7 +1891,7 @@ final class BuildPlanTests: XCTestCase {
             let contents = try localFileSystem.readFileContents(yaml).description
             XCTAssertTrue(contents.contains("""
                     inputs: ["/PkgA/Sources/swiftlib/lib.swift","/path/to/build/debug/exe"]
-                    outputs: ["/path/to/build/debug/swiftlib.build/lib.swift.o","/path/to/build/debug/swiftlib.swiftmodule"]
+                    outputs: ["/path/to/build/debug/swiftlib.build/lib.swift.o","/path/to/build/debug/
                 """), contents)
         }
     }
@@ -2136,7 +2132,8 @@ final class BuildPlanTests: XCTestCase {
                     outputs: ["/path/to/build/debug/exe.build/exe.swiftmodule.o"]
                     description: "Wrapping AST for exe for debugging"
                     args: ["/fake/path/to/swiftc","-modulewrap","/path/to/build/debug/exe.swiftmodule","-o","/path/to/build/debug/exe.build/exe.swiftmodule.o","-target","x86_64-unknown-linux-gnu"]
-
+                """))
+            XCTAssertMatch(contents, .contains("""
                   "/path/to/build/debug/lib.build/lib.swiftmodule.o":
                     tool: shell
                     inputs: ["/path/to/build/debug/lib.swiftmodule"]


### PR DESCRIPTION
A few minor fixes for issues uncovered when enabling the integrated Swift driver as the default:
* Unique the set of job inputs; only the tests seem to care, but it's the right thing to do anyway
* Loosen a few string-based output checks to account for benign differences between the integrated and traditional Swift driver
