### PR TITLE
Improve FileSystemError by adding associated path

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -611,7 +611,7 @@ private class GitFileSystemView: FileSystem {
             currentPath = currentPath.appending(component: component)
             // We have a component to resolve, so the current entry must be a tree.
             guard current.type == .tree else {
-                throw FileSystemError.notDirectory(currentPath)
+                throw FileSystemError(.notDirectory, currentPath)
             }
 
             // Fetch the tree.
@@ -700,10 +700,10 @@ private class GitFileSystemView: FileSystem {
 
     func getDirectoryContents(_ path: AbsolutePath) throws -> [String] {
         guard let entry = try getEntry(path) else {
-            throw FileSystemError.noEntry(path)
+            throw FileSystemError(.noEntry, path)
         }
         guard entry.type == .tree else {
-            throw FileSystemError.notDirectory(path)
+            throw FileSystemError(.notDirectory, path)
         }
 
         return try getTree(entry.hash).contents.map({ $0.name })
@@ -711,10 +711,10 @@ private class GitFileSystemView: FileSystem {
 
     func readFileContents(_ path: AbsolutePath) throws -> ByteString {
         guard let entry = try getEntry(path) else {
-            throw FileSystemError.noEntry(path)
+            throw FileSystemError(.noEntry, path)
         }
         guard entry.type != .tree else {
-            throw FileSystemError.isDirectory(path)
+            throw FileSystemError(.isDirectory, path)
         }
         guard entry.type != .symlink else {
             fatalError("FIXME: not implemented")
@@ -729,23 +729,23 @@ private class GitFileSystemView: FileSystem {
     }
 
     func createDirectory(_ path: AbsolutePath) throws {
-        throw FileSystemError.unsupported(path)
+        throw FileSystemError(.unsupported, path)
     }
 
     func createDirectory(_ path: AbsolutePath, recursive: Bool) throws {
-        throw FileSystemError.unsupported(path)
+        throw FileSystemError(.unsupported, path)
     }
 
     func writeFileContents(_ path: AbsolutePath, bytes: ByteString) throws {
-        throw FileSystemError.unsupported(path)
+        throw FileSystemError(.unsupported, path)
     }
 
     func removeFileTree(_ path: AbsolutePath) throws {
-        throw FileSystemError.unsupported(path)
+        throw FileSystemError(.unsupported, path)
     }
 
     func chmod(_ mode: FileMode, path: AbsolutePath, options: Set<FileMode.Option>) throws {
-        throw FileSystemError.unsupported(path)
+        throw FileSystemError(.unsupported, path)
     }
 
     func copy(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -603,13 +603,15 @@ private class GitFileSystemView: FileSystem {
         // Walk the components resolving the tree (starting with a synthetic
         // root entry).
         var current: Tree.Entry = Tree.Entry(hash: root, type: .tree, name: "/")
+        var currentPath = AbsolutePath.root
         for component in path.components.dropFirst(1) {
             // Skip the root pseudo-component.
             if component == "/" { continue }
 
+            currentPath = currentPath.appending(component: component)
             // We have a component to resolve, so the current entry must be a tree.
             guard current.type == .tree else {
-                throw FileSystemError.notDirectory
+                throw FileSystemError.notDirectory(currentPath)
             }
 
             // Fetch the tree.
@@ -698,10 +700,10 @@ private class GitFileSystemView: FileSystem {
 
     func getDirectoryContents(_ path: AbsolutePath) throws -> [String] {
         guard let entry = try getEntry(path) else {
-            throw FileSystemError.noEntry
+            throw FileSystemError.noEntry(path)
         }
         guard entry.type == .tree else {
-            throw FileSystemError.notDirectory
+            throw FileSystemError.notDirectory(path)
         }
 
         return try getTree(entry.hash).contents.map({ $0.name })
@@ -709,10 +711,10 @@ private class GitFileSystemView: FileSystem {
 
     func readFileContents(_ path: AbsolutePath) throws -> ByteString {
         guard let entry = try getEntry(path) else {
-            throw FileSystemError.noEntry
+            throw FileSystemError.noEntry(path)
         }
         guard entry.type != .tree else {
-            throw FileSystemError.isDirectory
+            throw FileSystemError.isDirectory(path)
         }
         guard entry.type != .symlink else {
             fatalError("FIXME: not implemented")
@@ -727,23 +729,23 @@ private class GitFileSystemView: FileSystem {
     }
 
     func createDirectory(_ path: AbsolutePath) throws {
-        throw FileSystemError.unsupported
+        throw FileSystemError.unsupported(path)
     }
 
     func createDirectory(_ path: AbsolutePath, recursive: Bool) throws {
-        throw FileSystemError.unsupported
+        throw FileSystemError.unsupported(path)
     }
 
     func writeFileContents(_ path: AbsolutePath, bytes: ByteString) throws {
-        throw FileSystemError.unsupported
+        throw FileSystemError.unsupported(path)
     }
 
     func removeFileTree(_ path: AbsolutePath) throws {
-        throw FileSystemError.unsupported
+        throw FileSystemError.unsupported(path)
     }
 
     func chmod(_ mode: FileMode, path: AbsolutePath, options: Set<FileMode.Option>) throws {
-        throw FileSystemError.unsupported
+        throw FileSystemError.unsupported(path)
     }
 
     func copy(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -211,33 +211,33 @@ class GitRepositoryTests: XCTestCase {
             let subdirPath = AbsolutePath("/subdir")
             XCTAssertEqual(try view.getDirectoryContents(AbsolutePath("/")).sorted(), ["file.swift", "subdir", "test-file-1.txt", "test-file-3.sh"])
             XCTAssertEqual(try view.getDirectoryContents(subdirPath).sorted(), ["test-file-2.txt"])
-            XCTAssertThrows(FileSystemError.isDirectory(subdirPath)) {
+            XCTAssertThrows(FileSystemError(.isDirectory, subdirPath)) {
                 _ = try view.readFileContents(subdirPath)
             }
 
             // Check read versus root.
             let rootPath = AbsolutePath("/")
-            XCTAssertThrows(FileSystemError.isDirectory(rootPath)) {
+            XCTAssertThrows(FileSystemError(.isDirectory, rootPath)) {
                 _ = try view.readFileContents(rootPath)
             }
 
             // Check read through a non-directory.
             let notDirectoryPath1 = AbsolutePath("/test-file-1.txt")
-            XCTAssertThrows(FileSystemError.notDirectory(notDirectoryPath1)) {
+            XCTAssertThrows(FileSystemError(.notDirectory, notDirectoryPath1)) {
                 _ = try view.getDirectoryContents(notDirectoryPath1)
             }
             let notDirectoryPath2 = AbsolutePath("/test-file-1.txt/thing")
-            XCTAssertThrows(FileSystemError.notDirectory(notDirectoryPath2)) {
+            XCTAssertThrows(FileSystemError(.notDirectory, notDirectoryPath2)) {
                 _ = try view.readFileContents(notDirectoryPath2)
             }
 
             // Check read/write into a missing directory.
             let noEntryPath1 = AbsolutePath("/does-not-exist")
-            XCTAssertThrows(FileSystemError.noEntry(noEntryPath1)) {
+            XCTAssertThrows(FileSystemError(.noEntry, noEntryPath1)) {
                 _ = try view.getDirectoryContents(noEntryPath1)
             }
             let noEntryPath2 = AbsolutePath("/does/not/exist")
-            XCTAssertThrows(FileSystemError.noEntry(noEntryPath2)) {
+            XCTAssertThrows(FileSystemError(.noEntry, noEntryPath2)) {
                 _ = try view.readFileContents(noEntryPath2)
             }
 

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -208,31 +208,37 @@ class GitRepositoryTests: XCTestCase {
             XCTAssert(view.isExecutableFile(AbsolutePath("/test-file-3.sh")))
 
             // Check read of a directory.
+            let subdirPath = AbsolutePath("/subdir")
             XCTAssertEqual(try view.getDirectoryContents(AbsolutePath("/")).sorted(), ["file.swift", "subdir", "test-file-1.txt", "test-file-3.sh"])
-            XCTAssertEqual(try view.getDirectoryContents(AbsolutePath("/subdir")).sorted(), ["test-file-2.txt"])
-            XCTAssertThrows(FileSystemError.isDirectory) {
-                _ = try view.readFileContents(AbsolutePath("/subdir"))
+            XCTAssertEqual(try view.getDirectoryContents(subdirPath).sorted(), ["test-file-2.txt"])
+            XCTAssertThrows(FileSystemError.isDirectory(subdirPath)) {
+                _ = try view.readFileContents(subdirPath)
             }
 
             // Check read versus root.
-            XCTAssertThrows(FileSystemError.isDirectory) {
-                _ = try view.readFileContents(AbsolutePath("/"))
+            let rootPath = AbsolutePath("/")
+            XCTAssertThrows(FileSystemError.isDirectory(rootPath)) {
+                _ = try view.readFileContents(rootPath)
             }
 
             // Check read through a non-directory.
-            XCTAssertThrows(FileSystemError.notDirectory) {
-                _ = try view.getDirectoryContents(AbsolutePath("/test-file-1.txt"))
+            let notDirectoryPath1 = AbsolutePath("/test-file-1.txt")
+            XCTAssertThrows(FileSystemError.notDirectory(notDirectoryPath1)) {
+                _ = try view.getDirectoryContents(notDirectoryPath1)
             }
-            XCTAssertThrows(FileSystemError.notDirectory) {
-                _ = try view.readFileContents(AbsolutePath("/test-file-1.txt/thing"))
+            let notDirectoryPath2 = AbsolutePath("/test-file-1.txt/thing")
+            XCTAssertThrows(FileSystemError.notDirectory(notDirectoryPath2)) {
+                _ = try view.readFileContents(notDirectoryPath2)
             }
 
             // Check read/write into a missing directory.
-            XCTAssertThrows(FileSystemError.noEntry) {
-                _ = try view.getDirectoryContents(AbsolutePath("/does-not-exist"))
+            let noEntryPath1 = AbsolutePath("/does-not-exist")
+            XCTAssertThrows(FileSystemError.noEntry(noEntryPath1)) {
+                _ = try view.getDirectoryContents(noEntryPath1)
             }
-            XCTAssertThrows(FileSystemError.noEntry) {
-                _ = try view.readFileContents(AbsolutePath("/does/not/exist"))
+            let noEntryPath2 = AbsolutePath("/does/not/exist")
+            XCTAssertThrows(FileSystemError.noEntry(noEntryPath2)) {
+                _ = try view.readFileContents(noEntryPath2)
             }
 
             // Check read of a file.

--- a/swift-tools-support-core/Sources/TSCBasic/Lock.swift
+++ b/swift-tools-support-core/Sources/TSCBasic/Lock.swift
@@ -88,7 +88,7 @@ public final class FileLock {
         if fileDescriptor == nil {
             let fd = TSCLibc.open(lockFile.pathString, O_WRONLY | O_CREAT | O_CLOEXEC, 0o666)
             if fd == -1 {
-                throw FileSystemError(errno: errno)
+                throw FileSystemError(errno: errno, lockFile)
             }
             self.fileDescriptor = fd
         }

--- a/swift-tools-support-core/Sources/TSCBasic/OutputByteStream.swift
+++ b/swift-tools-support-core/Sources/TSCBasic/OutputByteStream.swift
@@ -691,15 +691,10 @@ public final class LocalFileOutputByteStream: FileOutputByteStream {
     }
 
     func errorDetected(code: Int32?) {
-        switch (code, path) {
-        case let (code?, path?):
-            error = .ioError(code: code, path)
-        case let (code?, nil):
-            error = .fileDescriptorIOError(code: code)
-        case let (nil, path?):
-            error = .unknownOSError(path)
-        case (nil, nil):
-            error = .unknownFileDescriptorError
+        if let code = code {
+            error = .init(.ioError(code: code), path)
+        } else {
+            error = .init(.unknownOSError, path)
         }
     }
 

--- a/swift-tools-support-core/Sources/TSCUtility/Archiver.swift
+++ b/swift-tools-support-core/Sources/TSCUtility/Archiver.swift
@@ -51,12 +51,12 @@ public struct ZipArchiver: Archiver {
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         guard fileSystem.exists(archivePath) else {
-            completion(.failure(FileSystemError.noEntry(archivePath)))
+            completion(.failure(FileSystemError(.noEntry, archivePath)))
             return
         }
 
         guard fileSystem.isDirectory(destinationPath) else {
-            completion(.failure(FileSystemError.notDirectory(destinationPath)))
+            completion(.failure(FileSystemError(.notDirectory, destinationPath)))
             return
         }
 

--- a/swift-tools-support-core/Sources/TSCUtility/Archiver.swift
+++ b/swift-tools-support-core/Sources/TSCUtility/Archiver.swift
@@ -51,12 +51,12 @@ public struct ZipArchiver: Archiver {
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         guard fileSystem.exists(archivePath) else {
-            completion(.failure(FileSystemError.noEntry))
+            completion(.failure(FileSystemError.noEntry(archivePath)))
             return
         }
 
         guard fileSystem.isDirectory(destinationPath) else {
-            completion(.failure(FileSystemError.notDirectory))
+            completion(.failure(FileSystemError.notDirectory(destinationPath)))
             return
         }
 

--- a/swift-tools-support-core/Tests/TSCUtilityTests/ArchiverTests.swift
+++ b/swift-tools-support-core/Tests/TSCUtilityTests/ArchiverTests.swift
@@ -40,8 +40,9 @@ class ArchiverTests: XCTestCase {
 
         let fileSystem = InMemoryFileSystem()
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        archiver.extract(from: AbsolutePath("/archive.zip"), to: AbsolutePath("/"), completion: { result in
-            XCTAssertResultFailure(result, equals: FileSystemError.noEntry)
+        let archive = AbsolutePath("/archive.zip")
+        archiver.extract(from: archive, to: AbsolutePath("/"), completion: { result in
+            XCTAssertResultFailure(result, equals: FileSystemError(.noEntry, archive))
             expectation.fulfill()
         })
 
@@ -53,8 +54,9 @@ class ArchiverTests: XCTestCase {
 
         let fileSystem = InMemoryFileSystem(emptyFiles: "/archive.zip")
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        archiver.extract(from: AbsolutePath("/archive.zip"), to: AbsolutePath("/destination"), completion: { result in
-            XCTAssertResultFailure(result, equals: FileSystemError.notDirectory)
+        let destination = AbsolutePath("/destination")
+        archiver.extract(from: AbsolutePath("/archive.zip"), to: destination, completion: { result in
+            XCTAssertResultFailure(result, equals: FileSystemError(.notDirectory, destination))
             expectation.fulfill()
         })
 
@@ -66,8 +68,9 @@ class ArchiverTests: XCTestCase {
 
         let fileSystem = InMemoryFileSystem(emptyFiles: "/archive.zip", "/destination")
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        archiver.extract(from: AbsolutePath("/archive.zip"), to: AbsolutePath("/destination"), completion: { result in
-            XCTAssertResultFailure(result, equals: FileSystemError.notDirectory)
+        let destination = AbsolutePath("/destination")
+        archiver.extract(from: AbsolutePath("/archive.zip"), to: destination, completion: { result in
+            XCTAssertResultFailure(result, equals: FileSystemError(.notDirectory, destination))
             expectation.fulfill()
         })
 


### PR DESCRIPTION
I've recently stumbled upon this error when running `swift build`:

```
error: noEntry
```

This is the exact and only output of this `swift build` invocation. Unfortunately, I think it's impossible to diagnose without an attached debugger. It's also hard to pinpoint where exactly the error comes from in the source code, since `FileSystemError.noEntry` is thrown from multiple places.

In my opinion, for an error value to be helpful it should have associated information attached to it. In this case, it would make sense for almost all cases of `FileSystemError` to have an associated `AbsolutePath` value.

`FileSystemError` now also has to be explicitly declared `Equatable` to make the tests compile, but previously it was `Equatable` anyway, although implicitly by virtue of being an enum with no associated values. 