### PR TITLE
[5.3] Update the documentation to reflect the long-standing behavior of treating all C module headers as umbrella headers by default

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -713,12 +713,11 @@ automatically generate a modulemap for each C language library target for these
 * If `include/Foo.h` exists and `include` contains no other subdirectory then
   `include/Foo.h` becomes the umbrella header.
 
-* Otherwise, if the `include` directory only contains header files and no other
-  subdirectory, it becomes the umbrella directory.
+* Otherwise, the `include` directory becomes an umbrella directory, which means
+  that all headers under it will be included in the module.
 
-In case of complicated `include` layouts, a custom `module.modulemap` can be
-provided inside `include`. SwiftPM will error out if it can not generate
-a modulemap with respect to the above rules.
+In case of complicated `include` layouts or headers that are not compatible with
+modules, a custom `module.modulemap` can be provided in the `include` directory.
 
 For executable targets, only one valid C language main file is allowed, e.g., it
 is invalid to have `main.c` and `main.cpp` in the same target.


### PR DESCRIPTION
The currently documented behavior for how the headers in the  directory are handled doesn't match what actually happens.  Since the current behavior dates back to the original implementation and many packages rely on it, we keep the existing semantics but correct the documentation.  We may want to adjust the current semantics in a future evolution proposal.

rdar://problem/65751265