### PR TITLE
`--skip-integrated-driver-tests` should be a test argument

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -130,11 +130,6 @@ def add_build_args(parser):
         help="paths (relative to the project root) where to install build products [%(default)s]",
         default=["/tmp/swiftpm"],
         metavar="PATHS")
-    parser.add_argument(
-        "--skip-integrated-driver-tests",
-        action="store_true",
-        help="whether to skip tests with the integrated driver",
-        default=True)
 
 def add_test_args(parser):
     """Configures the parser with the arguments necessary for the test action."""
@@ -149,6 +144,11 @@ def add_test_args(parser):
         action="append",
         help="filter to apply on which tests to run",
         default=[])
+    parser.add_argument(
+        "--skip-integrated-driver-tests",
+        action="store_true",
+        help="whether to skip tests with the integrated driver",
+        default=True)
 
 def parse_global_args(args):
     """Parses and cleans arguments necessary for all actions."""


### PR DESCRIPTION
I accidentally added it as a build argument.