### PR TITLE
[PackageLoading] Add a method to properly reset manifest cache

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -77,6 +77,9 @@ public protocol ManifestLoaderProtocol {
         fileSystem: FileSystem?,
         diagnostics: DiagnosticsEngine?
     ) throws -> Manifest
+
+    /// Reset any internal cache held by the manifest loader.
+    func resetCache() throws
 }
 
 extension ManifestLoaderProtocol {
@@ -112,6 +115,9 @@ extension ManifestLoaderProtocol {
             diagnostics: diagnostics
         )
     }
+
+    public func resetCache() throws {
+    }
 }
 
 public protocol ManifestLoaderDelegate {
@@ -136,7 +142,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
     }
     let cacheDir: AbsolutePath!
     let delegate: ManifestLoaderDelegate?
-    let cache: PersistentCacheProtocol?
+    private(set) var cache: PersistentCacheProtocol?
 
     public init(
         manifestResources: ManifestResourceProvider,
@@ -155,11 +161,6 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             try? localFileSystem.createDirectory(cacheDir, recursive: true)
         }
         self.cacheDir = cacheDir.map(resolveSymlinks)
-
-        self.cache = cacheDir.flatMap {
-            // FIXME: It would be nice to emit a warning if we weren't able to create the cache.
-            try? SQLiteBackedPersistentCache(cacheFilePath: $0.appending(component: "manifest.db"))
-        }
     }
 
     @available(*, deprecated)
@@ -237,6 +238,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         fileSystem: FileSystem? = nil,
         diagnostics: DiagnosticsEngine? = nil
     ) throws -> Manifest {
+        try self.createCacheIfNeeded()
 
         // Inform the delegate.
         self.delegate?.willLoad(manifest: inputPath)
@@ -830,6 +832,25 @@ public final class ManifestLoader: ManifestLoaderProtocol {
     private func runtimePath(for version: ToolsVersion) -> AbsolutePath {
         // Bin dir will be set when developing swiftpm without building all of the runtimes.
         return resources.binDir ?? resources.libDir.appending(version.runtimeSubpath)
+    }
+
+    /// Returns path to the manifest database inside the given cache directory.
+    private static func manifestCacheDBPath(_ cacheDir: AbsolutePath) -> AbsolutePath {
+        return cacheDir.appending(component: "manifest.db")
+    }
+
+    func createCacheIfNeeded() throws {
+        // Return if we have already created the cache.
+        guard self.cache == nil else { return }
+        guard let manifestCacheDBPath = cacheDir.flatMap({ Self.manifestCacheDBPath($0) }) else { return }
+        self.cache = try SQLiteBackedPersistentCache(cacheFilePath: manifestCacheDBPath)
+    }
+
+    public func resetCache() throws {
+        guard let manifestCacheDBPath = cacheDir.flatMap({ Self.manifestCacheDBPath($0) }) else { return }
+        self.cache = nil
+        // Also remove the database file from disk.
+        try localFileSystem.removeFileTree(manifestCacheDBPath)
     }
 }
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -625,6 +625,7 @@ extension Workspace {
         guard removed else { return }
 
         repositoryManager.reset()
+        try? manifestLoader.resetCache()
         try? fileSystem.removeFileTree(dataPath)
     }
 

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -570,6 +570,11 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             for _ in 0..<2 {
                 check(loader: noCacheLoader, expectCached: false)
             }
+
+            // Resetting the cache should allow us to remove the cache
+            // directory without triggering assertions in sqlite.
+            try manifestLoader.resetCache()
+            try localFileSystem.removeFileTree(path)
         }
     }
 


### PR DESCRIPTION
Workspace's reset method removes the cache directory while the sqlite
database is in use, which is a considered a bug in client of sqlite
databases. This exposes a proper way to reset a cache that might be used
by a particular manifest loader implementation.

<rdar://problem/67712262>