### PR TITLE
Commands: make `--list-tests` work on Windows

### DIFF
--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -488,8 +488,9 @@ public struct SwiftTestTool: SwiftCommand {
             return try localFileSystem.readFileContents(tempFile.path).validDescription ?? ""
         }
       #else
+        let env = try constructTestEnvironment(toolchain: try swiftTool.getToolchain(), options: swiftOptions, buildParameters: swiftTool.buildParameters())
         let args = [path.description, "--dump-tests-json"]
-        let data = try Process.checkNonZeroExit(arguments: args)
+        let data = try Process.checkNonZeroExit(arguments: args, environment: env)
       #endif
         // Parse json and return TestSuites.
         return try TestSuite.parse(jsonString: data)


### PR DESCRIPTION
We need to construct the test environment on Windows to list the tests.
This adds that to the list test path on both Linux and Windows.  The
impact of this change on Linux is that additional environment variables
may be defined when executing the tests.

Resolve SR-13694!