### PR TITLE
[Build/PackageLoading] SR-13084: Improve user awareness for issues around missing resources

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -562,8 +562,8 @@ public final class SwiftTargetBuildDescription {
             self.moduleMap = try self.generateModuleMap()
         }
 
-        // Do nothing if we're not generating a bundle.
         if bundlePath != nil {
+            // If we've generated a bundle then create a plist and generate a `Bundle.module` accessor
             try self.generateResourceAccessor()
 
             let infoPlistPath = tempsPath.appending(component: "Info.plist")
@@ -571,6 +571,8 @@ public final class SwiftTargetBuildDescription {
                 resourceBundleInfoPlistPath = infoPlistPath
             }
         } else {
+            // If we've not generated a bundle then create an unavailable `Bundle.module` accessor in order to
+            // support easier debugging.
             try self.generateResourceUnavailableAccessor()
         }
     }

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -583,8 +583,7 @@ public final class SwiftTargetBuildDescription {
         // Compute the basename of the bundle.
         let bundleBasename = bundlePath.basename
 
-        let stream = BufferedOutputByteStream()
-        stream <<< """
+        let contents = """
         import class Foundation.Bundle
 
         extension Foundation.Bundle {
@@ -598,17 +597,9 @@ public final class SwiftTargetBuildDescription {
         }
         """
 
-        let subpath = RelativePath("resource_bundle_accessor.swift")
-
-        // Add the file to the dervied sources.
-        derivedSources.relativePaths.append(subpath)
-
-        // Write this file out.
-        // FIXME: We should generate this file during the actual build.
-        let path = derivedSources.root.appending(subpath)
-        try fs.writeIfChanged(path: path, bytes: stream.bytes)
+        try addFile(withPath: RelativePath("resource_bundle_accessor.swift"), contents: contents)
     }
-    
+
     /// Generate an inaccessible resource bundle accessor, if appropriate.
     ///
     /// This addresses SR-13084 by creating an unavailable accessor which informs users of the underlying issue.
@@ -617,8 +608,7 @@ public final class SwiftTargetBuildDescription {
         guard self.bundlePath == nil else { return }
 
         let message = "target '\(target.name)' is either missing or is solely containing invalid resource references"
-        let stream = BufferedOutputByteStream()
-        stream <<< """
+        let contents = """
         import class Foundation.Bundle
 
         extension Foundation.Bundle {
@@ -629,7 +619,13 @@ public final class SwiftTargetBuildDescription {
         }
         """
 
-        let subpath = RelativePath("resource_bundle_accessor.swift")
+        try addFile(withPath: RelativePath("resource_bundle_accessor.swift"), contents: contents)
+    }
+
+    /// Creates a new file with the contents provided at the path given. The file will be added to the target's derived sources.
+    private func addFile(withPath subpath: RelativePath, contents: String) throws {
+        let stream = BufferedOutputByteStream()
+        stream <<< contents
 
         // Add the file to the dervied sources.
         derivedSources.relativePaths.append(subpath)

--- a/Sources/Build/ManifestBuilder.swift
+++ b/Sources/Build/ManifestBuilder.swift
@@ -72,6 +72,13 @@ public class LLBuildManifestBuilder {
             createProductCommand(description)
         }
 
+        // Output a dot graph
+        if buildParameters.printManifestGraphviz {
+            var serializer = DOTManifestSerializer(manifest: manifest)
+            serializer.writeDOT(to: &stdoutStream)
+            stdoutStream.flush()
+        }
+
         try ManifestWriter().write(manifest, at: path)
     }
 

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -103,6 +103,9 @@ public class ToolOptions {
     /// Whether to use the explicit module build flow (with the integrated driver)
     public var useExplicitModuleBuild: Bool = false
 
+    /// Whether to output a graphviz file visualization of the combined job graph for all targets
+    public var printManifestGraphviz: Bool = false
+
     /// The build system to use.
     public var buildSystem: BuildSystemKind {
         // Force the Xcode build system if we want to build more than one arch.

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -126,11 +126,11 @@ public class TestToolOptions: ToolOptions {
 /// This is used to filter tests to run
 ///   .none     => No filtering
 ///   .specific => Specify test with fully quantified name
-///   .regex    => RegEx pattern
+///   .regex    => RegEx patterns
 public enum TestCaseSpecifier {
     case none
     case specific(String)
-    case regex(String)
+    case regex([String])
     case skip([String])
 }
 
@@ -415,7 +415,7 @@ public class SwiftTestTool: SwiftTool<TestToolOptions> {
             to: { $0.xUnitOutput = $1.path })
 
         binder.bind(
-            option: parser.add(option: "--filter", kind: String.self,
+            option: parser.add(option: "--filter", kind: [String].self,
                 usage: "Run test cases matching regular expression, Format: <test-target>.<test-case> or " +
                     "<test-target>.<test-case>/<test>"),
             to: { $0._testCaseSpecifier = .regex($1) })
@@ -958,10 +958,12 @@ fileprivate extension Dictionary where Key == AbsolutePath, Value == [TestSuite]
         switch specifier {
         case .none:
             return allTests
-        case .regex(let pattern):
+        case .regex(let patterns):
             return allTests.filter({ test in
-                test.specifier.range(of: pattern,
-                                     options: .regularExpression) != nil
+                patterns.contains { pattern in
+                    test.specifier.range(of: pattern,
+                                         options: .regularExpression) != nil
+                }
             })
         case .specific(let name):
             return allTests.filter{ $0.specifier == name }

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -431,7 +431,8 @@ public class SwiftTestTool: SwiftTool<TestToolOptions> {
             to: { $0.shouldPrintCodeCovPath = $1 })
 
         binder.bind(
-            option: parser.add(option: "--test-product", kind: String.self, usage: nil),
+            option: parser.add(option: "--test-product", kind: String.self, 
+                usage: "Test the specified product"),
             to: { $0.testProduct = $1 })
     }
 

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -465,6 +465,11 @@ public class SwiftTool<Options: ToolOptions> {
             to: { $0.useExplicitModuleBuild = $1 })
 
         binder.bind(
+            option: parser.add(option: "--print-manifest-job-graph", kind: Bool.self,
+                usage: "Write the command graph for the build manifest as a graphviz file"),
+            to: { $0.printManifestGraphviz = $1 })
+
+        binder.bind(
             option: parser.add(option: "--build-system", kind: BuildSystemKind.self, usage: nil),
             to: { $0._buildSystem = $1 })
 
@@ -822,7 +827,8 @@ public class SwiftTool<Options: ToolOptions> {
                 emitSwiftModuleSeparately: options.emitSwiftModuleSeparately,
                 useIntegratedSwiftDriver: options.useIntegratedSwiftDriver,
                 useExplicitModuleBuild: options.useExplicitModuleBuild,
-                isXcodeBuildSystemEnabled: options.buildSystem == .xcode
+                isXcodeBuildSystemEnabled: options.buildSystem == .xcode,
+                printManifestGraphviz: options.printManifestGraphviz
             )
         })
     }()

--- a/Sources/LLBuildManifest/CMakeLists.txt
+++ b/Sources/LLBuildManifest/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(LLBuildManifest
   BuildManifest.swift
   Command.swift
   ManifestWriter.swift
+  DOTManifestSerializer.swift
   Node.swift
   Target.swift
   Tools.swift)

--- a/Sources/LLBuildManifest/DOTManifestSerializer.swift
+++ b/Sources/LLBuildManifest/DOTManifestSerializer.swift
@@ -1,0 +1,66 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import TSCBasic
+
+/// Serializes an LLBuildManifest graph to a .dot file
+public struct DOTManifestSerializer {
+    var kindCounter = [String: Int]()
+    var hasEmittedStyling = Set<String>()
+    let manifest: BuildManifest
+
+    /// Creates a serializer that will serialize the given manifest.
+    public init(manifest: BuildManifest) {
+        self.manifest = manifest
+    }
+
+    /// Gets a unique label for a job name
+    mutating func label(for command: Command) -> String {
+        let toolName = "\(type(of: command.tool).name)"
+        var label = toolName
+        if let count = kindCounter[label] {
+            label += " \(count)"
+        }
+        kindCounter[toolName, default: 0] += 1
+        return label
+    }
+
+    /// Quote the name and escape the quotes and backslashes
+    func quoteName(_ name: String) -> String {
+        return "\"" + name.replacingOccurrences(of: "\"", with: "\\\"")
+                          .replacingOccurrences(of: "\\", with: "\\\\") + "\""
+    }
+
+    public mutating func writeDOT<Stream: TextOutputStream>(to stream: inout Stream) {
+        stream.write("digraph Jobs {\n")
+        for (name, command) in manifest.commands {
+            let jobName = quoteName(label(for: command))
+            if !hasEmittedStyling.contains(jobName) {
+                stream.write("  \(jobName) [style=bold];")
+                stream.write("// \(name)\n")
+            }
+            for input in command.tool.inputs {
+                let inputName = quoteName(input.name)
+                if hasEmittedStyling.insert(inputName).inserted {
+                    stream.write("  \(inputName) [fontsize=12];\n")
+                }
+                stream.write("  \(inputName) -> \(jobName) [color=blue];\n")
+            }
+            for output in command.tool.outputs {
+                let outputName = quoteName(output.name)
+                if hasEmittedStyling.insert(outputName).inserted {
+                    stream.write("  \(outputName) [fontsize=12];\n")
+                }
+                stream.write("  \(jobName) -> \(outputName) [color=green];\n")
+            }
+        }
+        stream.write("}\n")
+    }
+}

--- a/Sources/PackageDescription/Version.swift
+++ b/Sources/PackageDescription/Version.swift
@@ -25,7 +25,7 @@
 /// behavioral changes of the existing API.
 ///
 /// **The Minor Version**
-//
+///
 /// Update the second digit of a version, or *minor version*, if you add functionality in a backward-compatible manner.
 /// For example, the semantic versioning specification considers adding a new method
 /// or type without changing any other API to be backward-compatible.

--- a/Sources/PackageGraph/PinsStore.swift
+++ b/Sources/PackageGraph/PinsStore.swift
@@ -105,14 +105,6 @@ public final class PinsStore {
         // Reset the pins map.
         pinsMap = [:]
     }
-
-    /// Creates constraints based on the pins in the store.
-    public func createConstraints() -> [RepositoryPackageConstraint] {
-        return pins.map({ pin in
-            return RepositoryPackageConstraint(
-                container: pin.packageRef, requirement: pin.state.requirement(), products: .everything)
-        })
-    }
 }
 
 /// Persistence.

--- a/Sources/PackageGraph/PinsStore.swift
+++ b/Sources/PackageGraph/PinsStore.swift
@@ -23,17 +23,12 @@ public final class PinsStore {
         /// The pinned state.
         public let state: CheckoutState
 
-        /// The product filter applied by the pin.
-        public let productFilter: ProductFilter
-
         public init(
             packageRef: PackageReference,
-            state: CheckoutState,
-            productFilter: ProductFilter
+            state: CheckoutState
         ) {
             self.packageRef = packageRef
             self.state = state
-            self.productFilter = productFilter
         }
     }
 
@@ -88,13 +83,11 @@ public final class PinsStore {
     ///   - state: The state to pin at.
     public func pin(
         packageRef: PackageReference,
-        state: CheckoutState,
-        productFilter: ProductFilter
+        state: CheckoutState
     ) {
         pinsMap[packageRef.identity] = Pin(
             packageRef: packageRef,
-            state: state,
-            productFilter: productFilter
+            state: state
         )
     }
 
@@ -117,7 +110,7 @@ public final class PinsStore {
     public func createConstraints() -> [RepositoryPackageConstraint] {
         return pins.map({ pin in
             return RepositoryPackageConstraint(
-                container: pin.packageRef, requirement: pin.state.requirement(), products: pin.productFilter)
+                container: pin.packageRef, requirement: pin.state.requirement(), products: .everything)
         })
     }
 }
@@ -159,7 +152,6 @@ extension PinsStore.Pin: JSONMappable, JSONSerializable, Equatable {
         let ref = PackageReference(identity: identity, path: url)
         self.packageRef = name.flatMap(ref.with(newName:)) ?? ref
         self.state = try json.get("state")
-        self.productFilter = try json.get("products")
     }
 
     /// Convert the pin to JSON.
@@ -167,8 +159,7 @@ extension PinsStore.Pin: JSONMappable, JSONSerializable, Equatable {
         return .init([
             "package": packageRef.name.toJSON(),
             "repositoryURL": packageRef.path,
-            "state": state,
-            "products": productFilter,
+            "state": state
         ])
     }
 }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -711,7 +711,7 @@ public final class PackageBuilder {
             fs: fileSystem,
             diags: diagnostics
         )
