### PR TITLE
Build: repair the build after apple/swift-driver#144

### DIFF
--- a/Sources/Build/ManifestBuilder.swift
+++ b/Sources/Build/ManifestBuilder.swift
@@ -864,6 +864,9 @@ extension TypedVirtualPath {
 
         case .standardInput, .standardOutput:
             fatalError("Cannot handle standard input or output")
+
+        case .fileList:
+            fatalError("cannot handle fileList")
         }
     }
 }


### PR DESCRIPTION
apple/swift-driver#144 introduced a new case in the `VirtualPath` type,
resulting in the switch no longer being exhaustive.  Abort if this is
encountered until it can be handled properly.