### PR TITLE
[Build/PackageLoading] SR-13084: Improve user awareness for issues around missing resources

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -566,14 +566,18 @@ public final class SwiftTargetBuildDescription {
             self.moduleMap = try self.generateModuleMap()
         }
 
-        // Do nothing if we're not generating a bundle.
         if bundlePath != nil {
+            // If we've generated a bundle then create a plist and generate a `Bundle.module` accessor
             try self.generateResourceAccessor()
 
             let infoPlistPath = tempsPath.appending(component: "Info.plist")
             if try generateResourceInfoPlist(for: target, to: infoPlistPath) {
                 resourceBundleInfoPlistPath = infoPlistPath
             }
+        } else {
+            // If we've not generated a bundle then create an unavailable `Bundle.module` accessor in order to
+            // support easier debugging.
+            try self.generateResourceUnavailableAccessor()
         }
     }
 
@@ -582,8 +586,7 @@ public final class SwiftTargetBuildDescription {
         // Do nothing if we're not generating a bundle.
         guard let bundlePath = self.bundlePath else { return }
 
-        let stream = BufferedOutputByteStream()
-        stream <<< """
+        let contents = """
         import class Foundation.Bundle
 
         extension Foundation.Bundle {
@@ -602,7 +605,36 @@ public final class SwiftTargetBuildDescription {
         }
         """
 
-        let subpath = RelativePath("resource_bundle_accessor.swift")
+        try addFile(withPath: RelativePath("resource_bundle_accessor.swift"), contents: contents)
+    }
+    
+    /// Generate an inaccessible resource bundle accessor, if appropriate.
+    ///
+    /// This addresses SR-13084 by creating an unavailable accessor which informs users of the underlying issue.
+    private func generateResourceUnavailableAccessor() throws {
+        // If a bundle has been generated then we shouldn't be here.
+        guard self.bundlePath == nil else { return }
+
+        let message = "target '\(target.name)' is either missing or is solely containing invalid resource references"
+        
+        let contents = """
+        import class Foundation.Bundle
+
+        extension Foundation.Bundle {
+            @available(*, unavailable, message: "\(message)")
+            static var module: Bundle = {
+                fatalError("no resource bundle exists for this module")
+            }()
+        }
+        """
+
+        try addFile(withPath: RelativePath("resource_bundle_accessor.swift"), contents: contents)
+    }
+
+    /// Creates a new file with the contents provided at the path given. The file will be added to the target's derived sources.
+    private func addFile(withPath subpath: RelativePath, contents: String) throws {
+        let stream = BufferedOutputByteStream()
+        stream <<< contents
 
         // Add the file to the dervied sources.
         derivedSources.relativePaths.append(subpath)

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -330,7 +330,7 @@ final class BuildPlanTests: XCTestCase {
                 try llbuild.generateManifest(at: yaml)
                 let contents = try localFileSystem.readFileContents(yaml).description
                 XCTAssertMatch(contents, .contains("""
-                        inputs: ["/Pkg/Sources/exe/main.swift","/path/to/build/release/PkgLib.swiftmodule"]
+                        inputs: ["/Pkg/Sources/exe/main.swift","/path/to/build/release/exe.build/DerivedSources/resource_bundle_accessor.swift","/path/to/build/release/PkgLib.swiftmodule"]
                     """))
             }
         }
@@ -356,7 +356,7 @@ final class BuildPlanTests: XCTestCase {
                 try llbuild.generateManifest(at: yaml)
                 let contents = try localFileSystem.readFileContents(yaml).description
                 XCTAssertMatch(contents, .contains("""
-                        inputs: ["/Pkg/Sources/exe/main.swift"]
+                        inputs: ["/Pkg/Sources/exe/main.swift","/path/to/build/debug/exe.build/DerivedSources/resource_bundle_accessor.swift"]
                     """))
             }
         }
@@ -1996,8 +1996,8 @@ final class BuildPlanTests: XCTestCase {
             try llbuild.generateManifest(at: yaml)
             let contents = try localFileSystem.readFileContents(yaml).description
             XCTAssertTrue(contents.contains("""
-                    inputs: ["/PkgA/Sources/swiftlib/lib.swift","/path/to/build/debug/exe"]
-                    outputs: ["/path/to/build/debug/swiftlib.build/lib.swift.o","/path/to/build/debug/
+                    inputs: ["/PkgA/Sources/swiftlib/lib.swift","/path/to/build/debug/swiftlib.build/DerivedSources/resource_bundle_accessor.swift","/path/to/build/debug/exe"]
+                    outputs: ["/path/to/build/debug/swiftlib.build/lib.swift.o","/path/to/build/debug/swiftlib.build/resource_bundle_accessor.swift.o","/path/to/build/debug/swiftlib.swiftmodule"]
                 """), contents)
         }
     }
@@ -2361,6 +2361,7 @@ final class BuildPlanTests: XCTestCase {
         let barTarget = try result.target(for: "Bar").swiftTarget()
         XCTAssertEqual(barTarget.objects.map{ $0.pathString }, [
             "/path/to/build/debug/Bar.build/Bar.swift.o",
+            "/path/to/build/debug/Bar.build/resource_bundle_accessor.swift.o"
         ])
     }
 

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -291,6 +291,13 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, diagnostics in
             diagnostics.check(diagnostic: "localization directory 'Processed/en.lproj' in target 'Foo' contains sub-directories, which is forbidden", behavior: .error)
+            diagnostics.check(
+                diagnostic: .contains("""
+                target 'Foo' does not have resources at the following paths, they will be ignored
+                    'Processed' (/Processed)
+                """),
+                behavior: .warning
+            )
         }
     }
 
@@ -310,6 +317,13 @@ class TargetSourcesBuilderTests: XCTestCase {
                     and has an explicit localization declaration
                     """),
                 behavior: .error)
+            diagnostics.check(
+                diagnostic: .contains("""
+                target 'Foo' does not have resources at the following paths, they will be ignored
+                    'Resources' (/Resources)
+                """),
+                behavior: .warning
+            )
         }
     }
 

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -291,7 +291,6 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, diagnostics in
             diagnostics.check(diagnostic: "localization directory 'Processed/en.lproj' in target 'Foo' contains sub-directories, which is forbidden", behavior: .error)
-            diagnostics.checkUnordered(diagnostic: .contains("target 'Foo' does not have resources at the following paths"), behavior: .warning)
         }
     }
 
@@ -311,7 +310,6 @@ class TargetSourcesBuilderTests: XCTestCase {
                     and has an explicit localization declaration
                     """),
                 behavior: .error)
-            diagnostics.checkUnordered(diagnostic: .contains("target 'Foo' does not have resources at the following paths"), behavior: .warning)
         }
     }
 


### PR DESCRIPTION
ℹ️  This supersedes #2789 due to a bad rebase (🤦)

This addresses [SR-13084](https://bugs.swift.org/browse/SR-13084).

In looking to use the new resources capability of SPM I faced some confusion when my setup wasn't working - it turned out to be that my paths were relative to the Package.swift rather than to the target. There was no warning/error and so wasn't the easiest to debug -- this MR aims to resolve this in two parts:

1. Currently the `Bundle.module` accessor is only created if at least one valid resource is generated in the bundle. A change in this MR means that the accessor is *always* created but is marked unavailable (with a user friendly message) if there are no valid resources.

2. A warning is raised as part of the package description diagnostics which lists the exact resources which were seen as missing. A warning has been chosen to act as a non-breaking change (though an error may be more appropriate)

The messages may need more finessing to make more sense - open to suggestions.

First attempt at trying to contribute to SPM so hopefully this isn't horrendous!

Thank you 🙌  