### PR TITLE
Remove Product Filters from All Persistent Files

### DIFF
--- a/Sources/SPMTestSupport/TestWorkspace.swift
+++ b/Sources/SPMTestSupport/TestWorkspace.swift
@@ -346,7 +346,7 @@ public final class TestWorkspace {
     }
 
     public func set(
-        pins: [PackageReference: (version: CheckoutState, products: ProductFilter)] = [:],
+        pins: [PackageReference: CheckoutState] = [:],
         managedDependencies: [ManagedDependency] = [],
         managedArtifacts: [ManagedArtifact] = []
     ) throws {
@@ -354,7 +354,7 @@ public final class TestWorkspace {
         let pinsStore = try workspace.pinsStore.load()
 
         for (ref, state) in pins {
-            pinsStore.pin(packageRef: ref, state: state.version)
+            pinsStore.pin(packageRef: ref, state: state)
         }
 
         for dependency in managedDependencies {

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -61,7 +61,7 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
         completion: @escaping (Result<PackageContainer, Error>) -> Void
     ) {
         // Start by searching manifests from the Workspace's resolved dependencies.
-        if let manifest = dependencyManifests.dependencies.first(where: { $1.packageRef == identifier }) {
+        if let manifest = dependencyManifests.dependencies.first(where: { _, managed, _ in managed.packageRef == identifier }) {
             let container = LocalPackageContainer(
                 package: identifier,
                 manifest: manifest.manifest,

--- a/Sources/Workspace/WorkspaceState.swift
+++ b/Sources/Workspace/WorkspaceState.swift
@@ -49,9 +49,6 @@ public final class ManagedDependency {
     /// The state of the managed dependency.
     public let state: State
 
-    /// The product filter applied to the package.
-    public let productFilter: ProductFilter
-
     /// The checked out path of the dependency on disk, relative to the workspace checkouts path.
     public let subpath: RelativePath
 
@@ -65,25 +62,21 @@ public final class ManagedDependency {
     public init(
         packageRef: PackageReference,
         subpath: RelativePath,
-        checkoutState: CheckoutState,
-        productFilter: ProductFilter
+        checkoutState: CheckoutState
     ) {
         self.packageRef = packageRef
         self.state = .checkout(checkoutState)
-        self.productFilter = productFilter
         self.basedOn = nil
         self.subpath = subpath
     }
 
     /// Create a dependency present locally on the filesystem.
     public static func local(
-        packageRef: PackageReference,
-        productFilter: ProductFilter
+        packageRef: PackageReference
     ) -> ManagedDependency {
         return ManagedDependency(
             packageRef: packageRef,
             state: .local,
-            productFilter: productFilter,
             // FIXME: This is just a fake entry, we should fix it.
             subpath: RelativePath(packageRef.identity),
             basedOn: nil
@@ -93,7 +86,6 @@ public final class ManagedDependency {
     private init(
         packageRef: PackageReference,
         state: State,
-        productFilter: ProductFilter,
         subpath: RelativePath,
         basedOn: ManagedDependency?
     ) {
@@ -101,7 +93,6 @@ public final class ManagedDependency {
         self.subpath = subpath
         self.basedOn = basedOn
         self.state = state
-        self.productFilter = productFilter
     }
 
     private init(
@@ -114,7 +105,6 @@ public final class ManagedDependency {
         self.packageRef = dependency.packageRef
         self.subpath = subpath
         self.state = .edited(unmanagedPath)
-        self.productFilter = dependency.productFilter
     }
 
     /// Create an editable managed dependency based on a dependency which
@@ -358,7 +348,6 @@ extension ManagedDependency: JSONMappable, JSONSerializable, CustomStringConvert
         try self.init(
             packageRef: json.get("packageRef"),
             state: json.get("state"),
-            productFilter: json.get("products"),
             subpath: RelativePath(json.get("subpath")),
             basedOn: json.get("basedOn")
         )
@@ -369,13 +358,12 @@ extension ManagedDependency: JSONMappable, JSONSerializable, CustomStringConvert
             "packageRef": packageRef.toJSON(),
             "subpath": subpath,
             "basedOn": basedOn.toJSON(),
-            "state": state,
-            "products": productFilter
+            "state": state
         ])
     }
 
     public var description: String {
-        return "<ManagedDependency: \(packageRef.name) \(state) \(productFilter)>"
+        return "<ManagedDependency: \(packageRef.name) \(state)>"
     }
 }
 

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -32,7 +32,6 @@ final class PinsStoreTests: XCTestCase {
         let barRef = PackageReference(identity: bar, path: barRepo.url)
 
         let state = CheckoutState(revision: revision, version: v1)
-        let products: ProductFilter = .everything
         let pin = PinsStore.Pin(packageRef: fooRef, state: state)
         // We should be able to round trip from JSON.
         XCTAssertEqual(try PinsStore.Pin(json: pin.toJSON()), pin)
@@ -120,8 +119,7 @@ final class PinsStoreTests: XCTestCase {
                           "branch": null,
                           "revision": "90a9574276f0fd17f02f58979423c3fd4d73b59e",
                           "version": "1.0.2",
-                        },
-                        "products": ["a", "b"]
+                        }
                       },
                       {
                         "package": "Commandant",
@@ -130,8 +128,7 @@ final class PinsStoreTests: XCTestCase {
                           "branch": null,
                           "revision": "c281992c31c3f41c48b5036c5a38185eaec32626",
                           "version": "0.12.0"
-                        },
-                        "products": "all"
+                        }
                       }
                     ]
                   },

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -767,14 +767,8 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
-        let v1_5 = (
-            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-            products: ProductFilter.specific([])
-        )
-        let v2 = (
-            CheckoutState(revision: Revision(identifier: "hello"), version: "2.0.0"),
-            products: ProductFilter.specific([])
-        )
+        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
+        let v2 = CheckoutState(revision: Revision(identifier: "hello"), version: "2.0.0")
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -797,7 +791,7 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1_5, cRef: v2],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5.version, productFilter: v1_5.products)
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5)
                     .editedDependency(subpath: bPath, unmanagedPath: nil)
             ]
         )
