### PR TITLE
[Integrated Swift Driver] Do not create CompilerOutputParsers for swift-frontend jobs

### DIFF
--- a/Sources/Build/BuildDelegate.swift
+++ b/Sources/Build/BuildDelegate.swift
@@ -358,11 +358,7 @@ public final class BuildDelegate: BuildSystemDelegate, SwiftCompilerOutputParser
         let swiftParsers = bctx.buildDescription?.swiftCommands.mapValues { tool in
             SwiftCompilerOutputParser(targetName: tool.moduleName, delegate: self)
         } ?? [:]
-        let swiftFrontendParsers = bctx.buildDescription?.swiftFrontendCommands.mapValues { tool in
-            SwiftCompilerOutputParser(targetName: tool.moduleName, delegate: self)
-        } ?? [:]
-        self.swiftParsers = swiftParsers.merging(swiftFrontendParsers) { (_, _) in fatalError("duplicated Swift command")
-        }
+        self.swiftParsers = swiftParsers
     }
 
     public var fs: SPMLLBuild.FileSystem? {


### PR DESCRIPTION
The swift-frontend currently does not support parseable output, therefore, the parsers here are not needed.
The presence of these parsers also leads to these jobs to be skipped from being reported on in the LLBuild status line printing.

Resolves rdar://66594405