### PR TITLE
Commands: strip `\r` in diagnostics

### DIFF
--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -80,7 +80,7 @@ func print(diagnostic: Diagnostic, stdoutStream: OutputByteStream) {
         break
     }
 
-    writer.write(diagnostic.description)
+    writer.write(diagnostic.description.replacingOccurrences(of: "\r", with: ""))
     writer.write("\n")
 }
 


### PR DESCRIPTION
This strips the `\r` in diagnostics when rendering which significantly
improves the rendering of error messages on Windows which uses `\r\n` as
the line separator rather than `\n`.