@@ -813,10 +807,7 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
-        let v1 = (
-            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.0"),
-            products: ProductFilter.everything
-        )
+        let v1 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.0")
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -856,7 +847,7 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1.version, productFilter: v1.products)
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1)
             ]
         )
 
@@ -873,10 +864,7 @@ final class WorkspaceTests: XCTestCase {
         let cPath = RelativePath("C")
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let branchRequirement: TestDependency.Requirement = .branch("master")
-        let v1_5 = (
-            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-            products: ProductFilter.everything
-        )
+        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -916,8 +904,8 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1_5, cRef: v1_5],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5.version, productFilter: v1_5.products),
-                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5.version, productFilter: v1_5.products),
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5),
+                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5),
             ]
         )
 
@@ -925,7 +913,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.diagnostics.hasErrors, false)
             XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
                 package: cRef,
-                state: .checkout(v1_5.version),
+                state: .checkout(v1_5),
                 requirement: .revision("master")
             )))
         }
@@ -935,10 +923,7 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let cPath = RelativePath("C")
-        let v1_5 = (
-            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-            products: ProductFilter.everything
-        )
+        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
 
         let testWorkspace = try TestWorkspace(
             sandbox: sandbox,
@@ -969,7 +954,7 @@ final class WorkspaceTests: XCTestCase {
         try testWorkspace.set(
             pins: [cRef: v1_5],
             managedDependencies: [
-                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5.version, productFilter: v1_5.products),
+                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5),
             ]
         )
 
@@ -977,7 +962,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.diagnostics.hasErrors, false)
             XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
                 package: cRef,
-                state: .checkout(v1_5.version),
+                state: .checkout(v1_5),
                 requirement: .revision("hello")
             )))
         }
@@ -990,10 +975,7 @@ final class WorkspaceTests: XCTestCase {
         let bPath = RelativePath("B")
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let masterRequirement: TestDependency.Requirement = .branch("master")
-        let v1_5 = (
-            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-            products: ProductFilter.everything
-        )
+        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -1033,8 +1015,8 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1_5],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5.version, productFilter: v1_5.products),
-                ManagedDependency.local(packageRef: cRef, productFilter: .specific(["C"]))
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5),
+                ManagedDependency.local(packageRef: cRef)
             ]
         )
 
@@ -1055,10 +1037,7 @@ final class WorkspaceTests: XCTestCase {
         let cPath = RelativePath("C")
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let localRequirement: TestDependency.Requirement = .localPackage
-        let v1_5 = (
-            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-            products: ProductFilter.everything
-        )
+        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -1098,8 +1077,8 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1_5, cRef: v1_5],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5.version, productFilter: v1_5.products),
-                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5.version, productFilter: v1_5.products),
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5),
+                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5),
             ]
         )
 
@@ -1107,7 +1086,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.diagnostics.hasErrors, false)
             XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
                 package: cRef,
-                state: .checkout(v1_5.version),
+                state: .checkout(v1_5),
                 requirement: .unversioned
             )))
         }
@@ -1120,14 +1099,8 @@ final class WorkspaceTests: XCTestCase {
         let cPath = RelativePath("C")
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let localRequirement: TestDependency.Requirement = .localPackage
-        let v1_5 = (
-            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-            products: ProductFilter.everything
-        )
-        let master = (
-            version: CheckoutState(revision: Revision(identifier: "master"), branch: "master"),
-            products: ProductFilter.everything
-        )
+        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
+        let master = CheckoutState(revision: Revision(identifier: "master"), branch: "master")
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -1167,8 +1140,8 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1_5, cRef: master],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5.version, productFilter: v1_5.products),
-                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: master.version, productFilter: master.products),
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5),
+                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: master),
             ]
         )
 
