### PR TITLE
[Build] Add support for building targets in Explicit Module Build mode

### DIFF
--- a/Sources/Build/ManifestBuilder.swift
+++ b/Sources/Build/ManifestBuilder.swift
@@ -203,6 +203,9 @@ extension LLBuildManifestBuilder {
             var commandLine = target.emitCommandLine();
             commandLine.append("-driver-use-frontend-path")
             commandLine.append(buildParameters.toolchain.swiftCompiler.pathString)
+            if buildParameters.useExplicitModuleBuild {
+              commandLine.append("-experimental-explicit-module-build")
+            }
             var driver = try Driver(args: commandLine, fileSystem: target.fs)
             let jobs = try driver.planBuild()
             let resolver = try ArgsResolver(fileSystem: target.fs)

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -97,6 +97,9 @@ public class ToolOptions {
     /// to a separate process.
     public var useIntegratedSwiftDriver: Bool = false
 
+    /// Whether to use the explicit module build flow (with the integrated driver)
+    public var useExplicitModuleBuild: Bool = false
+
     /// The build system to use.
     public var buildSystem: BuildSystemKind = .native
 

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -455,6 +455,10 @@ public class SwiftTool<Options: ToolOptions> {
             to: { $0.useIntegratedSwiftDriver = $1 })
 
         binder.bind(
+            option: parser.add(option: "--experimental-explicit-module-build", kind: Bool.self, usage: nil),
+            to: { $0.useExplicitModuleBuild = $1 })
+
+        binder.bind(
             option: parser.add(option: "--build-system", kind: BuildSystemKind.self, usage: nil),
             to: { $0.buildSystem = $1 })
 
@@ -538,6 +542,10 @@ public class SwiftTool<Options: ToolOptions> {
         if result.exists(arg: "--multiroot-data-file") {
             diagnostics.emit(.unsupportedFlag("--multiroot-data-file"))
         }
+      if result.exists(arg: "--experimental-explicit-module-build") &&
+          !result.exists(arg: "--use-integrated-swift-driver") {
+        diagnostics.emit(error: "'--experimental-explicit-module-build' option requires '--use-integrated-swift-driver'")
+      }
     }
 
     class func defineArguments(parser: ArgumentParser, binder: ArgumentBinder<Options>) {
@@ -796,6 +804,7 @@ public class SwiftTool<Options: ToolOptions> {
                 enableTestDiscovery: options.enableTestDiscovery,
                 emitSwiftModuleSeparately: options.emitSwiftModuleSeparately,
                 useIntegratedSwiftDriver: options.useIntegratedSwiftDriver,
+                useExplicitModuleBuild: options.useExplicitModuleBuild,
                 isXcodeBuildSystemEnabled: options.buildSystem == .xcode
             )
         })

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -89,6 +89,9 @@ public struct BuildParameters: Encodable {
     /// to a separate process.
     public var useIntegratedSwiftDriver: Bool
 
+    // Whether to use the explicit module build flow (with the integrated driver)
+    public var useExplicitModuleBuild: Bool
+
     /// Whether to create dylibs for dynamic library products.
     public var shouldCreateDylibForDynamicProducts: Bool
 
@@ -135,6 +138,7 @@ public struct BuildParameters: Encodable {
         enableTestDiscovery: Bool = false,
         emitSwiftModuleSeparately: Bool = false,
         useIntegratedSwiftDriver: Bool = false,
+        useExplicitModuleBuild: Bool = false,
         isXcodeBuildSystemEnabled: Bool = false
     ) {
         self.dataPath = dataPath
@@ -155,6 +159,7 @@ public struct BuildParameters: Encodable {
         self.enableTestDiscovery = enableTestDiscovery
         self.emitSwiftModuleSeparately = emitSwiftModuleSeparately
         self.useIntegratedSwiftDriver = useIntegratedSwiftDriver
+        self.useExplicitModuleBuild = useExplicitModuleBuild
         self.isXcodeBuildSystemEnabled = isXcodeBuildSystemEnabled
     }
 


### PR DESCRIPTION
With the integrated Swift driver. The feature is hidden behind: 
`--use-integrated-swift-driver --experimental-explicit-module-build`.

While it is not yet in a shape where SwiftPM can bootstrap in this mode, this should allow us to start experimenting with it. 