### PR TITLE
Adding support for generating library product schemes

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -609,6 +609,13 @@ public class SwiftPackageTool: SwiftTool<PackageToolOptions> {
             subparser: PackageMode.generateXcodeproj.rawValue,
             overview: "Generates an Xcode project")
         binder.bind(
+            option: generateXcodeParser.add(
+                option: "--enable-library-schemes", kind: Bool.self,
+                usage: "Enables creation of schemes for library products"),
+            to: {
+                $0.xcodeprojOptions.isLibrarySchemeGenerationEnabled = $1
+            })
+        binder.bind(
             generateXcodeParser.add(
                 option: "--xcconfig-overrides", kind: PathArgument.self,
                 usage: "Path to xcconfig file"),

--- a/Sources/Xcodeproj/generate.swift
+++ b/Sources/Xcodeproj/generate.swift
@@ -26,6 +26,9 @@ public struct XcodeprojOptions {
 
     /// Whether code coverage should be enabled in the generated scheme.
     public var isCodeCoverageEnabled: Bool
+    
+    /// Whether library products are included while generating schemes.
+    public var isLibrarySchemeGenerationEnabled: Bool
 
     /// Whether to use legacy scheme generation logic.
     public var useLegacySchemeGenerator: Bool
@@ -43,6 +46,7 @@ public struct XcodeprojOptions {
         flags: BuildFlags = BuildFlags(),
         xcconfigOverrides: AbsolutePath? = nil,
         isCodeCoverageEnabled: Bool? = nil,
+        isLibrarySchemeGenerationEnabled: Bool? = nil,
         useLegacySchemeGenerator: Bool? = nil,
         enableAutogeneration: Bool? = nil,
         addExtraFiles: Bool? = nil
@@ -50,6 +54,7 @@ public struct XcodeprojOptions {
         self.flags = flags
         self.xcconfigOverrides = xcconfigOverrides
         self.isCodeCoverageEnabled = isCodeCoverageEnabled ?? false
+        self.isLibrarySchemeGenerationEnabled = isLibrarySchemeGenerationEnabled ?? false
         self.useLegacySchemeGenerator = useLegacySchemeGenerator ?? false
         self.enableAutogeneration = enableAutogeneration ?? false
         self.addExtraFiles = addExtraFiles ?? true
@@ -259,6 +264,7 @@ func generateSchemes(
             container: schemeContainer,
             schemesDir: schemesDir,
             isCodeCoverageEnabled: options.isCodeCoverageEnabled,
+            isLibrarySchemeGenerationEnabled: options.isLibrarySchemeGenerationEnabled,
             fs: localFileSystem
         ).generate()
     }

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -368,6 +368,7 @@ class PackageGraphTests: XCTestCase {
             container: "Foo.xcodeproj",
             schemesDir: AbsolutePath("/Foo.xcodeproj/xcshareddata/xcschemes"),
             isCodeCoverageEnabled: true,
+            isLibrarySchemeGenerationEnabled: false,
             fs: fs).buildSchemes()
 
         let schemes = Dictionary(uniqueKeysWithValues: generatedSchemes.map({ ($0.name, $0) }))
@@ -382,6 +383,28 @@ class PackageGraphTests: XCTestCase {
 
         XCTAssertEqual(schemes["Foo-Package"]?.testTargets.map({ $0.name }).sorted(), ["aTests", "bcTests", "dTests", "libdTests"])
         XCTAssertEqual(schemes["Foo-Package"]?.regularTargets.map({ $0.name }).sorted(), ["a", "b", "c", "d", "libd"])
+        
+        let generatedSchemesWithLibrariesEnabled = SchemesGenerator(
+            graph: graph,
+            container: "Foo.xcodeproj",
+            schemesDir: AbsolutePath("/Foo.xcodeproj/xcshareddata/xcschemes"),
+            isCodeCoverageEnabled: true,
+            isLibrarySchemeGenerationEnabled: true,
+            fs: fs).buildSchemes()
+
+        let schemesWithLibrariesEnabled = Dictionary(uniqueKeysWithValues: generatedSchemesWithLibrariesEnabled.map({ ($0.name, $0) }))
+
+        XCTAssertEqual(generatedSchemesWithLibrariesEnabled.count, 6)
+        XCTAssertEqual(schemesWithLibrariesEnabled["a"]?.testTargets.map({ $0.name }).sorted(), ["aTests"])
+        XCTAssertEqual(schemesWithLibrariesEnabled["a"]?.regularTargets.map({ $0.name }).sorted(), ["a"])
+
+        XCTAssertEqual(schemesWithLibrariesEnabled["b"]?.testTargets.map({ $0.name }).sorted(), ["aTests", "bcTests"])
+        XCTAssertEqual(schemesWithLibrariesEnabled["c"]?.testTargets.map({ $0.name }).sorted(), ["aTests", "bcTests"])
+        XCTAssertEqual(schemesWithLibrariesEnabled["d"]?.testTargets.map({ $0.name }).sorted(), ["aTests", "bcTests", "dTests"])
+        XCTAssertEqual(schemesWithLibrariesEnabled["libd"]?.regularTargets.map({ $0.name }).sorted(), ["libd"])
+        XCTAssertEqual(schemesWithLibrariesEnabled["libd"]?.testTargets.map({ $0.name }).sorted(), ["aTests", "bcTests", "dTests", "libdTests"])
+        XCTAssertEqual(schemesWithLibrariesEnabled["Foo-Package"]?.testTargets.map({ $0.name }).sorted(), ["aTests", "bcTests", "dTests", "libdTests"])
+        XCTAssertEqual(schemesWithLibrariesEnabled["Foo-Package"]?.regularTargets.map({ $0.name }).sorted(), ["a", "b", "c", "d", "libd"])
     }
 
     func testSwiftVersion() throws {


### PR DESCRIPTION
# Generating Library Product Schemes

This pull request adds a `swift package generate-xcodeproj` option `--enable-library-schemes` that will allow creation of schemes for library products during the scheme generation step of generating an Xcode project.

## Motivation

I'm very excited to see binary dependency support was added to swift package manager!  Once that is released, certain swift packages maintainers may want to start providing xcframework assets when they release their swift packages so that consumers can integrate with swift package manager's brand new feature.  

This pull request aims to add more options to scheme generation while generating an Xcode project, so that it is easier to use `xcodebuild` to create xcframeworks from swift packages.

## Use Case
The following is a common CI workflow that I can see some package maintainers desiring for their package repos: 

##### Build Trigger: Push a new release or beta Tag to a git repo
##### Build Steps:
1. Clone the package's repo
2. `swift package generate-xcodeproj`
3. Use `xcodebuild` to Archive your project using several destinations to get an archived framework for each apple SDK your Package supports.

<details>

Example using iOS and watchOS + Simulators:
```
xcodebuild archive -project "$PROJECT_NAME.xcodeproj" -scheme "$FRAMEWORK_NAME" 
            -destination "generic/platform=iOS" 
            -archivePath "archives/$PROJECT_NAME-iOS" 
            SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES   
```
```
xcodebuild archive -project "$PROJECT_NAME.xcodeproj" -scheme "$FRAMEWORK_NAME" 
            -destination "generic/platform=iOS Simulator" 
            -archivePath "archives/$PROJECT_NAME-iOS Simulator" 
            SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES   
```
```
xcodebuild archive -project "$PROJECT_NAME.xcodeproj" -scheme "$FRAMEWORK_NAME" 
            -destination "generic/platform=watchOS" 
            -archivePath "archives/$PROJECT_NAME-watchOS" 
            SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES   
```
```
xcodebuild archive -project "$PROJECT_NAME.xcodeproj" -scheme "$FRAMEWORK_NAME" 
            -destination "generic/platform=watchOS Simulator" 
            -archivePath "archives/$PROJECT_NAME-watchOS Simulator" 
            SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES   
```

</details>

4. Use `xcodebuild` to Combine the Frameworks from the previous step into an xcframework
5. Create a GitHub release for the new Tag
6. Attach the xcframework binary asset to the new GitHub release

## What's the Problem?

During scheme generation (in step 2 above), the current expected schemes generated are:

- [One scheme for each executable target](https://github.com/apple/swift-package-manager/blob/a3e6d241abd1008aed7107363dd7a968246484ae/Sources/Xcodeproj/SchemesGenerator.swift#L68)
- [One master scheme for the entire package](https://github.com/apple/swift-package-manager/blob/a3e6d241abd1008aed7107363dd7a968246484ae/Sources/Xcodeproj/SchemesGenerator.swift#L79) (the one suffixed with `-Package`)

**Notice that there will be no schemes generated for library product targets.**

This sounds reasonable at first glance, but it's a very common practice within the swift command line tooling community to split the source for your tool into multiples modules — pushing the majority of your code into one or several frameworks and then having a thin executable client that wraps your frameworks.  

A few examples of tools that I believe do this are [SwiftLint](https://github.com/realm/SwiftLint/blob/master/Package.swift), [Carthage](https://github.com/Carthage/Carthage/blob/master/Package.swift), [SwiftFormat](https://github.com/nicklockwood/SwiftFormat/blob/master/Package.swift), [swift-format](https://github.com/apple/swift-format/blob/master/Package.swift), and [Publish](https://github.com/JohnSundell/Publish).

Quoting [John Sundell in his article about creating command line tools](https://www.swiftbysundell.com/articles/building-a-command-line-tool-using-the-swift-package-manager/), there are good reasons for doing this:

- *This will make testing a lot easier, and will also (and this is really cool) enable your command line tool to also be used as a dependency in other tools.*

#### The problem I'm hoping to fix arises during archiving (step 3 above).  If you:
- Use swift package manager to generate the Xcode project for your package
- Your package contains an executable product alongside library products

**Expected Result: There should be a scheme that was created during Xcode project generation that will allow me to build the library products in preparation for creating an xcframework.**

**Actual Result: There will be no generated scheme that will build the library products in preparation for creating an xcframework.  You have to manually create a scheme to use.**

## What Other Changeless Options Are There?

1. Archive using the executable scheme or the master scheme.  That won't work since both of these schemes include the executable product.

<details>

If a user tries to archive their executable or master scheme against iOS, watchOS, or tvOS, they receive the following expected errors:

```
❌  error: unable to resolve product type 'com.apple.product-type.tool' for platform 'iphoneos' (in target 'MyProj' from project 'MyProj')
```
```
❌  error: unable to resolve product type 'com.apple.product-type.tool' for platform 'watchos' (in target 'MyProj' from project 'MyProj')
```
```
❌  error: unable to resolve product type 'com.apple.product-type.tool' for platform 'tvos' (in target 'MyProj' from project 'MyProj')
```
</details>

2. Commit your Xcode project along with manually created schemes for each library product you want to be able to archive.
<details>Generating your Xcode project means you will never have a project.pbxproj merge conflict, which is a **huge** benefit of using swift package manager!  It would be better if swift package manager could generate the library product schemes for us, so that we don't have to add an Xcode project or any schemes to version control.
</details>

3. Try to find an xcodebuild archive command that can archive a target without a scheme (use `-target` instead of `-scheme`).  

<details>

I don't think this will work either.  The man page for xcodebuild states that a scheme is requirement of archiving.

`archive                Archive a scheme from the build root (SYMROOT).  This requires specifying a scheme.`

</details>

## Proposed Solution

I kept backwards compatibility in mind for this change, to ensure that we don't affect the way that scheme generator is currently handled.  

#### Acceptance Criteria:
- Running: `swift package generate-xcodeproj` produces the same exact schemes as it did before this change.
- Running: `swift package generate-xcodeproj --enable-library-schemes` will add additional schemes for any library products.  
- Any new library product schemes generated using the `--enable-library-schemes` option will also contain test targets.

## Alternative Solutions Considered

#### Enable Library Product scheme generation by default
 
- I think this would be a sensible alternative.  Since I'm still relatively new here to contributing here I opted for the safer route of keeping default scheme generation as-is and adding the new behavior as an option that you have to enable.  If the community feels that this alternative is a better direction, I am happy to update this PR to this instead.