@@ -1176,7 +1149,7 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(result.diagnostics.hasErrors, false)
             XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
                 package: cRef,
-                state: .checkout(master.version),
+                state: .checkout(master),
                 requirement: .unversioned
             )))
         }
@@ -1189,10 +1162,7 @@ final class WorkspaceTests: XCTestCase {
         let cPath = RelativePath("C")
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let v2Requirement: TestDependency.Requirement = .range("2.0.0" ..< "3.0.0")
-        let v1_5 = (
-            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-            products: ProductFilter.everything
-        )
+        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -1232,8 +1202,8 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1_5, cRef: v1_5],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5.version, productFilter: v1_5.products),
-                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5.version, productFilter: v1_5.products),
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5),
+                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v1_5),
             ]
         )
 
@@ -1250,14 +1220,8 @@ final class WorkspaceTests: XCTestCase {
         let cPath = RelativePath("C")
         let v1Requirement: TestDependency.Requirement = .range("1.0.0" ..< "2.0.0")
         let v2Requirement: TestDependency.Requirement = .range("2.0.0" ..< "3.0.0")
-        let v1_5 = (
-            version: CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5"),
-            products: ProductFilter.everything
-        )
-        let v2 = (
-            version: CheckoutState(revision: Revision(identifier: "hello"), version: "2.0.0"),
-            products: ProductFilter.everything
-        )
+        let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
+        let v2 = CheckoutState(revision: Revision(identifier: "hello"), version: "2.0.0")
 
         let workspace = try TestWorkspace(
             sandbox: sandbox,
@@ -1297,8 +1261,8 @@ final class WorkspaceTests: XCTestCase {
         try workspace.set(
             pins: [bRef: v1_5, cRef: v2],
             managedDependencies: [
-                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5.version, productFilter: v1_5.products),
-                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v2.version, productFilter: v2.products),
+                ManagedDependency(packageRef: bRef, subpath: bPath, checkoutState: v1_5),
+                ManagedDependency(packageRef: cRef, subpath: cPath, checkoutState: v2),
             ]
         )
 
@@ -1963,7 +1927,7 @@ final class WorkspaceTests: XCTestCase {
         // Check failure.
         workspace.checkResolve(pkg: "Foo", roots: ["Root"], version: "1.3.0") { diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("Foo[Foo] 1.3.0"), behavior: .error)
+                result.check(diagnostic: .contains("Foo 1.3.0"), behavior: .error)
             }
         }
         workspace.checkManagedDependencies() { result in
@@ -4267,10 +4231,7 @@ final class WorkspaceTests: XCTestCase {
         let aRef = PackageReference(identity: "a", path: aPath)
         let aRepo = workspace.repoProvider.specifierMap[RepositorySpecifier(url: aPath)]!
         let aRevision = try aRepo.resolveRevision(tag: "1.0.0")
-        let aState = (
-            version: CheckoutState(revision: aRevision, version: "1.0.0"),
-            products: ProductFilter.everything
-        )
+        let aState = CheckoutState(revision: aRevision, version: "1.0.0")
 
         try workspace.set(
             pins: [aRef: aState],
@@ -4516,11 +4477,8 @@ final class WorkspaceTests: XCTestCase {
         let aRef = PackageReference(identity: "a", path: aPath)
         let aRepo = workspace.repoProvider.specifierMap[RepositorySpecifier(url: aPath)]!
         let aRevision = try aRepo.resolveRevision(tag: "1.0.0")
-        let aState = (
-            version: CheckoutState(revision: aRevision, version: "1.0.0"),
-            products: ProductFilter.everything
-        )
-        let aDependency = ManagedDependency(packageRef: aRef, subpath: RelativePath("A"), checkoutState: aState.version, productFilter: aState.products)
+        let aState = CheckoutState(revision: aRevision, version: "1.0.0")
+        let aDependency = ManagedDependency(packageRef: aRef, subpath: RelativePath("A"), checkoutState: aState)
 
         try workspace.set(
             pins: [aRef: aState],


### PR DESCRIPTION
#2792 removed product filters from pins. This takes the clean‐up further and removes product filters from managed dependencies, workspace state, and the pin testing utilities and fixtures.

To decouple the filters from `ManagedDependency` (to avoid encoding them), `DependencyManifests` and `loadDependencyManifests(root:diagnostics:)` required some refactoring to track the filters directly.

The rest of the changes are just the removal of dead properties and parameters.