### PR TITLE
[Xcodeproj]: Set CURRENT_PROJECT_VERSION to 1 in generated Xcode project

### DIFF
--- a/Sources/Xcodeproj/XcodeProjectModel.swift
+++ b/Sources/Xcodeproj/XcodeProjectModel.swift
@@ -354,6 +354,7 @@ public struct Xcode {
             public var CLANG_ENABLE_OBJC_ARC: String?
             public var COMBINE_HIDPI_IMAGES: String?
             public var COPY_PHASE_STRIP: String?
+            public var CURRENT_PROJECT_VERSION: String?
             public var DEBUG_INFORMATION_FORMAT: String?
             public var DEFINES_MODULE: String?
             public var DYLIB_INSTALL_NAME_BASE: String?
@@ -400,6 +401,7 @@ public struct Xcode {
                 CLANG_ENABLE_OBJC_ARC: String? = nil,
                 COMBINE_HIDPI_IMAGES: String? = nil,
                 COPY_PHASE_STRIP: String? = nil,
+                CURRENT_PROJECT_VERSION: String? = nil,
                 DEBUG_INFORMATION_FORMAT: String? = nil,
                 DEFINES_MODULE: String? = nil,
                 DYLIB_INSTALL_NAME_BASE: String? = nil,
@@ -445,6 +447,7 @@ public struct Xcode {
                 self.CLANG_ENABLE_OBJC_ARC = CLANG_CXX_LANGUAGE_STANDARD
                 self.COMBINE_HIDPI_IMAGES = COMBINE_HIDPI_IMAGES
                 self.COPY_PHASE_STRIP = COPY_PHASE_STRIP
+                self.CURRENT_PROJECT_VERSION = CURRENT_PROJECT_VERSION
                 self.DEBUG_INFORMATION_FORMAT = DEBUG_INFORMATION_FORMAT
                 self.DEFINES_MODULE = DEFINES_MODULE
                 self.DYLIB_INSTALL_NAME_BASE = DYLIB_INSTALL_NAME_BASE

--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -448,6 +448,11 @@ public func xcodeProject(
 
         let infoPlistFilePath = xcodeprojPath.appending(component: target.infoPlistFileName)
         targetSettings.common.INFOPLIST_FILE = infoPlistFilePath.relative(to: sourceRootDir).pathString
+        // The generated Info.plist has $(CURRENT_PROJECT_VERSION) as value for the CFBundleVersion key.
+        // CFBundleVersion is required for apps to e.g. be submitted to the app store.
+        // So we need to set it to some valid value in the project settings.
+        // TODO: Extract version from SPM target (see SR-4265 and SR-12926).
+        targetSettings.common.CURRENT_PROJECT_VERSION = "1"
 
         if target.type == .test {
             targetSettings.common.CLANG_ENABLE_MODULES = "YES"

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -123,6 +123,7 @@ class PackageGraphTests: XCTestCase {
                 XCTAssertEqual(targetResult.target.buildSettings.debug.SWIFT_ACTIVE_COMPILATION_CONDITIONS, ["DMACOS"])
                 XCTAssertNil(targetResult.target.buildSettings.release.SWIFT_ACTIVE_COMPILATION_CONDITIONS)
 
+                XCTAssertEqual(targetResult.commonBuildSettings.CURRENT_PROJECT_VERSION, "1")
                 XCTAssertEqual(targetResult.commonBuildSettings.OTHER_CFLAGS?.first, "$(inherited)")
                 XCTAssertEqual(targetResult.commonBuildSettings.OTHER_LDFLAGS?.first, "$(inherited)")
                 XCTAssertEqual(targetResult.commonBuildSettings.OTHER_SWIFT_FLAGS?.first, "$(inherited)")
@@ -134,6 +135,7 @@ class PackageGraphTests: XCTestCase {
             result.check(target: "Bar") { targetResult in
                 targetResult.check(productType: .framework)
                 targetResult.check(dependencies: ["Foo"])
+                XCTAssertEqual(targetResult.commonBuildSettings.CURRENT_PROJECT_VERSION, "1")
                 XCTAssertEqual(targetResult.commonBuildSettings.LD_RUNPATH_SEARCH_PATHS ?? [], ["$(inherited)", "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"])
                 XCTAssertEqual(targetResult.commonBuildSettings.OTHER_CFLAGS?.first, "$(inherited)")
                 XCTAssertEqual(targetResult.commonBuildSettings.OTHER_LDFLAGS?.first, "$(inherited)")
@@ -145,6 +147,7 @@ class PackageGraphTests: XCTestCase {
             result.check(target: "Sea") { targetResult in
                 targetResult.check(productType: .framework)
                 targetResult.check(dependencies: ["Foo"])
+                XCTAssertEqual(targetResult.commonBuildSettings.CURRENT_PROJECT_VERSION, "1")
                 XCTAssertEqual(targetResult.commonBuildSettings.CLANG_ENABLE_MODULES, "YES")
                 XCTAssertEqual(targetResult.commonBuildSettings.DEFINES_MODULE, "YES")
                 XCTAssertEqual(targetResult.commonBuildSettings.MODULEMAP_FILE, nil)
@@ -159,6 +162,7 @@ class PackageGraphTests: XCTestCase {
                 targetResult.check(productType: .framework)
                 targetResult.check(dependencies: ["Foo"])
                 XCTAssertNil(targetResult.commonBuildSettings.CLANG_ENABLE_MODULES)
+                XCTAssertEqual(targetResult.commonBuildSettings.CURRENT_PROJECT_VERSION, "1")
                 XCTAssertEqual(targetResult.commonBuildSettings.DEFINES_MODULE, "NO")
                 XCTAssertEqual(targetResult.commonBuildSettings.MODULEMAP_FILE, nil)
                 XCTAssertEqual(targetResult.commonBuildSettings.OTHER_CFLAGS?.first, "$(inherited)")
@@ -171,6 +175,7 @@ class PackageGraphTests: XCTestCase {
             result.check(target: "Sea3") { targetResult in
                 targetResult.check(productType: .framework)
                 XCTAssertNil(targetResult.commonBuildSettings.CLANG_ENABLE_MODULES)
+                XCTAssertEqual(targetResult.commonBuildSettings.CURRENT_PROJECT_VERSION, "1")
                 XCTAssertEqual(targetResult.commonBuildSettings.DEFINES_MODULE, "NO")
                 XCTAssertEqual(targetResult.commonBuildSettings.MODULEMAP_FILE, nil)
             }


### PR DESCRIPTION
This should resolve [SR-4265](https://bugs.swift.org/browse/SR-4265) for now, even though it might not be the final solution (as discussed in SR-4265).
I thought a first working solution is better than no solution... 🙂 