### PR TITLE
Handle new Job.Kind.backend enum case from swift-driver

### DIFF
--- a/Sources/Build/ManifestBuilder.swift
+++ b/Sources/Build/ManifestBuilder.swift
@@ -212,7 +212,7 @@ extension LLBuildManifestBuilder {
                 switch job.kind {
                 case .compile, .mergeModule, .emitModule, .generatePCH,
                     .generatePCM, .interpret, .repl, .printTargetInfo,
-                    .versionRequest:
+                    .versionRequest, .backend:
                     datool = buildParameters.toolchain.swiftCompiler.pathString
                     isSwiftFrontend = true
 
@@ -275,6 +275,9 @@ extension LLBuildManifestBuilder {
 
                 case .help:
                     description = "Swift help"
+
+                case .backend:
+                  description = "Embedding bitcode for \(moduleName)"
                 }
 
                 if isSwiftFrontend {


### PR DESCRIPTION
The new enum case was added to handle `-embed-bitcode` in https://github.com/apple/swift-driver/pull/101 , this PR handles it in a couple switches to fix a compile error.
