### PR TITLE
[SR-13334] A target should record the tools version of the package that declares it (so it can affect build semantics)

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1298,7 +1298,8 @@ public class BuildPlan {
             let swiftTarget = SwiftTarget(
                 testDiscoverySrc: src,
                 name: testProduct.name,
-                dependencies: testProduct.underlyingProduct.targets.map { .target($0, conditions: []) }
+                dependencies: testProduct.underlyingProduct.targets.map { .target($0, conditions: []) },
+                toolsVersion: .currentToolsVersion
             )
             let linuxMainTarget = ResolvedTarget(
                 target: swiftTarget,

--- a/Sources/PackageGraph/PackageGraphLoader.swift
+++ b/Sources/PackageGraph/PackageGraphLoader.swift
@@ -537,7 +537,8 @@ private final class ResolvedProductBuilder: ResolvedBuilder<ResolvedProduct> {
     override func constructImpl() -> ResolvedProduct {
         return ResolvedProduct(
             product: product,
-            targets: targets.map({ $0.construct() })
+            targets: targets.map({ $0.construct() }),
+            toolsVersion: packageBuilder.package.manifest.toolsVersion
         )
     }
 }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -429,7 +429,8 @@ public final class PackageBuilder {
                     platforms: self.platforms(),
                     path: packagePath, isImplicit: true,
                     pkgConfig: manifest.pkgConfig,
-                    providers: manifest.providers)
+                    providers: manifest.providers,
+                    toolsVersion: manifest.toolsVersion)
             ]
         }
 
@@ -628,7 +629,8 @@ public final class PackageBuilder {
             let target = try createTarget(
                 potentialModule: potentialModule,
                 manifestTarget: manifestTarget,
-                dependencies: dependencies
+                dependencies: dependencies,
+                toolsVersion: manifest.toolsVersion
             )
             // Add the created target to the map or print no sources warning.
             if let createdTarget = target {
@@ -655,7 +657,8 @@ public final class PackageBuilder {
     private func createTarget(
         potentialModule: PotentialModule,
         manifestTarget: TargetDescription?,
-        dependencies: [Target.Dependency]
+        dependencies: [Target.Dependency],
+        toolsVersion: ToolsVersion
     ) throws -> Target? {
         guard let manifestTarget = manifestTarget else { return nil }
 
@@ -671,7 +674,8 @@ public final class PackageBuilder {
                 platforms: self.platforms(),
                 path: potentialModule.path, isImplicit: false,
                 pkgConfig: manifestTarget.pkgConfig,
-                providers: manifestTarget.providers
+                providers: manifestTarget.providers,
+                toolsVersion: toolsVersion
             )
         } else if potentialModule.type == .binary {
             let remoteURL = remoteArtifacts.first(where: { $0.path == potentialModule.path })
@@ -680,7 +684,8 @@ public final class PackageBuilder {
                 name: potentialModule.name,
                 platforms: self.platforms(),
                 path: potentialModule.path,
-                artifactSource: artifactSource
+                artifactSource: artifactSource,
+                toolsVersion: toolsVersion
             )
         }
 
@@ -739,7 +744,8 @@ public final class PackageBuilder {
                 resources: resources,
                 dependencies: dependencies,
                 swiftVersion: try swiftVersion(),
-                buildSettings: buildSettings
+                buildSettings: buildSettings,
+                toolsVersion: manifest.toolsVersion
             )
         } else {
             return ClangTarget(
@@ -755,7 +761,8 @@ public final class PackageBuilder {
                 sources: sources,
                 resources: resources,
                 dependencies: dependencies,
-                buildSettings: buildSettings
+                buildSettings: buildSettings,
+                toolsVersion: manifest.toolsVersion
             )
         }
     }

--- a/Sources/PackageModel/ResolvedModels.swift
+++ b/Sources/PackageModel/ResolvedModels.swift
@@ -207,7 +207,7 @@ public final class ResolvedProduct: ObjectIdentifierProtocol, CustomStringConver
         return targets.first(where: { $0.type == .executable })!
     }
 
-    public init(product: Product, targets: [ResolvedTarget]) {
+    public init(product: Product, targets: [ResolvedTarget], toolsVersion: ToolsVersion) {
         assert(product.targets.count == targets.count && product.targets.map({ $0.name }) == targets.map({ $0.name }))
         self.underlyingProduct = product
         self.targets = targets
@@ -215,7 +215,7 @@ public final class ResolvedProduct: ObjectIdentifierProtocol, CustomStringConver
         self.linuxMainTarget = underlyingProduct.linuxMain.map({ linuxMain in
             // Create an executable resolved target with the linux main, adding product's targets as dependencies.
             let dependencies: [Target.Dependency] = product.targets.map { .target($0, conditions: []) }
-            let swiftTarget = SwiftTarget(linuxMain: linuxMain, name: product.name, dependencies: dependencies)
+            let swiftTarget = SwiftTarget(linuxMain: linuxMain, name: product.name, dependencies: dependencies, toolsVersion: toolsVersion)
             return ResolvedTarget(target: swiftTarget, dependencies: targets.map { .target($0, conditions: []) })
         })
     }

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -146,7 +146,7 @@ class ModuleMapGeneration: XCTestCase {
 
 func ModuleMapTester(_ name: String, includeDir: String = "include", in fileSystem: FileSystem, _ body: (ModuleMapResult) -> Void) {
     let includeDir = AbsolutePath.root.appending(component: includeDir)
-    let target = ClangTarget(name: name, cLanguageStandard: nil, cxxLanguageStandard: nil, includeDir: includeDir, isTest: false, sources: Sources(paths: [], root: .root))
+    let target = ClangTarget(name: name, cLanguageStandard: nil, cxxLanguageStandard: nil, includeDir: includeDir, isTest: false, sources: Sources(paths: [], root: .root), toolsVersion: .currentToolsVersion)
     let diagnostics = DiagnosticsEngine()
     var generator = ModuleMapGenerator(for: target, fileSystem: fileSystem, diagnostics: diagnostics)
     do {

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -2039,6 +2039,32 @@ class PackageBuilderTests: XCTestCase {
             }
         }
     }
+    
+    func testTargetToolsVersions() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Foo/Sources/Foo/foo.swift"
+        )
+        
+        func checkToolsVersion(_ toolsVersion: ToolsVersion) {
+            let manifest = Manifest.createManifest(
+                name: "Foo",
+                v: toolsVersion,
+                targets: [ TargetDescription(name: "Foo") ]
+            )
+
+            PackageBuilderTester(manifest, path: AbsolutePath("/Foo"), in: fs) { result, diagnostics in
+                result.checkModule("Foo") { result in
+                    XCTAssertEqual(result.target.toolsVersion, toolsVersion)
+                }
+            }
+        }
+        
+        checkToolsVersion(.v4)
+        checkToolsVersion(.v4_2)
+        checkToolsVersion(.v5_2)
+        checkToolsVersion(.vNext)
+    }
+
 }
 
 extension PackageModel.Product: ObjectIdentifierProtocol {}

