### PR TITLE
Add `appending` functions to RelativePath

### DIFF
--- a/swift-tools-support-core/Sources/TSCBasic/Path.swift
+++ b/swift-tools-support-core/Sources/TSCBasic/Path.swift
@@ -266,6 +266,30 @@ public struct RelativePath: Hashable {
     public var components: [String] {
         return _impl.components
     }
+
+    /// Returns the relative path with the given relative path applied.
+    public func appending(_ subpath: RelativePath) -> RelativePath {
+        return RelativePath(_impl.appending(relativePath: subpath._impl))
+    }
+
+    /// Returns the relative path with an additional literal component appended.
+    ///
+    /// This method accepts pseudo-path like '.' or '..', but should not contain "/".
+    public func appending(component: String) -> RelativePath {
+        return RelativePath(_impl.appending(component: component))
+    }
+
+    /// Returns the relative path with additional literal components appended.
+    ///
+    /// This method should only be used in cases where the input is guaranteed
+    /// to be a valid path component (i.e., it cannot be empty, contain a path
+    /// separator, or be a pseudo-path like '.' or '..').
+    public func appending(components names: String...) -> RelativePath {
+        // FIXME: This doesn't seem a particularly efficient way to do this.
+        return names.reduce(self, { path, name in
+            path.appending(component: name)
+        })
+    }
 }
 
 extension AbsolutePath: Codable {

--- a/swift-tools-support-core/Tests/TSCBasicTests/PathTests.swift
+++ b/swift-tools-support-core/Tests/TSCBasicTests/PathTests.swift
@@ -214,6 +214,9 @@ class PathTests: XCTestCase {
         XCTAssertEqual(AbsolutePath("/").appending(components: "..").pathString, "/")
         XCTAssertEqual(AbsolutePath("/").appending(components: ".").pathString, "/")
         XCTAssertEqual(AbsolutePath("/").appending(components: "..", "a").pathString, "/a")
+
+        XCTAssertEqual(RelativePath("hello").appending(components: "a", "b", "c", "..").pathString, "hello/a/b")
+        XCTAssertEqual(RelativePath("hello").appending(RelativePath("a/b/../c/d")).pathString, "hello/a/c/d")
     }
 
     func testPathComponents() {


### PR DESCRIPTION
These functions are present in the TSC repository (merged in https://github.com/apple/swift-tools-support-core/pull/85), but are not present in the SwiftPM repo yet, which breaks `build-script` builds.