### PR TITLE
Add a customized GitRepositoryError and funnel all Git operations through a method that throws one of those if an operation fails.

### DIFF
--- a/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainerProvider.swift
@@ -400,7 +400,7 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
             }.1
         } catch {
             // Examine the error to see if we can come up with a more informative and actionable error message.  We know that the revision is expected to be a branch name or a hash (tags are handled through a different code path).
-            if let gitInvocationError = error as? ProcessResult.Error, gitInvocationError.description.contains("Needed a single revision") {
+            if let error = error as? GitRepositoryError, error.description.contains("Needed a single revision") {
                 // It was a Git process invocation error.  Take a look at the repository to see if we can come up with a reasonable diagnostic.
                 if let rev = try? repository.resolveRevision(identifier: revision), repository.exists(revision: rev) {
                     // Revision does exist, so something else must be wrong.

--- a/Sources/SourceControl/Repository.swift
+++ b/Sources/SourceControl/Repository.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -69,15 +69,20 @@ extension RepositorySpecifier: JSONMappable, JSONSerializable {
 public protocol RepositoryProvider {
     /// Fetch the complete repository at the given location to `path`.
     ///
-    /// - Throws: If there is an error fetching the repository.
+    /// - Parameters:
+    ///   - repository: The specifier of the repository to fetch.
+    ///
+    /// - Throws: If there is any error fetching the repository.
     func fetch(repository: RepositorySpecifier, to path: AbsolutePath) throws
 
     /// Open the given repository.
     ///
     /// - Parameters:
-    ///   - repository: The specifier for the repository.
+    ///   - repository: The specifier of the original repository from which the
+    ///     local clone repository was created.
     ///   - path: The location of the repository on disk, at which the
     ///     repository has previously been created via `fetch`.
+    ///
     /// - Throws: If the repository is unable to be opened.
     func open(repository: RepositorySpecifier, at path: AbsolutePath) throws -> Repository
 
@@ -89,11 +94,15 @@ public protocol RepositoryProvider {
     /// followed by checking out the cloned working copy at a particular ref.
     ///
     /// - Parameters:
+    ///   - repository: The specifier of the original repository from which the
+    ///     local clone repository was created.
     ///   - sourcePath: The location of the repository on disk, at which the
     ///     repository has previously been created via `fetch`.
     ///   - destinationPath: The path at which to create the working copy; it is
     ///     expected to be non-existent when called.
     ///   - editable: The checkout is expected to be edited by users.
+    ///
+    /// - Throws: If there is any error cloning the repository.
     func cloneCheckout(
         repository: RepositorySpecifier,
         at sourcePath: AbsolutePath,
@@ -106,8 +115,8 @@ public protocol RepositoryProvider {
     /// Open a working repository copy.
     ///
     /// - Parameters:
-    ///   - path: The location of the repository on disk, at which the
-    ///     repository has previously been created via `cloneCheckout`.
+    ///   - path: The location of the repository on disk, at which the repository
+    ///     has previously been created via `cloneCheckout`.
     func openCheckout(at path: AbsolutePath) throws -> WorkingCheckout
 }
 

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -383,11 +383,15 @@ class GitRepositoryTests: XCTestCase {
             // Change remote.
             try repo.setURL(remote: "origin", url: "../bar")
             XCTAssertEqual(Dictionary(uniqueKeysWithValues: try repo.remotes().map { ($0.0, $0.1) }), ["origin": "../bar"])
-            // Try changing remote of non-existant remote.
+            // Try changing remote of non-existent remote.
             do {
                 try repo.setURL(remote: "fake", url: "../bar")
-                XCTFail("unexpected success")
-            } catch ProcessResult.Error.nonZeroExit {}
+                XCTFail("unexpected success (shouldn’t have been able to set URL of missing remote)")
+            }
+            catch let error as GitRepositoryError {
+                XCTAssertEqual(error.path, testRepoPath)
+                XCTAssertNotNil(error.diagnosticLocation)
+            }
         }
     }
 


### PR DESCRIPTION
This makes sure that Git failures clients can distinguish from other Process errors (so failure handling can be customized), and that they all have a location.  At present the location for an error during a cloning operation is the remote URL, while the operation for an operation on a local clone is the path of the local clone.  We might want to extend this in the future so that local clones also keep track of the URL, but this will require the GitRepository to keep a copy of the associated RepositorySpecifier of its origin remote.  This would in turn require a change to the Repository protocol so that all methods take a RepositorySpecificier, and it would require changes to all the clients.  So that should be a separate PR.