### PR TITLE
Commands: remove `signalled` cases for Windows

### DIFF
--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -647,8 +647,10 @@ final class TestRunner {
             switch result.exitStatus {
             case .terminated(code: 0):
                 success = true
+#if !os(Windows)
             case .signalled(let signal):
                 output += "\n" + exitSignalText(code: signal)
+#endif
             default: break
             }
         } catch {
@@ -668,8 +670,10 @@ final class TestRunner {
             switch result.exitStatus {
             case .terminated(code: 0):
                 return true
+#if !os(Windows)
             case .signalled(let signal):
                 print(exitSignalText(code: signal))
+#endif
             default: break
             }
         } catch {


### PR DESCRIPTION
Windows does not have the concept of signals, therefore processes may
not terminate with signalling exits.  Such an exit is encoded in the
exit status code on Windows.