### PR TITLE
Remove 'try XCTSkip()' from functional tests

### DIFF
--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -213,9 +213,6 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testSwiftTestParallel() throws {
-        // <rdar://problem/69448176> Fix and re-enable test related to "ParallelTestsPkg"
-        try XCTSkip()
-
         fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
           // First try normal serial testing.
           do {
@@ -261,9 +258,6 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testSwiftTestFilter() throws {
-        // <rdar://problem/69448176> Fix and re-enable test related to "ParallelTestsPkg"
-        try XCTSkip()
-
         fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
             let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--filter", ".*1", "-l", "--enable-test-discovery"], packagePath: prefix)
             XCTAssertMatch(stdout, .contains("testExample1"))
@@ -280,9 +274,6 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testSwiftTestSkip() throws {
-        // <rdar://problem/69448176> Fix and re-enable test related to "ParallelTestsPkg"
-        try XCTSkip()
-        
         fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
             let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--skip", "ParallelTestsTests", "-l", "--enable-test-discovery"], packagePath: prefix)
             XCTAssertNoMatch(stdout, .contains("testExample1"))
@@ -423,9 +414,6 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testSwiftTestLinuxMainGeneration() throws {
-        // <rdar://problem/69448176> Fix and re-enable test related to "ParallelTestsPkg"
-        try XCTSkip()
-
       #if os(macOS)
         fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
             let fs = localFileSystem


### PR DESCRIPTION
This PR fixes the following warnings when building the project with Xcode 12: 

> No calls to throwing functions occur within 'try' expression
>
> Fix warning: "Result of 'XCTSkip' initializer is unused"

I think the intention was for these to be `throw XCTSkip()` to skip these tests (#2948), but as far as I can tell, this change wouldn't have that effect. If the parallel tests are no longer causing CI failures, I think we should be able to remove these outright. 