### PR TITLE
Enable -static-stdlib on Linux (#2921)

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1040,11 +1040,11 @@ public final class ProductBuildDescription {
             }
         case .executable:
             // Link the Swift stdlib statically, if requested.
-            //
-            // FIXME: This does not work for linux yet (SR-648).
             if buildParameters.shouldLinkStaticSwiftStdlib {
                 if buildParameters.triple.isDarwin() {
                     diagnostics.emit(.swiftBackDeployError)
+                } else if buildParameters.triple.isLinux() {
+                    args += ["-static-stdlib"]
                 }
             }
             args += ["-emit-executable"]

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -144,7 +144,7 @@ final class BuildPlanTests: XCTestCase {
         let linkArguments = [
             "/fake/path/to/swiftc", "-L", "/path/to/build/debug",
             "-o", "/path/to/build/debug/exe", "-module-name", "exe",
-            "-emit-executable",
+            "-static-stdlib", "-emit-executable",
             "-Xlinker", "-rpath=$ORIGIN",
             "@/path/to/build/debug/exe.product/Objects.LinkFileList",
             "-target", defaultTargetTriple,


### PR DESCRIPTION
https://bugs.swift.org/browse/SR-648 has been resolved, so we can enable
this flag on Linux

Cherry pick of https://github.com/apple/swift-package-manager/pull/2921