### PR TITLE
[5.3] Mark the temporary v10_16 alias for macOS v11 as unavailable and having been renamed to v11

### DIFF
--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -209,11 +209,11 @@ extension SupportedPlatform {
         @available(_PackageDescription, introduced: 5.1)
         public static let v10_15: MacOSVersion = .init(string: "10.15")
 
-        /// The value that represents macOS 10.16, which is treated
-        /// as an alias for macOS 11.0.
+        /// The value that represents macOS 10.16, which has been
+        /// replaced by the value for macOS 11.0.
         ///
         /// - Since: First available in PackageDescription 5.3
-        @available(_PackageDescription, introduced: 5.3)
+        @available(*, unavailable, renamed: "v11")
         public static let v10_16: MacOSVersion = .init(string: "11.0")
 
         /// The value that represents macOS 11.0.

--- a/Tests/PackageLoadingTests/PD5LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5LoadingTests.swift
@@ -247,7 +247,7 @@ class PackageDescription5LoadingTests: PackageDescriptionLoadingTests {
             XCTAssertMatch(message, .contains("note: 'v14' was introduced in PackageDescription 5.3"))
         }
 
-        // Newer OS version alias.
+        // Newer OS version alias (now marked as unavailable).
         stream = BufferedOutputByteStream()
         stream <<< """
             import PackageDescription
@@ -267,8 +267,8 @@ class PackageDescription5LoadingTests: PackageDescriptionLoadingTests {
                 return XCTFail("\(error)")
             }
 
-            XCTAssertMatch(message, .contains("error: 'v10_16' is unavailable"))
-            XCTAssertMatch(message, .contains("note: 'v10_16' was introduced in PackageDescription 5.3"))
+            XCTAssertMatch(message, .contains("error: 'v10_16' has been renamed to 'v11'"))
+            XCTAssertMatch(message, .contains("note: 'v10_16' has been explicitly marked unavailable here"))
             XCTAssertMatch(message, .contains("note: 'v14' was introduced in PackageDescription 5.3"))
         }
     }


### PR DESCRIPTION
This is the 5.3 nomination for https://github.com/apple/swift-package-manager/pull/2816

This marks the temporary alias that was added during transition from 10.16 to 11 numbering for macOS 11 as unavailable.

rdar://65834459
