### PR TITLE
SPMBuildCore: correct naming scheme for libraries on Windows

### DIFF
--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -240,7 +240,11 @@ public struct BuildParameters: Encodable {
         case .library(.static):
             return RelativePath("lib\(product.name)\(triple.staticLibraryExtension)")
         case .library(.dynamic):
-            return RelativePath("lib\(product.name)\(triple.dynamicLibraryExtension)")
+            if self.triple.os == .windows {
+              return RelativePath("\(product.name)\(triple.dynamicLibraryExtension)")
+            } else {
+              return RelativePath("lib\(product.name)\(triple.dynamicLibraryExtension)")
+            }
         case .library(.automatic):
             fatalError()
         case .test:


### PR DESCRIPTION
Windows has a different naming scheme for libraries:
  lib<name>.lib: static libraries
  <name>.dll: shared libraries
  <name>.lib: import libraries for the shared library

Adjust the generated name for Windows targets.