### PR TITLE
Add an empty implementation of the new function `swiftCompilerFlags` in the ManifestResourceProvider

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -59,6 +59,10 @@ public extension ManifestResourceProvider {
         return nil
     }
 
+    var swiftCompilerFlags: [String] {
+        return []
+    }
+
     var xctestLocation: AbsolutePath? {
         return nil
     }


### PR DESCRIPTION
This allows clients of libSwiftPM to continue building without being modified.