### PR TITLE
swiftpm-xctest-helper: add Windows C library handling

### DIFF
--- a/Sources/swiftpm-xctest-helper/main.swift
+++ b/Sources/swiftpm-xctest-helper/main.swift
@@ -134,7 +134,11 @@ do {
 
 #else
 
+#if os(Windows)
+import func ucrt.exit
+#else
 import func Glibc.exit
+#endif
 print("Only macOS supported.")
 exit(1)
 


### PR DESCRIPTION
Windows does not use `Glibc` but rather uses `ucrt` for the C runtime.
Add the proper import for the `exit` function.  This is needed for
building swift-package-manager on Windows with swift-package-manager.`
function.  This is needed for building swift-package-manager on Windows
with swift-package-manager.