### PR TITLE
Bump minimum platform version to 10.13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,14 +13,14 @@
 import PackageDescription
 import class Foundation.ProcessInfo
 
-// We default to a 10.10 minimum deployment target for clients of libSwiftPM,
+// We default to a 10.13 minimum deployment target for clients of libSwiftPM,
 // but allow overriding it when building for a toolchain.
 
 let macOSPlatform: SupportedPlatform
 if let deploymentTarget = ProcessInfo.processInfo.environment["SWIFTPM_MACOS_DEPLOYMENT_TARGET"] {
     macOSPlatform = .macOS(deploymentTarget)
 } else {
-    macOSPlatform = .macOS(.v10_10)
+    macOSPlatform = .macOS(.v10_13)
 }
 
 let package = Package(


### PR DESCRIPTION
This change is set to be delivered as a part of support for Netrc in #2833, but I'm submitting it independently because we already merged the corresponding swift-driver change:
https://github.com/apple/swift-driver/pull/185

We could revert the swift-driver change, but since this change was already agreed upon, might as well bump it here, while #2833 and https://github.com/apple/swift-tools-support-core/pull/88 are in-review.

cc @sstadelman 

