### PR TITLE
Make sure that GetDependenciesError diagnostics have a associated diagnostic location that identifies the repository

### DIFF
--- a/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
@@ -251,7 +251,7 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
 
     // A wrapper for getDependencies() errors. This adds additional information
     // about the container to identify it for diagnostics.
-    public struct GetDependenciesError: Error, CustomStringConvertible {
+    public struct GetDependenciesError: Error, CustomStringConvertible, DiagnosticLocationProviding {
 
         /// The container (repository) that encountered the error.
         public let containerIdentifier: String
@@ -264,6 +264,10 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
         
         /// Optional suggestion for how to resolve the error.
         public let suggestion: String?
+        
+        public var diagnosticLocation: DiagnosticLocation? {
+            return PackageLocation.Remote(url: containerIdentifier, reference: reference)
+        }
         
         /// Description shown for errors of this kind.
         public var description: String {

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -543,13 +543,15 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             catch let error as RepositoryPackageContainer.GetDependenciesError {
                 // We expect to get an error message that mentions main.
                 XCTAssertMatch(error.description, .and(.prefix("could not find a branch named ‘master’"), .suffix("(did you mean ‘main’?)")))
+                XCTAssertMatch(error.diagnosticLocation?.description, .suffix("/SomePackage @ master"))
             }
             
             // Simulate accessing a fictitious dependency on some random commit that doesn't exist, and check that we get back the expected error.
             do { _ = try container.getDependencies(at: "535f4cb5b4a0872fa691473e82d7b27b9894df00", productFilter: .everything) }
             catch let error as RepositoryPackageContainer.GetDependenciesError {
-                // We expect to get an error message that mentions main.
+                // We expect to get an error message about the specific commit.
                 XCTAssertMatch(error.description, .prefix("could not find the commit 535f4cb5b4a0872fa691473e82d7b27b9894df00"))
+                XCTAssertMatch(error.diagnosticLocation?.description, .suffix("/SomePackage @ 535f4cb5b4a0872fa691473e82d7b27b9894df00"))
             }
         }
     }


### PR DESCRIPTION
This will help with error reporting, especially in clients of libSwiftPM.