-        let (sources, resources) = try sourcesBuilder.run()
+        let (sources, resources, headers) = try sourcesBuilder.run()
 
         // Make sure defaultLocalization is set if the target has localized resources.
         let hasLocalizedResources = resources.contains(where: { $0.localization != nil })
@@ -750,6 +750,7 @@ public final class PackageBuilder {
                 cLanguageStandard: manifest.cLanguageStandard,
                 cxxLanguageStandard: manifest.cxxLanguageStandard,
                 includeDir: publicHeadersPath,
+                headers: headers,
                 isTest: potentialModule.isTest,
                 sources: sources,
                 resources: resources,

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -103,7 +103,7 @@ public struct TargetSourcesBuilder {
     }
 
     /// Run the builder to produce the sources of the target.
-    public func run() throws -> (sources: Sources, resources: [Resource]) {
+    public func run() throws -> (sources: Sources, resources: [Resource], headers: [AbsolutePath]) {
         let contents = computeContents()
         var pathToRule: [AbsolutePath: Rule] = [:]
 
@@ -125,6 +125,7 @@ public struct TargetSourcesBuilder {
             }
         }
 
+        let headers = pathToRule.lazy.filter { $0.value.rule == .header }.map { $0.key }.sorted()
         let compilePaths = pathToRule.lazy.filter { $0.value.rule == .compile }.map { $0.key }
         let sources = Sources(paths: Array(compilePaths), root: targetPath)
         let resources: [Resource] = pathToRule.compactMap { resource(for: $0.key, with: $0.value) }
@@ -140,7 +141,7 @@ public struct TargetSourcesBuilder {
             throw Target.Error.mixedSources(targetPath)
         }
 
-        return (sources, resources)
+        return (sources, resources, headers)
     }
 
     private struct Rule {

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -257,7 +257,7 @@ public struct TargetSourcesBuilder {
         // Filter the package list of resources down to those which are not included in the valid resources array
         let invalidResources = self.target.resources.filter { targetResource in
             return resources.contains(where: { resource in
-                resource.path.relative(to: self.targetPath).pathString == targetResource.path
+                resource.path.relative(to: self.targetPath).pathString.hasPrefix(targetResource.path)
             }) == false
         }
         

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -135,6 +135,7 @@ public struct TargetSourcesBuilder {
         diagnoseLocalizedAndUnlocalizedVariants(in: resources)
         diagnoseMissingDevelopmentRegionResource(in: resources)
         diagnoseInfoPlistConflicts(in: resources)
+        diagnoseMissingResources(in: resources)
 
         // It's an error to contain mixed language source files.
         if sources.containsMixedLanguage {
@@ -247,6 +248,34 @@ public struct TargetSourcesBuilder {
         }
     }
 
+    private func diagnoseMissingResources(in resources: [Resource]) {
+        // Stop early if the valid resources array count is the same as the user defined list
+        if resources.count == self.target.resources.count {
+            return
+        }
+        
+        // Filter the package list of resources down to those which are not included in the valid resources array
+        let invalidResources = self.target.resources.filter { targetResource in
+            return resources.contains(where: { resource in
+                resource.path.relative(to: self.targetPath).pathString == targetResource.path
+            }) == false
+        }
+        
+        // If the list is empty then all were succesfully included so no error needs to be thrown
+        if invalidResources.isEmpty {
+            return
+        }
+        
+        var message = "target '\(self.target.name)' does not have resources at the following paths, they will be ignored\n"
+        
+        for resource in invalidResources {
+            let resourcePath = self.targetPath.appending(RelativePath(resource.path))
+            message += "    '\(resource.path)' (\(resourcePath))\n"
+        }
+        
+        diags.emit(.warning(message))
+    }
+    
     private func diagnoseConflictingResources(in resources: [Resource]) {
         let duplicateResources = resources.spm_findDuplicateElements(by: \.destination)
         for resources in duplicateResources {

--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -357,6 +357,11 @@ public class ClangTarget: Target {
     /// The path to include directory.
     public let includeDir: AbsolutePath
 
+    /// The headers present in the target.
+    ///
+    /// Note that this contains both public and non-public headers.
+    public let headers: [AbsolutePath]
+
     /// True if this is a C++ target.
     public let isCXX: Bool
 
@@ -374,6 +379,7 @@ public class ClangTarget: Target {
         cLanguageStandard: String?,
         cxxLanguageStandard: String?,
         includeDir: AbsolutePath,
+        headers: [AbsolutePath] = [],
         isTest: Bool = false,
         sources: Sources,
         resources: [Resource] = [],
@@ -386,6 +392,7 @@ public class ClangTarget: Target {
         self.cLanguageStandard = cLanguageStandard
         self.cxxLanguageStandard = cxxLanguageStandard
         self.includeDir = includeDir
+        self.headers = headers
         super.init(
             name: name,
             bundleName: bundleName,
@@ -400,12 +407,13 @@ public class ClangTarget: Target {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case includeDir, isCXX, cLanguageStandard, cxxLanguageStandard
+        case includeDir, headers, isCXX, cLanguageStandard, cxxLanguageStandard
     }
 
     public override func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(includeDir, forKey: .includeDir)
+        try container.encode(headers, forKey: .headers)
         try container.encode(isCXX, forKey: .isCXX)
         try container.encode(cLanguageStandard, forKey: .cLanguageStandard)
         try container.encode(cxxLanguageStandard, forKey: .cxxLanguageStandard)
@@ -415,6 +423,7 @@ public class ClangTarget: Target {
     required public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.includeDir = try container.decode(AbsolutePath.self, forKey: .includeDir)
+        self.headers = try container.decode([AbsolutePath].self, forKey: .headers)
         self.isCXX = try container.decode(Bool.self, forKey: .isCXX)
         self.cLanguageStandard = try container.decodeIfPresent(String.self, forKey: .cLanguageStandard)
         self.cxxLanguageStandard = try container.decodeIfPresent(String.self, forKey: .cxxLanguageStandard)

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -95,8 +95,11 @@ public struct BuildParameters: Encodable {
     /// to a separate process.
     public var useIntegratedSwiftDriver: Bool
 
-    // Whether to use the explicit module build flow (with the integrated driver)
+    /// Whether to use the explicit module build flow (with the integrated driver)
     public var useExplicitModuleBuild: Bool
+
+    /// Whether to output a graphviz file visualization of the combined job graph for all targets
+    public var printManifestGraphviz: Bool
 
     /// Whether to create dylibs for dynamic library products.
     public var shouldCreateDylibForDynamicProducts: Bool
@@ -147,7 +150,8 @@ public struct BuildParameters: Encodable {
         emitSwiftModuleSeparately: Bool = false,
         useIntegratedSwiftDriver: Bool = false,
         useExplicitModuleBuild: Bool = false,
-        isXcodeBuildSystemEnabled: Bool = false
+        isXcodeBuildSystemEnabled: Bool = false,
+        printManifestGraphviz: Bool = false
     ) {
         self.dataPath = dataPath
         self.configuration = configuration
@@ -171,6 +175,7 @@ public struct BuildParameters: Encodable {
         self.useIntegratedSwiftDriver = useIntegratedSwiftDriver
         self.useExplicitModuleBuild = useExplicitModuleBuild
         self.isXcodeBuildSystemEnabled = isXcodeBuildSystemEnabled
+        self.printManifestGraphviz = printManifestGraphviz
     }
 
     /// The path to the build directory (inside the data directory).

--- a/Sources/SPMTestSupport/TestWorkspace.swift
+++ b/Sources/SPMTestSupport/TestWorkspace.swift
@@ -346,7 +346,7 @@ public final class TestWorkspace {
     }
 
     public func set(
-        pins: [PackageReference: (version: CheckoutState, products: ProductFilter)] = [:],
+        pins: [PackageReference: CheckoutState] = [:],
         managedDependencies: [ManagedDependency] = [],
         managedArtifacts: [ManagedArtifact] = []
     ) throws {
@@ -354,7 +354,7 @@ public final class TestWorkspace {
         let pinsStore = try workspace.pinsStore.load()
 
         for (ref, state) in pins {
-            pinsStore.pin(packageRef: ref, state: state.version)
+            pinsStore.pin(packageRef: ref, state: state)
         }
 
         for dependency in managedDependencies {

--- a/Sources/SPMTestSupport/TestWorkspace.swift
+++ b/Sources/SPMTestSupport/TestWorkspace.swift
@@ -354,7 +354,7 @@ public final class TestWorkspace {
         let pinsStore = try workspace.pinsStore.load()
 
         for (ref, state) in pins {
-            pinsStore.pin(packageRef: ref, state: state.version, productFilter: state.products)
+            pinsStore.pin(packageRef: ref, state: state.version)
         }
 
         for dependency in managedDependencies {

--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -41,7 +41,7 @@ public struct Destination: Encodable, Equatable {
     public var archs: [String] = []
 
     /// The SDK used to compile for the destination.
-    public var sdk: AbsolutePath
+    public var sdk: AbsolutePath?
 
     /// The binDir in the containing the compilers/linker to be used for the compilation.
     public var binDir: AbsolutePath
@@ -58,7 +58,7 @@ public struct Destination: Encodable, Equatable {
     /// Creates a compilation destination with the specified properties.
     public init(
       target: Triple? = nil,
-      sdk: AbsolutePath,
+      sdk: AbsolutePath?,
       binDir: AbsolutePath,
       extraCCFlags: [String] = [],
       extraSwiftCFlags: [String] = [],
@@ -142,7 +142,7 @@ public struct Destination: Encodable, Equatable {
       #else
         return Destination(
             target: nil,
-            sdk: .root,
+            sdk: nil,
             binDir: binDir,
             extraCCFlags: ["-fPIC"],
             extraSwiftCFlags: [],

--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -130,6 +130,15 @@ public struct Destination: Encodable, Equatable {
             extraSwiftCFlags: extraSwiftCFlags,
             extraCPPFlags: ["-lc++"]
         )
+      #elseif os(Android)
+        return Destination(
+            target: nil,
+            sdk: AbsolutePath(ProcessEnv.vars["PREFIX"]!).parentDirectory,
+            binDir: binDir,
+            extraCCFlags: ["-fPIC"],
+            extraSwiftCFlags: [],
+            extraCPPFlags: ["-lstdc++"]
+        )
       #else
         return Destination(
             target: nil,

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -61,7 +61,7 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
         completion: @escaping (Result<PackageContainer, Error>) -> Void
     ) {
         // Start by searching manifests from the Workspace's resolved dependencies.
-        if let manifest = dependencyManifests.dependencies.first(where: { $1.packageRef == identifier }) {
+        if let manifest = dependencyManifests.dependencies.first(where: { _, managed, _ in managed.packageRef == identifier }) {
             let container = LocalPackageContainer(
                 package: identifier,
                 manifest: manifest.manifest,

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -206,10 +206,14 @@ public final class UserToolchain: Toolchain {
     }
 
     public static func deriveSwiftCFlags(triple: Triple, destination: Destination) -> [String] {
-      return (triple.isDarwin() || triple.isAndroid() || triple.isWASI()
-        ? ["-sdk", destination.sdk.pathString]
-        : [])
-        + destination.extraSwiftCFlags
+        guard let sdk = destination.sdk else {
+            return destination.extraSwiftCFlags
+        }
+
+        return (triple.isDarwin() || triple.isAndroid() || triple.isWASI()
+            ? ["-sdk", sdk.pathString]
+            : [])
+            + destination.extraSwiftCFlags
     }
 
     public init(destination: Destination, environment: [String: String] = ProcessEnv.vars) throws {
@@ -252,9 +256,13 @@ public final class UserToolchain: Toolchain {
 
         self.extraSwiftCFlags = UserToolchain.deriveSwiftCFlags(triple: triple, destination: destination)
 
-        self.extraCCFlags = [
-            triple.isDarwin() ? "-isysroot" : "--sysroot", destination.sdk.pathString
-        ] + destination.extraCCFlags
+        if let sdk = destination.sdk {
+            self.extraCCFlags = [
+                triple.isDarwin() ? "-isysroot" : "--sysroot", sdk.pathString
+            ] + destination.extraCCFlags
+        } else {
+            self.extraCCFlags = destination.extraCCFlags
+        }
 
         // Compute the path of directory containing the PackageDescription libraries.
         var pdLibDir = UserManifestResources.libDir(forBinDir: binDir)

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1541,7 +1541,7 @@ extension Workspace {
         // Clone the required pins.
         for pin in requiredPins {
             diagnostics.wrap {
-                _ = try self.clone(package: pin.packageRef, at: pin.state, productFilter: pin.productFilter)
+                _ = try self.clone(package: pin.packageRef, at: pin.state, productFilter: .everything)
             }
         }
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1616,9 +1616,6 @@ extension Workspace {
         // Compute the missing package identities.
         let missingPackageURLs = currentManifests.missingPackageURLs()
 
-        // The pins to use.
-        let validPins = pinsStore.createConstraints()
-
         // Compute if we need to run the resolver. We always run the resolver if
         // there are extra constraints.
         if !missingPackageURLs.isEmpty {
@@ -1658,7 +1655,6 @@ extension Workspace {
         let result = resolveDependencies(
             resolver: resolver,
             dependencies: constraints,
-            pins: validPins,
             pinsMap: pinsStore.pinsMap,
             diagnostics: diagnostics)
         activeResolver = nil
@@ -2038,7 +2034,6 @@ extension Workspace {
     fileprivate func resolveDependencies(
         resolver: PubgrubDependencyResolver,
         dependencies: [RepositoryPackageConstraint],
-        pins: [RepositoryPackageConstraint] = [],
         pinsMap: PinsStore.PinsMap,
         diagnostics: DiagnosticsEngine
     ) -> [(container: PackageReference, binding: BoundVersion, products: ProductFilter)] {

--- a/Sources/Workspace/WorkspaceState.swift
+++ b/Sources/Workspace/WorkspaceState.swift
@@ -49,9 +49,6 @@ public final class ManagedDependency {
     /// The state of the managed dependency.
     public let state: State
 
-    /// The product filter applied to the package.
-    public let productFilter: ProductFilter
-
     /// The checked out path of the dependency on disk, relative to the workspace checkouts path.
     public let subpath: RelativePath
 
@@ -65,25 +62,21 @@ public final class ManagedDependency {
     public init(
         packageRef: PackageReference,
         subpath: RelativePath,
-        checkoutState: CheckoutState,
-        productFilter: ProductFilter
+        checkoutState: CheckoutState
     ) {
         self.packageRef = packageRef
         self.state = .checkout(checkoutState)
-        self.productFilter = productFilter
         self.basedOn = nil
         self.subpath = subpath
     }
 
     /// Create a dependency present locally on the filesystem.
     public static func local(
-        packageRef: PackageReference,
-        productFilter: ProductFilter
+        packageRef: PackageReference
     ) -> ManagedDependency {
         return ManagedDependency(
             packageRef: packageRef,
             state: .local,
-            productFilter: productFilter,
             // FIXME: This is just a fake entry, we should fix it.
             subpath: RelativePath(packageRef.identity),
             basedOn: nil
@@ -93,7 +86,6 @@ public final class ManagedDependency {
     private init(
         packageRef: PackageReference,
         state: State,
-        productFilter: ProductFilter,
         subpath: RelativePath,
         basedOn: ManagedDependency?
     ) {
@@ -101,7 +93,6 @@ public final class ManagedDependency {
         self.subpath = subpath
         self.basedOn = basedOn
         self.state = state
-        self.productFilter = productFilter
     }
 
     private init(
@@ -114,7 +105,6 @@ public final class ManagedDependency {
         self.packageRef = dependency.packageRef
         self.subpath = subpath
         self.state = .edited(unmanagedPath)
-        self.productFilter = dependency.productFilter
     }
 
     /// Create an editable managed dependency based on a dependency which
@@ -358,7 +348,6 @@ extension ManagedDependency: JSONMappable, JSONSerializable, CustomStringConvert
         try self.init(
             packageRef: json.get("packageRef"),
             state: json.get("state"),
-            productFilter: json.get("products"),
             subpath: RelativePath(json.get("subpath")),
             basedOn: json.get("basedOn")
         )
@@ -369,13 +358,12 @@ extension ManagedDependency: JSONMappable, JSONSerializable, CustomStringConvert
             "packageRef": packageRef.toJSON(),
             "subpath": subpath,
             "basedOn": basedOn.toJSON(),
-            "state": state,
-            "products": productFilter
+            "state": state
         ])
     }
 
     public var description: String {
-        return "<ManagedDependency: \(packageRef.name) \(state) \(productFilter)>"
+        return "<ManagedDependency: \(packageRef.name) \(state)>"
     }
 }
 

--- a/Sources/Workspace/misc.swift
+++ b/Sources/Workspace/misc.swift
@@ -37,8 +37,7 @@ extension PinsStore {
 
         self.pin(
             packageRef: dependency.packageRef,
-            state: checkoutState,
-            productFilter: dependency.productFilter)
+            state: checkoutState)
     }
 }
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -2205,6 +2205,7 @@ final class BuildPlanTests: XCTestCase {
         let resourceAccessor = fooTarget.sources.first{ $0.basename == "resource_bundle_accessor.swift" }!
         let contents = try fs.readFileContents(resourceAccessor).cString
         XCTAssertTrue(contents.contains("extension Foundation.Bundle"), contents)
+        XCTAssertFalse(contents.contains("@available(*, unavailable,"), contents)
     }
     
     func testSwiftBundleUnavailableAccessor() throws {
@@ -2241,8 +2242,6 @@ final class BuildPlanTests: XCTestCase {
                 )
             ]
         )
-
-        XCTAssertNoDiagnostics(diagnostics)
 
         let plan = try BuildPlan(
             buildParameters: mockBuildParameters(),

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -259,8 +259,17 @@ class MiscellaneousTestCase: XCTestCase {
     func testSwiftTestFilter() throws {
         #if os(macOS)
             fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
-                let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--filter", ".*1"], packagePath: prefix)
-                XCTAssertMatch(stderr, .contains("testExample1"))
+                let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--filter", ".*1", "-l"], packagePath: prefix)
+                XCTAssertMatch(stdout, .contains("testExample1"))
+                XCTAssertNoMatch(stdout, .contains("testExample2"))
+                XCTAssertNoMatch(stdout, .contains("testSureFailure"))
+            }
+
+            fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
+                let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--filter", ".*1", "--filter", "testSureFailure", "-l"], packagePath: prefix)
+                XCTAssertMatch(stdout, .contains("testExample1"))
+                XCTAssertNoMatch(stdout, .contains("testExample2"))
+                XCTAssertMatch(stdout, .contains("testSureFailure"))
             }
         #endif
     }

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -2120,7 +2120,7 @@ class DependencyGraphBuilder {
         let store = try! PinsStore(pinsFile: AbsolutePath("/tmp/Package.resolved"), fileSystem: fs)
 
         for (package, pin) in pins {
-            store.pin(packageRef: reference(for: package), state: pin.0, productFilter: pin.1)
+            store.pin(packageRef: reference(for: package), state: pin.0)
         }
 
         try! store.saveState()

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -587,6 +587,7 @@ class PackageBuilderTests: XCTestCase {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/Foo/inc/module.modulemap",
             "/Sources/Foo/inc/Foo.h",
+            "/Sources/Foo/Foo_private.h",
             "/Sources/Foo/Foo.c",
             "/Sources/Bar/include/module.modulemap",
             "/Sources/Bar/include/Bar.h",
@@ -608,6 +609,8 @@ class PackageBuilderTests: XCTestCase {
             package.checkPredefinedPaths(target: "/Sources", testTarget: "/Tests")
 
             package.checkModule("Foo") { module in
+                let clangTarget = module.target as? ClangTarget
+                XCTAssertEqual(clangTarget?.headers.map{ $0.pathString }, ["/Sources/Foo/Foo_private.h", "/Sources/Foo/inc/Foo.h"])
                 module.check(c99name: "Foo", type: .library)
                 module.checkSources(root: "/Sources/Foo", paths: "Foo.c")
                 module.check(includeDir: "/Sources/Foo/inc")

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -143,7 +143,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             toolsVersion: .minimumRequired,
             fileTypes: ["something"])
 
-        build(target: target, additionalFileRules: [somethingRule], toolsVersion: .v5, fs: fs) { _, _, _ in
+        build(target: target, additionalFileRules: [somethingRule], toolsVersion: .v5, fs: fs) { _, _, _, _ in
             // No diagnostics
         }
     }
@@ -161,7 +161,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/Resources/Sub/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, diagnostics in
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, diagnostics in
                 diagnostics.check(diagnostic: "multiple resources named 'foo.txt' in target 'Foo'", behavior: .error)
                 diagnostics.checkUnordered(diagnostic: "found 'Resources/foo.txt'", behavior: .note)
                 diagnostics.checkUnordered(diagnostic: "found 'Resources/Sub/foo.txt'", behavior: .note)
@@ -181,7 +181,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/Copied/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, diagnostics in
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, diagnostics in
                 diagnostics.check(diagnostic: "multiple resources named 'foo.txt' in target 'Foo'", behavior: .error)
                 diagnostics.checkUnordered(diagnostic: "found 'Processed/foo.txt'", behavior: .note)
                 diagnostics.checkUnordered(diagnostic: "found 'Copied/foo.txt'", behavior: .note)
@@ -201,7 +201,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/Copied/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, diagnostics in
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, diagnostics in
                 // No diagnostics
             }
         }
@@ -219,7 +219,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/B/Copy/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, diagnostics in
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, diagnostics in
                 diagnostics.check(diagnostic: "multiple resources named 'Copy' in target 'Foo'", behavior: .error)
                 diagnostics.checkUnordered(diagnostic: "found 'A/Copy'", behavior: .note)
                 diagnostics.checkUnordered(diagnostic: "found 'B/Copy'", behavior: .note)
@@ -239,7 +239,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/B/EN.lproj/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, diagnostics in
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, diagnostics in
                 diagnostics.check(diagnostic: "multiple resources named 'en.lproj/foo.txt' in target 'Foo'", behavior: .error)
                 diagnostics.checkUnordered(diagnostic: "found 'A/en.lproj/foo.txt'", behavior: .note)
                 diagnostics.checkUnordered(diagnostic: "found 'B/EN.lproj/foo.txt'", behavior: .note)
@@ -259,7 +259,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/B/en.lproj/foo.txt"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, diagnostics in
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, diagnostics in
                 diagnostics.check(diagnostic: "resource 'B/en.lproj' in target 'Foo' conflicts with other localization directories", behavior: .error)
             }
         }
@@ -272,7 +272,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/en.lproj/Localizable.strings"
         )
 
-        build(target: target, toolsVersion: .v5_2, fs: fs) { _, resources, _ in
+        build(target: target, toolsVersion: .v5_2, fs: fs) { _, resources, _, _ in
             XCTAssert(resources.isEmpty)
             // No diagnostics
         }
@@ -289,7 +289,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Copied/en.lproj/sub/Localizable.strings"
         )
 
-        build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, diagnostics in
+        build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, diagnostics in
             diagnostics.check(diagnostic: "localization directory 'Processed/en.lproj' in target 'Foo' contains sub-directories, which is forbidden", behavior: .error)
         }
     }
@@ -303,7 +303,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Resources/en.lproj/Localizable.strings"
         )
 
-        build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, diagnostics in
+        build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, diagnostics in
             diagnostics.check(
                 diagnostic: .contains("""
                     resource 'Resources/en.lproj/Localizable.strings' in target 'Foo' is in a localization directory \
@@ -330,7 +330,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Icon.png"
         )
 
-        build(target: target, defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, _, diagnostics in
+        build(target: target, defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, _, _, diagnostics in
             diagnostics.check(
                 diagnostic: .contains("resource 'Icon.png' in target 'Foo' is missing the default localization 'fr'"),
                 behavior: .warning)
@@ -355,7 +355,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Icon.png"
         )
 
-        build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, diagnostics in
+        build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, diagnostics in
             diagnostics.checkUnordered(
                 diagnostic: .contains("resource 'Localizable.strings' in target 'Foo' has both localized and un-localized variants"),
                 behavior: .warning)
@@ -391,7 +391,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Other/Image.png"
         )
 
-        build(target: target, defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, resources, diagnostics in
+        build(target: target, defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, resources,  _, diagnostics in
             XCTAssertEqual(Set(resources), [
                 Resource(rule: .process, path: AbsolutePath("/Processed/foo.txt"), localization: nil),
                 Resource(rule: .process, path: AbsolutePath("/Processed/En-uS.lproj/Localizable.stringsdict"), localization: "en-us"),
@@ -412,7 +412,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             "/Foo/es.lproj/Image.png"
         )
 
-        build(target: TargetDescription(name: "Foo"), defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, resources, diagnostics in
+        build(target: TargetDescription(name: "Foo"), defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, resources, _, diagnostics in
             XCTAssertEqual(Set(resources), [
                 Resource(rule: .process, path: AbsolutePath("/Foo/fr.lproj/Image.png"), localization: "fr"),
                 Resource(rule: .process, path: AbsolutePath("/Foo/es.lproj/Image.png"), localization: "es"),
@@ -430,7 +430,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/Resources/Processed/Info.plist"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, diagnostics in
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, diagnostics in
                 diagnostics.check(
                     diagnostic: .contains("resource 'Resources/Processed/Info.plist' in target 'Foo' is forbidden"),
                     behavior: .error)
@@ -446,7 +446,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/Resources/Copied/Info.plist"
             )
 
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, diagnostics in
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, diagnostics in
                 diagnostics.check(
                     diagnostic: .contains("resource 'Resources/Copied/Info.plist' in target 'Foo' is forbidden"),
                     behavior: .error)
@@ -462,7 +462,7 @@ class TargetSourcesBuilderTests: XCTestCase {
         fs: FileSystem,
         file: StaticString = #file,
         line: UInt = #line,
-        checker: (Sources, [Resource], DiagnosticsEngineResult) -> ()
+        checker: (Sources, [Resource], [AbsolutePath], DiagnosticsEngineResult) -> ()
     ) {
         let diagnostics = DiagnosticsEngine()
         let builder = TargetSourcesBuilder(
@@ -478,10 +478,10 @@ class TargetSourcesBuilderTests: XCTestCase {
         )
 
         do {
-            let (sources, resources) = try builder.run()
+            let (sources, resources, headers) = try builder.run()
 
             DiagnosticsEngineTester(diagnostics, file: file, line: line) { diagnostics in
-                checker(sources, resources, diagnostics)
+                checker(sources, resources, headers, diagnostics)
             }
         } catch {
             XCTFail(error.localizedDescription, file: file, line: line)

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -471,6 +471,25 @@ class TargetSourcesBuilderTests: XCTestCase {
         }
         
         do {
+            // Ensure paths are normalised before comparison
+            let target = TargetDescription(name: "Foo", resources: [
+                .init(rule: .copy, path: "./foo.txt"),
+                .init(rule: .process, path: "./dir/bar.txt"),
+                .init(rule: .copy, path: "./dir/../baz.txt"),
+            ])
+            
+            let fs = InMemoryFileSystem(emptyFiles:
+                "/foo.txt",
+                "/dir/bar.txt",
+                "/baz.txt"
+            )
+            
+            build(target: target, toolsVersion: .v5_3, fs: fs) { (_, resources, _) in
+                XCTAssertEqual(resources.count, 3)
+            }
+        }
+        
+        do {
             // Complete Failure
             let target = TargetDescription(name: "Foo", resources: [
                 .init(rule: .copy, path: "foo.txt"),

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -165,6 +165,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                 diagnostics.check(diagnostic: "multiple resources named 'foo.txt' in target 'Foo'", behavior: .error)
                 diagnostics.checkUnordered(diagnostic: "found 'Resources/foo.txt'", behavior: .note)
                 diagnostics.checkUnordered(diagnostic: "found 'Resources/Sub/foo.txt'", behavior: .note)
+                diagnostics.checkUnordered(diagnostic: .contains("target 'Foo' does not have resources at the following paths"), behavior: .warning)
             }
         }
 
@@ -291,6 +292,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, diagnostics in
             diagnostics.check(diagnostic: "localization directory 'Processed/en.lproj' in target 'Foo' contains sub-directories, which is forbidden", behavior: .error)
+            diagnostics.checkUnordered(diagnostic: .contains("target 'Foo' does not have resources at the following paths"), behavior: .warning)
         }
     }
 
@@ -310,6 +312,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                     and has an explicit localization declaration
                     """),
                 behavior: .error)
+            diagnostics.checkUnordered(diagnostic: .contains("target 'Foo' does not have resources at the following paths"), behavior: .warning)
         }
     }
 
@@ -334,6 +337,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             diagnostics.check(
                 diagnostic: .contains("resource 'Icon.png' in target 'Foo' is missing the default localization 'fr'"),
                 behavior: .warning)
+            diagnostics.checkUnordered(diagnostic: .contains("target 'Foo' does not have resources at the following paths"), behavior: .warning)
         }
     }
 
@@ -367,6 +371,9 @@ class TargetSourcesBuilderTests: XCTestCase {
                 behavior: .warning)
             diagnostics.checkUnordered(
                 diagnostic: .contains("resource 'Icon.png' in target 'Foo' has both localized and un-localized variants"),
+                behavior: .warning)
+            diagnostics.checkUnordered(
+                diagnostic: .contains("target 'Foo' does not have resources at the following paths"),
                 behavior: .warning)
         }
     }
@@ -403,6 +410,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                 Resource(rule: .process, path: AbsolutePath("/Other/Launch.storyboard"), localization: "Base"),
                 Resource(rule: .process, path: AbsolutePath("/Other/Image.png"), localization: "fr"),
             ])
+            diagnostics.checkUnordered(diagnostic: .contains("target 'Foo' does not have resources at the following paths"), behavior: .warning)
         }
     }
 
@@ -418,6 +426,72 @@ class TargetSourcesBuilderTests: XCTestCase {
                 Resource(rule: .process, path: AbsolutePath("/Foo/es.lproj/Image.png"), localization: "es"),
             ])
         }
+    }
+    
+    func testMissingResources() {
+        
+        do {
+            // No Failures
+            let target = TargetDescription(name: "Foo", resources: [
+                .init(rule: .copy, path: "foo.txt"),
+                .init(rule: .process, path: "bar.txt")
+            ])
+            
+            let fs = InMemoryFileSystem(emptyFiles:
+                "/foo.txt",
+                "/bar.txt"
+            )
+            
+            build(target: target, toolsVersion: .v5_3, fs: fs) { (_, resources, _) in
+                XCTAssertEqual(resources.count, 2)
+            }
+        }
+        
+        do {
+            // Partial Success
+            let target = TargetDescription(name: "Foo", resources: [
+                .init(rule: .copy, path: "foo.txt"),
+                .init(rule: .process, path: "bar.txt")
+            ])
+            
+            let fs = InMemoryFileSystem(emptyFiles:
+                "/foo.txt"
+            )
+            
+            build(target: target, toolsVersion: .v5_3, fs: fs) { (_, resources, diagnostics) in
+                XCTAssertEqual(resources.count, 1)
+                diagnostics.check(
+                    diagnostic: .contains("""
+                    target 'Foo' does not have resources at the following paths, they will be ignored
+                        'bar.txt' (/bar.txt)
+                    """),
+                    behavior: .warning
+                )
+            }
+        }
+        
+        do {
+            // Complete Failure
+            let target = TargetDescription(name: "Foo", resources: [
+                .init(rule: .copy, path: "foo.txt"),
+                .init(rule: .process, path: "bar.txt")
+            ])
+            
+            let fs = InMemoryFileSystem(emptyFiles: [])
+            
+            build(target: target, toolsVersion: .v5_3, fs: fs) { (_, resources, diagnostics) in
+                XCTAssertEqual(resources.count, 0)
+                diagnostics.check(
+                    diagnostic: .contains("""
+                    target 'Foo' does not have resources at the following paths, they will be ignored
+                        'foo.txt' (/foo.txt)
+                        'bar.txt' (/bar.txt)
+                    """),
+                    behavior: .warning
+                )
+            }
+        }
+        
     }
 
     func testInfoPlistResource() {

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -165,7 +165,6 @@ class TargetSourcesBuilderTests: XCTestCase {
                 diagnostics.check(diagnostic: "multiple resources named 'foo.txt' in target 'Foo'", behavior: .error)
                 diagnostics.checkUnordered(diagnostic: "found 'Resources/foo.txt'", behavior: .note)
                 diagnostics.checkUnordered(diagnostic: "found 'Resources/Sub/foo.txt'", behavior: .note)
-                diagnostics.checkUnordered(diagnostic: .contains("target 'Foo' does not have resources at the following paths"), behavior: .warning)
             }
         }
 
@@ -337,7 +336,6 @@ class TargetSourcesBuilderTests: XCTestCase {
             diagnostics.check(
                 diagnostic: .contains("resource 'Icon.png' in target 'Foo' is missing the default localization 'fr'"),
                 behavior: .warning)
-            diagnostics.checkUnordered(diagnostic: .contains("target 'Foo' does not have resources at the following paths"), behavior: .warning)
         }
     }
 
@@ -371,9 +369,6 @@ class TargetSourcesBuilderTests: XCTestCase {
                 behavior: .warning)
             diagnostics.checkUnordered(
                 diagnostic: .contains("resource 'Icon.png' in target 'Foo' has both localized and un-localized variants"),
-                behavior: .warning)
-            diagnostics.checkUnordered(
-                diagnostic: .contains("target 'Foo' does not have resources at the following paths"),
                 behavior: .warning)
         }
     }
@@ -410,7 +405,6 @@ class TargetSourcesBuilderTests: XCTestCase {
                 Resource(rule: .process, path: AbsolutePath("/Other/Launch.storyboard"), localization: "Base"),
                 Resource(rule: .process, path: AbsolutePath("/Other/Image.png"), localization: "fr"),
             ])
-            diagnostics.checkUnordered(diagnostic: .contains("target 'Foo' does not have resources at the following paths"), behavior: .warning)
         }
     }
 
@@ -442,7 +436,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/bar.txt"
             )
             
-            build(target: target, toolsVersion: .v5_3, fs: fs) { (_, resources, _) in
+            build(target: target, toolsVersion: .v5_3, fs: fs) { (_, resources, _, _) in
                 XCTAssertEqual(resources.count, 2)
             }
         }
@@ -458,7 +452,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/foo.txt"
             )
             
-            build(target: target, toolsVersion: .v5_3, fs: fs) { (_, resources, diagnostics) in
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, resources, _, diagnostics in
                 XCTAssertEqual(resources.count, 1)
                 diagnostics.check(
                     diagnostic: .contains("""
@@ -484,7 +478,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/baz.txt"
             )
             
-            build(target: target, toolsVersion: .v5_3, fs: fs) { (_, resources, _) in
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, resources, _, _ in
                 XCTAssertEqual(resources.count, 3)
             }
         }
@@ -498,7 +492,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             
             let fs = InMemoryFileSystem(emptyFiles: [])
             
-            build(target: target, toolsVersion: .v5_3, fs: fs) { (_, resources, diagnostics) in
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, resources, _, diagnostics in
                 XCTAssertEqual(resources.count, 0)
                 diagnostics.check(
                     diagnostic: .contains("""

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -32,7 +32,6 @@ final class PinsStoreTests: XCTestCase {
         let barRef = PackageReference(identity: bar, path: barRepo.url)
 
         let state = CheckoutState(revision: revision, version: v1)
-        let products: ProductFilter = .everything
         let pin = PinsStore.Pin(packageRef: fooRef, state: state)
         // We should be able to round trip from JSON.
         XCTAssertEqual(try PinsStore.Pin(json: pin.toJSON()), pin)
@@ -120,8 +119,7 @@ final class PinsStoreTests: XCTestCase {
                           "branch": null,
                           "revision": "90a9574276f0fd17f02f58979423c3fd4d73b59e",
                           "version": "1.0.2",
-                        },
-                        "products": ["a", "b"]
+                        }
                       },
                       {
                         "package": "Commandant",
@@ -130,8 +128,7 @@ final class PinsStoreTests: XCTestCase {
                           "branch": null,
                           "revision": "c281992c31c3f41c48b5036c5a38185eaec32626",
                           "version": "0.12.0"
-                        },
-                        "products": "all"
+                        }
                       }
                     ]
                   },

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -33,7 +33,7 @@ final class PinsStoreTests: XCTestCase {
 
         let state = CheckoutState(revision: revision, version: v1)
         let products: ProductFilter = .everything
-        let pin = PinsStore.Pin(packageRef: fooRef, state: state, productFilter: products)
+        let pin = PinsStore.Pin(packageRef: fooRef, state: state)
         // We should be able to round trip from JSON.
         XCTAssertEqual(try PinsStore.Pin(json: pin.toJSON()), pin)
 
@@ -44,7 +44,7 @@ final class PinsStoreTests: XCTestCase {
         XCTAssert(!fs.exists(pinsFile))
         XCTAssert(store.pins.map{$0}.isEmpty)
 
-        store.pin(packageRef: fooRef, state: state, productFilter: products)
+        store.pin(packageRef: fooRef, state: state)
         try store.saveState()
 
         XCTAssert(fs.exists(pinsFile))
@@ -63,13 +63,12 @@ final class PinsStoreTests: XCTestCase {
         }
 
         // We should be able to pin again.
-        store.pin(packageRef: fooRef, state: state, productFilter: products)
+        store.pin(packageRef: fooRef, state: state)
         store.pin(
             packageRef: fooRef,
-            state: CheckoutState(revision: revision, version: "1.0.2"),
-            productFilter: .specific(["some", "products"])
+            state: CheckoutState(revision: revision, version: "1.0.2")
         )
-        store.pin(packageRef: barRef, state: state, productFilter: products)
+        store.pin(packageRef: barRef, state: state)
         try store.saveState()
 
         store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
@@ -79,8 +78,7 @@ final class PinsStoreTests: XCTestCase {
         do {
             store.pin(
                 packageRef: barRef,
-                state: CheckoutState(revision: revision, branch: "develop"),
-                productFilter: .specific(["a", "product"])
+                state: CheckoutState(revision: revision, branch: "develop")
             )
             try store.saveState()
             store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
@@ -94,7 +92,7 @@ final class PinsStoreTests: XCTestCase {
 
         // Test revision pin.
         do {
-            store.pin(packageRef: barRef, state: CheckoutState(revision: revision), productFilter: .specific(["other", "product"]))
+            store.pin(packageRef: barRef, state: CheckoutState(revision: revision))
             try store.saveState()
             store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
 
@@ -156,7 +154,7 @@ final class PinsStoreTests: XCTestCase {
 
         let fooRef = PackageReference(identity: "foo", path: "/foo")
         let revision = Revision(identifier: "81513c8fd220cf1ed1452b98060cd80d3725c5b7")
-        store.pin(packageRef: fooRef, state: CheckoutState(revision: revision, version: v1), productFilter: .specific([]))
+        store.pin(packageRef: fooRef, state: CheckoutState(revision: revision, version: v1))
 
         XCTAssert(!fs.exists(pinsFile))
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -767,14 +767,8 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
-        let v1_5 = (
-            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-            products: ProductFilter.specific([])
-        )
-        let v2 = (
-            CheckoutState(revision: Revision(identifier: "hello"), version: "2.0.0"),
-            products: ProductFilter.specific([])
-        )
+        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
+        let v2 = CheckoutState(revision: Revision(identifier: "hello"), version: "2.0.0")
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -797,7 +791,7 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1_5, cRef: v2],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5.version, productFilter: v1_5.products)
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5)
                     .editedDependency(subpath: bPath, unmanagedPath: nil)
             ]
         )
@@ -813,10 +807,7 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
-        let v1 = (
-            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.0"),
-            products: ProductFilter.everything
-        )
+        let v1 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.0")
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -856,7 +847,7 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1.version, productFilter: v1.products)
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1)
             ]
         )
 
@@ -873,10 +864,7 @@ final class WorkspaceTests: XCTestCase {
         let cPath = RelativePath("C")
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let branchRequirement: TestDependency.Requirement = .branch("master")
-        let v1_5 = (
-            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-            products: ProductFilter.everything
-        )
+        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -916,8 +904,8 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1_5, cRef: v1_5],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5.version, productFilter: v1_5.products),
-                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5.version, productFilter: v1_5.products),
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5),
+                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5),
             ]
         )
 
