### PR TITLE
[Docs] Fix broken link in Resources.md

### DIFF
--- a/Documentation/Resources.md
+++ b/Documentation/Resources.md
@@ -7,7 +7,7 @@
 * [PackageDescription API](PackageDescription.md)
 * [**Resources**](Resources.md)
   * [Support](#support)
-  * [Reporting a SwiftPM Bug](#reporting-a-good-swiftpm-bug)
+  * [Reporting a SwiftPM Bug](#reporting-a-swiftpm-bug)
 
 ---
 


### PR DESCRIPTION
This changes the internal link to match the linked heading