### PR TITLE
[5.2] Bump patch version

### DIFF
--- a/TSC/Sources/TSCUtility/Versioning.swift
+++ b/TSC/Sources/TSCUtility/Versioning.swift
@@ -74,7 +74,7 @@ public struct Versioning {
 
     /// The current version of the package manager.
     public static let currentVersion = SwiftVersion(
-        version: (5, 2, 0),
+        version: (5, 2, 5),
         isDevelopment: false,
         buildIdentifier: getBuildIdentifier())
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -4010,7 +4010,7 @@ final class WorkspaceTests: XCTestCase {
                     toolsVersion: .v5_2
                 ),
             ],
-            toolsVersion: .v5_2,
+            toolsVersion: ToolsVersion(version: "5.2.5"),
             enablePubGrub: true
         )
 


### PR DESCRIPTION
I noticed that the official SPM release for linux reports a wrong patch version:
```
> ./swift-5.2.4-RELEASE-ubuntu20.04/usr/bin/swift-build --version
Swift Package Manager - Swift 5.2.0
```
This pull fixes that. I ~wasn't able to run~ ran the tests on Ubuntu 20.04 ~even without this pull, some unrelated error that I'll look into~ after fixing an issue with the environment, all tests pass with the one fix I just added:
```
SWIFTCI_USE_LOCAL_DEPS=1 /home/butta/swift-5.2.4-RELEASE-ubuntu20.04/usr/bin/swift build -j 5
SWIFTCI_USE_LOCAL_DEPS=1 /home/butta/swift-5.2.4-RELEASE-ubuntu20.04/usr/bin/swift test -j 5 --parallel --package-path /home/butta/swift-package-manager/TSC/
SWIFTCI_USE_LOCAL_DEPS=1 SWIFT_EXEC=/home/butta/swift-5.2.4-RELEASE-ubuntu20.04/usr/bin/swiftc /home/butta/swift-5.2.4-RELEASE-ubuntu20.04/usr/bin/swift test -j 5 --parallel
```
I also tried running the tests by invoking the `swift-test` generated from the first build command instead, same results.

I'm not sure if the `InitPackage` change is wanted, can remove that if not.