### PR TITLE
Improve the diagnostics that are emitted when a package dependency specifies a non-existent branch or commit

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2064,16 +2064,7 @@ extension Workspace {
             return bindings
 
         case .error(let error):
-            switch error {
-            // Emit proper error if we were not able to parse some manifest during dependency resolution.
-            case let error as RepositoryPackageContainer.GetDependenciesErrorWrapper:
-                let location = PackageLocation.Remote(url: error.containerIdentifier, reference: error.reference)
-                diagnostics.emit(error.underlyingError, location: location)
-
-            default:
-                diagnostics.emit(error)
-            }
-
+            diagnostics.emit(error)
             return []
         }
     }


### PR DESCRIPTION
This also sets the code up to make it easier to do other similar heuristics as needed, and as a bonus, adds one that is related to the `master` -> `main` renaming (suggesting `main` if `master` is requested and doesn't exist, but `main` does).  There isn't yet any support for fix-its in SwiftPM, but this would be a case for such a facility once it is supported.

Note that tags go through different processing, since they are the inputs to the semantic versioning and missing tags are reported differently.  There is no way in SwiftPM to define an explicit dependency on a non-semver tag, which is why this code only needs to handle branches and commits.

The error message does not list all the branches, since there can be many, but that could be another future improvement (or at least to list all the branches whose names are similar to what was requested).

rdar://34099187