### PR TITLE
Conditionalize use of `.withoutEscapingSlashes`

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -545,7 +545,11 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
         let encoder = JSONEncoder()
         if #available(macOS 10.15, *) {
+            #if os(macOS)
             encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+            #else // `.withoutEscapingSlashes` is not in 5.3 on non-Darwin platforms
+            encoder.outputFormatting = [.sortedKeys]
+            #endif
         }
 
         try keyHash.withData {

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -93,7 +93,9 @@ public final class PIFBuilder {
                 encoder.outputFormatting.insert(.sortedKeys)
             }
             if #available(macOS 10.15, *) {
+                #if os(macOS) // `.withoutEscapingSlashes` is not in 5.3 on non-Darwin platforms
                 encoder.outputFormatting.insert(.withoutEscapingSlashes)
+                #endif
             }
           #endif
         }


### PR DESCRIPTION
This was only cherry-picked into 5.3 recently: https://github.com/apple/swift-corelibs-foundation/pull/2889, so to get SwiftPM to build with the 5.3 released toolchain on non-Darwin platforms, we have to conditionalize it.