### PR TITLE
Skip tests related to ParallelTestsPkgTests

### DIFF
--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -213,6 +213,9 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testSwiftTestParallel() throws {
+        // <rdar://problem/69448176> Fix and re-enable test related to "ParallelTestsPkg"
+        try XCTSkip()
+
         fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
           // First try normal serial testing.
           do {
@@ -258,6 +261,9 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testSwiftTestFilter() throws {
+        // <rdar://problem/69448176> Fix and re-enable test related to "ParallelTestsPkg"
+        try XCTSkip()
+
         fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
             let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--filter", ".*1", "-l", "--enable-test-discovery"], packagePath: prefix)
             XCTAssertMatch(stdout, .contains("testExample1"))
@@ -274,6 +280,9 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testSwiftTestSkip() throws {
+        // <rdar://problem/69448176> Fix and re-enable test related to "ParallelTestsPkg"
+        try XCTSkip()
+        
         fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
             let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--skip", "ParallelTestsTests", "-l", "--enable-test-discovery"], packagePath: prefix)
             XCTAssertNoMatch(stdout, .contains("testExample1"))
@@ -414,6 +423,9 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testSwiftTestLinuxMainGeneration() throws {
+        // <rdar://problem/69448176> Fix and re-enable test related to "ParallelTestsPkg"
+        try XCTSkip()
+
       #if os(macOS)
         fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
             let fs = localFileSystem


### PR DESCRIPTION
We are seeing CI failures of the form:
```/private/var/folders/_8/79jmzf2142z2xydc_01btlx00000gn/T/Miscellaneous_ParallelTestsPkg.s9qJNJ/Miscellaneous_ParallelTestsPkg/Tests/ParallelTestsPkgTests/ParallelTestsFailureTests.swift:1:8:
error: compiled module was created by an older version of the compiler;
rebuild 'XCTest' and try again:
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib/XCTest.swiftmodule/x86_64-apple-macos.swiftmodule
```
Let's skip these tests while we are investigating.