--- a/Tests/PackageLoadingTests/PkgConfigTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigTests.swift
@@ -22,7 +22,8 @@ extension SystemLibraryTarget {
             name: "Foo",
             path: AbsolutePath("/fake"),
             pkgConfig: pkgConfig.isEmpty ? nil : pkgConfig,
-            providers: providers.isEmpty ? nil : providers)
+            providers: providers.isEmpty ? nil : providers,
+            toolsVersion: .currentToolsVersion)
     }
 }
 

--- a/Tests/PackageModelTests/TargetTests.swift
+++ b/Tests/PackageModelTests/TargetTests.swift
@@ -18,7 +18,7 @@ private extension ResolvedTarget {
         self.init(
             target: SwiftTarget(
                 name: name, isTest: false, 
-                sources: Sources(paths: [], root: AbsolutePath("/")), dependencies: [], swiftVersion: .v4),
+                sources: Sources(paths: [], root: AbsolutePath("/")), dependencies: [], swiftVersion: .v4, toolsVersion: .v4),
             dependencies: deps.map { .target($0, conditions: []) })
     }
 }


### PR DESCRIPTION
A package's declared swift tools version determines not only the API that is available to the package manifest, but also the semantics used for the target at build time.  This could include how a Clang target's headers are represented in an automatically generated module map, etc.  The idea is that, as new build features are added (e.g. additional compilation flags, etc), whether or not they apply to a particular target can depend on the swift tools version of the package that declares it.  This lets older packages continue to build the way they have in the past without needing to be updated.

Currently, targets in the SwiftPM package model don't record the declared tools version of the package manifest from where they came.  This change plumbs that information through from the package, so that it is available to the build plan and libSwiftPM clients.

There is no semantic change in this PR, but it will enable fixes and new functionality where the semantics depend on the declared tools version of the package that defines the target.