### PR TITLE
[Integrated Swift driver] Handle derived source files in the integrated driver.

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -702,7 +702,7 @@ public final class SwiftTargetBuildDescription {
         }
 
         result.append("-c")
-        result.append(contentsOf: target.sources.paths.map { $0.pathString })
+        result.append(contentsOf: sources.map { $0.pathString })
 
         result.append("-I")
         result.append(buildParameters.buildPath.pathString)
@@ -831,7 +831,7 @@ public final class SwiftTargetBuildDescription {
         stream <<< "  },\n"
 
         // Write out the entries for each source file.
-        let sources = target.sources.paths
+        let sources = target.sources.paths + derivedSources.paths
         for (idx, source) in sources.enumerated() {
             let object = objects[idx]
             let objectDir = object.parentDirectory

--- a/Sources/Build/ManifestBuilder.swift
+++ b/Sources/Build/ManifestBuilder.swift
@@ -350,8 +350,6 @@ extension LLBuildManifestBuilder {
 
         // Commands.
         try addExplicitBuildSwiftCmds(description, inputs: inputs,
-                                      objectNodes: objectNodes,
-                                      moduleNode: moduleNode,
                                       targetDepGraphMap: &targetDepGraphMap)
 
         addTargetCmd(description, cmdOutputs: cmdOutputs)
@@ -360,8 +358,7 @@ extension LLBuildManifestBuilder {
 
     private func addExplicitBuildSwiftCmds(
         _ targetDescription: SwiftTargetBuildDescription,
-        inputs: [Node], objectNodes: [Node], moduleNode: Node,
-        targetDepGraphMap: inout [ResolvedTarget: InterModuleDependencyGraph]
+        inputs: [Node], targetDepGraphMap: inout [ResolvedTarget: InterModuleDependencyGraph]
     ) throws {
         // Pass the driver its external dependencies (target dependencies)
         var targetDependencyMap: SwiftDriver.ExternalDependencyArtifactMap = [:]


### PR DESCRIPTION
- When computing command line arguments for the integrated driver invocation, append all source files, both belonging to the package and derived.
- When writing out an output file map, add derived source files and their build artifacts to it as well.

Before this change, the [Implicit | Explicit] integrated driver flow ignores derived files when building a target and therefore is not able to handle targets with specified resource bundles, for example.