### PR TITLE
[bootstrap] Add the runtime library paths to [DY]LD_LIBRARY_PATHS…

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -607,7 +607,7 @@ def get_swiftpm_env_cmd(args):
         os.path.join(args.llbuild_build_dir, "lib"),
         os.path.join(args.yams_build_dir, "lib"),
         os.path.join(args.swift_driver_build_dir, "lib"),
-    ])
+    ] + args.target_info["paths"]["runtimeLibraryPaths"])
 
     if platform.system() == 'Darwin':
         env_cmd.append("DYLD_LIBRARY_PATH=%s" % libs_joined)


### PR DESCRIPTION
…so we use the just-built libswiftCore instead of the OS's copy.