@@ -925,7 +913,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.diagnostics.hasErrors, false)
             XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
                 package: cRef,
-                state: .checkout(v1_5.version),
+                state: .checkout(v1_5),
                 requirement: .revision("master")
             )))
         }
@@ -935,10 +923,7 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let cPath = RelativePath("C")
-        let v1_5 = (
-            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-            products: ProductFilter.everything
-        )
+        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
 
         let testWorkspace = try TestWorkspace(
             sandbox: sandbox,
@@ -969,7 +954,7 @@ final class WorkspaceTests: XCTestCase {
         try testWorkspace.set(
             pins: [cRef: v1_5],
             managedDependencies: [
-                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5.version, productFilter: v1_5.products),
+                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5),
             ]
         )
 
@@ -977,7 +962,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.diagnostics.hasErrors, false)
             XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
                 package: cRef,
-                state: .checkout(v1_5.version),
+                state: .checkout(v1_5),
                 requirement: .revision("hello")
             )))
         }
@@ -990,10 +975,7 @@ final class WorkspaceTests: XCTestCase {
         let bPath = RelativePath("B")
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let masterRequirement: TestDependency.Requirement = .branch("master")
-        let v1_5 = (
-            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-            products: ProductFilter.everything
-        )
+        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -1033,8 +1015,8 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1_5],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5.version, productFilter: v1_5.products),
-                ManagedDependency.local(packageRef: cRef, productFilter: .specific(["C"]))
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5),
+                ManagedDependency.local(packageRef: cRef)
             ]
         )
 
