### PR TITLE
SwiftPM should be more resilient against random binaries named `xcrun` and `sandbox-exec` in the PATH

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -741,7 +741,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                         moduleCachePath.map({ AbsolutePath($0) })
                     ].compactMap({ $0 })
                     let profile = sandboxProfile(toolsVersion: toolsVersion, cacheDirectories: cacheDirectories)
-                    cmd = ["sandbox-exec", "-p", profile] + cmd
+                    cmd = ["/usr/bin/sandbox-exec", "-p", profile] + cmd
                 }
               #endif
 

--- a/Sources/PackageLoading/MinimumDeploymentTarget.swift
+++ b/Sources/PackageLoading/MinimumDeploymentTarget.swift
@@ -25,7 +25,7 @@ public struct MinimumDeploymentTarget {
     }
 
     static func computeMinimumDeploymentTarget(of binaryPath: AbsolutePath) throws -> PlatformVersion? {
-        let runResult = try Process.popen(arguments: ["xcrun", "vtool", "-show-build", binaryPath.pathString])
+        let runResult = try Process.popen(arguments: ["/usr/bin/xcrun", "vtool", "-show-build", binaryPath.pathString])
         guard let versionString = try runResult.utf8Output().components(separatedBy: "\n").first(where: { $0.contains("minos") })?.components(separatedBy: " ").last else { return nil }
         return PlatformVersion(versionString)
     }
@@ -45,7 +45,7 @@ public struct MinimumDeploymentTarget {
         // On macOS, we are determining the deployment target by looking at the XCTest binary.
         #if os(macOS)
         do {
-            let runResult = try Process.popen(arguments: ["xcrun", "--sdk", sdkName, "--show-sdk-platform-path"])
+            let runResult = try Process.popen(arguments: ["/usr/bin/xcrun", "--sdk", sdkName, "--show-sdk-platform-path"])
 
             if let version = try computeXCTestMinimumDeploymentTarget(with: runResult) {
                 return version


### PR DESCRIPTION
For the tools that are in fixed locations, SwiftPM should run them using absolute paths.

Failing to do so will cause the build to fail when running `swift build` under certain environments such as tests where PATH is set incorrectly.  It's also a bad idea to run `sandbox-exec` out of a random location.

Furthermore, it is not valid to invoke `xcrun` from any other location but `/usr/bin`, so we should not spend time looking up a constant.

rdar://68374424