### PR TITLE
[5.3] On ELF platforms, remove the host toolchain rpath from executables and shared libraries

### DIFF
--- a/Sources/PackageDescription/CMakeLists.txt
+++ b/Sources/PackageDescription/CMakeLists.txt
@@ -47,6 +47,8 @@ foreach(PACKAGE_DESCRIPTION_VERSION 4 4_2)
     if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
       target_link_libraries(PD${PACKAGE_DESCRIPTION_VERSION} PRIVATE
         Foundation)
+      target_link_options(PD${PACKAGE_DESCRIPTION_VERSION} PRIVATE
+        "SHELL:-no-toolchain-stdlib-rpath")
     endif()
 
     if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -610,6 +610,11 @@ def get_swiftpm_flags(args):
     elif cross_compile_hosts:
         error("cannot cross-compile for %s" % cross_compile_hosts)
 
+    # On ELF platforms, remove the host toolchain's stdlib absolute rpath from
+    # installed executables and shared libraries.
+    if platform.system() != "Darwin" and args.command == 'install':
+        build_flags.extend(["-Xswiftc", "-no-toolchain-stdlib-rpath"])
+
     return build_flags
 
 if __name__ == '__main__':


### PR DESCRIPTION
before installing.

It has been suggested to me by some Swift devs that this would be good to get in before the 5.3 release, a cherry-pick from #2703.

This should be completely safe for the 5.3 branch, as it's just removing the build toolchain's stdlib rpath, which should be unused by SPM.