### PR TITLE
Fix property formatting in `PackageGraphRoot.swift`

### DIFF
--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -92,7 +92,7 @@ public struct PackageGraphRoot {
     public let manifests: [Manifest]
 
     /// The root package references.
-     public let packageRefs: [PackageReference]
+    public let packageRefs: [PackageReference]
 
     /// The top level dependencies.
     public let dependencies: [PackageDependency]


### PR DESCRIPTION
This property formatting was not alinged with the rest of the file.