### PR TITLE
Handle duplicated keys in `PinsStore`

### DIFF
--- a/Sources/PackageGraph/PinsStore.swift
+++ b/Sources/PackageGraph/PinsStore.swift
@@ -69,8 +69,8 @@ public final class PinsStore {
         pinsMap = [:]
         do {
             _ = try self.persistence.restoreState(self)
-        } catch SimplePersistence.Error.restoreFailure {
-            throw StringError("Package.resolved file is corrupted or malformed; fix or delete the file to continue")
+        } catch SimplePersistence.Error.restoreFailure(_, let error) {
+            throw StringError("Package.resolved file is corrupted or malformed; fix or delete the file to continue: \(error)")
         }
     }
 
@@ -123,7 +123,7 @@ extension PinsStore: SimplePersistanceProtocol {
     }
 
     public func restore(from json: JSON) throws {
-        self.pinsMap = try Dictionary(uniqueKeysWithValues: json.get("pins").map({ ($0.packageRef.identity, $0) }))
+        self.pinsMap = try Dictionary(json.get("pins").map({ ($0.packageRef.identity, $0) }), uniquingKeysWith: { first, _ in throw StringError("duplicated entry for package \"\(first.packageRef.name)\"") })
     }
 
     /// Saves the current state of pins.

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -1165,4 +1165,35 @@ class PackageGraphTests: XCTestCase {
 
         XCTAssert(diagnostics.diagnostics.isEmpty, "\(diagnostics.diagnostics)")
     }
+
+    func testPinsStoreIsResilientAgainstDupes() throws {
+        let json = try JSON(string: """
+              {
+                  "pins": [
+                    {
+                      "package": "Yams",
+                      "repositoryURL": "https://github.com/jpsim/yams",
+                      "state": {
+                        "branch": null,
+                        "revision": "b08dba4bcea978bf1ad37703a384097d3efce5af",
+                        "version": "1.0.2"
+                      }
+                    },
+                    {
+                      "package": "Yams",
+                      "repositoryURL": "https://github.com/jpsim/yams",
+                      "state": {
+                        "branch": null,
+                        "revision": "b08dba4bcea978bf1ad37703a384097d3efce5af",
+                        "version": "1.0.2"
+                      }
+                    }
+                  ]
+              }
+        """)
+
+        let fs = InMemoryFileSystem(emptyFiles: [])
+        let store = try PinsStore(pinsFile: AbsolutePath("/pins"), fileSystem: fs)
+        XCTAssertThrows(StringError("duplicated entry for package \"Yams\""), { try store.restore(from: json) })
+    }
 }


### PR DESCRIPTION
This used to be a fatal error, instead we're now printing a more friendly error to the user.

rdar://problem/68928705