### PR TITLE
Handle new SwiftDriver.VirtualPath case in ManifestBuilder

### DIFF
--- a/Sources/Build/ManifestBuilder.swift
+++ b/Sources/Build/ManifestBuilder.swift
@@ -859,7 +859,7 @@ extension TypedVirtualPath {
         case .absolute(let path):
             return Node.file(path)
 
-        case .temporary(let path):
+        case .temporary(let path), .fileList(let path, _):
             return Node.virtual(path.pathString)
 
         case .standardInput, .standardOutput:


### PR DESCRIPTION
This case was just added to swift-driver in https://github.com/apple/swift-driver/pull/144, causing an SPM build failure because the switch was no longer exhaustive. File lists can be treated the same as temporary files when resolving to a node.