### PR TITLE
Workspace: remove `-lstdc++` on Windows

### DIFF
--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -134,6 +134,8 @@ public struct Destination: Encodable, Equatable {
         var extraCPPFlags: [String] = []
 #if os(macOS)
         extraCPPFlags += ["-lc++"]
+#elseif os(Windows)
+        extraCPPFlags += []
 #else
         extraCPPFlags += ["-lstdc++"]
 #endif


### PR DESCRIPTION
Windows does not really use libstdc++ (although it would be useful under
MinGW).  This allows building on the Windows target.