### PR TITLE
Explicitly pass a DriverExecutor to the integrated swift driver

### DIFF
--- a/Sources/Build/ManifestBuilder.swift
+++ b/Sources/Build/ManifestBuilder.swift
@@ -213,8 +213,16 @@ extension LLBuildManifestBuilder {
             if buildParameters.useExplicitModuleBuild {
               commandLine.append("-experimental-explicit-module-build")
             }
-
-            var driver = try Driver(args: commandLine, fileSystem: target.fs)
+            // FIXME: At some point SwiftPM should provide its own executor for
+            // running jobs/launching processes during planning
+            let executor = try SwiftDriverExecutor(diagnosticsEngine: plan.diagnostics,
+                                                   processSet: ProcessSet(),
+                                                   fileSystem: target.fs,
+                                                   env: ProcessEnv.vars)
+            var driver = try Driver(args: commandLine,
+                                    diagnosticsEngine: plan.diagnostics,
+                                    fileSystem: target.fs,
+                                    executor: executor)
             let jobs = try driver.planBuild()
             let resolver = try ArgsResolver(fileSystem: target.fs)
 


### PR DESCRIPTION
This is mostly NFC, the executor we pass explicitly is the same as the default argument except it uses `plan.diagnostics` instead of a new DiagnosticsEngine (hopefully that's correct). This will allow me to drop the default argument value in SwiftDriver and eliminate a layering violation.

Eventually, SPM will probably implement its own executor. For now, this one is just used for jobs that run during planning (dependency scanning, -print-target-info, etc.)