### PR TITLE
Cross-compile flags should be in `get_swiftpm_flags`

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -577,13 +577,6 @@ def build_swiftpm_with_swiftpm(args, integrated_swift_driver):
     if integrated_swift_driver:
         swiftpm_args.append("--use-integrated-swift-driver")
 
-    build_target = get_build_target(args)
-    cross_compile_hosts = args.cross_compile_hosts
-    if build_target == 'x86_64-apple-macosx' and "macosx-arm64" in cross_compile_hosts:
-        swiftpm_args += ["--arch", "x86_64", "--arch", "arm64"]
-    elif cross_compile_hosts:
-        error("cannot cross-compile for %s" % cross_compile_hosts)
-
     call_swiftpm(args, swiftpm_args)
 
     # Setup symlinks that'll allow using swiftpm from the build directory.
@@ -733,6 +726,13 @@ def get_swiftpm_flags(args):
     # installed executables and shared libraries.
     if platform.system() != "Darwin" and args.command == 'install':
         build_flags.extend(["-Xswiftc", "-no-toolchain-stdlib-rpath"])
+
+    build_target = get_build_target(args)
+    cross_compile_hosts = args.cross_compile_hosts
+    if build_target == 'x86_64-apple-macosx' and "macosx-arm64" in cross_compile_hosts:
+        build_flags += ["--arch", "x86_64", "--arch", "arm64"]
+    elif cross_compile_hosts:
+        error("cannot cross-compile for %s" % cross_compile_hosts)
 
     return build_flags
 


### PR DESCRIPTION
These flags were only passed for regular builds, but not for testing or other actions.

rdar://problem/68542579