### PR TITLE
Compile the package manifest properly on Windows

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -656,7 +656,12 @@ public final class ManifestLoader: ManifestLoaderProtocol {
               #endif
 
                 // Run the compiled manifest.
-                let runResult = try Process.popen(arguments: cmd)
+                var environment = ProcessEnv.vars
+#if os(Windows)
+                let windowsPathComponent = runtimePath.pathString.replacingOccurrences(of: "/", with: "\\")
+                environment["Path"] = "\(windowsPathComponent);\(environment["Path"] ?? "")"
+#endif
+                let runResult = try Process.popen(arguments: cmd, environment: environment)
                 fclose(jsonOutputFileDesc)
                 let runOutput = try (runResult.utf8Output() + runResult.utf8stderrOutput()).spm_chuzzle()
                 if let runOutput = runOutput {

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -578,8 +578,12 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                 cmd += [
                     "-L", runtimePath.pathString,
                     "-lPackageDescription",
-                    "-Xlinker", "-rpath", "-Xlinker", runtimePath.pathString
                 ]
+#if !os(Windows)
+                // -rpath argument is not supported on Windows,
+                // so we add runtimePath to PATH when executing the manifest instead
+                cmd += ["-Xlinker", "-rpath", "-Xlinker", runtimePath.pathString]
+#endif
 
                 // note: this is not correct for all platforms, but we only actually use it on macOS.
                 macOSPackageDescriptionPath = runtimePath.appending(RelativePath("libPackageDescription.dylib"))

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -616,7 +616,12 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
             try withTemporaryDirectory(removeTreeOnDeinit: true) { tmpDir in
                 // Set path to compiled manifest executable.
-                let compiledManifestFile = tmpDir.appending(component: "\(packageIdentity)-manifest")
+#if os(Windows)
+                let executableSuffix = ".exe"
+#else
+                let executableSuffix = ""
+#endif
+                let compiledManifestFile = tmpDir.appending(component: "\(packageIdentity)-manifest\(executableSuffix)")
                 cmd += ["-o", compiledManifestFile.pathString]
 
                 // Compile the manifest.


### PR DESCRIPTION
Currently SwiftPM compiles the package manifest with an `-rpath` linker argument which is not supported on Windows.
On Windows it should instead execute the compiled manifest with an additional `PATH` component representing the `PackageDescription.dll` location.

This implementation relies on https://github.com/apple/swift-tools-support-core/pull/92 to pass the `PATH` environment variable to the manifest executable, but these PRs can be merged in any order.

After this change the compiled manifests can be executed manually by running `id-manifest.exe -fileno 1` 
– it prints the package manifest JSON to stdout.
(Execution by SwiftPM itself still fails because of a different issue: the file descriptor of the JSON output is not shared properly with the child process)