### PR TITLE
[PackageLoading] Improve flexibility in formatting Package manifests and correctness in parsing Swift tools version specifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Note: This is in reverse chronological order, so newer entries are added to the top.
 
 
+Swift 5.3.1
+-----------
+
+* [#2937](https://github.com/apple/swift-package-manager/pull/2937)
+  The Swift tools version specification at the top of each package manifest now accepts any combination of horizontal whitespace characters between `//` and `swift-tools-version`, if and only if the specified version > 5.3. For example, `//swift-tools-version:5.3.1` and `//	  swift-tools-version:5.4` are valid.
+
 Swift 4.2
 ---------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,11 @@ Note: This is in reverse chronological order, so newer entries are added to the 
 
 Swift 5.3.1
 -----------
-
-* [#2937](https://github.com/apple/swift-package-manager/pull/2937)
+* [#2937]
   
   Manifest files can now have any combination of leading line terminators. All [Unicode line terminators](https://www.unicode.org/reports/tr14/) are recognised. This allows more flexibility in formatting the Package manifest.
   
-  [SR-13566](https://bugs.swift.org/browse/SR-13566) The Swift tools version specification in each manifest file now accepts any combination of _horizontal_ whitespace characters between `//` and `swift-tools-version`, if and only if the specified version > 5.3. For example, `//swift-tools-version:5.3.1` and `//		 swift-tools-version:5.4` are valid.
+  [SR-13566] The Swift tools version specification in each manifest file now accepts any combination of _horizontal_ whitespace characters between `//` and `swift-tools-version`, if and only if the specified version > 5.3. For example, `//swift-tools-version:5.3.1` and `//		 swift-tools-version:5.4` are valid.
   
   * API Removal
   
@@ -23,25 +22,25 @@ Swift 5.3.1
 Swift 4.2
 ---------
 
-* [SE-209](https://github.com/apple/swift-evolution/blob/master/proposals/0209-package-manager-swift-lang-version-update.md)
+* [SE-0209]
 
   The `swiftLanguageVersions` property no longer takes its Swift language versions via
   a freeform Integer array; instead it should be passed as a new `SwiftVersion` enum
   array.
 
-* [SE-208](https://github.com/apple/swift-evolution/blob/master/proposals/0208-package-manager-system-library-targets.md)
+* [SE-0208]
 
   The `Package` manifest now accepts a new type of target, `systemLibrary`. This
   deprecates "system-module packages" which are now to be included in the packages
   that require system-installed dependencies.
 
-* [SE-201](https://github.com/apple/swift-evolution/blob/master/proposals/0201-package-manager-local-dependencies.md)
+* [SE-0201]
 
   Packages can now specify a dependency as `package(path: String)` to point to a
   path on the local filesystem which hosts a package. This will enable interconnected
   projects to be edited in parallel.
 
-* [#1604](https://github.com/apple/swift-package-manager/pull/1604)
+* [#1604]
 
   The `generate-xcodeproj` has a new `--watch` option to automatically regenerate the Xcode project
   if changes are detected. This uses the
@@ -53,21 +52,21 @@ Swift 4.2
   * One scheme per executable target containing the test targets whose dependencies
     intersect with the dependencies of the exectuable target.
 
-* [SR-6978](https://bugs.swift.org/browse/SR-6978)
+* [SR-6978]
   Packages which mix versions of the form `vX.X.X` with `Y.Y.Y` will now be parsed and
   ordered numerically.
 
-* [#1489](https://github.com/apple/swift-package-manager/pull/1489)
+* [#1489]
   A simpler progress bar is now generated for "dumb" terminals.
 
 Swift 4.1
 ---------
 
-* [#1485](https://github.com/apple/swift-package-manager/pull/1485)
+* [#1485]
   Support has been added to automatically generate the `LinuxMain` files for testing on
   Linux systems. On a macOS system, run `swift test --generate-linuxmain`.
 
-* [SR-5918](https://bugs.swift.org/browse/SR-5918)
+* [SR-5918]
   `Package` manifests that include multiple products with the same name will now throw an
   error.
 
@@ -85,14 +84,14 @@ Swift 4.0
 Swift 3.0
 ---------
 
-* [SE-0135](https://github.com/apple/swift-evolution/blob/master/proposals/0135-package-manager-support-for-differentiating-packages-by-swift-version.md)
+* [SE-0135]
 
   The package manager now supports writing Swift 3.0 specific tags and
   manifests, in order to support future evolution of the formats used in both
   cases while still allowing the Swift 3.0 package manager to continue to
   function.
 
-* [SE-0129](https://github.com/apple/swift-evolution/blob/master/proposals/0129-package-manager-test-naming-conventions.md)
+* [SE-0129]
 
   Test modules now *must* be named with a `Tests` suffix (e.g.,
   `Foo/Tests/BarTests/BarTests.swift`). This name also defines the name of the
@@ -104,3 +103,18 @@ Swift 3.0
   `swift build`.
 
 * The `Package` initializer now requires the `name:` parameter.
+
+[SE-0129]: https://github.com/apple/swift-evolution/blob/master/proposals/0129-package-manager-test-naming-conventions.md
+[SE-0135]: https://github.com/apple/swift-evolution/blob/master/proposals/0135-package-manager-support-for-differentiating-packages-by-swift-version.md
+[SE-0201]: https://github.com/apple/swift-evolution/blob/master/proposals/0201-package-manager-local-dependencies.md
+[SE-0208]: https://github.com/apple/swift-evolution/blob/master/proposals/0208-package-manager-system-library-targets.md
+[SE-0209]: https://github.com/apple/swift-evolution/blob/master/proposals/0209-package-manager-swift-lang-version-update.md
+
+[SR-5918]: https://bugs.swift.org/browse/SR-5918
+[SR-6978]: https://bugs.swift.org/browse/SR-6978
+[SR-13566]: https://bugs.swift.org/browse/SR-13566
+
+[#1485]: https://github.com/apple/swift-package-manager/pull/1485
+[#1489]: https://github.com/apple/swift-package-manager/pull/1489
+[#1604]: https://github.com/apple/swift-package-manager/pull/1604
+[#2937]: https://github.com/apple/swift-package-manager/pull/2937

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,23 @@ Note: This is in reverse chronological order, so newer entries are added to the 
 Swift 5.3.1
 -----------
 
-* [#2937](https://github.com/apple/swift-package-manager/pull/2937) [SR-13566](https://bugs.swift.org/browse/SR-13566)
+* [#2937](https://github.com/apple/swift-package-manager/pull/2937)
   
-  The Swift tools version specification in each manifest file now accepts any combination of _horizontal_ whitespace characters between `//` and `swift-tools-version`, if and only if the specified version > 5.3. For example, `//swift-tools-version:5.3.1` and `//		 swift-tools-version:5.4` are valid.
+  Manifest files can now have any combination of leading line terminators. All [Unicode line terminators](https://www.unicode.org/reports/tr14/) are recognised. Gone are ye olde days when a shebang-like directive must be at the start of file.
+  
+  [SR-13566](https://bugs.swift.org/browse/SR-13566) The Swift tools version specification in each manifest file now accepts any combination of _horizontal_ whitespace characters between `//` and `swift-tools-version`, if and only if the specified version > 5.3. For example, `//swift-tools-version:5.3.1` and `//		 swift-tools-version:5.4` are valid.
+  
+  * Deprecations
+    
+    `ToolsVersionLoader.split(_ bytes: ByteString) -> (versionSpecifier: String?, rest: [UInt8])` is now deprecated, and replaced by `ToolsVersionLoader.split(_ manifestContents: String) -> ManifestComponents`.
+  
+    `ToolsVersionLoader.Error.malformedToolsVersion(specifier: String, currentToolsVersion: ToolsVersion)` is not deprecated, and replaced by `ToolsVersionLoader.Error.malformedToolsVersionSpecification(_ malformation: ToolsVersionSpecificationMalformation)`.
+  
+  * Source Breakages
+    
+    SPM now throws an error if a manifest file contains invalid byte sequences such as `0x7F8F`.
+    
+    Swift tools version specifications that contain line terminators other than `U+000A` before either "swift-tool" or "tool-version" now silently falls back to using Swift 3.1 as the lowest supported version.
 
 Swift 4.2
 ---------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ Swift 5.3.1
   
   * API Removal
   
-    `ToolsVersionLoader.Error.malformedToolsVersion(specifier: String, currentToolsVersion: ToolsVersion)` is now obsoleted, and replaced by `ToolsVersionLoader.Error.malformedToolsVersionSpecification(_ malformation: ToolsVersionSpecificationMalformation)`.
+    `ToolsVersionLoader.Error.malformedToolsVersion(specifier: String, currentToolsVersion: ToolsVersion)` is replaced by `ToolsVersionLoader.Error.malformedToolsVersionSpecification(_ malformation: ToolsVersionSpecificationMalformation)`.
+    
+    `ToolsVersionLoader.split(_ bytes: ByteString) -> (versionSpecifier: String?, rest: [UInt8])` and `ToolsVersionLoader.regex` are together replaced by `ToolsVersionLoader.split(_ manifest: String) -> ManifestComponents`.
   
   * Source Breakages for Swift Packages
     

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Swift 5.3.1
   
   * Source Breakages
     
-    SPM now throws an error if a manifest file contains invalid byte sequences such as `0x7F8F`.
+    The package manager now throws an error if a manifest file contains invalid byte sequences such as `0x7F8F`.
     
     Swift tools version specifications that contain line terminators other than `U+000A` before either "swift-tool" or "tool-version" now silently falls back to using Swift 3.1 as the lowest supported version.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,9 @@ Swift 5.3.1
   
   [SR-13566](https://bugs.swift.org/browse/SR-13566) The Swift tools version specification in each manifest file now accepts any combination of _horizontal_ whitespace characters between `//` and `swift-tools-version`, if and only if the specified version > 5.3. For example, `//swift-tools-version:5.3.1` and `//		 swift-tools-version:5.4` are valid.
   
-  * Deprecations
-    
-    `ToolsVersionLoader.split(_ bytes: ByteString) -> (versionSpecifier: String?, rest: [UInt8])` is now deprecated, and replaced by `ToolsVersionLoader.split(_ manifestContents: String) -> ManifestComponents`.
+  * API Removal
   
-    `ToolsVersionLoader.Error.malformedToolsVersion(specifier: String, currentToolsVersion: ToolsVersion)` is not deprecated, and replaced by `ToolsVersionLoader.Error.malformedToolsVersionSpecification(_ malformation: ToolsVersionSpecificationMalformation)`.
+    `ToolsVersionLoader.Error.malformedToolsVersion(specifier: String, currentToolsVersion: ToolsVersion)` is now obsoleted, and replaced by `ToolsVersionLoader.Error.malformedToolsVersionSpecification(_ malformation: ToolsVersionSpecificationMalformation)`.
   
   * Source Breakages
     

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@ Swift 5.3.1
   
     `ToolsVersionLoader.Error.malformedToolsVersion(specifier: String, currentToolsVersion: ToolsVersion)` is now obsoleted, and replaced by `ToolsVersionLoader.Error.malformedToolsVersionSpecification(_ malformation: ToolsVersionSpecificationMalformation)`.
   
-  * Source Breakages
+  * Source Breakages for Swift packages
     
     The package manager now throws an error if a manifest file contains invalid UTF-8 byte sequences.
     
-    Swift tools version specifications that contain line terminators other than `U+000A` before either "swift-tool" or "tool-version" now silently falls back to using Swift 3.1 as the lowest supported version.
+    The package manager no longer silently falls back to using Swift 3.1 as the lowest supported version. Instead, a descriptive error is thrown for each misspelling or malformation in the manifest file.
 
 Swift 4.2
 ---------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Swift 5.3.1
 
 * [#2937](https://github.com/apple/swift-package-manager/pull/2937)
   
-  Manifest files can now have any combination of leading line terminators. All [Unicode line terminators](https://www.unicode.org/reports/tr14/) are recognised. Gone are ye olde days when a shebang-like directive must be at the start of file.
+  Manifest files can now have any combination of leading line terminators. All [Unicode line terminators](https://www.unicode.org/reports/tr14/) are recognised. This allows more flexibility in formatting the Package manifest.
   
   [SR-13566](https://bugs.swift.org/browse/SR-13566) The Swift tools version specification in each manifest file now accepts any combination of _horizontal_ whitespace characters between `//` and `swift-tools-version`, if and only if the specified version > 5.3. For example, `//swift-tools-version:5.3.1` and `//		 swift-tools-version:5.4` are valid.
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Swift 5.3.1
   
   * Source Breakages
     
-    The package manager now throws an error if a manifest file contains invalid byte sequences such as `0x7F8F`.
+    The package manager now throws an error if a manifest file contains invalid UTF-8 byte sequences.
     
     Swift tools version specifications that contain line terminators other than `U+000A` before either "swift-tool" or "tool-version" now silently falls back to using Swift 3.1 as the lowest supported version.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ Note: This is in reverse chronological order, so newer entries are added to the 
 Swift 5.3.1
 -----------
 
-* [#2937](https://github.com/apple/swift-package-manager/pull/2937)
-  The Swift tools version specification at the top of each package manifest now accepts any combination of horizontal whitespace characters between `//` and `swift-tools-version`, if and only if the specified version > 5.3. For example, `//swift-tools-version:5.3.1` and `//	  swift-tools-version:5.4` are valid.
+* [#2937](https://github.com/apple/swift-package-manager/pull/2937) [SR-13566](https://bugs.swift.org/browse/SR-13566)
+  
+  The Swift tools version specification in each manifest file now accepts any combination of _horizontal_ whitespace characters between `//` and `swift-tools-version`, if and only if the specified version > 5.3. For example, `//swift-tools-version:5.3.1` and `//		 swift-tools-version:5.4` are valid.
 
 Swift 4.2
 ---------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 Note: This is in reverse chronological order, so newer entries are added to the top.
 
-
-Swift 5.3.1
+Swift Next
 -----------
 * [#2937]
   
@@ -9,7 +8,7 @@ Swift 5.3.1
     
     `Package` manifests can now have any combination of leading whitespace characters. This allows more flexibility in formatting the manifests.
     
-    [SR-13566] The Swift tools version specification in each manifest file now accepts any combination of _horizontal_ whitespace characters surrounding `swift-tools-version`, if and only if the specified version > 5.3. For example, `//swift-tools-version:	5.3.1` and `//		 swift-tools-version: 5.4` are valid.
+    [SR-13566] The Swift tools version specification in each manifest file now accepts any combination of _horizontal_ whitespace characters surrounding `swift-tools-version`, if and only if the specified version ≥ `Next`. For example, `//swift-tools-version:	Next` and `//		 swift-tools-version: Next` are valid.
   
     All [Unicode line terminators](https://www.unicode.org/reports/tr14/) are now recognised in `Package` manifests. This ensures correctness in parsing manifests that are edited and/or built on many non-Unix-like platforms that use ASCII or Unicode encodings. 
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,19 @@ Swift 5.3.1
 -----------
 * [#2937]
   
-  Manifest files can now have any combination of leading line terminators. All [Unicode line terminators](https://www.unicode.org/reports/tr14/) are recognised. This allows more flexibility in formatting the Package manifest.
+  * Improvements
+    
+    `Package` manifests can now have any combination of leading whitespace characters. This allows more flexibility in formatting the manifests.
+    
+    [SR-13566] The Swift tools version specification in each manifest file now accepts any combination of _horizontal_ whitespace characters surrounding `swift-tools-version`, if and only if the specified version > 5.3. For example, `//swift-tools-version:	5.3.1` and `//		 swift-tools-version: 5.4` are valid.
   
-  [SR-13566] The Swift tools version specification in each manifest file now accepts any combination of _horizontal_ whitespace characters between `//` and `swift-tools-version`, if and only if the specified version > 5.3. For example, `//swift-tools-version:5.3.1` and `//		 swift-tools-version:5.4` are valid.
+    All [Unicode line terminators](https://www.unicode.org/reports/tr14/) are now recognised in `Package` manifests. This ensures correctness in parsing manifests that are edited and/or built on many non-Unix-like platforms that use ASCII or Unicode encodings. 
   
   * API Removal
   
     `ToolsVersionLoader.Error.malformedToolsVersion(specifier: String, currentToolsVersion: ToolsVersion)` is now obsoleted, and replaced by `ToolsVersionLoader.Error.malformedToolsVersionSpecification(_ malformation: ToolsVersionSpecificationMalformation)`.
   
-  * Source Breakages for Swift packages
+  * Source Breakages for Swift Packages
     
     The package manager now throws an error if a manifest file contains invalid UTF-8 byte sequences.
     

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -489,7 +489,7 @@ extension SwiftPackageTool {
             case .set(let value):
                 guard let toolsVersion = ToolsVersion(string: value) else {
                     // FIXME: Probably lift this error defination to ToolsVersion.
-					throw ToolsVersionLoader.Error.malformedToolsVersionSpecification(.versionSpecifier(.isMisspelt(value)))
+                    throw ToolsVersionLoader.Error.malformedToolsVersionSpecification(.versionSpecifier(.isMisspelt(value)))
                 }
                 try writeToolsVersion(at: pkg, version: toolsVersion, fs: localFileSystem)
 

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -489,7 +489,7 @@ extension SwiftPackageTool {
             case .set(let value):
                 guard let toolsVersion = ToolsVersion(string: value) else {
                     // FIXME: Probably lift this error defination to ToolsVersion.
-                    throw ToolsVersionLoader.Error.malformedToolsVersion(specifier: value, currentToolsVersion: .currentToolsVersion)
+					throw ToolsVersionLoader.Error.malformedToolsVersionSpecification(.versionSpecifier(value[...]))
                 }
                 try writeToolsVersion(at: pkg, version: toolsVersion, fs: localFileSystem)
 

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -489,7 +489,7 @@ extension SwiftPackageTool {
             case .set(let value):
                 guard let toolsVersion = ToolsVersion(string: value) else {
                     // FIXME: Probably lift this error defination to ToolsVersion.
-					throw ToolsVersionLoader.Error.malformedToolsVersionSpecification(.versionSpecifier(value[...]))
+                    throw ToolsVersionLoader.Error.malformedToolsVersionSpecification(.versionSpecifier(value[...]))
                 }
                 try writeToolsVersion(at: pkg, version: toolsVersion, fs: localFileSystem)
 

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -489,7 +489,7 @@ extension SwiftPackageTool {
             case .set(let value):
                 guard let toolsVersion = ToolsVersion(string: value) else {
                     // FIXME: Probably lift this error defination to ToolsVersion.
-                    throw ToolsVersionLoader.Error.malformedToolsVersionSpecification(.versionSpecifier(value))
+					throw ToolsVersionLoader.Error.malformedToolsVersionSpecification(.versionSpecifier(.isMisspelt(value)))
                 }
                 try writeToolsVersion(at: pkg, version: toolsVersion, fs: localFileSystem)
 

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -489,7 +489,7 @@ extension SwiftPackageTool {
             case .set(let value):
                 guard let toolsVersion = ToolsVersion(string: value) else {
                     // FIXME: Probably lift this error defination to ToolsVersion.
-                    throw ToolsVersionLoader.Error.malformedToolsVersionSpecification(.versionSpecifier(value[...]))
+                    throw ToolsVersionLoader.Error.malformedToolsVersionSpecification(.versionSpecifier(value))
                 }
                 try writeToolsVersion(at: pkg, version: toolsVersion, fs: localFileSystem)
 

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -218,7 +218,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
                 case .spacingAfterLabel(let spacing):
                     return "horizontal whitespace sequence \(unicodeCodePointsPrefixedByUPlus(of: spacing)) immediately preceding the version specifier is supported by only Swift > 5.3; consider removing the sequence for Swift \(specifiedVersion)"
                 case .unidentified:
-                    return "the manifest is backward-incompatible with Swift ≤ 5.3, but the package manager is unable to pinpoint the exact incompatibility; consider replacing the current Swift tools version specification with '// swift-tools-version:\(ToolsVersion.currentToolsVersion)' to specify the current Swift toolchain version as the lowest Swift version supported by the project, then move the new specification to the very beginning of this manifest file; additionally, please consider filing a bug report on https://bugs.swift.org with this file attached"
+                    return "the manifest is backward-incompatible with Swift ≤ 5.3, but the package manager is unable to pinpoint the exact incompatibility; consider replacing the current Swift tools version specification with '// swift-tools-version:\(specifiedVersion)' to specify Swift \(specifiedVersion) as the lowest Swift version supported by the project, then move the new specification to the very beginning of this manifest file; additionally, please consider filing a bug report on https://bugs.swift.org with this file attached"
                 }
             }
             
@@ -420,7 +420,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
             
             // The above If-statements should have covered all possible backward incompatibilities with Swift ≤ 5.3.
             // If you changed the logic in this file, and this fatal error is triggered, then you need to re-check the logic, and make sure all possible error conditions are covered in the Else-block.
-            throw Error.backwardIncompatiblePre5_3_1(.unidentified)
+            throw Error.backwardIncompatiblePre5_3_1(.unidentified, specifiedVersion: version)
         }
         
         return version

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -187,7 +187,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
                 case .commentMarker(let commentMarker):
                     switch commentMarker {
                     case .isMissing:
-                        return "the manifest is missing a Swift tools version specification; consider prepending to the manifest '// swift-tools-version:\(ToolsVersion.currentToolsVersion)' to specify the current Swift toolchain version as the lowest supported version by the project; if such a specification already exists, consider moving it to the top of the manifest, or prepending it with '//' to help Swift Package Manager find it"
+                        return "the manifest is missing a Swift tools version specification; consider prepending to the manifest '// swift-tools-version:\(ToolsVersion.currentToolsVersion)' to specify the current Swift toolchain version as the lowest Swift version supported by the project; if such a specification already exists, consider moving it to the top of the manifest, or prepending it with '//' to help Swift Package Manager find it"
                     case .isMisspelt(let misspeltCommentMarker):
                         return "the comment marker '\(misspeltCommentMarker)' is misspelt for the Swift tools version specification; consider replacing it with '//'"
                     }
@@ -202,9 +202,9 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
                     switch versionSpecifier {
                     case .isMissing:
                         // If the version specifier is missing, then its terminator must be missing as well. So, there is nothing in between the version specifier and everything that should be in front the version specifier. So, appending a valid version specifier will fix this error.
-                        return "the Swift tools version specification is missing a version specifier; consider appending '\(ToolsVersion.currentToolsVersion)' to the line to specify the current Swift toolchain version as the lowest supported version by the project"
+                        return "the Swift tools version specification is missing a version specifier; consider appending '\(ToolsVersion.currentToolsVersion)' to the line to specify the current Swift toolchain version as the lowest Swift version supported by the project"
                     case .isMisspelt(let misspeltVersionSpecifier):
-                        return "the Swift tools version '\(misspeltVersionSpecifier)' is misspelt or otherwise invalid; consider replacing it with '\(ToolsVersion.currentToolsVersion)' to specify the current Swift toolchain version as the lowest supported version by the project"
+                        return "the Swift tools version '\(misspeltVersionSpecifier)' is misspelt or otherwise invalid; consider replacing it with '\(ToolsVersion.currentToolsVersion)' to specify the current Swift toolchain version as the lowest Swift version supported by the project"
                     }
                 case .unidentified:
                     return "the Swift tools version specification has a formatting error, but the package manager is unable to find either the location or cause of it; consider replacing it with '// swift-tools-version:\(ToolsVersion.currentVersion)' to specify the current Swift toolchain version as the lowest Swift version supported by the project; additionally, please consider filing a bug report on https://bugs.swift.org with this file attached"

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -125,7 +125,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
             case label(_ malformationDetails: MalformationDetails)
             /// The version specifier is malformed.
             ///
-            /// If the version specifier is diagnosed as missing, it could be a misdiagnosis due to some misspellings in the label due to a compromise made in `ToolsVersionLoader.split(_:)`. For example, the following Swift tools version specification will be misdiagnosed to be missing a version specifier:
+            /// If the version specifier is diagnosed as missing, it could be a misdiagnosis of some misspellings in the label due to a compromise made in `ToolsVersionLoader.split(_:)`. For example, the following Swift tools version specification will be misdiagnosed to be missing a version specifier:
             ///
             ///     // swift-tools-version:;5.3
             ///

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -88,45 +88,121 @@ extension Manifest {
 }
 
 public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
-
+    
+    // FIXME: Remove this property and the initializer?
+    // Arbitrary tools versions are used only in `ToolsVersionLoaderTests.testVersionSpecificManifestFallbacks()`.
     let currentToolsVersion: ToolsVersion
 
     public init(currentToolsVersion: ToolsVersion = .currentToolsVersion) {
         self.currentToolsVersion = currentToolsVersion
     }
 
+    // FIXME: Use generic associated type `T: StringProtocol` instead of concrete types `String` and `Substring`, when/if this feature comes to Swift.
     public enum Error: Swift.Error, CustomStringConvertible {
+        
+        /// Details of the tools version specification's malformation.
+        public enum ToolsVersionSpecificationMalformation {
+            /// The tools version specification from the first character up to the version specifier is malformed.
+            case label(_ label: Substring)
+            /// The version specifier is malformed.
+            case versionSpecifier(_ versionSpecifier: Substring)
+            /// The entire tools version specification is malformed.
+            case entireLine(_ line: Substring)
+        }
+        
+        /// Details of backward-incompatible contents with Swift tools version ≤ 5.3.
+        public enum BackwardIncompatibilityPre5_3_1 {
+            /// The line terminators at the start of the manifest is not either empty or a single `U+000A`.
+            case leadingLineTerminators(_ lineTerminators: Substring)
+            /// The horizontal spacing between "//" and  "swift-tools-version" either is empty or uses whitespace characters unsupported by Swift ≤ 5.3.
+            case spacingAfterSlashes(_ spacing: Substring)
+        }
+        
         /// Package directory is inaccessible (missing, unreadable, etc).
         case inaccessiblePackage(path: AbsolutePath, reason: String)
         /// Package manifest file is inaccessible (missing, unreadable, etc).
         case inaccessibleManifest(path: AbsolutePath, reason: String)
+        /// Package manifest file's content can not be decoded as a UTF-8 string.
+        case nonUTF8EncodedManifest(path: AbsolutePath)
         /// Malformed tools version specifier.
+        /// - Warning: This case has been deprecated since Swift 5.3.1, please use `case malformedToolsVersionSpecification(_ malformation: ToolsVersionSpecificationMalformation)` instead.
+        @available(swift, deprecated: 5.3.1, renamed: "malformedToolsVersion(_:)")
         case malformedToolsVersion(specifier: String, currentToolsVersion: ToolsVersion)
-        // TODO: Make the case more general, to better adapt to future changes.
-        /// The spacing between "//" and  "swift-tools-version" either is empty or uses whitespace characters unsupported by Swift ≤ 5.3.
-        case invalidSpacingAfterSlashes(charactersUsed: String, specifiedVersion: ToolsVersion)
+        /// Malformed tools version specification.
+        case malformedToolsVersionSpecification(_ malformation: ToolsVersionSpecificationMalformation)
+        /// Backward-incompatible contents with Swift tools version ≤ 5.3.
+        case backwardIncompatiblePre5_3_1(_ incompatibility: BackwardIncompatibilityPre5_3_1, specifiedVersion: ToolsVersion)
 
         public var description: String {
-            switch self {
-            case .inaccessiblePackage(let packageDir, let reason):
-                return "the package at '\(packageDir)' cannot be accessed (\(reason))"
-            case .inaccessibleManifest(let manifestFile, let reason):
-                return "the package manifest at '\(manifestFile)' cannot be accessed (\(reason))"
-            case .malformedToolsVersion(let versionSpecifier, let currentToolsVersion):
-                return "the tools version '\(versionSpecifier)' is not valid; consider using '// swift-tools-version:\(currentToolsVersion.major).\(currentToolsVersion.minor)' to specify the current tools version"
-            case let .invalidSpacingAfterSlashes(charactersUsed, specifiedVersion):
-                // Tell the user what characters are currently used (invalidly) in the specification in place of U+0020.
-                let unicodeCodePointsOfCharactersUsed: [UInt32] = charactersUsed.flatMap(\.unicodeScalars).map(\.value)
-                let unicodeCodePointsOfCharactersUsedPrefixedByUPlus: [String] = unicodeCodePointsOfCharactersUsed.map { codePoint in
+            
+            /// Returns a description of the given characters' Unicode code points.
+            ///
+            /// This tells the user what characters are currently used in the specification.
+            ///
+            /// - Parameter characters: The given characters the description of whose code points are to be returned.
+            /// - Returns: A list of `characters`' code points, each prefixed by "U+", separated by commas, and bounded together by a pair of square brackets.
+            func unicodeCodePointsPrefixedByUPlus<T: StringProtocol>(of characters: T) -> String {
+                let unicodeCodePointsOfCharacters: [UInt32] = characters.flatMap(\.unicodeScalars).map(\.value)
+                let unicodeCodePointsOfCharactersPrefixedByUPlus: [String] = unicodeCodePointsOfCharacters.map { codePoint in
                     var codePointString = String(codePoint, radix: 16).uppercased()
                     if codePointString.count < 4 {
                         codePointString = String(repeating: "0", count: 4 - codePointString.count) + codePointString
                     }
                     return "U+\(codePointString)"
                 }
-                return "\(charactersUsed.isEmpty ? "zero spacing" : "horizontal whitespace sequence [\(unicodeCodePointsOfCharactersUsedPrefixedByUPlus.joined(separator: ", "))]") between \"//\" and \"swift-tools-version\" is supported by only Swift > 5.3; consider using a single space (U+0020) for Swift \(specifiedVersion)"
+                // FIXME: Use `ListFormatter` instead?
+                return "[\(unicodeCodePointsOfCharactersPrefixedByUPlus.joined(separator: ", "))]"
             }
+            
+            switch self {
+            case let .inaccessiblePackage(packageDirectoryPath, reason):
+                return "the package at '\(packageDirectoryPath)' cannot be accessed (\(reason))"
+            case let .inaccessibleManifest(manifestFilePath, reason):
+                return "the package manifest at '\(manifestFilePath)' cannot be accessed (\(reason))"
+            case let .nonUTF8EncodedManifest(manifestFilePath):
+                return "the package manifest at '\(manifestFilePath)' cannot be decoded using UTF-8"
+            case let .malformedToolsVersion(versionSpecifier, currentToolsVersion):
+                return "the tools version '\(versionSpecifier)' is not valid; consider using '// swift-tools-version:\(currentToolsVersion.major).\(currentToolsVersion.minor)' to specify the current tools version"
+            case let .malformedToolsVersionSpecification(malformation):
+                switch malformation {
+                case let .label(label):
+                    return "the tools version specification label '\(label)' is malformed; consider using '// swift-tools-version:\(ToolsVersion.currentToolsVersion)' to specify the current tools version"
+                case let .versionSpecifier(versionSpecifier):
+                    return "the tools version '\(versionSpecifier)' is not valid; consider using '// swift-tools-version:\(ToolsVersion.currentToolsVersion)' to specify the current tools version"
+                case let .entireLine(line):
+                    return "the tools version specification '\(line)' is not valid; consider using '// swift-tools-version:\(ToolsVersion.currentToolsVersion)' to specify the current tools version"
+                }
+            // FIXME: The error messages probably can be more concise, while still hitting all the key points.
+            case let .backwardIncompatiblePre5_3_1(incompatibility, specifiedVersion):
+                switch incompatibility {
+                case let .leadingLineTerminators(lineTerminators):
+                    return "leading line terminator sequence \(unicodeCodePointsPrefixedByUPlus(of: lineTerminators)) in manifest is supported by only Swift > 5.3; for the specified version \(specifiedVersion), only zero or one newline (U+000A) at the beginning of the manifest is supported; consider moving the tools version specification to the first line of the manifest"
+                case let .spacingAfterSlashes(spacing):
+                    return "\(spacing.isEmpty ? "zero spacing" : "horizontal whitespace sequence \(unicodeCodePointsPrefixedByUPlus(of: spacing))") between \"//\" and \"swift-tools-version\" is supported by only Swift > 5.3; consider using a single space (U+0020) for Swift \(specifiedVersion)"
+                }
+            }
+            
         }
+    }
+    
+    /// A representation of a manifest in its constituent parts.
+    public struct ManifestComponents {
+        /// The line terminators at the start of the manifest.
+        public let leadingLineTerminators: Substring
+        /// The tools version specification, excluding the ending line terminator.
+        public let toolsVersionSpecification: Substring
+        /// The remaining contents of the manifest that follows right after the tools version specification line.
+        public let contentsAfterToolsVersionSpecification: Substring
+        /// The components of the tools version specification that are captured by the `regex`.
+        public let toolsVersionSpecificationCapturedComponents: ToolsVersionSpecificationCapturedComponents
+    }
+    
+    /// Components of the tools version specification that are captured by the `regex`.
+    public struct ToolsVersionSpecificationCapturedComponents {
+        /// The horizontal spacing between "//" and  "swift-tools-version".
+        public let spacingAfterSlashes: Substring?
+        /// The version specifier.
+        public let versionSpecifier: Substring?
     }
 
     public func load(at path: AbsolutePath, fileSystem: FileSystem) throws -> ToolsVersion {
@@ -140,6 +216,8 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         return try load(file: file, fileSystem: fileSystem)
     }
 
+    // FIXME: Using "file" as the parameter name (and label) sounds wrong in some subsequent use of it in the function body.
+    // Maybe rename the function as `fileprivate func load(fileAt filePath: AbsolutePath, fileSystem: FileSystem) throws -> ToolsVersion`?
     fileprivate func load(file: AbsolutePath, fileSystem: FileSystem) throws -> ToolsVersion {
         // FIXME: We don't need the entire file, just the first line.
         let contents: ByteString
@@ -147,54 +225,76 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
             throw Error.inaccessibleManifest(path: file, reason: String(describing: error))
         }
         
+        // FIXME: This is doubly inefficient.
+        // `contents`'s value comes from `FileSystem.readFileContents(_)`, which is [inefficient](https://github.com/apple/swift-tools-support-core/blob/8f9838e5d4fefa0e12267a1ff87d67c40c6d4214/Sources/TSCBasic/FileSystem.swift#L167). Calling `ByteString.validDescription` on `contents` is also [inefficient, and possibly incorrect](https://github.com/apple/swift-tools-support-core/blob/8f9838e5d4fefa0e12267a1ff87d67c40c6d4214/Sources/TSCBasic/ByteString.swift#L121). However, this is a one-time thing for each package manifest, and almost necessary in order to work with all Unicode line-terminators. We probably can improve its efficiency and correctness by using `URL` for the file's path, and get is content via `Foundation.String(contentsOf:encoding:)`. Swift System's [`FilePath`](https://github.com/apple/swift-system/blob/8ffa04c0a0592e6f4f9c30926dedd8fa1c5371f9/Sources/System/FilePath.swift) and friends might help as well.
+        // FIXME: This is source-breaking.
+        // A manifest that has an [invalid byte sequence](https://en.wikipedia.org/wiki/UTF-8#Invalid_sequences_and_error_handling) (such as `0x7F8F`) after the tools version specification line could work in Swift ≤ 5.3, but results in an error since Swift 5.3.1.
+        guard let contentsDecodedWithUTF8 = contents.validDescription else {
+            throw Error.nonUTF8EncodedManifest(path: file)
+        }
+        
         /// The constituent parts of the swift tools version specification found in the comment.
-        let deconstructedToolsVersionSpecification = ToolsVersionLoader.split(contents)
+        let manifestComponents = ToolsVersionLoader.split(contentsDecodedWithUTF8)
+        let toolsVersionSpecificationComponents = manifestComponents.toolsVersionSpecificationCapturedComponents
         
         // Get the version specifier string from tools version file.
         guard
-            let spacingAfterSlashes = deconstructedToolsVersionSpecification.spacingAfterSlashes,
-            let versionSpecifier = deconstructedToolsVersionSpecification.versionSpecifier
+            let spacingAfterSlashes = toolsVersionSpecificationComponents.spacingAfterSlashes,
+            let versionSpecifier = toolsVersionSpecificationComponents.versionSpecifier
         else {
             // TODO: Make the diagnosis more granular by having the regex capture more groups.
             // Try to diagnose if there is a misspelling of the swift-tools-version comment.
-            let splitted = contents.contents.split(
-                separator: UInt8(ascii: "\n"),
-                maxSplits: 1,
-                omittingEmptySubsequences: false)
+            let toolsVersionSpecification = manifestComponents.toolsVersionSpecification
             let misspellings = ["swift-tool", "tool-version"]
-            if let firstLine = ByteString(splitted[0]).validDescription,
-               misspellings.first(where: firstLine.lowercased().contains) != nil {
-                throw Error.malformedToolsVersion(specifier: firstLine, currentToolsVersion: currentToolsVersion)
+            if misspellings.first(where: toolsVersionSpecification.lowercased().contains) != nil {
+                throw Error.malformedToolsVersionSpecification(.entireLine(toolsVersionSpecification))
             }
             // Otherwise assume the default to be v3.
             return .v3
         }
-
+        
         // Ensure we can construct the version from the specifier.
-        guard let version = ToolsVersion(string: versionSpecifier) else {
-            throw Error.malformedToolsVersion(specifier: versionSpecifier, currentToolsVersion: currentToolsVersion)
+        guard let version = ToolsVersion(string: String(versionSpecifier)) else {
+            throw Error.malformedToolsVersionSpecification(.versionSpecifier(versionSpecifier))
         }
         
-        // Ensure that for Swift ≤ 5.3, a single U+0020 is used as spacing between "//" and "swift-tools-version".
-		guard spacingAfterSlashes == " " || version > .v5_3 else {
-            throw Error.invalidSpacingAfterSlashes(charactersUsed: spacingAfterSlashes, specifiedVersion: version)
+        // The order of the following `guard` statements must be preserved.
+        // It translates to the precedence of the error to throw.
+        // If the order is changed, the test cases in `ToolsVersionLoaderTests.testBackwardCompatibilityError()` must also be changed accordingly.
+        
+        // Ensure that for Swift ≤ 5.3, only 0 or 1 U+000A and nothing else is before the tools version specification.
+        guard version > .v5_3 || manifestComponents.leadingLineTerminators.isEmpty || manifestComponents.leadingLineTerminators == "\n" else {
+            throw Error.backwardIncompatiblePre5_3_1(.leadingLineTerminators(manifestComponents.leadingLineTerminators), specifiedVersion: version)
+        }
+        
+        // Ensure that for Swift ≤ 5.3, exactly a single U+0020 is used as spacing between "//" and "swift-tools-version".
+        guard version > .v5_3 || spacingAfterSlashes == " " else {
+            throw Error.backwardIncompatiblePre5_3_1(.spacingAfterSlashes(spacingAfterSlashes), specifiedVersion: version)
         }
         
         return version
     }
-
-    /// Splits the bytes to constituent parts of the swift tools version specification and rest of the contents.
+    
+    // FIXME: Remove this function?
+    // This function is currently preserved because it's declared as public.
+    // Removing it is probably source-breaking.
+    /// Splits the bytes to find the Swift tools version specifier and the contents sans the first line of the manifest.
     ///
-    /// The constituent parts include the spacing between "//" and "swift-tools-version", and the version specifier, if either is present.
+    /// - Warning: This function has been deprecated since Swift 5.3.1, please use `split(_ manifestContents: String) -> ManifestComponents` instead.
+    ///
+    /// - Bug: This function treats only `U+000A` as a line terminator.
+    ///
+    /// - Bug: If there is a single leading `U+000A` in the manifest file, this function treats the second line of the manifest as its first line.
     ///
     /// - Parameter bytes: The raw bytes of the content of the manifest.
-    /// - Returns: The spacing between "//" and "swift-tools-version" (if present, or `nil`), the version specifier (if present, or `nil`), and the raw bytes of the rest of the content of the manifest.
-    public static func split(_ bytes: ByteString) -> (spacingAfterSlashes: String?, versionSpecifier: String?, rest: [UInt8]) {
+    /// - Returns: The version specifier (if present, or `nil`) and the raw bytes of the contents sans the first line of the manifest.
+    @available(swift, deprecated: 5.3.1, renamed: "ToolsVersionLoader.split(_:)")
+    public static func split(_ bytes: ByteString) -> (versionSpecifier: String?, rest: [UInt8]) {
         let splitted = bytes.contents.split(
             separator: UInt8(ascii: "\n"),
             maxSplits: 1,
             omittingEmptySubsequences: false)
-        // Try to match our regex and see if a valid specifier line.
+        // Try to match our regex and see if the "first" line is a valid tools version specification line.
         guard let firstLine = ByteString(splitted[0]).validDescription,
               let match = ToolsVersionLoader.regex.firstMatch(
                   in: firstLine, options: [], range: NSRange(location: 0, length: firstLine.count)),
@@ -205,14 +305,97 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
               // Since the version specifier is in the last range, if the number of ranges is less than 3, then no version specifier is captured by the regex.
               // FIXME: Should this be `== 3` instead?
               match.numberOfRanges >= 3 else {
-            return (nil, nil, bytes.contents)
+            return (nil, bytes.contents)
         }
-        let spacingAfterSlashes = NSString(string: firstLine).substring(with: match.range(at: 1))
         let versionSpecifier = NSString(string: firstLine).substring(with: match.range(at: 2))
         // FIXME: We can probably optimize here and return array slice.
-        return (spacingAfterSlashes, versionSpecifier, splitted.count == 1 ? [] : Array(splitted[1]))
+        return (versionSpecifier, splitted.count == 1 ? [] : Array(splitted[1]))
     }
-
+    
+    /// Splits the given manifest into its constituent components.
+    ///
+    /// The components include the leading line terminators, the tools version specification, and the rest of the manifest. Spacing between "//" and "swift-tools-version" and the version specifier are included separately, if found in the tools version specification.
+    ///
+    /// - Parameter manifestContents: The UTF-8-encoded content of the manifest.
+    /// - Returns: The components of the given manifest.
+    public static func split(_ manifestContents: String) -> ManifestComponents {
+        
+        // We split the string manually instead of using `split(maxSplits:omittingEmptySubsequences:whereSeparator:)`,
+        // because the latter method fails in the edge case where the manifest starts with a single line terminator.
+        
+        /// The position of the first character of the tools version specification line in the manifest.
+        ///
+        /// Because the tools version specification is the first non-empty line in the manifest, the position of its first character is also the position of the first non-line-terminating character in the manifest.
+        let startIndexOfToolsVersionSpecification = manifestContents.firstIndex(where: { !$0.isNewline } ) ?? manifestContents.startIndex
+        
+        /// The line terminators at the start of the manifest.
+        ///
+        /// Because the tools version specification is the first non-empty line in the manifest, the manifest's leading line terminators are the only characters in front of the tools version specification.
+        let leadingLineTerminators = manifestContents[..<startIndexOfToolsVersionSpecification]
+        
+        /// The position right past the last character of the tools version specification line in the manifest.
+        ///
+        /// Because the tools version specification is the first non-empty line in the manifest, the position right past its last character is the position of the first non-leading line terminator in the manifest. If no such line terminator exists, then the position is the `endIndex` of the manifest.
+        let endIndexOfToolsVersionSpecification = manifestContents[startIndexOfToolsVersionSpecification...].firstIndex(where: \.isNewline) ?? manifestContents.endIndex
+        
+        /// The Swift tools version specification.
+        ///
+        /// The specification is the first comment in the manifest that declares the version of the `PackageDescription` library, the minimum version of the Swift tools and Swift language compatibility version to process the manifest, and the minimum version of the Swift tools that are needed to use the Swift package.
+        let toolsVersionSpecification = manifestContents[startIndexOfToolsVersionSpecification..<endIndexOfToolsVersionSpecification]
+        
+        /// The position of the first character of the tools version specification line in the manifest.
+        ///
+        /// If no such character exists, then the position is the `endIndex` of the manifest.
+        let startIndexOfManifestContentsAfterToolsVersionSpecification = endIndexOfToolsVersionSpecification == manifestContents.endIndex ? manifestContents.endIndex : manifestContents.index(after: endIndexOfToolsVersionSpecification)
+        
+        /// The remaining contents of the manifest that follows right after the tools version specification line.
+        let manifestContentsAfterToolsVersionSpecification = manifestContents[startIndexOfManifestContentsAfterToolsVersionSpecification...]
+        
+        // `NSRegularExpression.firstMatch(in:options:range:)` accepts only a `String` instance as the first parameter.
+        /// The string of the Swift tools version specification.
+        let toolsVersionSpecificationString = String(toolsVersionSpecification)
+        
+        // Try to match our regex and see if the tools version specification is valid.
+        guard
+            let match = regex.firstMatch(in: toolsVersionSpecificationString, options: [], range: NSRange(toolsVersionSpecificationString.startIndex..<toolsVersionSpecificationString.endIndex, in: toolsVersionSpecificationString)),
+            // The 3 ranges are:
+            //   1. The entire matched string.
+            //   2. Capture group 1: the comment spacing.
+            //   3. Capture group 2: The version specifier.
+            // Since the version specifier is in the last range, if the number of ranges is less than 3, then no version specifier is captured by the regex.
+            // FIXME: Should this be `== 3` instead?
+            match.numberOfRanges >= 3
+        else {
+            return ManifestComponents(
+                leadingLineTerminators: leadingLineTerminators,
+                toolsVersionSpecification: toolsVersionSpecification,
+                contentsAfterToolsVersionSpecification: manifestContentsAfterToolsVersionSpecification,
+                toolsVersionSpecificationCapturedComponents: ToolsVersionSpecificationCapturedComponents(spacingAfterSlashes: nil, versionSpecifier: nil)
+            )
+        }
+        
+        // Try to match our regex and see if the tools version specification is valid.
+        guard let rangeOfSpacingAfterSlashes = Range(match.range(at: 1), in: toolsVersionSpecificationString),
+              let rangeOfVersionSpecifier = Range(match.range(at: 2), in: toolsVersionSpecificationString) else {
+            fatalError("failed to initialise instances of Range<String.Index> from valid regex match ranges")
+        }
+        
+        /// The horizontal spacing between "//" and  "swift-tools-version".
+        let spacingAfterSlashes = toolsVersionSpecificationString[rangeOfSpacingAfterSlashes]
+        /// The version number specifier.
+        let versionSpecifier = toolsVersionSpecificationString[rangeOfVersionSpecifier]
+        
+        return ManifestComponents(
+            leadingLineTerminators: leadingLineTerminators,
+            toolsVersionSpecification: toolsVersionSpecification,
+            contentsAfterToolsVersionSpecification: manifestContentsAfterToolsVersionSpecification,
+            toolsVersionSpecificationCapturedComponents: ToolsVersionSpecificationCapturedComponents(
+                spacingAfterSlashes: spacingAfterSlashes,
+                versionSpecifier: versionSpecifier
+            )
+        )
+    }
+    
     /// The regex to match swift tools version specification.
     ///
     /// The specification must have the following format:

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -376,12 +376,12 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
     /// - Warning: This function has been deprecated since Swift 5.3.1, please use `split(_ manifestContents: String) -> ManifestComponents` instead.
     ///
     /// - Note: This function imposes the following limitations that are removed in its replacement:
-    ///   - Leading line terminators (other than at most 1 `U+000A`) are not accepted in the given manifest contents.
+    ///   - Leading whitespace, other than a sequence of newline characters (`U+000A`), is not accepted in the given manifest contents.
     ///   - Only `U+000A` is recognised as a line terminator.
     ///   - A Swift tools version specification must be prefixed with `// swift-tools-version:` verbatim, where the spacing between `//` and `swift-tools-version` is exactly 1 `U+0020`.
     ///
     /// - Bug: This function treats only `U+000A` as a line terminator.
-    /// - Bug: If there is a single leading `U+000A` in the manifest file, this function mistakes the second line of the manifest as its first line.
+    /// - Bug: If there is a contiguous sequence of `U+000A` at the very beginning of the manifest file, this function mistakes the first non-empty line of the manifest as its first line.
     ///
     /// - Parameter bytes: The raw bytes of the content of the manifest.
     /// - Returns: The version specifier (if present, or `nil`) and the raw bytes of the contents sans the first line of the manifest.
@@ -436,7 +436,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
     /// - Returns: The components of the given manifest.
     public static func split(_ manifest: String) -> ManifestComponents {
         
-        // We split the string manually instead of using `split(maxSplits:omittingEmptySubsequences:whereSeparator:)`, because the latter method fails in the edge case where the manifest starts with a single line terminator.
+        // We split the string manually instead of using `split(maxSplits:omittingEmptySubsequences:whereSeparator:)`, because the latter "strips" leading and trailing line terminators, and we need to record the leading line terminators to check for backward-compatibility later.
         
         /// The position of the first character of the Swift tools version specification line in the manifest.
         ///

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -124,10 +124,6 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         case inaccessibleManifest(path: AbsolutePath, reason: String)
         /// Package manifest file's content can not be decoded as a UTF-8 string.
         case nonUTF8EncodedManifest(path: AbsolutePath)
-        /// Malformed tools version specifier.
-        /// - Warning: This case has been deprecated since Swift 5.3.1, please use `case malformedToolsVersionSpecification(_ malformation: ToolsVersionSpecificationMalformation)` instead.
-        @available(swift, deprecated: 5.3.1, renamed: "malformedToolsVersion(_:)")
-        case malformedToolsVersion(specifier: String, currentToolsVersion: ToolsVersion)
         /// Malformed tools version specification.
         case malformedToolsVersionSpecification(_ malformation: ToolsVersionSpecificationMalformation)
         /// Backward-incompatible contents with Swift tools version ≤ 5.3.

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -100,7 +100,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         case inaccessiblePackage(path: AbsolutePath, reason: String)
         /// Package manifest file is inaccessible (missing, unreadable, etc).
         case inaccessibleManifest(path: AbsolutePath, reason: String)
-        /// Malformed tools version specifier
+        /// Malformed tools version specifier.
         case malformedToolsVersion(specifier: String, currentToolsVersion: ToolsVersion)
         // TODO: Make the case more general, to better adapt to future changes.
         /// The spacing between "//" and  "swift-tools-version" either is empty or uses whitespace characters unsupported by Swift ≤ 5.3.

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -547,7 +547,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         /// - Note: For a misspelt Swift tools version specification `"// swift-too1s-version: 5.3.1"`, the label stops at the second `"o"`, so only `"swift-too"` is recognised as the label with no spacing following it.
         let labelWithTrailingWhitespace = specificationWithIgnoredTrailingContents[endIndexOfSpacingAfterCommentMarker..<startIndexOfVersionSpecifier]
         
-        /// The position of the first character in the spacing after the label part of the Swift version specification.
+        /// The position of the first character in the spacing after the label part of the Swift tools version specification.
         ///
         /// Because there is no whitespace within the label, and because the spacing consists of only horizontal whitespace characters, so this position is the same as the position of the first whitespace character between the beginning of the label and the beginning of the version specifier. If no such whitespace character exists, then there is no spacing, and so this position is the `endIndex` of these sequence of characters (i.e. the starting position of the version specifier).
         let startIndexOfSpacingAfterLabel = labelWithTrailingWhitespace.firstIndex(where: \.isWhitespace) ?? startIndexOfVersionSpecifier

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -131,7 +131,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         ///
         /// A backward-incompatibility is not necessarily a malformation.
         public enum BackwardIncompatibilityPre5_3_1 {
-            /// The line terminators at the start of the manifest is not either empty or a single `U+000A`.
+            /// The line terminators at the start of the manifest are not all `U+000A`.
             case leadingLineTerminators(_ lineTerminators: Substring)
             /// The horizontal spacing between "//" and  "swift-tools-version" either is empty or uses whitespace characters unsupported by Swift ≤ 5.3.
             case spacingAfterCommentMarker(_ spacing: Substring)
@@ -205,7 +205,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
             case let .backwardIncompatiblePre5_3_1(incompatibility, specifiedVersion):
                 switch incompatibility {
                 case let .leadingLineTerminators(lineTerminators):
-                    return "leading line terminator sequence \(unicodeCodePointsPrefixedByUPlus(of: lineTerminators)) in manifest is supported by only Swift > 5.3; for the specified version \(specifiedVersion), only zero or one newline (U+000A) at the beginning of the manifest is supported; consider moving the Swift tools version specification to the first line of the manifest"
+                    return "leading line terminator sequence \(unicodeCodePointsPrefixedByUPlus(of: lineTerminators)) in manifest is supported by only Swift > 5.3; for the specified version \(specifiedVersion), only newline characters (U+000A) at the beginning of the manifest is supported; consider moving the Swift tools version specification to the first line of the manifest"
                 case let .spacingAfterCommentMarker(spacing):
                     return "\(spacing.isEmpty ? "zero spacing" : "horizontal whitespace sequence \(unicodeCodePointsPrefixedByUPlus(of: spacing))") between '//' and 'swift-tools-version' is supported by only Swift > 5.3; consider using a single space (U+0020) for Swift \(specifiedVersion)"
                 }
@@ -224,7 +224,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         public let contentsAfterToolsVersionSpecification: Substring
         /// A Boolean value indicating whether the manifest represented in its constituent parts is backward-compatible with Swift ≤ 5.3.
         public var isCompatibleWithPreSwift5_3_1: Bool {
-            (leadingLineTerminators.isEmpty || leadingLineTerminators == "\n") && toolsVersionSpecificationComponents.isCompatibleWithPreSwift5_3_1
+            leadingLineTerminators.allSatisfy { $0 == "\n" } && toolsVersionSpecificationComponents.isCompatibleWithPreSwift5_3_1
         }
     }
     
@@ -351,7 +351,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         
         guard version > .v5_3 || manifestComponents.isCompatibleWithPreSwift5_3_1 else {
             let manifestLeadingLineTerminators = manifestComponents.leadingLineTerminators
-            if !manifestLeadingLineTerminators.isEmpty && manifestLeadingLineTerminators != "\n" {
+            if !manifestLeadingLineTerminators.allSatisfy({ $0 == "\n" }) {
                 throw Error.backwardIncompatiblePre5_3_1(.leadingLineTerminators(manifestLeadingLineTerminators), specifiedVersion: version)
             }
             

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -620,6 +620,8 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
     /// There are 2 capture groups in the regex pattern:
     /// 1. The continuous sequence of whitespace characters between "//" and "swift-tools-version".
     /// 2. The version specifier.
+    ///
+    /// - Bug: Although any combination of all _horizontal_ whitespace characters should be allowed between `//`and `swift-tools-version:`, currently only a single space (`U+0020`) is allowed.
     @available(swift, deprecated: 5.3.1)
     static let regex = try! NSRegularExpression(
         pattern: "^// swift-tools-version:(.*?)(?:;.*|$)",

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -203,7 +203,6 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
                         return "the Swift tools version '\(misspeltVersionSpecifier)' is misspelt or otherwise invalid; consider replacing it with '\(ToolsVersion.currentToolsVersion)' to specify the current Swift toolchain version as the lowest supported version by the project"
                     }
                 }
-            // FIXME: The error messages probably can be more concise, while still hitting all the key points.
             case let .backwardIncompatiblePre5_3_1(incompatibility, specifiedVersion):
                 switch incompatibility {
                 case let .leadingWhitespace(whitespace):

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -125,7 +125,11 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
             case label(_ malformationDetails: MalformationDetails)
             /// The version specifier is malformed.
             ///
-            /// If the version specifier is diagnosed as missing, it could be a misdiagnosis due to some misspellings in the label. This is because of a compromise made in `ToolsVersionLoader.split(_:)`.
+            /// If the version specifier is diagnosed as missing, it could be a misdiagnosis due to some misspellings in the label due to a compromise made in `ToolsVersionLoader.split(_:)`. For example, the following Swift tools version specification will be misdiagnosed to be missing a version specifier:
+            ///
+            ///     // swift-tools-version:;5.3
+            ///
+            /// This is because the position right past `":"` is considered as the `startIndex` of the version specifier, but at the same time the character at this position is `";"`, a terminator of the Swift tools version specification. This misleads `ToolsVersionLoader.load(file:fileSystem:)` to believe the version specifier is empty (i.e. missing).
             case versionSpecifier(_ malformationDetails: MalformationDetails)
             /// An unidentifiable component of the Swift tools version specification is malformed.
             case unidentified

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -176,8 +176,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         }
         
         // Ensure that for Swift ≤ 5.3, a single U+0020 is used as spacing between "//" and "swift-tools-version".
-        // Use `ToolsVersion(version:)` instead of `ToolsVeresion(string:)` here to avoid forced unwrappiing.
-        guard spacingAfterSlashes == " " || version > ToolsVersion(version: "5.3.0") else {
+		guard spacingAfterSlashes == " " || version > .v5_3 else {
             throw Error.invalidSpacingAfterSlashes(charactersUsed: spacingAfterSlashes, specifiedVersion: version)
         }
         

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -384,9 +384,8 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         return version
     }
     
-    // FIXME: Remove this function?
-    // This function is currently preserved because it's declared as public.
-    // Removing it is probably source-breaking.
+    // FIXME: Remove this function.
+    // This function is currently preserved because it's used in `writeToolsVersion(at:version:fs:).
     /// Splits the bytes to find the Swift tools version specifier and the contents sans the first line of the manifest.
     ///
     /// - Warning: This function has been deprecated since Swift 5.3.1, please use `split(_ manifestContents: String) -> ManifestComponents` instead.

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -132,9 +132,9 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         /// A backward-incompatibility is not necessarily a malformation.
         public enum BackwardIncompatibilityPre5_3_1 {
             /// The line terminators at the start of the manifest are not all `U+000A`.
-            case leadingLineTerminators(_ lineTerminators: Substring)
+            case leadingLineTerminators(_ lineTerminators: String)
             /// The horizontal spacing between "//" and  "swift-tools-version" either is empty or uses whitespace characters unsupported by Swift ≤ 5.3.
-            case spacingAfterCommentMarker(_ spacing: Substring)
+            case spacingAfterCommentMarker(_ spacing: String)
         }
         
         /// Package directory is inaccessible (missing, unreadable, etc).
@@ -352,12 +352,12 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         guard version > .v5_3 || manifestComponents.isCompatibleWithPreSwift5_3_1 else {
             let manifestLeadingLineTerminators = manifestComponents.leadingLineTerminators
             if !manifestLeadingLineTerminators.allSatisfy({ $0 == "\n" }) {
-                throw Error.backwardIncompatiblePre5_3_1(.leadingLineTerminators(manifestLeadingLineTerminators), specifiedVersion: version)
+                throw Error.backwardIncompatiblePre5_3_1(.leadingLineTerminators(String(manifestLeadingLineTerminators)), specifiedVersion: version)
             }
             
             let spacingAfterCommentMarker = toolsVersionSpecificationComponents.spacingAfterCommentMarker
             if spacingAfterCommentMarker != "\u{20}" {
-                throw Error.backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker(spacingAfterCommentMarker), specifiedVersion: version)
+                throw Error.backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker(String(spacingAfterCommentMarker)), specifiedVersion: version)
             }
             
             // The above If-statements should have covered all possible backward incompatibilities with Swift ≤ 5.3.

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -455,7 +455,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
     /// - Returns: The components of the given manifest.
     public static func split(_ manifest: String) -> ManifestComponents {
         
-        // We split the string manually instead of using `Collection.split(maxSplits:omittingEmptySubsequences:whereSeparator:)`, because the latter "strips" leading and trailing whatespace, and we need to record the leading whitespace to check for backward-compatibility later.
+        // We split the string manually instead of using `Collection.split(maxSplits:omittingEmptySubsequences:whereSeparator:)`, because the latter "strips" leading and trailing whitespace, and we need to record the leading whitespace to check for backward-compatibility later.
         
         /// The position of the first character of the Swift tools version specification line in the manifest.
         ///

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -271,11 +271,15 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         
         /// A Boolean value indicating whether everything up to the version specifier in the Swift tools version specification represented in its constituent parts is well-formed.
         public var everythingUpToVersionSpecifierIsWellFormed: Bool {
-            // FIXME: Make `label` case sensitive?
-            // FIXME: Replace with `commentMarker == "//" && (label == "swift-tools-version:" || label.lowercased() == "swift-tools-version:")`?
+            // The label is case-insensitive.
+            // Making it case-sensitive is source breaking for all existing Swift versions.
+            //
+            // An argument for making it case-sensitive is that it can make the package manager slightly more efficient:
+            //
             // "swift-tools-version:" has more than 15 UTF-8 code units, so `label` is likely to have more than 15 UTF-8 code units too.
             // Strings with more than 15 UTF-8 code units are heap-allocated on 64-bit platforms, 10 on 32-bit platforms.
-            // `lowercase()` returns a heap-allocated string here, and this is inefficient, although the inefficiency is perhaps insignificant.
+            // `Substring.lowercase()` returns a heap-allocated string here, and this is inefficient.
+            // Although, the allocation happens only once per manifest (once per loading attempt), so the inefficiency is rather insignificant.
             // Short-circuiting the `lowercase()` can remove an allocation.
             commentMarker == "//" && label.lowercased() == "swift-tools-version:"
         }

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -135,11 +135,11 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
             /// The version specifier is missing.
             case missingVersionSpecifier
             /// The comment marker is malformed.
-            case commentMarker(_ commentMarker: Substring)
+            case commentMarker(_ commentMarker: String)
             /// The label part of the Swift tools version specification is malformed.
-            case label(_ label: Substring)
+            case label(_ label: String)
             /// The version specifier is malformed.
-            case versionSpecifier(_ versionSpecifier: Substring)
+            case versionSpecifier(_ versionSpecifier: String)
         }
         
         /// Details of backward-incompatible contents with Swift tools version ≤ 5.3.
@@ -339,11 +339,11 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         
         guard toolsVersionSpecificationComponents.everythingUpToVersionSpecifierIsWellFormed else {
             if commentMarker != "//" {
-                throw Error.malformedToolsVersionSpecification(.commentMarker(commentMarker))
+                throw Error.malformedToolsVersionSpecification(.commentMarker(String(commentMarker)))
             }
             
             if label.lowercased() != "swift-tools-version:" {
-                throw Error.malformedToolsVersionSpecification(.label(label))
+                throw Error.malformedToolsVersionSpecification(.label(String(label)))
             }
             
             // The above If-statements should have covered all possible malformations in Swift tools version specification up to the version specifier.
@@ -352,7 +352,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         }
         
         guard let version = ToolsVersion(string: String(versionSpecifier)) else {
-            throw Error.malformedToolsVersionSpecification(.versionSpecifier(versionSpecifier))
+            throw Error.malformedToolsVersionSpecification(.versionSpecifier(String(versionSpecifier)))
         }
         
         guard version > .v5_3 || manifestComponents.isCompatibleWithPreSwift5_3_1 else {

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -207,7 +207,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
                         return "the Swift tools version '\(misspeltVersionSpecifier)' is misspelt or otherwise invalid; consider replacing it with '\(ToolsVersion.currentToolsVersion)' to specify the current Swift toolchain version as the lowest Swift version supported by the project"
                     }
                 case .unidentified:
-                    return "the Swift tools version specification has a formatting error, but the package manager is unable to find either the location or cause of it; consider replacing it with '// swift-tools-version:\(ToolsVersion.currentVersion)' to specify the current Swift toolchain version as the lowest Swift version supported by the project; additionally, please consider filing a bug report on https://bugs.swift.org with this file attached"
+                    return "the Swift tools version specification has a formatting error, but the package manager is unable to find either the location or cause of it; consider replacing it with '// swift-tools-version:\(ToolsVersion.currentToolsVersion)' to specify the current Swift toolchain version as the lowest Swift version supported by the project; additionally, please consider filing a bug report on https://bugs.swift.org with this file attached"
                 }
             case let .backwardIncompatiblePre5_3_1(incompatibility, specifiedVersion):
                 switch incompatibility {
@@ -218,7 +218,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
                 case .spacingAfterLabel(let spacing):
                     return "horizontal whitespace sequence \(unicodeCodePointsPrefixedByUPlus(of: spacing)) immediately preceding the version specifier is supported by only Swift > 5.3; consider removing the sequence for Swift \(specifiedVersion)"
                 case .unidentified:
-                    return "the manifest is backward-incompatible with Swift ≤ 5.3, but the package manager is unable to pinpoint the exact incompatibility; consider replacing the current Swift tools version specification with '// swift-tools-version:\(ToolsVersion.currentVersion)' to specify the current Swift toolchain version as the lowest Swift version supported by the project, then move the new specification to the very beginning of this manifest file; additionally, please consider filing a bug report on https://bugs.swift.org with this file attached"
+                    return "the manifest is backward-incompatible with Swift ≤ 5.3, but the package manager is unable to pinpoint the exact incompatibility; consider replacing the current Swift tools version specification with '// swift-tools-version:\(ToolsVersion.currentToolsVersion)' to specify the current Swift toolchain version as the lowest Swift version supported by the project, then move the new specification to the very beginning of this manifest file; additionally, please consider filing a bug report on https://bugs.swift.org with this file attached"
                 }
             }
             

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -30,7 +30,7 @@ extension Manifest {
     /// Returns the manifest at the given package path.
     ///
     /// Version specific manifest is chosen if present, otherwise path to regular
-    /// manfiest is returned.
+    /// manifest is returned.
     public static func path(
         atPackagePath packagePath: AbsolutePath,
         currentToolsVersion: ToolsVersion = .currentToolsVersion,
@@ -69,7 +69,7 @@ extension Manifest {
         let regularManifest = packagePath.appending(component: filename)
         let toolsVersionLoader = ToolsVersionLoader(currentToolsVersion: currentToolsVersion)
 
-        // Find the version-specific manifest that statisfies the current tools version.
+        // Find the version-specific manifest that satisfies the current tools version.
         if let versionSpecificCandidate = versionSpecificManifests.keys.sorted(by: >).first(where: { $0 <= currentToolsVersion }) {
             let versionSpecificManifest = packagePath.appending(component: versionSpecificManifests[versionSpecificCandidate]!)
 
@@ -155,7 +155,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
             let spacingAfterSlashes = deconstructedToolsVersionSpecification.spacingAfterSlashes,
             let versionSpecifier = deconstructedToolsVersionSpecification.versionSpecifier
         else {
-            // TODO: Make the diagnsosis more granular by having the regex capture more groups.
+            // TODO: Make the diagnosis more granular by having the regex capture more groups.
             // Try to diagnose if there is a misspelling of the swift-tools-version comment.
             let splitted = contents.contents.split(
                 separator: UInt8(ascii: "\n"),
@@ -188,7 +188,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
     /// The constituent parts include the spacing between "//" and "swift-tools-version", and the version specifier, if either is present.
     ///
     /// - Parameter bytes: The raw bytes of the content of the manifest.
-    /// - Returns: The spacing between "//" and "swift-tools-version" (if present, or `nil`), the version specifier (if present, or `nil`), and of raw bytes of the rest of the content of the manifest.
+    /// - Returns: The spacing between "//" and "swift-tools-version" (if present, or `nil`), the version specifier (if present, or `nil`), and the raw bytes of the rest of the content of the manifest.
     public static func split(_ bytes: ByteString) -> (spacingAfterSlashes: String?, versionSpecifier: String?, rest: [UInt8]) {
         let splitted = bytes.contents.split(
             separator: UInt8(ascii: "\n"),

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -308,7 +308,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         
         // FIXME: This is doubly inefficient.
         // `contents`'s value comes from `FileSystem.readFileContents(_)`, which is [inefficient](https://github.com/apple/swift-tools-support-core/blob/8f9838e5d4fefa0e12267a1ff87d67c40c6d4214/Sources/TSCBasic/FileSystem.swift#L167). Calling `ByteString.validDescription` on `contents` is also [inefficient, and possibly incorrect](https://github.com/apple/swift-tools-support-core/blob/8f9838e5d4fefa0e12267a1ff87d67c40c6d4214/Sources/TSCBasic/ByteString.swift#L121). However, this is a one-time thing for each package manifest, and almost necessary in order to work with all Unicode line-terminators. We probably can improve its efficiency and correctness by using `URL` for the file's path, and get is content via `Foundation.String(contentsOf:encoding:)`. Swift System's [`FilePath`](https://github.com/apple/swift-system/blob/8ffa04c0a0592e6f4f9c30926dedd8fa1c5371f9/Sources/System/FilePath.swift) and friends might help as well.
-        // FIXME: This is source-breaking.
+        // This is source-breaking.
         // A manifest that has an [invalid byte sequence](https://en.wikipedia.org/wiki/UTF-8#Invalid_sequences_and_error_handling) (such as `0x7F8F`) after the tools version specification line could work in Swift ≤ 5.3, but results in an error since Swift 5.3.1.
         guard let manifestContentsDecodedWithUTF8 = manifestContents.validDescription else {
             throw Error.nonUTF8EncodedManifest(path: file)

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -217,7 +217,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
             case let .backwardIncompatiblePre5_3_1(incompatibility, specifiedVersion):
                 switch incompatibility {
                 case .leadingWhitespace(let whitespace):
-                    return "leading whitespace sequence \(unicodeCodePointsPrefixedByUPlus(of: whitespace)) in manifest is supported by only Swift > 5.3; the specified version \(specifiedVersion) supports only newline characters (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
+                    return "leading whitespace sequence \(unicodeCodePointsPrefixedByUPlus(of: whitespace)) in manifest is supported by only Swift > 5.3; the specified version \(specifiedVersion) supports only line feeds (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
                 case .spacingAfterCommentMarker(let spacing):
                     return "\(spacing.isEmpty ? "zero spacing" : "horizontal whitespace sequence \(unicodeCodePointsPrefixedByUPlus(of: spacing))") between '//' and 'swift-tools-version' is supported by only Swift > 5.3; consider replacing the sequence with a single space (U+0020) for Swift \(specifiedVersion)"
                 case .spacingAfterLabel(let spacing):

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -224,6 +224,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
     /// 1. The continuous sequence of whitespace characters between "//" and "swift-tools-version".
     /// 2. The version specifier.
     static let regex = try! NSRegularExpression(
-        pattern: "^//(\\h*?)swift-tools-version:(.*?)(?:;.*|$)",
+        // The pattern is a raw string, so backslashes should not be escaped.
+        pattern: #"^//(\h*?)swift-tools-version:(.*?)(?:;.*|$)"#,
         options: [.caseInsensitive])
 }

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -174,11 +174,11 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         return (versionSpecifier, splitted.count == 1 ? [] : Array(splitted[1]))
     }
 
-    // The regex to match swift tools version specification:
-    // * It should start with `//` followed by any amount of whitespace.
-    // * Following that it should contain the case insensitive string `swift-tools-version:`.
-    // * The text between the above string and `;` or string end becomes the tools version specifier.
+    /// The regex to match swift tools version specification:
+    /// * It should start with `//` followed by any amount of _horizontal_ whitespace characters.
+    /// * Following that it should contain the case insensitive string `swift-tools-version:`.
+    /// * The text between the above string and `;` or string end becomes the tools version specifier.
     static let regex = try! NSRegularExpression(
-        pattern: "^// swift-tools-version:(.*?)(?:;.*|$)",
+        pattern: "^//\\h*?swift-tools-version:(.*?)(?:;.*|$)",
         options: [.caseInsensitive])
 }

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -8,6 +8,23 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+// FIXME: Be careful when replacing "Next" with a concrete version number.
+// "Next" in `ToolsVersionLoader` and `ToolsVersionLoaderTests` can not be replaced using a simple text-level search-and-replace. Please consider the following suggestions:
+// Assuming that Swift Next is Swift 5.4, then
+// 1. If "Next" is in a symbol such as a type or variable name, then it should be replaced by "5_4".
+// 2. If "Next" is not in a symbol, then it can be replaced by "5.4".
+// 3. If "Next" is in a string, it's likely an error message, so it must be replaced in tandem with its corresponding assertions in `ToolsVersionTests`.
+// 4. If "Next" is in a comment, then make sure no chart is misaligned after the replacement.
+// 5. Swift Next is assumed to be Swift 5.4, so some comments use version strings like "5:4:0" or "5-4-1" to illustrate misspelt versions. If it Swift Next turns out to be a different version, such as Swift 5.3.2 or Swift 6, then those version strings in comments need to be changed.
+// Alternatively, it might be easier to revert the commit (not the merge commit) that this comment is from, then do the following in both `ToolsVersionLoader` and `ToolsVersionLoaderTests`:
+// Assuming that Swift Next is Swift 5.4, then
+// 1. Replace all occurrences of "5_3_1" with "5_4".
+// 2. Replace all occurrences of "≤ 5.3" with "< 5.4".
+// 3. Replace all occurrences of "> 5.3" with "≥ 5.4".
+// 4. Replace all occurrences of "5.3.1" with "5.4".
+// 5. Replace version strings such as "5:3:1" and "5-3-1" with "5:4:1" and "5-4-1".
+// 6. Maintain alignments in charts in some comments.
+
 import TSCBasic
 import PackageModel
 import TSCUtility
@@ -135,17 +152,17 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
             case unidentified
         }
         
-        /// Details of backward-incompatible contents with Swift tools version ≤ 5.3.
+        /// Details of backward-incompatible contents with Swift tools version < Next.
         ///
         /// A backward-incompatibility is not necessarily a malformation.
-        public enum BackwardIncompatibilityPre5_3_1 {
+        public enum BackwardIncompatibilityPreNext {
             /// The whitespace at the start of the manifest is not all `U+000A`.
             case leadingWhitespace(_ whitespace: String)
-            /// The horizontal spacing between "//" and  "swift-tools-version" either is empty or uses whitespace characters unsupported by Swift ≤ 5.3.
+            /// The horizontal spacing between "//" and  "swift-tools-version" either is empty or uses whitespace characters unsupported by Swift < Next.
             case spacingAfterCommentMarker(_ spacing: String)
             /// There is a non-empty spacing between the label part of the Swift tools version specification and the version specifier.
             case spacingAfterLabel(_ spacing: String)
-            /// There is an unidentifiable backward-incompatibility with Swift tools version ≤ 5.3 within the manifest.
+            /// There is an unidentifiable backward-incompatibility with Swift tools version < Next within the manifest.
             case unidentified
         }
         
@@ -157,8 +174,8 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         case nonUTF8EncodedManifest(path: AbsolutePath)
         /// Malformed tools version specification.
         case malformedToolsVersionSpecification(_ malformationLocation: ToolsVersionSpecificationMalformationLocation)
-        /// Backward-incompatible contents with Swift tools version ≤ 5.3.
-        case backwardIncompatiblePre5_3_1(_ incompatibility: BackwardIncompatibilityPre5_3_1, specifiedVersion: ToolsVersion)
+        /// Backward-incompatible contents with Swift tools version < Next.
+        case backwardIncompatiblePreNext(_ incompatibility: BackwardIncompatibilityPreNext, specifiedVersion: ToolsVersion)
 
         public var description: String {
             
@@ -214,16 +231,16 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
                 case .unidentified:
                     return "the Swift tools version specification has a formatting error, but the package manager is unable to find either the location or cause of it; consider replacing it with '// swift-tools-version:\(ToolsVersion.currentToolsVersion)' to specify the current Swift toolchain version as the lowest Swift version supported by the project; additionally, please consider filing a bug report on https://bugs.swift.org with this file attached"
                 }
-            case let .backwardIncompatiblePre5_3_1(incompatibility, specifiedVersion):
+            case let .backwardIncompatiblePreNext(incompatibility, specifiedVersion):
                 switch incompatibility {
                 case .leadingWhitespace(let whitespace):
-                    return "leading whitespace sequence \(unicodeCodePointsPrefixedByUPlus(of: whitespace)) in manifest is supported by only Swift > 5.3; the specified version \(specifiedVersion) supports only line feeds (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
+                    return "leading whitespace sequence \(unicodeCodePointsPrefixedByUPlus(of: whitespace)) in manifest is supported by only Swift ≥ Next; the specified version \(specifiedVersion) supports only line feeds (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
                 case .spacingAfterCommentMarker(let spacing):
-                    return "\(spacing.isEmpty ? "zero spacing" : "horizontal whitespace sequence \(unicodeCodePointsPrefixedByUPlus(of: spacing))") between '//' and 'swift-tools-version' is supported by only Swift > 5.3; consider replacing the sequence with a single space (U+0020) for Swift \(specifiedVersion)"
+                    return "\(spacing.isEmpty ? "zero spacing" : "horizontal whitespace sequence \(unicodeCodePointsPrefixedByUPlus(of: spacing))") between '//' and 'swift-tools-version' is supported by only Swift ≥ Next; consider replacing the sequence with a single space (U+0020) for Swift \(specifiedVersion)"
                 case .spacingAfterLabel(let spacing):
-                    return "horizontal whitespace sequence \(unicodeCodePointsPrefixedByUPlus(of: spacing)) immediately preceding the version specifier is supported by only Swift > 5.3; consider removing the sequence for Swift \(specifiedVersion)"
+                    return "horizontal whitespace sequence \(unicodeCodePointsPrefixedByUPlus(of: spacing)) immediately preceding the version specifier is supported by only Swift ≥ Next; consider removing the sequence for Swift \(specifiedVersion)"
                 case .unidentified:
-                    return "the manifest is backward-incompatible with Swift ≤ 5.3, but the package manager is unable to pinpoint the exact incompatibility; consider replacing the current Swift tools version specification with '// swift-tools-version:\(specifiedVersion)' to specify Swift \(specifiedVersion) as the lowest Swift version supported by the project, then move the new specification to the very beginning of this manifest file; additionally, please consider filing a bug report on https://bugs.swift.org with this file attached"
+                    return "the manifest is backward-incompatible with Swift < Next, but the package manager is unable to pinpoint the exact incompatibility; consider replacing the current Swift tools version specification with '// swift-tools-version:\(specifiedVersion)' to specify Swift \(specifiedVersion) as the lowest Swift version supported by the project, then move the new specification to the very beginning of this manifest file; additionally, please consider filing a bug report on https://bugs.swift.org with this file attached"
                 }
             }
             
@@ -238,9 +255,9 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         public let toolsVersionSpecificationComponents: ToolsVersionSpecificationComponents
         /// The remaining contents of the manifest that follows right after the tools version specification line.
         public let contentsAfterToolsVersionSpecification: Substring
-        /// A Boolean value indicating whether the manifest represented in its constituent parts is backward-compatible with Swift ≤ 5.3.
-        public var isCompatibleWithPreSwift5_3_1: Bool {
-            leadingWhitespace.allSatisfy { $0 == "\n" } && toolsVersionSpecificationComponents.isCompatibleWithPreSwift5_3_1
+        /// A Boolean value indicating whether the manifest represented in its constituent parts is backward-compatible with Swift < Next.
+        public var isCompatibleWithPreSwiftNext: Bool {
+            leadingWhitespace.allSatisfy { $0 == "\n" } && toolsVersionSpecificationComponents.isCompatibleWithPreSwiftNext
         }
     }
     
@@ -248,8 +265,8 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
     ///
     /// A Swift tools version specification consists of the following parts:
     ///
-    ///     //  swift-tools-version:  5.3.1
-    ///     ⌃~⌃~⌃~~~~~~~~~~~~~~~~~~~⌃~⌃~~~~
+    ///     //  swift-tools-version:  Next
+    ///     ⌃~⌃~⌃~~~~~~~~~~~~~~~~~~~⌃~⌃~~~
     ///     │ │ └ label             │ └ version specifier
     ///     │ └ spacing             └ spacing
     ///     └ comment marker
@@ -264,7 +281,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         ///
         /// In a well-formed Swift tools version specification, the spacing after the comment marker is a continuous sequence of horizontal whitespace characters.
         ///
-        /// For Swift ≤ 5.3, the spacing after the comment marker must be a single `U+0020`.
+        /// For Swift < Next, the spacing after the comment marker must be a single `U+0020`.
         public let spacingAfterCommentMarker: Substring
         
         /// The label part of the Swift tools version specification.
@@ -276,7 +293,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         ///
         /// In a well-formed Swift tools version specification, the spacing after the label is a continuous sequence of horizontal whitespace characters.
         ///
-        /// For Swift ≤ 5.3, no spacing is allowed after the label.
+        /// For Swift < Next, no spacing is allowed after the label.
         public let spacingAfterLabel: Substring
         
         /// The version specifier.
@@ -297,8 +314,8 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
             commentMarker == "//" && label.lowercased() == "swift-tools-version:"
         }
         
-        /// A Boolean value indicating whether the Swift tools version specification represented in its constituent parts is backward-compatible with Swift ≤ 5.3.
-        public var isCompatibleWithPreSwift5_3_1: Bool {
+        /// A Boolean value indicating whether the Swift tools version specification represented in its constituent parts is backward-compatible with Swift < Next.
+        public var isCompatibleWithPreSwiftNext: Bool {
             everythingUpToVersionSpecifierIsWellFormed && spacingAfterCommentMarker == "\u{20}" && spacingAfterLabel.isEmpty
         }
     }
@@ -326,7 +343,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         // FIXME: This is doubly inefficient.
         // `contents`'s value comes from `FileSystem.readFileContents(_)`, which is [inefficient](https://github.com/apple/swift-tools-support-core/blob/8f9838e5d4fefa0e12267a1ff87d67c40c6d4214/Sources/TSCBasic/FileSystem.swift#L167). Calling `ByteString.validDescription` on `contents` is also [inefficient, and possibly incorrect](https://github.com/apple/swift-tools-support-core/blob/8f9838e5d4fefa0e12267a1ff87d67c40c6d4214/Sources/TSCBasic/ByteString.swift#L121). However, this is a one-time thing for each package manifest, and almost necessary in order to work with all Unicode line-terminators. We probably can improve its efficiency and correctness by using `URL` for the file's path, and get is content via `Foundation.String(contentsOf:encoding:)`. Swift System's [`FilePath`](https://github.com/apple/swift-system/blob/8ffa04c0a0592e6f4f9c30926dedd8fa1c5371f9/Sources/System/FilePath.swift) and friends might help as well.
         // This is source-breaking.
-        // A manifest that has an [invalid byte sequence](https://en.wikipedia.org/wiki/UTF-8#Invalid_sequences_and_error_handling) (such as `0x7F8F`) after the tools version specification line could work in Swift ≤ 5.3, but results in an error since Swift 5.3.1.
+        // A manifest that has an [invalid byte sequence](https://en.wikipedia.org/wiki/UTF-8#Invalid_sequences_and_error_handling) (such as `0x7F8F`) after the tools version specification line could work in Swift < Next, but results in an error since Swift Next.
         guard let manifestContentsDecodedWithUTF8 = manifestContents.validDescription else {
             throw Error.nonUTF8EncodedManifest(path: file)
         }
@@ -340,7 +357,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         //
         // 1. Check that the comment marker, the label, and the version specifier in the Swift tools version specification are not missing (empty).
         //
-        // 2. Check that everything in the Swift tools version specification up to the version specifier is formatted correctly according to the relaxed rules since Swift 5.3.1. Backward-compatibility is not considered here, because the user-specified version is unknown yet.
+        // 2. Check that everything in the Swift tools version specification up to the version specifier is formatted correctly according to the relaxed rules since Swift Next. Backward-compatibility is not considered here, because the user-specified version is unknown yet.
         //
         //    1. Check that the comment marker is formatted correctly.
         //
@@ -350,13 +367,13 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         //
         // 3. Check that the version spicier is formatted correctly.
         //
-        // 4. Check that the manifest is formatted backward-compatibly, if the user-specified version is ≤ 5.3. Backward-compatibility checks are now possible, because the user-specified version has become known since the previous step.
+        // 4. Check that the manifest is formatted backward-compatibly, if the user-specified version is < Next. Backward-compatibility checks are now possible, because the user-specified version has become known since the previous step.
         //
-        //    1. Check that the manifest's leading whitespace is backward-compatible with Swift ≤ 5.3.
+        //    1. Check that the manifest's leading whitespace is backward-compatible with Swift < Next.
         //
-        //    2. Check that the spacing after the comment marker in the Swift tools version specification is backward-compatible with Swift ≤ 5.3.
+        //    2. Check that the spacing after the comment marker in the Swift tools version specification is backward-compatible with Swift < Next.
         //
-        //    3. Check that the spacing after the label in the Swift tools version specification is backward-compatible with Swift ≤ 5.3.
+        //    3. Check that the spacing after the label in the Swift tools version specification is backward-compatible with Swift < Next.
         //
         // This order is based on the general idea that a manifest's readability should come before its validity when being diagnosed. The package manager must first understand what is written in the manifest before it can tell if anything is wrong. This idea is manifested (no pun intended) in 2 areas of the diagnosis process:
         //
@@ -407,25 +424,25 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
             throw Error.malformedToolsVersionSpecification(.versionSpecifier(.isMisspelt(String(versionSpecifier))))
         }
         
-        guard version > .v5_3 || manifestComponents.isCompatibleWithPreSwift5_3_1 else {
+        guard version > .vNext || manifestComponents.isCompatibleWithPreSwiftNext else {
             let manifestLeadingWhitespace = manifestComponents.leadingWhitespace
             if !manifestLeadingWhitespace.allSatisfy({ $0 == "\n" }) {
-                throw Error.backwardIncompatiblePre5_3_1(.leadingWhitespace(String(manifestLeadingWhitespace)), specifiedVersion: version)
+                throw Error.backwardIncompatiblePreNext(.leadingWhitespace(String(manifestLeadingWhitespace)), specifiedVersion: version)
             }
             
             let spacingAfterCommentMarker = toolsVersionSpecificationComponents.spacingAfterCommentMarker
             if spacingAfterCommentMarker != "\u{20}" {
-                throw Error.backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker(String(spacingAfterCommentMarker)), specifiedVersion: version)
+                throw Error.backwardIncompatiblePreNext(.spacingAfterCommentMarker(String(spacingAfterCommentMarker)), specifiedVersion: version)
             }
             
             let spacingAfterLabel = toolsVersionSpecificationComponents.spacingAfterLabel
             if !spacingAfterLabel.isEmpty {
-                throw Error.backwardIncompatiblePre5_3_1(.spacingAfterLabel(String(spacingAfterLabel)), specifiedVersion: version)
+                throw Error.backwardIncompatiblePreNext(.spacingAfterLabel(String(spacingAfterLabel)), specifiedVersion: version)
             }
             
-            // The above If-statements should have covered all possible backward incompatibilities with Swift ≤ 5.3.
+            // The above If-statements should have covered all possible backward incompatibilities with Swift < Next.
             // If you changed the logic in this file, and this fatal error is triggered, then you need to re-check the logic, and make sure all possible error conditions are covered in the Else-block.
-            throw Error.backwardIncompatiblePre5_3_1(.unidentified, specifiedVersion: version)
+            throw Error.backwardIncompatiblePreNext(.unidentified, specifiedVersion: version)
         }
         
         return version
@@ -441,12 +458,12 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
     ///                                                      ⎪
     ///                                                      ⎭
     ///       ┌ Swift tools version specification
-    ///       │                              ┌ ignored trailing contents
-    ///       ⌄~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~⌄~~~~~~~~~~
-    ///       //  swift-tools-version:  5.3.1;2020-09-16     } the Swift tools version specification line
-    ///     ⌃~⌃~⌃~⌃~~~~~~~~~~~~~~~~~~~⌃~⌃~~~~⌃⌃~~~~~~~~~
-    ///     │ │ │ └ label             │ │    │└ trailing comment segment including a trailing line terminator, if any (not returned by this function)
-    ///     │ │ └ spacing             │ │    └ specification terminator (not returned by this function)
+    ///       │                             ┌ ignored trailing contents
+    ///       ⌄~~~~~~~~~~~~~~~~~~~~~~~~~~~~~⌄~~~~~~~~~~
+    ///       //  swift-tools-version:  Next;2020-09-16     } the Swift tools version specification line
+    ///     ⌃~⌃~⌃~⌃~~~~~~~~~~~~~~~~~~~⌃~⌃~~~⌃⌃~~~~~~~~~
+    ///     │ │ │ └ label             │ │   │└ trailing comment segment including a trailing line terminator, if any (not returned by this function)
+    ///     │ │ └ spacing             │ │   └ specification terminator (not returned by this function)
     ///     │ └ comment marker        │ └ version specifier
     ///     │                         └ spacing
     ///     └ additional leading whitespace
@@ -520,28 +537,28 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         //
         // 1. A well-formatted Swift tools version specification
         //
-        //        // swift-tools-version: 5.3.1
+        //        // swift-tools-version: Next
         //
         //    The `endIndex` of the label can be clearly identified with the first ":", and the `startIndex` of the version specifier can be clearly identified with the first digit "5".
         //
         // 2. A misspelt label with a digit within:
         //
-        //        // swift-too1s-version: 5.3.1
+        //        // swift-too1s-version: Next
         //    The `endIndex` of the label can be identified with the first ":"; the `startIndex` of the version specifier can be identified with the digit "5", if and only if the search for the first ":" takes precedence.
         //
         // 3. A misspelt label with a colon and a digit within:
         //
-        //        // sw:ft-too1s-version: 5.3.1
+        //        // sw:ft-too1s-version: Next
         //
         //    The `endIndex` of the label can be identified with the last ":";  the `startIndex` of the version specifier can be identified with the digit "5", if and only if the search for the last ":" takes precedence.
         //
         // Between example 2 and 3, the rules are already conflicting. Although the examples above are purposely constructed to illustrate the ineffectiveness of using ":" and digits to locate the label and the version specifier, it's undeniable a human can flawlessly point out where the labels and version specifiers are at a glance. There are more examples that shows it's even harder to find a one-size-fits-all landmark-based rule than illustrated above:
         //
-        //     // swift-too1s-version:-5.3.1
-        //     // swift-too1s-version 5:3:1
-        //     // swift tools version 5-3-l
-        //     // swift-tools-version: s.3.1
-        //     // swift-tools-version::5.3.1
+        //     // swift-too1s-version:-Next
+        //     // swift-too1s-version 5:4:0
+        //     // swift tools version 5-4-1
+        //     // swift-tools-version: S.A.I
+        //     // swift-tools-version::Next
         //     ...
         //
         // One useful information we can glean from these examples is that using both ":" and digits as landmarks doesn't work, so it's better to stick with just one of them and ignore the other. Because the version specifier is the more important component than the label is, the current implementation of this function searches for the first numerical character in the sequence to prioritize the identification of the version specifier. The ":"-first approach isn't completely abandoned, either: If the sequence is prefixed with "swift-tools-version:" (case-insensitive), then we can be mostly certain that the user has provided a well-formatted label, and use the position past that of the first ":" in the sequence as the `startIndex` of the label. There are still countless label misspellings that begin with "swift-tools-version:", but since for all of them, the misspelt part comes after the well-formed part, in the interest of keeping the logic relatively straightforward, the labels' misspellings in this sort of situation are carried over as the version specifiers'.
@@ -577,18 +594,18 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
             // `Character.isNumber` is true for more than just decimal characters (e.g. ㊅ and 𝟘), but `CharacterSet.contains(_:)` works only on Unicode scalars.
             startIndexOfVersionSpecifier = specificationSnippetFromLabelToLineTerminator.firstIndex(where: \.isNumber) ?? specificationWithIgnoredTrailingContents.endIndex
             /// The label part of the Swift tools version specification with the whitespace sequence between the label and the version specifier.
-            /// - Note: For a misspelt Swift tools version specification `"// swift-too1s-version: 5.3.1"`, the label stops at the second `"o"`, so only `"swift-too"` is recognised as the label with no spacing following it.
+            /// - Note: For a misspelt Swift tools version specification `"// swift-too1s-version: Next"`, the label stops at the second `"o"`, so only `"swift-too"` is recognised as the label with no spacing following it.
             let labelWithTrailingWhitespace = specificationWithIgnoredTrailingContents[startIndexOfLabel..<startIndexOfVersionSpecifier]
             // Because there is no whitespace within the label, and because the spacing consists of only horizontal whitespace characters, the end index of the label is the same as the position of the first whitespace character between the beginning of the label and the beginning of the version specifier. If no such whitespace character exists, then there is no spacing, and so this position is the `endIndex` of these sequence of characters (i.e. the starting position of the version specifier).
             endIndexOfLabel = labelWithTrailingWhitespace.firstIndex(where: \.isWhitespace) ?? startIndexOfVersionSpecifier
         }
         
         /// The label part of the Swift tools version specification.
-        /// - Note: For a misspelt Swift tools version specification `"// swift-too1s-version: 5.3.1"`, the label stops at the second `"o"`, so only `"swift-too"` is recognised as the label.
+        /// - Note: For a misspelt Swift tools version specification `"// swift-too1s-version: Next"`, the label stops at the second `"o"`, so only `"swift-too"` is recognised as the label.
         let label = specificationSnippetFromLabelToLineTerminator[startIndexOfLabel..<endIndexOfLabel]
         
         /// The spacing between the label part of the Swift tools version specification and the version specifier.
-        /// - Note: For a misspelt Swift tools version specification `"// swift-too1s-version: 5.3.1"`, the label stops at the second `"o"`, and the version specifier starts from the first `"1"`, so no spacing is recognised.
+        /// - Note: For a misspelt Swift tools version specification `"// swift-too1s-version: Next"`, the label stops at the second `"o"`, and the version specifier starts from the first `"1"`, so no spacing is recognised.
         let spacingAfterLabel = specificationSnippetFromLabelToLineTerminator[endIndexOfLabel..<startIndexOfVersionSpecifier]
         
         /// The position of the version specifier's terminator.
@@ -598,7 +615,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         //                                                                                                                                          ☝️
         // Technically, this is looking for the position of the first ";" only, not the first line terminator. However, because the Swift tools version specification does not contain any line terminator, we can safely search just the first ";".
         
-        // If the label doesn't start with "// swift-too1s-version: 5.3.1", the version specifier and its terminator together are first found by locating the first numeric character in the specification line, and the version specifier starts with that first numeric character. So, if the version specifier is empty, then the line has no numeric characters, then the specification's ignored trailing contents are empty too. Basically, if the version specifier is empty, then the specification has no ignored trailing contents. This is only true for when the label doesn't start with "// swift-too1s-version: 5.3.1".
+        // If the label doesn't start with "// swift-too1s-version: Next", the version specifier and its terminator together are first found by locating the first numeric character in the specification line, and the version specifier starts with that first numeric character. So, if the version specifier is empty, then the line has no numeric characters, then the specification's ignored trailing contents are empty too. Basically, if the version specifier is empty, then the specification has no ignored trailing contents. This is only true for when the label doesn't start with "// swift-too1s-version: Next".
         
         /// The version specifier.
         /// - Note: For a misspelt Swift tools version specification `"// swift-too1s-version:5.3"`, the first `"1"` is considered as the first character of the version specifier, and so `"1s-version:5.3"` is taken as the version specifier.

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -188,8 +188,8 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
     ///
     /// The constituent parts include the spacing between "//" and "swift-tools-version", and the version specifier, if either is present.
     ///
-    /// - Parameter bytes: The raw bytes of the content of `Package.swift`.
-    /// - Returns: The spacing between "//" and "swift-tools-version" (if present, or `nil`), the version specifier (if present, or `nil`), and of raw bytes of the rest of the content of `Package.swift`.
+    /// - Parameter bytes: The raw bytes of the content of the manifest.
+    /// - Returns: The spacing between "//" and "swift-tools-version" (if present, or `nil`), the version specifier (if present, or `nil`), and of raw bytes of the rest of the content of the manifest.
     public static func split(_ bytes: ByteString) -> (spacingAfterSlashes: String?, versionSpecifier: String?, rest: [UInt8]) {
         let splitted = bytes.contents.split(
             separator: UInt8(ascii: "\n"),

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -174,10 +174,10 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         return (versionSpecifier, splitted.count == 1 ? [] : Array(splitted[1]))
     }
 
-    /// The regex to match swift tools version specification:
-    /// * It should start with `//` followed by any amount of _horizontal_ whitespace characters.
-    /// * Following that it should contain the case insensitive string `swift-tools-version:`.
-    /// * The text between the above string and `;` or string end becomes the tools version specifier.
+    /// The regex to match swift tools version specification
+    /// - It should start with `//` followed by any amount of _horizontal_ whitespace characters.
+    /// - Following that it should contain the case insensitive string `swift-tools-version:`.
+    /// - The text between the above string and `;` or string end becomes the tools version specifier.
     static let regex = try! NSRegularExpression(
         pattern: "^//\\h*?swift-tools-version:(.*?)(?:;.*|$)",
         options: [.caseInsensitive])

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -174,7 +174,7 @@ public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
         return (versionSpecifier, splitted.count == 1 ? [] : Array(splitted[1]))
     }
 
-    /// The regex to match swift tools version specification
+    /// The regex to match swift tools version specification.
     /// - It should start with `//` followed by any amount of _horizontal_ whitespace characters.
     /// - Following that it should contain the case insensitive string `swift-tools-version:`.
     /// - The text between the above string and `;` or string end becomes the tools version specifier.

--- a/Sources/Workspace/ToolsVersionWriter.swift
+++ b/Sources/Workspace/ToolsVersionWriter.swift
@@ -35,6 +35,13 @@ public func writeToolsVersion(at path: AbsolutePath, version: ToolsVersion, fs: 
     stream <<< "\n"
     // Append the file contents except for version specifier line.
     stream <<< ToolsVersionLoader.split(contents).rest
+	// FIXME: `split(_:)` above has been deprecated.
+	// However, its replacement (commented out below) causes failures in `FunctionTests` and `WorkspaceTests`.
+//	guard let contentsDecodedWithUTF8 = contents.validDescription else {
+//		throw ToolsVersionLoader.Error.nonUTF8EncodedManifest(path: file)
+//	}
+//	// It's safe to force-unwrap, because `contentsDecodedWithUTF8` has been successfully decoded using UTF-8.
+//	stream <<< ToolsVersionLoader.split(contentsDecodedWithUTF8).contentsAfterToolsVersionSpecification.data(using: .utf8)!
 
     try fs.writeFileContents(file, bytes: stream.bytes)
 }

--- a/Sources/Workspace/ToolsVersionWriter.swift
+++ b/Sources/Workspace/ToolsVersionWriter.swift
@@ -22,7 +22,7 @@ public func writeToolsVersion(at path: AbsolutePath, version: ToolsVersion, fs: 
     let file = path.appending(component: Manifest.filename)
     assert(fs.isFile(file), "Tools version file not present")
 
-    // Get the current contents of the file.
+    /// The current contents of the file.
     let contents = try fs.readFileContents(file)
 
     let stream = BufferedOutputByteStream()
@@ -33,15 +33,24 @@ public func writeToolsVersion(at path: AbsolutePath, version: ToolsVersion, fs: 
         stream <<< "." <<< Format.asJSON(version.patch)
     }
     stream <<< "\n"
-    // Append the file contents except for version specifier line.
-    stream <<< ToolsVersionLoader.split(contents).rest
-	// FIXME: `split(_:)` above has been deprecated.
-	// However, its replacement (commented out below) causes failures in `FunctionTests` and `WorkspaceTests`.
-//	guard let contentsDecodedWithUTF8 = contents.validDescription else {
-//		throw ToolsVersionLoader.Error.nonUTF8EncodedManifest(path: file)
-//	}
-//	// It's safe to force-unwrap, because `contentsDecodedWithUTF8` has been successfully decoded using UTF-8.
-//	stream <<< ToolsVersionLoader.split(contentsDecodedWithUTF8).contentsAfterToolsVersionSpecification.data(using: .utf8)!
+    
+    // The following lines up to line 54 append the file contents except for the Swift tools version specification line.
+    
+    guard let contentsDecodedWithUTF8 = contents.validDescription else {
+        throw ToolsVersionLoader.Error.nonUTF8EncodedManifest(path: file)
+    }
+    
+    let manifestComponents = ToolsVersionLoader.split(contentsDecodedWithUTF8)
+    
+    let toolsVersionSpecificationComponents = manifestComponents.toolsVersionSpecificationComponents
+    
+    // Replace the Swift tools version specification line if and only if it's well-formed up to the version specifier.
+    // This matches the behaviour of the old (now removed) [`ToolsVersionLoader.split(:_)`](https://github.com/WowbaggersLiquidLunch/swift-package-manager/blob/49cfc46bc5defd3ce8e0c0261e3e2cb475bcdb91/Sources/PackageLoading/ToolsVersionLoader.swift#L160).
+    if toolsVersionSpecificationComponents.everythingUpToVersionSpecifierIsWellFormed {
+        stream <<< ByteString(encodingAsUTF8: String(manifestComponents.contentsAfterToolsVersionSpecification))
+    } else {
+        stream <<< contents
+    }
 
     try fs.writeFileContents(file, bytes: stream.bytes)
 }

--- a/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
@@ -33,7 +33,7 @@ class ToolsVersionLoaderTests: XCTestCase {
     func testValidVersions() throws {
 
         let validVersions = [
-            // No space between "//" and "swift-tools-version" for Swift > 5.3:
+            // No spacing between "//" and "swift-tools-version" for Swift > 5.3:
             "//swift-tools-version:5.4"                : (5, 4, 0, "5.4.0"),
             "//swift-tools-version:5.4-dev"            : (5, 4, 0, "5.4.0"),
             "//swift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
@@ -44,7 +44,7 @@ class ToolsVersionLoaderTests: XCTestCase {
             "//swift-tools-version:6.1.2;x;x;x;x;x;"   : (6, 1, 2, "6.1.2"),
             "//swift-toolS-version:5.5.2;hello"        : (5, 5, 2, "5.5.2"),
             "//sWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n"       : (5, 5, 2, "5.5.2"),
-            // 1 space character (" ") between "//" and "swift-tools-version":
+            // 1 space (U+0020) between "//" and "swift-tools-version":
             "// swift-tools-version:3.1"                : (3, 1, 0, "3.1.0"),
             "// swift-tools-version:3.1-dev"            : (3, 1, 0, "3.1.0"),
             "// swift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
@@ -55,7 +55,7 @@ class ToolsVersionLoaderTests: XCTestCase {
             "// swift-tools-version:3.1.2;x;x;x;x;x;"   : (3, 1, 2, "3.1.2"),
             "// swift-toolS-version:3.5.2;hello"        : (3, 5, 2, "3.5.2"),
             "// sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : (3, 5, 2, "3.5.2"),
-            // 1 horizontal tab character ("    ") between "//" and "swift-tools-version" for Swift > 5.3:
+            // 1 character tabulation (U+0009) between "//" and "swift-tools-version" for Swift > 5.3:
             "//\tswift-tools-version:5.4"                : (5, 4, 0, "5.4.0"),
             "//\tswift-tools-version:5.4-dev"            : (5, 4, 0, "5.4.0"),
             "//\tswift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
@@ -66,7 +66,7 @@ class ToolsVersionLoaderTests: XCTestCase {
             "//\tswift-tools-version:6.1.2;x;x;x;x;x;"   : (6, 1, 2, "6.1.2"),
             "//\tswift-toolS-version:5.5.2;hello"        : (5, 5, 2, "5.5.2"),
             "//\tsWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n"       : (5, 5, 2, "5.5.2"),
-//            // 1 horizontal tab character followed by 1 space character ("     ") between "//" and "swift-tools-version" for Swift > 5.3:
+            // 1 character tabulation (U+0009) followed by 1 space (U+0020) between "//" and "swift-tools-version" for Swift > 5.3:
             "// \tswift-tools-version:5.4"                : (5, 4, 0, "5.4.0"),
             "// \tswift-tools-version:5.4-dev"            : (5, 4, 0, "5.4.0"),
             "// \tswift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
@@ -77,7 +77,7 @@ class ToolsVersionLoaderTests: XCTestCase {
             "// \tswift-tools-version:6.1.2;x;x;x;x;x;"   : (6, 1, 2, "6.1.2"),
             "// \tswift-toolS-version:5.5.2;hello"        : (5, 5, 2, "5.5.2"),
             "// \tsWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n"       : (5, 5, 2, "5.5.2"),
-//            // An assortment of horizontal whitespace characters between "//" and "swift-tools-version" for Swift > 5.3:
+            // An assortment of horizontal whitespace characters between "//" and "swift-tools-version" for Swift > 5.3:
             "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.4"                : (5, 4, 0, "5.4.0"),
             "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.4-dev"            : (5, 4, 0, "5.4.0"),
             "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
@@ -172,7 +172,7 @@ class ToolsVersionLoaderTests: XCTestCase {
     /// Verifies that for Swift tools version ≤ 5.3, an error is thrown if anything but a single U+0020 is used as spacing between "//" and "swift-tools-version".
     func testBackwardCompatibilityError() throws {
         
-        // MARK: No space between "//" and "swift-tools-version" for Swift ≤ 5.3
+        // MARK: No spacing between "//" and "swift-tools-version" for Swift ≤ 5.3
         
         let specificationsWithZeroSpacing = [
             "//swift-tools-version:3.1"                : "3.1.0",
@@ -206,7 +206,7 @@ class ToolsVersionLoaderTests: XCTestCase {
             }
         }
         
-        // MARK: 1 horizontal tab character (U+0009) between "//" and "swift-tools-version"
+        // MARK: 1 character tabulation (U+0009) between "//" and "swift-tools-version"
         
         let specificationsWith1TabAfterSlashes = [
             "//\tswift-tools-version:3.1"                : "3.1.0",
@@ -240,7 +240,7 @@ class ToolsVersionLoaderTests: XCTestCase {
             }
         }
         
-        // MARK: 1 space and 1 horizontal tab character (U+0009) between "//" and "swift-tools-version"
+        // MARK: 1 space (U+0020) and 1 character tabulation (U+0009) between "//" and "swift-tools-version"
         
         let specificationsWith1SpaceAnd1TabAfterSlashes = [
             "// \tswift-tools-version:3.1"                : "3.1.0",

--- a/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
@@ -166,7 +166,7 @@ class ToolsVersionLoaderTests: XCTestCase {
                 
                 XCTAssertEqual(
                     error.description,
-                    "the manifest is missing a Swift tools version specification; consider prepending to the manifest '// swift-tools-version:\(ToolsVersion.currentToolsVersion)' to specify the current Swift toolchain version as the lowest supported version by the project; if such a specification already exists, consider moving it to the top of the manifest, or prepending it with '//' to help Swift Package Manager find it"
+                    "the manifest is missing a Swift tools version specification; consider prepending to the manifest '// swift-tools-version:\(ToolsVersion.currentToolsVersion)' to specify the current Swift toolchain version as the lowest Swift version supported by the project; if such a specification already exists, consider moving it to the top of the manifest, or prepending it with '//' to help Swift Package Manager find it"
                 )
             }
         }
@@ -206,7 +206,7 @@ class ToolsVersionLoaderTests: XCTestCase {
                 }
                 XCTAssertEqual(
                     error.description,
-                    "the manifest is missing a Swift tools version specification; consider prepending to the manifest '// swift-tools-version:\(ToolsVersion.currentToolsVersion)' to specify the current Swift toolchain version as the lowest supported version by the project; if such a specification already exists, consider moving it to the top of the manifest, or prepending it with '//' to help Swift Package Manager find it"
+                    "the manifest is missing a Swift tools version specification; consider prepending to the manifest '// swift-tools-version:\(ToolsVersion.currentToolsVersion)' to specify the current Swift toolchain version as the lowest Swift version supported by the project; if such a specification already exists, consider moving it to the top of the manifest, or prepending it with '//' to help Swift Package Manager find it"
                 )
             }
         }
@@ -273,7 +273,7 @@ class ToolsVersionLoaderTests: XCTestCase {
                 }
                 XCTAssertEqual(
                     error.description,
-                    "the Swift tools version specification is missing a version specifier; consider appending '\(ToolsVersion.currentToolsVersion)' to the line to specify the current Swift toolchain version as the lowest supported version by the project"
+                    "the Swift tools version specification is missing a version specifier; consider appending '\(ToolsVersion.currentToolsVersion)' to the line to specify the current Swift toolchain version as the lowest Swift version supported by the project"
                 )
             }
         }
@@ -360,7 +360,7 @@ class ToolsVersionLoaderTests: XCTestCase {
                 }
                 XCTAssertEqual(
                     error.description,
-                    "the Swift tools version '\(misspeltVersionSpecifier)' is misspelt or otherwise invalid; consider replacing it with '\(ToolsVersion.currentToolsVersion)' to specify the current Swift toolchain version as the lowest supported version by the project"
+                    "the Swift tools version '\(misspeltVersionSpecifier)' is misspelt or otherwise invalid; consider replacing it with '\(ToolsVersion.currentToolsVersion)' to specify the current Swift toolchain version as the lowest Swift version supported by the project"
                 )
             }
         }

--- a/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
@@ -273,7 +273,7 @@ class ToolsVersionLoaderTests: XCTestCase {
                 }
                 XCTAssertEqual(
                     error.description,
-                    "the Swift tools version specification is missing a version specifier; consider appending '\(ToolsVersion.currentToolsVersion)' to the line to specify the current Swift toolchain version as the lowest Swift version supported by the project"
+                    "the Swift tools version specification is possibly missing a version specifier; consider using 'swift-tools-version:\(ToolsVersion.currentToolsVersion)' to specify the current Swift toolchain version as the lowest Swift version supported by the project"
                 )
             }
         }
@@ -345,6 +345,9 @@ class ToolsVersionLoaderTests: XCTestCase {
             "// swift-tools-version:5²",
             "// swift-tools-version:5⃣️.2⃣️",
             "// swift-tools-version:5 ÷ 2 = 2.5",
+            // If the label starts with exactly "swift-tools-version:" (case-insensitive), then all its misspellings are treated as the version specifier's.
+            "// swift-tools-version::5.2",
+            "// Swift-tOOls-versIon:-2.5",
             // Misspelt version specifiers are diagnosed before backward-compatibility checks.
             "\u{A}\u{B}\u{C}\u{D}//\u{3000}swift-tools-version:五.二\u{2028}",
         ]

--- a/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
@@ -192,8 +192,8 @@ class ToolsVersionLoaderTests: XCTestCase {
                 try load(ByteString(encodingAsUTF8: manifestSnippet)),
                 "a 'ToolsVersionLoader.Error' should've been thrown, because the Swift tools version specification is missing from the manifest snippet"
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .malformedToolsVersionSpecification(.missingCommentMarker) = error else {
-                    XCTFail("'ToolsVersionLoader.Error.malformedToolsVersionSpecification(.missingCommentMarker)' should've been thrown, but a different error is thrown")
+                guard let error = error as? ToolsVersionLoader.Error, case .malformedToolsVersionSpecification(.commentMarker(.isMissing)) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.malformedToolsVersionSpecification(.commentMarker(.isMissing))' should've been thrown, but a different error is thrown")
                     return
                 }
                 
@@ -233,8 +233,8 @@ class ToolsVersionLoaderTests: XCTestCase {
                 try load(ByteString(encodingAsUTF8: manifestSnippet)),
                 "a 'ToolsVersionLoader.Error' should've been thrown, because the comment marker is missing from the Swift tools version specification"
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .malformedToolsVersionSpecification(.missingCommentMarker) = error else {
-                    XCTFail("'ToolsVersionLoader.Error.malformedToolsVersionSpecification(.missingCommentMarker)' should've been thrown, but a different error is thrown")
+                guard let error = error as? ToolsVersionLoader.Error, case .malformedToolsVersionSpecification(.commentMarker(.isMissing)) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.malformedToolsVersionSpecification(.commentMarker(.isMissing))' should've been thrown, but a different error is thrown")
                     return
                 }
                 XCTAssertEqual(
@@ -268,8 +268,8 @@ class ToolsVersionLoaderTests: XCTestCase {
                 try load(ByteString(encodingAsUTF8: manifestSnippet)),
                 "a 'ToolsVersionLoader.Error' should've been thrown, because the label is missing from the Swift tools version specification"
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .malformedToolsVersionSpecification(.missingLabel) = error else {
-                    XCTFail("'ToolsVersionLoader.Error.malformedToolsVersionSpecification(.missingLabel)' should've been thrown, but a different error is thrown")
+                guard let error = error as? ToolsVersionLoader.Error, case .malformedToolsVersionSpecification(.label(.isMissing)) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.malformedToolsVersionSpecification(.label(.isMissing))' should've been thrown, but a different error is thrown")
                     return
                 }
                 XCTAssertEqual(
@@ -300,8 +300,8 @@ class ToolsVersionLoaderTests: XCTestCase {
                 try load(ByteString(encodingAsUTF8: manifestSnippet)),
                 "a 'ToolsVersionLoader.Error' should've been thrown, because the version specifier is missing from the Swift tools version specification"
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .malformedToolsVersionSpecification(.missingVersionSpecifier) = error else {
-                    XCTFail("'ToolsVersionLoader.Error.malformedToolsVersionSpecification(.missingVersionSpecifier)' should've been thrown, but a different error is thrown")
+                guard let error = error as? ToolsVersionLoader.Error, case .malformedToolsVersionSpecification(.versionSpecifier(.isMissing)) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.malformedToolsVersionSpecification(.versionSpecifier(.isMissing))' should've been thrown, but a different error is thrown")
                     return
                 }
                 XCTAssertEqual(
@@ -332,13 +332,13 @@ class ToolsVersionLoaderTests: XCTestCase {
                 try load(ByteString(encodingAsUTF8: manifestSnippet)),
                 "a 'ToolsVersionLoader.Error' should've been thrown, because the comment marker is misspelt in the Swift tools version specification"
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .malformedToolsVersionSpecification(.commentMarker(let misspeltCommentMarker)) = error else {
-                    XCTFail("'ToolsVersionLoader.Error.malformedToolsVersionSpecification(.commentMarker)' should've been thrown, but a different error is thrown")
+                guard let error = error as? ToolsVersionLoader.Error, case .malformedToolsVersionSpecification(.commentMarker(.isMisspelt(let misspeltCommentMarker))) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.malformedToolsVersionSpecification(.commentMarker(.isMisspelt))' should've been thrown, but a different error is thrown")
                     return
                 }
                 XCTAssertEqual(
                     error.description,
-                    "the comment marker '\(misspeltCommentMarker)' is malformed for the Swift tools version specification; consider replacing it with '//'"
+                    "the comment marker '\(misspeltCommentMarker)' is misspelt for the Swift tools version specification; consider replacing it with '//'"
                 )
             }
         }
@@ -360,13 +360,13 @@ class ToolsVersionLoaderTests: XCTestCase {
                 try load(ByteString(encodingAsUTF8: manifestSnippet)),
                 "a 'ToolsVersionLoader.Error' should've been thrown, because the label is misspelt in the Swift tools version specification"
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .malformedToolsVersionSpecification(.label(let misspeltLabel)) = error else {
-                    XCTFail("'ToolsVersionLoader.Error.malformedToolsVersionSpecification(.label)' should've been thrown, but a different error is thrown")
+                guard let error = error as? ToolsVersionLoader.Error, case .malformedToolsVersionSpecification(.label(.isMisspelt(let misspeltLabel))) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.malformedToolsVersionSpecification(.label(.isMisspelt))' should've been thrown, but a different error is thrown")
                     return
                 }
                 XCTAssertEqual(
                     error.description,
-                    "the Swift tools version specification's label '\(misspeltLabel)' is malformed; consider replacing it with 'swift-tools-version:'"
+                    "the Swift tools version specification's label '\(misspeltLabel)' is misspelt; consider replacing it with 'swift-tools-version:'"
                 )
             }
         }
@@ -387,13 +387,13 @@ class ToolsVersionLoaderTests: XCTestCase {
                 try load(ByteString(encodingAsUTF8: manifestSnippet)),
                 "a 'ToolsVersionLoader.Error' should've been thrown, because the version specifier is misspelt in the Swift tools version specification"
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .malformedToolsVersionSpecification(.versionSpecifier(let misspeltVersionSpecifier)) = error else {
-                    XCTFail("'ToolsVersionLoader.Error.malformedToolsVersionSpecification(.versionSpecifier)' should've been thrown, but a different error is thrown")
+                guard let error = error as? ToolsVersionLoader.Error, case .malformedToolsVersionSpecification(.versionSpecifier(.isMisspelt(let misspeltVersionSpecifier))) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.malformedToolsVersionSpecification(.versionSpecifier(.isMisspelt))' should've been thrown, but a different error is thrown")
                     return
                 }
                 XCTAssertEqual(
                     error.description,
-                    "the Swift tools version '\(misspeltVersionSpecifier)' is not valid; consider replacing it with '\(ToolsVersion.currentToolsVersion)' to specify the current Swift toolchain version as the lowest supported version by the project"
+                    "the Swift tools version '\(misspeltVersionSpecifier)' is misspelt or otherwise invalid; consider replacing it with '\(ToolsVersion.currentToolsVersion)' to specify the current Swift toolchain version as the lowest supported version by the project"
                 )
             }
         }

--- a/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
@@ -8,6 +8,11 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+// FIXME: Be careful when replacing "Next" with a concrete version number.
+// Please read the corresponding FIXME in `ToolsVersionLoader.swift` first.
+// In order for tests to work with Swift Next, many version numbers's major version increased by 9990 (i.e. prepended by "999"). Please subtract them all by 9990 when replacing Swift Next to a concrete version.
+// Swift Next is assumed to be Swift 5.4 in this file. If this assumption is incorrect, then please change all occurrences of "5.4" and "5.4.0" to the correct version number, and change all version numbers in any failing cases accordingly by adding the difference between the correct Next version and 5.4 to them.
+
 import XCTest
 
 import TSCBasic
@@ -33,83 +38,83 @@ class ToolsVersionLoaderTests: XCTestCase {
     func testValidVersions() throws {
 
         let validVersions = [
-            // No spacing surrounding the label for Swift > 5.3:
-            "//swift-tools-version:5.4"                : (5, 4, 0, "5.4.0"),
-            "//swift-tools-version:5.4-dev"            : (5, 4, 0, "5.4.0"),
-            "//swift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
-            "//swift-tools-version:5.8.0-dev.al+sha.x" : (5, 8, 0, "5.8.0"),
-            "//swift-tools-version:6.1.2"              : (6, 1, 2, "6.1.2"),
-            "//swift-tools-version:6.1.2;"             : (6, 1, 2, "6.1.2"),
-            "//swift-tools-vErsion:6.1.2;;;;;"         : (6, 1, 2, "6.1.2"),
-            "//swift-tools-version:6.1.2;x;x;x;x;x;"   : (6, 1, 2, "6.1.2"),
-            "//swift-toolS-version:5.5.2;hello"        : (5, 5, 2, "5.5.2"),
-            "//sWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n"       : (5, 5, 2, "5.5.2"),
-            // No spacing before, and 1 space (U+0020) after the label for Swift > 5.3:
-            "//swift-tools-version: 5.4"                : (5, 4, 0, "5.4.0"),
-            "//swift-tools-version: 5.4-dev"            : (5, 4, 0, "5.4.0"),
-            "//swift-tools-version: 5.8.0"              : (5, 8, 0, "5.8.0"),
-            "//swift-tools-version: 5.8.0-dev.al+sha.x" : (5, 8, 0, "5.8.0"),
-            "//swift-tools-version: 6.1.2"              : (6, 1, 2, "6.1.2"),
-            "//swift-tools-version: 6.1.2;"             : (6, 1, 2, "6.1.2"),
-            "//swift-tools-vErsion: 6.1.2;;;;;"         : (6, 1, 2, "6.1.2"),
-            "//swift-tools-version: 6.1.2;x;x;x;x;x;"   : (6, 1, 2, "6.1.2"),
-            "//swift-toolS-version: 5.5.2;hello"        : (5, 5, 2, "5.5.2"),
-            "//sWiFt-tOoLs-vErSiOn: 5.5.2\nkkk\n"       : (5, 5, 2, "5.5.2"),
+            // No spacing surrounding the label for Swift ≥ Next:
+            "//swift-tools-version:9995.4.0"              : (9995, 4, 0, "9995.4.0"),
+            "//swift-tools-version:9995.4-dev"            : (9995, 4, 0, "9995.4.0"),
+            "//swift-tools-version:9995.8.0"              : (9995, 8, 0, "9995.8.0"),
+            "//swift-tools-version:9995.8.0-dev.al+sha.x" : (9995, 8, 0, "9995.8.0"),
+            "//swift-tools-version:9996.1.2"              : (9996, 1, 2, "9996.1.2"),
+            "//swift-tools-version:9996.1.2;"             : (9996, 1, 2, "9996.1.2"),
+            "//swift-tools-vErsion:9996.1.2;;;;;"         : (9996, 1, 2, "9996.1.2"),
+            "//swift-tools-version:9996.1.2;x;x;x;x;x;"   : (9996, 1, 2, "9996.1.2"),
+            "//swift-toolS-version:9995.5.2;hello"        : (9995, 5, 2, "9995.5.2"),
+            "//sWiFt-tOoLs-vErSiOn:9995.5.2\nkkk\n"       : (9995, 5, 2, "9995.5.2"),
+            // No spacing before, and 1 space (U+0020) after the label for Swift ≥ Next:
+            "//swift-tools-version: 9995.4.0"              : (9995, 4, 0, "9995.4.0"),
+            "//swift-tools-version: 9995.4-dev"            : (9995, 4, 0, "9995.4.0"),
+            "//swift-tools-version: 9995.8.0"              : (9995, 8, 0, "9995.8.0"),
+            "//swift-tools-version: 9995.8.0-dev.al+sha.x" : (9995, 8, 0, "9995.8.0"),
+            "//swift-tools-version: 9996.1.2"              : (9996, 1, 2, "9996.1.2"),
+            "//swift-tools-version: 9996.1.2;"             : (9996, 1, 2, "9996.1.2"),
+            "//swift-tools-vErsion: 9996.1.2;;;;;"         : (9996, 1, 2, "9996.1.2"),
+            "//swift-tools-version: 9996.1.2;x;x;x;x;x;"   : (9996, 1, 2, "9996.1.2"),
+            "//swift-toolS-version: 9995.5.2;hello"        : (9995, 5, 2, "9995.5.2"),
+            "//sWiFt-tOoLs-vErSiOn: 9995.5.2\nkkk\n"       : (9995, 5, 2, "9995.5.2"),
             // 1 space (U+0020) before, and no spacing after the label:
-            "// swift-tools-version:3.1"                : (3, 1, 0, "3.1.0"),
-            "// swift-tools-version:3.1-dev"            : (3, 1, 0, "3.1.0"),
-            "// swift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
-            "// swift-tools-version:5.8.0-dev.al+sha.x" : (5, 8, 0, "5.8.0"),
-            "// swift-tools-version:3.1.2"              : (3, 1, 2, "3.1.2"),
-            "// swift-tools-version:3.1.2;"             : (3, 1, 2, "3.1.2"),
-            "// swift-tools-vErsion:3.1.2;;;;;"         : (3, 1, 2, "3.1.2"),
-            "// swift-tools-version:3.1.2;x;x;x;x;x;"   : (3, 1, 2, "3.1.2"),
-            "// swift-toolS-version:3.5.2;hello"        : (3, 5, 2, "3.5.2"),
-            "// sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : (3, 5, 2, "3.5.2"),
+            "// swift-tools-version:9993.1"                : (9993, 1, 0, "9993.1.0"),
+            "// swift-tools-version:9993.1-dev"            : (9993, 1, 0, "9993.1.0"),
+            "// swift-tools-version:9995.8.0"              : (9995, 8, 0, "9995.8.0"),
+            "// swift-tools-version:9995.8.0-dev.al+sha.x" : (9995, 8, 0, "9995.8.0"),
+            "// swift-tools-version:9993.1.2"              : (9993, 1, 2, "9993.1.2"),
+            "// swift-tools-version:9993.1.2;"             : (9993, 1, 2, "9993.1.2"),
+            "// swift-tools-vErsion:9993.1.2;;;;;"         : (9993, 1, 2, "9993.1.2"),
+            "// swift-tools-version:9993.1.2;x;x;x;x;x;"   : (9993, 1, 2, "9993.1.2"),
+            "// swift-toolS-version:9993.5.2;hello"        : (9993, 5, 2, "9993.5.2"),
+            "// sWiFt-tOoLs-vErSiOn:9993.5.2\nkkk\n"       : (9993, 5, 2, "9993.5.2"),
             // leading line feeds (U+000A) before the specification, and 1 space (U+0020) before, and no spacing after the label:
-            "\n// swift-tools-version:3.1"                            : (3, 1, 0, "3.1.0"),
-            "\n\n// swift-tools-version:3.2-dev"                      : (3, 2, 0, "3.2.0"),
-            "\n\n\n// swift-tools-version:3.8.0"                      : (3, 8, 0, "3.8.0"),
-            "\n\n\n\n// swift-tools-version:4.8.0-dev.al+sha.x"       : (4, 8, 0, "4.8.0"),
-            "\n\n\n\n\n// swift-tools-version:3.1.2"                  : (3, 1, 2, "3.1.2"),
-            "\n\n\n\n\n\n// swift-tools-version:4.1.2;"               : (4, 1, 2, "4.1.2"),
-            "\n\n\n\n\n\n\n// swift-tools-vErsion:5.1.2;;;;;"         : (5, 1, 2, "5.1.2"),
-            "\n\n\n\n\n\n\n\n// swift-tools-version:6.1.2;x;x;x;x;x;" : (6, 1, 2, "6.1.2"),
-            "\n\n\n\n\n\n\n\n\n// swift-toolS-version:3.5.2;hello"    : (3, 5, 2, "3.5.2"),
-            "\n\n\n\n\n\n\n\n\n\n// sWiFt-tOoLs-vErSiOn:4.5.2\nkkk\n" : (4, 5, 2, "4.5.2"),
-            // An assortment of horizontal whitespace characters surrounding the label for Swift > 5.3:
-            "//swift-tools-version:\u{2002}\u{202F}\u{3000}\u{A0}\u{1680}\t\u{2000}\u{2001}5.4"                : (5, 4, 0, "5.4.0"),
-            "//\u{2001}swift-tools-version:\u{2002}\u{202F}\u{3000}\u{A0}\u{1680}\t\u{2000}5.4-dev"            : (5, 4, 0, "5.4.0"),
-            "//\t\u{2000}\u{2001}swift-tools-version:\u{2002}\u{202F}\u{3000}\u{A0}\u{1680}5.8.0"              : (5, 8, 0, "5.8.0"),
-            "//\u{1680}\t\u{2000}\u{2001}swift-tools-version:\u{2002}\u{202F}\u{3000}\u{A0}5.8.0-dev.al+sha.x" : (5, 8, 0, "5.8.0"),
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001}swift-tools-version:\u{2002}\u{202F}\u{3000}6.1.2"              : (6, 1, 2, "6.1.2"),
-            "//\u{3000}\u{A0}\u{1680}\t\u{2000}\u{2001}swift-tools-version:\u{2002}\u{202F}6.1.2;"             : (6, 1, 2, "6.1.2"),
-            "//\u{202F}\u{3000}\u{A0}\u{1680}\t\u{2000}\u{2001}swift-tools-vErsion:\u{2002}6.1.2;;;;;"         : (6, 1, 2, "6.1.2"),
-            "//\u{2002}\u{202F}\u{3000}\u{A0}\u{1680}\t\u{2000}\u{2001}swift-tools-version:6.1.2;x;x;x;x;x;"   : (6, 1, 2, "6.1.2"),
-            "//\u{2000}\u{2002}\u{202F}\u{3000}\t\u{2001}swift-toolS-version:\u{A0}\u{1680}5.5.2;hello"        : (5, 5, 2, "5.5.2"),
-            "//\u{2000}\u{2001}\u{2002}\u{202F}\u{3000}\tsWiFt-tOoLs-vErSiOn:\u{A0}\u{1680}5.5.2\nkkk\n"       : (5, 5, 2, "5.5.2"),
-            // Some leading whitespace characters, and no spacing surrounding the label for Swift > 5.3:
-            "\u{A} //swift-tools-version:5.4"                               : (5, 4, 0, "5.4.0"),
-            "\u{B}\t\u{A}//swift-tools-version:5.4-dev"                     : (5, 4, 0, "5.4.0"),
-            "\u{3000}\u{A0}\u{C}//swift-tools-version:5.8.0"                : (5, 8, 0, "5.8.0"),
-            "\u{2002}\u{D}\u{2001}//swift-tools-version:5.8.0-dev.al+sha.x" : (5, 8, 0, "5.8.0"),
-            "\u{D}\u{A}\u{A0}\u{1680}//swift-tools-version:6.1.2"           : (6, 1, 2, "6.1.2"),
-            "   \u{85}//swift-tools-version:6.1.2;"                         : (6, 1, 2, "6.1.2"),
-            "\u{2028}//swift-tools-vErsion:6.1.2;;;;;"                      : (6, 1, 2, "6.1.2"),
-            "\u{202F}\u{2029}//swift-tools-version:6.1.2;x;x;x;x;x;"        : (6, 1, 2, "6.1.2"),
-            "\u{A}\u{B}\u{C}\u{D}\u{A}\u{D}\u{85}\u{202F}\u{2029}\u{2001}\u{2002}\u{205F}\u{85}\u{2028}//swift-toolS-version:5.5.2;hello" : (5, 5, 2, "5.5.2"),
-            "\u{B}  \u{200A}\u{D}\u{A}\t\u{85}\u{85}\u{A}\u{2028}\u{2009}\u{2001}\u{C}//sWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n"                 : (5, 5, 2, "5.5.2"),
-            // Some leading whitespace characters, and an assortment of horizontal whitespace characters surrounding the label for Swift > 5.3:
-            "\u{2002}\u{202F}\u{A}//\u{A0}\u{1680}\t\u{2004}\u{2001} \u{2002}swift-tools-version:\u{3000}5.4"         : (5, 4, 0, "5.4.0"),
-            "\u{B}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}swift-tools-version:\u{202F}\u{3000}5.4-dev"             : (5, 4, 0, "5.4.0"),
-            "\u{C}//\u{A0}\u{1680}\t\u{2000}\u{2001} swift-tools-version:\u{2002}\u{202F}\u{3000}5.8.0"               : (5, 8, 0, "5.8.0"),
-            "\u{D}//\u{A0}\u{1680}\t\u{2005} \u{202F}\u{3000}swift-tools-version:\u{2001}5.8.0-dev.al+sha.x"          : (5, 8, 0, "5.8.0"),
-            "\u{D}\u{A}//\u{A0}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:\u{1680}\t\u{2000}6.1.2"          : (6, 1, 2, "6.1.2"),
-            "\u{85}//\u{2000}\u{2001} \u{2006}\u{202F}\u{3000}swift-tools-version:\u{A0}\u{1680}\t6.1.2;"             : (6, 1, 2, "6.1.2"),
-            "\u{2028}//\u{2001} \u{2002}\u{2007}\u{3000}swift-tools-vErsion:\u{A0}\u{1680}\t\u{2000}6.1.2;;;;;"       : (6, 1, 2, "6.1.2"),
-            "\u{2029}//\u{202F}\u{3000}swift-tools-version:\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}6.1.2;x;x;x;x;x;" : (6, 1, 2, "6.1.2"),
-            "\u{A}\u{D}\u{85}\u{202F}\u{2029}\u{A}\u{2028}//\u{2000}\u{2001}\u{9}swift-toolS-version:\u{A0}\u{1680}\t\u{2000}\u{2009} \u{2002}\u{202F}5.5.2;hello" : (5, 5, 2, "5.5.2"),
-            "\u{D}\u{A}\t\u{85}\u{85}\u{A}\u{2028}\u{2029}//\u{2001}\u{2002}\u{202F}sWiFt-tOoLs-vErSiOn:\u{1680}\t\u{2000}\u{200A} \u{2002}\u{202F}5.5.2\nkkk\n"   : (5, 5, 2, "5.5.2"),
+            "\n// swift-tools-version:9993.1"                            : (9993, 1, 0, "9993.1.0"),
+            "\n\n// swift-tools-version:9993.2-dev"                      : (9993, 2, 0, "9993.2.0"),
+            "\n\n\n// swift-tools-version:9993.8.0"                      : (9993, 8, 0, "9993.8.0"),
+            "\n\n\n\n// swift-tools-version:9994.8.0-dev.al+sha.x"       : (9994, 8, 0, "9994.8.0"),
+            "\n\n\n\n\n// swift-tools-version:9993.1.2"                  : (9993, 1, 2, "9993.1.2"),
+            "\n\n\n\n\n\n// swift-tools-version:9994.1.2;"               : (9994, 1, 2, "9994.1.2"),
+            "\n\n\n\n\n\n\n// swift-tools-vErsion:9995.1.2;;;;;"         : (9995, 1, 2, "9995.1.2"),
+            "\n\n\n\n\n\n\n\n// swift-tools-version:9996.1.2;x;x;x;x;x;" : (9996, 1, 2, "9996.1.2"),
+            "\n\n\n\n\n\n\n\n\n// swift-toolS-version:9993.5.2;hello"    : (9993, 5, 2, "9993.5.2"),
+            "\n\n\n\n\n\n\n\n\n\n// sWiFt-tOoLs-vErSiOn:9994.5.2\nkkk\n" : (9994, 5, 2, "9994.5.2"),
+            // An assortment of horizontal whitespace characters surrounding the label for Swift ≥ Next:
+            "//swift-tools-version:\u{2002}\u{202F}\u{3000}\u{A0}\u{1680}\t\u{2000}\u{2001}9995.4.0"              : (9995, 4, 0, "9995.4.0"),
+            "//\u{2001}swift-tools-version:\u{2002}\u{202F}\u{3000}\u{A0}\u{1680}\t\u{2000}9995.4-dev"            : (9995, 4, 0, "9995.4.0"),
+            "//\t\u{2000}\u{2001}swift-tools-version:\u{2002}\u{202F}\u{3000}\u{A0}\u{1680}9995.8.0"              : (9995, 8, 0, "9995.8.0"),
+            "//\u{1680}\t\u{2000}\u{2001}swift-tools-version:\u{2002}\u{202F}\u{3000}\u{A0}9995.8.0-dev.al+sha.x" : (9995, 8, 0, "9995.8.0"),
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001}swift-tools-version:\u{2002}\u{202F}\u{3000}9996.1.2"              : (9996, 1, 2, "9996.1.2"),
+            "//\u{3000}\u{A0}\u{1680}\t\u{2000}\u{2001}swift-tools-version:\u{2002}\u{202F}9996.1.2;"             : (9996, 1, 2, "9996.1.2"),
+            "//\u{202F}\u{3000}\u{A0}\u{1680}\t\u{2000}\u{2001}swift-tools-vErsion:\u{2002}9996.1.2;;;;;"         : (9996, 1, 2, "9996.1.2"),
+            "//\u{2002}\u{202F}\u{3000}\u{A0}\u{1680}\t\u{2000}\u{2001}swift-tools-version:9996.1.2;x;x;x;x;x;"   : (9996, 1, 2, "9996.1.2"),
+            "//\u{2000}\u{2002}\u{202F}\u{3000}\t\u{2001}swift-toolS-version:\u{A0}\u{1680}9995.5.2;hello"        : (9995, 5, 2, "9995.5.2"),
+            "//\u{2000}\u{2001}\u{2002}\u{202F}\u{3000}\tsWiFt-tOoLs-vErSiOn:\u{A0}\u{1680}9995.5.2\nkkk\n"       : (9995, 5, 2, "9995.5.2"),
+            // Some leading whitespace characters, and no spacing surrounding the label for Swift ≥ Next:
+            "\u{A} //swift-tools-version:9995.4.0"                             : (9995, 4, 0, "9995.4.0"),
+            "\u{B}\t\u{A}//swift-tools-version:9995.4-dev"                     : (9995, 4, 0, "9995.4.0"),
+            "\u{3000}\u{A0}\u{C}//swift-tools-version:9995.8.0"                : (9995, 8, 0, "9995.8.0"),
+            "\u{2002}\u{D}\u{2001}//swift-tools-version:9995.8.0-dev.al+sha.x" : (9995, 8, 0, "9995.8.0"),
+            "\u{D}\u{A}\u{A0}\u{1680}//swift-tools-version:9996.1.2"           : (9996, 1, 2, "9996.1.2"),
+            "   \u{85}//swift-tools-version:9996.1.2;"                         : (9996, 1, 2, "9996.1.2"),
+            "\u{2028}//swift-tools-vErsion:9996.1.2;;;;;"                      : (9996, 1, 2, "9996.1.2"),
+            "\u{202F}\u{2029}//swift-tools-version:9996.1.2;x;x;x;x;x;"        : (9996, 1, 2, "9996.1.2"),
+            "\u{A}\u{B}\u{C}\u{D}\u{A}\u{D}\u{85}\u{202F}\u{2029}\u{2001}\u{2002}\u{205F}\u{85}\u{2028}//swift-toolS-version:9995.5.2;hello" : (9995, 5, 2, "9995.5.2"),
+            "\u{B}  \u{200A}\u{D}\u{A}\t\u{85}\u{85}\u{A}\u{2028}\u{2009}\u{2001}\u{C}//sWiFt-tOoLs-vErSiOn:9995.5.2\nkkk\n"                 : (9995, 5, 2, "9995.5.2"),
+            // Some leading whitespace characters, and an assortment of horizontal whitespace characters surrounding the label for Swift ≥ Next:
+            "\u{2002}\u{202F}\u{A}//\u{A0}\u{1680}\t\u{2004}\u{2001} \u{2002}swift-tools-version:\u{3000}9995.4.0"       : (9995, 4, 0, "9995.4.0"),
+            "\u{B}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}swift-tools-version:\u{202F}\u{3000}9995.4-dev"             : (9995, 4, 0, "9995.4.0"),
+            "\u{C}//\u{A0}\u{1680}\t\u{2000}\u{2001} swift-tools-version:\u{2002}\u{202F}\u{3000}9995.8.0"               : (9995, 8, 0, "9995.8.0"),
+            "\u{D}//\u{A0}\u{1680}\t\u{2005} \u{202F}\u{3000}swift-tools-version:\u{2001}9995.8.0-dev.al+sha.x"          : (9995, 8, 0, "9995.8.0"),
+            "\u{D}\u{A}//\u{A0}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:\u{1680}\t\u{2000}9996.1.2"          : (9996, 1, 2, "9996.1.2"),
+            "\u{85}//\u{2000}\u{2001} \u{2006}\u{202F}\u{3000}swift-tools-version:\u{A0}\u{1680}\t9996.1.2;"             : (9996, 1, 2, "9996.1.2"),
+            "\u{2028}//\u{2001} \u{2002}\u{2007}\u{3000}swift-tools-vErsion:\u{A0}\u{1680}\t\u{2000}9996.1.2;;;;;"       : (9996, 1, 2, "9996.1.2"),
+            "\u{2029}//\u{202F}\u{3000}swift-tools-version:\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}9996.1.2;x;x;x;x;x;" : (9996, 1, 2, "9996.1.2"),
+            "\u{A}\u{D}\u{85}\u{202F}\u{2029}\u{A}\u{2028}//\u{2000}\u{2001}\u{9}swift-toolS-version:\u{A0}\u{1680}\t\u{2000}\u{2009} \u{2002}\u{202F}9995.5.2;hello" : (9995, 5, 2, "9995.5.2"),
+            "\u{D}\u{A}\t\u{85}\u{85}\u{A}\u{2028}\u{2029}//\u{2001}\u{2002}\u{202F}sWiFt-tOoLs-vErSiOn:\u{1680}\t\u{2000}\u{200A} \u{2002}\u{202F}9995.5.2\nkkk\n"   : (9995, 5, 2, "9995.5.2"),
         ]
 
         for (version, result) in validVersions {
@@ -369,11 +374,11 @@ class ToolsVersionLoaderTests: XCTestCase {
         }
     }
     
-    /// Verifies that a correct error is thrown, if the manifest is valid for Swift tools version > 5.3, but invalid for version ≤ 5.3.
-    func testBackwardIncompatibilityPre5_3_1() throws {
+    /// Verifies that a correct error is thrown, if the manifest is valid for Swift tools version ≥ Next, but invalid for version < Next.
+    func testBackwardIncompatibilityPreNext() throws {
         
         // The order of tests in this function:
-        // 1. Test backward-incompatible leading whitespace for Swift ≤ 5.3.
+        // 1. Test backward-incompatible leading whitespace for Swift < Next.
         // 2. Test that backward-incompatible leading whitespace is diagnosed before backward-incompatible spacings.
         // 3. Test spacings before the label.
         // 4. Test that backward-incompatible spacings before the label are diagnosed before those after the label.
@@ -400,15 +405,15 @@ class ToolsVersionLoaderTests: XCTestCase {
         for (specification, toolsVersionString) in manifestSnippetWith1LeadingCarriageReturn {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with a U+000D, and the specified version \(toolsVersionString) (≤ 5.3) supports only leading line feeds (U+000A)."
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with a U+000D, and the specified version \(toolsVersionString) (< Next) supports only leading line feeds (U+000A)."
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.leadingWhitespace, _) = error else {
-                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.leadingWhitespace, _)' should've been thrown, but a different error is thrown.")
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePreNext(.leadingWhitespace, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePreNext(.leadingWhitespace, _)' should've been thrown, but a different error is thrown.")
                     return
                 }
                 XCTAssertEqual(
                     error.description,
-                    "leading whitespace sequence [U+000D] in manifest is supported by only Swift > 5.3; the specified version \(toolsVersionString) supports only line feeds (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
+                    "leading whitespace sequence [U+000D] in manifest is supported by only Swift ≥ Next; the specified version \(toolsVersionString) supports only line feeds (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
                 )
             }
         }
@@ -434,15 +439,15 @@ class ToolsVersionLoaderTests: XCTestCase {
         for (specification, toolsVersionString) in manifestSnippetWith1LeadingSpace {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with a U+0020, and the specified version \(toolsVersionString) (≤ 5.3) supports only leading line feeds (U+000A)."
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with a U+0020, and the specified version \(toolsVersionString) (< Next) supports only leading line feeds (U+000A)."
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.leadingWhitespace, _) = error else {
-                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.leadingWhitespace, _)' should've been thrown, but a different error is thrown.")
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePreNext(.leadingWhitespace, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePreNext(.leadingWhitespace, _)' should've been thrown, but a different error is thrown.")
                     return
                 }
                 XCTAssertEqual(
                     error.description,
-                    "leading whitespace sequence [U+0020] in manifest is supported by only Swift > 5.3; the specified version \(toolsVersionString) supports only line feeds (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
+                    "leading whitespace sequence [U+0020] in manifest is supported by only Swift ≥ Next; the specified version \(toolsVersionString) supports only line feeds (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
                 )
             }
         }
@@ -468,15 +473,15 @@ class ToolsVersionLoaderTests: XCTestCase {
         for (specification, toolsVersionString) in manifestSnippetWithAnAssortmentOfLeadingWhitespaceCharacters {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with an assortment of whitespace characters, and the specified version \(toolsVersionString) (≤ 5.3) supports only leading line feeds (U+000A)."
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with an assortment of whitespace characters, and the specified version \(toolsVersionString) (< Next) supports only leading line feeds (U+000A)."
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.leadingWhitespace, _) = error else {
-                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.leadingWhitespace, _)' should've been thrown, but a different error is thrown.")
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePreNext(.leadingWhitespace, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePreNext(.leadingWhitespace, _)' should've been thrown, but a different error is thrown.")
                     return
                 }
                 XCTAssertEqual(
                     error.description,
-                    "leading whitespace sequence [U+000A, U+00A0, U+000B, U+1680, U+000C, U+0009, U+2000, U+000D, U+000D, U+000A, U+0085, U+2001, U+2028, U+2002, U+202F, U+2029, U+3000] in manifest is supported by only Swift > 5.3; the specified version \(toolsVersionString) supports only line feeds (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
+                    "leading whitespace sequence [U+000A, U+00A0, U+000B, U+1680, U+000C, U+0009, U+2000, U+000D, U+000D, U+000A, U+0085, U+2001, U+2028, U+2002, U+202F, U+2029, U+3000] in manifest is supported by only Swift ≥ Next; the specified version \(toolsVersionString) supports only line feeds (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
                 )
             }
         }
@@ -504,15 +509,15 @@ class ToolsVersionLoaderTests: XCTestCase {
         for (specification, toolsVersionString) in manifestSnippetWithAnAssortmentOfLeadingWhitespaceCharactersAndAnAssortmentOfWhitespacesSurroundingLabel {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with an assortment of whitespace characters, and the specified version \(toolsVersionString) (≤ 5.3) supports only leading line feeds (U+000A)."
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with an assortment of whitespace characters, and the specified version \(toolsVersionString) (< Next) supports only leading line feeds (U+000A)."
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.leadingWhitespace, _) = error else {
-                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.leadingWhitespace, _)' should've been thrown, but a different error is thrown.")
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePreNext(.leadingWhitespace, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePreNext(.leadingWhitespace, _)' should've been thrown, but a different error is thrown.")
                     return
                 }
                 XCTAssertEqual(
                     error.description,
-                    "leading whitespace sequence [U+000D, U+202F, U+2029, U+0085, U+2001, U+2028, U+3000, U+000A, U+000D, U+000A, U+2002, U+00A0, U+000B, U+1680, U+000C, U+0009, U+2000] in manifest is supported by only Swift > 5.3; the specified version \(toolsVersionString) supports only line feeds (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
+                    "leading whitespace sequence [U+000D, U+202F, U+2029, U+0085, U+2001, U+2028, U+3000, U+000A, U+000D, U+000A, U+2002, U+00A0, U+000B, U+1680, U+000C, U+0009, U+2000] in manifest is supported by only Swift ≥ Next; the specified version \(toolsVersionString) supports only line feeds (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
                 )
             }
         }
@@ -538,15 +543,15 @@ class ToolsVersionLoaderTests: XCTestCase {
         for (specification, toolsVersionString) in specificationsWithZeroSpacing {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "a 'ToolsVersionLoader.Error' should've been thrown, because there is no spacing between '//' and 'swift-tools-version', and the specified version \(toolsVersionString) (≤ 5.3) supports exactly 1 space (U+0020) there"
+                "a 'ToolsVersionLoader.Error' should've been thrown, because there is no spacing between '//' and 'swift-tools-version', and the specified version \(toolsVersionString) (< Next) supports exactly 1 space (U+0020) there"
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _) = error else {
-                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _)' should've been thrown, but a different error is thrown.")
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePreNext(.spacingAfterCommentMarker, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePreNext(.spacingAfterCommentMarker, _)' should've been thrown, but a different error is thrown.")
                     return
                 }
                 XCTAssertEqual(
                     error.description,
-                    "zero spacing between '//' and 'swift-tools-version' is supported by only Swift > 5.3; consider replacing the sequence with a single space (U+0020) for Swift \(toolsVersionString)"
+                    "zero spacing between '//' and 'swift-tools-version' is supported by only Swift ≥ Next; consider replacing the sequence with a single space (U+0020) for Swift \(toolsVersionString)"
                 )
             }
         }
@@ -572,15 +577,15 @@ class ToolsVersionLoaderTests: XCTestCase {
         for (specification, toolsVersionString) in specificationsWithAnAssortmentOfWhitespacesBeforeLabel {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "a 'ToolsVersionLoader.Error' should've been thrown, because the spacing between '//' and 'swift-tools-version' is an assortment of horizontal whitespace characters, and the specified version \(toolsVersionString) (≤ 5.3) supports exactly 1 space (U+0020) there."
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the spacing between '//' and 'swift-tools-version' is an assortment of horizontal whitespace characters, and the specified version \(toolsVersionString) (< Next) supports exactly 1 space (U+0020) there."
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _) = error else {
-                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _)' should've been thrown, but a different error is thrown.")
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePreNext(.spacingAfterCommentMarker, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePreNext(.spacingAfterCommentMarker, _)' should've been thrown, but a different error is thrown.")
                     return
                 }
                 XCTAssertEqual(
                     error.description,
-                    "horizontal whitespace sequence [U+0009, U+0020, U+00A0, U+1680, U+2000, U+2001, U+2002, U+2003, U+2004, U+2005, U+2006, U+2007, U+2008, U+2009, U+200A, U+202F, U+205F, U+3000] between '//' and 'swift-tools-version' is supported by only Swift > 5.3; consider replacing the sequence with a single space (U+0020) for Swift \(toolsVersionString)"
+                    "horizontal whitespace sequence [U+0009, U+0020, U+00A0, U+1680, U+2000, U+2001, U+2002, U+2003, U+2004, U+2005, U+2006, U+2007, U+2008, U+2009, U+200A, U+202F, U+205F, U+3000] between '//' and 'swift-tools-version' is supported by only Swift ≥ Next; consider replacing the sequence with a single space (U+0020) for Swift \(toolsVersionString)"
                 )
             }
         }
@@ -608,15 +613,15 @@ class ToolsVersionLoaderTests: XCTestCase {
         for (specification, toolsVersionString) in specificationsWithAnAssortmentOfWhitespacesBeforeAndAfterLabel {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "a 'ToolsVersionLoader.Error' should've been thrown, because the spacing between '//' and 'swift-tools-version' is an assortment of horizontal whitespace characters, and the specified version \(toolsVersionString) (≤ 5.3) supports exactly 1 space (U+0020) there."
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the spacing between '//' and 'swift-tools-version' is an assortment of horizontal whitespace characters, and the specified version \(toolsVersionString) (< Next) supports exactly 1 space (U+0020) there."
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _) = error else {
-                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _)' should've been thrown, but a different error is thrown.")
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePreNext(.spacingAfterCommentMarker, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePreNext(.spacingAfterCommentMarker, _)' should've been thrown, but a different error is thrown.")
                     return
                 }
                 XCTAssertEqual(
                     error.description,
-                    "horizontal whitespace sequence [U+0009, U+0020, U+00A0, U+1680, U+2000, U+2001, U+2002, U+2003, U+2004] between '//' and 'swift-tools-version' is supported by only Swift > 5.3; consider replacing the sequence with a single space (U+0020) for Swift \(toolsVersionString)"
+                    "horizontal whitespace sequence [U+0009, U+0020, U+00A0, U+1680, U+2000, U+2001, U+2002, U+2003, U+2004] between '//' and 'swift-tools-version' is supported by only Swift ≥ Next; consider replacing the sequence with a single space (U+0020) for Swift \(toolsVersionString)"
                 )
             }
         }
@@ -642,15 +647,15 @@ class ToolsVersionLoaderTests: XCTestCase {
         for (specification, toolsVersionString) in specificationsWithAnAssortmentOfWhitespacesAfterLabel {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "a 'ToolsVersionLoader.Error' should've been thrown, because the spacing between 'swift-tools-version' and the version specifier is an assortment of horizontal whitespace characters, and the specified version \(toolsVersionString) (≤ 5.3) supports no spacing there."
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the spacing between 'swift-tools-version' and the version specifier is an assortment of horizontal whitespace characters, and the specified version \(toolsVersionString) (< Next) supports no spacing there."
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.spacingAfterLabel, _) = error else {
-                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.spacingAfterLabel, _)' should've been thrown, but a different error is thrown.")
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePreNext(.spacingAfterLabel, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePreNext(.spacingAfterLabel, _)' should've been thrown, but a different error is thrown.")
                     return
                 }
                 XCTAssertEqual(
                     error.description,
-                    "horizontal whitespace sequence [U+0009, U+0020, U+00A0, U+1680, U+2000, U+2001, U+2002, U+2003, U+2004, U+2005, U+2006, U+2007, U+2008, U+2009, U+200A, U+202F, U+205F, U+3000] immediately preceding the version specifier is supported by only Swift > 5.3; consider removing the sequence for Swift \(toolsVersionString)"
+                    "horizontal whitespace sequence [U+0009, U+0020, U+00A0, U+1680, U+2000, U+2001, U+2002, U+2003, U+2004, U+2005, U+2006, U+2007, U+2008, U+2009, U+200A, U+202F, U+205F, U+3000] immediately preceding the version specifier is supported by only Swift ≥ Next; consider removing the sequence for Swift \(toolsVersionString)"
                 )
             }
         }

--- a/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
@@ -310,7 +310,7 @@ class ToolsVersionLoaderTests: XCTestCase {
         
     }
     
-    /// Verifies that if the first line of `Package.swift` is invalid but doesn't contain any pre-defined misspelling, then the Swift tools version defaults to 3.1.
+    /// Verifies that if the first line of the manifest is invalid but doesn't contain any pre-defined misspelling, then the Swift tools version defaults to 3.1.
     func testDefault() throws {
         let invalidVersionSpecificationsDefaultedTo3_1 = [
             "//\nswift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),

--- a/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
@@ -33,6 +33,18 @@ class ToolsVersionLoaderTests: XCTestCase {
     func testBasics() throws {
 
         let validVersions = [
+            // No space between "//" and "swift-tools-version":
+            "//swift-tools-version:3.1"                : (3, 1, 0, "3.1.0"),
+            "//swift-tools-version:3.1-dev"            : (3, 1, 0, "3.1.0"),
+            "//swift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
+            "//swift-tools-version:5.8.0-dev.al+sha.x" : (5, 8, 0, "5.8.0"),
+            "//swift-tools-version:3.1.2"              : (3, 1, 2, "3.1.2"),
+            "//swift-tools-version:3.1.2;"             : (3, 1, 2, "3.1.2"),
+            "//swift-tools-vErsion:3.1.2;;;;;"         : (3, 1, 2, "3.1.2"),
+            "//swift-tools-version:3.1.2;x;x;x;x;x;"   : (3, 1, 2, "3.1.2"),
+            "//swift-toolS-version:3.5.2;hello"        : (3, 5, 2, "3.5.2"),
+            "//sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : (3, 5, 2, "3.5.2"),
+            // 1 space character (" ") between "//" and "swift-tools-version":
             "// swift-tools-version:3.1"                : (3, 1, 0, "3.1.0"),
             "// swift-tools-version:3.1-dev"            : (3, 1, 0, "3.1.0"),
             "// swift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
@@ -43,6 +55,39 @@ class ToolsVersionLoaderTests: XCTestCase {
             "// swift-tools-version:3.1.2;x;x;x;x;x;"   : (3, 1, 2, "3.1.2"),
             "// swift-toolS-version:3.5.2;hello"        : (3, 5, 2, "3.5.2"),
             "// sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : (3, 5, 2, "3.5.2"),
+            // 1 horizontal tab character ("    ") between "//" and "swift-tools-version":
+            "//\tswift-tools-version:3.1"                : (3, 1, 0, "3.1.0"),
+            "//\tswift-tools-version:3.1-dev"            : (3, 1, 0, "3.1.0"),
+            "//\tswift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
+            "//\tswift-tools-version:5.8.0-dev.al+sha.x" : (5, 8, 0, "5.8.0"),
+            "//\tswift-tools-version:3.1.2"              : (3, 1, 2, "3.1.2"),
+            "//\tswift-tools-version:3.1.2;"             : (3, 1, 2, "3.1.2"),
+            "//\tswift-tools-vErsion:3.1.2;;;;;"         : (3, 1, 2, "3.1.2"),
+            "//\tswift-tools-version:3.1.2;x;x;x;x;x;"   : (3, 1, 2, "3.1.2"),
+            "//\tswift-toolS-version:3.5.2;hello"        : (3, 5, 2, "3.5.2"),
+            "//\tsWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : (3, 5, 2, "3.5.2"),
+            // 1 horizontal tab character followed by 1 space character ("     ") between "//" and "swift-tools-version":
+            "// \tswift-tools-version:3.1"                : (3, 1, 0, "3.1.0"),
+            "// \tswift-tools-version:3.1-dev"            : (3, 1, 0, "3.1.0"),
+            "// \tswift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
+            "// \tswift-tools-version:5.8.0-dev.al+sha.x" : (5, 8, 0, "5.8.0"),
+            "// \tswift-tools-version:3.1.2"              : (3, 1, 2, "3.1.2"),
+            "// \tswift-tools-version:3.1.2;"             : (3, 1, 2, "3.1.2"),
+            "// \tswift-tools-vErsion:3.1.2;;;;;"         : (3, 1, 2, "3.1.2"),
+            "// \tswift-tools-version:3.1.2;x;x;x;x;x;"   : (3, 1, 2, "3.1.2"),
+            "// \tswift-toolS-version:3.5.2;hello"        : (3, 5, 2, "3.5.2"),
+            "// \tsWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : (3, 5, 2, "3.5.2"),
+            // An assortment of horizontal whitespace characters between "//" and "swift-tools-version":
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:3.1"                : (3, 1, 0, "3.1.0"),
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:3.1-dev"            : (3, 1, 0, "3.1.0"),
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.8.0-dev.al+sha.x" : (5, 8, 0, "5.8.0"),
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:3.1.2"              : (3, 1, 2, "3.1.2"),
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:3.1.2;"             : (3, 1, 2, "3.1.2"),
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-vErsion:3.1.2;;;;;"         : (3, 1, 2, "3.1.2"),
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:3.1.2;x;x;x;x;x;"   : (3, 1, 2, "3.1.2"),
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-toolS-version:3.5.2;hello"        : (3, 5, 2, "3.5.2"),
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : (3, 5, 2, "3.5.2"),
         ]
 
         for (version, result) in validVersions {
@@ -105,6 +150,29 @@ class ToolsVersionLoaderTests: XCTestCase {
         assertFailure("// swift-tools-version:6.1.2.0\n", "6.1.2.0")
         assertFailure("// swift-tools-version:-1.1.2\n", "-1.1.2")
         assertFailure("// swift-tools-version:3.1hello", "3.1hello")
+        
+        // FIXME: Newline and line feed characters following "//" cause test failures.
+        
+        // Verify no matching for vertical white space charaters between "//" and "swift-tools-version":
+        assertFailure("//\nswift-tools-version:5.3\n", "//\nswift-tools-version:5.3")
+        assertFailure("// \nswift-tools-version:5.3\n", "// \nswift-tools-version:5.3")
+        assertFailure("//\n swift-tools-version:5.3\n", "//\n swift-tools-version:5.3")
+        assertFailure("//\rswift-tools-version:5.3\n", "//\rswift-tools-version:5.3")
+        assertFailure("// \rswift-tools-version:5.3\n", "// \rswift-tools-version:5.3")
+        assertFailure("//\r swift-tools-version:5.3\n", "//\r swift-tools-version:5.3")
+        assertFailure("//\r\nswift-tools-version:5.3\n", "//\r\nswift-tools-version:5.3")
+        assertFailure("//\n\rswift-tools-version:5.3\n", "//\n\rswift-tools-version:5.3")
+        assertFailure("//\u{B}swift-tools-version:5.3\n", "//\u{B}swift-tools-version:5.3")
+        assertFailure("//\u{2028}swift-tools-version:5.3\n", "//\u{2028}swift-tools-version:5.3")
+        assertFailure("//\u{2029}swift-tools-version:5.3\n", "//\u{2029}swift-tools-version:5.3")
+        
+        // Verify no matching for related Unicode characters without `White_Space` property, between "//" and "swift-tools-version":
+        assertFailure("//\u{180E}swift-tools-version:5.3\n", "//\u{180E}swift-tools-version:5.3")
+        assertFailure("//\u{200B}swift-tools-version:5.3\n", "//\u{200B}swift-tools-version:5.3")
+        assertFailure("//\u{200C}swift-tools-version:5.3\n", "//\u{200C}swift-tools-version:5.3")
+        assertFailure("//\u{200D}swift-tools-version:5.3\n", "//\u{200D}swift-tools-version:5.3")
+        assertFailure("//\u{2060}swift-tools-version:5.3\n", "//\u{2060}swift-tools-version:5.3")
+        assertFailure("//\u{FEFF}swift-tools-version:5.3\n", "//\u{FEFF}swift-tools-version:5.3")
     }
 
     func testVersionSpecificManifest() throws {

--- a/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
@@ -68,15 +68,15 @@ class ToolsVersionLoaderTests: XCTestCase {
             "// sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : (3, 5, 2, "3.5.2"),
             // leading newline characters (U+000A) before the specification, and 1 space (U+0020) before, and no spacing after the label:
             "\n// swift-tools-version:3.1"                            : (3, 1, 0, "3.1.0"),
-            "\n\n// swift-tools-version:3.2-dev"                      : (3, 1, 0, "3.2.0"),
-            "\n\n\n// swift-tools-version:3.8.0"                      : (5, 8, 0, "3.8.0"),
-            "\n\n\n\n// swift-tools-version:4.8.0-dev.al+sha.x"       : (5, 8, 0, "4.8.0"),
+            "\n\n// swift-tools-version:3.2-dev"                      : (3, 2, 0, "3.2.0"),
+            "\n\n\n// swift-tools-version:3.8.0"                      : (3, 8, 0, "3.8.0"),
+            "\n\n\n\n// swift-tools-version:4.8.0-dev.al+sha.x"       : (4, 8, 0, "4.8.0"),
             "\n\n\n\n\n// swift-tools-version:3.1.2"                  : (3, 1, 2, "3.1.2"),
-            "\n\n\n\n\n\n// swift-tools-version:4.1.2;"               : (3, 1, 2, "4.1.2"),
-            "\n\n\n\n\n\n\n// swift-tools-vErsion:5.1.2;;;;;"         : (3, 1, 2, "5.1.2"),
-            "\n\n\n\n\n\n\n\n// swift-tools-version:6.1.2;x;x;x;x;x;" : (3, 1, 2, "6.1.2"),
+            "\n\n\n\n\n\n// swift-tools-version:4.1.2;"               : (4, 1, 2, "4.1.2"),
+            "\n\n\n\n\n\n\n// swift-tools-vErsion:5.1.2;;;;;"         : (5, 1, 2, "5.1.2"),
+            "\n\n\n\n\n\n\n\n// swift-tools-version:6.1.2;x;x;x;x;x;" : (6, 1, 2, "6.1.2"),
             "\n\n\n\n\n\n\n\n\n// swift-toolS-version:3.5.2;hello"    : (3, 5, 2, "3.5.2"),
-            "\n\n\n\n\n\n\n\n\n\n// sWiFt-tOoLs-vErSiOn:4.5.2\nkkk\n" : (3, 5, 2, "4.5.2"),
+            "\n\n\n\n\n\n\n\n\n\n// sWiFt-tOoLs-vErSiOn:4.5.2\nkkk\n" : (4, 5, 2, "4.5.2"),
             // An assortment of horizontal whitespace characters surrounding the label for Swift > 5.3:
             "//swift-tools-version:\u{2002}\u{202F}\u{3000}\u{A0}\u{1680}\t\u{2000}\u{2001}5.4"                : (5, 4, 0, "5.4.0"),
             "//\u{2001}swift-tools-version:\u{2002}\u{202F}\u{3000}\u{A0}\u{1680}\t\u{2000}5.4-dev"            : (5, 4, 0, "5.4.0"),
@@ -106,10 +106,10 @@ class ToolsVersionLoaderTests: XCTestCase {
             "\u{D}//\u{A0}\u{1680}\t\u{2005} \u{202F}\u{3000}swift-tools-version:\u{2001}5.8.0-dev.al+sha.x"          : (5, 8, 0, "5.8.0"),
             "\u{D}\u{A}//\u{A0}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:\u{1680}\t\u{2000}6.1.2"          : (6, 1, 2, "6.1.2"),
             "\u{85}//\u{2000}\u{2001} \u{2006}\u{202F}\u{3000}swift-tools-version:\u{A0}\u{1680}\t6.1.2;"             : (6, 1, 2, "6.1.2"),
-            "\u{2028}//\u{2001} \u{2002}\u{2027}\u{3000}swift-tools-vErsion:\u{A0}\u{1680}\t\u{2000}6.1.2;;;;;"       : (6, 1, 2, "6.1.2"),
+            "\u{2028}//\u{2001} \u{2002}\u{2007}\u{3000}swift-tools-vErsion:\u{A0}\u{1680}\t\u{2000}6.1.2;;;;;"       : (6, 1, 2, "6.1.2"),
             "\u{2029}//\u{202F}\u{3000}swift-tools-version:\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}6.1.2;x;x;x;x;x;" : (6, 1, 2, "6.1.2"),
-            "\u{A}\u{D}\u{85}\u{202F}\u{2029}\u{A}\u{2028}\u{2000}\u{2001}\u{9}swift-toolS-version:\u{A0}\u{1680}\t\u{2000}\u{2009} \u{2002}\u{202F}5.5.2;hello" : (5, 5, 2, "5.5.2"),
-            "\u{D}\u{A}\t\u{85}\u{85}\u{A}\u{2028}\u{2029}\u{2001}\u{2002}\u{202F}sWiFt-tOoLs-vErSiOn:\u{1680}\t\u{2000}\u{200A} \u{2002}\u{202F}5.5.2\nkkk\n"   : (5, 5, 2, "5.5.2"),
+            "\u{A}\u{D}\u{85}\u{202F}\u{2029}\u{A}\u{2028}//\u{2000}\u{2001}\u{9}swift-toolS-version:\u{A0}\u{1680}\t\u{2000}\u{2009} \u{2002}\u{202F}5.5.2;hello" : (5, 5, 2, "5.5.2"),
+            "\u{D}\u{A}\t\u{85}\u{85}\u{A}\u{2028}\u{2029}//\u{2001}\u{2002}\u{202F}sWiFt-tOoLs-vErSiOn:\u{1680}\t\u{2000}\u{200A} \u{2002}\u{202F}5.5.2\nkkk\n"   : (5, 5, 2, "5.5.2"),
         ]
 
         for (version, result) in validVersions {
@@ -439,7 +439,7 @@ class ToolsVersionLoaderTests: XCTestCase {
                 }
                 XCTAssertEqual(
                     error.description,
-                    "leading whitespace sequence [U+000D, U+000A] in manifest is supported by only Swift > 5.3; the specified version \(toolsVersionString) supports only newline characters (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
+                    "leading whitespace sequence [U+0020] in manifest is supported by only Swift > 5.3; the specified version \(toolsVersionString) supports only newline characters (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
                 )
             }
         }
@@ -473,7 +473,7 @@ class ToolsVersionLoaderTests: XCTestCase {
                 }
                 XCTAssertEqual(
                     error.description,
-                    "leading whitespace sequence [U+000A, U+00A0, U+000B, U+1680, U+000C, U+2000, U+000D, U+000D, U+000A, U+0085, U+2001, U+2028, U+2002, U+202F, U+2029, U+3000] in manifest is supported by only Swift > 5.3; the specified version \(toolsVersionString) supports only newline characters (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
+                    "leading whitespace sequence [U+000A, U+00A0, U+000B, U+1680, U+000C, U+0009, U+2000, U+000D, U+000D, U+000A, U+0085, U+2001, U+2028, U+2002, U+202F, U+2029, U+3000] in manifest is supported by only Swift > 5.3; the specified version \(toolsVersionString) supports only newline characters (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
                 )
             }
         }
@@ -543,7 +543,7 @@ class ToolsVersionLoaderTests: XCTestCase {
                 }
                 XCTAssertEqual(
                     error.description,
-                    "zero spacing between '//' and 'swift-tools-version' is supported by only Swift > 5.3; consider using a single space (U+0020) for Swift \(toolsVersionString)"
+                    "zero spacing between '//' and 'swift-tools-version' is supported by only Swift > 5.3; consider replacing the sequence with a single space (U+0020) for Swift \(toolsVersionString)"
                 )
             }
         }
@@ -577,7 +577,7 @@ class ToolsVersionLoaderTests: XCTestCase {
                 }
                 XCTAssertEqual(
                     error.description,
-                    "horizontal whitespace sequence [U+0009, U+0020, U+00A0, U+1680, U+2000, U+2001, U+2002, U+2003, U+2004, U+2005, U+2006, U+2007, U+2008, U+2009, U+200A, U+202F, U+205F, U+3000] between '//' and 'swift-tools-version' is supported by only Swift > 5.3; consider using a single space (U+0020) for Swift \(toolsVersionString)"
+                    "horizontal whitespace sequence [U+0009, U+0020, U+00A0, U+1680, U+2000, U+2001, U+2002, U+2003, U+2004, U+2005, U+2006, U+2007, U+2008, U+2009, U+200A, U+202F, U+205F, U+3000] between '//' and 'swift-tools-version' is supported by only Swift > 5.3; consider replacing the sequence with a single space (U+0020) for Swift \(toolsVersionString)"
                 )
             }
         }

--- a/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
@@ -30,20 +30,20 @@ class ToolsVersionLoaderTests: XCTestCase {
         body?(toolsVersion)
     }
 
-    func testBasics() throws {
+    func testValidVersions() throws {
 
         let validVersions = [
-            // No space between "//" and "swift-tools-version":
-            "//swift-tools-version:3.1"                : (3, 1, 0, "3.1.0"),
-            "//swift-tools-version:3.1-dev"            : (3, 1, 0, "3.1.0"),
+            // No space between "//" and "swift-tools-version" for Swift ≥ 5.3:
+            "//swift-tools-version:5.4"                : (5, 4, 0, "5.4.0"),
+            "//swift-tools-version:5.4-dev"            : (5, 4, 0, "5.4.0"),
             "//swift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
             "//swift-tools-version:5.8.0-dev.al+sha.x" : (5, 8, 0, "5.8.0"),
-            "//swift-tools-version:3.1.2"              : (3, 1, 2, "3.1.2"),
-            "//swift-tools-version:3.1.2;"             : (3, 1, 2, "3.1.2"),
-            "//swift-tools-vErsion:3.1.2;;;;;"         : (3, 1, 2, "3.1.2"),
-            "//swift-tools-version:3.1.2;x;x;x;x;x;"   : (3, 1, 2, "3.1.2"),
-            "//swift-toolS-version:3.5.2;hello"        : (3, 5, 2, "3.5.2"),
-            "//sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : (3, 5, 2, "3.5.2"),
+            "//swift-tools-version:6.1.2"              : (6, 1, 2, "6.1.2"),
+            "//swift-tools-version:6.1.2;"             : (6, 1, 2, "6.1.2"),
+            "//swift-tools-vErsion:6.1.2;;;;;"         : (6, 1, 2, "6.1.2"),
+            "//swift-tools-version:6.1.2;x;x;x;x;x;"   : (6, 1, 2, "6.1.2"),
+            "//swift-toolS-version:5.5.2;hello"        : (5, 5, 2, "5.5.2"),
+            "//sWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n"       : (5, 5, 2, "5.5.2"),
             // 1 space character (" ") between "//" and "swift-tools-version":
             "// swift-tools-version:3.1"                : (3, 1, 0, "3.1.0"),
             "// swift-tools-version:3.1-dev"            : (3, 1, 0, "3.1.0"),
@@ -56,38 +56,38 @@ class ToolsVersionLoaderTests: XCTestCase {
             "// swift-toolS-version:3.5.2;hello"        : (3, 5, 2, "3.5.2"),
             "// sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : (3, 5, 2, "3.5.2"),
             // 1 horizontal tab character ("    ") between "//" and "swift-tools-version":
-            "//\tswift-tools-version:3.1"                : (3, 1, 0, "3.1.0"),
-            "//\tswift-tools-version:3.1-dev"            : (3, 1, 0, "3.1.0"),
+            "//\tswift-tools-version:5.4"                : (5, 4, 0, "5.4.0"),
+            "//\tswift-tools-version:5.4-dev"            : (5, 4, 0, "5.4.0"),
             "//\tswift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
             "//\tswift-tools-version:5.8.0-dev.al+sha.x" : (5, 8, 0, "5.8.0"),
-            "//\tswift-tools-version:3.1.2"              : (3, 1, 2, "3.1.2"),
-            "//\tswift-tools-version:3.1.2;"             : (3, 1, 2, "3.1.2"),
-            "//\tswift-tools-vErsion:3.1.2;;;;;"         : (3, 1, 2, "3.1.2"),
-            "//\tswift-tools-version:3.1.2;x;x;x;x;x;"   : (3, 1, 2, "3.1.2"),
-            "//\tswift-toolS-version:3.5.2;hello"        : (3, 5, 2, "3.5.2"),
-            "//\tsWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : (3, 5, 2, "3.5.2"),
-            // 1 horizontal tab character followed by 1 space character ("     ") between "//" and "swift-tools-version":
-            "// \tswift-tools-version:3.1"                : (3, 1, 0, "3.1.0"),
-            "// \tswift-tools-version:3.1-dev"            : (3, 1, 0, "3.1.0"),
+            "//\tswift-tools-version:6.1.2"              : (6, 1, 2, "6.1.2"),
+            "//\tswift-tools-version:6.1.2;"             : (6, 1, 2, "6.1.2"),
+            "//\tswift-tools-vErsion:6.1.2;;;;;"         : (6, 1, 2, "6.1.2"),
+            "//\tswift-tools-version:6.1.2;x;x;x;x;x;"   : (6, 1, 2, "6.1.2"),
+            "//\tswift-toolS-version:5.5.2;hello"        : (5, 5, 2, "5.5.2"),
+            "//\tsWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n"       : (5, 5, 2, "5.5.2"),
+//            // 1 horizontal tab character followed by 1 space character ("     ") between "//" and "swift-tools-version":
+            "// \tswift-tools-version:5.4"                : (5, 4, 0, "5.4.0"),
+            "// \tswift-tools-version:5.4-dev"            : (5, 4, 0, "5.4.0"),
             "// \tswift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
             "// \tswift-tools-version:5.8.0-dev.al+sha.x" : (5, 8, 0, "5.8.0"),
-            "// \tswift-tools-version:3.1.2"              : (3, 1, 2, "3.1.2"),
-            "// \tswift-tools-version:3.1.2;"             : (3, 1, 2, "3.1.2"),
-            "// \tswift-tools-vErsion:3.1.2;;;;;"         : (3, 1, 2, "3.1.2"),
-            "// \tswift-tools-version:3.1.2;x;x;x;x;x;"   : (3, 1, 2, "3.1.2"),
-            "// \tswift-toolS-version:3.5.2;hello"        : (3, 5, 2, "3.5.2"),
-            "// \tsWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : (3, 5, 2, "3.5.2"),
-            // An assortment of horizontal whitespace characters between "//" and "swift-tools-version":
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:3.1"                : (3, 1, 0, "3.1.0"),
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:3.1-dev"            : (3, 1, 0, "3.1.0"),
+            "// \tswift-tools-version:6.1.2"              : (6, 1, 2, "6.1.2"),
+            "// \tswift-tools-version:6.1.2;"             : (6, 1, 2, "6.1.2"),
+            "// \tswift-tools-vErsion:6.1.2;;;;;"         : (6, 1, 2, "6.1.2"),
+            "// \tswift-tools-version:6.1.2;x;x;x;x;x;"   : (6, 1, 2, "6.1.2"),
+            "// \tswift-toolS-version:5.5.2;hello"        : (5, 5, 2, "5.5.2"),
+            "// \tsWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n"       : (5, 5, 2, "5.5.2"),
+//            // An assortment of horizontal whitespace characters between "//" and "swift-tools-version":
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.4"                : (5, 4, 0, "5.4.0"),
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.4-dev"            : (5, 4, 0, "5.4.0"),
             "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
             "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.8.0-dev.al+sha.x" : (5, 8, 0, "5.8.0"),
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:3.1.2"              : (3, 1, 2, "3.1.2"),
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:3.1.2;"             : (3, 1, 2, "3.1.2"),
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-vErsion:3.1.2;;;;;"         : (3, 1, 2, "3.1.2"),
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:3.1.2;x;x;x;x;x;"   : (3, 1, 2, "3.1.2"),
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-toolS-version:3.5.2;hello"        : (3, 5, 2, "3.5.2"),
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : (3, 5, 2, "3.5.2"),
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:6.1.2"              : (6, 1, 2, "6.1.2"),
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:6.1.2;"             : (6, 1, 2, "6.1.2"),
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-vErsion:6.1.2;;;;;"         : (6, 1, 2, "6.1.2"),
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:6.1.2;x;x;x;x;x;"   : (6, 1, 2, "6.1.2"),
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-toolS-version:5.5.2;hello"        : (5, 5, 2, "5.5.2"),
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}sWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n"       : (5, 5, 2, "5.5.2"),
         ]
 
         for (version, result) in validVersions {
@@ -151,17 +151,11 @@ class ToolsVersionLoaderTests: XCTestCase {
         assertFailure("// swift-tools-version:-1.1.2\n", "-1.1.2")
         assertFailure("// swift-tools-version:3.1hello", "3.1hello")
         
-        // FIXME: Newline and line feed characters following "//" cause test failures.
-        
-        // Verify no matching for vertical white space charaters between "//" and "swift-tools-version":
-        assertFailure("//\nswift-tools-version:5.3\n", "//\nswift-tools-version:5.3")
-        assertFailure("// \nswift-tools-version:5.3\n", "// \nswift-tools-version:5.3")
-        assertFailure("//\n swift-tools-version:5.3\n", "//\n swift-tools-version:5.3")
+        // Verify no matching for vertical whitespace charaters between "//" and "swift-tools-version":
+        // Newline is excluded from these assertions, because `ToolsVersionLoader` assumes the default Swift version to be 3.1, if it sees a newline character before finding 1 of the 2 pre-defined misspellings in the specification.
         assertFailure("//\rswift-tools-version:5.3\n", "//\rswift-tools-version:5.3")
         assertFailure("// \rswift-tools-version:5.3\n", "// \rswift-tools-version:5.3")
         assertFailure("//\r swift-tools-version:5.3\n", "//\r swift-tools-version:5.3")
-        assertFailure("//\r\nswift-tools-version:5.3\n", "//\r\nswift-tools-version:5.3")
-        assertFailure("//\n\rswift-tools-version:5.3\n", "//\n\rswift-tools-version:5.3")
         assertFailure("//\u{B}swift-tools-version:5.3\n", "//\u{B}swift-tools-version:5.3")
         assertFailure("//\u{2028}swift-tools-version:5.3\n", "//\u{2028}swift-tools-version:5.3")
         assertFailure("//\u{2029}swift-tools-version:5.3\n", "//\u{2029}swift-tools-version:5.3")
@@ -173,6 +167,183 @@ class ToolsVersionLoaderTests: XCTestCase {
         assertFailure("//\u{200D}swift-tools-version:5.3\n", "//\u{200D}swift-tools-version:5.3")
         assertFailure("//\u{2060}swift-tools-version:5.3\n", "//\u{2060}swift-tools-version:5.3")
         assertFailure("//\u{FEFF}swift-tools-version:5.3\n", "//\u{FEFF}swift-tools-version:5.3")
+    }
+    
+    /// Verifies that for Swift tools version ≤ 5.3, an error is thrown if anything but a single U+0020 is used as spacing between "//" and "swift-tools-version".
+    func testBackwardCompatibilityError() throws {
+        
+        // MARK: No space between "//" and "swift-tools-version" for Swift ≤ 5.3
+        
+        let specificationsWithZeroSpacing = [
+            "//swift-tools-version:3.1"                : "3.1.0",
+            "//swift-tools-version:3.1-dev"            : "3.1.0",
+            "//swift-tools-version:5.3"                : "5.3.0",
+            "//swift-tools-version:5.3.0"              : "5.3.0",
+            "//swift-tools-version:5.3-dev"            : "5.3.0",
+            "//swift-tools-version:4.8.0"              : "4.8.0",
+            "//swift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
+            "//swift-tools-version:3.1.2"              : "3.1.2",
+            "//swift-tools-version:3.1.2;"             : "3.1.2",
+            "//swift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
+            "//swift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
+            "//swift-toolS-version:3.5.2;hello"        : "3.5.2",
+            "//sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
+        ]
+        
+        for (specification, toolsVersionString) in specificationsWithZeroSpacing {
+            XCTAssertThrowsError(
+                try load(ByteString(encodingAsUTF8: specification)),
+                "`ToolsVersionLoader.Error.invalidSpacingAfterSlashes` should've been thrown, because there is no spacing between \"//\" and \"swift-tools-version\", and the specified Swift version is less than or equal to 5.3, but no error is thrown."
+            ) { error in
+                guard let error = error as? ToolsVersionLoader.Error else {
+                    XCTFail("`ToolsVersionLoader.Error.invalidSpacingAfterSlashes` should've been thrown, a differently typed error is thrown.")
+                    return
+                }
+                XCTAssertEqual(
+                    error.description,
+                    "zero spacing between \"//\" and \"swift-tools-version\" is supported by only Swift > 5.3; consider using a single space (U+0020) for Swift \(toolsVersionString)"
+                )
+            }
+        }
+        
+        // MARK: 1 horizontal tab character (U+0009) between "//" and "swift-tools-version"
+        
+        let specificationsWith1TabAfterSlashes = [
+            "//\tswift-tools-version:3.1"                : "3.1.0",
+            "//\tswift-tools-version:3.1-dev"            : "3.1.0",
+            "//\tswift-tools-version:5.3"                : "5.3.0",
+            "//\tswift-tools-version:5.3.0"              : "5.3.0",
+            "//\tswift-tools-version:5.3-dev"            : "5.3.0",
+            "//\tswift-tools-version:4.8.0"              : "4.8.0",
+            "//\tswift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
+            "//\tswift-tools-version:3.1.2"              : "3.1.2",
+            "//\tswift-tools-version:3.1.2;"             : "3.1.2",
+            "//\tswift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
+            "//\tswift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
+            "//\tswift-toolS-version:3.5.2;hello"        : "3.5.2",
+            "//\tsWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
+        ]
+        
+        for (specification, toolsVersionString) in specificationsWith1TabAfterSlashes {
+            XCTAssertThrowsError(
+                try load(ByteString(encodingAsUTF8: specification)),
+                "`ToolsVersionLoader.Error.invalidSpacingAfterSlashes` should've been thrown, because the spacing between \"//\" and \"swift-tools-version\" is a horizontal tab character, and the specified Swift version is less than or equal to 5.3, but no error is thrown."
+            ) { error in
+                guard let error = error as? ToolsVersionLoader.Error else {
+                    XCTFail("`ToolsVersionLoader.Error.invalidSpacingAfterSlashes` should've been thrown, a differently typed error is thrown.")
+                    return
+                }
+                XCTAssertEqual(
+                    error.description,
+                    "horizontal whitespace sequence [U+0009] between \"//\" and \"swift-tools-version\" is supported by only Swift > 5.3; consider using a single space (U+0020) for Swift \(toolsVersionString)"
+                )
+            }
+        }
+        
+        // MARK: 1 space and 1 horizontal tab character (U+0009) between "//" and "swift-tools-version"
+        
+        let specificationsWith1SpaceAnd1TabAfterSlashes = [
+            "// \tswift-tools-version:3.1"                : "3.1.0",
+            "// \tswift-tools-version:3.1-dev"            : "3.1.0",
+            "// \tswift-tools-version:5.3"                : "5.3.0",
+            "// \tswift-tools-version:5.3.0"              : "5.3.0",
+            "// \tswift-tools-version:5.3-dev"            : "5.3.0",
+            "// \tswift-tools-version:4.8.0"              : "4.8.0",
+            "// \tswift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
+            "// \tswift-tools-version:3.1.2"              : "3.1.2",
+            "// \tswift-tools-version:3.1.2;"             : "3.1.2",
+            "// \tswift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
+            "// \tswift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
+            "// \tswift-toolS-version:3.5.2;hello"        : "3.5.2",
+            "// \tsWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
+        ]
+        
+        for (specification, toolsVersionString) in specificationsWith1SpaceAnd1TabAfterSlashes {
+            XCTAssertThrowsError(
+                try load(ByteString(encodingAsUTF8: specification)),
+                "`ToolsVersionLoader.Error.invalidSpacingAfterSlashes` should've been thrown, because the spacing between \"//\" and \"swift-tools-version\" is a horizontal tab character, and the specified Swift version is less than or equal to 5.3, but no error is thrown."
+            ) { error in
+                guard let error = error as? ToolsVersionLoader.Error else {
+                    XCTFail("`ToolsVersionLoader.Error.invalidSpacingAfterSlashes` should've been thrown, a differently typed error is thrown.")
+                    return
+                }
+                XCTAssertEqual(
+                    error.description,
+                    "horizontal whitespace sequence [U+0020, U+0009] between \"//\" and \"swift-tools-version\" is supported by only Swift > 5.3; consider using a single space (U+0020) for Swift \(toolsVersionString)"
+                )
+            }
+        }
+        
+        // MARK: An assortment of horizontal whitespace characters between "//" and "swift-tools-version"
+        
+        let specificationsWithAnAssortmentOfWhitespacesAfterSlashes = [
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:3.1"                : "3.1.0",
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:3.1-dev"            : "3.1.0",
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.3"                : "5.3.0",
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.3.0"              : "5.3.0",
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.3-dev"            : "5.3.0",
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:4.8.0"              : "4.8.0",
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:3.1.2"              : "3.1.2",
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:3.1.2;"             : "3.1.2",
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-toolS-version:3.5.2;hello"        : "3.5.2",
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
+        ]
+        
+        for (specification, toolsVersionString) in specificationsWithAnAssortmentOfWhitespacesAfterSlashes {
+            XCTAssertThrowsError(
+                try load(ByteString(encodingAsUTF8: specification)),
+                "`ToolsVersionLoader.Error.invalidSpacingAfterSlashes` should've been thrown, because the spacing between \"//\" and \"swift-tools-version\" is a horizontal tab character, and the specified Swift version is less than or equal to 5.3, but no error is thrown."
+            ) { error in
+                guard let error = error as? ToolsVersionLoader.Error else {
+                    XCTFail("`ToolsVersionLoader.Error.invalidSpacingAfterSlashes` should've been thrown, a differently typed error is thrown.")
+                    return
+                }
+                XCTAssertEqual(
+                    error.description,
+                    "horizontal whitespace sequence [U+00A0, U+1680, U+0009, U+2000, U+2001, U+0020, U+2002, U+202F, U+3000] between \"//\" and \"swift-tools-version\" is supported by only Swift > 5.3; consider using a single space (U+0020) for Swift \(toolsVersionString)"
+                )
+            }
+        }
+        
+    }
+    
+    /// Verifies that if the first line of `Package.swift` is invalid but doesn't contain any pre-defined misspelling, then the Swift tools version defaults to 3.1.
+    func testDefault() throws {
+        let invalidVersionSpecificationsDefaultedTo3_1 = [
+            "//\nswift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
+            "// \nswift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
+            "//\n swift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
+            "//\r\nswift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
+            "//\n\rswift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
+            "//\nswift-tool-version:5.3\n": (3, 1, 0, "3.1.0"),
+            "// \nswift-tool-version:5.3\n": (3, 1, 0, "3.1.0"),
+            "//\n swift-tool-version:5.3\n": (3, 1, 0, "3.1.0"),
+            "//\r\nswift-tool-version:5.3\n": (3, 1, 0, "3.1.0"),
+            "//\n\rswift-tool-version:5.3\n": (3, 1, 0, "3.1.0"),
+            "//\ntool-version:5.3\n": (3, 1, 0, "3.1.0"),
+            "// \ntool-version:5.3\n": (3, 1, 0, "3.1.0"),
+            "//\n tool-version:5.3\n": (3, 1, 0, "3.1.0"),
+            "//\r\ntool-version:5.3\n": (3, 1, 0, "3.1.0"),
+            "//\n\rtool-version:5.3\n": (3, 1, 0, "3.1.0"),
+            "//\nswift-tool:5.3\n": (3, 1, 0, "3.1.0"),
+            "// \nswift-tool:5.3\n": (3, 1, 0, "3.1.0"),
+            "//\n swift-tool:5.3\n": (3, 1, 0, "3.1.0"),
+            "//\r\nswift-tool:5.3\n": (3, 1, 0, "3.1.0"),
+            "//\n\rswift-tool:5.3\n": (3, 1, 0, "3.1.0"),
+        ]
+        
+        for (specification, expectedResult) in invalidVersionSpecificationsDefaultedTo3_1 {
+            try load(ByteString(encodingAsUTF8: specification)) { toolsVersion in
+                XCTAssertEqual(toolsVersion.major, expectedResult.0)
+                XCTAssertEqual(toolsVersion.minor, expectedResult.1)
+                XCTAssertEqual(toolsVersion.patch, expectedResult.2)
+                XCTAssertEqual(toolsVersion.description, expectedResult.3)
+            }
+        }
+        
     }
 
     func testVersionSpecificManifest() throws {

--- a/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -33,7 +33,7 @@ class ToolsVersionLoaderTests: XCTestCase {
     func testValidVersions() throws {
 
         let validVersions = [
-            // No spacing between "//" and "swift-tools-version" for Swift > 5.3:
+            // No spacing surrounding the label for Swift > 5.3:
             "//swift-tools-version:5.4"                : (5, 4, 0, "5.4.0"),
             "//swift-tools-version:5.4-dev"            : (5, 4, 0, "5.4.0"),
             "//swift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
@@ -44,7 +44,18 @@ class ToolsVersionLoaderTests: XCTestCase {
             "//swift-tools-version:6.1.2;x;x;x;x;x;"   : (6, 1, 2, "6.1.2"),
             "//swift-toolS-version:5.5.2;hello"        : (5, 5, 2, "5.5.2"),
             "//sWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n"       : (5, 5, 2, "5.5.2"),
-            // 1 space (U+0020) between "//" and "swift-tools-version":
+            // No spacing before, and 1 space (U+0020) after the label for Swift > 5.3:
+            "//swift-tools-version: 5.4"                : (5, 4, 0, "5.4.0"),
+            "//swift-tools-version: 5.4-dev"            : (5, 4, 0, "5.4.0"),
+            "//swift-tools-version: 5.8.0"              : (5, 8, 0, "5.8.0"),
+            "//swift-tools-version: 5.8.0-dev.al+sha.x" : (5, 8, 0, "5.8.0"),
+            "//swift-tools-version: 6.1.2"              : (6, 1, 2, "6.1.2"),
+            "//swift-tools-version: 6.1.2;"             : (6, 1, 2, "6.1.2"),
+            "//swift-tools-vErsion: 6.1.2;;;;;"         : (6, 1, 2, "6.1.2"),
+            "//swift-tools-version: 6.1.2;x;x;x;x;x;"   : (6, 1, 2, "6.1.2"),
+            "//swift-toolS-version: 5.5.2;hello"        : (5, 5, 2, "5.5.2"),
+            "//sWiFt-tOoLs-vErSiOn: 5.5.2\nkkk\n"       : (5, 5, 2, "5.5.2"),
+            // 1 space (U+0020) before, and no spacing after the label:
             "// swift-tools-version:3.1"                : (3, 1, 0, "3.1.0"),
             "// swift-tools-version:3.1-dev"            : (3, 1, 0, "3.1.0"),
             "// swift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
@@ -55,105 +66,50 @@ class ToolsVersionLoaderTests: XCTestCase {
             "// swift-tools-version:3.1.2;x;x;x;x;x;"   : (3, 1, 2, "3.1.2"),
             "// swift-toolS-version:3.5.2;hello"        : (3, 5, 2, "3.5.2"),
             "// sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : (3, 5, 2, "3.5.2"),
-            // leading newline characters (U+000A), and 1 space (U+0020) between "//" and "swift-tools-version":
+            // leading newline characters (U+000A) before the specification, and 1 space (U+0020) before, and no spacing after the label:
             "\n// swift-tools-version:3.1"                            : (3, 1, 0, "3.1.0"),
-            "\n\n// swift-tools-version:3.1-dev"                      : (3, 1, 0, "3.1.0"),
-            "\n\n\n// swift-tools-version:5.8.0"                      : (5, 8, 0, "5.8.0"),
-            "\n\n\n\n// swift-tools-version:5.8.0-dev.al+sha.x"       : (5, 8, 0, "5.8.0"),
+            "\n\n// swift-tools-version:3.2-dev"                      : (3, 1, 0, "3.2.0"),
+            "\n\n\n// swift-tools-version:3.8.0"                      : (5, 8, 0, "3.8.0"),
+            "\n\n\n\n// swift-tools-version:4.8.0-dev.al+sha.x"       : (5, 8, 0, "4.8.0"),
             "\n\n\n\n\n// swift-tools-version:3.1.2"                  : (3, 1, 2, "3.1.2"),
-            "\n\n\n\n\n\n// swift-tools-version:3.1.2;"               : (3, 1, 2, "3.1.2"),
-            "\n\n\n\n\n\n\n// swift-tools-vErsion:3.1.2;;;;;"         : (3, 1, 2, "3.1.2"),
-            "\n\n\n\n\n\n\n\n// swift-tools-version:3.1.2;x;x;x;x;x;" : (3, 1, 2, "3.1.2"),
+            "\n\n\n\n\n\n// swift-tools-version:4.1.2;"               : (3, 1, 2, "4.1.2"),
+            "\n\n\n\n\n\n\n// swift-tools-vErsion:5.1.2;;;;;"         : (3, 1, 2, "5.1.2"),
+            "\n\n\n\n\n\n\n\n// swift-tools-version:6.1.2;x;x;x;x;x;" : (3, 1, 2, "6.1.2"),
             "\n\n\n\n\n\n\n\n\n// swift-toolS-version:3.5.2;hello"    : (3, 5, 2, "3.5.2"),
-            "\n\n\n\n\n\n\n\n\n\n// sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n" : (3, 5, 2, "3.5.2"),
-            // 1 character tabulation (U+0009) between "//" and "swift-tools-version" for Swift > 5.3:
-            "//\tswift-tools-version:5.4"                : (5, 4, 0, "5.4.0"),
-            "//\tswift-tools-version:5.4-dev"            : (5, 4, 0, "5.4.0"),
-            "//\tswift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
-            "//\tswift-tools-version:5.8.0-dev.al+sha.x" : (5, 8, 0, "5.8.0"),
-            "//\tswift-tools-version:6.1.2"              : (6, 1, 2, "6.1.2"),
-            "//\tswift-tools-version:6.1.2;"             : (6, 1, 2, "6.1.2"),
-            "//\tswift-tools-vErsion:6.1.2;;;;;"         : (6, 1, 2, "6.1.2"),
-            "//\tswift-tools-version:6.1.2;x;x;x;x;x;"   : (6, 1, 2, "6.1.2"),
-            "//\tswift-toolS-version:5.5.2;hello"        : (5, 5, 2, "5.5.2"),
-            "//\tsWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n"       : (5, 5, 2, "5.5.2"),
-            // 1 character tabulation (U+0009) followed by 1 space (U+0020) between "//" and "swift-tools-version" for Swift > 5.3:
-            "// \tswift-tools-version:5.4"                : (5, 4, 0, "5.4.0"),
-            "// \tswift-tools-version:5.4-dev"            : (5, 4, 0, "5.4.0"),
-            "// \tswift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
-            "// \tswift-tools-version:5.8.0-dev.al+sha.x" : (5, 8, 0, "5.8.0"),
-            "// \tswift-tools-version:6.1.2"              : (6, 1, 2, "6.1.2"),
-            "// \tswift-tools-version:6.1.2;"             : (6, 1, 2, "6.1.2"),
-            "// \tswift-tools-vErsion:6.1.2;;;;;"         : (6, 1, 2, "6.1.2"),
-            "// \tswift-tools-version:6.1.2;x;x;x;x;x;"   : (6, 1, 2, "6.1.2"),
-            "// \tswift-toolS-version:5.5.2;hello"        : (5, 5, 2, "5.5.2"),
-            "// \tsWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n"       : (5, 5, 2, "5.5.2"),
-            // An assortment of horizontal whitespace characters between "//" and "swift-tools-version" for Swift > 5.3:
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.4"                : (5, 4, 0, "5.4.0"),
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.4-dev"            : (5, 4, 0, "5.4.0"),
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.8.0-dev.al+sha.x" : (5, 8, 0, "5.8.0"),
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:6.1.2"              : (6, 1, 2, "6.1.2"),
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:6.1.2;"             : (6, 1, 2, "6.1.2"),
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-vErsion:6.1.2;;;;;"         : (6, 1, 2, "6.1.2"),
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:6.1.2;x;x;x;x;x;"   : (6, 1, 2, "6.1.2"),
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-toolS-version:5.5.2;hello"        : (5, 5, 2, "5.5.2"),
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}sWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n"       : (5, 5, 2, "5.5.2"),
-            // Some leading line terminators, and no spacing between "//" and "swift-tools-version" for Swift > 5.3:
-            "\u{A}//swift-tools-version:5.4"                 : (5, 4, 0, "5.4.0"),
-            "\u{B}//swift-tools-version:5.4-dev"             : (5, 4, 0, "5.4.0"),
-            "\u{C}//swift-tools-version:5.8.0"               : (5, 8, 0, "5.8.0"),
-            "\u{D}//swift-tools-version:5.8.0-dev.al+sha.x"  : (5, 8, 0, "5.8.0"),
-            "\u{D}\u{A}//swift-tools-version:6.1.2"          : (6, 1, 2, "6.1.2"),
-            "\u{85}//swift-tools-version:6.1.2;"             : (6, 1, 2, "6.1.2"),
-            "\u{2028}//swift-tools-vErsion:6.1.2;;;;;"       : (6, 1, 2, "6.1.2"),
-            "\u{2029}//swift-tools-version:6.1.2;x;x;x;x;x;" : (6, 1, 2, "6.1.2"),
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-toolS-version:5.5.2;hello"  : (5, 5, 2, "5.5.2"),
-            "\u{A}\u{A}\u{B}\u{B}\u{C}\u{C}\u{D}\u{D}\u{D}\u{A}\u{D}\u{A}\u{85}\u{85}\u{2028}\u{2028}\u{2029}\u{2029}//sWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n" : (5, 5, 2, "5.5.2"),
-            // Some leading line terminators, and 1 space (U+0020) between "//" and "swift-tools-version" for Swift > 5.3:
-            "\u{A}// swift-tools-version:5.4"                 : (5, 4, 0, "5.4.0"),
-            "\u{B}// swift-tools-version:5.4-dev"             : (5, 4, 0, "5.4.0"),
-            "\u{C}// swift-tools-version:5.8.0"               : (5, 8, 0, "5.8.0"),
-            "\u{D}// swift-tools-version:5.8.0-dev.al+sha.x"  : (5, 8, 0, "5.8.0"),
-            "\u{D}\u{A}// swift-tools-version:6.1.2"          : (6, 1, 2, "6.1.2"),
-            "\u{85}// swift-tools-version:6.1.2;"             : (6, 1, 2, "6.1.2"),
-            "\u{2028}// swift-tools-vErsion:6.1.2;;;;;"       : (6, 1, 2, "6.1.2"),
-            "\u{2029}// swift-tools-version:6.1.2;x;x;x;x;x;" : (6, 1, 2, "6.1.2"),
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}// swift-toolS-version:5.5.2;hello"  : (5, 5, 2, "5.5.2"),
-            "\u{A}\u{A}\u{B}\u{B}\u{C}\u{C}\u{D}\u{D}\u{D}\u{A}\u{D}\u{A}\u{85}\u{85}\u{2028}\u{2028}\u{2029}\u{2029}// sWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n" : (5, 5, 2, "5.5.2"),
-            // Some leading line terminators, and 1 character tabulation (U+0009) between "//" and "swift-tools-version" for Swift > 5.3:
-            "\u{A}//\tswift-tools-version:5.4"                 : (5, 4, 0, "5.4.0"),
-            "\u{B}//\tswift-tools-version:5.4-dev"             : (5, 4, 0, "5.4.0"),
-            "\u{C}//\tswift-tools-version:5.8.0"               : (5, 8, 0, "5.8.0"),
-            "\u{D}//\tswift-tools-version:5.8.0-dev.al+sha.x"  : (5, 8, 0, "5.8.0"),
-            "\u{D}\u{A}//\tswift-tools-version:6.1.2"          : (6, 1, 2, "6.1.2"),
-            "\u{85}//\tswift-tools-version:6.1.2;"             : (6, 1, 2, "6.1.2"),
-            "\u{2028}//\tswift-tools-vErsion:6.1.2;;;;;"       : (6, 1, 2, "6.1.2"),
-            "\u{2029}//\tswift-tools-version:6.1.2;x;x;x;x;x;" : (6, 1, 2, "6.1.2"),
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\tswift-toolS-version:5.5.2;hello"  : (5, 5, 2, "5.5.2"),
-            "\u{A}\u{A}\u{B}\u{B}\u{C}\u{C}\u{D}\u{D}\u{D}\u{A}\u{D}\u{A}\u{85}\u{85}\u{2028}\u{2028}\u{2029}\u{2029}//\tsWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n" : (5, 5, 2, "5.5.2"),
-            // Some leading line terminators, and 1 character tabulation (U+0009) followed by 1 space (U+0020) between "//" and "swift-tools-version" for Swift > 5.3:
-            "\u{A}// \tswift-tools-version:5.4"                 : (5, 4, 0, "5.4.0"),
-            "\u{B}// \tswift-tools-version:5.4-dev"             : (5, 4, 0, "5.4.0"),
-            "\u{C}// \tswift-tools-version:5.8.0"               : (5, 8, 0, "5.8.0"),
-            "\u{D}// \tswift-tools-version:5.8.0-dev.al+sha.x"  : (5, 8, 0, "5.8.0"),
-            "\u{D}\u{A}// \tswift-tools-version:6.1.2"          : (6, 1, 2, "6.1.2"),
-            "\u{85}// \tswift-tools-version:6.1.2;"             : (6, 1, 2, "6.1.2"),
-            "\u{2028}// \tswift-tools-vErsion:6.1.2;;;;;"       : (6, 1, 2, "6.1.2"),
-            "\u{2029}// \tswift-tools-version:6.1.2;x;x;x;x;x;" : (6, 1, 2, "6.1.2"),
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}// \tswift-toolS-version:5.5.2;hello"  : (5, 5, 2, "5.5.2"),
-            "\u{A}\u{A}\u{B}\u{B}\u{C}\u{C}\u{D}\u{D}\u{D}\u{A}\u{D}\u{A}\u{85}\u{85}\u{2028}\u{2028}\u{2029}\u{2029}// \tsWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n" : (5, 5, 2, "5.5.2"),
-            // Some leading line terminators, and an assortment of horizontal whitespace characters between "//" and "swift-tools-version" for Swift > 5.3:
-            "\u{A}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.4"                 : (5, 4, 0, "5.4.0"),
-            "\u{B}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.4-dev"             : (5, 4, 0, "5.4.0"),
-            "\u{C}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.8.0"               : (5, 8, 0, "5.8.0"),
-            "\u{D}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.8.0-dev.al+sha.x"  : (5, 8, 0, "5.8.0"),
-            "\u{D}\u{A}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:6.1.2"          : (6, 1, 2, "6.1.2"),
-            "\u{85}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:6.1.2;"             : (6, 1, 2, "6.1.2"),
-            "\u{2028}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-vErsion:6.1.2;;;;;"       : (6, 1, 2, "6.1.2"),
-            "\u{2029}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:6.1.2;x;x;x;x;x;" : (6, 1, 2, "6.1.2"),
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-toolS-version:5.5.2;hello"  : (5, 5, 2, "5.5.2"),
-            "\u{A}\u{A}\u{B}\u{B}\u{C}\u{C}\u{D}\u{D}\u{D}\u{A}\u{D}\u{A}\u{85}\u{85}\u{2028}\u{2028}\u{2029}\u{2029}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}sWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n" : (5, 5, 2, "5.5.2"),
+            "\n\n\n\n\n\n\n\n\n\n// sWiFt-tOoLs-vErSiOn:4.5.2\nkkk\n" : (3, 5, 2, "4.5.2"),
+            // An assortment of horizontal whitespace characters surrounding the label for Swift > 5.3:
+            "//swift-tools-version:\u{2002}\u{202F}\u{3000}\u{A0}\u{1680}\t\u{2000}\u{2001}5.4"                : (5, 4, 0, "5.4.0"),
+            "//\u{2001}swift-tools-version:\u{2002}\u{202F}\u{3000}\u{A0}\u{1680}\t\u{2000}5.4-dev"            : (5, 4, 0, "5.4.0"),
+            "//\t\u{2000}\u{2001}swift-tools-version:\u{2002}\u{202F}\u{3000}\u{A0}\u{1680}5.8.0"              : (5, 8, 0, "5.8.0"),
+            "//\u{1680}\t\u{2000}\u{2001}swift-tools-version:\u{2002}\u{202F}\u{3000}\u{A0}5.8.0-dev.al+sha.x" : (5, 8, 0, "5.8.0"),
+            "//\u{A0}\u{1680}\t\u{2000}\u{2001}swift-tools-version:\u{2002}\u{202F}\u{3000}6.1.2"              : (6, 1, 2, "6.1.2"),
+            "//\u{3000}\u{A0}\u{1680}\t\u{2000}\u{2001}swift-tools-version:\u{2002}\u{202F}6.1.2;"             : (6, 1, 2, "6.1.2"),
+            "//\u{202F}\u{3000}\u{A0}\u{1680}\t\u{2000}\u{2001}swift-tools-vErsion:\u{2002}6.1.2;;;;;"         : (6, 1, 2, "6.1.2"),
+            "//\u{2002}\u{202F}\u{3000}\u{A0}\u{1680}\t\u{2000}\u{2001}swift-tools-version:6.1.2;x;x;x;x;x;"   : (6, 1, 2, "6.1.2"),
+            "//\u{2000}\u{2002}\u{202F}\u{3000}\t\u{2001}swift-toolS-version:\u{A0}\u{1680}5.5.2;hello"        : (5, 5, 2, "5.5.2"),
+            "//\u{2000}\u{2001}\u{2002}\u{202F}\u{3000}\tsWiFt-tOoLs-vErSiOn:\u{A0}\u{1680}5.5.2\nkkk\n"       : (5, 5, 2, "5.5.2"),
+            // Some leading whitespace characters, and no spacing surrounding the label for Swift > 5.3:
+            "\u{A} //swift-tools-version:5.4"                               : (5, 4, 0, "5.4.0"),
+            "\u{B}\t\u{A}//swift-tools-version:5.4-dev"                     : (5, 4, 0, "5.4.0"),
+            "\u{3000}\u{A0}\u{C}//swift-tools-version:5.8.0"                : (5, 8, 0, "5.8.0"),
+            "\u{2002}\u{D}\u{2001}//swift-tools-version:5.8.0-dev.al+sha.x" : (5, 8, 0, "5.8.0"),
+            "\u{D}\u{A}\u{A0}\u{1680}//swift-tools-version:6.1.2"           : (6, 1, 2, "6.1.2"),
+            "   \u{85}//swift-tools-version:6.1.2;"                         : (6, 1, 2, "6.1.2"),
+            "\u{2028}//swift-tools-vErsion:6.1.2;;;;;"                      : (6, 1, 2, "6.1.2"),
+            "\u{202F}\u{2029}//swift-tools-version:6.1.2;x;x;x;x;x;"        : (6, 1, 2, "6.1.2"),
+            "\u{A}\u{B}\u{C}\u{D}\u{A}\u{D}\u{85}\u{202F}\u{2029}\u{2001}\u{2002}\u{205F}\u{85}\u{2028}//swift-toolS-version:5.5.2;hello" : (5, 5, 2, "5.5.2"),
+            "\u{B}  \u{200A}\u{D}\u{A}\t\u{85}\u{85}\u{A}\u{2028}\u{2009}\u{2001}\u{C}//sWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n"                 : (5, 5, 2, "5.5.2"),
+            // Some leading whitespace characters, and an assortment of horizontal whitespace characters surrounding the label for Swift > 5.3:
+            "\u{2002}\u{202F}\u{A}//\u{A0}\u{1680}\t\u{2004}\u{2001} \u{2002}swift-tools-version:\u{3000}5.4"         : (5, 4, 0, "5.4.0"),
+            "\u{B}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}swift-tools-version:\u{202F}\u{3000}5.4-dev"             : (5, 4, 0, "5.4.0"),
+            "\u{C}//\u{A0}\u{1680}\t\u{2000}\u{2001} swift-tools-version:\u{2002}\u{202F}\u{3000}5.8.0"               : (5, 8, 0, "5.8.0"),
+            "\u{D}//\u{A0}\u{1680}\t\u{2005} \u{202F}\u{3000}swift-tools-version:\u{2001}5.8.0-dev.al+sha.x"          : (5, 8, 0, "5.8.0"),
+            "\u{D}\u{A}//\u{A0}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:\u{1680}\t\u{2000}6.1.2"          : (6, 1, 2, "6.1.2"),
+            "\u{85}//\u{2000}\u{2001} \u{2006}\u{202F}\u{3000}swift-tools-version:\u{A0}\u{1680}\t6.1.2;"             : (6, 1, 2, "6.1.2"),
+            "\u{2028}//\u{2001} \u{2002}\u{2027}\u{3000}swift-tools-vErsion:\u{A0}\u{1680}\t\u{2000}6.1.2;;;;;"       : (6, 1, 2, "6.1.2"),
+            "\u{2029}//\u{202F}\u{3000}swift-tools-version:\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}6.1.2;x;x;x;x;x;" : (6, 1, 2, "6.1.2"),
+            "\u{A}\u{D}\u{85}\u{202F}\u{2029}\u{A}\u{2028}\u{2000}\u{2001}\u{9}swift-toolS-version:\u{A0}\u{1680}\t\u{2000}\u{2009} \u{2002}\u{202F}5.5.2;hello" : (5, 5, 2, "5.5.2"),
+            "\u{D}\u{A}\t\u{85}\u{85}\u{A}\u{2028}\u{2029}\u{2001}\u{2002}\u{202F}sWiFt-tOoLs-vErSiOn:\u{1680}\t\u{2000}\u{200A} \u{2002}\u{202F}5.5.2\nkkk\n"   : (5, 5, 2, "5.5.2"),
         ]
 
         for (version, result) in validVersions {
@@ -414,9 +370,11 @@ class ToolsVersionLoaderTests: XCTestCase {
     func testBackwardIncompatibilityPre5_3_1() throws {
         
         // The order of tests in this function:
-        // 1. Test leading line terminators that are invalid for Swift ≤ 5.3.
-        // 2. Test that backward-incompatible leading line terminators are diagnosed before backward-incompatible spacings after the comment marker.
-        // 3. Test spacings after the comment marker.
+        // 1. Test backward-incompatible leading whitespace for Swift ≤ 5.3.
+        // 2. Test that backward-incompatible leading whitespace is diagnosed before backward-incompatible spacings.
+        // 3. Test spacings before the label.
+        // 4. Test that backward-incompatible spacings before the label are diagnosed before those after the label.
+        // 5. Test spacings after the label.
         
         // MARK: 1 leading u+000D
         
@@ -439,124 +397,124 @@ class ToolsVersionLoaderTests: XCTestCase {
         for (specification, toolsVersionString) in manifestSnippetWith1LeadingCarriageReturn {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with a U+000D, and the specified version \(toolsVersionString) (≤ 5.3) supports only 0 or 1 leading U+000A."
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with a U+000D, and the specified version \(toolsVersionString) (≤ 5.3) supports only leading newline characters (U+000A)."
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.leadingLineTerminators, _) = error else {
-                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.leadingLineTerminators, _)' should've been thrown, but a different error is thrown.")
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.leadingWhitespace, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.leadingWhitespace, _)' should've been thrown, but a different error is thrown.")
                     return
                 }
                 XCTAssertEqual(
                     error.description,
-                    "leading line terminator sequence [U+000D] in manifest is supported by only Swift > 5.3; for the specified version \(toolsVersionString), only newline characters (U+000A) at the beginning of the manifest is supported; consider moving the Swift tools version specification to the first line of the manifest"
+                    "leading whitespace sequence [U+000D] in manifest is supported by only Swift > 5.3; the specified version \(toolsVersionString) supports only newline characters (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
                 )
             }
         }
         
-        // MARK: 1 leading U+000D followed by 1 U+000A
+        // MARK: 1 U+0020
         
-        let manifestSnippetWith1LeadingCarriageReturnFollowedBy1LineFeed = [
-            "\u{D}\u{A}//swift-tools-version:3.1"                : "3.1.0",
-            "\u{D}\u{A}//swift-tools-version:3.1-dev"            : "3.1.0",
-            "\u{D}\u{A}//swift-tools-version:5.3"                : "5.3.0",
-            "\u{D}\u{A}//swift-tools-version:5.3.0"              : "5.3.0",
-            "\u{D}\u{A}//swift-tools-version:5.3-dev"            : "5.3.0",
-            "\u{D}\u{A}//swift-tools-version:4.8.0"              : "4.8.0",
-            "\u{D}\u{A}//swift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
-            "\u{D}\u{A}//swift-tools-version:3.1.2"              : "3.1.2",
-            "\u{D}\u{A}//swift-tools-version:3.1.2;"             : "3.1.2",
-            "\u{D}\u{A}//swift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
-            "\u{D}\u{A}//swift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
-            "\u{D}\u{A}//swift-toolS-version:3.5.2;hello"        : "3.5.2",
-            "\u{D}\u{A}//sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
+        let manifestSnippetWith1LeadingSpace = [
+            "\u{20}//swift-tools-version:3.1"                : "3.1.0",
+            "\u{20}//swift-tools-version:3.1-dev"            : "3.1.0",
+            "\u{20}//swift-tools-version:5.3"                : "5.3.0",
+            "\u{20}//swift-tools-version:5.3.0"              : "5.3.0",
+            "\u{20}//swift-tools-version:5.3-dev"            : "5.3.0",
+            "\u{20}//swift-tools-version:4.8.0"              : "4.8.0",
+            "\u{20}//swift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
+            "\u{20}//swift-tools-version:3.1.2"              : "3.1.2",
+            "\u{20}//swift-tools-version:3.1.2;"             : "3.1.2",
+            "\u{20}//swift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
+            "\u{20}//swift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
+            "\u{20}//swift-toolS-version:3.5.2;hello"        : "3.5.2",
+            "\u{20}//sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
         ]
         
-        for (specification, toolsVersionString) in manifestSnippetWith1LeadingCarriageReturnFollowedBy1LineFeed {
+        for (specification, toolsVersionString) in manifestSnippetWith1LeadingSpace {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with a U+000D followed by a U+000A, and the specified version \(toolsVersionString) (≤ 5.3) supports only 0 or 1 leading U+000A."
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with a U+0020, and the specified version \(toolsVersionString) (≤ 5.3) supports only leading newline characters (U+000A)."
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.leadingLineTerminators, _) = error else {
-                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.leadingLineTerminators, _)' should've been thrown, but a different error is thrown.")
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.leadingWhitespace, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.leadingWhitespace, _)' should've been thrown, but a different error is thrown.")
                     return
                 }
                 XCTAssertEqual(
                     error.description,
-                    "leading line terminator sequence [U+000D, U+000A] in manifest is supported by only Swift > 5.3; for the specified version \(toolsVersionString), only newline characters (U+000A) at the beginning of the manifest is supported; consider moving the Swift tools version specification to the first line of the manifest"
+                    "leading whitespace sequence [U+000D, U+000A] in manifest is supported by only Swift > 5.3; the specified version \(toolsVersionString) supports only newline characters (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
                 )
             }
         }
         
-        // MARK: An assortment of leading line terminators
+        // MARK: An assortment of leading whitespace characters
         
-        let manifestSnippetWithAnAssortmentOfLeadingLineTerminators = [
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-tools-version:3.1"                : "3.1.0",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-tools-version:3.1-dev"            : "3.1.0",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-tools-version:5.3"                : "5.3.0",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-tools-version:5.3.0"              : "5.3.0",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-tools-version:5.3-dev"            : "5.3.0",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-tools-version:4.8.0"              : "4.8.0",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-tools-version:3.1.2"              : "3.1.2",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-tools-version:3.1.2;"             : "3.1.2",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-toolS-version:3.5.2;hello"        : "3.5.2",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
+        let manifestSnippetWithAnAssortmentOfLeadingWhitespaceCharacters = [
+            "\u{A}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}\u{D}\u{D}\u{A}\u{85}\u{2001}\u{2028}\u{2002}\u{202F}\u{2029}\u{3000}//swift-tools-version:3.1"                : "3.1.0",
+            "\u{A}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}\u{D}\u{D}\u{A}\u{85}\u{2001}\u{2028}\u{2002}\u{202F}\u{2029}\u{3000}//swift-tools-version:3.1-dev"            : "3.1.0",
+            "\u{A}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}\u{D}\u{D}\u{A}\u{85}\u{2001}\u{2028}\u{2002}\u{202F}\u{2029}\u{3000}//swift-tools-version:5.3"                : "5.3.0",
+            "\u{A}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}\u{D}\u{D}\u{A}\u{85}\u{2001}\u{2028}\u{2002}\u{202F}\u{2029}\u{3000}//swift-tools-version:5.3.0"              : "5.3.0",
+            "\u{A}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}\u{D}\u{D}\u{A}\u{85}\u{2001}\u{2028}\u{2002}\u{202F}\u{2029}\u{3000}//swift-tools-version:5.3-dev"            : "5.3.0",
+            "\u{A}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}\u{D}\u{D}\u{A}\u{85}\u{2001}\u{2028}\u{2002}\u{202F}\u{2029}\u{3000}//swift-tools-version:4.8.0"              : "4.8.0",
+            "\u{A}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}\u{D}\u{D}\u{A}\u{85}\u{2001}\u{2028}\u{2002}\u{202F}\u{2029}\u{3000}//swift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
+            "\u{A}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}\u{D}\u{D}\u{A}\u{85}\u{2001}\u{2028}\u{2002}\u{202F}\u{2029}\u{3000}//swift-tools-version:3.1.2"              : "3.1.2",
+            "\u{A}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}\u{D}\u{D}\u{A}\u{85}\u{2001}\u{2028}\u{2002}\u{202F}\u{2029}\u{3000}//swift-tools-version:3.1.2;"             : "3.1.2",
+            "\u{A}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}\u{D}\u{D}\u{A}\u{85}\u{2001}\u{2028}\u{2002}\u{202F}\u{2029}\u{3000}//swift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
+            "\u{A}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}\u{D}\u{D}\u{A}\u{85}\u{2001}\u{2028}\u{2002}\u{202F}\u{2029}\u{3000}//swift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
+            "\u{A}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}\u{D}\u{D}\u{A}\u{85}\u{2001}\u{2028}\u{2002}\u{202F}\u{2029}\u{3000}//swift-toolS-version:3.5.2;hello"        : "3.5.2",
+            "\u{A}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}\u{D}\u{D}\u{A}\u{85}\u{2001}\u{2028}\u{2002}\u{202F}\u{2029}\u{3000}//sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
         ]
         
-        for (specification, toolsVersionString) in manifestSnippetWithAnAssortmentOfLeadingLineTerminators {
+        for (specification, toolsVersionString) in manifestSnippetWithAnAssortmentOfLeadingWhitespaceCharacters {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with an assortment of line terminators, and the specified version \(toolsVersionString) (≤ 5.3) supports only 0 or 1 leading U+000A."
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with an assortment of whitespace characters, and the specified version \(toolsVersionString) (≤ 5.3) supports only leading newline characters (U+000A)."
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.leadingLineTerminators, _) = error else {
-                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.leadingLineTerminators, _)' should've been thrown, but a different error is thrown.")
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.leadingWhitespace, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.leadingWhitespace, _)' should've been thrown, but a different error is thrown.")
                     return
                 }
                 XCTAssertEqual(
                     error.description,
-                    "leading line terminator sequence [U+000A, U+000B, U+000C, U+000D, U+000D, U+000A, U+0085, U+2028, U+2029] in manifest is supported by only Swift > 5.3; for the specified version \(toolsVersionString), only newline characters (U+000A) at the beginning of the manifest is supported; consider moving the Swift tools version specification to the first line of the manifest"
+                    "leading whitespace sequence [U+000A, U+00A0, U+000B, U+1680, U+000C, U+2000, U+000D, U+000D, U+000A, U+0085, U+2001, U+2028, U+2002, U+202F, U+2029, U+3000] in manifest is supported by only Swift > 5.3; the specified version \(toolsVersionString) supports only newline characters (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
                 )
             }
         }
         
-        // MARK: An assortment of leading line terminators and an assortment of horizontal whitespace characters between "//" and "swift-tools-version"
+        // MARK: An assortment of leading whitespace characters and an assortment of horizontal whitespace characters surrounding the label
         
-        let manifestSnippetWithAnAssortmentOfLeadingLineTerminatorsAndAnAssortmentOfWhitespacesAfterSpecifcationCommentMarker = [
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1"                : "3.1.0",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1-dev"            : "3.1.0",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:5.3"                : "5.3.0",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:5.3.0"              : "5.3.0",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:5.3-dev"            : "5.3.0",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:4.8.0"              : "4.8.0",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1.2"              : "3.1.2",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1.2;"             : "3.1.2",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-toolS-version:3.5.2;hello"        : "3.5.2",
-            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
+        let manifestSnippetWithAnAssortmentOfLeadingWhitespaceCharactersAndAnAssortmentOfWhitespacesSurroundingLabel = [
+            "\u{D}\u{202F}\u{2029}\u{85}\u{2001}\u{2028}\u{3000}\u{A}\u{D}\u{A}\u{2002}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}3.1"                : "3.1.0",
+            "\u{D}\u{202F}\u{2029}\u{85}\u{2001}\u{2028}\u{3000}\u{A}\u{D}\u{A}\u{2002}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}3.1-dev"            : "3.1.0",
+            "\u{D}\u{202F}\u{2029}\u{85}\u{2001}\u{2028}\u{3000}\u{A}\u{D}\u{A}\u{2002}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}5.3"                : "5.3.0",
+            "\u{D}\u{202F}\u{2029}\u{85}\u{2001}\u{2028}\u{3000}\u{A}\u{D}\u{A}\u{2002}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}5.3.0"              : "5.3.0",
+            "\u{D}\u{202F}\u{2029}\u{85}\u{2001}\u{2028}\u{3000}\u{A}\u{D}\u{A}\u{2002}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}5.3-dev"            : "5.3.0",
+            "\u{D}\u{202F}\u{2029}\u{85}\u{2001}\u{2028}\u{3000}\u{A}\u{D}\u{A}\u{2002}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}4.8.0"              : "4.8.0",
+            "\u{D}\u{202F}\u{2029}\u{85}\u{2001}\u{2028}\u{3000}\u{A}\u{D}\u{A}\u{2002}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}4.8.0-dev.al+sha.x" : "4.8.0",
+            "\u{D}\u{202F}\u{2029}\u{85}\u{2001}\u{2028}\u{3000}\u{A}\u{D}\u{A}\u{2002}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}3.1.2"              : "3.1.2",
+            "\u{D}\u{202F}\u{2029}\u{85}\u{2001}\u{2028}\u{3000}\u{A}\u{D}\u{A}\u{2002}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}3.1.2;"             : "3.1.2",
+            "\u{D}\u{202F}\u{2029}\u{85}\u{2001}\u{2028}\u{3000}\u{A}\u{D}\u{A}\u{2002}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-vErsion:\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}3.1.2;;;;;"         : "3.1.2",
+            "\u{D}\u{202F}\u{2029}\u{85}\u{2001}\u{2028}\u{3000}\u{A}\u{D}\u{A}\u{2002}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}3.1.2;x;x;x;x;x;"   : "3.1.2",
+            "\u{D}\u{202F}\u{2029}\u{85}\u{2001}\u{2028}\u{3000}\u{A}\u{D}\u{A}\u{2002}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-toolS-version:\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}3.5.2;hello"        : "3.5.2",
+            "\u{D}\u{202F}\u{2029}\u{85}\u{2001}\u{2028}\u{3000}\u{A}\u{D}\u{A}\u{2002}\u{A0}\u{B}\u{1680}\u{C}\t\u{2000}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}sWiFt-tOoLs-vErSiOn:\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}3.5.2\nkkk\n"       : "3.5.2",
         ]
         
-        // Backward-incompatible leading line terminators are diagnosed before backward-incompatible spacings after the comment marker.
-        // So the error thrown here should be about invalid leading line terminators, although both the line terminators and the spacing here are backward-incompatible.
-        for (specification, toolsVersionString) in manifestSnippetWithAnAssortmentOfLeadingLineTerminatorsAndAnAssortmentOfWhitespacesAfterSpecifcationCommentMarker {
+        // Backward-incompatible leading whitespace is diagnosed before backward-incompatible spacings surrounding the label.
+        // So the errors thrown here should be about invalid leading whitespace, although both the leading whitespace and the spacings here are backward-incompatible.
+        for (specification, toolsVersionString) in manifestSnippetWithAnAssortmentOfLeadingWhitespaceCharactersAndAnAssortmentOfWhitespacesSurroundingLabel {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with an assortment of line terminators, and the specified version \(toolsVersionString) (≤ 5.3) supports only 0 or 1 leading U+000A."
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with an assortment of whitespace characters, and the specified version \(toolsVersionString) (≤ 5.3) supports only leading newline characters (U+000A)."
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.leadingLineTerminators, _) = error else {
-                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.leadingLineTerminators, _)' should've been thrown, but a different error is thrown.")
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.leadingWhitespace, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.leadingWhitespace, _)' should've been thrown, but a different error is thrown.")
                     return
                 }
                 XCTAssertEqual(
                     error.description,
-                    "leading line terminator sequence [U+000A, U+000B, U+000C, U+000D, U+000D, U+000A, U+0085, U+2028, U+2029] in manifest is supported by only Swift > 5.3; for the specified version \(toolsVersionString), only newline characters (U+000A) at the beginning of the manifest is supported; consider moving the Swift tools version specification to the first line of the manifest"
+                    "leading whitespace sequence [U+000D, U+202F, U+2029, U+0085, U+2001, U+2028, U+3000, U+000A, U+000D, U+000A, U+2002, U+00A0, U+000B, U+1680, U+000C, U+0009, U+2000] in manifest is supported by only Swift > 5.3; the specified version \(toolsVersionString) supports only newline characters (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
                 )
             }
         }
         
-        // MARK: No spacing between "//" and "swift-tools-version" for Swift ≤ 5.3
+        // MARK: No spacing surrounding the label
         
         let specificationsWithZeroSpacing = [
             "//swift-tools-version:3.1"                : "3.1.0",
@@ -577,7 +535,7 @@ class ToolsVersionLoaderTests: XCTestCase {
         for (specification, toolsVersionString) in specificationsWithZeroSpacing {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "a 'ToolsVersionLoader.Error' should've been thrown, because there is no spacing between '//' and 'swift-tools-version', and the specified version \(toolsVersionString) (≤ 5.3) supports exactly 1 space (U+0020) between '//' and 'swift-tools-version'"
+                "a 'ToolsVersionLoader.Error' should've been thrown, because there is no spacing between '//' and 'swift-tools-version', and the specified version \(toolsVersionString) (≤ 5.3) supports exactly 1 space (U+0020) there"
             ) { error in
                 guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _) = error else {
                     XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _)' should've been thrown, but a different error is thrown.")
@@ -590,77 +548,9 @@ class ToolsVersionLoaderTests: XCTestCase {
             }
         }
         
-        // MARK: 1 character tabulation (U+0009) between "//" and "swift-tools-version"
+        // MARK: An assortment of horizontal whitespace characters before the label
         
-        let specificationsWith1TabAfterCommentMarker = [
-            "//\tswift-tools-version:3.1"                : "3.1.0",
-            "//\tswift-tools-version:3.1-dev"            : "3.1.0",
-            "//\tswift-tools-version:5.3"                : "5.3.0",
-            "//\tswift-tools-version:5.3.0"              : "5.3.0",
-            "//\tswift-tools-version:5.3-dev"            : "5.3.0",
-            "//\tswift-tools-version:4.8.0"              : "4.8.0",
-            "//\tswift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
-            "//\tswift-tools-version:3.1.2"              : "3.1.2",
-            "//\tswift-tools-version:3.1.2;"             : "3.1.2",
-            "//\tswift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
-            "//\tswift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
-            "//\tswift-toolS-version:3.5.2;hello"        : "3.5.2",
-            "//\tsWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
-        ]
-        
-        for (specification, toolsVersionString) in specificationsWith1TabAfterCommentMarker {
-            XCTAssertThrowsError(
-                try load(ByteString(encodingAsUTF8: specification)),
-                "a 'ToolsVersionLoader.Error' should've been thrown, because the spacing between \"//\" and \"swift-tools-version\" is a character tabulation (U+0009), and the specified version \(toolsVersionString) (≤ 5.3) supports exactly 1 space (U+0020) between \"//\" and \"swift-tools-version\"."
-            ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _) = error else {
-                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _)' should've been thrown, but a different error is thrown.")
-                    return
-                }
-                XCTAssertEqual(
-                    error.description,
-                    "horizontal whitespace sequence [U+0009] between '//' and 'swift-tools-version' is supported by only Swift > 5.3; consider using a single space (U+0020) for Swift \(toolsVersionString)"
-                )
-            }
-        }
-        
-        // MARK: 1 space (U+0020) and 1 character tabulation (U+0009) between "//" and "swift-tools-version"
-        
-        let specificationsWith1SpaceAnd1TabAfterCommentMarker = [
-            "// \tswift-tools-version:3.1"                : "3.1.0",
-            "// \tswift-tools-version:3.1-dev"            : "3.1.0",
-            "// \tswift-tools-version:5.3"                : "5.3.0",
-            "// \tswift-tools-version:5.3.0"              : "5.3.0",
-            "// \tswift-tools-version:5.3-dev"            : "5.3.0",
-            "// \tswift-tools-version:4.8.0"              : "4.8.0",
-            "// \tswift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
-            "// \tswift-tools-version:3.1.2"              : "3.1.2",
-            "// \tswift-tools-version:3.1.2;"             : "3.1.2",
-            "// \tswift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
-            "// \tswift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
-            "// \tswift-toolS-version:3.5.2;hello"        : "3.5.2",
-            "// \tsWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
-        ]
-        
-        for (specification, toolsVersionString) in specificationsWith1SpaceAnd1TabAfterCommentMarker {
-            XCTAssertThrowsError(
-                try load(ByteString(encodingAsUTF8: specification)),
-                "a 'ToolsVersionLoader.Error' should've been thrown, because the spacing between \"//\" and \"swift-tools-version\" is a space (U+0020) and a character tabulation (U+0009), and the specified version \(toolsVersionString) (≤ 5.3) supports exactly 1 space (U+0020) between \"//\" and \"swift-tools-version\"."
-            ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _) = error else {
-                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _)' should've been thrown, but a different error is thrown.")
-                    return
-                }
-                XCTAssertEqual(
-                    error.description,
-                    "horizontal whitespace sequence [U+0020, U+0009] between '//' and 'swift-tools-version' is supported by only Swift > 5.3; consider using a single space (U+0020) for Swift \(toolsVersionString)"
-                )
-            }
-        }
-        
-        // MARK: An assortment of horizontal whitespace characters between "//" and "swift-tools-version"
-        
-        let specificationsWithAnAssortmentOfWhitespacesAfterCommentMarker = [
+        let specificationsWithAnAssortmentOfWhitespacesBeforeLabel = [
             "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1"                : "3.1.0",
             "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1-dev"            : "3.1.0",
             "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:5.3"                : "5.3.0",
@@ -676,10 +566,10 @@ class ToolsVersionLoaderTests: XCTestCase {
             "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
         ]
         
-        for (specification, toolsVersionString) in specificationsWithAnAssortmentOfWhitespacesAfterCommentMarker {
+        for (specification, toolsVersionString) in specificationsWithAnAssortmentOfWhitespacesBeforeLabel {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "a 'ToolsVersionLoader.Error' should've been thrown, because the spacing between \"//\" and \"swift-tools-version\" is an assortment of horizontal whitespace characters, and the specified version \(toolsVersionString) (≤ 5.3) supports exactly 1 space (U+0020) between \"//\" and \"swift-tools-version\"."
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the spacing between '//' and 'swift-tools-version' is an assortment of horizontal whitespace characters, and the specified version \(toolsVersionString) (≤ 5.3) supports exactly 1 space (U+0020) there."
             ) { error in
                 guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _) = error else {
                     XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _)' should've been thrown, but a different error is thrown.")
@@ -688,6 +578,76 @@ class ToolsVersionLoaderTests: XCTestCase {
                 XCTAssertEqual(
                     error.description,
                     "horizontal whitespace sequence [U+0009, U+0020, U+00A0, U+1680, U+2000, U+2001, U+2002, U+2003, U+2004, U+2005, U+2006, U+2007, U+2008, U+2009, U+200A, U+202F, U+205F, U+3000] between '//' and 'swift-tools-version' is supported by only Swift > 5.3; consider using a single space (U+0020) for Swift \(toolsVersionString)"
+                )
+            }
+        }
+        
+        // MARK: An assortment of horizontal whitespace characters surrounding the label
+        
+        let specificationsWithAnAssortmentOfWhitespacesBeforeAndAfterLabel = [
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}swift-tools-version:\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}3.1"                : "3.1.0",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}swift-tools-version:\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}3.1-dev"            : "3.1.0",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}swift-tools-version:\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}5.3"                : "5.3.0",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}swift-tools-version:\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}5.3.0"              : "5.3.0",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}swift-tools-version:\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}5.3-dev"            : "5.3.0",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}swift-tools-version:\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}4.8.0"              : "4.8.0",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}swift-tools-version:\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}4.8.0-dev.al+sha.x" : "4.8.0",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}swift-tools-version:\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}3.1.2"              : "3.1.2",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}swift-tools-version:\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}3.1.2;"             : "3.1.2",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}swift-tools-vErsion:\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}3.1.2;;;;;"         : "3.1.2",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}swift-tools-version:\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}3.1.2;x;x;x;x;x;"   : "3.1.2",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}swift-toolS-version:\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}3.5.2;hello"        : "3.5.2",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}sWiFt-tOoLs-vErSiOn:\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}3.5.2\nkkk\n"       : "3.5.2",
+        ]
+        
+        // Backward-incompatible spacings after the comment marker is diagnosed before backward-incompatible spacings after the label.
+        // So the errors thrown here should be about invalid spacing after comment marker, although both the spacings here are backward-incompatible.
+        for (specification, toolsVersionString) in specificationsWithAnAssortmentOfWhitespacesBeforeAndAfterLabel {
+            XCTAssertThrowsError(
+                try load(ByteString(encodingAsUTF8: specification)),
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the spacing between '//' and 'swift-tools-version' is an assortment of horizontal whitespace characters, and the specified version \(toolsVersionString) (≤ 5.3) supports exactly 1 space (U+0020) there."
+            ) { error in
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _)' should've been thrown, but a different error is thrown.")
+                    return
+                }
+                XCTAssertEqual(
+                    error.description,
+                    "horizontal whitespace sequence [U+0009, U+0020, U+00A0, U+1680, U+2000, U+2001, U+2002, U+2003, U+2004] between '//' and 'swift-tools-version' is supported by only Swift > 5.3; consider replacing the sequence with a single space (U+0020) for Swift \(toolsVersionString)"
+                )
+            }
+        }
+        
+        // MARK: 1 U+0020 before the label and an assortment of horizontal whitespace characters after the label
+        
+        let specificationsWithAnAssortmentOfWhitespacesAfterLabel = [
+            "// swift-tools-version:\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}3.1"                : "3.1.0",
+            "// swift-tools-version:\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}3.1-dev"            : "3.1.0",
+            "// swift-tools-version:\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}5.3"                : "5.3.0",
+            "// swift-tools-version:\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}5.3.0"              : "5.3.0",
+            "// swift-tools-version:\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}5.3-dev"            : "5.3.0",
+            "// swift-tools-version:\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}4.8.0"              : "4.8.0",
+            "// swift-tools-version:\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}4.8.0-dev.al+sha.x" : "4.8.0",
+            "// swift-tools-version:\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}3.1.2"              : "3.1.2",
+            "// swift-tools-version:\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}3.1.2;"             : "3.1.2",
+            "// swift-tools-vErsion:\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}3.1.2;;;;;"         : "3.1.2",
+            "// swift-tools-version:\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}3.1.2;x;x;x;x;x;"   : "3.1.2",
+            "// swift-toolS-version:\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}3.5.2;hello"        : "3.5.2",
+            "// sWiFt-tOoLs-vErSiOn:\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}3.5.2\nkkk\n"       : "3.5.2",
+        ]
+        
+        for (specification, toolsVersionString) in specificationsWithAnAssortmentOfWhitespacesAfterLabel {
+            XCTAssertThrowsError(
+                try load(ByteString(encodingAsUTF8: specification)),
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the spacing between 'swift-tools-version' and the version specifier is an assortment of horizontal whitespace characters, and the specified version \(toolsVersionString) (≤ 5.3) supports no spacing there."
+            ) { error in
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.spacingAfterLabel, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.spacingAfterLabel, _)' should've been thrown, but a different error is thrown.")
+                    return
+                }
+                XCTAssertEqual(
+                    error.description,
+                    "horizontal whitespace sequence [U+0009, U+0020, U+00A0, U+1680, U+2000, U+2001, U+2002, U+2003, U+2004, U+2005, U+2006, U+2007, U+2008, U+2009, U+200A, U+202F, U+205F, U+3000] immediately preceding the version specifier is supported by only Swift > 5.3; consider removing the sequence for Swift \(toolsVersionString)"
                 )
             }
         }

--- a/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
@@ -174,204 +174,238 @@ class ToolsVersionLoaderTests: XCTestCase {
             }
         }
     }
-
-    // FIXME: Currently only tools version specifications that contain either "swift-tool" or "tool-version" are treated as having malformed labels.
-    // Specification that don't contain these 2 misspellings silently fall back to version 3.1.
-    // Improve diagnostics, so that malformation checks don't depend on these 2 misspellings.
-    func testNonMatching() throws {
-        do {
-            let stream = BufferedOutputByteStream()
-            stream <<< "// \n"
-            stream <<< "// swift-tools-version:6.1.0\n"
-            stream <<< "// swift-tools-version:4.1.0\n\n\n\n"
-            stream <<< "let package = .."
-            try load(stream.bytes) { toolsVersion in
-                XCTAssertEqual(toolsVersion, .v3)
+    
+    /// Verifies that the correct error is thrown for each manifest missing its Swift tools version specification.
+    func testMissingSpecifications() throws {
+        /// Leading snippets of manifest files that don't have Swift tools version specifications.
+        let manifestSnippetsWithoutSpecification = [
+            "",
+            "\n",
+            "\n\r\r\n",
+            "ni",
+            "\rimport PackageDescription",
+            "let package = Package(\n",
+        ]
+        
+        for manifestSnippet in manifestSnippetsWithoutSpecification {
+            XCTAssertThrowsError(
+                try load(ByteString(encodingAsUTF8: manifestSnippet)),
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the Swift tools version specification is missing from the manifest snippet"
+            ) { error in
+                guard let error = error as? ToolsVersionLoader.Error, case .malformedToolsVersionSpecification(.missingCommentMarker) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.malformedToolsVersionSpecification(.missingCommentMarker)' should've been thrown, but a different error is thrown")
+                    return
+                }
+                
+                XCTAssertEqual(
+                    error.description,
+                    "the manifest is missing a Swift tools version specification; consider prepending to the manifest '// swift-tools-version:\(ToolsVersion.currentToolsVersion)' to specify the current Swift toolchain version as the lowest supported version by the project; if such a specification already exists, consider moving it to the top of the manifest, or prepending it with '//' to help Swift Package Manager find it"
+                )
             }
         }
-
-        try load("// \n// swift-tools-version:6.1.0\n") { toolsVersion in
-            XCTAssertEqual(toolsVersion, .v3)
+    }
+    
+    /// Verifies that the correct error is thrown for each Swift tools version specification missing its comment marker.
+    func testMissingSpecificationCommentMarkers() throws {
+        let manifestSnippetsWithoutSpecificationCommentMarker = [
+            " swift-tools-version:4.0",
+            // Missing comment markers are diagnosed before missing Labels.
+            " 4.2",
+            // Missing comment markers are diagnosed before missing version specifiers.
+            " swift-tools-version:",
+            " ",
+            // Missing comment markers are diagnosed before misspelt labels.
+            " Swift toolchain version 5.1",
+            " shiny-tools-version",
+            // Missing comment markers are diagnosed before misspelt version specifiers.
+            " swift-tools-version:0",
+            " The Answer to the Ultimate Question of Life, the Universe, and Everything is 42",
+            " 9999999",
+            // Missing comment markers are diagnosed before backward-compatibility checks.
+            "\n\n\nswift-tools-version:3.1\r",
+            "\r\n\r\ncontrafibularity",
+            "\n\r\t3.14",
+            "",
+        ]
+        
+        for manifestSnippet in manifestSnippetsWithoutSpecificationCommentMarker {
+            XCTAssertThrowsError(
+                try load(ByteString(encodingAsUTF8: manifestSnippet)),
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the comment marker is missing from the Swift tools version specification"
+            ) { error in
+                guard let error = error as? ToolsVersionLoader.Error, case .malformedToolsVersionSpecification(.missingCommentMarker) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.malformedToolsVersionSpecification(.missingCommentMarker)' should've been thrown, but a different error is thrown")
+                    return
+                }
+                XCTAssertEqual(
+                    error.description,
+                    "the manifest is missing a Swift tools version specification; consider prepending to the manifest '// swift-tools-version:\(ToolsVersion.currentToolsVersion)' to specify the current Swift toolchain version as the lowest supported version by the project; if such a specification already exists, consider moving it to the top of the manifest, or prepending it with '//' to help Swift Package Manager find it"
+                )
+            }
         }
-
-        // Verify no matching for malformed labels.
-        // FIXME: Improve diagnostics, so that `assertFailure` compares labels instead of the entire specification for label failures.
-        assertFailure("//swift-tools-:6.1.0\n", "//swift-tools-:6.1.0", "6.1.0")
-        assertFailure("//swift-tool-version:6.1.0\n", "//swift-tool-version:6.1.0", "6.1.0")
-        assertFailure("//  swift-tool-version:6.1.0\n", "//  swift-tool-version:6.1.0", "6.1.0")
-        assertFailure("// swift-tool-version:6.1.0\n", "// swift-tool-version:6.1.0", "6.1.0")
-        assertFailure("// swift-tool-version:2.1.0\n// swift-tools-version:6.1.0\n", "// swift-tool-version:2.1.0", "2.1.0")
-        assertFailure("\u{A}\u{A}\u{D}\u{A}\u{B}// swallow-tool-version:2-coconut-halves", "// swallow-tool-version:2-coconut-halves", "2-coconut-halves")
-        assertFailure("noway// swift-tools-version:6.1.0\n", "noway// swift-tools-version:6.1.0", "6.1.0")
-        assertFailure("//// swift-tools-version:6.1.0\n", "//// swift-tools-version:6.1.0", "6.1.0")
-        assertFailure("// swift-tools-version 6.1.0\n", "// swift-tools-version 6.1.0", "6.1.0")
-        assertFailure("// swift-tOols-Version 6.1.0\n", "// swift-tOols-Version 6.1.0", "6.1.0")
-        assertFailure("// haha swift-tools-version:6.1.0\n", "// haha swift-tools-version:6.1.0", "6.1.0")
+    }
+    
+    /// Verifies that the correct error is thrown for each Swift tools version specification missing its label.
+    func testMissingSpecificationLabels() throws {
+        let manifestSnippetsWithoutSpecificationLabel = [
+            "// 5.3",
+            // Missing labels are diagnosed before missing version specifiers.
+            "// ",
+            // Missing labels are diagnosed before misspelt comment markers.
+            "/// ",
+            "/* ",
+            // Missing labels are diagnosed before misspelt version specifiers.
+            "// 6 × 9 = 42",
+            "/// 99 little bugs in the code",
+            // Missing labels are diagnosed before backward-compatibility checks.
+            "\r\n// ",
+            "//",
+            "\n\r///\t2.1\r",
+        ]
         
-        // Verify no matching for malformed version specifiers.
-        assertFailure("// swift-tools-version:6.1.2.0\n", "// swift-tools-version:6.1.2.0", "6.1.2.0")
-        assertFailure("// swift-tools-version:-1.1.2\n", "// swift-tools-version:-1.1.2", "-1.1.2")
-        assertFailure("// swift-tools-version:3.1hello", "// swift-tools-version:3.1hello", "3.1hello")
+        for manifestSnippet in manifestSnippetsWithoutSpecificationLabel {
+            XCTAssertThrowsError(
+                try load(ByteString(encodingAsUTF8: manifestSnippet)),
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the label is missing from the Swift tools version specification"
+            ) { error in
+                guard let error = error as? ToolsVersionLoader.Error, case .malformedToolsVersionSpecification(.missingLabel) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.malformedToolsVersionSpecification(.missingLabel)' should've been thrown, but a different error is thrown")
+                    return
+                }
+                XCTAssertEqual(
+                    error.description,
+                    "the Swift tools version specification is missing a label; consider inserting 'swift-tools-version:' between the comment marker and the version specifier"
+                )
+            }
+        }
+    }
+    
+    /// Verifies that the correct error is thrown for each Swift tools version specification missing its version specifier.
+    func testMissingVersionSpecifiers() throws {
+        let manifestSnippetsWithoutVersionSpecifier = [
+            "// swift-tools-version:",
+            // Missing version specifiers are diagnosed before misspelt comment markers.
+            "/// swift-tools-version:",
+            "/* swift-tools-version:",
+            // Missing version specifiers are diagnosed before misspelt labels.
+            "// swallow tools version:",
+            "/// We are the knights who say 'Ni!'",
+            // Missing version specifiers are diagnosed before backward-compatibility checks.
+            "\r\n//\tswift-tools-version:",
+            "\n\r///The swifts hung in the sky in much the same way that bricks don't.\u{85}",
+        ]
         
-        // Verify no matching for line terminators other than U+000A between "//" and "swift-tools-version":
-        // FIXME: The following 8 test cases fail, because all Unicode line terminators are recognised.
-        // This is inconsistent with Swift ≤ 5.3's behaviour, for which only U+000A is recognised.
-        assertFailure("//\u{D}swift-tools-version:5.3\n", "//\rswift-tools-version:5.3", "5.3")
-        assertFailure("// \u{D}swift-tools-version:5.3\n", "// \rswift-tools-version:5.3", "5.3")
-        assertFailure("//\u{D} swift-tools-version:5.3\n", "//\r swift-tools-version:5.3", "5.3")
-        assertFailure("//\u{C}swift-tools-version:5.3\n", "//\u{B}swift-tools-version:5.3", "5.3")
-        assertFailure("//\u{B}swift-tools-version:5.3\n", "//\u{2028}swift-tools-version:5.3", "5.3")
-        assertFailure("//\u{85}swift-tools-version:5.3\n", "//\u{2029}swift-tools-version:5.3", "5.3")
-        assertFailure("//\u{2028}swift-tools-version:5.3\n", "//\u{B}swift-tools-version:5.3", "5.3")
-        assertFailure("//\u{2029}swift-tools-version:5.3\n", "//\u{2028}swift-tools-version:5.3", "5.3")
+        for manifestSnippet in manifestSnippetsWithoutVersionSpecifier {
+            XCTAssertThrowsError(
+                try load(ByteString(encodingAsUTF8: manifestSnippet)),
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the version specifier is missing from the Swift tools version specification"
+            ) { error in
+                guard let error = error as? ToolsVersionLoader.Error, case .malformedToolsVersionSpecification(.missingVersionSpecifier) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.malformedToolsVersionSpecification(.missingVersionSpecifier)' should've been thrown, but a different error is thrown")
+                    return
+                }
+                XCTAssertEqual(
+                    error.description,
+                    "the Swift tools version specification is missing a version specifier; consider appending '\(ToolsVersion.currentToolsVersion)' to the line to specify the current Swift toolchain version as the lowest supported version by the project"
+                )
+            }
+        }
+    }
+    
+    /// Verifies that the correct error is thrown for each misspelt comment marker in Swift tools version specification.
+    func testMisspeltSpecificationCommentMarkers() throws {
+        let manifestSnippetsWithMisspeltSpecificationCommentMarker = [
+            "/// swift-tools-version:4.0",
+            "/** swift-tools-version:4.1",
+            // Misspelt comment markers are diagnosed before misspelt labels.
+            "//// Shiny toolchain version 4.2",
+            // Misspelt comment markers are diagnosed before misspelt version specifiers.
+            "/* swift-tools-version:43",
+            "/** Swift version 4.4 **/",
+            // Misspelt comment markers are diagnosed before backward-compatibility checks.
+            "\r\r\r*/swift-tools-version:4.5",
+            "\n\n\n/*/*\t\tSwift5\r",
+        ]
         
-        // Verify no matching for related Unicode characters without `White_Space` property, between "//" and "swift-tools-version":
-        assertFailure("//\u{180E}swift-tools-version:5.3\n", "//\u{180E}swift-tools-version:5.3", "5.3")
-        assertFailure("//\u{200B}swift-tools-version:5.3\n", "//\u{200B}swift-tools-version:5.3", "5.3")
-        assertFailure("//\u{200C}swift-tools-version:5.3\n", "//\u{200C}swift-tools-version:5.3", "5.3")
-        assertFailure("//\u{200D}swift-tools-version:5.3\n", "//\u{200D}swift-tools-version:5.3", "5.3")
-        assertFailure("//\u{2060}swift-tools-version:5.3\n", "//\u{2060}swift-tools-version:5.3", "5.3")
-        assertFailure("//\u{FEFF}swift-tools-version:5.3\n", "//\u{FEFF}swift-tools-version:5.3", "5.3")
+        for manifestSnippet in manifestSnippetsWithMisspeltSpecificationCommentMarker {
+            XCTAssertThrowsError(
+                try load(ByteString(encodingAsUTF8: manifestSnippet)),
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the comment marker is misspelt in the Swift tools version specification"
+            ) { error in
+                guard let error = error as? ToolsVersionLoader.Error, case .malformedToolsVersionSpecification(.commentMarker(let misspeltCommentMarker)) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.malformedToolsVersionSpecification(.commentMarker)' should've been thrown, but a different error is thrown")
+                    return
+                }
+                XCTAssertEqual(
+                    error.description,
+                    "the comment marker '\(misspeltCommentMarker)' is malformed for the Swift tools version specification; consider replacing it with '//'"
+                )
+            }
+        }
+    }
+    
+    /// Verifies that the correct error is thrown for each misspelt label in Swift tools version specification.
+    func testMisspeltSpecificationLabels() throws {
+        let manifestSnippetsWithMisspeltSpecificationLabel = [
+            "// fast-tools-version:3.0",
+            // Misspelt labels are diagnosed before misspelt version specifiers.
+            "// rapid-tools-version:3",
+            "// swift-too1s-version:3.0",
+            // Misspelt labels are diagnosed before backward-compatibility checks.
+            "\n\r//\t\u{A0}prompt-t00ls-version:3.0.0.0\r\n",
+        ]
+        
+        for manifestSnippet in manifestSnippetsWithMisspeltSpecificationLabel {
+            XCTAssertThrowsError(
+                try load(ByteString(encodingAsUTF8: manifestSnippet)),
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the label is misspelt in the Swift tools version specification"
+            ) { error in
+                guard let error = error as? ToolsVersionLoader.Error, case .malformedToolsVersionSpecification(.label(let misspeltLabel)) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.malformedToolsVersionSpecification(.label)' should've been thrown, but a different error is thrown")
+                    return
+                }
+                XCTAssertEqual(
+                    error.description,
+                    "the Swift tools version specification's label '\(misspeltLabel)' is malformed; consider replacing it with 'swift-tools-version:'"
+                )
+            }
+        }
+    }
+    
+    /// Verifies that the correct error is thrown for each misspelt version specifier in Swift tools version specification.
+    func testMisspeltVersionSpecifiers() throws {
+        let manifestSnippetsWithMisspeltVersionSpecifier = [
+            "// swift-tools-version:5²",
+            "// swift-tools-version:5⃣️.2⃣️",
+            "// swift-tools-version:5 ÷ 2 = 2.5",
+            // Misspelt version specifiers are diagnosed before backward-compatibility checks.
+            "\u{A}\u{B}\u{C}\u{D}//\u{3000}swift-tools-version:五.二\u{2028}",
+        ]
+        
+        for manifestSnippet in manifestSnippetsWithMisspeltVersionSpecifier {
+            XCTAssertThrowsError(
+                try load(ByteString(encodingAsUTF8: manifestSnippet)),
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the version specifier is misspelt in the Swift tools version specification"
+            ) { error in
+                guard let error = error as? ToolsVersionLoader.Error, case .malformedToolsVersionSpecification(.versionSpecifier(let misspeltVersionSpecifier)) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.malformedToolsVersionSpecification(.versionSpecifier)' should've been thrown, but a different error is thrown")
+                    return
+                }
+                XCTAssertEqual(
+                    error.description,
+                    "the Swift tools version '\(misspeltVersionSpecifier)' is not valid; consider replacing it with '\(ToolsVersion.currentToolsVersion)' to specify the current Swift toolchain version as the lowest supported version by the project"
+                )
+            }
+        }
     }
     
     /// Verifies that a correct error is thrown, if the manifest is valid for Swift tools version > 5.3, but invalid for version ≤ 5.3.
     func testBackwardIncompatibilityPre5_3_1() throws {
         
-        // MARK: No spacing between "//" and "swift-tools-version" for Swift ≤ 5.3
-        
-        let specificationsWithZeroSpacing = [
-            "//swift-tools-version:3.1"                : "3.1.0",
-            "//swift-tools-version:3.1-dev"            : "3.1.0",
-            "//swift-tools-version:5.3"                : "5.3.0",
-            "//swift-tools-version:5.3.0"              : "5.3.0",
-            "//swift-tools-version:5.3-dev"            : "5.3.0",
-            "//swift-tools-version:4.8.0"              : "4.8.0",
-            "//swift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
-            "//swift-tools-version:3.1.2"              : "3.1.2",
-            "//swift-tools-version:3.1.2;"             : "3.1.2",
-            "//swift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
-            "//swift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
-            "//swift-toolS-version:3.5.2;hello"        : "3.5.2",
-            "//sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
-        ]
-        
-        for (specification, toolsVersionString) in specificationsWithZeroSpacing {
-            XCTAssertThrowsError(
-                try load(ByteString(encodingAsUTF8: specification)),
-                "`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, because there is no spacing between \"//\" and \"swift-tools-version\", and the specified lowest version \(toolsVersionString) ≤ 5.3, supporting exactly 1 space (U+0020) between \"//\" and \"swift-tools-version\"."
-            ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1 = error else {
-                    XCTFail("`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, a differently typed error is thrown.")
-                    return
-                }
-                XCTAssertEqual(
-                    error.description,
-                    "zero spacing between \"//\" and \"swift-tools-version\" is supported by only Swift > 5.3; consider using a single space (U+0020) for Swift \(toolsVersionString)"
-                )
-            }
-        }
-        
-        // MARK: 1 character tabulation (U+0009) between "//" and "swift-tools-version"
-        
-        let specificationsWith1TabAfterSlashes = [
-            "//\tswift-tools-version:3.1"                : "3.1.0",
-            "//\tswift-tools-version:3.1-dev"            : "3.1.0",
-            "//\tswift-tools-version:5.3"                : "5.3.0",
-            "//\tswift-tools-version:5.3.0"              : "5.3.0",
-            "//\tswift-tools-version:5.3-dev"            : "5.3.0",
-            "//\tswift-tools-version:4.8.0"              : "4.8.0",
-            "//\tswift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
-            "//\tswift-tools-version:3.1.2"              : "3.1.2",
-            "//\tswift-tools-version:3.1.2;"             : "3.1.2",
-            "//\tswift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
-            "//\tswift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
-            "//\tswift-toolS-version:3.5.2;hello"        : "3.5.2",
-            "//\tsWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
-        ]
-        
-        for (specification, toolsVersionString) in specificationsWith1TabAfterSlashes {
-            XCTAssertThrowsError(
-                try load(ByteString(encodingAsUTF8: specification)),
-                "`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, because the spacing between \"//\" and \"swift-tools-version\" is a character tabulation (U+0009), and the specified lowest version \(toolsVersionString) ≤ 5.3, supporting exactly 1 space (U+0020) between \"//\" and \"swift-tools-version\"."
-            ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1 = error else {
-                    XCTFail("`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, a differently typed error is thrown.")
-                    return
-                }
-                XCTAssertEqual(
-                    error.description,
-                    "horizontal whitespace sequence [U+0009] between \"//\" and \"swift-tools-version\" is supported by only Swift > 5.3; consider using a single space (U+0020) for Swift \(toolsVersionString)"
-                )
-            }
-        }
-        
-        // MARK: 1 space (U+0020) and 1 character tabulation (U+0009) between "//" and "swift-tools-version"
-        
-        let specificationsWith1SpaceAnd1TabAfterSlashes = [
-            "// \tswift-tools-version:3.1"                : "3.1.0",
-            "// \tswift-tools-version:3.1-dev"            : "3.1.0",
-            "// \tswift-tools-version:5.3"                : "5.3.0",
-            "// \tswift-tools-version:5.3.0"              : "5.3.0",
-            "// \tswift-tools-version:5.3-dev"            : "5.3.0",
-            "// \tswift-tools-version:4.8.0"              : "4.8.0",
-            "// \tswift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
-            "// \tswift-tools-version:3.1.2"              : "3.1.2",
-            "// \tswift-tools-version:3.1.2;"             : "3.1.2",
-            "// \tswift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
-            "// \tswift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
-            "// \tswift-toolS-version:3.5.2;hello"        : "3.5.2",
-            "// \tsWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
-        ]
-        
-        for (specification, toolsVersionString) in specificationsWith1SpaceAnd1TabAfterSlashes {
-            XCTAssertThrowsError(
-                try load(ByteString(encodingAsUTF8: specification)),
-                "`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, because the spacing between \"//\" and \"swift-tools-version\" is a space (U+0020) and a character tabulation (U+0009), and the specified lowest version \(toolsVersionString) ≤ 5.3, supporting exactly 1 space (U+0020) between \"//\" and \"swift-tools-version\"."
-            ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1 = error else {
-                    XCTFail("`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, a differently typed error is thrown.")
-                    return
-                }
-                XCTAssertEqual(
-                    error.description,
-                    "horizontal whitespace sequence [U+0020, U+0009] between \"//\" and \"swift-tools-version\" is supported by only Swift > 5.3; consider using a single space (U+0020) for Swift \(toolsVersionString)"
-                )
-            }
-        }
-        
-        // MARK: An assortment of horizontal whitespace characters between "//" and "swift-tools-version"
-        
-        let specificationsWithAnAssortmentOfWhitespacesAfterSlashes = [
-            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1"                : "3.1.0",
-            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1-dev"            : "3.1.0",
-            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:5.3"                : "5.3.0",
-            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:5.3.0"              : "5.3.0",
-            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:5.3-dev"            : "5.3.0",
-            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:4.8.0"              : "4.8.0",
-            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
-            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1.2"              : "3.1.2",
-            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1.2;"             : "3.1.2",
-            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
-            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
-            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-toolS-version:3.5.2;hello"        : "3.5.2",
-            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
-        ]
-        
-        for (specification, toolsVersionString) in specificationsWithAnAssortmentOfWhitespacesAfterSlashes {
-            XCTAssertThrowsError(
-                try load(ByteString(encodingAsUTF8: specification)),
-                "`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, because the spacing between \"//\" and \"swift-tools-version\" is an assortment of horizontal whitespace characters, and the specified lowest version \(toolsVersionString) ≤ 5.3, supporting exactly 1 space (U+0020) between \"//\" and \"swift-tools-version\"."
-            ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1 = error else {
-                    XCTFail("`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, a differently typed error is thrown.")
-                    return
-                }
-                XCTAssertEqual(
-                    error.description,
-                    "horizontal whitespace sequence [U+0009, U+0020, U+00A0, U+1680, U+2000, U+2001, U+2002, U+2003, U+2004, U+2005, U+2006, U+2007, U+2008, U+2009, U+200A, U+202F, U+205F, U+3000] between \"//\" and \"swift-tools-version\" is supported by only Swift > 5.3; consider using a single space (U+0020) for Swift \(toolsVersionString)"
-                )
-            }
-        }
+        // The order of tests in this function:
+        // 1. Test leading line terminators that are invalid for Swift ≤ 5.3.
+        // 2. Test that backward-incompatible leading line terminators are diagnosed before backward-incompatible spacings after the comment marker.
+        // 3. Test spacings after the comment marker.
         
         // MARK: 2 leading line feed (U+000A)
         
@@ -394,15 +428,15 @@ class ToolsVersionLoaderTests: XCTestCase {
         for (specification, toolsVersionString) in manifestSnippetWith2LeadingLineFeeds {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, because the manifest starts with more than 1 line terminator, and the specified lowest version \(toolsVersionString) ≤ 5.3, supporting at most 1 leading U+000A."
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with more than 1 line terminator, and the specified version \(toolsVersionString) (≤ 5.3) supports at most 1 leading U+000A."
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1 = error else {
-                    XCTFail("`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, a differently typed error is thrown.")
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.leadingLineTerminators, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.leadingLineTerminators, _)' should've been thrown, but a different error is thrown.")
                     return
                 }
                 XCTAssertEqual(
                     error.description,
-                    "leading line terminator sequence [U+000A, U+000A] in manifest is supported by only Swift > 5.3; for the specified version \(toolsVersionString), only zero or one newline (U+000A) at the beginning of the manifest is supported"
+                    "leading line terminator sequence [U+000A, U+000A] in manifest is supported by only Swift > 5.3; for the specified version \(toolsVersionString), only zero or one newline (U+000A) at the beginning of the manifest is supported; consider moving the Swift tools version specification to the first line of the manifest"
                 )
             }
         }
@@ -428,15 +462,15 @@ class ToolsVersionLoaderTests: XCTestCase {
         for (specification, toolsVersionString) in manifestSnippetWith1LeadingCarriageReturn {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, because the manifest starts with a U+000D, and the specified lowest version \(toolsVersionString) ≤ 5.3, supporting only 0 or 1 leading U+000A."
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with a U+000D, and the specified version \(toolsVersionString) (≤ 5.3) supports only 0 or 1 leading U+000A."
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1 = error else {
-                    XCTFail("`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, a differently typed error is thrown.")
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.leadingLineTerminators, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.leadingLineTerminators, _)' should've been thrown, but a different error is thrown.")
                     return
                 }
                 XCTAssertEqual(
                     error.description,
-                    "leading line terminator sequence [U+000D] in manifest is supported by only Swift > 5.3; for the specified version \(toolsVersionString), only zero or one newline (U+000A) at the beginning of the manifest is supported"
+                    "leading line terminator sequence [U+000D] in manifest is supported by only Swift > 5.3; for the specified version \(toolsVersionString), only zero or one newline (U+000A) at the beginning of the manifest is supported; consider moving the Swift tools version specification to the first line of the manifest"
                 )
             }
         }
@@ -462,15 +496,15 @@ class ToolsVersionLoaderTests: XCTestCase {
         for (specification, toolsVersionString) in manifestSnippetWith1LeadingCarriageReturnFollowedBy1LineFeed {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, because the manifest starts with a U+000D followed by a U+000A, and the specified lowest version \(toolsVersionString) ≤ 5.3, supporting only 0 or 1 leading U+000A."
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with a U+000D followed by a U+000A, and the specified version \(toolsVersionString) (≤ 5.3) supports only 0 or 1 leading U+000A."
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1 = error else {
-                    XCTFail("`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, a differently typed error is thrown.")
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.leadingLineTerminators, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.leadingLineTerminators, _)' should've been thrown, but a different error is thrown.")
                     return
                 }
                 XCTAssertEqual(
                     error.description,
-                    "leading line terminator sequence [U+000D, U+000A] in manifest is supported by only Swift > 5.3; for the specified version \(toolsVersionString), only zero or one newline (U+000A) at the beginning of the manifest is supported"
+                    "leading line terminator sequence [U+000D, U+000A] in manifest is supported by only Swift > 5.3; for the specified version \(toolsVersionString), only zero or one newline (U+000A) at the beginning of the manifest is supported; consider moving the Swift tools version specification to the first line of the manifest"
                 )
             }
         }
@@ -496,22 +530,22 @@ class ToolsVersionLoaderTests: XCTestCase {
         for (specification, toolsVersionString) in manifestSnippetWithAnAssortmentOfLeadingLineTerminators {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, because the manifest starts with an assortment of line terminators, and the specified lowest version \(toolsVersionString) ≤ 5.3, supporting only 0 or 1 leading U+000A."
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with an assortment of line terminators, and the specified version \(toolsVersionString) (≤ 5.3) supports only 0 or 1 leading U+000A."
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1 = error else {
-                    XCTFail("`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, a differently typed error is thrown.")
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.leadingLineTerminators, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.leadingLineTerminators, _)' should've been thrown, but a different error is thrown.")
                     return
                 }
                 XCTAssertEqual(
                     error.description,
-                    "leading line terminator sequence [U+000A, U+000B, U+000C, U+000D, U+000D, U+000A, U+0085, U+2028, U+2029] in manifest is supported by only Swift > 5.3; for the specified version \(toolsVersionString), only zero or one newline (U+000A) at the beginning of the manifest is supported"
+                    "leading line terminator sequence [U+000A, U+000B, U+000C, U+000D, U+000D, U+000A, U+0085, U+2028, U+2029] in manifest is supported by only Swift > 5.3; for the specified version \(toolsVersionString), only zero or one newline (U+000A) at the beginning of the manifest is supported; consider moving the Swift tools version specification to the first line of the manifest"
                 )
             }
         }
         
         // MARK: An assortment of leading line terminators and an assortment of horizontal whitespace characters between "//" and "swift-tools-version"
         
-        let manifestSnippetWithAnAssortmentOfLeadingLineTerminatorsAndAnAssortmentOfWhitespacesAfterSlashes = [
+        let manifestSnippetWithAnAssortmentOfLeadingLineTerminatorsAndAnAssortmentOfWhitespacesAfterSpecifcationCommentMarker = [
             "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1"                : "3.1.0",
             "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1-dev"            : "3.1.0",
             "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:5.3"                : "5.3.0",
@@ -527,72 +561,157 @@ class ToolsVersionLoaderTests: XCTestCase {
             "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
         ]
         
-        // The backward-compatibility check for leading line terminators comes before that for spacing after slashes.
+        // Backward-incompatible leading line terminators are diagnosed before backward-incompatible spacings after the comment marker.
         // So the error thrown here should be about invalid leading line terminators, although both the line terminators and the spacing here are backward-incompatible.
-        for (specification, toolsVersionString) in manifestSnippetWithAnAssortmentOfLeadingLineTerminatorsAndAnAssortmentOfWhitespacesAfterSlashes {
+        for (specification, toolsVersionString) in manifestSnippetWithAnAssortmentOfLeadingLineTerminatorsAndAnAssortmentOfWhitespacesAfterSpecifcationCommentMarker {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, because the manifest starts with an assortment of line terminators, and the specified lowest version \(toolsVersionString) ≤ 5.3, supporting only 0 or 1 leading U+000A."
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with an assortment of line terminators, and the specified version \(toolsVersionString) (≤ 5.3) supports only 0 or 1 leading U+000A."
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1 = error else {
-                    XCTFail("`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, a differently typed error is thrown.")
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.leadingLineTerminators, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.leadingLineTerminators, _)' should've been thrown, but a different error is thrown.")
                     return
                 }
                 XCTAssertEqual(
                     error.description,
-                    "leading line terminator sequence [U+000A, U+000B, U+000C, U+000D, U+000D, U+000A, U+0085, U+2028, U+2029] in manifest is supported by only Swift > 5.3; for the specified version \(toolsVersionString), only zero or one newline (U+000A) at the beginning of the manifest is supported"
+                    "leading line terminator sequence [U+000A, U+000B, U+000C, U+000D, U+000D, U+000A, U+0085, U+2028, U+2029] in manifest is supported by only Swift > 5.3; for the specified version \(toolsVersionString), only zero or one newline (U+000A) at the beginning of the manifest is supported; consider moving the Swift tools version specification to the first line of the manifest"
                 )
             }
         }
         
-    }
-    
-    /// Verifies that if the first line of the manifest is invalid but doesn't contain any pre-defined misspelling, then the Swift tools version falls back to 3.1.
-    func testFallbackTo3_1() throws {
-        let invalidVersionSpecificationsDefaultedTo3_1 = [
-            "//\nswift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
-            "// \nswift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
-            "//\n swift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
-            "//\r\nswift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
-            "//\n\rswift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
-            "//\nswift-tool-version:5.3\n": (3, 1, 0, "3.1.0"),
-            "// \nswift-tool-version:5.3\n": (3, 1, 0, "3.1.0"),
-            "//\n swift-tool-version:5.3\n": (3, 1, 0, "3.1.0"),
-            "//\r\nswift-tool-version:5.3\n": (3, 1, 0, "3.1.0"),
-            "//\n\rswift-tool-version:5.3\n": (3, 1, 0, "3.1.0"),
-            "//\ntool-version:5.3\n": (3, 1, 0, "3.1.0"),
-            "// \ntool-version:5.3\n": (3, 1, 0, "3.1.0"),
-            "//\n tool-version:5.3\n": (3, 1, 0, "3.1.0"),
-            "//\r\ntool-version:5.3\n": (3, 1, 0, "3.1.0"),
-            "//\n\rtool-version:5.3\n": (3, 1, 0, "3.1.0"),
-            "//\nswift-tool:5.3\n": (3, 1, 0, "3.1.0"),
-            "// \nswift-tool:5.3\n": (3, 1, 0, "3.1.0"),
-            "//\n swift-tool:5.3\n": (3, 1, 0, "3.1.0"),
-            "//\r\nswift-tool:5.3\n": (3, 1, 0, "3.1.0"),
-            "//\n\rswift-tool:5.3\n": (3, 1, 0, "3.1.0"),
-            " \n": (3, 1, 0, "3.1.0"),
-            " ": (3, 1, 0, "3.1.0"),
-            "\n ": (3, 1, 0, "3.1.0"),
-            "\n": (3, 1, 0, "3.1.0"),
-            "": (3, 1, 0, "3.1.0"),
-            // FIXME: The following line terminators are source breaking.
-            // For Swift ≤ 5.3, only U+000A is treated as a line terminator, so SPM does not default the lowest version to 3.1 if the compiler version ≤ 5.3.
-            "//\u{D}swift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
-            "// \u{D}swift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
-            "//\u{D} swift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
-            "//\u{C}swift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
-            "//\u{B}swift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
-            "//\u{85}swift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
-            "//\u{2028}swift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
-            "//\u{2029}swift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
+        // MARK: No spacing between "//" and "swift-tools-version" for Swift ≤ 5.3
+        
+        let specificationsWithZeroSpacing = [
+            "//swift-tools-version:3.1"                : "3.1.0",
+            "//swift-tools-version:3.1-dev"            : "3.1.0",
+            "//swift-tools-version:5.3"                : "5.3.0",
+            "//swift-tools-version:5.3.0"              : "5.3.0",
+            "//swift-tools-version:5.3-dev"            : "5.3.0",
+            "//swift-tools-version:4.8.0"              : "4.8.0",
+            "//swift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
+            "//swift-tools-version:3.1.2"              : "3.1.2",
+            "//swift-tools-version:3.1.2;"             : "3.1.2",
+            "//swift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
+            "//swift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
+            "//swift-toolS-version:3.5.2;hello"        : "3.5.2",
+            "//sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
         ]
         
-        for (specification, expectedResult) in invalidVersionSpecificationsDefaultedTo3_1 {
-            try load(ByteString(encodingAsUTF8: specification)) { toolsVersion in
-                XCTAssertEqual(toolsVersion.major, expectedResult.0)
-                XCTAssertEqual(toolsVersion.minor, expectedResult.1)
-                XCTAssertEqual(toolsVersion.patch, expectedResult.2)
-                XCTAssertEqual(toolsVersion.description, expectedResult.3)
+        for (specification, toolsVersionString) in specificationsWithZeroSpacing {
+            XCTAssertThrowsError(
+                try load(ByteString(encodingAsUTF8: specification)),
+                "a 'ToolsVersionLoader.Error' should've been thrown, because there is no spacing between '//' and 'swift-tools-version', and the specified version \(toolsVersionString) (≤ 5.3) supports exactly 1 space (U+0020) between '//' and 'swift-tools-version'"
+            ) { error in
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _)' should've been thrown, but a different error is thrown.")
+                    return
+                }
+                XCTAssertEqual(
+                    error.description,
+                    "zero spacing between '//' and 'swift-tools-version' is supported by only Swift > 5.3; consider using a single space (U+0020) for Swift \(toolsVersionString)"
+                )
+            }
+        }
+        
+        // MARK: 1 character tabulation (U+0009) between "//" and "swift-tools-version"
+        
+        let specificationsWith1TabAfterCommentMarker = [
+            "//\tswift-tools-version:3.1"                : "3.1.0",
+            "//\tswift-tools-version:3.1-dev"            : "3.1.0",
+            "//\tswift-tools-version:5.3"                : "5.3.0",
+            "//\tswift-tools-version:5.3.0"              : "5.3.0",
+            "//\tswift-tools-version:5.3-dev"            : "5.3.0",
+            "//\tswift-tools-version:4.8.0"              : "4.8.0",
+            "//\tswift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
+            "//\tswift-tools-version:3.1.2"              : "3.1.2",
+            "//\tswift-tools-version:3.1.2;"             : "3.1.2",
+            "//\tswift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
+            "//\tswift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
+            "//\tswift-toolS-version:3.5.2;hello"        : "3.5.2",
+            "//\tsWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
+        ]
+        
+        for (specification, toolsVersionString) in specificationsWith1TabAfterCommentMarker {
+            XCTAssertThrowsError(
+                try load(ByteString(encodingAsUTF8: specification)),
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the spacing between \"//\" and \"swift-tools-version\" is a character tabulation (U+0009), and the specified version \(toolsVersionString) (≤ 5.3) supports exactly 1 space (U+0020) between \"//\" and \"swift-tools-version\"."
+            ) { error in
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _)' should've been thrown, but a different error is thrown.")
+                    return
+                }
+                XCTAssertEqual(
+                    error.description,
+                    "horizontal whitespace sequence [U+0009] between '//' and 'swift-tools-version' is supported by only Swift > 5.3; consider using a single space (U+0020) for Swift \(toolsVersionString)"
+                )
+            }
+        }
+        
+        // MARK: 1 space (U+0020) and 1 character tabulation (U+0009) between "//" and "swift-tools-version"
+        
+        let specificationsWith1SpaceAnd1TabAfterCommentMarker = [
+            "// \tswift-tools-version:3.1"                : "3.1.0",
+            "// \tswift-tools-version:3.1-dev"            : "3.1.0",
+            "// \tswift-tools-version:5.3"                : "5.3.0",
+            "// \tswift-tools-version:5.3.0"              : "5.3.0",
+            "// \tswift-tools-version:5.3-dev"            : "5.3.0",
+            "// \tswift-tools-version:4.8.0"              : "4.8.0",
+            "// \tswift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
+            "// \tswift-tools-version:3.1.2"              : "3.1.2",
+            "// \tswift-tools-version:3.1.2;"             : "3.1.2",
+            "// \tswift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
+            "// \tswift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
+            "// \tswift-toolS-version:3.5.2;hello"        : "3.5.2",
+            "// \tsWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
+        ]
+        
+        for (specification, toolsVersionString) in specificationsWith1SpaceAnd1TabAfterCommentMarker {
+            XCTAssertThrowsError(
+                try load(ByteString(encodingAsUTF8: specification)),
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the spacing between \"//\" and \"swift-tools-version\" is a space (U+0020) and a character tabulation (U+0009), and the specified version \(toolsVersionString) (≤ 5.3) supports exactly 1 space (U+0020) between \"//\" and \"swift-tools-version\"."
+            ) { error in
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _)' should've been thrown, but a different error is thrown.")
+                    return
+                }
+                XCTAssertEqual(
+                    error.description,
+                    "horizontal whitespace sequence [U+0020, U+0009] between '//' and 'swift-tools-version' is supported by only Swift > 5.3; consider using a single space (U+0020) for Swift \(toolsVersionString)"
+                )
+            }
+        }
+        
+        // MARK: An assortment of horizontal whitespace characters between "//" and "swift-tools-version"
+        
+        let specificationsWithAnAssortmentOfWhitespacesAfterCommentMarker = [
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1"                : "3.1.0",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1-dev"            : "3.1.0",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:5.3"                : "5.3.0",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:5.3.0"              : "5.3.0",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:5.3-dev"            : "5.3.0",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:4.8.0"              : "4.8.0",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1.2"              : "3.1.2",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1.2;"             : "3.1.2",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-toolS-version:3.5.2;hello"        : "3.5.2",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
+        ]
+        
+        for (specification, toolsVersionString) in specificationsWithAnAssortmentOfWhitespacesAfterCommentMarker {
+            XCTAssertThrowsError(
+                try load(ByteString(encodingAsUTF8: specification)),
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the spacing between \"//\" and \"swift-tools-version\" is an assortment of horizontal whitespace characters, and the specified version \(toolsVersionString) (≤ 5.3) supports exactly 1 space (U+0020) between \"//\" and \"swift-tools-version\"."
+            ) { error in
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _) = error else {
+                    XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.spacingAfterCommentMarker, _)' should've been thrown, but a different error is thrown.")
+                    return
+                }
+                XCTAssertEqual(
+                    error.description,
+                    "horizontal whitespace sequence [U+0009, U+0020, U+00A0, U+1680, U+2000, U+2001, U+2002, U+2003, U+2004, U+2005, U+2006, U+2007, U+2008, U+2009, U+200A, U+202F, U+205F, U+3000] between '//' and 'swift-tools-version' is supported by only Swift > 5.3; consider using a single space (U+0020) for Swift \(toolsVersionString)"
+                )
             }
         }
         
@@ -671,24 +790,5 @@ class ToolsVersionLoaderTests: XCTestCase {
             XCTAssertEqual(version.description, "3.4.8")
         }
     }
-
-    func assertFailure(_ bytes: ByteString, _ theSpecification: String, _ theSpecifier: String, file: StaticString = #file, line: UInt = #line) {
-        do {
-            try load(bytes) {
-                XCTFail("unexpected success - \($0)", file: file, line: line)
-            }
-            XCTFail("unexpected success", file: file, line: line)
-        } catch let ToolsVersionLoader.Error.malformedToolsVersionSpecification(malformation) {
-            switch malformation {
-            case let .versionSpecifier(versionSpecifier):
-                XCTAssertEqual(String(versionSpecifier), theSpecifier, file: file, line: line)
-            case let .entireLine(entireLine):
-                XCTAssertEqual(String(entireLine), theSpecification, file: file, line: line)
-            default:
-                XCTFail("Failed with error \(ToolsVersionLoader.Error.malformedToolsVersionSpecification(malformation))")
-            }
-        } catch {
-            XCTFail("Failed with error \(error)")
-        }
-    }
+    
 }

--- a/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
@@ -151,7 +151,7 @@ class ToolsVersionLoaderTests: XCTestCase {
         assertFailure("// swift-tools-version:-1.1.2\n", "-1.1.2")
         assertFailure("// swift-tools-version:3.1hello", "3.1hello")
         
-        // Verify no matching for vertical whitespace charaters between "//" and "swift-tools-version":
+        // Verify no matching for vertical whitespace characters between "//" and "swift-tools-version":
         // Newline is excluded from these assertions, because `ToolsVersionLoader` assumes the default Swift version to be 3.1, if it sees a newline character before finding 1 of the 2 pre-defined misspellings in the specification.
         assertFailure("//\rswift-tools-version:5.3\n", "//\rswift-tools-version:5.3")
         assertFailure("// \rswift-tools-version:5.3\n", "// \rswift-tools-version:5.3")

--- a/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
@@ -33,7 +33,7 @@ class ToolsVersionLoaderTests: XCTestCase {
     func testValidVersions() throws {
 
         let validVersions = [
-            // No space between "//" and "swift-tools-version" for Swift ≥ 5.3:
+            // No space between "//" and "swift-tools-version" for Swift > 5.3:
             "//swift-tools-version:5.4"                : (5, 4, 0, "5.4.0"),
             "//swift-tools-version:5.4-dev"            : (5, 4, 0, "5.4.0"),
             "//swift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
@@ -55,7 +55,7 @@ class ToolsVersionLoaderTests: XCTestCase {
             "// swift-tools-version:3.1.2;x;x;x;x;x;"   : (3, 1, 2, "3.1.2"),
             "// swift-toolS-version:3.5.2;hello"        : (3, 5, 2, "3.5.2"),
             "// sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : (3, 5, 2, "3.5.2"),
-            // 1 horizontal tab character ("    ") between "//" and "swift-tools-version":
+            // 1 horizontal tab character ("    ") between "//" and "swift-tools-version" for Swift > 5.3:
             "//\tswift-tools-version:5.4"                : (5, 4, 0, "5.4.0"),
             "//\tswift-tools-version:5.4-dev"            : (5, 4, 0, "5.4.0"),
             "//\tswift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
@@ -66,7 +66,7 @@ class ToolsVersionLoaderTests: XCTestCase {
             "//\tswift-tools-version:6.1.2;x;x;x;x;x;"   : (6, 1, 2, "6.1.2"),
             "//\tswift-toolS-version:5.5.2;hello"        : (5, 5, 2, "5.5.2"),
             "//\tsWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n"       : (5, 5, 2, "5.5.2"),
-//            // 1 horizontal tab character followed by 1 space character ("     ") between "//" and "swift-tools-version":
+//            // 1 horizontal tab character followed by 1 space character ("     ") between "//" and "swift-tools-version" for Swift > 5.3:
             "// \tswift-tools-version:5.4"                : (5, 4, 0, "5.4.0"),
             "// \tswift-tools-version:5.4-dev"            : (5, 4, 0, "5.4.0"),
             "// \tswift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),
@@ -77,7 +77,7 @@ class ToolsVersionLoaderTests: XCTestCase {
             "// \tswift-tools-version:6.1.2;x;x;x;x;x;"   : (6, 1, 2, "6.1.2"),
             "// \tswift-toolS-version:5.5.2;hello"        : (5, 5, 2, "5.5.2"),
             "// \tsWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n"       : (5, 5, 2, "5.5.2"),
-//            // An assortment of horizontal whitespace characters between "//" and "swift-tools-version":
+//            // An assortment of horizontal whitespace characters between "//" and "swift-tools-version" for Swift > 5.3:
             "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.4"                : (5, 4, 0, "5.4.0"),
             "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.4-dev"            : (5, 4, 0, "5.4.0"),
             "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.8.0"              : (5, 8, 0, "5.8.0"),

--- a/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
@@ -66,7 +66,7 @@ class ToolsVersionLoaderTests: XCTestCase {
             "// swift-tools-version:3.1.2;x;x;x;x;x;"   : (3, 1, 2, "3.1.2"),
             "// swift-toolS-version:3.5.2;hello"        : (3, 5, 2, "3.5.2"),
             "// sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : (3, 5, 2, "3.5.2"),
-            // leading newline characters (U+000A) before the specification, and 1 space (U+0020) before, and no spacing after the label:
+            // leading line feeds (U+000A) before the specification, and 1 space (U+0020) before, and no spacing after the label:
             "\n// swift-tools-version:3.1"                            : (3, 1, 0, "3.1.0"),
             "\n\n// swift-tools-version:3.2-dev"                      : (3, 2, 0, "3.2.0"),
             "\n\n\n// swift-tools-version:3.8.0"                      : (3, 8, 0, "3.8.0"),
@@ -400,7 +400,7 @@ class ToolsVersionLoaderTests: XCTestCase {
         for (specification, toolsVersionString) in manifestSnippetWith1LeadingCarriageReturn {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with a U+000D, and the specified version \(toolsVersionString) (≤ 5.3) supports only leading newline characters (U+000A)."
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with a U+000D, and the specified version \(toolsVersionString) (≤ 5.3) supports only leading line feeds (U+000A)."
             ) { error in
                 guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.leadingWhitespace, _) = error else {
                     XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.leadingWhitespace, _)' should've been thrown, but a different error is thrown.")
@@ -408,7 +408,7 @@ class ToolsVersionLoaderTests: XCTestCase {
                 }
                 XCTAssertEqual(
                     error.description,
-                    "leading whitespace sequence [U+000D] in manifest is supported by only Swift > 5.3; the specified version \(toolsVersionString) supports only newline characters (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
+                    "leading whitespace sequence [U+000D] in manifest is supported by only Swift > 5.3; the specified version \(toolsVersionString) supports only line feeds (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
                 )
             }
         }
@@ -434,7 +434,7 @@ class ToolsVersionLoaderTests: XCTestCase {
         for (specification, toolsVersionString) in manifestSnippetWith1LeadingSpace {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with a U+0020, and the specified version \(toolsVersionString) (≤ 5.3) supports only leading newline characters (U+000A)."
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with a U+0020, and the specified version \(toolsVersionString) (≤ 5.3) supports only leading line feeds (U+000A)."
             ) { error in
                 guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.leadingWhitespace, _) = error else {
                     XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.leadingWhitespace, _)' should've been thrown, but a different error is thrown.")
@@ -442,7 +442,7 @@ class ToolsVersionLoaderTests: XCTestCase {
                 }
                 XCTAssertEqual(
                     error.description,
-                    "leading whitespace sequence [U+0020] in manifest is supported by only Swift > 5.3; the specified version \(toolsVersionString) supports only newline characters (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
+                    "leading whitespace sequence [U+0020] in manifest is supported by only Swift > 5.3; the specified version \(toolsVersionString) supports only line feeds (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
                 )
             }
         }
@@ -468,7 +468,7 @@ class ToolsVersionLoaderTests: XCTestCase {
         for (specification, toolsVersionString) in manifestSnippetWithAnAssortmentOfLeadingWhitespaceCharacters {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with an assortment of whitespace characters, and the specified version \(toolsVersionString) (≤ 5.3) supports only leading newline characters (U+000A)."
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with an assortment of whitespace characters, and the specified version \(toolsVersionString) (≤ 5.3) supports only leading line feeds (U+000A)."
             ) { error in
                 guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.leadingWhitespace, _) = error else {
                     XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.leadingWhitespace, _)' should've been thrown, but a different error is thrown.")
@@ -476,7 +476,7 @@ class ToolsVersionLoaderTests: XCTestCase {
                 }
                 XCTAssertEqual(
                     error.description,
-                    "leading whitespace sequence [U+000A, U+00A0, U+000B, U+1680, U+000C, U+0009, U+2000, U+000D, U+000D, U+000A, U+0085, U+2001, U+2028, U+2002, U+202F, U+2029, U+3000] in manifest is supported by only Swift > 5.3; the specified version \(toolsVersionString) supports only newline characters (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
+                    "leading whitespace sequence [U+000A, U+00A0, U+000B, U+1680, U+000C, U+0009, U+2000, U+000D, U+000D, U+000A, U+0085, U+2001, U+2028, U+2002, U+202F, U+2029, U+3000] in manifest is supported by only Swift > 5.3; the specified version \(toolsVersionString) supports only line feeds (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
                 )
             }
         }
@@ -504,7 +504,7 @@ class ToolsVersionLoaderTests: XCTestCase {
         for (specification, toolsVersionString) in manifestSnippetWithAnAssortmentOfLeadingWhitespaceCharactersAndAnAssortmentOfWhitespacesSurroundingLabel {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with an assortment of whitespace characters, and the specified version \(toolsVersionString) (≤ 5.3) supports only leading newline characters (U+000A)."
+                "a 'ToolsVersionLoader.Error' should've been thrown, because the manifest starts with an assortment of whitespace characters, and the specified version \(toolsVersionString) (≤ 5.3) supports only leading line feeds (U+000A)."
             ) { error in
                 guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1(.leadingWhitespace, _) = error else {
                     XCTFail("'ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1(.leadingWhitespace, _)' should've been thrown, but a different error is thrown.")
@@ -512,7 +512,7 @@ class ToolsVersionLoaderTests: XCTestCase {
                 }
                 XCTAssertEqual(
                     error.description,
-                    "leading whitespace sequence [U+000D, U+202F, U+2029, U+0085, U+2001, U+2028, U+3000, U+000A, U+000D, U+000A, U+2002, U+00A0, U+000B, U+1680, U+000C, U+0009, U+2000] in manifest is supported by only Swift > 5.3; the specified version \(toolsVersionString) supports only newline characters (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
+                    "leading whitespace sequence [U+000D, U+202F, U+2029, U+0085, U+2001, U+2028, U+3000, U+000A, U+000D, U+000A, U+2002, U+00A0, U+000B, U+1680, U+000C, U+0009, U+2000] in manifest is supported by only Swift > 5.3; the specified version \(toolsVersionString) supports only line feeds (U+000A) preceding the Swift tools version specification; consider moving the Swift tools version specification to the first line of the manifest"
                 )
             }
         }

--- a/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionLoaderTests.swift
@@ -88,6 +88,61 @@ class ToolsVersionLoaderTests: XCTestCase {
             "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:6.1.2;x;x;x;x;x;"   : (6, 1, 2, "6.1.2"),
             "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-toolS-version:5.5.2;hello"        : (5, 5, 2, "5.5.2"),
             "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}sWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n"       : (5, 5, 2, "5.5.2"),
+            // Some leading line terminators, and no spacing between "//" and "swift-tools-version" for Swift > 5.3:
+            "\u{A}//swift-tools-version:5.4"                 : (5, 4, 0, "5.4.0"),
+            "\u{B}//swift-tools-version:5.4-dev"             : (5, 4, 0, "5.4.0"),
+            "\u{C}//swift-tools-version:5.8.0"               : (5, 8, 0, "5.8.0"),
+            "\u{D}//swift-tools-version:5.8.0-dev.al+sha.x"  : (5, 8, 0, "5.8.0"),
+            "\u{D}\u{A}//swift-tools-version:6.1.2"          : (6, 1, 2, "6.1.2"),
+            "\u{85}//swift-tools-version:6.1.2;"             : (6, 1, 2, "6.1.2"),
+            "\u{2028}//swift-tools-vErsion:6.1.2;;;;;"       : (6, 1, 2, "6.1.2"),
+            "\u{2029}//swift-tools-version:6.1.2;x;x;x;x;x;" : (6, 1, 2, "6.1.2"),
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-toolS-version:5.5.2;hello"  : (5, 5, 2, "5.5.2"),
+            "\u{A}\u{A}\u{B}\u{B}\u{C}\u{C}\u{D}\u{D}\u{D}\u{A}\u{D}\u{A}\u{85}\u{85}\u{2028}\u{2028}\u{2029}\u{2029}//sWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n" : (5, 5, 2, "5.5.2"),
+            // Some leading line terminators, and 1 space (U+0020) between "//" and "swift-tools-version" for Swift > 5.3:
+            "\u{A}// swift-tools-version:5.4"                 : (5, 4, 0, "5.4.0"),
+            "\u{B}// swift-tools-version:5.4-dev"             : (5, 4, 0, "5.4.0"),
+            "\u{C}// swift-tools-version:5.8.0"               : (5, 8, 0, "5.8.0"),
+            "\u{D}// swift-tools-version:5.8.0-dev.al+sha.x"  : (5, 8, 0, "5.8.0"),
+            "\u{D}\u{A}// swift-tools-version:6.1.2"          : (6, 1, 2, "6.1.2"),
+            "\u{85}// swift-tools-version:6.1.2;"             : (6, 1, 2, "6.1.2"),
+            "\u{2028}// swift-tools-vErsion:6.1.2;;;;;"       : (6, 1, 2, "6.1.2"),
+            "\u{2029}// swift-tools-version:6.1.2;x;x;x;x;x;" : (6, 1, 2, "6.1.2"),
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}// swift-toolS-version:5.5.2;hello"  : (5, 5, 2, "5.5.2"),
+            "\u{A}\u{A}\u{B}\u{B}\u{C}\u{C}\u{D}\u{D}\u{D}\u{A}\u{D}\u{A}\u{85}\u{85}\u{2028}\u{2028}\u{2029}\u{2029}// sWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n" : (5, 5, 2, "5.5.2"),
+            // Some leading line terminators, and 1 character tabulation (U+0009) between "//" and "swift-tools-version" for Swift > 5.3:
+            "\u{A}//\tswift-tools-version:5.4"                 : (5, 4, 0, "5.4.0"),
+            "\u{B}//\tswift-tools-version:5.4-dev"             : (5, 4, 0, "5.4.0"),
+            "\u{C}//\tswift-tools-version:5.8.0"               : (5, 8, 0, "5.8.0"),
+            "\u{D}//\tswift-tools-version:5.8.0-dev.al+sha.x"  : (5, 8, 0, "5.8.0"),
+            "\u{D}\u{A}//\tswift-tools-version:6.1.2"          : (6, 1, 2, "6.1.2"),
+            "\u{85}//\tswift-tools-version:6.1.2;"             : (6, 1, 2, "6.1.2"),
+            "\u{2028}//\tswift-tools-vErsion:6.1.2;;;;;"       : (6, 1, 2, "6.1.2"),
+            "\u{2029}//\tswift-tools-version:6.1.2;x;x;x;x;x;" : (6, 1, 2, "6.1.2"),
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\tswift-toolS-version:5.5.2;hello"  : (5, 5, 2, "5.5.2"),
+            "\u{A}\u{A}\u{B}\u{B}\u{C}\u{C}\u{D}\u{D}\u{D}\u{A}\u{D}\u{A}\u{85}\u{85}\u{2028}\u{2028}\u{2029}\u{2029}//\tsWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n" : (5, 5, 2, "5.5.2"),
+            // Some leading line terminators, and 1 character tabulation (U+0009) followed by 1 space (U+0020) between "//" and "swift-tools-version" for Swift > 5.3:
+            "\u{A}// \tswift-tools-version:5.4"                 : (5, 4, 0, "5.4.0"),
+            "\u{B}// \tswift-tools-version:5.4-dev"             : (5, 4, 0, "5.4.0"),
+            "\u{C}// \tswift-tools-version:5.8.0"               : (5, 8, 0, "5.8.0"),
+            "\u{D}// \tswift-tools-version:5.8.0-dev.al+sha.x"  : (5, 8, 0, "5.8.0"),
+            "\u{D}\u{A}// \tswift-tools-version:6.1.2"          : (6, 1, 2, "6.1.2"),
+            "\u{85}// \tswift-tools-version:6.1.2;"             : (6, 1, 2, "6.1.2"),
+            "\u{2028}// \tswift-tools-vErsion:6.1.2;;;;;"       : (6, 1, 2, "6.1.2"),
+            "\u{2029}// \tswift-tools-version:6.1.2;x;x;x;x;x;" : (6, 1, 2, "6.1.2"),
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}// \tswift-toolS-version:5.5.2;hello"  : (5, 5, 2, "5.5.2"),
+            "\u{A}\u{A}\u{B}\u{B}\u{C}\u{C}\u{D}\u{D}\u{D}\u{A}\u{D}\u{A}\u{85}\u{85}\u{2028}\u{2028}\u{2029}\u{2029}// \tsWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n" : (5, 5, 2, "5.5.2"),
+            // Some leading line terminators, and an assortment of horizontal whitespace characters between "//" and "swift-tools-version" for Swift > 5.3:
+            "\u{A}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.4"                 : (5, 4, 0, "5.4.0"),
+            "\u{B}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.4-dev"             : (5, 4, 0, "5.4.0"),
+            "\u{C}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.8.0"               : (5, 8, 0, "5.8.0"),
+            "\u{D}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.8.0-dev.al+sha.x"  : (5, 8, 0, "5.8.0"),
+            "\u{D}\u{A}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:6.1.2"          : (6, 1, 2, "6.1.2"),
+            "\u{85}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:6.1.2;"             : (6, 1, 2, "6.1.2"),
+            "\u{2028}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-vErsion:6.1.2;;;;;"       : (6, 1, 2, "6.1.2"),
+            "\u{2029}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:6.1.2;x;x;x;x;x;" : (6, 1, 2, "6.1.2"),
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-toolS-version:5.5.2;hello"  : (5, 5, 2, "5.5.2"),
+            "\u{A}\u{A}\u{B}\u{B}\u{C}\u{C}\u{D}\u{D}\u{D}\u{A}\u{D}\u{A}\u{85}\u{85}\u{2028}\u{2028}\u{2029}\u{2029}//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}sWiFt-tOoLs-vErSiOn:5.5.2\nkkk\n" : (5, 5, 2, "5.5.2"),
         ]
 
         for (version, result) in validVersions {
@@ -120,6 +175,9 @@ class ToolsVersionLoaderTests: XCTestCase {
         }
     }
 
+    // FIXME: Currently only tools version specifications that contain either "swift-tool" or "tool-version" are treated as having malformed labels.
+    // Specification that don't contain these 2 misspellings silently fall back to version 3.1.
+    // Improve diagnostics, so that malformation checks don't depend on these 2 misspellings.
     func testNonMatching() throws {
         do {
             let stream = BufferedOutputByteStream()
@@ -136,41 +194,48 @@ class ToolsVersionLoaderTests: XCTestCase {
             XCTAssertEqual(toolsVersion, .v3)
         }
 
-        assertFailure("//swift-tools-:6.1.0\n", "//swift-tools-:6.1.0")
-        assertFailure("//swift-tool-version:6.1.0\n", "//swift-tool-version:6.1.0")
-        assertFailure("//  swift-tool-version:6.1.0\n", "//  swift-tool-version:6.1.0")
-        assertFailure("// swift-tool-version:6.1.0\n", "// swift-tool-version:6.1.0")
-        assertFailure("noway// swift-tools-version:6.1.0\n", "noway// swift-tools-version:6.1.0")
-        assertFailure("// swift-tool-version:2.1.0\n// swift-tools-version:6.1.0\n", "// swift-tool-version:2.1.0")
-
-        assertFailure("// haha swift-tools-version:6.1.0\n", "// haha swift-tools-version:6.1.0")
-        assertFailure("//// swift-tools-version:6.1.0\n", "//// swift-tools-version:6.1.0")
-        assertFailure("// swift-tools-version 6.1.0\n", "// swift-tools-version 6.1.0")
-        assertFailure("// swift-tOols-Version 6.1.0\n", "// swift-tOols-Version 6.1.0")
-        assertFailure("// swift-tools-version:6.1.2.0\n", "6.1.2.0")
-        assertFailure("// swift-tools-version:-1.1.2\n", "-1.1.2")
-        assertFailure("// swift-tools-version:3.1hello", "3.1hello")
+        // Verify no matching for malformed labels.
+        // FIXME: Improve diagnostics, so that `assertFailure` compares labels instead of the entire specification for label failures.
+        assertFailure("//swift-tools-:6.1.0\n", "//swift-tools-:6.1.0", "6.1.0")
+        assertFailure("//swift-tool-version:6.1.0\n", "//swift-tool-version:6.1.0", "6.1.0")
+        assertFailure("//  swift-tool-version:6.1.0\n", "//  swift-tool-version:6.1.0", "6.1.0")
+        assertFailure("// swift-tool-version:6.1.0\n", "// swift-tool-version:6.1.0", "6.1.0")
+        assertFailure("// swift-tool-version:2.1.0\n// swift-tools-version:6.1.0\n", "// swift-tool-version:2.1.0", "2.1.0")
+        assertFailure("\u{A}\u{A}\u{D}\u{A}\u{B}// swallow-tool-version:2-coconut-halves", "// swallow-tool-version:2-coconut-halves", "2-coconut-halves")
+        assertFailure("noway// swift-tools-version:6.1.0\n", "noway// swift-tools-version:6.1.0", "6.1.0")
+        assertFailure("//// swift-tools-version:6.1.0\n", "//// swift-tools-version:6.1.0", "6.1.0")
+        assertFailure("// swift-tools-version 6.1.0\n", "// swift-tools-version 6.1.0", "6.1.0")
+        assertFailure("// swift-tOols-Version 6.1.0\n", "// swift-tOols-Version 6.1.0", "6.1.0")
+        assertFailure("// haha swift-tools-version:6.1.0\n", "// haha swift-tools-version:6.1.0", "6.1.0")
         
-        // Verify no matching for vertical whitespace characters between "//" and "swift-tools-version":
-        // Newline is excluded from these assertions, because `ToolsVersionLoader` assumes the default Swift version to be 3.1, if it sees a newline character before finding 1 of the 2 pre-defined misspellings in the specification.
-        assertFailure("//\rswift-tools-version:5.3\n", "//\rswift-tools-version:5.3")
-        assertFailure("// \rswift-tools-version:5.3\n", "// \rswift-tools-version:5.3")
-        assertFailure("//\r swift-tools-version:5.3\n", "//\r swift-tools-version:5.3")
-        assertFailure("//\u{B}swift-tools-version:5.3\n", "//\u{B}swift-tools-version:5.3")
-        assertFailure("//\u{2028}swift-tools-version:5.3\n", "//\u{2028}swift-tools-version:5.3")
-        assertFailure("//\u{2029}swift-tools-version:5.3\n", "//\u{2029}swift-tools-version:5.3")
+        // Verify no matching for malformed version specifiers.
+        assertFailure("// swift-tools-version:6.1.2.0\n", "// swift-tools-version:6.1.2.0", "6.1.2.0")
+        assertFailure("// swift-tools-version:-1.1.2\n", "// swift-tools-version:-1.1.2", "-1.1.2")
+        assertFailure("// swift-tools-version:3.1hello", "// swift-tools-version:3.1hello", "3.1hello")
+        
+        // Verify no matching for line terminators other than U+000A between "//" and "swift-tools-version":
+        // FIXME: The following 8 test cases fail, because all Unicode line terminators are recognised.
+        // This is inconsistent with Swift ≤ 5.3's behaviour, for which only U+000A is recognised.
+        assertFailure("//\u{D}swift-tools-version:5.3\n", "//\rswift-tools-version:5.3", "5.3")
+        assertFailure("// \u{D}swift-tools-version:5.3\n", "// \rswift-tools-version:5.3", "5.3")
+        assertFailure("//\u{D} swift-tools-version:5.3\n", "//\r swift-tools-version:5.3", "5.3")
+        assertFailure("//\u{C}swift-tools-version:5.3\n", "//\u{B}swift-tools-version:5.3", "5.3")
+        assertFailure("//\u{B}swift-tools-version:5.3\n", "//\u{2028}swift-tools-version:5.3", "5.3")
+        assertFailure("//\u{85}swift-tools-version:5.3\n", "//\u{2029}swift-tools-version:5.3", "5.3")
+        assertFailure("//\u{2028}swift-tools-version:5.3\n", "//\u{B}swift-tools-version:5.3", "5.3")
+        assertFailure("//\u{2029}swift-tools-version:5.3\n", "//\u{2028}swift-tools-version:5.3", "5.3")
         
         // Verify no matching for related Unicode characters without `White_Space` property, between "//" and "swift-tools-version":
-        assertFailure("//\u{180E}swift-tools-version:5.3\n", "//\u{180E}swift-tools-version:5.3")
-        assertFailure("//\u{200B}swift-tools-version:5.3\n", "//\u{200B}swift-tools-version:5.3")
-        assertFailure("//\u{200C}swift-tools-version:5.3\n", "//\u{200C}swift-tools-version:5.3")
-        assertFailure("//\u{200D}swift-tools-version:5.3\n", "//\u{200D}swift-tools-version:5.3")
-        assertFailure("//\u{2060}swift-tools-version:5.3\n", "//\u{2060}swift-tools-version:5.3")
-        assertFailure("//\u{FEFF}swift-tools-version:5.3\n", "//\u{FEFF}swift-tools-version:5.3")
+        assertFailure("//\u{180E}swift-tools-version:5.3\n", "//\u{180E}swift-tools-version:5.3", "5.3")
+        assertFailure("//\u{200B}swift-tools-version:5.3\n", "//\u{200B}swift-tools-version:5.3", "5.3")
+        assertFailure("//\u{200C}swift-tools-version:5.3\n", "//\u{200C}swift-tools-version:5.3", "5.3")
+        assertFailure("//\u{200D}swift-tools-version:5.3\n", "//\u{200D}swift-tools-version:5.3", "5.3")
+        assertFailure("//\u{2060}swift-tools-version:5.3\n", "//\u{2060}swift-tools-version:5.3", "5.3")
+        assertFailure("//\u{FEFF}swift-tools-version:5.3\n", "//\u{FEFF}swift-tools-version:5.3", "5.3")
     }
     
-    /// Verifies that for Swift tools version ≤ 5.3, an error is thrown if anything but a single U+0020 is used as spacing between "//" and "swift-tools-version".
-    func testBackwardCompatibilityError() throws {
+    /// Verifies that a correct error is thrown, if the manifest is valid for Swift tools version > 5.3, but invalid for version ≤ 5.3.
+    func testBackwardIncompatibilityPre5_3_1() throws {
         
         // MARK: No spacing between "//" and "swift-tools-version" for Swift ≤ 5.3
         
@@ -193,10 +258,10 @@ class ToolsVersionLoaderTests: XCTestCase {
         for (specification, toolsVersionString) in specificationsWithZeroSpacing {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "`ToolsVersionLoader.Error.invalidSpacingAfterSlashes` should've been thrown, because there is no spacing between \"//\" and \"swift-tools-version\", and the specified Swift version is less than or equal to 5.3, but no error is thrown."
+                "`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, because there is no spacing between \"//\" and \"swift-tools-version\", and the specified lowest version \(toolsVersionString) ≤ 5.3, supporting exactly 1 space (U+0020) between \"//\" and \"swift-tools-version\"."
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error else {
-                    XCTFail("`ToolsVersionLoader.Error.invalidSpacingAfterSlashes` should've been thrown, a differently typed error is thrown.")
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1 = error else {
+                    XCTFail("`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, a differently typed error is thrown.")
                     return
                 }
                 XCTAssertEqual(
@@ -227,10 +292,10 @@ class ToolsVersionLoaderTests: XCTestCase {
         for (specification, toolsVersionString) in specificationsWith1TabAfterSlashes {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "`ToolsVersionLoader.Error.invalidSpacingAfterSlashes` should've been thrown, because the spacing between \"//\" and \"swift-tools-version\" is a horizontal tab character, and the specified Swift version is less than or equal to 5.3, but no error is thrown."
+                "`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, because the spacing between \"//\" and \"swift-tools-version\" is a character tabulation (U+0009), and the specified lowest version \(toolsVersionString) ≤ 5.3, supporting exactly 1 space (U+0020) between \"//\" and \"swift-tools-version\"."
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error else {
-                    XCTFail("`ToolsVersionLoader.Error.invalidSpacingAfterSlashes` should've been thrown, a differently typed error is thrown.")
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1 = error else {
+                    XCTFail("`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, a differently typed error is thrown.")
                     return
                 }
                 XCTAssertEqual(
@@ -261,10 +326,10 @@ class ToolsVersionLoaderTests: XCTestCase {
         for (specification, toolsVersionString) in specificationsWith1SpaceAnd1TabAfterSlashes {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "`ToolsVersionLoader.Error.invalidSpacingAfterSlashes` should've been thrown, because the spacing between \"//\" and \"swift-tools-version\" is a horizontal tab character, and the specified Swift version is less than or equal to 5.3, but no error is thrown."
+                "`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, because the spacing between \"//\" and \"swift-tools-version\" is a space (U+0020) and a character tabulation (U+0009), and the specified lowest version \(toolsVersionString) ≤ 5.3, supporting exactly 1 space (U+0020) between \"//\" and \"swift-tools-version\"."
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error else {
-                    XCTFail("`ToolsVersionLoader.Error.invalidSpacingAfterSlashes` should've been thrown, a differently typed error is thrown.")
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1 = error else {
+                    XCTFail("`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, a differently typed error is thrown.")
                     return
                 }
                 XCTAssertEqual(
@@ -277,41 +342,213 @@ class ToolsVersionLoaderTests: XCTestCase {
         // MARK: An assortment of horizontal whitespace characters between "//" and "swift-tools-version"
         
         let specificationsWithAnAssortmentOfWhitespacesAfterSlashes = [
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:3.1"                : "3.1.0",
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:3.1-dev"            : "3.1.0",
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.3"                : "5.3.0",
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.3.0"              : "5.3.0",
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:5.3-dev"            : "5.3.0",
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:4.8.0"              : "4.8.0",
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:3.1.2"              : "3.1.2",
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:3.1.2;"             : "3.1.2",
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}swift-toolS-version:3.5.2;hello"        : "3.5.2",
-            "//\u{A0}\u{1680}\t\u{2000}\u{2001} \u{2002}\u{202F}\u{3000}sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1"                : "3.1.0",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1-dev"            : "3.1.0",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:5.3"                : "5.3.0",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:5.3.0"              : "5.3.0",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:5.3-dev"            : "5.3.0",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:4.8.0"              : "4.8.0",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1.2"              : "3.1.2",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1.2;"             : "3.1.2",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-toolS-version:3.5.2;hello"        : "3.5.2",
+            "//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
         ]
         
         for (specification, toolsVersionString) in specificationsWithAnAssortmentOfWhitespacesAfterSlashes {
             XCTAssertThrowsError(
                 try load(ByteString(encodingAsUTF8: specification)),
-                "`ToolsVersionLoader.Error.invalidSpacingAfterSlashes` should've been thrown, because the spacing between \"//\" and \"swift-tools-version\" is a horizontal tab character, and the specified Swift version is less than or equal to 5.3, but no error is thrown."
+                "`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, because the spacing between \"//\" and \"swift-tools-version\" is an assortment of horizontal whitespace characters, and the specified lowest version \(toolsVersionString) ≤ 5.3, supporting exactly 1 space (U+0020) between \"//\" and \"swift-tools-version\"."
             ) { error in
-                guard let error = error as? ToolsVersionLoader.Error else {
-                    XCTFail("`ToolsVersionLoader.Error.invalidSpacingAfterSlashes` should've been thrown, a differently typed error is thrown.")
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1 = error else {
+                    XCTFail("`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, a differently typed error is thrown.")
                     return
                 }
                 XCTAssertEqual(
                     error.description,
-                    "horizontal whitespace sequence [U+00A0, U+1680, U+0009, U+2000, U+2001, U+0020, U+2002, U+202F, U+3000] between \"//\" and \"swift-tools-version\" is supported by only Swift > 5.3; consider using a single space (U+0020) for Swift \(toolsVersionString)"
+                    "horizontal whitespace sequence [U+0009, U+0020, U+00A0, U+1680, U+2000, U+2001, U+2002, U+2003, U+2004, U+2005, U+2006, U+2007, U+2008, U+2009, U+200A, U+202F, U+205F, U+3000] between \"//\" and \"swift-tools-version\" is supported by only Swift > 5.3; consider using a single space (U+0020) for Swift \(toolsVersionString)"
+                )
+            }
+        }
+        
+        // MARK: 2 leading line feed (U+000A)
+        
+        let manifestSnippetWith2LeadingLineFeeds = [
+            "\u{A}\u{A}//swift-tools-version:3.1"                : "3.1.0",
+            "\u{A}\u{A}//swift-tools-version:3.1-dev"            : "3.1.0",
+            "\u{A}\u{A}//swift-tools-version:5.3"                : "5.3.0",
+            "\u{A}\u{A}//swift-tools-version:5.3.0"              : "5.3.0",
+            "\u{A}\u{A}//swift-tools-version:5.3-dev"            : "5.3.0",
+            "\u{A}\u{A}//swift-tools-version:4.8.0"              : "4.8.0",
+            "\u{A}\u{A}//swift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
+            "\u{A}\u{A}//swift-tools-version:3.1.2"              : "3.1.2",
+            "\u{A}\u{A}//swift-tools-version:3.1.2;"             : "3.1.2",
+            "\u{A}\u{A}//swift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
+            "\u{A}\u{A}//swift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
+            "\u{A}\u{A}//swift-toolS-version:3.5.2;hello"        : "3.5.2",
+            "\u{A}\u{A}//sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
+        ]
+        
+        for (specification, toolsVersionString) in manifestSnippetWith2LeadingLineFeeds {
+            XCTAssertThrowsError(
+                try load(ByteString(encodingAsUTF8: specification)),
+                "`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, because the manifest starts with more than 1 line terminator, and the specified lowest version \(toolsVersionString) ≤ 5.3, supporting at most 1 leading U+000A."
+            ) { error in
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1 = error else {
+                    XCTFail("`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, a differently typed error is thrown.")
+                    return
+                }
+                XCTAssertEqual(
+                    error.description,
+                    "leading line terminator sequence [U+000A, U+000A] in manifest is supported by only Swift > 5.3; for the specified version \(toolsVersionString), only zero or one newline (U+000A) at the beginning of the manifest is supported"
+                )
+            }
+        }
+        
+        // MARK: 1 leading u+000D
+        
+        let manifestSnippetWith1LeadingCarriageReturn = [
+            "\u{D}//swift-tools-version:3.1"                : "3.1.0",
+            "\u{D}//swift-tools-version:3.1-dev"            : "3.1.0",
+            "\u{D}//swift-tools-version:5.3"                : "5.3.0",
+            "\u{D}//swift-tools-version:5.3.0"              : "5.3.0",
+            "\u{D}//swift-tools-version:5.3-dev"            : "5.3.0",
+            "\u{D}//swift-tools-version:4.8.0"              : "4.8.0",
+            "\u{D}//swift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
+            "\u{D}//swift-tools-version:3.1.2"              : "3.1.2",
+            "\u{D}//swift-tools-version:3.1.2;"             : "3.1.2",
+            "\u{D}//swift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
+            "\u{D}//swift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
+            "\u{D}//swift-toolS-version:3.5.2;hello"        : "3.5.2",
+            "\u{D}//sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
+        ]
+        
+        for (specification, toolsVersionString) in manifestSnippetWith1LeadingCarriageReturn {
+            XCTAssertThrowsError(
+                try load(ByteString(encodingAsUTF8: specification)),
+                "`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, because the manifest starts with a U+000D, and the specified lowest version \(toolsVersionString) ≤ 5.3, supporting only 0 or 1 leading U+000A."
+            ) { error in
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1 = error else {
+                    XCTFail("`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, a differently typed error is thrown.")
+                    return
+                }
+                XCTAssertEqual(
+                    error.description,
+                    "leading line terminator sequence [U+000D] in manifest is supported by only Swift > 5.3; for the specified version \(toolsVersionString), only zero or one newline (U+000A) at the beginning of the manifest is supported"
+                )
+            }
+        }
+        
+        // MARK: 1 leading U+000D followed by 1 U+000A
+        
+        let manifestSnippetWith1LeadingCarriageReturnFollowedBy1LineFeed = [
+            "\u{D}\u{A}//swift-tools-version:3.1"                : "3.1.0",
+            "\u{D}\u{A}//swift-tools-version:3.1-dev"            : "3.1.0",
+            "\u{D}\u{A}//swift-tools-version:5.3"                : "5.3.0",
+            "\u{D}\u{A}//swift-tools-version:5.3.0"              : "5.3.0",
+            "\u{D}\u{A}//swift-tools-version:5.3-dev"            : "5.3.0",
+            "\u{D}\u{A}//swift-tools-version:4.8.0"              : "4.8.0",
+            "\u{D}\u{A}//swift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
+            "\u{D}\u{A}//swift-tools-version:3.1.2"              : "3.1.2",
+            "\u{D}\u{A}//swift-tools-version:3.1.2;"             : "3.1.2",
+            "\u{D}\u{A}//swift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
+            "\u{D}\u{A}//swift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
+            "\u{D}\u{A}//swift-toolS-version:3.5.2;hello"        : "3.5.2",
+            "\u{D}\u{A}//sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
+        ]
+        
+        for (specification, toolsVersionString) in manifestSnippetWith1LeadingCarriageReturnFollowedBy1LineFeed {
+            XCTAssertThrowsError(
+                try load(ByteString(encodingAsUTF8: specification)),
+                "`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, because the manifest starts with a U+000D followed by a U+000A, and the specified lowest version \(toolsVersionString) ≤ 5.3, supporting only 0 or 1 leading U+000A."
+            ) { error in
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1 = error else {
+                    XCTFail("`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, a differently typed error is thrown.")
+                    return
+                }
+                XCTAssertEqual(
+                    error.description,
+                    "leading line terminator sequence [U+000D, U+000A] in manifest is supported by only Swift > 5.3; for the specified version \(toolsVersionString), only zero or one newline (U+000A) at the beginning of the manifest is supported"
+                )
+            }
+        }
+        
+        // MARK: An assortment of leading line terminators
+        
+        let manifestSnippetWithAnAssortmentOfLeadingLineTerminators = [
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-tools-version:3.1"                : "3.1.0",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-tools-version:3.1-dev"            : "3.1.0",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-tools-version:5.3"                : "5.3.0",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-tools-version:5.3.0"              : "5.3.0",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-tools-version:5.3-dev"            : "5.3.0",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-tools-version:4.8.0"              : "4.8.0",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-tools-version:3.1.2"              : "3.1.2",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-tools-version:3.1.2;"             : "3.1.2",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//swift-toolS-version:3.5.2;hello"        : "3.5.2",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
+        ]
+        
+        for (specification, toolsVersionString) in manifestSnippetWithAnAssortmentOfLeadingLineTerminators {
+            XCTAssertThrowsError(
+                try load(ByteString(encodingAsUTF8: specification)),
+                "`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, because the manifest starts with an assortment of line terminators, and the specified lowest version \(toolsVersionString) ≤ 5.3, supporting only 0 or 1 leading U+000A."
+            ) { error in
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1 = error else {
+                    XCTFail("`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, a differently typed error is thrown.")
+                    return
+                }
+                XCTAssertEqual(
+                    error.description,
+                    "leading line terminator sequence [U+000A, U+000B, U+000C, U+000D, U+000D, U+000A, U+0085, U+2028, U+2029] in manifest is supported by only Swift > 5.3; for the specified version \(toolsVersionString), only zero or one newline (U+000A) at the beginning of the manifest is supported"
+                )
+            }
+        }
+        
+        // MARK: An assortment of leading line terminators and an assortment of horizontal whitespace characters between "//" and "swift-tools-version"
+        
+        let manifestSnippetWithAnAssortmentOfLeadingLineTerminatorsAndAnAssortmentOfWhitespacesAfterSlashes = [
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1"                : "3.1.0",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1-dev"            : "3.1.0",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:5.3"                : "5.3.0",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:5.3.0"              : "5.3.0",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:5.3-dev"            : "5.3.0",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:4.8.0"              : "4.8.0",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:4.8.0-dev.al+sha.x" : "4.8.0",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1.2"              : "3.1.2",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1.2;"             : "3.1.2",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-vErsion:3.1.2;;;;;"         : "3.1.2",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-tools-version:3.1.2;x;x;x;x;x;"   : "3.1.2",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}swift-toolS-version:3.5.2;hello"        : "3.5.2",
+            "\u{A}\u{B}\u{C}\u{D}\u{D}\u{A}\u{85}\u{2028}\u{2029}//\u{9}\u{20}\u{A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{202F}\u{205F}\u{3000}sWiFt-tOoLs-vErSiOn:3.5.2\nkkk\n"       : "3.5.2",
+        ]
+        
+        // The backward-compatibility check for leading line terminators comes before that for spacing after slashes.
+        // So the error thrown here should be about invalid leading line terminators, although both the line terminators and the spacing here are backward-incompatible.
+        for (specification, toolsVersionString) in manifestSnippetWithAnAssortmentOfLeadingLineTerminatorsAndAnAssortmentOfWhitespacesAfterSlashes {
+            XCTAssertThrowsError(
+                try load(ByteString(encodingAsUTF8: specification)),
+                "`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, because the manifest starts with an assortment of line terminators, and the specified lowest version \(toolsVersionString) ≤ 5.3, supporting only 0 or 1 leading U+000A."
+            ) { error in
+                guard let error = error as? ToolsVersionLoader.Error, case .backwardIncompatiblePre5_3_1 = error else {
+                    XCTFail("`ToolsVersionLoader.Error.backwardIncompatiblePre5_3_1` should've been thrown, a differently typed error is thrown.")
+                    return
+                }
+                XCTAssertEqual(
+                    error.description,
+                    "leading line terminator sequence [U+000A, U+000B, U+000C, U+000D, U+000D, U+000A, U+0085, U+2028, U+2029] in manifest is supported by only Swift > 5.3; for the specified version \(toolsVersionString), only zero or one newline (U+000A) at the beginning of the manifest is supported"
                 )
             }
         }
         
     }
     
-    /// Verifies that if the first line of the manifest is invalid but doesn't contain any pre-defined misspelling, then the Swift tools version defaults to 3.1.
-    func testDefault() throws {
+    /// Verifies that if the first line of the manifest is invalid but doesn't contain any pre-defined misspelling, then the Swift tools version falls back to 3.1.
+    func testFallbackTo3_1() throws {
         let invalidVersionSpecificationsDefaultedTo3_1 = [
             "//\nswift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
             "// \nswift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
@@ -333,6 +570,21 @@ class ToolsVersionLoaderTests: XCTestCase {
             "//\n swift-tool:5.3\n": (3, 1, 0, "3.1.0"),
             "//\r\nswift-tool:5.3\n": (3, 1, 0, "3.1.0"),
             "//\n\rswift-tool:5.3\n": (3, 1, 0, "3.1.0"),
+            " \n": (3, 1, 0, "3.1.0"),
+            " ": (3, 1, 0, "3.1.0"),
+            "\n ": (3, 1, 0, "3.1.0"),
+            "\n": (3, 1, 0, "3.1.0"),
+            "": (3, 1, 0, "3.1.0"),
+            // FIXME: The following line terminators are source breaking.
+            // For Swift ≤ 5.3, only U+000A is treated as a line terminator, so SPM does not default the lowest version to 3.1 if the compiler version ≤ 5.3.
+            "//\u{D}swift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
+            "// \u{D}swift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
+            "//\u{D} swift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
+            "//\u{C}swift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
+            "//\u{B}swift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
+            "//\u{85}swift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
+            "//\u{2028}swift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
+            "//\u{2029}swift-tools-version:5.3\n": (3, 1, 0, "3.1.0"),
         ]
         
         for (specification, expectedResult) in invalidVersionSpecificationsDefaultedTo3_1 {
@@ -420,14 +672,21 @@ class ToolsVersionLoaderTests: XCTestCase {
         }
     }
 
-    func assertFailure(_ bytes: ByteString, _ theSpecifier: String, file: StaticString = #file, line: UInt = #line) {
+    func assertFailure(_ bytes: ByteString, _ theSpecification: String, _ theSpecifier: String, file: StaticString = #file, line: UInt = #line) {
         do {
             try load(bytes) {
                 XCTFail("unexpected success - \($0)", file: file, line: line)
             }
             XCTFail("unexpected success", file: file, line: line)
-        } catch ToolsVersionLoader.Error.malformedToolsVersion(let specifier, _) {
-            XCTAssertEqual(specifier, theSpecifier, file: file, line: line)
+        } catch let ToolsVersionLoader.Error.malformedToolsVersionSpecification(malformation) {
+            switch malformation {
+            case let .versionSpecifier(versionSpecifier):
+                XCTAssertEqual(String(versionSpecifier), theSpecifier, file: file, line: line)
+            case let .entireLine(entireLine):
+                XCTAssertEqual(String(entireLine), theSpecification, file: file, line: line)
+            default:
+                XCTFail("Failed with error \(ToolsVersionLoader.Error.malformedToolsVersionSpecification(malformation))")
+            }
         } catch {
             XCTFail("Failed with error \(error)")
         }

--- a/Tests/WorkspaceTests/ToolsVersionWriterTests.swift
+++ b/Tests/WorkspaceTests/ToolsVersionWriterTests.swift
@@ -77,7 +77,7 @@ class ToolsVersionWriterTests: XCTestCase {
             XCTAssertEqual(result, "// swift-tools-version:4.1.2\n...")
         }
 
-        // Contents with valid specifier string and some meta data.
+        // Contents with invalid specifier string and some meta data.
         stream = BufferedOutputByteStream()
         stream <<< "// swift-tools-version:-3.1.2;hello\n"
         stream <<< "..."


### PR DESCRIPTION
ORIGINAL DESCRIPTION
---------------

[SR-13566](https://bugs.swift.org/browse/SR-13566)

This pull request changes the regex pattern on line [181 of swift-package-manager/Sources/PackageLoading/ToolsVersionLoader.swift](https://github.com/apple/swift-package-manager/blob/9e0a63fe8e148cf8b645a8d870b43f8e59ff6701/Sources/PackageLoading/ToolsVersionLoader.swift#L181) to allow any combination of _horizontal_ whitespace characters between "//" and "swift-tools-version" in the swift tools version specification in `Package.swift`

The old regex pattern is `^// swift-tools-version:(.*?)(?:;.*|$)`

The new regex pattern is `^//\h*?swift-tools-version:(.*?)(?:;.*|$)`

---

NEW DESCRIPTION (2020-11-04)
---------------

This PR proposes the following changes to the parsing of the `Package` manifest and its Swift tools version specification, starting from Swift Next (assumed to be Swift 5.4):

- Allow leading (any combination of all) [whitespace characters](https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt) in the `Package` manifest, instead of just line feed characters (`U+000A`).
  
  **Rationale**: This allows SwiftPM to skip all initial whitespace-only lines (if any) when looking for the Swift tools version specification, eliminating a common source of bug for Swift packages. Additionally, this allows SwiftPM to recognise all Unicode line terminators, because all of them are whitespace characters.

- Allow any combination of all _horizontal_ whitespace characters¹ immediately after the comment marker (`//`) in the Swift tools version specification, instead of just a single space (`U+0020`).
  
  **Rationale**: Sometimes a user may prefer to follow the comment marker with a character tabulation (`U+0009`) or 2 space characters, or some other _horizontal_ whitespace characters, in order to line up developer (`//`) and documentation (`///`) comments throughout the source files. For example:
  
  ```swift
  //  This is a demonstration of how comments may be lined up.
  /// A struct that represents nothing.
  struct Foo {}
  ```

- Allow any combination of all _horizontal_ whitespace characters immediately before the version specifier in the Swift tools version specification. 
  
  **Rationale**: This mirrors the most common style of type declaration in Swift sources. For example,
  
  ```swift
  let foo: Foo
  ```

- Recognise all [Unicode line terminators](https://www.unicode.org/reports/tr14/) instead of just line feed (`U+000A`) in the `Package` manifest up to the line terminator that immediately follows the Swift tools version specification line².
  
  **Rationale**: With Swift becoming supported on more and more platforms (many of them Unix-unlike or POSIX-incompliant), SwiftPM will see more and more `Package` manifests that use line terminators other than line feed. Further, even though many systems are not yet supported, Swift source files can still be edited on them, and many IDEs/editors silently changes the line terminators to the platforms' native ones when saving the edited files. SwiftPM needs to recognise all possible line terminators³ before it becomes a problem

- End the silent fallback to using Swift 3.1 as the lowest supported version. This used to happen when the Swift tools version specification is malformed AND SwiftPM couldn't find either `swift-tool` or `tool-version` in the specification.
  
  **Rationale**: It is actively harmful to hide this behaviour from the user. It is also actively harmful to decide on a Swift version without user consent. With source breaks from past Swift releases accumulated, this could result in unexpected behaviour in Swift packages. This behaviour was originally intended to peacefully accept Swift packages created before the Swift tools version specification was required. However, this purpose has become outdated.

Additional user-facing changes as the result of implementing the changes above:

- If the manifest has a formatting error, SwiftPM now identifies more accurately where the error is, and provides to the user a more detailed description/explanation and a suggestion tailored for each error.

- SwiftPM now throws an error if the manifest is not properly encoded in UTF-8.

Additional SwiftPM client-facing changes as the result of implementing the changes above:

- `ToolsVersionLoader.Error.malformedToolsVersion(specifier: String, currentToolsVersion: ToolsVersion)` is replaced by more granular error cases.

- `ToolsVersionLoader.split(_ bytes: ByteString) -> (versionSpecifier: String?, rest: [UInt8])` and `ToolsVersionLoader.regex` are replaced by the `Substring`-oriented `ToolsVersionLoader.split(_ manifest: String) -> ManifestComponents`.

¹ Whitespace characters consists of horizontal and vertical whitespace characters. No whitespace character can be both horizontal and vertical. All vertical whitespace characters are line terminators, and vice versa. In the PR's implementation, horizontal whitespace characters are not identified directly, but through the process of elimination: All line terminators are "stripped" from the manifest first, then the horizontal whitespace characters are identified by being whitespace characters.

² Everything after the Swift tools version specification, such as the initilisation of the `Package` instance, is handled by the Swift compiler's lexer. It's beyond the power of `ToolsVersionLoader` and SwiftPM's manifest-loading in general.

³ Only Unicode line terminators are recognised, so line terminators in some other encodings such as [EBCDIC](https://en.wikipedia.org/wiki/EBCDIC#NL) are not recognised. This is fine because if a `Package` manifest isn't encoded in UTF-8, then it's already entirely unreadable by SwiftPM.