### PR TITLE
Support C++ headers in TargetSourcesBuilder.swift

### DIFF
--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -517,7 +517,7 @@ public struct FileRuleDescription {
         .init(
             rule: .header,
             toolsVersion: .minimumRequired,
-            fileTypes: ["h", "hh", "hpp", "h++"]
+            fileTypes: ["h", "hh", "hpp", "h++", "hp", "hxx", "H", "ipp", "def"]
         )
     }()
 

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -517,7 +517,7 @@ public struct FileRuleDescription {
         .init(
             rule: .header,
             toolsVersion: .minimumRequired,
-            fileTypes: ["h"]
+            fileTypes: ["h", "hh", "hpp", "h++"]
         )
     }()
 


### PR DESCRIPTION
Currently only `.h` header extension is supported.