### PR TITLE
Define libSwiftPMDataModel for clients that want the libSwiftPM data model but not the build system

### DIFF
--- a/Documentation/libSwiftPM.md
+++ b/Documentation/libSwiftPM.md
@@ -6,6 +6,10 @@ SwiftPM has a library based architecture and the top-level library product is
 called `libSwiftPM`. Other packages can add SwiftPM as a package dependency and
 create powerful custom build tools on top of `libSwiftPM`.
 
+A subset of `libSwiftPM` that includes only the data model (without SwiftPM's
+build system) is available as `libSwiftPMDataModel`.  Any one client should
+depend on one or the other, but not both.
+
 The SwiftPM repository contains an [example](https://github.com/apple/swift-package-manager/tree/master/Examples/package-info) that demonstrates the use of
 `libSwiftPM` in a Swift package. Use the following commands to run the example
 package:

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -28,7 +28,8 @@ let package = Package(
     platforms: [macOSPlatform],
     products: [
         // The `libSwiftPM` set of interfaces to programatically work with Swift
-        // packages.
+        // packages.  `libSwiftPM` includes all of the SwiftPM code except the
+        // command line tools, while `libSwiftPM` includes only the data model.
         //
         // NOTE: This API is *unstable* and may change at any time.
         .library(
@@ -56,6 +57,18 @@ let package = Package(
                 "PackageLoading",
                 "PackageGraph",
                 "Build",
+                "Xcodeproj",
+                "Workspace"
+            ]
+        ),
+        .library(
+            name: "SwiftPMDataModel",
+            type: .dynamic,
+            targets: [
+                "SourceControl",
+                "PackageModel",
+                "PackageLoading",
+                "PackageGraph",
                 "Xcodeproj",
                 "Workspace"
             ]

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -124,6 +124,10 @@ def add_build_args(parser):
         metavar='PATH',
         help="where to install libSwiftPM")
     parser.add_argument(
+        "--libswiftpmdatamodel-install-dir",
+        metavar='PATH',
+        help="where to install libSwiftPMDataModel")
+    parser.add_argument(
         "--prefix",
         dest="install_prefixes",
         nargs='*',
@@ -344,11 +348,6 @@ def install(args):
 
     # Install libSwiftPM if an install directory was provided.
     if args.libswiftpm_install_dir:
-        dest = args.libswiftpm_install_dir
-
-        # FIXME: Don't hardcode the suffix.
-        install_binary(args, "libSwiftPM.dylib", dest)
-
         libswiftpm_modules = [
             "TSCLibc", "TSCBasic",
             "TSCUtility", "SourceControl",
@@ -357,17 +356,18 @@ def install(args):
             "PackageGraph", "SPMBuildCore", "Build",
             "Xcodeproj", "Workspace"
         ]
+        install_libswiftpm_dylib(args, "SwiftPM", args.libswiftpm_install_dir, libswiftpm_modules)
 
-        # Install the swiftmodule and swiftdoc files.
-        for module in libswiftpm_modules:
-            install_binary(args, module + ".swiftmodule", dest)
-            if not args.cross_compile_hosts: # When compiling for multiple arches, swiftdoc is part of the swiftmodule directory
-                install_binary(args, module + ".swiftdoc", dest)
-
-        # Install the C headers.
-        tscclibc_include_dir = os.path.join(args.tsc_source_dir, "Sources/TSCclibc/include")
-        tscclibc_include_dir_dest = os.path.join(dest, "TSCclibc")
-        dir_util.copy_tree(tscclibc_include_dir, tscclibc_include_dir_dest)
+    # Install libSwiftPMDataModel if an install directory was provided.
+    if args.libswiftpmdatamodel_install_dir:
+        libswiftpmdatamodel_modules = [
+            "TSCLibc", "TSCBasic",
+            "TSCUtility", "SourceControl",
+            "PackageModel", "PackageLoading",
+            "PackageGraph", "SPMBuildCore",
+            "Xcodeproj", "Workspace"
+        ]
+        install_libswiftpm_dylib(args, "SwiftPMDataModel", args.libswiftpmdatamodel_install_dir, libswiftpmdatamodel_modules)
 
 def install_swiftpm(prefix, args):
     # Install swiftpm binaries.
@@ -399,6 +399,22 @@ def install_swiftpm(prefix, args):
             note("Installing %s to %s" % (src, dest))
 
             file_util.copy_file(src, dest, update=1)
+
+
+def install_libswiftpm_dylib(args, library_name, install_dir, module_names):
+    # FIXME: Don't hardcode the prefix and suffix.
+    install_binary(args, "lib" + library_name + ".dylib", install_dir)
+
+    # Install the swiftmodule and swiftdoc files.
+    for module in module_names:
+        install_binary(args, module + ".swiftmodule", install_dir)
+        if not args.cross_compile_hosts: # When compiling for multiple arches, swiftdoc is part of the swiftmodule directory
+            install_binary(args, module + ".swiftdoc", install_dir)
+
+    # Install the C headers.
+    tscclibc_include_dir = os.path.join(args.tsc_source_dir, "Sources/TSCclibc/include")
+    tscclibc_include_dir_dest = os.path.join(install_dir, "TSCclibc")
+    dir_util.copy_tree(tscclibc_include_dir, tscclibc_include_dir_dest)
 
 
 def install_binary(args, binary, dest_dir):


### PR DESCRIPTION
This is a subset of the libSwiftPM library, which remains unchanged so as to avoid breaking any clients.  In order to avoid too much duplication in the bootstrap script, I factored it so that multiple dylibs with different names and different combinations of modules can be built.  There are separate flags to build the different libraries, so that building just the data model doesn't require building the code that it doesn't depend on.