### PR TITLE
Use .none as the default test specification

### DIFF
--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -114,7 +114,13 @@ struct TestToolOptions: ParsableArguments {
 
     var testCaseSkip: TestCaseSpecifier {
         // TODO: Remove this once the environment variable is no longer used.
-        testCaseSkipOverride() ?? .skip(_testCaseSkip)
+        if let override = testCaseSkipOverride() {
+            return override
+        }
+      
+        return _testCaseSkip.isEmpty
+            ? .none
+            : .skip(_testCaseSkip)
     }
 
     @Option(name: .customLong("skip"),


### PR DESCRIPTION
The ArgumentParser adoption changed the default test specification to be `.skip([])` instead of `.none` — this change switches it back. I'll follow up with test coverage in a later PR.