### PR TITLE
Workspace: remove unnecessary flags on Windows

### DIFF
--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -245,19 +245,7 @@ public final class UserToolchain: Toolchain {
                         }
                     }
 
-                    return [
-                        "-sdk", root.pathString,
-
-                        // FIXME: these should not be necessary with the `-sdk`
-                        // parameter.  However, it seems that the layout on Windows
-                        // is not entirely correct yet and the driver does not pick
-                        // up the include search path, library search path, nor
-                        // resource dir.  Workaround that for the time being to
-                        // enable use of swift-package-manager on Windows.
-                        "-I", root.appending(RelativePath("usr/lib/swift")).pathString,
-                        "-L", root.appending(RelativePath("usr/lib/swift/windows")).pathString,
-                        "-resource-dir", root.appending(RelativePath("usr/lib/swift")).pathString,
-                    ] + xctest + runtime
+                    return [ "-sdk", root.pathString, ] + runtime + xctest
                 }
             }
 


### PR DESCRIPTION
This cleans up the unnecessary flags now that they are not absolutely
required.  This will break compatibility with older releases, however,
because there is no current stable release on Windows with
swift-package-manager support, this is acceptable.