### PR TITLE
Workspace: handle `SWIFTPM_PD_LIBS` properly on Windows

### DIFF
--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -269,8 +269,14 @@ public final class UserToolchain: Toolchain {
 
         // Look for an override in the env.
         if let pdLibDirEnvStr = ProcessEnv.vars["SWIFTPM_PD_LIBS"] {
-            // We pick the first path which exists in a colon seperated list.
-            let paths = pdLibDirEnvStr.split(separator: ":").map(String.init)
+            // We pick the first path which exists in an environment variable
+            // delimited by the platform specific string separator.
+#if os(Windows)
+            let separator: Character = ";"
+#else
+            let separator: Character = ":"
+#endif
+            let paths = pdLibDirEnvStr.split(separator: separator).map(String.init)
             var foundPDLibDir = false
             for pathString in paths {
                 if let path = try? AbsolutePath(validating: pathString), localFileSystem.exists(path) {


### PR DESCRIPTION
This environment variable is needed during bootstrapping.  Using `:` as
a delimiter does not allow passing a valid windows path as `:` is the
drive separator.  Use the traditional path separator `;` on Windows and
use `:` on the other platforms.  This allows setting the correct path to
the package description modules.