### PR TITLE
Don't pass / as default sysroot on Linux

### DIFF
--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -41,7 +41,7 @@ public struct Destination: Encodable, Equatable {
     public var archs: [String] = []
 
     /// The SDK used to compile for the destination.
-    public var sdk: AbsolutePath
+    public var sdk: AbsolutePath?
 
     /// The binDir in the containing the compilers/linker to be used for the compilation.
     public var binDir: AbsolutePath
@@ -58,7 +58,7 @@ public struct Destination: Encodable, Equatable {
     /// Creates a compilation destination with the specified properties.
     public init(
       target: Triple? = nil,
-      sdk: AbsolutePath,
+      sdk: AbsolutePath?,
       binDir: AbsolutePath,
       extraCCFlags: [String] = [],
       extraSwiftCFlags: [String] = [],
@@ -142,7 +142,7 @@ public struct Destination: Encodable, Equatable {
       #else
         return Destination(
             target: nil,
-            sdk: .root,
+            sdk: nil,
             binDir: binDir,
             extraCCFlags: ["-fPIC"],
             extraSwiftCFlags: [],

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -206,10 +206,14 @@ public final class UserToolchain: Toolchain {
     }
 
     public static func deriveSwiftCFlags(triple: Triple, destination: Destination) -> [String] {
-      return (triple.isDarwin() || triple.isAndroid() || triple.isWASI()
-        ? ["-sdk", destination.sdk.pathString]
-        : [])
-        + destination.extraSwiftCFlags
+        guard let sdk = destination.sdk else {
+            return destination.extraSwiftCFlags
+        }
+
+        return (triple.isDarwin() || triple.isAndroid() || triple.isWASI()
+            ? ["-sdk", sdk.pathString]
+            : [])
+            + destination.extraSwiftCFlags
     }
 
     public init(destination: Destination, environment: [String: String] = ProcessEnv.vars) throws {
@@ -252,9 +256,13 @@ public final class UserToolchain: Toolchain {
 
         self.extraSwiftCFlags = UserToolchain.deriveSwiftCFlags(triple: triple, destination: destination)
 
-        self.extraCCFlags = [
-            triple.isDarwin() ? "-isysroot" : "--sysroot", destination.sdk.pathString
-        ] + destination.extraCCFlags
+        if let sdk = destination.sdk {
+            self.extraCCFlags = [
+                triple.isDarwin() ? "-isysroot" : "--sysroot", sdk.pathString
+            ] + destination.extraCCFlags
+        } else {
+            self.extraCCFlags = destination.extraCCFlags
+        }
 
         // Compute the path of directory containing the PackageDescription libraries.
         var pdLibDir = UserManifestResources.libDir(forBinDir: binDir)


### PR DESCRIPTION
Passing / as sysroot breaks usage of toolchains installed in custom locations.