### PR TITLE
build: list the `PackageLoading` dependency

### DIFF
--- a/Sources/Workspace/CMakeLists.txt
+++ b/Sources/Workspace/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(Workspace PUBLIC
   TSCUtility
   Build
   PackageGraph
+  PackageLoading
   PackageModel
   SourceControl
   Xcodeproj)


### PR DESCRIPTION
`Sources/Workspace/UserToolchain.swift` references `PackageLoading` but
the build did not list the dependency.  Add the missing dependency.