### PR TITLE
Check if swiftc exists at path in bootstrap

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -203,7 +203,9 @@ def get_swiftc_path(args):
     if os.path.basename(swiftc_path) == 'swift':
         swiftc_path = swiftc_path + 'c'
 
-    return swiftc_path
+    if os.path.exists(swiftc_path):
+        return swiftc_path
+    error("unable to find swiftc at %s" % swiftc_path)
 
 def get_clang_path(args):
     """Returns the path to the Clang compiler."""


### PR DESCRIPTION
Currently, when the `bootstrap` script is given an invalid `swiftc` path, its error message is unhelpful:

```
--- bootstrap: error: [Errno 2] No such file or directory
```

The `boostrap` script should clarify which exact file it was looking for and at what path. With this change a check for `swiftc` path is added, which is consistent with an existing path check in `get_llbuild_source_path`. Now the error message specifies the exact path it was looking for:

```
--- bootstrap: error: unable to find swiftc at
/home/builder/source/host-toolchain-sdk/swift-wasm-DEVELOPMENT-SNAPSHOT-2020-05-18-a/usr/bin/swiftc
```