### PR TITLE
Allow empty build settings arrays

### DIFF
--- a/Sources/PackageLoading/PackageDescription4Loader.swift
+++ b/Sources/PackageLoading/PackageDescription4Loader.swift
@@ -172,12 +172,7 @@ extension ManifestBuilder {
     }
 
     func parseBuildSettings(_ json: JSON, tool: TargetBuildSettingDescription.Tool, settingName: String) throws -> [TargetBuildSettingDescription.Setting] {
-
         let declaredSettings = try json.getArray()
-        if declaredSettings.isEmpty {
-            throw ManifestParseError.runtimeManifestErrors(["\(settingName) cannot be an empty array; provide at least one setting or remove it"])
-        }
-
         return try declaredSettings.map({
             try parseBuildSetting($0, tool: tool)
         })

--- a/Tests/PackageLoadingTests/PD5LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5LoadingTests.swift
@@ -431,12 +431,7 @@ class PackageDescription5LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        do {
-            try loadManifestThrowing(stream.bytes) { _ in }
-            XCTFail("Unexpected success")
-        } catch ManifestParseError.runtimeManifestErrors(let errors) {
-            XCTAssertEqual(errors, ["cSettings cannot be an empty array; provide at least one setting or remove it"])
-        }
+        try loadManifestThrowing(stream.bytes) { _ in }
     }
 
     func testWindowsPlatform() throws {


### PR DESCRIPTION
In this case:

```swift
let linkerSettings: [LinkerSetting]
if ProcessInfo.processInfo.environment["SOMETHING"] == nil {
    linkerSettings = []
} else {
    linkerSettings = [
        .unsafeFlags(["something"]),
    ]
}

// pass linkerSettings to a .target below
```

It's useful to be able to pass empty lists here.