### PR TITLE
Add swiftpm-xctest-helper rpath on macOS.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -167,7 +167,10 @@ let package = Package(
         .target(
             /** Shim tool to find test names on OS X */
             name: "swiftpm-xctest-helper",
-            dependencies: []),
+            dependencies: [],
+            linkerSettings: [
+                .unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "@executable_path/../../../lib/swift/macosx"], .when(platforms: [.macOS])),
+            ]),
 
         // MARK: Additional Test Dependencies
 


### PR DESCRIPTION
Add an extra rpath for swiftpm-xctest-helper on macOS:
`@executable_path/../../../lib/swift/macosx`.

This fixes SR-12600:
```console
$ swift test --filter a
error: signalled(6): /Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2020-06-10-a.xctoolchain/usr/libexec/swift/pm/swiftpm-xctest-helper /Users/danielzheng/TestPkg/.build/x86_64-apple-macosx/debug/TestPkgPackageTests.xctest /var/folders/m_/6f7q8zfs3n9fr0c_4gy8840m00hc_q/T/TemporaryFile.3eFu0u output:
    dyld: Library not loaded: @rpath/XCTest.framework/Versions/A/XCTest
      Referenced from: /Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2020-06-10-a.xctoolchain/usr/libexec/swift/pm/swiftpm-xctest-helper
      Reason: image not found
```

---

Fix found by @abertelrud in https://github.com/apple/swift-package-manager/pull/2694#issuecomment-628207883.