### PR TITLE
PackageLoading,Workspace: derive flags for Windows

### DIFF
--- a/Examples/package-info/Sources/package-info/main.swift
+++ b/Examples/package-info/Sources/package-info/main.swift
@@ -31,9 +31,9 @@ let package = localFileSystem.currentWorkingDirectory!
 // There are several levels of information available.
 // Each takes longer to load than the level above it, but provides more detail.
 let diagnostics = DiagnosticsEngine()
-let manifest = try ManifestLoader.loadManifest(packagePath: package, swiftCompiler: swiftCompiler, packageKind: .local)
-let loadedPackage = try PackageBuilder.loadPackage(packagePath: package, swiftCompiler: swiftCompiler, diagnostics: diagnostics)
-let graph = try Workspace.loadGraph(packagePath: package, swiftCompiler: swiftCompiler, diagnostics: diagnostics)
+let manifest = try ManifestLoader.loadManifest(packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], packageKind: .local)
+let loadedPackage = try PackageBuilder.loadPackage(packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], diagnostics: diagnostics)
+let graph = try Workspace.loadGraph(packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], diagnostics: diagnostics)
 
 // EXAMPLES
 // ========

--- a/Sources/PackageLoading/CMakeLists.txt
+++ b/Sources/PackageLoading/CMakeLists.txt
@@ -17,8 +17,7 @@ add_library(PackageLoading
   Target+PkgConfig.swift
   TargetSourcesBuilder.swift
   ToolsVersionLoader.swift
-  UserManifestResources.swift
-  ../Workspace/WindowsToolchainInfo.swift)
+  UserManifestResources.swift)
 target_link_libraries(PackageLoading PUBLIC
   TSCBasic
   PackageModel

--- a/Sources/PackageLoading/CMakeLists.txt
+++ b/Sources/PackageLoading/CMakeLists.txt
@@ -17,12 +17,15 @@ add_library(PackageLoading
   Target+PkgConfig.swift
   TargetSourcesBuilder.swift
   ToolsVersionLoader.swift
-  UserManifestResources.swift)
+  UserManifestResources.swift
+  ../Workspace/WindowsToolchainInfo.swift)
 target_link_libraries(PackageLoading PUBLIC
   TSCBasic
   PackageModel
   TSCUtility
   SPMLLBuild)
