### PR TITLE
Commands: make `swift test` work on Windows

### DIFF
--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -1017,6 +1017,11 @@ fileprivate func constructTestEnvironment(
     }
 
   #if !os(macOS)
+#if os(Windows)
+    if let location = toolchain.manifestResources.xctestLocation {
+      env["Path"] = "\(location.pathString);\(env["Path"] ?? "")"
+    }
+#endif
     return env
   #else
     // Fast path when no sanitizers are enabled.

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -43,6 +43,9 @@ public protocol ManifestResourceProvider {
 
     /// Extra flags to pass the Swift compiler.
     var swiftCompilerFlags: [String] { get }
+
+    /// XCTest Location
+    var xctestLocation: AbsolutePath? { get }
 }
 
 /// Default implemention for the resource provider.
@@ -53,6 +56,10 @@ public extension ManifestResourceProvider {
     }
 
     var binDir: AbsolutePath? {
+        return nil
+    }
+
+    var xctestLocation: AbsolutePath? {
         return nil
     }
 }

--- a/Sources/PackageLoading/UserManifestResources.swift
+++ b/Sources/PackageLoading/UserManifestResources.swift
@@ -16,6 +16,7 @@ public struct UserManifestResources: ManifestResourceProvider {
     public let swiftCompilerFlags: [String]
     public let libDir: AbsolutePath
     public let sdkRoot: AbsolutePath?
+    public let xctestLocation: AbsolutePath?
     public let binDir: AbsolutePath?
 
     public init(
@@ -23,12 +24,14 @@ public struct UserManifestResources: ManifestResourceProvider {
         swiftCompilerFlags: [String],
         libDir: AbsolutePath,
         sdkRoot: AbsolutePath? = nil,
+        xctestLocation: AbsolutePath? = nil,
         binDir: AbsolutePath? = nil
     ) {
         self.swiftCompiler = swiftCompiler
         self.swiftCompilerFlags = swiftCompilerFlags
         self.libDir = libDir
         self.sdkRoot = sdkRoot
+        self.xctestLocation = xctestLocation
         self.binDir = binDir
     }
 

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -339,11 +339,29 @@ public final class UserToolchain: Toolchain {
             }
         }
 
+        var xctestLocation: AbsolutePath?
+#if os(Windows)
+        if let DEVELOPER_DIR = ProcessEnv.vars["DEVELOPER_DIR"],
+                let root = try? AbsolutePath(validating: DEVELOPER_DIR)
+                                    .appending(component: "Platforms")
+                                    .appending(component: "Windows.platform") {
+            if let info = WindowsPlatformInfo(reading: root.appending(component: "Info.plist"),
+                                              diagnostics: nil, filesystem: localFileSystem) {
+                xctestLocation = root.appending(component: "Developer")
+                                     .appending(component: "Library")
+                                     .appending(component: "XCTest-\(info.defaults.xctestVersion)")
+                                     .appending(component: "usr")
+                                     .appending(component: "bin")
+            }
+        }
+#endif
+
         manifestResources = UserManifestResources(
             swiftCompiler: swiftCompilers.manifest,
             swiftCompilerFlags: self.extraSwiftCFlags,
             libDir: pdLibDir,
             sdkRoot: self.destination.sdk,
+            xctestLocation: xctestLocation,
             // Set the bin directory if we don't have a lib dir.
             binDir: localFileSystem.exists(pdLibDir) ? nil : binDir
         )


### PR DESCRIPTION
Windows does not support the concept of `rpath`.  Adjust the path when
invoking the test binary to include XCTest in the Path, enabling the
test execution.