### PR TITLE
Add Build Success Message in Console

### DIFF
--- a/Sources/Build/BuildDelegate.swift
+++ b/Sources/Build/BuildDelegate.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2018 Apple Inc. and the Swift project authors
+ Copyright (c) 2018-2020 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -570,6 +570,13 @@ fileprivate struct CommandTaskTracker {
             totalCount -= 1
             break
         case .isComplete:
+            if (totalCount == finishedCount) {
+                let latestOutput: String? = latestFinishedText
+                latestFinishedText = """
+                \(latestOutput ?? "")\n
+                * Build Completed!
+                """
+            }
             break
         @unknown default:
             assertionFailure("unhandled command status kind \(kind) for command \(command)")


### PR DESCRIPTION
rdar://69970428

After running `swift build` the final output could display a ‘success message’ (if the build is successful) and some basic infos about where the generated binaries are located.
Currently, after a successful build, it ends with exit code 0 and the output is:
`[476/476] Linking swift-package`

Result after changes:

**Success**:

<img width="308" alt="Screen Shot 2020-10-16 at 7 08 27 AM" src="https://user-images.githubusercontent.com/59409/96268949-8d8c2500-0f7e-11eb-9d66-7a0abd297f18.png">




