### PR TITLE
Fix search for the Swift compiler on Windows

### DIFF
--- a/swift-tools-support-core/Sources/TSCBasic/Path.swift
+++ b/swift-tools-support-core/Sources/TSCBasic/Path.swift
@@ -397,6 +397,12 @@ private struct UNIXPath: Path {
         return name != "" && name != "." && name != ".." && !name.contains("/")
     }
 
+#if os(Windows)
+    static func isAbsolutePath(_ path: String) -> Bool {
+        return !path.withCString(encodedAs: UTF16.self, PathIsRelativeW)
+    }
+#endif
+
     var dirname: String {
 #if os(Windows)
         let dir = string.deletingLastPathComponent
@@ -421,7 +427,11 @@ private struct UNIXPath: Path {
     }
 
     var isAbsolute: Bool {
-        string.hasPrefix("/")
+#if os(Windows)
+        return UNIXPath.isAbsolutePath(string)
+#else
+        return string.hasPrefix("/")
+#endif
     }
 
     var basename: String {
@@ -608,7 +618,7 @@ private struct UNIXPath: Path {
         defer { fsr.deallocate() }
 
         let realpath = String(cString: fsr)
-        if realpath.withCString(encodedAs: UTF16.self, PathIsRelativeW) {
+        if !UNIXPath.isAbsolutePath(realpath) {
             throw PathValidationError.invalidAbsolutePath(path)
         }
         self.init(normalizingAbsolutePath: path)
@@ -630,7 +640,7 @@ private struct UNIXPath: Path {
         defer { fsr.deallocate() }
 
         let realpath: String = String(cString: fsr)
-        if !realpath.withCString(encodedAs: UTF16.self, PathIsRelativeW) {
+        if UNIXPath.isAbsolutePath(realpath) {
             throw PathValidationError.invalidRelativePath(path)
         }
         self.init(normalizingRelativePath: path)

--- a/swift-tools-support-core/Sources/TSCBasic/misc.swift
+++ b/swift-tools-support-core/Sources/TSCBasic/misc.swift
@@ -49,15 +49,10 @@ public func getEnvSearchPaths(
 ) -> [AbsolutePath] {
     // Compute search paths from PATH variable.
     return (pathString ?? "").split(separator: ":").map(String.init).compactMap({ pathString in
-        // If this is an absolute path, we're done.
-        if pathString.first == "/" {
-            return AbsolutePath(pathString)
+        if let cwd = currentWorkingDirectory {
+            return AbsolutePath(pathString, relativeTo: cwd)
         }
-        // Otherwise convert it into absolute path relative to the working directory.
-        guard let cwd = currentWorkingDirectory else {
-            return nil
-        }
-        return AbsolutePath(pathString, relativeTo: cwd)
+        return try? AbsolutePath(validating: pathString)
     })
 }
 

--- a/swift-tools-support-core/Sources/TSCLibc/libc.swift
+++ b/swift-tools-support-core/Sources/TSCLibc/libc.swift
@@ -20,19 +20,72 @@
 @_exported import TSCclibc
 
 #if os(Windows)
+private extension String {
+  func withCStringW<Result>(_ body: (UnsafePointer<wchar_t>, Int) throws -> Result) rethrows -> Result {
+    return try withCString(encodedAs: UTF16.self) {
+      let capacity: Int = wcslen($0) + 1
+      return try $0.withMemoryRebound(to: wchar_t.self, capacity: capacity) {
+        try body($0, capacity)
+      }
+    }
+  }
+}
+
+private extension UnsafeMutablePointer where Pointee == CChar {
+  func assign(from source: UnsafePointer<wchar_t>) {
+    String(decodingCString: source, as: UTF16.self).utf8CString.withUnsafeBytes {
+      assign(from: $0.bindMemory(to: CChar.self).baseAddress!,
+             count: $0.count)
+    }
+  }
+}
+
 // char *realpath(const char *path, char *resolved_path);
 public func realpath(
     _ path: String,
     _ resolvedPath: UnsafeMutablePointer<CChar>?
 ) -> UnsafeMutablePointer<CChar>? {
-  fatalError("realpath is unimplemented")
+  let result: UnsafeMutablePointer<CChar>
+  if let resolvedPath = resolvedPath {
+    result = resolvedPath
+  } else {
+    result = UnsafeMutablePointer<CChar>.allocate(capacity: Int(MAX_PATH))
+  }
+  return String(cString: result).withCStringW { resultW, capacity in
+    return path.withCStringW { pathW, _ in
+      guard _wfullpath(UnsafeMutablePointer(mutating: resultW), pathW, capacity) != nil else {
+        return nil
+      }
+      result.assign(from: resultW)
+      return result
+    }
+  }
 }
 
 // char *mkdtemp(char *template);
 public func mkdtemp(
     _ template: UnsafeMutablePointer<CChar>?
 ) -> UnsafeMutablePointer<CChar>? {
-  fatalError("mkdtemp is unimplemented")
+  guard let template = template else { return nil }
+
+  func createDirectory() -> UnsafeMutablePointer<CChar>? {
+    let path = String(String(cString: template).dropLast(6) +
+               String(Int.random(in: 1..<1000000)))
+    return path.withCStringW { pathW, _ in
+      guard CreateDirectoryW(pathW, nil) else {
+        return nil
+      }
+      template.assign(from: pathW)
+      return template
+    }
+  }
+
+  var result: UnsafeMutablePointer<CChar>?
+  repeat {
+    result = createDirectory()
+  } while result == nil && Int32(GetLastError()) == ERROR_ALREADY_EXISTS
+
+  return result
 }
 
 // int mkstemps(char *template, int suffixlen);
@@ -41,23 +94,17 @@ public func mkstemps(
     _ suffixlen: Int32
 ) -> Int32 {
   guard let template = template else { return -EINVAL }
-  return String(cString: template).withCString(encodedAs: UTF16.self) {
-    let capacity: Int = wcslen($0) + 1
-    return $0.withMemoryRebound(to: wchar_t.self, capacity: capacity) {
-      guard _wmktemp_s(UnsafeMutablePointer(mutating: $0), capacity) == 0 else {
-        return -EINVAL
-      }
-
-      var fd: Int32 = -1
-      _wsopen_s(&fd, $0, _O_RDWR | _O_CREAT | _O_BINARY | _O_NOINHERIT,
-                _SH_DENYNO, _S_IREAD | _S_IWRITE)
-
-      String(decodingCString: $0, as: UTF16.self).utf8CString.withUnsafeBytes {
-        template.assign(from: $0.bindMemory(to: CChar.self).baseAddress!,
-                        count: $0.count)
-      }
-      return fd
+  return String(cString: template).withCStringW { templateW, capacity in
+    guard _wmktemp_s(UnsafeMutablePointer(mutating: templateW), capacity) == 0 else {
+      return -EINVAL
     }
+
+    var fd: Int32 = -1
+    _wsopen_s(&fd, templateW, _O_RDWR | _O_CREAT | _O_BINARY | _O_NOINHERIT,
+              _SH_DENYNO, _S_IREAD | _S_IWRITE)
+
+    template.assign(from: templateW)
+    return fd
   }
 }
 #endif


### PR DESCRIPTION
Since the `Path.isAbsolute` implementation isn't valid for Windows paths, SwiftPM tries to find the Swift compiler in paths like this:
```
C:/Users/User/Documents/C:/Library/Developer/Toolchains/custom-development.xctoolchain/usr/bin/swiftc.exe
```
while the actual path is:
```
C:/Library/Developer/Toolchains/custom-development.xctoolchain/usr/bin/swiftc.exe
```

After this change SwiftPM can successfully find `swiftc.exe` on Windows, create a temporary directory for the artifacts and run the compiler (which currently results in an unrelated error).