### PR TITLE
[Build/PackageLoading] SR-13084: Improve user awareness for issues around missing resources

### DIFF
--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -173,6 +173,7 @@ public struct TargetSourcesBuilder {
         diagnoseMissingDevelopmentRegionResource(in: resources)
         diagnoseInfoPlistConflicts(in: resources)
         diagnoseInvalidResource(in: target.resources)
+        diagnoseMissingResources(in: resources)
 
         // It's an error to contain mixed language source files.
         if sources.containsMixedLanguage {
@@ -285,6 +286,35 @@ public struct TargetSourcesBuilder {
         }
     }
 
+    private func diagnoseMissingResources(in resources: [Resource]) {
+        // Stop early if the valid resources array count is the same as the user defined list
+        if resources.count == self.target.resources.count {
+            return
+        }
+        
+        // Filter the package list of resources down to those which are not included in the valid resources array
+        let invalidResources = self.target.resources.filter { targetResource in
+            let targetResourcePath = self.targetPath.appending(RelativePath(targetResource.path))
+            return resources.contains(where: { resource in
+                resource.path.contains(targetResourcePath)
+            }) == false
+         }
+        
+        // If the list is empty then all were succesfully included so no error needs to be thrown
+        if invalidResources.isEmpty {
+            return
+        }
+        
+        var message = "target '\(self.target.name)' does not have resources at the following paths, they will be ignored\n"
+        
+        for resource in invalidResources {
+            let resourcePath = self.targetPath.appending(RelativePath(resource.path))
+            message += "    '\(resource.path)' (\(resourcePath))\n"
+        }
+        
+        diags.emit(.warning(message))
+    }
+    
     private func diagnoseConflictingResources(in resources: [Resource]) {
         let duplicateResources = resources.spm_findDuplicateElements(by: \.destination)
         for resources in duplicateResources {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -2418,16 +2418,15 @@ final class BuildPlanTests: XCTestCase {
 
         let diagnostics = DiagnosticsEngine()
 
-        let graph = loadPackageGraph(
+        let graph = try loadPackageGraph(
             fs: fs,
             diagnostics: diagnostics,
             manifests: [
                 Manifest.createManifest(
                     name: "PkgA",
                     path: "/PkgA",
-                    url: "/PkgA",
-                    v: .v5_2,
                     packageKind: .root,
+                    v: .v5_2,
                     targets: [
                         TargetDescription(
                             name: "Foo",

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -325,6 +325,13 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         build(target: target, toolsVersion: .v5_3, fs: fs) { _, _, _, _, diagnostics in
             diagnostics.check(diagnostic: "localization directory 'Processed/en.lproj' in target 'Foo' contains sub-directories, which is forbidden", behavior: .error)
+            diagnostics.check(
+                diagnostic: .contains("""
+                target 'Foo' does not have resources at the following paths, they will be ignored
+                    'Processed' (/Processed)
+                """),
+                behavior: .warning
+            )
         }
     }
 
@@ -344,6 +351,13 @@ class TargetSourcesBuilderTests: XCTestCase {
                     and has an explicit localization declaration
                     """),
                 behavior: .error)
+            diagnostics.check(
+                diagnostic: .contains("""
+                target 'Foo' does not have resources at the following paths, they will be ignored
+                    'Resources' (/Resources)
+                """),
+                behavior: .warning
+            )
         }
     }
 
@@ -452,6 +466,91 @@ class TargetSourcesBuilderTests: XCTestCase {
                 Resource(rule: .process, path: AbsolutePath("/Foo/es.lproj/Image.png"), localization: "es"),
             ])
         }
+    }
+    
+    func testMissingResources() {
+        
+        do {
+            // No Failures
+            let target = TargetDescription(name: "Foo", resources: [
+                .init(rule: .copy, path: "foo.txt"),
+                .init(rule: .process, path: "bar.txt")
+            ])
+            
+            let fs = InMemoryFileSystem(emptyFiles:
+                "/foo.txt",
+                "/bar.txt"
+            )
+            
+            build(target: target, toolsVersion: .v5_3, fs: fs) { (_, resources, _, _) in
+                XCTAssertEqual(resources.count, 2)
+            }
+        }
+        
+        do {
+            // Partial Success
+            let target = TargetDescription(name: "Foo", resources: [
+                .init(rule: .copy, path: "foo.txt"),
+                .init(rule: .process, path: "bar.txt")
+            ])
+            
+            let fs = InMemoryFileSystem(emptyFiles:
+                "/foo.txt"
+            )
+            
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, resources, _, diagnostics in
+                XCTAssertEqual(resources.count, 1)
+                diagnostics.check(
+                    diagnostic: .contains("""
+                    target 'Foo' does not have resources at the following paths, they will be ignored
+                        'bar.txt' (/bar.txt)
+                    """),
+                    behavior: .warning
+                )
+            }
+        }
+        
+        do {
+            // Ensure paths are normalised before comparison
+            let target = TargetDescription(name: "Foo", resources: [
+                .init(rule: .copy, path: "./foo.txt"),
+                .init(rule: .process, path: "./dir/bar.txt"),
+                .init(rule: .copy, path: "./dir/../baz.txt"),
+            ])
+            
+            let fs = InMemoryFileSystem(emptyFiles:
+                "/foo.txt",
+                "/dir/bar.txt",
+                "/baz.txt"
+            )
+            
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, resources, _, _ in
+                XCTAssertEqual(resources.count, 3)
+            }
+        }
+        
+        do {
+            // Complete Failure
+            let target = TargetDescription(name: "Foo", resources: [
+                .init(rule: .copy, path: "foo.txt"),
+                .init(rule: .process, path: "bar.txt")
+            ])
+            
+            let fs = InMemoryFileSystem(emptyFiles: [])
+            
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, resources, _, diagnostics in
+                XCTAssertEqual(resources.count, 0)
+                diagnostics.check(
+                    diagnostic: .contains("""
+                    target 'Foo' does not have resources at the following paths, they will be ignored
+                        'foo.txt' (/foo.txt)
+                        'bar.txt' (/bar.txt)
+                    """),
+                    behavior: .warning
+                )
+            }
+        }
+        
     }
 
     func testInfoPlistResource() throws {

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -468,11 +468,11 @@ class TargetSourcesBuilderTests: XCTestCase {
         }
     }
     
-    func testMissingResources() {
+    func testMissingResources() throws {
         
         do {
             // No Failures
-            let target = TargetDescription(name: "Foo", resources: [
+            let target = try TargetDescription(name: "Foo", resources: [
                 .init(rule: .copy, path: "foo.txt"),
                 .init(rule: .process, path: "bar.txt")
             ])
@@ -482,14 +482,14 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/bar.txt"
             )
             
-            build(target: target, toolsVersion: .v5_3, fs: fs) { (_, resources, _, _) in
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, resources, _, _, _ in
                 XCTAssertEqual(resources.count, 2)
             }
         }
         
         do {
             // Partial Success
-            let target = TargetDescription(name: "Foo", resources: [
+            let target = try TargetDescription(name: "Foo", resources: [
                 .init(rule: .copy, path: "foo.txt"),
                 .init(rule: .process, path: "bar.txt")
             ])
@@ -498,7 +498,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/foo.txt"
             )
             
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, resources, _, diagnostics in
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, resources, _, _, diagnostics in
                 XCTAssertEqual(resources.count, 1)
                 diagnostics.check(
                     diagnostic: .contains("""
@@ -512,7 +512,7 @@ class TargetSourcesBuilderTests: XCTestCase {
         
         do {
             // Ensure paths are normalised before comparison
-            let target = TargetDescription(name: "Foo", resources: [
+            let target = try TargetDescription(name: "Foo", resources: [
                 .init(rule: .copy, path: "./foo.txt"),
                 .init(rule: .process, path: "./dir/bar.txt"),
                 .init(rule: .copy, path: "./dir/../baz.txt"),
@@ -524,21 +524,21 @@ class TargetSourcesBuilderTests: XCTestCase {
                 "/baz.txt"
             )
             
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, resources, _, _ in
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, resources, _, _, _ in
                 XCTAssertEqual(resources.count, 3)
             }
         }
         
         do {
             // Complete Failure
-            let target = TargetDescription(name: "Foo", resources: [
+            let target = try TargetDescription(name: "Foo", resources: [
                 .init(rule: .copy, path: "foo.txt"),
                 .init(rule: .process, path: "bar.txt")
             ])
             
             let fs = InMemoryFileSystem(emptyFiles: [])
             
-            build(target: target, toolsVersion: .v5_3, fs: fs) { _, resources, _, diagnostics in
+            build(target: target, toolsVersion: .v5_3, fs: fs) { _, resources, _, _, diagnostics in
                 XCTAssertEqual(resources.count, 0)
                 diagnostics.check(
                     diagnostic: .contains("""


### PR DESCRIPTION
Follow up from https://github.com/apple/swift-package-manager/pull/2810 (GitHub wasn't letting me update the base branch the PR was targeting)

This addresses [SR-13084](https://bugs.swift.org/browse/SR-13084).

In looking to use the new resources capability of SPM I faced some confusion when my setup wasn't working - it turned out to be that my paths were relative to the Package.swift rather than to the target. There was no warning/error and so wasn't the easiest to debug -- this MR aims to resolve this in two parts:

1. Currently the `Bundle.module` accessor is only created if at least one valid resource is generated in the bundle. A change in this MR means that the accessor is *always* created but is marked unavailable (with a user friendly message) if there are no valid resources.

2. A warning is raised as part of the package description diagnostics which lists the exact resources which were seen as missing. A warning has been chosen to act as a non-breaking change (though an error may be more appropriate)

The messages may need more finessing to make more sense - open to suggestions.

First attempt at trying to contribute to SPM so hopefully this isn't horrendous!

Thank you 🙌  