### PR TITLE
Avoid switching over SwiftDriver.VirtualPath

### DIFF
--- a/Sources/Build/ManifestBuilder.swift
+++ b/Sources/Build/ManifestBuilder.swift
@@ -860,18 +860,14 @@ extension TypedVirtualPath {
     /// Resolve a typed virtual path provided by the Swift driver to
     /// a node in the build graph.
     func resolveToNode() -> Node {
-        switch file {
-        case .relative(let path):
-            return Node.file(localFileSystem.currentWorkingDirectory!.appending(path))
-
-        case .absolute(let path):
-            return Node.file(path)
-
-        case .temporary(let path), .fileList(let path, _):
-            return Node.virtual(path.pathString)
-
-        case .standardInput, .standardOutput:
-            fatalError("Cannot handle standard input or output")
+        if let absolutePath = file.absolutePath {
+            return Node.file(absolutePath)
+        } else if let relativePath = file.relativePath {
+            return Node.file(localFileSystem.currentWorkingDirectory!.appending(relativePath))
+        } else if let temporaryFileName = file.temporaryFileName {
+            return Node.virtual(temporaryFileName.pathString)
+        } else {
+            fatalError("Cannot resolve VirtualPath: \(file)")
         }
     }
 }


### PR DESCRIPTION
This will allow adding new enum cases without breaking the SPM build, like in https://github.com/apple/swift-driver/pull/250. It's not a perfect solution, but it solves the immediate issues with exposing an enum (`VirtualPath`) as public API.