### PR TITLE
[Xcodeproj] Quote space-separated build settings when necessary.

### DIFF
--- a/Tests/XcodeprojTests/XcodeProjectModelSerializationTests.swift
+++ b/Tests/XcodeprojTests/XcodeProjectModelSerializationTests.swift
@@ -142,6 +142,33 @@ class XcodeProjectModelSerializationTests: XCTestCase {
         XCTAssertEqual(activeCompilationConditions, activeCompilationConditionsValues)
     }
 
+    func testSpaceSeparatedBuildSettingsSerialization() {
+        var buildSettings = Xcode.BuildSettingsTable.BuildSettings()
+        buildSettings.HEADER_SEARCH_PATHS = ["value", "value with spaces", "\"value with spaces\"", #"value\ with\ spaces"#]
+
+        let plist = buildSettings.asPropertyList()
+
+        guard case let .dictionary(buildSettingsDict) = plist else {
+            XCTFail("build settings plist must be a dictionary")
+            return
+        }
+
+        guard case let .array(headerSearchPathsArray) = buildSettingsDict["HEADER_SEARCH_PATHS"] else {
+            XCTFail("header search paths plist must be an array")
+            return
+        }
+
+        let headerSearchPaths = headerSearchPathsArray.compactMap { pathPlist -> String? in
+            guard case let .string(path) = pathPlist else {
+                XCTFail("headerSearchPaths plist must be a string")
+                return nil
+            }
+            return path
+        }
+
+        XCTAssertEqual(headerSearchPaths, ["value", "\"value with spaces\"", "\"value with spaces\"", #"value\ with\ spaces"#])
+    }
+
     func testBuildFileSettingsSerialization() {
 
         // Create build file settings.


### PR DESCRIPTION
SR-1754: Spaces should be escaped in HEADER_SEARCH_PATHS