### PR TITLE
Allow SwiftCompilerMessages with no outputs

### DIFF
--- a/Sources/Build/SwiftCompilerOutputParser.swift
+++ b/Sources/Build/SwiftCompilerOutputParser.swift
@@ -28,14 +28,14 @@ public struct SwiftCompilerMessage {
         public struct BeganInfo {
             public let pid: Int
             public let inputs: [String]
-            public let outputs: [Output]
+            public let outputs: [Output]?
             public let commandExecutable: String
             public let commandArguments: [String]
 
             public init(
                 pid: Int,
                 inputs: [String],
-                outputs: [Output],
+                outputs: [Output]?,
                 commandExecutable: String,
                 commandArguments: [String]
             ) {
@@ -49,7 +49,7 @@ public struct SwiftCompilerMessage {
 
         public struct SkippedInfo {
             public let inputs: [String]
-            public let outputs: [Output]
+            public let outputs: [Output]?
 
             public init(inputs: [String], outputs: [SwiftCompilerMessage.Kind.Output]) {
                 self.inputs = inputs

--- a/Tests/BuildTests/SwiftCompilerOutputParserTests.swift
+++ b/Tests/BuildTests/SwiftCompilerOutputParserTests.swift
@@ -57,6 +57,17 @@ class SwiftCompilerOutputParserTests: XCTestCase {
               ],
               "pid": 58776
             }
+            250
+            {
+              "kind": "began",
+              "name": "verify-module-interface",
+              "inputs": [
+                "main.swiftinterface"
+              ],
+              "pid": 31337,
+              "command_executable": "swift",
+              "command_arguments" : ["-frontend", "-typecheck-module-from-interface", "main.swiftinterface"]
+            }
             299
             {
               "kind": "began",
@@ -108,6 +119,14 @@ class SwiftCompilerOutputParserTests: XCTestCase {
                     outputs: [.init(
                         type: "object",
                         path: "/var/folders/yc/rgflx8m11p5d71k1ydy0l_pr0000gn/T/test2-77d991.o")]))),
+            SwiftCompilerMessage(
+                name: "verify-module-interface",
+                kind: .began(.init(
+                    pid: 31337,
+                    inputs: ["main.swiftinterface"],
+                    outputs: nil,
+                    commandExecutable: "swift",
+                    commandArguments: ["-frontend", "-typecheck-module-from-interface", "main.swiftinterface"]))),
             SwiftCompilerMessage(
                 name: "link",
                 kind: .began(.init(


### PR DESCRIPTION
Swift frontend jobs are not required to have outputs. When they don’t, there is no “output” field in the driver’s JSON. SwiftPM previously assumed an “output” field must be present; this commit disabuses it of that notion.

(Necessary for apple/swift#33114; previously, the Swift driver never happened to do this for the compiles SwiftPM requested.)