### PR TITLE
Replace SwiftDriverExecutor with SPMSwiftDriverExecutor

### DIFF
--- a/Sources/Build/CMakeLists.txt
+++ b/Sources/Build/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(Build
   BuildOperation.swift
   BuildPlan.swift
   ManifestBuilder.swift
+  SPMSwiftDriverExecutor.swift
   SwiftCompilerOutputParser.swift
   XCFrameworkInfo.swift)
 target_link_libraries(Build PUBLIC

--- a/Sources/Build/ManifestBuilder.swift
+++ b/Sources/Build/ManifestBuilder.swift
@@ -220,24 +220,24 @@ extension LLBuildManifestBuilder {
         commandLine.append(buildParameters.toolchain.swiftCompiler.pathString)
         // FIXME: At some point SwiftPM should provide its own executor for
         // running jobs/launching processes during planning
-        let executor = try SwiftDriverExecutor(diagnosticsEngine: plan.diagnostics,
-                                               processSet: ProcessSet(),
-                                               fileSystem: target.fs,
-                                               env: ProcessEnv.vars)
+        let resolver = try ArgsResolver(fileSystem: target.fs)
+        let executor = SPMSwiftDriverExecutor(resolver: resolver,
+                                              fileSystem: target.fs,
+                                              env: ProcessEnv.vars)
         var driver = try Driver(args: commandLine,
                                 diagnosticsEngine: plan.diagnostics,
                                 fileSystem: target.fs,
                                 executor: executor)
         let jobs = try driver.planBuild()
-        try addSwiftDriverJobs(for: target, jobs: jobs, inputs: inputs,
+        try addSwiftDriverJobs(for: target, jobs: jobs, inputs: inputs, resolver: resolver,
                                isMainModule: { driver.isExplicitMainModuleJob(job: $0)})
     }
 
     private func addSwiftDriverJobs(for targetDescription: SwiftTargetBuildDescription,
                                     jobs: [Job], inputs: [Node],
+                                    resolver: ArgsResolver,
                                     isMainModule: (Job) -> Bool) throws {
         // Add build jobs to the manifest
-        let resolver = try ArgsResolver(fileSystem: targetDescription.fs)
         for job in jobs {
             let tool = try resolver.resolve(.path(job.tool))
             let commandLine = try job.commandLine.map{ try resolver.resolve($0) }
@@ -377,10 +377,10 @@ extension LLBuildManifestBuilder {
         commandLine.append("-experimental-explicit-module-build")
         // FIXME: At some point SwiftPM should provide its own executor for
         // running jobs/launching processes during planning
-        let executor = try SwiftDriverExecutor(diagnosticsEngine: plan.diagnostics,
-                                               processSet: ProcessSet(),
-                                               fileSystem: targetDescription.fs,
-                                               env: ProcessEnv.vars)
+        let resolver = try ArgsResolver(fileSystem: targetDescription.fs)
+        let executor = SPMSwiftDriverExecutor(resolver: resolver,
+                                              fileSystem: targetDescription.fs,
+                                              env: ProcessEnv.vars)
         var driver = try Driver(args: commandLine, fileSystem: targetDescription.fs,
                                 executor: executor,
                                 externalModuleDependencies: targetDependencyMap)
@@ -392,7 +392,7 @@ extension LLBuildManifestBuilder {
             fatalError("Expected module dependency graph for target: \(targetDescription)")
         }
         targetDepGraphMap[targetDescription.target] = dependencyGraph
-        try addSwiftDriverJobs(for: targetDescription, jobs: jobs, inputs: inputs,
+        try addSwiftDriverJobs(for: targetDescription, jobs: jobs, inputs: inputs, resolver: resolver,
                                isMainModule: { driver.isExplicitMainModuleJob(job: $0)})
     }
 

--- a/Sources/Build/SPMSwiftDriverExecutor.swift
+++ b/Sources/Build/SPMSwiftDriverExecutor.swift
@@ -1,0 +1,89 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+@_implementationOnly import SwiftDriver
+import TSCBasic
+import Foundation
+
+final class SPMSwiftDriverExecutor: DriverExecutor {
+
+  private enum Error: Swift.Error, DiagnosticData {
+    case inPlaceExecutionUnsupported
+
+    var description: String {
+      switch self {
+      case .inPlaceExecutionUnsupported:
+        return "the integrated Swift driver does not support in-place execution"
+      }
+    }
+  }
+
+  let resolver: ArgsResolver
+  let fileSystem: FileSystem
+  let env: [String: String]
+
+  init(resolver: ArgsResolver,
+       fileSystem: FileSystem,
+       env: [String: String]) {
+    self.resolver = resolver
+    self.fileSystem = fileSystem
+    self.env = env
+  }
+
+  func execute(job: Job,
+               forceResponseFiles: Bool,
+               recordedInputModificationDates: [TypedVirtualPath : Date]) throws -> ProcessResult {
+    let arguments: [String] = try resolver.resolveArgumentList(for: job,
+                                                               forceResponseFiles: forceResponseFiles)
+
+    try job.verifyInputsNotModified(since: recordedInputModificationDates,
+                                    fileSystem: fileSystem)
+    
+    if job.requiresInPlaceExecution {
+      throw Error.inPlaceExecutionUnsupported
+    }
+
+    var childEnv = env
+    childEnv.merge(job.extraEnvironment, uniquingKeysWith: { (_, new) in new })
+
+    let process = try Process.launchProcess(arguments: arguments, env: childEnv)
+    return try process.waitUntilExit()
+  }
+
+  func execute(jobs: [Job], delegate: JobExecutionDelegate,
+               numParallelJobs: Int, forceResponseFiles: Bool,
+               recordedInputModificationDates: [TypedVirtualPath : Date]) throws {
+    fatalError("Multi-job build plans should be lifted into the SPM build graph.")
+  }
+
+  func checkNonZeroExit(args: String..., environment: [String : String]) throws -> String {
+    return try Process.checkNonZeroExit(arguments: args, environment: environment)
+  }
+
+  func description(of job: Job, forceResponseFiles: Bool) throws -> String {
+    // FIXME: This is duplicated from SwiftDriver, maybe it shouldn't be a protocol requirement.
+    let (args, usedResponseFile) = try resolver.resolveArgumentList(for: job,
+                                                                    forceResponseFiles: forceResponseFiles)
+    var result = args.joined(separator: " ")
+
+    if usedResponseFile {
+      // Print the response file arguments as a comment.
+      result += " # \(job.commandLine.joinedArguments)"
+    }
+
+    if !job.extraEnvironment.isEmpty {
+      result += " #"
+      for (envVar, val) in job.extraEnvironment {
+        result += " \(envVar)=\(val)"
+      }
+    }
+    return result
+  }
+}


### PR DESCRIPTION
SPM does not need or use the full functionality of SwiftDriverExecutor, which we're planning to move to a separate library so that the SwiftDriver planning library no longer depends on LLBuild. Introduce a minimal SPMSwiftDriverExecutor for the processes the integrated driver needs to launch during planning.