@@ -1055,10 +1037,7 @@ final class WorkspaceTests: XCTestCase {
         let cPath = RelativePath("C")
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let localRequirement: TestDependency.Requirement = .localPackage
-        let v1_5 = (
-            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-            products: ProductFilter.everything
-        )
+        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -1098,8 +1077,8 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1_5, cRef: v1_5],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5.version, productFilter: v1_5.products),
-                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5.version, productFilter: v1_5.products),
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5),
+                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5),
             ]
         )
 
@@ -1107,7 +1086,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.diagnostics.hasErrors, false)
             XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
                 package: cRef,
-                state: .checkout(v1_5.version),
+                state: .checkout(v1_5),
                 requirement: .unversioned
             )))
         }
@@ -1120,14 +1099,8 @@ final class WorkspaceTests: XCTestCase {
         let cPath = RelativePath("C")
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let localRequirement: TestDependency.Requirement = .localPackage
-        let v1_5 = (
-            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-            products: ProductFilter.everything
-        )
-        let master = (
-            version: CheckoutState(revision: Revision(identifier: "master"), branch: "master"),
-            products: ProductFilter.everything
-        )
+        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
+        let master = CheckoutState(revision: Revision(identifier: "master"), branch: "master")
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -1167,8 +1140,8 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1_5, cRef: master],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5.version, productFilter: v1_5.products),
-                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: master.version, productFilter: master.products),
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5),
+                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: master),
             ]
         )
 
