### PR TITLE
PackageLoading: introduce `-Xmanifest`

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -42,7 +42,13 @@ struct BuildFlagsGroup: ParsableArguments {
                 "Pass flag through to the Xcode build system invocations",
                 shouldDisplay: false))
     var xcbuildFlags: [String] = []
-    
+
+    @Option(name: .customLong("Xmanifest", withSingleDash: true),
+            parsing: .unconditionalSingleValue,
+            help: ArgumentHelp("Pass flag to the manifest build invocation",
+                               shouldDisplay: false))
+    var manifestFlags: [String] = []
+
     var buildFlags: BuildFlags {
         BuildFlags(
             xcc: cCompilerFlags,
@@ -96,7 +102,11 @@ public struct SwiftToolOptions: ParsableArguments {
     var xcbuildFlags: [String] {
         buildFlagsGroup.xcbuildFlags
     }
-    
+
+    var manifestFlags: [String] {
+        buildFlagsGroup.manifestFlags
+    }
+
     /// Build configuration.
     @Option(name: .shortAndLong, help: "Build with configuration")
     var configuration: BuildConfiguration = .debug

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -655,7 +655,8 @@ public class SwiftTool {
                 // Always use the host toolchain's resources for parsing manifest.
                 manifestResources: self._hostToolchain.get().manifestResources,
                 isManifestSandboxEnabled: !self.options.shouldDisableSandbox,
-                cacheDir: self.options.shouldDisableManifestCaching ? nil : self.buildPath
+                cacheDir: self.options.shouldDisableManifestCaching ? nil : self.buildPath,
+                extraManifestFlags: self.options.manifestFlags
             )
         })
     }()

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -143,18 +143,21 @@ public final class ManifestLoader: ManifestLoaderProtocol {
     let cacheDir: AbsolutePath!
     let delegate: ManifestLoaderDelegate?
     private(set) var cache: PersistentCacheProtocol?
+    private let extraManifestFlags: [String]
 
     public init(
         manifestResources: ManifestResourceProvider,
         serializedDiagnostics: Bool = false,
         isManifestSandboxEnabled: Bool = true,
         cacheDir: AbsolutePath? = nil,
-        delegate: ManifestLoaderDelegate? = nil
+        delegate: ManifestLoaderDelegate? = nil,
+        extraManifestFlags: [String] = []
     ) {
         self.resources = manifestResources
         self.serializedDiagnostics = serializedDiagnostics
         self.isManifestSandboxEnabled = isManifestSandboxEnabled
         self.delegate = delegate
+        self.extraManifestFlags = extraManifestFlags
 
         // Resolve symlinks since we can't use them in sandbox profiles.
         if let cacheDir = cacheDir {
@@ -689,6 +692,8 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             }
 
             cmd += [manifestPath.pathString]
+
+            cmd += self.extraManifestFlags
 
             try withTemporaryDirectory(removeTreeOnDeinit: true) { tmpDir in
                 // Set path to compiled manifest executable.


### PR DESCRIPTION
This introduces a new `-Xmanifest` flag that will allow the user to pass
additional flags to the manifest build invocation.  This is particularly
important for the case of Windows, where the split SDK/toolchain model
requires the additional flags such as `-sdk` or `-resource-dir` to be
passed to the manifest build system.