### PR TITLE
Mark `--build-system` as experimental

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -318,7 +318,7 @@ public class SwiftTool<Options: ToolOptions> {
         binder.bindArray(
             option: parser.add(
                 option: "-Xxcbuild", kind: [String].self, strategy: .oneByOne,
-                usage: "Pass flag through to the Xcode build system invocations"),
+                usage: nil),
             to: { $0.xcbuildFlags = $1 })
 
         binder.bind(
@@ -392,7 +392,7 @@ public class SwiftTool<Options: ToolOptions> {
         binder.bind(
             option: parser.add(
                 option: "--arch", kind: [String].self, strategy: .oneByOne,
-                usage: "Build the package for the these architectures"),
+                usage: nil),
             to: { $0.archs = $1 })
 
         // FIXME: We need to allow -vv type options for this.


### PR DESCRIPTION
Typically, we only hide options from help to do that. The `--build-system` option itself is already not shown, but `-Xxcbuild` was. This hides `-Xxcbuild` as well. The same is true for `-arch` which requires using XCBuild today.

rdar://problem/65633615