### PR TITLE
On Darwin, pass CMAKE_OSX_ARCHITECTURES with just the host during the CMake portion of the bootstrap.

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -464,6 +464,10 @@ def build_llbuild(args):
         "-DLLBUILD_SUPPORT_BINDINGS:=Swift",
     ]
 
+    # On Darwin, make sure we're building for the host architecture.
+    if platform.system() == 'Darwin':
+        flags.append("-DCMAKE_OSX_ARCHITECTURES:=%s" % (get_build_target(args).split('-')[0]))
+
     if args.sysroot:
         flags.append("-DSQLite3_INCLUDE_DIR=%s/usr/include" % args.sysroot)
 


### PR DESCRIPTION
This makes bootstrapping immune to whatever defaults are set in swift-llbuild's own CMake files, and makes bootstrapping succeed again.

rdar://68383324