### PR TITLE
Fix skipping of tests and skip some additional ones

### DIFF
--- a/Tests/FunctionalTests/CFamilyTargetTests.swift
+++ b/Tests/FunctionalTests/CFamilyTargetTests.swift
@@ -74,7 +74,10 @@ class CFamilyTargetTestCase: XCTestCase {
         }
     }
 
-    func testObjectiveCPackageWithTestTarget(){
+    func testObjectiveCPackageWithTestTarget() throws {
+        // <rdar://problem/70382477> Fix and re-enable tests which run `swift test` on newly created packages
+        try XCTSkipIf(true)
+
       #if os(macOS)
         fixture(name: "CFamilyTargets/ObjCmacOSPackage") { prefix in
             // Build the package.

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -214,7 +214,7 @@ class MiscellaneousTestCase: XCTestCase {
 
     func testSwiftTestParallel() throws {
         // <rdar://problem/69448176> Fix and re-enable test related to "ParallelTestsPkg"
-        try XCTSkip()
+        try XCTSkipIf(true)
 
         fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
           // First try normal serial testing.
@@ -262,7 +262,7 @@ class MiscellaneousTestCase: XCTestCase {
 
     func testSwiftTestFilter() throws {
         // <rdar://problem/69448176> Fix and re-enable test related to "ParallelTestsPkg"
-        try XCTSkip()
+        try XCTSkipIf(true)
 
         fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
             let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--filter", ".*1", "-l", "--enable-test-discovery"], packagePath: prefix)
@@ -281,7 +281,7 @@ class MiscellaneousTestCase: XCTestCase {
 
     func testSwiftTestSkip() throws {
         // <rdar://problem/69448176> Fix and re-enable test related to "ParallelTestsPkg"
-        try XCTSkip()
+        try XCTSkipIf(true)
         
         fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
             let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--skip", "ParallelTestsTests", "-l", "--enable-test-discovery"], packagePath: prefix)
@@ -424,7 +424,7 @@ class MiscellaneousTestCase: XCTestCase {
 
     func testSwiftTestLinuxMainGeneration() throws {
         // <rdar://problem/69448176> Fix and re-enable test related to "ParallelTestsPkg"
-        try XCTSkip()
+        try XCTSkipIf(true)
 
       #if os(macOS)
         fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in

--- a/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
+++ b/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
@@ -16,7 +16,10 @@ import Commands
 import Workspace
 
 class SwiftPMXCTestHelperTests: XCTestCase {
-    func testBasicXCTestHelper() {
+    func testBasicXCTestHelper() throws {
+        // <rdar://problem/70382477> Fix and re-enable tests which run `swift test` on newly created packages
+        try XCTSkipIf(true)
+
       #if os(macOS)
         fixture(name: "Miscellaneous/SwiftPMXCTestHelper") { prefix in
             // Build the package.

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -220,6 +220,9 @@ class InitTests: XCTestCase {
     }
     
     func testNonC99NameExecutablePackage() throws {
+        // <rdar://problem/70382477> Fix and re-enable tests which run `swift test` on newly created packages
+        try XCTSkipIf(true)
+
         try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDirPath in
             XCTAssertTrue(localFileSystem.isDirectory(tempDirPath))
             


### PR DESCRIPTION
- we were actually not really skipping a few tests, because I didn't do
that correctly in #2948
- we need to skip a few additional tests which are using the same
functionality (running an inferior `swift test`)

Supersedes #2982