### PR TITLE
Update `swift-tools-version` in newly created packages to 5.3.

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -14,7 +14,7 @@ import PackageModel
 /// Create an initial template package.
 public final class InitPackage {
     /// The tool version to be used for new packages.
-    public static let newPackageToolsVersion = ToolsVersion(version: "5.2.0")
+    public static let newPackageToolsVersion = ToolsVersion(version: "5.3.0")
 
     /// Options for the template package.
     public struct InitPackageOptions {


### PR DESCRIPTION
This only affects `swift init`, not existing packages.

The existing unit test `testInitManifest` checks that the manifest of the instantiated package has the updated version number.

rdar://63365232