### PR TITLE
Workspace: use `ProcessEnv.path` rather `ProcessEnv.vars["PATH"]`

### DIFF
--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -222,7 +222,7 @@ public final class UserToolchain: Toolchain {
 
         // Get the search paths from PATH.
         let searchPaths = getEnvSearchPaths(
-            pathString: ProcessEnv.vars["PATH"], currentWorkingDirectory: localFileSystem.currentWorkingDirectory)
+            pathString: ProcessEnv.path, currentWorkingDirectory: localFileSystem.currentWorkingDirectory)
 
         self.envSearchPaths = searchPaths
 


### PR DESCRIPTION
The path environment variable spelt `Path` on Windows and `PATH` on
Unicies (since most of Windows is case insensitive).  This is already
properly handled in swit-tools-support-core.   Use the helper accessor
rather than duplicate that knowledge here.