### PR TITLE
Pin the argument parser dependency to 0.3.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -263,7 +263,7 @@ if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("master")),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.3.0")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", .exact("0.3.0")),
         .package(url: "https://github.com/apple/swift-driver.git", .branch("master")),
     ]
 } else {


### PR DESCRIPTION
Version 0.3.1+ triggers an assertion, so we pin the previous version until we can investigate this further.

https://github.com/apple/swift-package-manager/pull/2907#issuecomment-687262168