### PR TITLE
The PackageDescription.swiftdoc file is missing on Darwin

### DIFF
--- a/Sources/PackageDescription/CMakeLists.txt
+++ b/Sources/PackageDescription/CMakeLists.txt
@@ -57,6 +57,7 @@ foreach(PACKAGE_DESCRIPTION_VERSION 4 4_2)
     if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
         install(FILES
             ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}/PackageDescription.swiftinterface
+            ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}/PackageDescription.swiftdoc
             DESTINATION lib/swift/pm/${PACKAGE_DESCRIPTION_VERSION}
         )
     else()

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -389,7 +389,7 @@ def install_swiftpm(prefix, args):
             files_to_install.append("PackageDescription.swiftinterface")
         else:
             files_to_install.append("PackageDescription.swiftmodule")
-            files_to_install.append("PackageDescription.swiftdoc")
+        files_to_install.append("PackageDescription.swiftdoc")
 
         for file in files_to_install:
             src = os.path.join(runtime_lib_src, runtime, file)


### PR DESCRIPTION
Without it, we don't see API documentation.

This fix covers both CMake and the bootstrap script.