### PR TITLE
Do not store products in resolved file

### DIFF
--- a/Sources/PackageGraph/PinsStore.swift
+++ b/Sources/PackageGraph/PinsStore.swift
@@ -23,17 +23,12 @@ public final class PinsStore {
         /// The pinned state.
         public let state: CheckoutState
 
-        /// The product filter applied by the pin.
-        public let productFilter: ProductFilter
-
         public init(
             packageRef: PackageReference,
-            state: CheckoutState,
-            productFilter: ProductFilter
+            state: CheckoutState
         ) {
             self.packageRef = packageRef
             self.state = state
-            self.productFilter = productFilter
         }
     }
 
@@ -88,13 +83,11 @@ public final class PinsStore {
     ///   - state: The state to pin at.
     public func pin(
         packageRef: PackageReference,
-        state: CheckoutState,
-        productFilter: ProductFilter
+        state: CheckoutState
     ) {
         pinsMap[packageRef.identity] = Pin(
             packageRef: packageRef,
-            state: state,
-            productFilter: productFilter
+            state: state
         )
     }
 
@@ -117,7 +110,7 @@ public final class PinsStore {
     public func createConstraints() -> [RepositoryPackageConstraint] {
         return pins.map({ pin in
             return RepositoryPackageConstraint(
-                container: pin.packageRef, requirement: pin.state.requirement(), products: pin.productFilter)
+                container: pin.packageRef, requirement: pin.state.requirement(), products: .everything)
         })
     }
 }
@@ -159,7 +152,6 @@ extension PinsStore.Pin: JSONMappable, JSONSerializable, Equatable {
         let ref = PackageReference(identity: identity, path: url)
         self.packageRef = name.flatMap(ref.with(newName:)) ?? ref
         self.state = try json.get("state")
-        self.productFilter = try json.get("products")
     }
 
     /// Convert the pin to JSON.
@@ -167,8 +159,7 @@ extension PinsStore.Pin: JSONMappable, JSONSerializable, Equatable {
         return .init([
             "package": packageRef.name.toJSON(),
             "repositoryURL": packageRef.path,
-            "state": state,
-            "products": productFilter,
+            "state": state
         ])
     }
 }

--- a/Sources/SPMTestSupport/TestWorkspace.swift
+++ b/Sources/SPMTestSupport/TestWorkspace.swift
@@ -354,7 +354,7 @@ public final class TestWorkspace {
         let pinsStore = try workspace.pinsStore.load()
 
         for (ref, state) in pins {
-            pinsStore.pin(packageRef: ref, state: state.version, productFilter: state.products)
+            pinsStore.pin(packageRef: ref, state: state.version)
         }
 
         for dependency in managedDependencies {

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1541,7 +1541,7 @@ extension Workspace {
         // Clone the required pins.
         for pin in requiredPins {
             diagnostics.wrap {
-                _ = try self.clone(package: pin.packageRef, at: pin.state, productFilter: pin.productFilter)
+                _ = try self.clone(package: pin.packageRef, at: pin.state, productFilter: .everything)
             }
         }
 

--- a/Sources/Workspace/misc.swift
+++ b/Sources/Workspace/misc.swift
@@ -37,8 +37,7 @@ extension PinsStore {
 
         self.pin(
             packageRef: dependency.packageRef,
-            state: checkoutState,
-            productFilter: dependency.productFilter)
+            state: checkoutState)
     }
 }
 

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -2120,7 +2120,7 @@ class DependencyGraphBuilder {
         let store = try! PinsStore(pinsFile: AbsolutePath("/tmp/Package.resolved"), fileSystem: fs)
 
         for (package, pin) in pins {
-            store.pin(packageRef: reference(for: package), state: pin.0, productFilter: pin.1)
+            store.pin(packageRef: reference(for: package), state: pin.0)
         }
 
         try! store.saveState()

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -33,7 +33,7 @@ final class PinsStoreTests: XCTestCase {
 
         let state = CheckoutState(revision: revision, version: v1)
         let products: ProductFilter = .everything
-        let pin = PinsStore.Pin(packageRef: fooRef, state: state, productFilter: products)
+        let pin = PinsStore.Pin(packageRef: fooRef, state: state)
         // We should be able to round trip from JSON.
         XCTAssertEqual(try PinsStore.Pin(json: pin.toJSON()), pin)
 
@@ -44,7 +44,7 @@ final class PinsStoreTests: XCTestCase {
         XCTAssert(!fs.exists(pinsFile))
         XCTAssert(store.pins.map{$0}.isEmpty)
 
-        store.pin(packageRef: fooRef, state: state, productFilter: products)
+        store.pin(packageRef: fooRef, state: state)
         try store.saveState()
 
         XCTAssert(fs.exists(pinsFile))
@@ -63,13 +63,12 @@ final class PinsStoreTests: XCTestCase {
         }
 
         // We should be able to pin again.
-        store.pin(packageRef: fooRef, state: state, productFilter: products)
+        store.pin(packageRef: fooRef, state: state)
         store.pin(
             packageRef: fooRef,
-            state: CheckoutState(revision: revision, version: "1.0.2"),
-            productFilter: .specific(["some", "products"])
+            state: CheckoutState(revision: revision, version: "1.0.2")
         )
-        store.pin(packageRef: barRef, state: state, productFilter: products)
+        store.pin(packageRef: barRef, state: state)
         try store.saveState()
 
         store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
@@ -79,8 +78,7 @@ final class PinsStoreTests: XCTestCase {
         do {
             store.pin(
                 packageRef: barRef,
-                state: CheckoutState(revision: revision, branch: "develop"),
-                productFilter: .specific(["a", "product"])
+                state: CheckoutState(revision: revision, branch: "develop")
             )
             try store.saveState()
             store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
@@ -94,7 +92,7 @@ final class PinsStoreTests: XCTestCase {
 
         // Test revision pin.
         do {
-            store.pin(packageRef: barRef, state: CheckoutState(revision: revision), productFilter: .specific(["other", "product"]))
+            store.pin(packageRef: barRef, state: CheckoutState(revision: revision))
             try store.saveState()
             store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
 
@@ -156,7 +154,7 @@ final class PinsStoreTests: XCTestCase {
 
         let fooRef = PackageReference(identity: "foo", path: "/foo")
         let revision = Revision(identifier: "81513c8fd220cf1ed1452b98060cd80d3725c5b7")
-        store.pin(packageRef: fooRef, state: CheckoutState(revision: revision, version: v1), productFilter: .specific([]))
+        store.pin(packageRef: fooRef, state: CheckoutState(revision: revision, version: v1))
 
         XCTAssert(!fs.exists(pinsFile))
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3608,7 +3608,7 @@ final class WorkspaceTests: XCTestCase {
             let revision = try fooRepo.resolveRevision(tag: "1.0.0")
             let newState = CheckoutState(revision: revision, version: "1.0.0")
 
-            pinsStore.pin(packageRef: fooPin.packageRef, state: newState, productFilter: .specific(["Foo"]))
+            pinsStore.pin(packageRef: fooPin.packageRef, state: newState)
             try pinsStore.saveState()
         }
 


### PR DESCRIPTION
We can safely make the assumption that any dependency in the resolved file was required.