### PR TITLE
build: loosen swfit-argument-parser dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -263,7 +263,7 @@ if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("master")),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", .exact("0.3.0")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor("0.3.1")),
         .package(url: "https://github.com/apple/swift-driver.git", .branch("master")),
     ]
 } else {

--- a/Package.swift
+++ b/Package.swift
@@ -263,7 +263,7 @@ if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("master")),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor("0.3.1")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.3.1")),
         .package(url: "https://github.com/apple/swift-driver.git", .branch("master")),
     ]
 } else {


### PR DESCRIPTION
When building SourceKit-LSP without local deps, swift-argument-parser is taken to be 0.3.1..<0.4.0.  However, swift-package-manager, a dependency of SourceKit-LSP requires =0.3.0.  This results in a conflicting version statement that cannot be resolved.  This only impacts the build in the non-local dependency situation which is why this probably hasn't been noticed.