### PR TITLE
Correct and clean up some of the target dependencies in the closure of libSwiftPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -127,7 +127,7 @@ let package = Package(
         .target(
             /** Builds Modules and Products */
             name: "Build",
-            dependencies: ["SwiftToolsSupport-auto", "SPMBuildCore", "PackageGraph", "LLBuildManifest", "SwiftDriver"]),
+            dependencies: ["SwiftToolsSupport-auto", "SPMBuildCore", "PackageGraph", "LLBuildManifest", "SwiftDriver", "SPMLLBuild"]),
         .target(
             /** Support for building using Xcode's build system */
             name: "XCBuildSupport",

--- a/Package.swift
+++ b/Package.swift
@@ -109,7 +109,7 @@ let package = Package(
         .target(
             /** Package model conventions and loading support */
             name: "PackageLoading",
-            dependencies: ["SwiftToolsSupport-auto", "PackageModel", "SPMLLBuild"]),
+            dependencies: ["SwiftToolsSupport-auto", "PackageModel"]),
 
         // MARK: Package Dependency Resolution
 

--- a/Package.swift
+++ b/Package.swift
@@ -140,7 +140,7 @@ let package = Package(
         .target(
             /** High level functionality */
             name: "Workspace",
-            dependencies: ["SwiftToolsSupport-auto", "Build", "PackageGraph", "PackageModel", "SourceControl", "Xcodeproj"]),
+            dependencies: ["SwiftToolsSupport-auto", "SPMBuildCore", "PackageGraph", "PackageModel", "SourceControl", "Xcodeproj"]),
 
         // MARK: Commands
 

--- a/Sources/Build/CMakeLists.txt
+++ b/Sources/Build/CMakeLists.txt
@@ -18,7 +18,8 @@ target_link_libraries(Build PUBLIC
   TSCBasic
   PackageGraph
   LLBuildManifest
-  SPMBuildCore)
+  SPMBuildCore
+  SPMLLBuild)
 target_link_libraries(Build PRIVATE
   SwiftDriver)
 

--- a/Sources/PackageLoading/CMakeLists.txt
+++ b/Sources/PackageLoading/CMakeLists.txt
@@ -21,8 +21,7 @@ add_library(PackageLoading
 target_link_libraries(PackageLoading PUBLIC
   TSCBasic
   PackageModel
-  TSCUtility
-  SPMLLBuild)
+  TSCUtility)
 if(Foundation_FOUND)
   target_link_libraries(PackageLoading PUBLIC
     $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)

--- a/Sources/Workspace/CMakeLists.txt
+++ b/Sources/Workspace/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See http://swift.org/LICENSE.txt for license information
@@ -23,7 +23,7 @@ add_library(Workspace
 target_link_libraries(Workspace PUBLIC
   TSCBasic
   TSCUtility
-  Build
+  SPMBuildCore
   PackageGraph
   PackageLoading
   PackageModel

--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -1,6 +1,5 @@
 import TSCBasic
 import TSCUtility
-import Build
 import SPMBuildCore
 
 public enum DestinationError: Swift.Error {

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -12,7 +12,6 @@ import TSCBasic
 import TSCUtility
 import PackageLoading
 import SPMBuildCore
-import Build
 import Foundation
 
 #if os(Windows)


### PR DESCRIPTION
The declared dependencies haven't followed some of the code changes, and this corrects some of those.  This prunes some of the dependencies of the Workspace and the PackageLoading targets down to no longer have indirect dependencies on llbuild.