### PR TITLE
Demote unhandled file diagnostic to a warning

### DIFF
--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -117,11 +117,11 @@ public struct TargetSourcesBuilder {
         if toolsVersion >= .v5_3 {
             let filesWithNoRules = pathToRule.filter { $0.value.rule == .none }
             if !filesWithNoRules.isEmpty {
-                var error = "found \(filesWithNoRules.count) file(s) which are unhandled; explicitly declare them as resources or exclude from the target\n"
+                var warning = "found \(filesWithNoRules.count) file(s) which are unhandled; explicitly declare them as resources or exclude from the target\n"
                 for (file, _) in filesWithNoRules {
-                    error += "    " + file.pathString + "\n"
+                    warning += "    " + file.pathString + "\n"
                 }
-                diags.emit(.error(error))
+                diags.emit(.warning(warning))
             }
         }
 


### PR DESCRIPTION
This was an error before, but we decided to make it a warning instead in order to ease transition to tools-version 5.3.

rdar://problem/65345954