### PR TITLE
[PackageLoading] Use a simpler manifest cache

### DIFF
--- a/swift-tools-support-core/Sources/TSCUtility/CMakeLists.txt
+++ b/swift-tools-support-core/Sources/TSCUtility/CMakeLists.txt
@@ -13,20 +13,20 @@ add_library(TSCUtility
   BuildFlags.swift
   CollectionExtensions.swift
   Diagnostics.swift
-  dlopen.swift
   Downloader.swift
-  FloatingPointExtensions.swift
   FSWatch.swift
+  FloatingPointExtensions.swift
   Git.swift
   IndexStore.swift
   InterruptHandler.swift
   JSONMessageStreamingParser.swift
-  misc.swift
   OSLog.swift
+  PersistenceCache.swift
   PkgConfig.swift
   Platform.swift
   PolymorphicCodable.swift
   ProgressAnimation.swift
+  SQLite.swift
   SimplePersistence.swift
   StringExtensions.swift
   StringMangling.swift
@@ -34,6 +34,8 @@ add_library(TSCUtility
   Verbosity.swift
   Version.swift
   Versioning.swift
+  dlopen.swift
+  misc.swift
 )
 target_link_libraries(TSCUtility PUBLIC
   TSCBasic)


### PR DESCRIPTION
This switches the manifest cache approach used inside manifest loader to
directly use sqlite database instead of going through llbuild. The main
reason for this switch is to simplify caching behavior and take
advantage of SQLite's WAL mode for concurrent access. A separate PR will
make the manifest cache global for the user.