### PR TITLE
Add an option to output a dot graph of the build manifest.

### DIFF
--- a/Sources/Build/ManifestBuilder.swift
+++ b/Sources/Build/ManifestBuilder.swift
@@ -72,6 +72,13 @@ public class LLBuildManifestBuilder {
             createProductCommand(description)
         }
 
+        // Output a dot graph
+        if buildParameters.printManifestGraphviz {
+            var serializer = DOTManifestSerializer(manifest: manifest)
+            serializer.writeDOT(to: &stdoutStream)
+            stdoutStream.flush()
+        }
+
         try ManifestWriter().write(manifest, at: path)
     }
 

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -103,6 +103,9 @@ public class ToolOptions {
     /// Whether to use the explicit module build flow (with the integrated driver)
     public var useExplicitModuleBuild: Bool = false
 
+    /// Whether to output a graphviz file visualization of the combined job graph for all targets
+    public var printManifestGraphviz: Bool = false
+
     /// The build system to use.
     public var buildSystem: BuildSystemKind {
         // Force the Xcode build system if we want to build more than one arch.

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -465,6 +465,11 @@ public class SwiftTool<Options: ToolOptions> {
             to: { $0.useExplicitModuleBuild = $1 })
 
         binder.bind(
+            option: parser.add(option: "--print-manifest-job-graph", kind: Bool.self,
+                usage: "Write the command graph for the build manifest as a graphviz file"),
+            to: { $0.printManifestGraphviz = $1 })
+
+        binder.bind(
             option: parser.add(option: "--build-system", kind: BuildSystemKind.self, usage: nil),
             to: { $0._buildSystem = $1 })
 
@@ -822,7 +827,8 @@ public class SwiftTool<Options: ToolOptions> {
                 emitSwiftModuleSeparately: options.emitSwiftModuleSeparately,
                 useIntegratedSwiftDriver: options.useIntegratedSwiftDriver,
                 useExplicitModuleBuild: options.useExplicitModuleBuild,
-                isXcodeBuildSystemEnabled: options.buildSystem == .xcode
+                isXcodeBuildSystemEnabled: options.buildSystem == .xcode,
+                printManifestGraphviz: options.printManifestGraphviz
             )
         })
     }()

--- a/Sources/LLBuildManifest/CMakeLists.txt
+++ b/Sources/LLBuildManifest/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(LLBuildManifest
   BuildManifest.swift
   Command.swift
   ManifestWriter.swift
+  DOTManifestSerializer.swift
   Node.swift
   Target.swift
   Tools.swift)

--- a/Sources/LLBuildManifest/DOTManifestSerializer.swift
+++ b/Sources/LLBuildManifest/DOTManifestSerializer.swift
@@ -32,9 +32,10 @@ public struct DOTManifestSerializer {
         return label
     }
 
-    /// Quote the name and escape the quotes
+    /// Quote the name and escape the quotes and backslashes
     func quoteName(_ name: String) -> String {
-        return "\"" + name.replacingOccurrences(of: "\"", with: "\\\"") + "\""
+        return "\"" + name.replacingOccurrences(of: "\"", with: "\\\"")
+                          .replacingOccurrences(of: "\\", with: "\\\\") + "\""
     }
 
     public mutating func writeDOT<Stream: TextOutputStream>(to stream: inout Stream) {

--- a/Sources/LLBuildManifest/DOTManifestSerializer.swift
+++ b/Sources/LLBuildManifest/DOTManifestSerializer.swift
@@ -1,0 +1,65 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import TSCBasic
+
+/// Serializes an LLBuildManifest graph to a .dot file
+public struct DOTManifestSerializer {
+    var kindCounter = [String: Int]()
+    var hasEmittedStyling = Set<String>()
+    let manifest: BuildManifest
+
+    /// Creates a serializer that will serialize the given manifest.
+    public init(manifest: BuildManifest) {
+        self.manifest = manifest
+    }
+
+    /// Gets a unique label for a job name
+    mutating func label(for command: Command) -> String {
+        let toolName = "\(type(of: command.tool).name)"
+        var label = toolName
+        if let count = kindCounter[label] {
+            label += " \(count)"
+        }
+        kindCounter[toolName, default: 0] += 1
+        return label
+    }
+
+    /// Quote the name and escape the quotes
+    func quoteName(_ name: String) -> String {
+        return "\"" + name.replacingOccurrences(of: "\"", with: "\\\"") + "\""
+    }
+
+    public mutating func writeDOT<Stream: TextOutputStream>(to stream: inout Stream) {
+        stream.write("digraph Jobs {\n")
+        for (name, command) in manifest.commands {
+            let jobName = quoteName(label(for: command))
+            if !hasEmittedStyling.contains(jobName) {
+                stream.write("  \(jobName) [style=bold];")
+                stream.write("// \(name)\n")
+            }
+            for input in command.tool.inputs {
+                let inputName = quoteName(input.name)
+                if hasEmittedStyling.insert(inputName).inserted {
+                    stream.write("  \(inputName) [fontsize=12];\n")
+                }
+                stream.write("  \(inputName) -> \(jobName) [color=blue];\n")
+            }
+            for output in command.tool.outputs {
+                let outputName = quoteName(output.name)
+                if hasEmittedStyling.insert(outputName).inserted {
+                    stream.write("  \(outputName) [fontsize=12];\n")
+                }
+                stream.write("  \(jobName) -> \(outputName) [color=green];\n")
+            }
+        }
+        stream.write("}\n")
+    }
+}

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -95,8 +95,11 @@ public struct BuildParameters: Encodable {
     /// to a separate process.
     public var useIntegratedSwiftDriver: Bool
 
-    // Whether to use the explicit module build flow (with the integrated driver)
+    /// Whether to use the explicit module build flow (with the integrated driver)
     public var useExplicitModuleBuild: Bool
+
+    /// Whether to output a graphviz file visualization of the combined job graph for all targets
+    public var printManifestGraphviz: Bool
 
     /// Whether to create dylibs for dynamic library products.
     public var shouldCreateDylibForDynamicProducts: Bool
@@ -147,7 +150,8 @@ public struct BuildParameters: Encodable {
         emitSwiftModuleSeparately: Bool = false,
         useIntegratedSwiftDriver: Bool = false,
         useExplicitModuleBuild: Bool = false,
-        isXcodeBuildSystemEnabled: Bool = false
+        isXcodeBuildSystemEnabled: Bool = false,
+        printManifestGraphviz: Bool = false
     ) {
         self.dataPath = dataPath
         self.configuration = configuration
@@ -171,6 +175,7 @@ public struct BuildParameters: Encodable {
         self.useIntegratedSwiftDriver = useIntegratedSwiftDriver
         self.useExplicitModuleBuild = useExplicitModuleBuild
         self.isXcodeBuildSystemEnabled = isXcodeBuildSystemEnabled
+        self.printManifestGraphviz = printManifestGraphviz
     }
 
     /// The path to the build directory (inside the data directory).


### PR DESCRIPTION
Similarly to how swift-driver can serialize Jobs for a given compilation target, add a capability to write out the entire build manifest as a dot graph. 
This was extremely useful for debugging various build issues. 