### PR TITLE
Improve sanitizer usage

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -90,6 +90,27 @@ enum BuildSystemKind: String, ExpressibleByArgument, CaseIterable {
     case xcode
 }
 
+public extension Sanitizer {
+    init(argument: String) throws {
+        if let sanitizer = Sanitizer(rawValue: argument) {
+            self = sanitizer
+            return
+        }
+
+        for sanitizer in Sanitizer.allCases where sanitizer.shortName == argument {
+            self = sanitizer
+            return
+        }
+
+        throw ArgumentConversionError.custom("valid sanitizers: \(Sanitizer.formattedValues)")
+    }
+
+    /// All sanitizer options in a comma separated string
+    fileprivate static var formattedValues: String {
+        return Sanitizer.allCases.map(\.rawValue).joined(separator: ", ")
+    }
+}
+
 public struct SwiftToolOptions: ParsableArguments {
     @OptionGroup()
     var buildFlagsGroup: BuildFlagsGroup

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -180,7 +180,7 @@ public struct SwiftToolOptions: ParsableArguments {
 
     /// Which compile-time sanitizers should be enabled.
     @Option(name: .customLong("sanitize"),
-            help: "Turn on runtime checks for erroneous behavior",
+            help: "Turn on runtime checks for erroneous behavior, possible values: \(Sanitizer.formattedValues)",
             transform: { try Sanitizer(argument: $0) })
     var sanitizers: [Sanitizer] = []
 

--- a/Sources/SPMBuildCore/Sanitizers.swift
+++ b/Sources/SPMBuildCore/Sanitizers.swift
@@ -18,25 +18,6 @@ public enum Sanitizer: String, Encodable, CaseIterable {
     case undefined
     case scudo
 
-    public init(argument: String) throws {
-        if let sanitizer = Sanitizer(rawValue: argument) {
-            self = sanitizer
-            return
-        }
-
-        for sanitizer in Sanitizer.allCases where sanitizer.shortName == argument {
-            self = sanitizer
-            return
-        }
-
-        throw ArgumentConversionError.custom("valid sanitizers: \(Sanitizer.formattedValues)")
-    }
-
-    /// All sanitizer options in a comma separated string
-    public static var formattedValues: String {
-        return Sanitizer.allCases.map(\.rawValue).joined(separator: ", ")
-    }
-
     /// Return an established short name for a sanitizer, e.g. "asan".
     public var shortName: String {
         switch self {

--- a/Sources/SPMBuildCore/Sanitizers.swift
+++ b/Sources/SPMBuildCore/Sanitizers.swift
@@ -12,11 +12,30 @@ import TSCBasic
 import TSCUtility
 
 /// Available runtime sanitizers.
-public enum Sanitizer: String, Encodable {
+public enum Sanitizer: String, Encodable, CaseIterable {
     case address
     case thread
     case undefined
     case scudo
+
+    public init(argument: String) throws {
+        if let sanitizer = Sanitizer(rawValue: argument) {
+            self = sanitizer
+            return
+        }
+
+        for sanitizer in Sanitizer.allCases where sanitizer.shortName == argument {
+            self = sanitizer
+            return
+        }
+
+        throw ArgumentConversionError.custom("valid sanitizers: \(Sanitizer.formattedValues)")
+    }
+
+    /// All sanitizer options in a comma separated string
+    public static var formattedValues: String {
+        return Sanitizer.allCases.map(\.rawValue).joined(separator: ", ")
+    }
 
     /// Return an established short name for a sanitizer, e.g. "asan".
     public var shortName: String {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -2464,6 +2464,22 @@ final class BuildPlanTests: XCTestCase {
         try testBinaryTargets(platform: "macos", arch: "arm64e", destinationTriple: arm64eTriple)
     }
 
+    func testCreatingSanitizers() throws {
+        for sanitizer in Sanitizer.allCases {
+            XCTAssertEqual(sanitizer, try Sanitizer(argument: sanitizer.shortName))
+        }
+    }
+
+    func testInvalidSanitizer() throws {
+        do {
+            _ = try Sanitizer(argument: "invalid")
+            XCTFail("Should have failed to create Sanitizer")
+        } catch let error as ArgumentConversionError {
+            XCTAssertEqual(
+                error.description, "valid sanitizers: address, thread, undefined, scudo")
+        }
+    }
+
     func testAddressSanitizer() throws {
         try sanitizerTest(.address, expectedName: "address")
     }


### PR DESCRIPTION
This makes a few small improvements to using sanitizers:

1. Include the valid values in `--help`.

Before:

```
--sanitize <sanitize>  Turn on runtime checks for erroneous behavior
```

After:

```
--sanitize <sanitize>  Turn on runtime checks for erroneous behavior,
                       possible values: address, thread, undefined, scudo
```

2. Improve error for invalid values.

Before:

```
error: unknown value 'invalid' for argument --sanitize; use --help to print usage
```

After:

```
error: The value 'invalid' is invalid for '--sanitize <sanitize>': valid sanitizers: address, thread, undefined, scudo
```

3. Allow underlying values as arguments.

Before:

```
error: unknown value 'tsan' for argument --sanitize; use --help to print usage
```

After:

Works!

Fixes:

- https://bugs.swift.org/browse/SR-12545
- https://bugs.swift.org/browse/SR-12546