### PR TITLE
Re-enable self-hosted builds

### DIFF
--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# FIXME: Temporarily disabled until #2876 lands
-exit 0
-
 set -eu
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
This can be merged once the installed toolchain has the fix in #2876 or once https://github.com/apple/swift-llbuild/pull/683 lands.