### PR TITLE
Add `obsoleted` attribute to testTarget method without resources argument

### DIFF
--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -435,7 +435,7 @@ public final class Target {
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    @available(_PackageDescription, introduced: 5)
+    @available(_PackageDescription, introduced: 5, obsoleted: 5.3)
     public static func testTarget(
         name: String,
         dependencies: [Dependency] = [],


### PR DESCRIPTION
Exposing just one `Target.testTarget` method with the recently introduced `resources` argument (which has a default value) is enough.

This makes `Target.testTarget` consistent with `Target.target` which already has this attribute and doesn't expose the `resource`-less version of the method.