### PR TITLE
build: remove Yams references from SPM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,6 @@ endif()
 find_package(dispatch QUIET)
 find_package(Foundation QUIET)
 
-find_package(Yams CONFIG REQUIRED)
 find_package(ArgumentParser CONFIG REQUIRED)
 find_package(SwiftDriver CONFIG REQUIRED)
 

--- a/Sources/Build/CMakeLists.txt
+++ b/Sources/Build/CMakeLists.txt
@@ -18,9 +18,7 @@ target_link_libraries(Build PUBLIC
   TSCBasic
   PackageGraph
   LLBuildManifest
-  SPMBuildCore
-  CYaml
-  Yams)
+  SPMBuildCore)
 target_link_libraries(Build PRIVATE
   SwiftDriver)
 


### PR DESCRIPTION
Yams is not directly used by swift-package-manager.  Remove the
unnecessary check and linkage.