### PR TITLE
[5.3] Improve the diagnostics that are emitted when a package dependency specifies a non-existent branch or commit

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2007,7 +2007,8 @@ extension Workspace {
             // Emit proper error if we were not able to parse some manifest during dependency resolution.
             case let error as RepositoryPackageContainer.GetDependenciesErrorWrapper:
                 let location = PackageLocation.Remote(url: error.containerIdentifier, reference: error.reference)
-                diagnostics.emit(error.underlyingError, location: location)
+                let suggestion = error.suggestion.flatMap{ " (\($0))" }
+                diagnostics.emit(StringError("\(error.underlyingError)\(suggestion ?? "")"), location: location)
 
             default:
                 diagnostics.emit(error)


### PR DESCRIPTION
This is a 5.3 nomination of a fix that is already in the main branch.  The code is not exactly the same as the one in the main branch, since that made use of previous main-branch changes.  It has also been trimmed down to reduce risk.  So I'd like to ask for thorough code review on this one.

This improves the handling of errors thrown by Git, and is quite safe because it does not affect the successful code path.  If the Git invocation fails, it checks for the common case of a missing branch name or commit hash, and if so, customizes the error message.

As a bonus, adds a specific check to provide a suggestion to use `main` if a `master` branch is requested but doesn't exist but if `main` does exist.

Instead of seeing:
```
git rev-parse --verify 'master^{commit}' output:
    fatal: Needed a single revision
```
we now see:
```
https://github.com/apple/swift-cluster-membership.git: error: could not find a branch named ‘master’ (did you mean ‘main’?)
```
with the suggestion at the end only appearing if `main` exists and `master` doesn’t.

This is being nominated for SwiftPM 5.3.x since the `master` -> `main` renaming is happening in the Swift repositories right now, and people are particularly likely to run into this issue in the next few months.

Note that tags go through different processing, since they are the inputs to the semantic versioning and missing tags are reported differently.  There is no way in SwiftPM to define an explicit dependency on a non-semver tag, which is why this code only needs to handle branches and commits.

The error message does not list all the branches, since there can be many, but that could be another future improvement (or at least to list all the branches whose names are similar to what was requested).

The original PR was https://github.com/apple/swift-package-manager/pull/2925

rdar://69413377