### PR TITLE
Add Workspace callbacks for when each package is loaded

### DIFF
--- a/Sources/SPMTestSupport/TestWorkspace.swift
+++ b/Sources/SPMTestSupport/TestWorkspace.swift
@@ -750,4 +750,12 @@ public final class TestWorkspaceDelegate: WorkspaceDelegate {
     public func willResolveDependencies(reason: WorkspaceResolveReason) {
         events.append("will resolve dependencies")
     }
+    
+    public func willLoadManifest(packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind) {
+        events.append("will load manifest for \(packageKind) package: \(url)")
+    }
+    
+    public func didLoadManifest(packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Diagnostic]) {
+        events.append("did load manifest for \(packageKind) package: \(url)")
+    }
 }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -89,6 +89,18 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "baz", at: .checkout(.version("1.0.0")))
             result.check(dependency: "quix", at: .checkout(.version("1.2.0")))
         }
+
+        // Check the load-package callbacks.
+        XCTAssertMatch(workspace.delegate.events, [
+            .equal("will load manifest for root package: /tmp/ws/roots/Foo"),
+            .equal("did load manifest for root package: /tmp/ws/roots/Foo"),
+        ])
+        XCTAssertMatch(workspace.delegate.events, [
+            .equal("will load manifest for remote package: /tmp/ws/pkgs/Quix"),
+            .equal("did load manifest for remote package: /tmp/ws/pkgs/Quix"),
+            .equal("will load manifest for remote package: /tmp/ws/pkgs/Baz"),
+            .equal("did load manifest for remote package: /tmp/ws/pkgs/Baz")
+        ])
 
         // Close and reopen workspace.
         workspace.closeWorkspace()
@@ -2720,7 +2732,7 @@ final class WorkspaceTests: XCTestCase {
         // Check we don't have updating Foo event.
         workspace.checkUpdate(roots: ["Root"]) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            XCTAssertEqual(workspace.delegate.events, ["Everything is already up-to-date"])
+            XCTAssertMatch(workspace.delegate.events, ["Everything is already up-to-date"])
         }
     }
 


### PR DESCRIPTION
(for status and logs in clients such as IDEs)