### PR TITLE
[SR-12758] Clang targets imported by other Clang targets should only use modulemaps for tools version 5.2 or later

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1611,8 +1611,11 @@ public class BuildPlan {
 
                 // Add the modulemap of the dependency if it has one.
                 if case let .clang(dependencyTargetDescription)? = targetMap[dependency] {
-                    if let moduleMap = dependencyTargetDescription.moduleMap {
-                        clangTarget.additionalFlags += ["-fmodule-map-file=\(moduleMap.pathString)"]
+                    let dependencyTargetToolsVersion = graph.package(for: dependencyTargetDescription.target)!.manifest.toolsVersion
+                    if dependencyTargetToolsVersion >= .v5_2 {
+                        if let moduleMap = dependencyTargetDescription.moduleMap {
+                            clangTarget.additionalFlags += ["-fmodule-map-file=\(moduleMap.pathString)"]
+                        }
                     }
                 }
             case let target as SystemLibraryTarget:

--- a/Sources/PackageGraph/PackageGraph.swift
+++ b/Sources/PackageGraph/PackageGraph.swift
@@ -49,6 +49,12 @@ public struct PackageGraph {
         return rootPackages.contains(package)
     }
 
+    /// Looks up and returns the package that contains the target.
+    public func package(for target: ResolvedTarget) -> ResolvedPackage? {
+        // FIXME: This can be easily cached.
+        return packages.first { $0.targets.contains(target) }
+    }
+
     /// All root and root dependency packages provided as input to the graph.
     public let inputPackages: [ResolvedPackage]
 


### PR DESCRIPTION
The fix for SR-10707 unconditionally added a `-fmodule-map-file` argument to the build of any Clang target that imports another Clang target.  This broke packages whose headers are incompatible with module maps, even if those packages specify an older Swift Tools version.  In order to apply the new semantics introduced by the fix for SR-10707, while also letting older targets build unmodified, this PR makes the addition of the `-fmodule-map-file` flag be conditional on whether the package that defines the target specifies a tools version of 5.2 or later.

There is a risk that this will break some other packages that specify a tools version older than 5.2 but that rely on the new behavior introduced in 5.2.  That has to be balanced against unbreaking the older packages that were broken by the change in 5.2.  There doesn't seem to be a good way to unbreak older packages, such as the ones described in SR-12758 and SR-12197, without risking also breaking packages that rely on the new behavior but specify an older tools version (note that such packages would also have been broken when building using an older version of the toolchain).

Conceptually, it seems correct that the change in the behavior introduced in 5.2 should be conditional on a Swift tools version of 5.2 or later.  In general, changing to the semantics of how packages get built should go by the tools version when possible, so that existing packages don't break.

This PR adds a `PackageGraph` method to look up the `ResolvedPackage` that defines a particular `ResolvedTarget`.  This is done in favor of adding the tools version to each `ResolvedTarget`, as a separate PR had proposed to do.

rdar://66294379