### PR TITLE
Remove warning and update the documentation to reflect the long-stand ing behavior of treating all C module headers as umbrella headers by default

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -730,12 +730,11 @@ automatically generate a modulemap for each C language library target for these
 * If `include/Foo.h` exists and `include` contains no other subdirectory, then
   `include/Foo.h` becomes the umbrella header.
 
-* Otherwise, if the `include` directory only contains header files and no other
-  subdirectory, it becomes the umbrella directory.
+* Otherwise, the `include` directory becomes an umbrella directory, which means
+  that all headers under it will be included in the module.
 
-In case of complicated `include` layouts, a custom `module.modulemap` can be
-provided inside `include`. SwiftPM will error out if it can not generate
-a modulemap with respect to the above rules.
+In case of complicated `include` layouts or headers that are not compatible with
+modules, a custom `module.modulemap` can be provided in the `include` directory.
 
 For executable targets, only one valid C language main file is allowed, e.g., it
 is invalid to have `main.c` and `main.cpp` in the same target.

--- a/Sources/PackageLoading/ModuleMapGenerator.swift
+++ b/Sources/PackageLoading/ModuleMapGenerator.swift
@@ -143,11 +143,7 @@ public struct ModuleMapGenerator {
             return
         }
         
-        // Otherwise, the target's public headers are considered to be incompatible with modules.  Other C targets can still import them, but Swift won't be able to see them.  This is documented as an error, but because SwiftPM has previously allowed it (creating module maps that then cause errors when used), we instead emit a warning and for now, continue to emit what SwiftPM has historically emitted (an umbrella directory include).
-        warningStream <<< "warning: the include directory of target '\(target.name)' has "
-        warningStream <<< "a layout that is incompatible with modules; consider adding a "
-        warningStream <<< "custom module map to the target"
-        warningStream.flush()
+        // Otherwise, the target's public headers are considered to be incompatible with modules.  Per the original design, an umbrella directory is still created for them.  This is will lead to build failures if those headers are included and they are not compatible with modules.  A future evolution proposal should revisit these semantics.
         try createModuleMap(inDir: wd, type: .directory(includeDir))
     }
 

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -82,6 +82,19 @@ class ModuleMapGeneration: XCTestCase {
             "/include/Bar.h",
             "/Foo.c")
         checkExpected()
+        
+        fs = InMemoryFileSystem(emptyFiles:
+            "/include/Baz/Foo.h",
+            "/include/Bar/Bar.h",
+            "/Foo.c")
+        let expected2 = BufferedOutputByteStream()
+        expected2 <<< "module Foo {\n"
+        expected2 <<< "    umbrella \"/include\"\n"
+        expected2 <<< "    export *\n"
+        expected2 <<< "}\n"
+        ModuleMapTester("Foo", in: fs) { result in
+            result.check(value: expected2.bytes)
+        }
     }
 
     func testWarnings() throws {
@@ -103,20 +116,6 @@ class ModuleMapGeneration: XCTestCase {
         ModuleMapTester("F-o-o", in: fs) { result in
             result.check(value: expected.bytes)
             result.checkDiagnostics("warning: /include/F-o-o.h should be renamed to /include/F_o_o.h to be used as an umbrella header")
-        }
-        
-        fs = InMemoryFileSystem(emptyFiles:
-            "/include/Baz/Foo.h",
-            "/include/Bar/Bar.h",
-            "/Foo.c")
-        let expected2 = BufferedOutputByteStream()
-        expected2 <<< "module Foo {\n"
-        expected2 <<< "    umbrella \"/include\"\n"
-        expected2 <<< "    export *\n"
-        expected2 <<< "}\n"
-        ModuleMapTester("Foo", in: fs) { result in
-            result.check(value: expected2.bytes)
-            result.checkDiagnostics("warning: the include directory of target \'Foo\' has a layout that is incompatible with modules; consider adding a custom module map to the target")
         }
     }
 


### PR DESCRIPTION
After more discussion about this, we will be removing the warning and just updating the documentation to match the behavior that’s been in place since 2016.  This is because the current implemented behavior was, according to the extensive PR discussion, the intended behavior, and there is concern about how many existing packages would require changes to get rid of the warning.

We will put up an evolution proposal with refined module map semantics, and at that time, probably tie it to the tools version, since this has now been the semantic for four years and a lot of packages have been written in the meantime.

rdar://65692136