### PR TITLE
[5.3] Fix crash related to build conditionals

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -829,12 +829,12 @@ public final class PackageBuilder {
     func buildConditions(from condition: PackageConditionDescription?) -> [PackageConditionProtocol] {
         var conditions: [PackageConditionProtocol] = []
 
-        if let config = condition?.config.map({ BuildConfiguration(rawValue: $0)! }) {
+        if let config = condition?.config.flatMap({ BuildConfiguration(rawValue: $0) }) {
             let condition = ConfigurationCondition(configuration: config)
             conditions.append(condition)
         }
 
-        if let platforms = condition?.platformNames.map({ platformRegistry.platformByName[$0]! }), !platforms.isEmpty {
+        if let platforms = condition?.platformNames.flatMap({ platformRegistry.platformByName[$0] }), !platforms.isEmpty {
             let condition = PlatformsCondition(platforms: platforms)
             conditions.append(condition)
         }


### PR DESCRIPTION
This fixes a crash related to build conditionals which looks like a
longer standing bug that was triggered by https://github.com/apple/swift-llbuild/pull/681
Unforunately, llbuild CI doesn't test the package, so it slipped through
and now causes SwiftPM to crash when building itself

rdar://problem/67432513