### PR TITLE
SPMBuildCore: detect Windows hosts properly

### DIFF
--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -117,6 +117,8 @@ public struct BuildParameters: Encodable {
             return .android
         } else if self.triple.isWASI() {
             return .wasi
+        } else if self.triple.isWindows() {
+            return .windows
         } else {
             return .linux
         }


### PR DESCRIPTION
This ensures that SPM identifies the host correctly enabling platform
specific linker and compile settings to be applied properly.
Previously, we would treat Windows as Linux resulting in incorrect
application of linker options.  This was detected when building
swift-package-manager with swift-package-manager on Windows and we would
attempt to link against `libm`.