### PR TITLE
Add Windows and MSVC to swift-tools-support-core

### DIFF
--- a/swift-tools-support-core/Sources/TSCUtility/Platform.swift
+++ b/swift-tools-support-core/Sources/TSCUtility/Platform.swift
@@ -26,16 +26,16 @@ public enum Platform: Equatable {
 
     /// Lazily checked current platform.
     public static var currentPlatform = Platform._findCurrentPlatform(localFileSystem)
-    /// Attempt to match `uname` with recognized platforms.
-    /// Additionally, try `ver` to recognize Windows.
+
     public static func _findCurrentPlatform(_ fs: FileSystem) -> Platform? {
-        guard let uname = try? Process.checkNonZeroExit(args: "uname").spm_chomp().lowercased() else {
-            if let ver = try? Process.checkNonZeroExit(args: "ver"),
-                ver.hasPrefix("Microsoft Windows") {
-                return .windows
-            }
-            return nil
-        }
+        /// Recognize Darwin and Windows at compile time.
+      #if os(Darwin)
+        return .darwin
+      #elseif os(Windows)
+        return .windows
+      #else
+        /// Attempt to match `uname` with other recognized platforms.
+        guard let uname = try? Process.checkNonZeroExit(args: "uname").spm_chomp().lowercased() else { return nil }
         switch uname {
         case "darwin":
             return .darwin
@@ -44,6 +44,7 @@ public enum Platform: Equatable {
         default:
             return nil
         }
+      #endif
     }
 
     public static func _findCurrentPlatformLinux(_ fs: FileSystem) -> Platform? {

--- a/swift-tools-support-core/Sources/TSCUtility/Platform.swift
+++ b/swift-tools-support-core/Sources/TSCUtility/Platform.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -16,6 +16,7 @@ public enum Platform: Equatable {
     case android
     case darwin
     case linux(LinuxFlavor)
+    case windows
 
     /// Recognized flavors of linux.
     public enum LinuxFlavor: Equatable {
@@ -26,8 +27,15 @@ public enum Platform: Equatable {
     /// Lazily checked current platform.
     public static var currentPlatform = Platform._findCurrentPlatform(localFileSystem)
     /// Attempt to match `uname` with recognized platforms.
+    /// Additionally, try `ver` to recognize Windows.
     public static func _findCurrentPlatform(_ fs: FileSystem) -> Platform? {
-        guard let uname = try? Process.checkNonZeroExit(args: "uname").spm_chomp().lowercased() else { return nil }
+        guard let uname = try? Process.checkNonZeroExit(args: "uname").spm_chomp().lowercased() else {
+            if let ver = try? Process.checkNonZeroExit(args: "ver"),
+                ver.hasPrefix("Microsoft Windows") {
+                return .windows
+            }
+            return nil
+        }
         switch uname {
         case "darwin":
             return .darwin

--- a/swift-tools-support-core/Sources/TSCUtility/Triple.swift
+++ b/swift-tools-support-core/Sources/TSCUtility/Triple.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -160,7 +160,7 @@ public struct Triple: Encodable, Equatable {
 }
 
 extension Triple {
-    /// The file prefix for dynamcic libraries
+    /// The file prefix for dynamic libraries
     public var dynamicLibraryPrefix: String {
         switch os {
         case .windows:

--- a/swift-tools-support-core/Sources/TSCUtility/Triple.swift
+++ b/swift-tools-support-core/Sources/TSCUtility/Triple.swift
@@ -199,7 +199,12 @@ extension Triple {
     
     /// The file extension for static libraries.
     public var staticLibraryExtension: String {
-        return ".a"
+        switch abi {
+        case .msvc:
+            return ".lib"
+        default:
+            return ".a"
+        }
     }
 
     /// The file extension for Foundation-style bundle.

--- a/swift-tools-support-core/Sources/TSCUtility/Triple.swift
+++ b/swift-tools-support-core/Sources/TSCUtility/Triple.swift
@@ -62,6 +62,7 @@ public struct Triple: Encodable, Equatable {
     public enum ABI: String, Encodable {
         case unknown
         case android
+        case msvc
     }
 
     public init(_ string: String) throws {
@@ -101,6 +102,9 @@ public struct Triple: Encodable, Equatable {
     fileprivate static func parseABI(_ string: String) -> ABI? {
         if string.hasPrefix(ABI.android.rawValue) {
             return ABI.android
+        }
+        if string == ABI.msvc.rawValue {
+            return ABI.msvc
         }
         return nil
     }


### PR DESCRIPTION
- Add `.windows` to `Platform`
- Add `.msvc` to `Triple.ABI`