### PR TITLE
Wasm/WASI: propagate PATH to UserToolchain to fix sysroot search

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -639,10 +639,6 @@ public class SwiftTool {
         } catch {
             return .failure(error)
         }
-        // Get the search paths from PATH.
-        let searchPaths = getEnvSearchPaths(
-            pathString: ProcessEnv.vars["PATH"], currentWorkingDirectory: localFileSystem.currentWorkingDirectory)
-
         // Apply any manual overrides.
         if let triple = self.options.customCompileTriple {
             destination.target = triple
@@ -656,7 +652,7 @@ public class SwiftTool {
             // Set default SDK path when target is WASI whose SDK is embeded
             // in Swift toolchain
             do {
-                let compilers = try UserToolchain.determineSwiftCompilers(binDir: destination.binDir, envSearchPaths: searchPaths)
+                let compilers = try UserToolchain.determineSwiftCompilers(binDir: destination.binDir)
                 destination.sdk = compilers.compile
                     .parentDirectory // bin
                     .parentDirectory // usr
@@ -672,17 +668,14 @@ public class SwiftTool {
             return self._hostToolchain
         }
 
-        return Result(catching: { try UserToolchain(destination: destination, searchPaths: searchPaths) })
+        return Result(catching: { try UserToolchain(destination: destination) })
     }()
 
     /// Lazily compute the host toolchain used to compile the package description.
     private lazy var _hostToolchain: Result<UserToolchain, Swift.Error> = {
-        // Get the search paths from PATH.
-        let searchPaths = getEnvSearchPaths(
-            pathString: ProcessEnv.vars["PATH"], currentWorkingDirectory: localFileSystem.currentWorkingDirectory)
         return Result(catching: {
             try UserToolchain(destination: Destination.hostDestination(
-                        originalWorkingDirectory: self.originalWorkingDirectory), searchPaths: searchPaths)
+                        originalWorkingDirectory: self.originalWorkingDirectory))
         })
     }()
 

--- a/Sources/SPMTestSupport/Resources.swift
+++ b/Sources/SPMTestSupport/Resources.swift
@@ -59,9 +59,7 @@ public class Resources: ManifestResourceProvider {
       #else
         binDir = AbsolutePath(CommandLine.arguments[0], relativeTo: localFileSystem.currentWorkingDirectory!).parentDirectory
       #endif
-        let searchPaths = getEnvSearchPaths(
-            pathString: ProcessEnv.vars["PATH"], currentWorkingDirectory: localFileSystem.currentWorkingDirectory)
-        toolchain = try! UserToolchain(destination: Destination.hostDestination(binDir), searchPaths: searchPaths)
+        toolchain = try! UserToolchain(destination: Destination.hostDestination(binDir))
     }
 
     /// True if SwiftPM has PackageDescription 4 runtime available.

--- a/Sources/SPMTestSupport/Resources.swift
+++ b/Sources/SPMTestSupport/Resources.swift
@@ -59,7 +59,9 @@ public class Resources: ManifestResourceProvider {
       #else
         binDir = AbsolutePath(CommandLine.arguments[0], relativeTo: localFileSystem.currentWorkingDirectory!).parentDirectory
       #endif
-        toolchain = try! UserToolchain(destination: Destination.hostDestination(binDir))
+        let searchPaths = getEnvSearchPaths(
+            pathString: ProcessEnv.vars["PATH"], currentWorkingDirectory: localFileSystem.currentWorkingDirectory)
+        toolchain = try! UserToolchain(destination: Destination.hostDestination(binDir), searchPaths: searchPaths)
     }
 
     /// True if SwiftPM has PackageDescription 4 runtime available.

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -270,7 +270,7 @@ public final class UserToolchain: Toolchain {
             + destination.extraSwiftCFlags
     }
 
-    public init(destination: Destination) throws {
+    public init(destination: Destination, environment: [String: String] = ProcessEnv.vars) throws {
         self.destination = destination
 
         // Get the search paths from PATH.
@@ -302,7 +302,9 @@ public final class UserToolchain: Toolchain {
         if triple.isDarwin() {
             // FIXME: We should have some general utility to find tools.
             let xctestFindArgs = ["/usr/bin/xcrun", "--sdk", "macosx", "--find", "xctest"]
-            self.xctest = try AbsolutePath(validating: Process.checkNonZeroExit(arguments: xctestFindArgs, environment: ProcessEnv.vars).spm_chomp())
+            self.xctest = try AbsolutePath(
+                validating: Process.checkNonZeroExit(arguments: xctestFindArgs, environment: environment
+            ).spm_chomp())
         } else {
             self.xctest = nil
         }


### PR DESCRIPTION
Currently, when building for WASI, our users need to provide a `destination.json` file that contains a WASI sysroot path. It would be great if the sysroot path could be inferred automatically from PATH, when the appropriate WASI triple is requested as the destination platform. With this PR it's enough to pass `--triple wasm32-unknown-wasi` to `swift build` to build for WASI.

Unused private `processEnvironment` property of `UserToolchain` is removed.

(cc @kateinoigakukun)