### PR TITLE
build: permit building without Foundation build roots

### DIFF
--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -32,8 +32,10 @@ target_link_libraries(Commands PUBLIC
   XCBuildSupport
   Xcodeproj)
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  target_link_libraries(Commands PUBLIC
-    FoundationXML)
+  if(Foundation_FOUND)
+    target_link_libraries(Commands PUBLIC
+      FoundationXML)
+  endif()
 endif()
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(Commands PROPERTIES

--- a/Sources/PackageDescription/CMakeLists.txt
+++ b/Sources/PackageDescription/CMakeLists.txt
@@ -45,8 +45,10 @@ foreach(PACKAGE_DESCRIPTION_VERSION 4 4_2)
     )
 
     if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-      target_link_libraries(PD${PACKAGE_DESCRIPTION_VERSION} PRIVATE
-        Foundation)
+      if(Foundation_FOUND)
+        target_link_libraries(PD${PACKAGE_DESCRIPTION_VERSION} PRIVATE
+          Foundation)
+      endif()
       target_link_options(PD${PACKAGE_DESCRIPTION_VERSION} PRIVATE
         "SHELL:-no-toolchain-stdlib-rpath")
       set_target_properties(PD${PACKAGE_DESCRIPTION_VERSION} PROPERTIES

--- a/Sources/PackageLoading/CMakeLists.txt
+++ b/Sources/PackageLoading/CMakeLists.txt
@@ -23,8 +23,10 @@ target_link_libraries(PackageLoading PUBLIC
   PackageModel
   TSCUtility
   SPMLLBuild)
-target_link_libraries(PackageLoading PUBLIC
-  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
+if(Foundation_FOUND)
+  target_link_libraries(PackageLoading PUBLIC
+    $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
+endif()
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(PackageLoading PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/Workspace/CMakeLists.txt
+++ b/Sources/Workspace/CMakeLists.txt
@@ -27,8 +27,10 @@ target_link_libraries(Workspace PUBLIC
   PackageModel
   SourceControl
   Xcodeproj)
-target_link_libraries(PackageLoading PUBLIC
-  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
+if(Foundation_FOUND)
+  target_link_libraries(PackageLoading PUBLIC
+    $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
+endif()
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(Workspace PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})


### PR DESCRIPTION
This is meant to support the Windows toolchain build which uses a staged
build where Foundation is prebuilt and will be used from the prebuilt
image rather than from a build root.