### PR TITLE
Improve check for unsafe flags

### DIFF
--- a/Sources/PackageGraph/PackageGraphLoader.swift
+++ b/Sources/PackageGraph/PackageGraphLoader.swift
@@ -571,7 +571,7 @@ private final class ResolvedTargetBuilder: ResolvedBuilder<ResolvedTarget> {
 
     func diagnoseInvalidUseOfUnsafeFlags(_ product: ResolvedProduct) {
         // Diagnose if any target in this product uses an unsafe flag.
-        for target in product.targets {
+        for target in product.recursiveTargetDependencies() {
             let declarations = target.underlyingTarget.buildSettings.assignments.keys
             for decl in declarations {
                 if BuildSettings.Declaration.unsafeSettings.contains(decl) {

--- a/Sources/PackageModel/ResolvedModels.swift
+++ b/Sources/PackageModel/ResolvedModels.swift
@@ -235,6 +235,12 @@ public final class ResolvedProduct: ObjectIdentifierProtocol, CustomStringConver
       // contain Swift code we don't know about as part of this build).
       return targets.contains { $0.underlyingTarget is SwiftTarget }
     }
+
+    /// Returns the recursive target dependencies.
+    public func recursiveTargetDependencies() -> [ResolvedTarget] {
+        let recursiveDependencies = targets.lazy.flatMap { $0.recursiveTargetDependencies() }
+        return Array(Set(targets).union(recursiveDependencies))
+    }
 }
 
 extension ResolvedTarget.Dependency: CustomStringConvertible {

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3843,7 +3843,8 @@ final class WorkspaceTests: XCTestCase {
         // We should only see errors about use of unsafe flag in the version-based dependency.
         workspace.checkPackageGraph(roots: ["Foo", "Bar"]) { (graph, diagnostics) in
             DiagnosticsEngineTester(diagnostics, ignoreNotes: true) { result in
-               result.check(diagnostic: .equal("the target 'Baz' in product 'Baz' contains unsafe build flags"), behavior: .error)
+               result.checkUnordered(diagnostic: .equal("the target 'Baz' in product 'Baz' contains unsafe build flags"), behavior: .error)
+               result.checkUnordered(diagnostic: .equal("the target 'Bar' in product 'Baz' contains unsafe build flags"), behavior: .error)
            }
         }
     }


### PR DESCRIPTION
We prohibit unsafe flags in package dependencies, but the check was only looking at targets which are direct dependencies of a product, not transitive ones.

rdar://problem/66499615