+target_link_libraries(PackageLoading PUBLIC
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(PackageLoading PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -627,7 +627,6 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
             // Compute the path to runtime we need to load.
             let runtimePath = self.runtimePath(for: toolsVersion)
-            let compilerFlags = self.interpreterFlags(for: toolsVersion)
 
             // FIXME: Workaround for the module cache bug that's been haunting Swift CI
             // <rdar://problem/48443680>
@@ -705,7 +704,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             }
 #endif
 
-            cmd += compilerFlags
+            cmd += self.interpreterFlags(for: toolsVersion)
             if let moduleCachePath = moduleCachePath {
                 cmd += ["-module-cache-path", moduleCachePath]
             }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -677,6 +677,40 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             cmd += ["-target", "\(triple.tripleString(forPlatformVersion: version))"]
             #endif
 
+#if os(Windows)
+            // Infer the default flags from the SDKROOT environment variable
+            //
+            // Windows uses a variable named SDKROOT to determine the root of
+            // the SDK.  This is not the same value as the SDKROOT parameter
+            // in Xcode, however, the value represents a similar concept.
+            if let SDKROOT = ProcessEnv.vars["SDKROOT"], let root = try? AbsolutePath(validating: SDKROOT) {
+                cmd += [ "-sdk", root.pathString ]
+
+                // FIXME: these should not be necessary with the `-sdk`
+                // parameter.  However, it seems that the layout on Windows is
+                // not entirely correct yet and the driver does not pick up the
+                // include search path, library search path, nor resource dir.
+                // Workaround that for the time being to enable use of
+                // swift-package-manager on Windows.
+                cmd += [
+                  "-I", root.appending(RelativePath("usr/lib/swift")).pathString,
+                  "-L", root.appending(RelativePath("usr/lib/swift/windows")).pathString,
+                  "-resource-dir", root.appending(RelativePath("usr/lib/swift")).pathString,
+                ]
+
+                let SDKSettingsPList = root.appending(component: "SDKSettings.plist")
+                if let contents = FileManager.default.contents(atPath: SDKSettingsPList.pathString) {
+                    if let plist = try? PropertyListSerialization.propertyList(from: contents, format: nil) as? [String:AnyObject] {
+                        if let defaults: [String:AnyObject] = plist["DefaultProperties"] as? [String:AnyObject] {
+                            if let UseRuntime = defaults["DEFAULT_USE_RUNTIME"] as? String {
+                                cmd += [ "-libc", UseRuntime ]
+                            }
+                        }
+                    }
+                }
+            }
+#endif
+
             cmd += compilerFlags
             if let moduleCachePath = moduleCachePath {
                 cmd += ["-module-cache-path", moduleCachePath]

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -698,15 +698,9 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                   "-resource-dir", root.appending(RelativePath("usr/lib/swift")).pathString,
                 ]
 
-                let SDKSettingsPList = root.appending(component: "SDKSettings.plist")
-                if let contents = FileManager.default.contents(atPath: SDKSettingsPList.pathString) {
-                    if let plist = try? PropertyListSerialization.propertyList(from: contents, format: nil) as? [String:AnyObject] {
-                        if let defaults: [String:AnyObject] = plist["DefaultProperties"] as? [String:AnyObject] {
-                            if let UseRuntime = defaults["DEFAULT_USE_RUNTIME"] as? String {
-                                cmd += [ "-libc", UseRuntime ]
-                            }
-                        }
-                    }
+                if let settings = WindowsSDKSettings(reading: root.appending(component: "SDKSettings.plist"),
+                                                     diagnostics: nil, filesystem: localFileSystem) {
+                    cmd += [ "-libc", settings.defaults.runtime.rawValue ]
                 }
             }
 #endif

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -276,6 +276,7 @@ public final class PackageBuilder {
     public static func loadPackage(
         packagePath: AbsolutePath,
         swiftCompiler: AbsolutePath,
+        swiftCompilerFlags: [String],
         xcTestMinimumDeploymentTargets: [PackageModel.Platform:PlatformVersion]
             = MinimumDeploymentTarget.default.xcTestMinimumDeploymentTargets,
         diagnostics: DiagnosticsEngine,
@@ -284,6 +285,7 @@ public final class PackageBuilder {
         let manifest = try ManifestLoader.loadManifest(
             packagePath: packagePath,
             swiftCompiler: swiftCompiler,
+            swiftCompilerFlags: swiftCompilerFlags,
             packageKind: kind)
         let builder = PackageBuilder(
             manifest: manifest,

--- a/Sources/PackageLoading/UserManifestResources.swift
+++ b/Sources/PackageLoading/UserManifestResources.swift
@@ -13,17 +13,20 @@ import TSCBasic
 /// Concrete object for manifest resource provider.
 public struct UserManifestResources: ManifestResourceProvider {
     public let swiftCompiler: AbsolutePath
+    public let swiftCompilerFlags: [String]
     public let libDir: AbsolutePath
     public let sdkRoot: AbsolutePath?
     public let binDir: AbsolutePath?
 
     public init(
         swiftCompiler: AbsolutePath,
+        swiftCompilerFlags: [String],
         libDir: AbsolutePath,
         sdkRoot: AbsolutePath? = nil,
         binDir: AbsolutePath? = nil
     ) {
         self.swiftCompiler = swiftCompiler
+        self.swiftCompilerFlags = swiftCompilerFlags
         self.libDir = libDir
         self.sdkRoot = sdkRoot
         self.binDir = binDir
@@ -37,10 +40,11 @@ public struct UserManifestResources: ManifestResourceProvider {
     ///
     /// - Parameters:
     ///     - swiftCompiler: The absolute path of the associated `swiftc` executable.
-    public init(swiftCompiler: AbsolutePath) throws {
+    public init(swiftCompiler: AbsolutePath, swiftCompilerFlags: [String]) throws {
         let binDir = swiftCompiler.parentDirectory
         self.init(
             swiftCompiler: swiftCompiler,
+            swiftCompilerFlags: swiftCompilerFlags,
             libDir: UserManifestResources.libDir(forBinDir: binDir))
     }
 }

--- a/Sources/SPMTestSupport/Resources.swift
+++ b/Sources/SPMTestSupport/Resources.swift
@@ -38,6 +38,10 @@ public class Resources: ManifestResourceProvider {
         return toolchain.manifestResources.binDir
     }
 
+    public var swiftCompilerFlags: [String] {
+        return []
+    }
+
   #if os(macOS)
     public var sdkPlatformFrameworksPath: AbsolutePath {
         return Destination.sdkPlatformFrameworkPaths()!.fwk

--- a/Sources/Workspace/CMakeLists.txt
+++ b/Sources/Workspace/CMakeLists.txt
@@ -16,7 +16,8 @@ add_library(Workspace
   ToolsVersionWriter.swift
   UserToolchain.swift
   Workspace.swift
-  WorkspaceState.swift)
+  WorkspaceState.swift
+  WindowsToolchainInfo.swift)
 target_link_libraries(Workspace PUBLIC
   TSCBasic
   TSCUtility
@@ -26,6 +27,8 @@ target_link_libraries(Workspace PUBLIC
   PackageModel
   SourceControl
   Xcodeproj)
+target_link_libraries(PackageLoading PUBLIC
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(Workspace PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -216,34 +216,25 @@ public final class UserToolchain: Toolchain {
                     var runtime: [String] = []
                     var xctest: [String] = []
 
-                    let SDKSettingsPList = root.appending(component: "SDKSettings.plist")
-                    if let contents = FileManager.default.contents(atPath: SDKSettingsPList.pathString) {
-                        if let plist = try? PropertyListSerialization.propertyList(from: contents, format: nil) as? [String:AnyObject] {
-                            if let defaults: [String:AnyObject] = plist["DefaultProperties"] as? [String:AnyObject] {
-                                if let UseRuntime = defaults["DEFAULT_USE_RUNTIME"] as? String {
-                                    runtime = [ "-libc", UseRuntime ]
-                                }
-                            }
-                        }
+                    if let settings = WindowsSDKSettings(reading: root.appending(component: "SDKSettings.plist"),
+                                                         diagnostics: nil, filesystem: localFileSystem) {
+                        runtime = [ "-libc", settings.defaults.runtime.rawValue ]
                     }
 
                     if let DEVELOPER_DIR = ProcessEnv.vars["DEVELOPER_DIR"],
                             let root = try? AbsolutePath(validating: DEVELOPER_DIR)
                                                 .appending(component: "Platforms")
                                                 .appending(component: "Windows.platform") {
-                        let InfoPList = root.appending(component: "Info.plist")
-                        if let contents = FileManager.default.contents(atPath: InfoPList.pathString) {
-                            if let plist = try? PropertyListSerialization.propertyList(from: contents, format: nil) as? [String:AnyObject] {
-                                if let defaults = plist["DefaultProperties"] as? [String:AnyObject] {
-                                    if let version: String = defaults["XCTEST_VERSION"] as? String {
-                                        let path: AbsolutePath = root.appending(RelativePath("Developer/Library/XCTest-\(version)"))
-                                        xctest = [
-                                            "-I", path.appending(RelativePath("usr/lib/swift/windows/\(triple.arch)")).pathString,
-                                            "-L", path.appending(RelativePath("usr/lib/swift/windows")).pathString,
-                                        ]
-                                    }
-                                }
-                            }
+                        if let info = WindowsPlatformInfo(reading: root.appending(component: "Info.plist"),
+                                                          diagnostics: nil, filesystem: localFileSystem) {
+                            let path: AbsolutePath =
+                                    root.appending(component: "Developer")
+                                        .appending(component: "Library")
+                                        .appending(component: "XCTest-\(info.defaults.xctestVersion)")
+                            xctest = [
+                                "-I", path.appending(RelativePath("usr/lib/swift/windows/\(triple.arch)")).pathString,
+                                "-L", path.appending(RelativePath("usr/lib/swift/windows")).pathString,
+                            ]
                         }
                     }
 

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -213,6 +213,7 @@ public final class UserToolchain: Toolchain {
                 // the SDK.  This is not the same value as the SDKROOT parameter
                 // in Xcode, however, the value represents a similar concept.
                 if let SDKROOT = ProcessEnv.vars["SDKROOT"], let root = try? AbsolutePath(validating: SDKROOT) {
+
                     var runtime: [String] = []
                     var xctest: [String] = []
 
@@ -337,8 +338,10 @@ public final class UserToolchain: Toolchain {
                 fatalError("Couldn't find any SWIFTPM_PD_LIBS directory: \(pdLibDirEnvStr)")
             }
         }
+
         manifestResources = UserManifestResources(
             swiftCompiler: swiftCompilers.manifest,
+            swiftCompilerFlags: self.extraSwiftCFlags,
             libDir: pdLibDir,
             sdkRoot: self.destination.sdk,
             // Set the bin directory if we don't have a lib dir.

--- a/Sources/Workspace/WindowsToolchainInfo.swift
+++ b/Sources/Workspace/WindowsToolchainInfo.swift
@@ -1,0 +1,111 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Foundation
+import TSCBasic
+
+public struct WindowsSDKSettings {
+    public struct DefaultProperties {
+        public enum Runtime: String, Decodable {
+        /// MultiThreadedDebugDLL
+        /// Use the debug variant of the C runtime with shared linking.
+        case multithreadedDebugDLL = "MDd"
+
+        /// MultiThreadedDLL
+        /// Use the release variant of the C runtime with shared linking.
+        case multithreadedDLL = "MD"
+
+        /// MultiThreadedDebug
+        /// Use the debug variant of the C runtime with static linking.
+        case multithreadedDebug = "MTd"
+
+        /// MultiThreaded
+        /// Use the release variant of the C runtime with static linking.
+        case multithreaded = "MT"
+        }
+
+        /// DEFAULT_USE_RUNTIME - specifies the C runtime variant to use
+        public let runtime: Runtime
+    }
+
+    public let defaults: DefaultProperties
+}
+
+extension WindowsSDKSettings.DefaultProperties: Decodable {
+    enum CodingKeys: String, CodingKey {
+    case runtime = "DEFAULT_USE_RUNTIME"
+    }
+}
+
+extension WindowsSDKSettings: Decodable {
+    enum CodingKeys: String, CodingKey {
+    case defaults = "DefaultProperties"
+    }
+}
+
+extension WindowsSDKSettings {
+    public init?(reading path: AbsolutePath, diagnostics: DiagnosticsEngine?, filesystem: FileSystem) {
+        guard filesystem.exists(path) else {
+            diagnostics?.emit(error: "missing SDKSettings.plist at '\(path)'")
+            return nil
+        }
+
+        do {
+            let contents = try filesystem.readFileContents(path)
+            self = try contents.withData {
+                try PropertyListDecoder().decode(WindowsSDKSettings.self, from: $0)
+            }
+        } catch {
+            diagnostics?.emit(error: "failed to load SDKSettings.plist at '\(path)': \(error)")
+            return nil
+        }
+    }
+}
+
+public struct WindowsPlatformInfo {
+    public struct DefaultProperties {
+        /// XCTEST_VERSION
+        /// specifies the version string of the bundled XCTest.
+        public let xctestVersion: String
+    }
+
+    public let defaults: DefaultProperties
+}
+
+extension WindowsPlatformInfo.DefaultProperties: Decodable {
+    enum CodingKeys: String, CodingKey {
+    case xctestVersion = "XCTEST_VERSION"
+    }
+}
+
+extension WindowsPlatformInfo: Decodable {
+    enum CodingKeys: String, CodingKey {
+    case defaults = "DefaultProperties"
+    }
+}
+
+extension WindowsPlatformInfo {
+    public init?(reading path: AbsolutePath, diagnostics: DiagnosticsEngine?, filesystem: FileSystem) {
+        guard filesystem.exists(path) else {
+            diagnostics?.emit(error: "missing Info.plist at '\(path)'")
+            return nil
+        }
+
+        do {
+            let contents = try filesystem.readFileContents(path)
+            self = try contents.withData {
+                try PropertyListDecoder().decode(WindowsPlatformInfo.self, from: $0)
+            }
+        } catch {
+            diagnostics?.emit(error: "failed to load Info.plist at '\(path)': \(error)")
+            return nil
+        }
+    }
+}

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -736,9 +736,10 @@ extension Workspace {
     public static func loadGraph(
         packagePath: AbsolutePath,
         swiftCompiler: AbsolutePath,
+        swiftCompilerFlags: [String],
         diagnostics: DiagnosticsEngine
     ) throws -> PackageGraph {
-        let resources = try UserManifestResources(swiftCompiler: swiftCompiler)
+        let resources = try UserManifestResources(swiftCompiler: swiftCompiler, swiftCompilerFlags: swiftCompilerFlags)
         let loader = ManifestLoader(manifestResources: resources)
         let workspace = Workspace.create(forRootPackage: packagePath, manifestLoader: loader)
         return workspace.loadPackageGraph(root: packagePath, diagnostics: diagnostics)

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3674,11 +3674,11 @@ final class WorkspaceTests: XCTestCase {
         // From here the API should be simple and straightforward:
         let diagnostics = DiagnosticsEngine()
         let manifest = try ManifestLoader.loadManifest(
-            packagePath: package, swiftCompiler: swiftCompiler, packageKind: .local)
+            packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], packageKind: .local)
         let loadedPackage = try PackageBuilder.loadPackage(
-            packagePath: package, swiftCompiler: swiftCompiler, xcTestMinimumDeploymentTargets: [:], diagnostics: diagnostics)
+            packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], xcTestMinimumDeploymentTargets: [:], diagnostics: diagnostics)
         let graph = try Workspace.loadGraph(
-            packagePath: package, swiftCompiler: swiftCompiler, diagnostics: diagnostics)
+            packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], diagnostics: diagnostics)
 
         XCTAssertEqual(manifest.name, "SwiftPM")
         XCTAssertEqual(loadedPackage.name, "SwiftPM")


### PR DESCRIPTION
Use the special environment variable named `SDKROOT` which provides the
root of the SDK as a means for deriving the flags for building code on
Windows.  We assume that the layout is in the following canonical
layout (subject to incompatible evolution):

```
  Developer                                         (%DEVELOPER_DIR%)
    `- Platforms
        `- Windows.platform
            +- Developer
            |   +- Library
            |   |    `- XCTest-[Version]
            |   `- SDKs
            |       `- Windows.sdk                  (%SDKROOT%)
            |           +- SDKSettings.plist
            `- Info.plist
```

This adds 3 sets of flags to the `Xmanifest` options by default:
- `-sdk` which should theoretically be sufficient for everything
- `-I`, `-L`, `-resource-dir` which serve as workarounds for bugs in the
  SDK and swift driver
- `-libc MD` by inspecting the contents of SDKSettings.plist which
  contains the `DEFAULT_USE_RUNTIME` entry in the DefaultSettings tree
  of the plist.

It also adds 4 sets of flags to the default UserToolchain on Windows:
- `-sdk` which should theoretically be sufficient for the resource dir,
  include paths, and library search paths.
- `-I`, `-L`, `-resource-dir` which serve as workarounds for bugs in the
  SDK and swift driver
- `-libc MD` by inspecting the contents of SDKSettings.plist which
  contains the `DEFAULT_USE_RUNTIME` entry in the DefaultSettings tree
  of the plist.
- An additional library and include path by inspecting the Info.plist
  which contains a XCTEST_VERSION entry in the DefaultSettings tree of
  the plist.

Because the platform Info.plist is expected to be provided by the
packaging and is generated at build time, we expect it to be in sync
with the contents of the platform bundle.  The SDKSettings.plist
similarly is expected to be in sync with the SDK that it corresponds to.
By using these auxiliary files we can derive the correct flags for the
SDK that the user is using.

The expectation is that the user is using the same runtime as the SDK
for the toolchain when building by default.  If this does not hold, then
the user must use a `-destination` with the appropriate configuration to
ensure that the build is correct.  However, the build of the manifest
would still use the `SDKROOT` environment variable to determine the
correct configuration of the runtime.