### PR TITLE
Build: treat `SwiftDriver` as a private link dependency

### DIFF
--- a/Sources/Build/CMakeLists.txt
+++ b/Sources/Build/CMakeLists.txt
@@ -19,7 +19,8 @@ target_link_libraries(Build PUBLIC
   LLBuildManifest
   SPMBuildCore
   CYaml
-  Yams
+  Yams)
+target_link_libraries(Build PRIVATE
   SwiftDriver)
 
 # NOTE(compnerd) workaround for CMake not setting up include flags yet


### PR DESCRIPTION
This module is marked as `@_implementationOnly`.  The users of `Build`
should not have to link against `SwiftDriver`.