### PR TITLE
[SR-12912] Fix crash in test targets when accessing Bundle.module

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -578,7 +578,7 @@ public final class SwiftTargetBuildDescription {
         // Do nothing if we're not generating a bundle.
         guard let bundlePath = self.bundlePath else { return }
       
-        let pathToModule = isTestTarget ? bundlePath : "Bundle.main.bundlePath/\(bundlePath.basename)"
+        let pathToModule = isTestTarget ? #""\#(bundlePath.pathString)""# : #"Bundle.main.bundlePath + "/" + "\#(bundlePath.basename)""#
       
         let stream = BufferedOutputByteStream()
         stream <<< """
@@ -586,7 +586,7 @@ public final class SwiftTargetBuildDescription {
 
         extension Foundation.Bundle {
             static var module: Bundle = {
-                let bundlePath = "\(pathToModule)"
+                let bundlePath = \(pathToModule)
                 guard let bundle = Bundle(path: bundlePath) else {
                     fatalError("could not load resource bundle: \\(bundlePath)")
                 }

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -578,16 +578,13 @@ public final class SwiftTargetBuildDescription {
         // Do nothing if we're not generating a bundle.
         guard let bundlePath = self.bundlePath else { return }
 
-        // Compute the basename of the bundle.
-        let bundleBasename = bundlePath.basename
-
         let stream = BufferedOutputByteStream()
         stream <<< """
         import class Foundation.Bundle
 
         extension Foundation.Bundle {
             static var module: Bundle = {
-                let bundlePath = Bundle.main.bundlePath + "/" + "\(bundleBasename)"
+                let bundlePath = "\(bundlePath)"
                 guard let bundle = Bundle(path: bundlePath) else {
                     fatalError("could not load resource bundle: \\(bundlePath)")
                 }

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -588,9 +588,8 @@ public final class SwiftTargetBuildDescription {
                 let buildPath = "\(bundlePath.pathString)"
 
                 let preferredBundle = Bundle(path: mainPath)
-                let fallBackBundle = Bundle(path: buildPath)
 
-                guard let bundle = preferredBundle != nil ? preferredBundle : fallBackBundle else {
+                guard let bundle = preferredBundle != nil ? preferredBundle : Bundle(path: buildPath) else {
                     fatalError("could not load resource bundle: from \\(mainPath) or \\(buildPath)")
                 }
 

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -578,17 +578,14 @@ public final class SwiftTargetBuildDescription {
         // Do nothing if we're not generating a bundle.
         guard let bundlePath = self.bundlePath else { return }
 
-        let buildPath = #""\#(bundlePath.pathString)""#
-        let mainPath = #"Bundle.main.bundlePath + "/" + "\#(bundlePath.basename)""#
-
         let stream = BufferedOutputByteStream()
         stream <<< """
         import class Foundation.Bundle
 
         extension Foundation.Bundle {
             static var module: Bundle = {
-                let mainPath = \(mainPath)
-                let buildPath = \(buildPath)
+                let mainPath = Bundle.main.bundlePath + "/" + "\(bundlePath.basename)"
+                let buildPath = "\(bundlePath.pathString)"
 
                 let preferredBundle = Bundle(path: mainPath)
                 let fallBackBundle = Bundle(path: buildPath)

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -577,14 +577,16 @@ public final class SwiftTargetBuildDescription {
     private func generateResourceAccessor() throws {
         // Do nothing if we're not generating a bundle.
         guard let bundlePath = self.bundlePath else { return }
-
+      
+        let pathToModule = isTestTarget ? bundlePath : "Bundle.main.bundlePath/\(bundlePath.basename)"
+      
         let stream = BufferedOutputByteStream()
         stream <<< """
         import class Foundation.Bundle
 
         extension Foundation.Bundle {
             static var module: Bundle = {
-                let bundlePath = "\(bundlePath)"
+                let bundlePath = "\(pathToModule)"
                 guard let bundle = Bundle(path: bundlePath) else {
                     fatalError("could not load resource bundle: \\(bundlePath)")
                 }

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -11,6 +11,8 @@
 import XCTest
 
 import SPMTestSupport
+import TSCBasic
+import TSCTestSupport
 import Commands
 
 final class TestToolTests: XCTestCase {
@@ -53,5 +55,75 @@ final class TestToolTests: XCTestCase {
             }
         }
         #endif
+    }
+  
+    func testSwiftTestWithResources() throws {
+        try withTemporaryDirectory { dir in
+            let toolDir = dir.appending(component: "swiftTestResources")
+            try localFileSystem.createDirectory(toolDir)
+            try localFileSystem.writeFileContents(
+              toolDir.appending(component: "Package.swift"),
+              bytes: ByteString(encodingAsUTF8: """
+                    // swift-tools-version:5.3
+                    import PackageDescription
+
+                    let package = Package(
+                       name: "AwesomeResources",
+                       targets: [
+                           .target(name: "AwesomeResources", resources: [.copy("hello.txt")]),
+                           .testTarget(name: "AwesomeResourcesTest", dependencies: ["AwesomeResources"], resources: [.copy("world.txt")])
+                       ]
+                    )
+                    """)
+            )
+            try localFileSystem.createDirectory(toolDir.appending(component: "Sources"))
+            try localFileSystem.createDirectory(toolDir.appending(components: "Sources", "AwesomeResources"))
+            try localFileSystem.writeFileContents(
+              toolDir.appending(components: "Sources", "AwesomeResources", "AwesomeResource.swift"),
+              bytes: ByteString(encodingAsUTF8: """
+                    import Foundation
+
+                    public struct AwesomeResource {
+                      public init() {}
+                      public let hello = try! String(contentsOf: Bundle.module.url(forResource: "hello", withExtension: "txt")!)
+                    }
+
+                    """)
+            )
+
+            try localFileSystem.writeFileContents(
+              toolDir.appending(components: "Sources", "AwesomeResources", "hello.txt"),
+              bytes: ByteString(encodingAsUTF8: "hello")
+            )
+
+            try localFileSystem.createDirectory(toolDir.appending(component: "Tests"))
+            try localFileSystem.createDirectory(toolDir.appending(components: "Tests", "AwesomeResourcesTest"))
+
+            try localFileSystem.writeFileContents(
+              toolDir.appending(components: "Tests", "AwesomeResourcesTest", "world.txt"),
+              bytes: ByteString(encodingAsUTF8: "world")
+            )
+
+            try localFileSystem.writeFileContents(
+                toolDir.appending(components: "Tests", "AwesomeResourcesTest", "MyTests.swift"),
+                bytes: ByteString(encodingAsUTF8: """
+                    import XCTest
+                    import Foundation
+                    import AwesomeResources
+
+                    final class MyTests: XCTestCase {
+                        func testFoo() {
+                            XCTAssertTrue(AwesomeResource().hello == "hello")
+                        }
+                        func testBar() {
+                            let world = try! String(contentsOf: Bundle.module.url(forResource: "world", withExtension: "txt")!)
+                            XCTAssertTrue(world == "world")
+                        }
+                    }
+                    """))
+          
+            XCTAssert(try execute(["--package-path", "\(toolDir)", "--filter", "MyTests.*"]).stderr.contains("Executed 2 tests, with 0 failures"))
+
+        }
     }
 }

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -11,8 +11,6 @@
 import XCTest
 
 import SPMTestSupport
-import TSCBasic
-import TSCTestSupport
 import Commands
 
 final class TestToolTests: XCTestCase {
@@ -55,75 +53,5 @@ final class TestToolTests: XCTestCase {
             }
         }
         #endif
-    }
-  
-    func testSwiftTestWithResources() throws {
-        try withTemporaryDirectory { dir in
-            let toolDir = dir.appending(component: "swiftTestResources")
-            try localFileSystem.createDirectory(toolDir)
-            try localFileSystem.writeFileContents(
-              toolDir.appending(component: "Package.swift"),
-              bytes: ByteString(encodingAsUTF8: """
-                    // swift-tools-version:5.3
-                    import PackageDescription
-
-                    let package = Package(
-                       name: "AwesomeResources",
-                       targets: [
-                           .target(name: "AwesomeResources", resources: [.copy("hello.txt")]),
-                           .testTarget(name: "AwesomeResourcesTest", dependencies: ["AwesomeResources"], resources: [.copy("world.txt")])
-                       ]
-                    )
-                    """)
-            )
-            try localFileSystem.createDirectory(toolDir.appending(component: "Sources"))
-            try localFileSystem.createDirectory(toolDir.appending(components: "Sources", "AwesomeResources"))
-            try localFileSystem.writeFileContents(
-              toolDir.appending(components: "Sources", "AwesomeResources", "AwesomeResource.swift"),
-              bytes: ByteString(encodingAsUTF8: """
-                    import Foundation
-
-                    public struct AwesomeResource {
-                      public init() {}
-                      public let hello = try! String(contentsOf: Bundle.module.url(forResource: "hello", withExtension: "txt")!)
-                    }
-
-                    """)
-            )
-
-            try localFileSystem.writeFileContents(
-              toolDir.appending(components: "Sources", "AwesomeResources", "hello.txt"),
-              bytes: ByteString(encodingAsUTF8: "hello")
-            )
-
-            try localFileSystem.createDirectory(toolDir.appending(component: "Tests"))
-            try localFileSystem.createDirectory(toolDir.appending(components: "Tests", "AwesomeResourcesTest"))
-
-            try localFileSystem.writeFileContents(
-              toolDir.appending(components: "Tests", "AwesomeResourcesTest", "world.txt"),
-              bytes: ByteString(encodingAsUTF8: "world")
-            )
-
-            try localFileSystem.writeFileContents(
-                toolDir.appending(components: "Tests", "AwesomeResourcesTest", "MyTests.swift"),
-                bytes: ByteString(encodingAsUTF8: """
-                    import XCTest
-                    import Foundation
-                    import AwesomeResources
-
-                    final class MyTests: XCTestCase {
-                        func testFoo() {
-                            XCTAssertTrue(AwesomeResource().hello == "hello")
-                        }
-                        func testBar() {
-                            let world = try! String(contentsOf: Bundle.module.url(forResource: "world", withExtension: "txt")!)
-                            XCTAssertTrue(world == "world")
-                        }
-                    }
-                    """))
-          
-            XCTAssert(try execute(["--package-path", "\(toolDir)", "--filter", "MyTests.*"]).stderr.contains("Executed 2 tests, with 0 failures"))
-
-        }
     }
 }


### PR DESCRIPTION
Currently, running `swift test` fails when a test target accesses `Bundle.module` during a test (https://forums.swift.org/t/swift-5-3-spm-resources-in-tests-uses-wrong-bundle-path/37051).
This patch uses the bundlePath that already exists instead of crafting the path from `Bundle.main`. I've tested this in both library, executable, and test targets on macOS and it seems to do the trick.