### PR TITLE
Create dylibs by default when using XCBuild

### DIFF
--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -141,7 +141,7 @@ public struct BuildParameters: Encodable {
         jobs: UInt32 = UInt32(ProcessInfo.processInfo.activeProcessorCount),
         shouldLinkStaticSwiftStdlib: Bool = false,
         shouldEnableManifestCaching: Bool = false,
-        shouldCreateDylibForDynamicProducts: Bool = false,
+        shouldCreateDylibForDynamicProducts: Bool = true,
         sanitizers: EnabledSanitizers = EnabledSanitizers(),
         enableCodeCoverage: Bool = false,
         indexStoreMode: IndexStoreMode = .auto,

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -450,9 +450,15 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         let executableName: String
         let productType: PIF.Target.ProductType
         if product.type == .library(.dynamic) {
-            pifTargetProductName = product.name + ".framework"
-            executableName = product.name
-            productType = .framework
+            if parameters.shouldCreateDylibForDynamicProducts {
+                pifTargetProductName = "lib\(product.name).dylib"
+                executableName = pifTargetProductName
+                productType = .dynamicLibrary
+            } else {
+                pifTargetProductName = product.name + ".framework"
+                executableName = product.name
+                productType = .framework
+            }
         } else {
             pifTargetProductName = "lib\(product.name).a"
             executableName = pifTargetProductName


### PR DESCRIPTION
This changes the default to be dylibs when using XCBuild since we only create frameworks in Xcode for App Store submission. It also fixes an issue where even when dylib creation was enabled, we weren't producing dylibs.

rdar://problem/66849186