### PR TITLE
Add missing kind values to TargetStartedInfo

### DIFF
--- a/Sources/XCBuildSupport/XCBuildOutputParser.swift
+++ b/Sources/XCBuildSupport/XCBuildOutputParser.swift
@@ -46,6 +46,9 @@ public enum XCBuildMessage {
     public struct TargetStartedInfo {
         public enum Kind: String {
             case native = "Native"
+            case aggregate = "Aggregate"
+            case external = "External"
+            case packageProduct = "Package Product"
         }
 
         public let targetID: Int


### PR DESCRIPTION
When I use:
`swift build --build-system xcode -v`
I get:
error: failed parsing XCBuild output: unexpected JSON message: : dataCorrupted(Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "type", intValue: nil)], debugDescription: "Cannot initialize Kind from invalid String value Package Product", underlyingError: nil))