### PR TITLE
[Xcode] Fix missing escapes for spaces in HEADER_SEARCH_PATHS

### DIFF
--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -501,7 +501,7 @@ public func xcodeProject(
             // See: <rdar://problem/21912068> SourceKit cannot handle relative include paths (working directory)
             switch depModule.underlyingTarget {
               case let systemTarget as SystemLibraryTarget:
-                hdrInclPaths.append("$(SRCROOT)/\(systemTarget.path.relative(to: sourceRootDir).pathString)")
+                hdrInclPaths.append("\"$(SRCROOT)/\(systemTarget.path.relative(to: sourceRootDir).pathString)\"")
                 if let pkgArgs = pkgConfigArgs(for: systemTarget, diagnostics: diagnostics) {
                     targetSettings.common.OTHER_LDFLAGS += pkgArgs.libs
                     targetSettings.common.OTHER_SWIFT_FLAGS += pkgArgs.cFlags
@@ -671,7 +671,7 @@ public func xcodeProject(
                 // Workaround for a interface generation bug. <rdar://problem/30071677>
                 if moduleMap.isGenerated {
                     xcodeTarget.buildSettings.common.HEADER_SEARCH_PATHS += [
-                        "$(SRCROOT)/\(moduleMap.path.parentDirectory.relative(to: sourceRootDir).pathString)"
+                        "\"$(SRCROOT)/\(moduleMap.path.parentDirectory.relative(to: sourceRootDir).pathString)\""
                     ]
                 }
             }
@@ -817,11 +817,11 @@ func appendSetting(
     case .HEADER_SEARCH_PATHS:
         switch config {
         case .debug?:
-            table.debug.HEADER_SEARCH_PATHS += value
+            table.debug.HEADER_SEARCH_PATHS += "\"\(value)\""
         case .release?:
-            table.release.HEADER_SEARCH_PATHS += value
+            table.release.HEADER_SEARCH_PATHS += "\"\(value)\""
         case nil:
-            table.common.HEADER_SEARCH_PATHS += value
+            table.common.HEADER_SEARCH_PATHS += "\"\(value)\""
         }
     case .OTHER_CFLAGS:
         switch config {


### PR DESCRIPTION
[HEADER_SEARCH_PATHS](https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html#//apple_ref/doc/uid/TP40003931-CH3-SW86) is a space-separated list meaning each plist string inside the plist array
may provide multiple values by using space as a separator: ("value1", "value2 value3").

To avoid separation either the space must be escaped ("value2\\\\ value3") or whole string
must be quoted: ("\\"value2 value3\\""). Since this treatment happens at Xcode-level and not plist-level
it cannot be fixed inside the PropertyList enum.

SR-1754: Spaces should be escaped in HEADER_SEARCH_PATHS