### PR TITLE
Add option to define custom scheme for generated xcode project

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -554,6 +554,9 @@ extension SwiftPackageTool {
             
             @Flag(help: "Do not add file references for extra files to the generated Xcode project")
             var skipExtraFiles: Bool = false
+
+            @Option(name: .customLong("scheme"), help: "Provide custom scheme name")
+            var schemeName: String?
         }
 
         @OptionGroup()
@@ -569,7 +572,8 @@ extension SwiftPackageTool {
                 isCodeCoverageEnabled: swiftOptions.shouldEnableCodeCoverage,
                 useLegacySchemeGenerator: options.useLegacySchemeGenerator,
                 enableAutogeneration: options.enableAutogeneration,
-                addExtraFiles: !options.skipExtraFiles)
+                addExtraFiles: !options.skipExtraFiles,
+                schemeName: options.schemeName)
         }
 
         func run(_ swiftTool: SwiftTool) throws {

--- a/Sources/Xcodeproj/SchemesGenerator.swift
+++ b/Sources/Xcodeproj/SchemesGenerator.swift
@@ -43,19 +43,22 @@ public final class SchemesGenerator {
     private let schemesDir: AbsolutePath
     private let isCodeCoverageEnabled: Bool
     private let fs: FileSystem
+    private let schemeName: String
 
     public init(
         graph: PackageGraph,
         container: String,
         schemesDir: AbsolutePath,
         isCodeCoverageEnabled: Bool,
-        fs: FileSystem
+        fs: FileSystem,
+        schemeName: String
     ) {
         self.graph = graph
         self.container = container
         self.schemesDir = schemesDir
         self.isCodeCoverageEnabled = isCodeCoverageEnabled
         self.fs = fs
+        self.schemeName = schemeName
     }
 
     public func buildSchemes() -> [Scheme] {
@@ -86,7 +89,7 @@ public final class SchemesGenerator {
             }
         })
         schemes.append(Scheme(
-            name: rootPackage.name + "-Package",
+            name: schemeName,
             regularTargets: regularTargets,
             testTargets: rootPackage.targets.filter({ $0.type == .test })
         ))

--- a/Sources/Xcodeproj/generate.swift
+++ b/Sources/Xcodeproj/generate.swift
@@ -39,13 +39,17 @@ public struct XcodeprojOptions {
     /// Reference to manifest loader, if present.
     public var manifestLoader: ManifestLoader?
 
+    /// Custom name for package scheme.
+    public var schemeName: String?
+
     public init(
         flags: BuildFlags = BuildFlags(),
         xcconfigOverrides: AbsolutePath? = nil,
         isCodeCoverageEnabled: Bool? = nil,
         useLegacySchemeGenerator: Bool? = nil,
         enableAutogeneration: Bool? = nil,
-        addExtraFiles: Bool? = nil
+        addExtraFiles: Bool? = nil,
+        schemeName: String? = nil
     ) {
         self.flags = flags
         self.xcconfigOverrides = xcconfigOverrides
@@ -53,6 +57,7 @@ public struct XcodeprojOptions {
         self.useLegacySchemeGenerator = useLegacySchemeGenerator ?? false
         self.enableAutogeneration = enableAutogeneration ?? false
         self.addExtraFiles = addExtraFiles ?? true
+        self.schemeName = schemeName
     }
 }
 
@@ -221,13 +226,14 @@ func generateSchemes(
     options: XcodeprojOptions,
     schemeContainer: String
 ) throws {
+    let schemeName = options.schemeName ?? "\(graph.rootPackages[0].name)-Package"
     if options.useLegacySchemeGenerator {
         // The scheme acts like an aggregate target for all our targets it has all
         // tests associated so testing works. We suffix the name of this scheme with
         // -Package so its name doesn't collide with any products or target with
         // same name.
-        let schemeName = "\(graph.rootPackages[0].name)-Package.xcscheme"
-        try open(schemesDir.appending(RelativePath(schemeName))) { stream in
+        let schemeFileName = "\(schemeName).xcscheme"
+        try open(schemesDir.appending(RelativePath(schemeFileName))) { stream in
             legacySchemeGenerator(
                 container: schemeContainer,
                 graph: graph,
@@ -259,7 +265,8 @@ func generateSchemes(
             container: schemeContainer,
             schemesDir: schemesDir,
             isCodeCoverageEnabled: options.isCodeCoverageEnabled,
-            fs: localFileSystem
+            fs: localFileSystem,
+            schemeName: schemeName
         ).generate()
     }
 }

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -373,7 +373,8 @@ class PackageGraphTests: XCTestCase {
             container: "Foo.xcodeproj",
             schemesDir: AbsolutePath("/Foo.xcodeproj/xcshareddata/xcschemes"),
             isCodeCoverageEnabled: true,
-            fs: fs).buildSchemes()
+            fs: fs,
+            schemeName: "Foo-Package").buildSchemes()
 
         let schemes = Dictionary(uniqueKeysWithValues: generatedSchemes.map({ ($0.name, $0) }))
 


### PR DESCRIPTION
Hello 👋 
I would like to propose adding new option for defining custom scheme name to the `generate-xcodeproj`. Currently there is hardcoded name for scheme which is package name + `-Package` suffix (introduced in #1154). 
Thanks to new option added in this PR it is now possible to specify  `generate-xcodeproj --scheme MySchemeName` which is useful for people who would like to use to SPM generated Xcode projects and don't like to have hardcoded scheme. In my case I would like to create xcframeworks from various packages - currently this requires generating Xcode projects for them and using `xcodebuild` so controlling schemes for it would simplify it a lot.
 