@@ -1176,7 +1149,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.diagnostics.hasErrors, false)
             XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
                 package: cRef,
-                state: .checkout(master.version),
+                state: .checkout(master),
                 requirement: .unversioned
             )))
         }
@@ -1189,10 +1162,7 @@ final class WorkspaceTests: XCTestCase {
         let cPath = RelativePath("C")
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let v2Requirement: TestDependency.Requirement = .range("2.0.0" ..< "3.0.0")
-        let v1_5 = (
-            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-            products: ProductFilter.everything
-        )
+        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -1232,8 +1202,8 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1_5, cRef: v1_5],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5.version, productFilter: v1_5.products),
-                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5.version, productFilter: v1_5.products),
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5),
+                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5),
             ]
         )
 
@@ -1250,14 +1220,8 @@ final class WorkspaceTests: XCTestCase {
         let cPath = RelativePath("C")
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let v2Requirement: TestDependency.Requirement = .range("2.0.0" ..< "3.0.0")
-        let v1_5 = (
-            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-            products: ProductFilter.everything
-        )
-        let v2 = (
-            version: CheckoutState(revision: Revision(identifier: "hello"), version: "2.0.0"),
-            products: ProductFilter.everything
-        )
+        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
+        let v2 = CheckoutState(revision: Revision(identifier: "hello"), version: "2.0.0")
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -1297,8 +1261,8 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1_5, cRef: v2],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5.version, productFilter: v1_5.products),
-                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v2.version, productFilter: v2.products),
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5),
+                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v2),
             ]
         )
 
