### PR TITLE
Revert "Android: add host destination to the workspace"

### DIFF
--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -130,15 +130,6 @@ public struct Destination: Encodable, Equatable {
             extraSwiftCFlags: extraSwiftCFlags,
             extraCPPFlags: ["-lc++"]
         )
-      #elseif os(Android)
-        return Destination(
-            target: nil,
-            sdk: AbsolutePath(ProcessEnv.vars["PREFIX"]!).parentDirectory,
-            binDir: binDir,
-            extraCCFlags: ["-fPIC"],
-            extraSwiftCFlags: [],
-            extraCPPFlags: ["-lstdc++"]
-        )
       #else
         return Destination(
             target: nil,


### PR DESCRIPTION
Instead, use #2797, which made the SDK path optional, and simply pass nil by default as on linux.

The only reason I added it in #2790 was that setting the SDK path was mandatory at the time, but it was never necessary for builds, as the Swift and clang compilers in Termux are already pre-configured with the Termux sysroot. Now that it's optional, clear it and the user can always set it on the command-line if wanted, just like on linux.