### PR TITLE
Use global code coverage flag in `swift package generate-xcodeproj`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -263,7 +263,12 @@ if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("master")),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", .exact("0.3.0")),
+        // The 'swift-argument-parser' version declared here must match that
+        // used by 'swift-driver' and 'sourcekit-lsp'. Please coordinate
+        // dependency version changes here with those projects.
+        .package(
+            url: "https://github.com/apple/swift-argument-parser.git",
+            .upToNextMinor(from: "0.3.1")),
         .package(url: "https://github.com/apple/swift-driver.git", .branch("master")),
     ]
 } else {

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -189,7 +189,9 @@ public struct SwiftToolOptions: ParsableArguments {
     }
     
     /// Whether to enable code coverage.
-    @Flag(name: .customLong("enable-code-coverage"), help: "Test with code coverage enabled")
+    @Flag(name: .customLong("code-coverage"),
+          inversion: .prefixedEnableDisable,
+          help: "Enable code coverage")
     var shouldEnableCodeCoverage: Bool = false
 
     // TODO: Does disable-automatic-resolution alias force-resolved-versions?


### PR DESCRIPTION
There's a conflict between '--enable-code-coverage' in the top-level options and the same flag in the Xcode-project generation command. This uses the top-level flag (which is required for the build parameters, even though it's only ever used by `swift test`) for both purposes.