@@ -1963,7 +1927,7 @@ final class WorkspaceTests: XCTestCase {
         // Check failure.
         workspace.checkResolve(pkg: "Foo", roots: ["Root"], version: "1.3.0") { diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("Foo[Foo] 1.3.0"), behavior: .error)
+                result.check(diagnostic: .contains("Foo 1.3.0"), behavior: .error)
             }
         }
         workspace.checkManagedDependencies() { result in
@@ -4267,10 +4231,7 @@ final class WorkspaceTests: XCTestCase {
         let aRef = PackageReference(identity: "a", path: aPath)
         let aRepo = workspace.repoProvider.specifierMap[RepositorySpecifier(url: aPath)]!
         let aRevision = try aRepo.resolveRevision(tag: "1.0.0")
-        let aState = (
-            version: CheckoutState(revision: aRevision, version: "1.0.0"),
-            products: ProductFilter.everything
-        )
+        let aState = CheckoutState(revision: aRevision, version: "1.0.0")
 
         try workspace.set(
             pins: [aRef: aState],
@@ -4516,11 +4477,8 @@ final class WorkspaceTests: XCTestCase {
         let aRef = PackageReference(identity: "a", path: aPath)
         let aRepo = workspace.repoProvider.specifierMap[RepositorySpecifier(url: aPath)]!
         let aRevision = try aRepo.resolveRevision(tag: "1.0.0")
-        let aState = (
-            version: CheckoutState(revision: aRevision, version: "1.0.0"),
-            products: ProductFilter.everything
-        )
-        let aDependency = ManagedDependency(packageRef: aRef, subpath: RelativePath("A"), checkoutState: aState.version, productFilter: aState.products)
+        let aState = CheckoutState(revision: aRevision, version: "1.0.0")
+        let aDependency = ManagedDependency(packageRef: aRef, subpath: RelativePath("A"), checkoutState: aState)
 
         try workspace.set(
             pins: [aRef: aState],

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3608,7 +3608,7 @@ final class WorkspaceTests: XCTestCase {
             let revision = try fooRepo.resolveRevision(tag: "1.0.0")
             let newState = CheckoutState(revision: revision, version: "1.0.0")
 
-            pinsStore.pin(packageRef: fooPin.packageRef, state: newState, productFilter: .specific(["Foo"]))
+            pinsStore.pin(packageRef: fooPin.packageRef, state: newState)
             try pinsStore.saveState()
         }
 

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -528,6 +528,7 @@ def build_swiftpm_with_swiftpm(args, integrated_swift_driver):
 
     swiftpm_args = [
         "SWIFT_EXEC=" + args.swiftc_path,
+        "SWIFT_DRIVER_SWIFT_EXEC=" + args.swiftc_path,
         "SWIFTPM_PD_LIBS=" + os.path.join(args.bootstrap_dir, "pm"),
         os.path.join(args.bootstrap_dir, "bin/swift-build"),
         "--disable-sandbox",

--- a/swift-tools-support-core/Sources/TSCBasic/Path.swift
+++ b/swift-tools-support-core/Sources/TSCBasic/Path.swift
@@ -266,6 +266,30 @@ public struct RelativePath: Hashable {
     public var components: [String] {
         return _impl.components
     }
+
+    /// Returns the relative path with the given relative path applied.
+    public func appending(_ subpath: RelativePath) -> RelativePath {
+        return RelativePath(_impl.appending(relativePath: subpath._impl))
+    }
+
+    /// Returns the relative path with an additional literal component appended.
+    ///
+    /// This method accepts pseudo-path like '.' or '..', but should not contain "/".
+    public func appending(component: String) -> RelativePath {
+        return RelativePath(_impl.appending(component: component))
+    }
+
+    /// Returns the relative path with additional literal components appended.
+    ///
+    /// This method should only be used in cases where the input is guaranteed
+    /// to be a valid path component (i.e., it cannot be empty, contain a path
+    /// separator, or be a pseudo-path like '.' or '..').
+    public func appending(components names: String...) -> RelativePath {
+        // FIXME: This doesn't seem a particularly efficient way to do this.
+        return names.reduce(self, { path, name in
+            path.appending(component: name)
+        })
+    }
 }
 
 extension AbsolutePath: Codable {

--- a/swift-tools-support-core/Sources/TSCUtility/Version.swift
+++ b/swift-tools-support-core/Sources/TSCUtility/Version.swift
@@ -204,29 +204,29 @@ extension Version: Codable {
 
 // MARK:- Range operations
 
+@available(*, unavailable)
 extension ClosedRange where Bound == Version {
     /// Marked as unavailable because we have custom rules for contains.
     public func contains(_ element: Version) -> Bool {
-        // Unfortunately, we can't use unavailable here.
         fatalError("contains(_:) is unavailable, use contains(version:)")
     }
 }
 
 // Disabled because compiler hits an assertion https://bugs.swift.org/browse/SR-5014
 #if false
+@available(*, unavailable)
 extension CountableRange where Bound == Version {
     /// Marked as unavailable because we have custom rules for contains.
     public func contains(_ element: Version) -> Bool {
-        // Unfortunately, we can't use unavailable here.
         fatalError("contains(_:) is unavailable, use contains(version:)")
     }
 }
 #endif
 
+@available(*, unavailable)
 extension Range where Bound == Version {
     /// Marked as unavailable because we have custom rules for contains.
     public func contains(_ element: Version) -> Bool {
-        // Unfortunately, we can't use unavailable here.
         fatalError("contains(_:) is unavailable, use contains(version:)")
     }
 }

--- a/swift-tools-support-core/Tests/TSCBasicTests/PathTests.swift
+++ b/swift-tools-support-core/Tests/TSCBasicTests/PathTests.swift
@@ -214,6 +214,9 @@ class PathTests: XCTestCase {
         XCTAssertEqual(AbsolutePath("/").appending(components: "..").pathString, "/")
         XCTAssertEqual(AbsolutePath("/").appending(components: ".").pathString, "/")
         XCTAssertEqual(AbsolutePath("/").appending(components: "..", "a").pathString, "/a")
+
+        XCTAssertEqual(RelativePath("hello").appending(components: "a", "b", "c", "..").pathString, "hello/a/b")
+        XCTAssertEqual(RelativePath("hello").appending(RelativePath("a/b/../c/d")).pathString, "hello/a/c/d")
     }
 
     func testPathComponents() {


### PR DESCRIPTION
This addresses [SR-13084](https://bugs.swift.org/browse/SR-13084).

In looking to use the new resources capability of SPM I faced some confusion when my setup wasn't working - it turned out to be that my paths were relative to the Package.swift rather than to the target. There was no warning/error and so wasn't the easiest to debug -- this MR aims to resolve this in two parts:

1. Currently the `Bundle.module` accessor is only created if at least one valid resource is generated in the bundle. A change in this MR means that the accessor is *always* created but is marked unavailable (with a user friendly message) if there are no valid resources.

2. A warning is raised as part of the package description diagnostics which lists the exact resources which were seen as missing. A warning has been chosen to act as a non-breaking change (though an error may be more appropriate)

The messages may need more finessing to make more sense - open to suggestions.

First attempt at trying to contribute to SPM so hopefully this isn't horrendous!

Thank you 🙌  