### PR TITLE
Fix Absolute Path Dependencies in `.pc` Files

### DIFF
--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1452,7 +1452,7 @@ final class BuildPlanTests: XCTestCase {
 
         let diagnostic = diagnostics.diagnostics.last!
 
-        XCTAssertEqual(diagnostic.message.text, "couldn't find pc file")
+        XCTAssertEqual(diagnostic.message.text, "couldn't find pc file for BTarget")
         XCTAssertEqual(diagnostic.message.behavior, .warning)
         XCTAssertEqual(diagnostic.location.description, "'BTarget' BTarget.pc")
     }

--- a/swift-tools-support-core/Sources/TSCUtility/PkgConfig.swift
+++ b/swift-tools-support-core/Sources/TSCUtility/PkgConfig.swift
@@ -110,9 +110,6 @@ public struct PkgConfig {
     /// DiagnosticsEngine to emit diagnostics
     let diagnostics: DiagnosticsEngine
 
-    /// Helper to query `pkg-config` for library locations
-    private let pkgFileFinder: PCFileFinder
-
     /// Load the information for the named package.
     ///
     /// It will search `fileSystem` for the pkg config file in the following order:
@@ -132,12 +129,19 @@ public struct PkgConfig {
         fileSystem: FileSystem = localFileSystem,
         brewPrefix: AbsolutePath?
     ) throws {
-        self.name = name
-        self.pkgFileFinder = PCFileFinder(diagnostics: diagnostics, brewPrefix: brewPrefix)
-        self.pcFile = try pkgFileFinder.locatePCFile(
-            name: name,
-            customSearchPaths: PkgConfig.envSearchPaths + additionalSearchPaths,
-            fileSystem: fileSystem)
+
+        if let path = try? AbsolutePath(validating: name) {
+            guard fileSystem.isFile(path) else { throw PkgConfigError.couldNotFindConfigFile }
+            self.name = path.basenameWithoutExt
+            self.pcFile = path
+        } else {
+            self.name = name
+            let pkgFileFinder = PCFileFinder(diagnostics: diagnostics, brewPrefix: brewPrefix)
+            self.pcFile = try pkgFileFinder.locatePCFile(
+                name: name,
+                customSearchPaths: PkgConfig.envSearchPaths + additionalSearchPaths,
+                fileSystem: fileSystem)
+        }
 
         self.diagnostics = diagnostics
         var parser = PkgConfigParser(pcFile: pcFile, fileSystem: fileSystem)

--- a/swift-tools-support-core/Sources/TSCUtility/PkgConfig.swift
+++ b/swift-tools-support-core/Sources/TSCUtility/PkgConfig.swift
@@ -157,6 +157,7 @@ public struct PkgConfig {
                     name: dep, 
                     additionalSearchPaths: additionalSearchPaths,
                     diagnostics: diagnostics,
+                    fileSystem: fileSystem,
                     brewPrefix: brewPrefix
                 )
 

--- a/swift-tools-support-core/Sources/TSCUtility/PkgConfig.swift
+++ b/swift-tools-support-core/Sources/TSCUtility/PkgConfig.swift
@@ -12,14 +12,14 @@ import TSCBasic
 import Foundation
 
 public enum PkgConfigError: Swift.Error, CustomStringConvertible {
-    case couldNotFindConfigFile
+    case couldNotFindConfigFile(name: String)
     case parsingError(String)
     case nonWhitelistedFlags(String)
 
     public var description: String {
         switch self {
-        case .couldNotFindConfigFile:
-            return "couldn't find pc file"
+        case .couldNotFindConfigFile(let name):
+            return "couldn't find pc file for \(name)"
         case .parsingError(let error):
             return "parsing error(s): \(error)"
         case .nonWhitelistedFlags(let flags):
@@ -89,7 +89,7 @@ public struct PCFileFinder {
             PCFileFinder.shouldEmitPkgConfigPathsDiagnostic = false
             diagnostics.emit(warning: "failed to retrieve search paths with pkg-config; maybe pkg-config is not installed")
         }
-        throw PkgConfigError.couldNotFindConfigFile
+        throw PkgConfigError.couldNotFindConfigFile(name: name)
     }
 }
 
@@ -131,7 +131,7 @@ public struct PkgConfig {
     ) throws {
 
         if let path = try? AbsolutePath(validating: name) {
-            guard fileSystem.isFile(path) else { throw PkgConfigError.couldNotFindConfigFile }
+            guard fileSystem.isFile(path) else { throw PkgConfigError.couldNotFindConfigFile(name: name) }
             self.name = path.basenameWithoutExt
             self.pcFile = path
         } else {

--- a/swift-tools-support-core/Tests/TSCUtilityTests/pkgconfigInputs/gobject-2.0.pc
+++ b/swift-tools-support-core/Tests/TSCUtilityTests/pkgconfigInputs/gobject-2.0.pc
@@ -1,0 +1,12 @@
+prefix=/usr/local/Cellar/glib/2.64.3
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: GObject
+Description: GLib Type, Object, Parameter and Signal Library
+Version: 2.64.3
+# Requires: glib-2.0
+Requires.private: /usr/local/opt/libffi/lib/pkgconfig/libffi.pc >=  3.0.0
+Libs: -L${libdir} -lgobject-2.0
+Libs.private: -lintl
+Cflags:-I${includedir}

--- a/swift-tools-support-core/Tests/TSCUtilityTests/pkgconfigInputs/libffi.pc
+++ b/swift-tools-support-core/Tests/TSCUtilityTests/pkgconfigInputs/libffi.pc
@@ -1,0 +1,11 @@
+prefix=/usr/local/Cellar/libffi/3.3
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+toolexeclibdir=${libdir}
+includedir=${prefix}/include
+
+Name: libffi
+Description: Library supporting Foreign Function Interfaces
+Version: 3.3
+Libs: -L${toolexeclibdir} -lffi
+Cflags: -I${includedir}


### PR DESCRIPTION
This adds support for absolute paths in the `Requires` and `Requires.private` fields of a `.pc` file, which currently cause the `PkgConfig` initializer to fail.

On macOS, the Homebrew-provided package `gobject-2.0` (GLib's GObject library) has an absolute path dependency:

```
$ cat $(brew --prefix)/opt/glib/lib/pkgconfig/gobject-2.0.pc
prefix=/usr/local/Cellar/glib/2.64.3
libdir=${prefix}/lib
includedir=${prefix}/include

Name: GObject
Description: GLib Type, Object, Parameter and Signal Library
Version: 2.64.3
Requires: glib-2.0
Requires.private: /usr/local/opt/libffi/lib/pkgconfig/libffi.pc >=  3.0.0
Libs: -L${libdir} -lgobject-2.0
Libs.private: -lintl
Cflags:-I${includedir}
```

This prevents any system library dependencies that depend on `glib` from having their search paths correctly configured.

[SR-12937](https://bugs.swift.org/browse/SR-12937)