### PR TITLE
[Commands] Allow skipping tests with a flag

### DIFF
--- a/Documentation/Development.md
+++ b/Documentation/Development.md
@@ -47,6 +47,9 @@ $ swift test --parallel
 
 # Run a single test.
 $ swift test --filter PackageGraphTests.DependencyResolverTests/testBasics
+
+# Run tests for the test targets BuildTests and WorkspaceTests, but skip some test cases.
+$ swift test --filter BuildTests --skip BuildPlanTests --filter WorkspaceTests --skip InitTests
 ```
 
 Note: PackageDescription v4 is not available when developing using this method.
@@ -183,14 +186,6 @@ installed. This path can be overridden by setting the environment variable
 absolute search paths. SwiftPM will choose the first
 path which exists on disk. If none of the paths are present on disk, it will fall
 back to built-in computation.
-
-## Skipping SwiftPM tests
-
-SwiftPM has a hidden env variable `_SWIFTPM_SKIP_TESTS_LIST` that can be used
-to skip a list of tests. This value of the variable is either a file path that contains a
-newline separated list of tests to skip, or a colon-separated list of tests.
-
-This is only a development feature and should be considered _unsupported_.
 
 ## Making changes in TSC targets
 

--- a/IntegrationTests/Tests/IntegrationTests/BasicTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/BasicTests.swift
@@ -222,13 +222,13 @@ final class BasicTests: XCTestCase {
                         func testBaz() { }
                     }
                     """))
-            let testOutput = try sh(swiftTest, "--package-path", toolDir, "--filter", "MyTests.*").stderr
+            let testOutput = try sh(swiftTest, "--package-path", toolDir, "--filter", "MyTests.*", "--skip", "testBaz").stderr
 
             // Check the test log.
             XCTAssertContents(testOutput) { checker in
                 checker.check(.contains("Test Suite 'MyTests' started"))
                 checker.check(.contains("Test Suite 'MyTests' passed"))
-                checker.check(.contains("Executed 3 tests, with 0 failures"))
+                checker.check(.contains("Executed 2 tests, with 0 failures"))
             }
         }
     }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -213,19 +213,21 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testSwiftTestParallel() throws {
-        // Running swift-test fixtures on linux is not yet possible.
-      #if os(macOS)
         fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
           // First try normal serial testing.
           do {
-            _ = try SwiftPMProduct.SwiftTest.execute([], packagePath: prefix)
-          } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
-            XCTAssertTrue(stderr.contains("Executed 2 tests"))
+            _ = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"], packagePath: prefix)
+          } catch SwiftPMProductError.executionFailure(_, let output, let stderr) {
+            #if os(macOS)
+              XCTAssertTrue(stderr.contains("Executed 2 tests"))
+            #else
+              XCTAssertTrue(output.contains("Executed 2 tests"))
+            #endif
           }
 
           do {
             // Run tests in parallel.
-            _ = try SwiftPMProduct.SwiftTest.execute(["--parallel"], packagePath: prefix)
+            _ = try SwiftPMProduct.SwiftTest.execute(["--parallel", "--enable-test-discovery"], packagePath: prefix)
           } catch SwiftPMProductError.executionFailure(_, let output, _) {
             XCTAssert(output.contains("testExample1"))
             XCTAssert(output.contains("testExample2"))
@@ -238,7 +240,7 @@ class MiscellaneousTestCase: XCTestCase {
           do {
             // Run tests in parallel with verbose output.
             _ = try SwiftPMProduct.SwiftTest.execute(
-                ["--parallel", "--verbose", "--xunit-output", xUnitOutput.pathString],
+                ["--parallel", "--verbose", "--xunit-output", xUnitOutput.pathString, "--enable-test-discovery"],
                 packagePath: prefix)
           } catch SwiftPMProductError.executionFailure(_, let output, _) {
             XCTAssert(output.contains("testExample1"))
@@ -253,25 +255,22 @@ class MiscellaneousTestCase: XCTestCase {
           let contents = try localFileSystem.readFileContents(xUnitOutput).description
           XCTAssertTrue(contents.contains("tests=\"3\" failures=\"1\""))
         }
-      #endif
     }
 
     func testSwiftTestFilter() throws {
-        #if os(macOS)
-            fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
-                let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--filter", ".*1", "-l"], packagePath: prefix)
-                XCTAssertMatch(stdout, .contains("testExample1"))
-                XCTAssertNoMatch(stdout, .contains("testExample2"))
-                XCTAssertNoMatch(stdout, .contains("testSureFailure"))
-            }
+        fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
+            let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--filter", ".*1", "-l", "--enable-test-discovery"], packagePath: prefix)
+            XCTAssertMatch(stdout, .contains("testExample1"))
+            XCTAssertNoMatch(stdout, .contains("testExample2"))
+            XCTAssertNoMatch(stdout, .contains("testSureFailure"))
+        }
 
-            fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
-                let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--filter", ".*1", "--filter", "testSureFailure", "-l"], packagePath: prefix)
-                XCTAssertMatch(stdout, .contains("testExample1"))
-                XCTAssertNoMatch(stdout, .contains("testExample2"))
-                XCTAssertMatch(stdout, .contains("testSureFailure"))
-            }
-        #endif
+        fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
+            let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--filter", ".*1", "--filter", "testSureFailure", "-l", "--enable-test-discovery"], packagePath: prefix)
+            XCTAssertMatch(stdout, .contains("testExample1"))
+            XCTAssertNoMatch(stdout, .contains("testExample2"))
+            XCTAssertMatch(stdout, .contains("testSureFailure"))
+        }
     }
 
     func testOverridingSwiftcArguments() throws {

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -266,10 +266,34 @@ class MiscellaneousTestCase: XCTestCase {
         }
 
         fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
-            let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--filter", ".*1", "--filter", "testSureFailure", "-l", "--enable-test-discovery"], packagePath: prefix)
-            XCTAssertMatch(stdout, .contains("testExample1"))
+            let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--filter", "ParallelTestsTests", "--skip", ".*1", "--filter", "testSureFailure", "-l", "--enable-test-discovery"], packagePath: prefix)
+            XCTAssertNoMatch(stdout, .contains("testExample1"))
+            XCTAssertMatch(stdout, .contains("testExample2"))
+            XCTAssertMatch(stdout, .contains("testSureFailure"))
+        }
+    }
+
+    func testSwiftTestSkip() throws {
+        fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
+            let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--skip", "ParallelTestsTests", "-l", "--enable-test-discovery"], packagePath: prefix)
+            XCTAssertNoMatch(stdout, .contains("testExample1"))
             XCTAssertNoMatch(stdout, .contains("testExample2"))
             XCTAssertMatch(stdout, .contains("testSureFailure"))
+        }
+
+        fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
+            let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--filter", "ParallelTestsTests", "--skip", ".*2", "--filter", "TestsFailure", "--skip", "testSureFailure", "-l", "--enable-test-discovery"], packagePath: prefix)
+            XCTAssertMatch(stdout, .contains("testExample1"))
+            XCTAssertNoMatch(stdout, .contains("testExample2"))
+            XCTAssertNoMatch(stdout, .contains("testSureFailure"))
+        }
+
+        fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
+            let (stdout, stderr) = try SwiftPMProduct.SwiftTest.execute(["--skip", "Tests", "--enable-test-discovery"], packagePath: prefix)
+            XCTAssertNoMatch(stdout, .contains("testExample1"))
+            XCTAssertNoMatch(stdout, .contains("testExample2"))
+            XCTAssertNoMatch(stdout, .contains("testSureFailure"))
+            XCTAssertMatch(stderr, .contains("No matching test cases were run"))
         }
     }
 


### PR DESCRIPTION
Multiple `--skip` invocations can be used to skip multiple tests. Keep the environment variable around till its users switch over.

@aciidb0mb3r added the functionality to skip tests in #2181 last summer, but it was only available from an environment variable. I was unaware of that and really wanted the option to skip tests, especially when segfaulting tests cause the whole test run to stop, so I looked into implementing it and found his code. Simply adding this flag surfaces his implementation to the user and works, but ~is~was incomplete.

I ~'d go~went further and ~make~made it so that `--filter` and `---skip` could be used at the same time ~(the naive implementation in this WIP pull causes the skip flag to override the filter flag)~, so one could `--filter BuildTests --skip SwiftCompilerOutputParserTests` and have much more fine-grained control of what tests are run. ~I simply reused the colon-separated scheme of the environment variable, but something like @keith's #2800, ie allowing multiple invocations of `--skip`, would be more consistent.~

I ~figured I'd~ implemented it by moving the `.skip` case to its own function `skippedTests` which is a `fileprivate extension` to `[UnitTest]`, similar to `filteredTests`, then changed all three invocations of `filteredTests` in this module to `filteredTests().skippedTests()`.

~Before I go down that road, I thought I'd post this minimal implementation and see what the maintainers think.~ @keith, let me know if this would help you too.