### PR TITLE
Workspace: assume that the user is always correct

### DIFF
--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -121,10 +121,10 @@ public final class UserToolchain: Toolchain {
         // We require there is at least one valid swift compiler, either in the
         // bin dir or SWIFT_EXEC.
         let resolvedBinDirCompiler: AbsolutePath
-        if let binDirCompiler = try? UserToolchain.getTool("swiftc", binDir: binDir) {
-            resolvedBinDirCompiler = binDirCompiler
-        } else if let SWIFT_EXEC = SWIFT_EXEC {
+        if let SWIFT_EXEC = SWIFT_EXEC {
             resolvedBinDirCompiler = SWIFT_EXEC
+        } else if let binDirCompiler = try? UserToolchain.getTool("swiftc", binDir: binDir) {
+            resolvedBinDirCompiler = binDirCompiler
         } else {
             // Try to lookup swift compiler on the system which is possible when
             // we're built outside of the Swift toolchain.


### PR DESCRIPTION
When the user specifies the Swift executable via `SWIFT_EXEC` in the
environment, assume that the value is supposed to be used.  This changes
the order in which the Swift compiler is evaluated as being present.
This can avoid an unnecessary lookup for the executable in the case that
it is specified by the user.