### PR TITLE
[Explicit Module Builds] Use c99name instead of name when forming a list of external module dependencies

### DIFF
--- a/Sources/Build/ManifestBuilder.swift
+++ b/Sources/Build/ManifestBuilder.swift
@@ -432,9 +432,8 @@ extension LLBuildManifestBuilder {
         guard let dependencyGraph = targetDepGraphMap[target] else {
             fatalError("Expected dependency graph for target: \(target.description)")
         }
-        let moduleName = target.name
         let dependencyModulePath = dependencySwiftTargetDescription.moduleOutputPath
-        dependencyArtifactMap[ModuleDependencyId.swiftPlaceholder(moduleName)] =
+        dependencyArtifactMap[ModuleDependencyId.swiftPlaceholder(target.c99name)] =
             (dependencyModulePath, dependencyGraph)
 
         collectTargetDependencyInfos(for: target,


### PR DESCRIPTION
This name matches the actual language-level module name versus the target name.
These names are not always the same so when we get it wrong, module dependencies get lost.