### PR TITLE
repair the build after apple/swift-tools-support-core#88

### DIFF
--- a/Sources/SPMTestSupport/MockDownloader.swift
+++ b/Sources/SPMTestSupport/MockDownloader.swift
@@ -49,6 +49,7 @@ public class MockDownloader: Downloader {
     public func downloadFile(
         at url: Foundation.URL,
         to destinationPath: AbsolutePath,
+        withAuthorizationProvider: AuthorizationProviding? = nil,
         progress: @escaping Downloader.Progress,
         completion: @escaping Downloader.Completion
     ) {

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1421,6 +1421,7 @@ extension Workspace {
             downloader.downloadFile(
                 at: parsedURL,
                 to: archivePath,
+                withAuthorizationProvider: nil,
                 progress: { bytesDownloaded, totalBytesToDownload in
                     self.delegate?.downloadingBinaryArtifact(
                         from: url,


### PR DESCRIPTION
The new parameter seems to trip up the build on Windows.  This adds the
parameter in explicitly which repairs the build.