### PR TITLE
[SR-13235] libSwiftPM should vend a ClangTarget's module map generation information to clients

### DIFF
--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -153,3 +153,28 @@ extension Diagnostic.Message {
         .error("downloaded archive of binary target '\(targetName)' does not contain expected binary artifact '\(artifactName)'")
     }
 }
+
+
+extension FileSystemError: CustomStringConvertible {
+    
+    public var description: String {
+        switch self {
+        case .invalidAccess:
+            return "invalid access"
+        case .ioError:
+            return "encountered I/O error"
+        case .isDirectory:
+            return "is a directory"
+        case .noEntry:
+            return "doesn't exist in file system"
+        case .notDirectory:
+            return "is not a directory"
+        case .unsupported:
+            return "unsupported operation"
+        case .unknownOSError:
+            return "unknown system error"
+        case .alreadyExistsAtDestination:
+            return "already exists in file system"
+        }
+    }
+}

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -211,6 +211,7 @@ class PackageBuilderTests: XCTestCase {
             package.checkModule("clib") { module in
                 module.check(c99name: "clib", type: .library)
                 module.checkSources(root: "/Sources/clib", paths: "clib.c")
+                module.check(moduleMapType: .custom(AbsolutePath("/Sources/clib/include/module.modulemap")))
             }
         }
     }
@@ -242,6 +243,7 @@ class PackageBuilderTests: XCTestCase {
             package.checkModule("clib") { module in
                 module.check(c99name: "clib", type: .library)
                 module.checkSources(root: "/Sources", paths: "clib/clib.c", "clib/clib2.c", "clib/nested/nested.c")
+                module.check(moduleMapType: .umbrellaHeader(AbsolutePath("/Sources/clib/clib.h")))
             }
         }
     }
@@ -614,12 +616,14 @@ class PackageBuilderTests: XCTestCase {
                 module.check(c99name: "Foo", type: .library)
                 module.checkSources(root: "/Sources/Foo", paths: "Foo.c")
                 module.check(includeDir: "/Sources/Foo/inc")
+                module.check(moduleMapType: .custom(AbsolutePath("/Sources/Foo/inc/module.modulemap")))
             }
 
             package.checkModule("Bar") { module in
                 module.check(c99name: "Bar", type: .library)
                 module.checkSources(root: "/Sources/Bar", paths: "Bar.c")
                 module.check(includeDir: "/Sources/Bar/include")
+                module.check(moduleMapType: .custom(AbsolutePath("/Sources/Bar/include/module.modulemap")))
             }
         }
     }
@@ -1712,6 +1716,7 @@ class PackageBuilderTests: XCTestCase {
             package.checkModule("lib") { module in
                 module.checkSources(root: "/Sources/lib", paths: "lib.c")
                 module.check(includeDir: "/Sources/lib/include")
+                module.check(moduleMapType: .umbrellaHeader(AbsolutePath("/Sources/lib/include/lib.h")))
             }
         }
     }
@@ -1736,6 +1741,7 @@ class PackageBuilderTests: XCTestCase {
             package.checkModule("lib") { module in
                 module.checkSources(root: "/Sources/lib", paths: "movie.mkv", "lib.c")
                 module.check(includeDir: "/Sources/lib/include")
+                module.check(moduleMapType: .umbrellaHeader(AbsolutePath("/Sources/lib/include/lib.h")))
             }
         }
     }
@@ -2179,6 +2185,13 @@ final class PackageBuilderTester {
                 return XCTFail("Include directory is being checked on a non clang target", file: file, line: line)
             }
             XCTAssertEqual(target.includeDir.pathString, includeDir, file: file, line: line)
+        }
+
+        func check(moduleMapType: ModuleMapType, file: StaticString = #file, line: UInt = #line) {
+            guard case let target as ClangTarget = target else {
+                return XCTFail("Module map type is being checked on a non-Clang target", file: file, line: line)
+            }
+            XCTAssertEqual(target.moduleMapType, moduleMapType, file: file, line: line)
         }
 
         func check(c99name: String? = nil, type: PackageModel.Target.Kind? = nil, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
This also modifies module map generation to use the unified logic for determining the module map type, and cleans up diagnostics reporting.

With detection of module map type (based on a target's header layout) separate from generation of a module map, the existing ModuleMapGenerator API of having a struct that gets initialized only to perform the one operation (either determining module map type of generating a module map) is a bit clunky.  We may want to refine that to make these standalone functions, but I think that can be done as a separate PR.

Vending the target's module map layout information provides more semantic information to the client than just vending the raw contents of the generated module map.  This semantic information can then (for example) be shown in the user interface of an IDE, etc.

rdar://65678318