### PR TITLE
mark unavailable to range contains of Version

### DIFF
--- a/swift-tools-support-core/Sources/TSCUtility/Version.swift
+++ b/swift-tools-support-core/Sources/TSCUtility/Version.swift
@@ -204,29 +204,29 @@ extension Version: Codable {
 
 // MARK:- Range operations
 
+@available(*, unavailable)
 extension ClosedRange where Bound == Version {
     /// Marked as unavailable because we have custom rules for contains.
     public func contains(_ element: Version) -> Bool {
-        // Unfortunately, we can't use unavailable here.
         fatalError("contains(_:) is unavailable, use contains(version:)")
     }
 }
 
 // Disabled because compiler hits an assertion https://bugs.swift.org/browse/SR-5014
 #if false
+@available(*, unavailable)
 extension CountableRange where Bound == Version {
     /// Marked as unavailable because we have custom rules for contains.
     public func contains(_ element: Version) -> Bool {
-        // Unfortunately, we can't use unavailable here.
         fatalError("contains(_:) is unavailable, use contains(version:)")
     }
 }
 #endif
 
+@available(*, unavailable)
 extension Range where Bound == Version {
     /// Marked as unavailable because we have custom rules for contains.
     public func contains(_ element: Version) -> Bool {
-        // Unfortunately, we can't use unavailable here.
         fatalError("contains(_:) is unavailable, use contains(version:)")
     }
 }


### PR DESCRIPTION
```swift
@available(*, unavailable)
extension Range where Bound == Version {
    /// Marked as unavailable because we have custom rules for contains.
    public func contains(_ element: Version) -> Bool {
        // Unfortunately, we can't use unavailable here.
        fatalError("contains(_:) is unavailable, use contains(version:)")
    }
}
```
It can be marked as unavailable.
```swift
let range = Version(1, 0, 0)..<Version(2, 0, 0)
range.contains(Version(1, 0, 0)) // error message: 'contains' is unavailable
```