### PR TITLE
Enable testability if test discovery is enabled

### DIFF
--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -20,13 +20,18 @@ import PackageGraph
 /// The parameters required by `PIFBuilder`.
 public struct PIFBuilderParameters {
 
+    /// Whether or not test discovery is enabled.
+    public let enableTestDiscovery: Bool
+
     /// Whether to create dylibs for dynamic library products.
     public let shouldCreateDylibForDynamicProducts: Bool
 
     /// Creates a `PIFBuilderParameters` instance.
     /// - Parameters:
+    ///   - enableTestDiscovery: Whether or not test discovery is enabled.
     ///   - shouldCreateDylibForDynamicProducts: Whether to create dylibs for dynamic library products.
-    public init(shouldCreateDylibForDynamicProducts: Bool) {
+    public init(enableTestDiscovery: Bool, shouldCreateDylibForDynamicProducts: Bool) {
+        self.enableTestDiscovery = enableTestDiscovery
         self.shouldCreateDylibForDynamicProducts = shouldCreateDylibForDynamicProducts
     }
 }
@@ -315,6 +320,11 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         releaseSettings[.DEBUG_INFORMATION_FORMAT] = "dwarf-with-dsym"
         releaseSettings[.GCC_OPTIMIZATION_LEVEL] = "s"
         releaseSettings[.SWIFT_OPTIMIZATION_LEVEL] = "-Owholemodule"
+
+        if parameters.enableTestDiscovery {
+            releaseSettings[.ENABLE_TESTABILITY] = "YES"
+        }
+
         addBuildConfiguration(name: "Release", settings: releaseSettings)
 
         for product in package.products.sorted(by: { $0.name < $1.name }) {

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -218,6 +218,7 @@ extension BuildConfiguration {
 extension PIFBuilderParameters {
     public init(_ buildParameters: BuildParameters) {
         self.init(
+            enableTestDiscovery: buildParameters.enableTestDiscovery,
             shouldCreateDylibForDynamicProducts: buildParameters.shouldCreateDylibForDynamicProducts
         )
     }

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -2162,6 +2162,7 @@ extension PIFBuilderParameters {
         shouldCreateDylibForDynamicProducts: Bool = false
     ) -> Self {
         PIFBuilderParameters(
+            enableTestDiscovery: false,
             shouldCreateDylibForDynamicProducts: shouldCreateDylibForDynamicProducts
         )
     }


### PR DESCRIPTION
This just makes XCBuild support match what we do in SwiftPM's own build
system here: https://github.com/apple/swift-package-manager/blob/master/Sources/XCBuildSupport/PIFBuilder.swift#L308

We should probably revisit this behaviour, because this seems like a
very confusing side effect on macOS where test discovery isn't even a
thing, but right now we just want to match what the builtin build system
does.

(cherry picked from commit 57f9d0d305fd3dc9fa53e00ae82db62249e14569)