### PR TITLE
[Build] Add support for content-based file tracking

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -103,6 +103,9 @@ public class ToolOptions {
     /// Extra arguments to pass when using xcbuild.
     public var xcbuildFlags: [String] = []
 
+    /// Track content hash instead of stat info for incremental builds.
+    public var experimentalTrackContentHash: Bool = false
+
     public required init() {}
 }
 

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -458,6 +458,10 @@ public class SwiftTool<Options: ToolOptions> {
             option: parser.add(option: "--build-system", kind: BuildSystemKind.self, usage: nil),
             to: { $0.buildSystem = $1 })
 
+        binder.bind(
+            option: parser.add(option: "--experimental-track-content-hash", kind: Bool.self, usage: nil),
+            to: { $0.experimentalTrackContentHash = $1 })
+
         // Let subclasses bind arguments.
         type(of: self).defineArguments(parser: parser, binder: binder)
 
@@ -796,7 +800,8 @@ public class SwiftTool<Options: ToolOptions> {
                 enableTestDiscovery: options.enableTestDiscovery,
                 emitSwiftModuleSeparately: options.emitSwiftModuleSeparately,
                 useIntegratedSwiftDriver: options.useIntegratedSwiftDriver,
-                isXcodeBuildSystemEnabled: options.buildSystem == .xcode
+                isXcodeBuildSystemEnabled: options.buildSystem == .xcode,
+                trackContentHash: options.experimentalTrackContentHash
             )
         })
     }()

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -116,6 +116,9 @@ public struct BuildParameters: Encodable {
     /// Extra arguments to pass when using xcbuild.
     public var xcbuildFlags: [String]
 
+    /// Track content hash instead of stat info for incremental builds.
+    public var trackContentHash: Bool
+
     public init(
         dataPath: AbsolutePath,
         configuration: BuildConfiguration,
@@ -135,7 +138,8 @@ public struct BuildParameters: Encodable {
         enableTestDiscovery: Bool = false,
         emitSwiftModuleSeparately: Bool = false,
         useIntegratedSwiftDriver: Bool = false,
-        isXcodeBuildSystemEnabled: Bool = false
+        isXcodeBuildSystemEnabled: Bool = false,
+        trackContentHash: Bool = false
     ) {
         self.dataPath = dataPath
         self.configuration = configuration
@@ -156,6 +160,7 @@ public struct BuildParameters: Encodable {
         self.emitSwiftModuleSeparately = emitSwiftModuleSeparately
         self.useIntegratedSwiftDriver = useIntegratedSwiftDriver
         self.isXcodeBuildSystemEnabled = isXcodeBuildSystemEnabled
+        self.trackContentHash = trackContentHash
     }
 
     /// The path to the build directory (inside the data directory).


### PR DESCRIPTION
This adds experimental support for content-based file tracking behind
`--experimental-track-content-hash` flag. This is currently implemented
by mangling the file hash into some of the stat fields used by llbuild
but we can move to the proper API once it's available. This feels a bit
awkward but it allows us to immediately start experimenting this
approach on Swift packages.