### PR TITLE
Fix docker-utils

### DIFF
--- a/Utilities/Docker/docker-utils
+++ b/Utilities/Docker/docker-utils
@@ -31,6 +31,8 @@ def docker_run(command_args):
     """Runs a command in the container."""
     swiftpm_dir = os.path.normpath(os.path.join(script_dir, '../..'))
     llbuild_dir = os.path.normpath(os.path.join(swiftpm_dir, '../llbuild'))
+    swift_driver_dir = os.path.normpath(os.path.join(swiftpm_dir, '../swift-driver'))
+    yams_dir = os.path.normpath(os.path.join(swiftpm_dir, '../yams'))
     call([
         "docker",
         "run",
@@ -38,6 +40,8 @@ def docker_run(command_args):
         "--security-opt", "seccomp=unconfined",
         "-v", "%s:/swiftpm" % swiftpm_dir,
         "-v", "%s:/llbuild" % llbuild_dir,
+        "-v", "%s:/swift-driver" % swift_driver_dir,
+        "-v", "%s:/yams" % yams_dir,
         "-w", "/swiftpm",
         "--rm",
         "swiftpm-docker-1804"

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -468,10 +468,11 @@ def build_yams(args):
         cmake_flags.append("-DCMAKE_C_FLAGS=-target x86_64-apple-macosx%s" % g_macos_deployment_target)
         cmake_flags.append("-DCMAKE_OSX_DEPLOYMENT_TARGET=%s" % g_macos_deployment_target)
     else:
-        cmake_flags += [
-            get_dispatch_cmake_arg(args),
-            get_foundation_cmake_arg(args),
-        ]
+        if args.dispatch_build_dir:
+            cmake_flags.append(get_dispatch_cmake_arg(args))
+
+        if args.foundation_build_dir:
+            cmake_flags.append(get_foundation_cmake_arg(args))
 
     build_with_cmake(args, cmake_flags, args.yams_source_dir, args.yams_build_dir)
 


### PR DESCRIPTION
- paths to swift-driver and yams were missing
- the dispatch and foundation dir arguments became mandatory on
non-macOS, this makes them optional again