### PR TITLE
Symlink swift-autolink-extract into the SPM build dir

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -541,6 +541,7 @@ def build_swiftpm_with_swiftpm(args, integrated_swift_driver):
     # Setup symlinks that'll allow using swiftpm from the build directory.
     symlink_force(args.swiftc_path, os.path.join(args.target_dir, args.conf, "swiftc"))
     symlink_force(args.swiftc_path, os.path.join(args.target_dir, args.conf, "swift"))
+    symlink_force(args.swiftc_path, os.path.join(args.target_dir, args.conf, "swift-autolink-extract"))
 
     lib_dir = os.path.join(args.target_dir, "lib", "swift")
 


### PR DESCRIPTION
When using the integrated swift-driver, SPM may need to look up swift-autolink-extract. Symlinking it into the build dir alongside `swift` and `swiftc` prevents some test failures caused by apple/swift-driver#208 (which fixes generation of autolink-extract jobs on linux)