### PR TITLE
Pass -output-dir to swift-symbolgraph-extract instead of -o, which was removed

### DIFF
--- a/Sources/Commands/SymbolGraphExtract.swift
+++ b/Sources/Commands/SymbolGraphExtract.swift
@@ -46,7 +46,7 @@ public struct SymbolGraphExtract {
             args += buildPlan.createAPIDigesterArgs()
             args += ["-module-cache-path", buildParameters.moduleCache.pathString]
 
-            args += ["-o", symbolGraphDirectory.appending(components: target.name + ".json").pathString]
+            args += ["-output-dir", symbolGraphDirectory.pathString]
 
             print("-- Emitting symbol graph for", target.name)
             try runTool(args)


### PR DESCRIPTION
This is also broken on the 5.3 branch, not sure if it's too late to cherry-pick