### PR TITLE
[SR-13484] Use `--no-checkout` when cloning packages, since it's immediately followed by a `checkout` anyway

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -83,7 +83,7 @@ public class GitRepositoryProvider: RepositoryProvider {
             // a clone from our cache of repositories and then we replace the remote to the one originally
             // present in the bare repository.
             try Process.checkNonZeroExit(args:
-                    Git.tool, "clone", sourcePath.pathString, destinationPath.pathString)
+                    Git.tool, "clone", "--no-checkout", sourcePath.pathString, destinationPath.pathString)
             // The default name of the remote.
             let origin = "origin"
             // In destination repo remove the remote which will be pointing to the source repo.
@@ -102,7 +102,7 @@ public class GitRepositoryProvider: RepositoryProvider {
             // only ever expect to get back a revision that remains present in the
             // object storage.
             try Process.checkNonZeroExit(args:
-                    Git.tool, "clone", "--shared", sourcePath.pathString, destinationPath.pathString)
+                    Git.tool, "clone", "--shared", "--no-checkout", sourcePath.pathString, destinationPath.pathString)
         }
     }
 

--- a/Sources/SourceControl/InMemoryGitRepository.swift
+++ b/Sources/SourceControl/InMemoryGitRepository.swift
@@ -341,7 +341,6 @@ public final class InMemoryGitRepositoryProvider: RepositoryProvider {
     ) throws {
         let checkout = fetchedMap[sourcePath]!.copy(at: destinationPath)
         checkoutsMap[destinationPath] = checkout
-        try checkout.installHead()
     }
 
     public func checkoutExists(at path: AbsolutePath) throws -> Bool {

--- a/Sources/SourceControl/Repository.swift
+++ b/Sources/SourceControl/Repository.swift
@@ -83,7 +83,10 @@ public protocol RepositoryProvider {
 
     /// Clone a managed repository into a working copy at on the local file system.
     ///
-    /// Once complete, the repository can be opened using `openCheckout`.
+    /// Once complete, the repository can be opened using `openCheckout`. Note
+    /// that there is no requirement that the files have been materialized into
+    /// the file system at the completion of this call, since it will always be
+    /// followed by checking out the cloned working copy at a particular ref.
     ///
     /// - Parameters:
     ///   - sourcePath: The location of the repository on disk, at which the


### PR DESCRIPTION
SwiftPM fetches a remote repository by mirroring it to the local file system, then clones that local repository to a working directory, after which it checks out a specific ref.

When the local clone happens, Git also does a checkout.  This is unnecessary, since the checkout will immediately be replaced by the intended ref, and it also makes the checkout sensitive to whether the default branch name is set up correctly for the repository.

Since the working copy is guaranteed to be checked out after the clone, there is no need to do a checkout as part of the cloning.

rdar://68165300