### PR TITLE
Fix swift-tools-support-core path in Utilities/import

### DIFF
--- a/swift-tools-support-core/Utilities/import
+++ b/swift-tools-support-core/Utilities/import
@@ -15,7 +15,7 @@ __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SRCROOT="`cd "${__dir}/..";pwd`"
 echo "SRCROOT is $SRCROOT"
 
-IMPORT_DIR="`cd "${SRCROOT}/../swiftpm/TSC";pwd`"
+IMPORT_DIR="`cd "${SRCROOT}/../swiftpm/swift-tools-support-core";pwd`"
 
 echo Copying from $IMPORT_DIR
 cp -r ${IMPORT_DIR}/* $SRCROOT


### PR DESCRIPTION
Currently the directory is named swift-tools-support-core, not TSC.