### PR TITLE
Add basenameWithoutExt method to RelativePath

### DIFF
--- a/swift-tools-support-core/Sources/TSCBasic/Path.swift
+++ b/swift-tools-support-core/Sources/TSCBasic/Path.swift
@@ -243,6 +243,14 @@ public struct RelativePath: Hashable {
         return _impl.basename
     }
 
+    /// Returns the basename without the extension.
+    public var basenameWithoutExt: String {
+        if let ext = self.extension {
+            return String(basename.dropLast(ext.count + 1))
+        }
+        return basename
+    }
+
     /// Suffix (including leading `.` character) if any.  Note that a basename
     /// that starts with a `.` character is not considered a suffix, nor is a
     /// trailing `.` character.

--- a/swift-tools-support-core/Tests/TSCBasicTests/PathTests.swift
+++ b/swift-tools-support-core/Tests/TSCBasicTests/PathTests.swift
@@ -365,7 +365,5 @@ class PathTests: XCTestCase {
 
     // FIXME: We also need tests for join() operations.
 
-    // FIXME: We also need tests for dirname, suffix, etc.
-
     // FIXME: We also need test for stat() operations.
 }

--- a/swift-tools-support-core/Tests/TSCBasicTests/PathTests.swift
+++ b/swift-tools-support-core/Tests/TSCBasicTests/PathTests.swift
@@ -133,7 +133,7 @@ class PathTests: XCTestCase {
         XCTAssertEqual(RelativePath(".").dirname, ".")
     }
 
-    func testBaseNameExtraction() {
+    func testBasenameExtraction() {
         XCTAssertEqual(AbsolutePath("/").basename, "/")
         XCTAssertEqual(AbsolutePath("/a").basename, "a")
         XCTAssertEqual(AbsolutePath("/./a").basename, "a")
@@ -147,6 +147,28 @@ class PathTests: XCTestCase {
         XCTAssertEqual(RelativePath("abc").basename, "abc")
         XCTAssertEqual(RelativePath("").basename, ".")
         XCTAssertEqual(RelativePath(".").basename, ".")
+    }
+
+    func testBasenameWithoutExtExtraction() {
+        XCTAssertEqual(AbsolutePath("/").basenameWithoutExt, "/")
+        XCTAssertEqual(AbsolutePath("/a").basenameWithoutExt, "a")
+        XCTAssertEqual(AbsolutePath("/./a").basenameWithoutExt, "a")
+        XCTAssertEqual(AbsolutePath("/../..").basenameWithoutExt, "/")
+        XCTAssertEqual(AbsolutePath("/a.txt").basenameWithoutExt, "a")
+        XCTAssertEqual(AbsolutePath("/b/c/../a.txt").basenameWithoutExt, "a")
+        XCTAssertEqual(AbsolutePath("/b/c/../a.bcd.txt").basenameWithoutExt, "a.bcd")
+        XCTAssertEqual(RelativePath("../..").basenameWithoutExt, "..")
+        XCTAssertEqual(RelativePath("../a").basenameWithoutExt, "a")
+        XCTAssertEqual(RelativePath("../a/..").basenameWithoutExt, "..")
+        XCTAssertEqual(RelativePath("a/..").basenameWithoutExt, ".")
+        XCTAssertEqual(RelativePath("./..").basenameWithoutExt, "..")
+        XCTAssertEqual(RelativePath("a/../////../////./////").basenameWithoutExt, "..")
+        XCTAssertEqual(RelativePath("abc").basenameWithoutExt, "abc")
+        XCTAssertEqual(RelativePath("").basenameWithoutExt, ".")
+        XCTAssertEqual(RelativePath(".").basenameWithoutExt, ".")
+        XCTAssertEqual(RelativePath("a.txt").basenameWithoutExt, "a")
+        XCTAssertEqual(RelativePath("b/c/../a.txt").basenameWithoutExt, "a")
+        XCTAssertEqual(RelativePath("b/c/../a.bcd.txt").basenameWithoutExt, "a.bcd")
     }
 
     func testSuffixExtraction() {
@@ -343,7 +365,7 @@ class PathTests: XCTestCase {
 
     // FIXME: We also need tests for join() operations.
 
-    // FIXME: We also need tests for dirname, basename, suffix, etc.
+    // FIXME: We also need tests for dirname, suffix, etc.
 
     // FIXME: We also need test for stat() operations.
 }


### PR DESCRIPTION
`basenameWithoutExt` method is very useful and already present in `AbsolutePath` type. It would be nice to have it also available in `RelativePath`.

Removed ` // FIXME: We also need tests for dirname, basename, suffix, etc.`, looks it has been already addressed.