### PR TITLE
Skip testExplicitSwiftPackageBuild instead of silently passing if toolchain is too old

### DIFF
--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -255,7 +255,7 @@ final class BuildPlanTests: XCTestCase {
                 // will not be able to parse the `-print-target-info` output. In which case,
                 // we cannot yet rely on the integrated swift driver.
                 // This effectively guards the test from running on unupported, older toolchains.
-                return
+                throw XCTSkip()
             }
         }
     }


### PR DESCRIPTION
This makes it easier to tell whether or not the environment is properly configured to test explicit module builds.