### PR TITLE
Use host triple in createIndexStoreAPI

### DIFF
--- a/Sources/Build/BuildDelegate.swift
+++ b/Sources/Build/BuildDelegate.swift
@@ -262,7 +262,7 @@ public final class BuildExecutionContext {
     private var indexStoreAPICache = LazyCache(createIndexStoreAPI)
     private func createIndexStoreAPI() -> Result<IndexStoreAPI, Error> {
         Result {
-            let ext = buildParameters.triple.dynamicLibraryExtension
+            let ext = buildParameters.hostTriple.dynamicLibraryExtension
             let indexStoreLib = buildParameters.toolchain.toolchainLibDir.appending(component: "libIndexStore" + ext)
             return try IndexStoreAPI(dylib: indexStoreLib)
         }

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -46,6 +46,9 @@ public struct BuildParameters: Encodable {
     public var toolchain: Toolchain { _toolchain.toolchain }
     private let _toolchain: _Toolchain
 
+    /// Host triple.
+    public var hostTriple: Triple
+
     /// Destination triple.
     public var triple: Triple
 
@@ -140,6 +143,7 @@ public struct BuildParameters: Encodable {
         self.dataPath = dataPath
         self.configuration = configuration
         self._toolchain = _Toolchain(toolchain: toolchain)
+        self.hostTriple = .getHostTriple(usingSwiftCompiler: toolchain.swiftCompiler)
         self.triple = destinationTriple ?? .getHostTriple(usingSwiftCompiler: toolchain.swiftCompiler)
         self.flags = flags
         self.xcbuildFlags = xcbuildFlags

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -123,6 +123,7 @@ public struct BuildParameters: Encodable {
         dataPath: AbsolutePath,
         configuration: BuildConfiguration,
         toolchain: Toolchain,
+        hostTriple: Triple? = nil,
         destinationTriple: Triple? = nil,
         flags: BuildFlags,
         xcbuildFlags: [String] = [],
@@ -143,7 +144,7 @@ public struct BuildParameters: Encodable {
         self.dataPath = dataPath
         self.configuration = configuration
         self._toolchain = _Toolchain(toolchain: toolchain)
-        self.hostTriple = .getHostTriple(usingSwiftCompiler: toolchain.swiftCompiler)
+        self.hostTriple = hostTriple ?? .getHostTriple(usingSwiftCompiler: toolchain.swiftCompiler)
         self.triple = destinationTriple ?? .getHostTriple(usingSwiftCompiler: toolchain.swiftCompiler)
         self.flags = flags
         self.xcbuildFlags = xcbuildFlags

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -66,6 +66,7 @@ final class BuildPlanTests: XCTestCase {
             dataPath: buildPath,
             configuration: config,
             toolchain: MockToolchain(),
+            hostTriple: hostTriple,
             destinationTriple: destinationTriple,
             flags: flags,
             jobs: 3,


### PR DESCRIPTION
Currently, with the `--enable-test-discovery` flag SwiftPM looks for `libIndexStore` using the target triple if one was present, instead of the host triple. This breaks when cross-compiling, since you actually need `libIndexStore` from the host, not the target. This is resolved by adding a new `hostTriple` property, as opposed to the existing target `triple` property. New `hostTriple` is used in `createIndexStoreAPI` to infer the extension of `libIndexStore` when searching for it.