### PR TITLE
NFC: clarify Target.publicHeadersPath comment

### DIFF
--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -102,6 +102,7 @@ public final class Target {
 
     /// The path to the directory containing public headers of a C-family target.
     ///
+    /// This path should be relative to the path specified in `path`.
     /// If this is `nil`, the directory is set to `include`.
     public var publicHeadersPath: String?
 


### PR DESCRIPTION
The doc comment doesn't specify that the value of `publicHeadersPath` should be relative to the value specified in `path`.