### PR TITLE
Android: add host destination to the workspace

### DIFF
--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -130,6 +130,15 @@ public struct Destination: Encodable, Equatable {
             extraSwiftCFlags: extraSwiftCFlags,
             extraCPPFlags: ["-lc++"]
         )
+      #elseif os(Android)
+        return Destination(
+            target: nil,
+            sdk: AbsolutePath(ProcessEnv.vars["PREFIX"]!).parentDirectory,
+            binDir: binDir,
+            extraCCFlags: ["-fPIC"],
+            extraSwiftCFlags: [],
+            extraCPPFlags: ["-lstdc++"]
+        )
       #else
         return Destination(
             target: nil,


### PR DESCRIPTION
The Termux app sets the `PREFIX` environment variable with its root of `/data/data/com.termux/files/usr`, so read that and set the SDK path for Android.

Until now, [I was simply hard-coding](https://github.com/termux/termux-packages/blob/master/packages/swift/swiftpm-Sources-Workspace-Destination.swift#L10) that [path at compile time](https://github.com/termux/termux-packages/blob/master/packages/swift/build.sh#L73). This is the last patch needed to build SPM natively on Android.