### PR TITLE
PackageModel: add `windows` to the list of known platforms

### DIFF
--- a/Sources/PackageModel/Platform.swift
+++ b/Sources/PackageModel/Platform.swift
@@ -29,7 +29,7 @@ public final class PlatformRegistry {
 
     /// The static list of known platforms.
     private static var _knownPlatforms: [Platform] {
-        return [.macOS, .iOS, .tvOS, .watchOS, .linux, .android, .wasi]
+        return [.macOS, .iOS, .tvOS, .watchOS, .linux, .windows, .android, .wasi]
     }
 }
 

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -1570,6 +1570,7 @@ class PackageBuilderTests: XCTestCase {
             "tvos": "9.0",
             "watchos": "2.0",
             "android": "0.0",
+            "windows": "0.0",
             "wasi": "0.0",
         ]
 
@@ -1625,6 +1626,7 @@ class PackageBuilderTests: XCTestCase {
             "ios": "9.0",
             "watchos": "2.0",
             "android": "0.0",
+            "windows": "0.0",
             "wasi": "0.0",
         ]
 


### PR DESCRIPTION
Ensure that Windows is listed as a known platform.  Failure to
acknowledge that will result in failures to map the platform from the
string representation.