### PR TITLE
Adapt to new SwiftDriver.VirtualPath.temporaryWithKnownContents API

### DIFF
--- a/Sources/Build/ManifestBuilder.swift
+++ b/Sources/Build/ManifestBuilder.swift
@@ -859,7 +859,8 @@ extension TypedVirtualPath {
         case .absolute(let path):
             return Node.file(path)
 
-        case .temporary(let path), .fileList(let path, _):
+        case .temporary(let path), .temporaryWithKnownContents(let path, _),
+             .fileList(let path, _):
             return Node.virtual(path.pathString)
 
         case .standardInput, .standardOutput:


### PR DESCRIPTION
This is yet another kind of temporary file, so it can be treated like file lists and regular temporaries when resolving to a node.

swift-driver counterpart: https://github.com/apple/swift-driver/pull/250