### PR TITLE
PackageDescription: renegotiate the PackageDescription contract

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -699,7 +699,16 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                 guard let jsonOutputFileDesc = fopen(jsonOutputFile.pathString, "w") else {
                     throw StringError("couldn't create the manifest's JSON output file")
                 }
-                cmd = [compiledManifestFile.pathString, "-fileno", "\(fileno(jsonOutputFileDesc))"]
+
+                cmd = [compiledManifestFile.pathString]
+#if os(Windows)
+                // NOTE: `_get_osfhandle` returns a non-owning, unsafe,
+                // unretained HANDLE.  DO NOT invoke `CloseHandle` on `hFile`.
+                let hFile: Int = _get_osfhandle(_fileno(jsonOutputFileDesc))
+                cmd += ["-handle", "\(String(hFile, radix: 16))"]
+#else
+                cmd += ["-fileno", "\(fileno(jsonOutputFileDesc))"]
+#endif
 
               #if os(macOS)
                 // If enabled, use sandbox-exec on macOS. This provides some safety against


### PR DESCRIPTION
Passing fileno through to the child from the parent is not viable on
Windows.  "File Descriptors" are not a first class entity on Windows.
The concept of file descriptors is specifically a userspace concept that
is emulated via the C runtime.  The system speaks only in HANDLEs.

Because the file descriptor is emulated, the value of the file
descriptor is not shared across the parent and child.  Instead of
passing the file descriptor, reach into the C library and fetch out the
underlying system HANDLE.  Because the `HANDLE` was constructed via
`_open`, it will be marked with `bInherit` as `TRUE` (this can be
verified via `GetHandleInformation` which will pass back
`HANDLE_FLAG_INHERIT`.

We now serialize the handle and pass that explicitly to the child.  The
child then does this dance in reverse, creating a new file descriptor
from the handle, and then converting the file descriptor to a `FILE *`
which can then be written to.

This dance is possible to avoid if there is a previous contract that is
made on the file encoding.  In such a case, it is possible to take the
string content and convert that to the proper encoding and then directly
write that to the `HANDLE` via `WriteFile` system call.  Although that
would be safer and more efficient by completely side-stepping the C
library and the emulation of the POSIX file system semantics, it avoid
then require the additional encoding negotiation.  For now, take the
long way out.

With this change we can now reliably process the manifest enabling
processing of the projects on Windows.