### PR TITLE
Rename SwiftPMConfig to DependencyMirrors

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -643,8 +643,8 @@ extension SwiftPackageTool.Config {
         var mirrorURL: String
         
         func run(_ swiftTool: SwiftTool) throws {
-            let config = try swiftTool.getSwiftPMConfig()
-            try config.load()
+            let mirrors = try swiftTool.getDependencyMirrors()
+            try mirrors.load()
 
             if packageURL != nil {
                 swiftTool.diagnostics.emit(
@@ -656,7 +656,7 @@ extension SwiftPackageTool.Config {
                 throw ExitCode.failure
             }
 
-            try config.set(mirrorURL: mirrorURL, forURL: originalURL)
+            try mirrors.set(mirrorURL: mirrorURL, forURL: originalURL)
         }
     }
 
@@ -677,8 +677,8 @@ extension SwiftPackageTool.Config {
         var mirrorURL: String?
         
         func run(_ swiftTool: SwiftTool) throws {
-            let config = try swiftTool.getSwiftPMConfig()
-            try config.load()
+            let mirrors = try swiftTool.getDependencyMirrors()
+            try mirrors.load()
 
             if packageURL != nil {
                 swiftTool.diagnostics.emit(
@@ -690,7 +690,7 @@ extension SwiftPackageTool.Config {
                 throw ExitCode.failure
             }
 
-            try config.unset(originalOrMirrorURL: originalOrMirrorURL)
+            try mirrors.unset(originalOrMirrorURL: originalOrMirrorURL)
         }
     }
 
@@ -708,8 +708,8 @@ extension SwiftPackageTool.Config {
         var originalURL: String?
 
         func run(_ swiftTool: SwiftTool) throws {
-            let config = try swiftTool.getSwiftPMConfig()
-            try config.load()
+            let mirrors = try swiftTool.getDependencyMirrors()
+            try mirrors.load()
 
             if packageURL != nil {
                 swiftTool.diagnostics.emit(
@@ -721,7 +721,7 @@ extension SwiftPackageTool.Config {
                 throw ExitCode.failure
             }
 
-            if let mirror = config.getMirror(forURL: originalURL) {
+            if let mirror = mirrors.getMirror(forURL: originalURL) {
                 print(mirror)
             } else {
                 stderrStream <<< "not found\n"

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -644,7 +644,6 @@ extension SwiftPackageTool.Config {
         
         func run(_ swiftTool: SwiftTool) throws {
             let mirrors = try swiftTool.getDependencyMirrors()
-            try mirrors.load()
 
             if packageURL != nil {
                 swiftTool.diagnostics.emit(
@@ -656,7 +655,8 @@ extension SwiftPackageTool.Config {
                 throw ExitCode.failure
             }
 
-            try mirrors.set(mirrorURL: mirrorURL, forURL: originalURL)
+            mirrors.set(mirrorURL: mirrorURL, forURL: originalURL)
+            try mirrors.saveState()
         }
     }
 
@@ -678,7 +678,6 @@ extension SwiftPackageTool.Config {
         
         func run(_ swiftTool: SwiftTool) throws {
             let mirrors = try swiftTool.getDependencyMirrors()
-            try mirrors.load()
 
             if packageURL != nil {
                 swiftTool.diagnostics.emit(
@@ -691,6 +690,7 @@ extension SwiftPackageTool.Config {
             }
 
             try mirrors.unset(originalOrMirrorURL: originalOrMirrorURL)
+            try mirrors.saveState()
         }
     }
 
@@ -709,7 +709,6 @@ extension SwiftPackageTool.Config {
 
         func run(_ swiftTool: SwiftTool) throws {
             let mirrors = try swiftTool.getDependencyMirrors()
-            try mirrors.load()
 
             if packageURL != nil {
                 swiftTool.diagnostics.emit(

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -411,11 +411,11 @@ public class SwiftTool {
         return try getPackageRoot().appending(components: ".swiftpm", "config")
     }
 
-    func getSwiftPMConfig() throws -> SwiftPMConfig {
+    func getSwiftPMConfig() throws -> DependencyMirrors {
         return try _swiftpmConfig.get()
     }
-    private lazy var _swiftpmConfig: Result<SwiftPMConfig, Swift.Error> = {
-        return Result(catching: { SwiftPMConfig(path: try configFilePath()) })
+    private lazy var _swiftpmConfig: Result<DependencyMirrors, Swift.Error> = {
+        return Result(catching: { DependencyMirrors(path: try configFilePath()) })
     }()
     
     func resolvedNetrcFilePath() -> AbsolutePath? {

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -412,10 +412,10 @@ public class SwiftTool {
     }
 
     func getDependencyMirrors() throws -> DependencyMirrors {
-        return try _swiftpmConfig.get()
+        return try _dependencyMirrors.get()
     }
-    private lazy var _swiftpmConfig: Result<DependencyMirrors, Swift.Error> = {
-        return Result(catching: { DependencyMirrors(path: try configFilePath()) })
+    private lazy var _dependencyMirrors: Result<DependencyMirrors, Swift.Error> = {
+        return Result(catching: { try DependencyMirrors(path: try configFilePath()) })
     }()
     
     func resolvedNetrcFilePath() -> AbsolutePath? {

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -411,7 +411,7 @@ public class SwiftTool {
         return try getPackageRoot().appending(components: ".swiftpm", "config")
     }
 
-    func getSwiftPMConfig() throws -> DependencyMirrors {
+    func getDependencyMirrors() throws -> DependencyMirrors {
         return try _swiftpmConfig.get()
     }
     private lazy var _swiftpmConfig: Result<DependencyMirrors, Swift.Error> = {
@@ -444,7 +444,7 @@ public class SwiftTool {
             manifestLoader: try getManifestLoader(),
             toolsVersionLoader: ToolsVersionLoader(),
             delegate: delegate,
-            config: try getSwiftPMConfig(),
+            mirrors: try getDependencyMirrors(),
             repositoryProvider: provider,
             netrcFilePath: resolvedNetrcFilePath(),
             isResolverPrefetchingEnabled: options.shouldEnableResolverPrefetching,

--- a/Sources/PackageGraph/LocalPackageContainer.swift
+++ b/Sources/PackageGraph/LocalPackageContainer.swift
@@ -51,7 +51,7 @@ public class LocalPackageContainer: BasePackageContainer  {
     }
 
     public override func getUnversionedDependencies(productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
-        return try loadManifest().dependencyConstraints(productFilter: productFilter, config: config)
+        return try loadManifest().dependencyConstraints(productFilter: productFilter, mirrors: mirrors)
     }
 
     public override func getUpdatedIdentifier(at boundVersion: BoundVersion) throws -> Identifier {
@@ -62,7 +62,7 @@ public class LocalPackageContainer: BasePackageContainer  {
 
     public init(
         _ identifier: Identifier,
-        config: DependencyMirrors,
+        mirrors: DependencyMirrors,
         manifestLoader: ManifestLoaderProtocol,
         toolsVersionLoader: ToolsVersionLoaderProtocol,
         currentToolsVersion: ToolsVersion,
@@ -72,7 +72,7 @@ public class LocalPackageContainer: BasePackageContainer  {
         self.fs = fs
         super.init(
             identifier,
-            config: config,
+            mirrors: mirrors,
             manifestLoader: manifestLoader,
             toolsVersionLoader: toolsVersionLoader,
             currentToolsVersion: currentToolsVersion

--- a/Sources/PackageGraph/LocalPackageContainer.swift
+++ b/Sources/PackageGraph/LocalPackageContainer.swift
@@ -62,7 +62,7 @@ public class LocalPackageContainer: BasePackageContainer  {
 
     public init(
         _ identifier: Identifier,
-        config: SwiftPMConfig,
+        config: DependencyMirrors,
         manifestLoader: ManifestLoaderProtocol,
         toolsVersionLoader: ToolsVersionLoaderProtocol,
         currentToolsVersion: ToolsVersion,

--- a/Sources/PackageGraph/PackageContainer.swift
+++ b/Sources/PackageGraph/PackageContainer.swift
@@ -141,7 +141,7 @@ public class BasePackageContainer: PackageContainer {
 
     public let identifier: Identifier
 
-    let config: DependencyMirrors
+    let mirrors: DependencyMirrors
 
     /// The manifest loader.
     let manifestLoader: ManifestLoaderProtocol
@@ -182,13 +182,13 @@ public class BasePackageContainer: PackageContainer {
 
     init(
         _ identifier: Identifier,
-        config: DependencyMirrors,
+        mirrors: DependencyMirrors,
         manifestLoader: ManifestLoaderProtocol,
         toolsVersionLoader: ToolsVersionLoaderProtocol,
         currentToolsVersion: ToolsVersion
     ) {
         self.identifier = identifier
-        self.config = config
+        self.mirrors = mirrors
         self.manifestLoader = manifestLoader
         self.toolsVersionLoader = toolsVersionLoader
         self.currentToolsVersion = currentToolsVersion

--- a/Sources/PackageGraph/PackageContainer.swift
+++ b/Sources/PackageGraph/PackageContainer.swift
@@ -141,7 +141,7 @@ public class BasePackageContainer: PackageContainer {
 
     public let identifier: Identifier
 
-    let config: SwiftPMConfig
+    let config: DependencyMirrors
 
     /// The manifest loader.
     let manifestLoader: ManifestLoaderProtocol
@@ -182,7 +182,7 @@ public class BasePackageContainer: PackageContainer {
 
     init(
         _ identifier: Identifier,
-        config: SwiftPMConfig,
+        config: DependencyMirrors,
         manifestLoader: ManifestLoaderProtocol,
         toolsVersionLoader: ToolsVersionLoaderProtocol,
         currentToolsVersion: ToolsVersion

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -19,7 +19,7 @@ extension PackageGraph {
     /// Load the package graph for the given package path.
     public static func load(
         root: PackageGraphRoot,
-        config: SwiftPMConfig = SwiftPMConfig(),
+        config: DependencyMirrors = DependencyMirrors(),
         additionalFileRules: [FileRuleDescription] = [],
         externalManifests: [Manifest],
         requiredDependencies: Set<PackageReference> = [],
@@ -187,7 +187,7 @@ private func checkAllDependenciesAreUsed(_ rootPackages: [ResolvedPackage], _ di
 /// Create resolved packages from the loaded packages.
 private func createResolvedPackages(
     allManifests: [GraphLoadingNode],
-    config: SwiftPMConfig,
+    config: DependencyMirrors,
     manifestToPackage: [Manifest: Package],
     // FIXME: This shouldn't be needed once <rdar://problem/33693433> is fixed.
     rootManifestSet: Set<Manifest>,

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -19,7 +19,7 @@ extension PackageGraph {
     /// Load the package graph for the given package path.
     public static func load(
         root: PackageGraphRoot,
-        config: DependencyMirrors = DependencyMirrors(),
+        mirrors: DependencyMirrors = DependencyMirrors(),
         additionalFileRules: [FileRuleDescription] = [],
         externalManifests: [Manifest],
         requiredDependencies: Set<PackageReference> = [],
@@ -42,7 +42,7 @@ extension PackageGraph {
         let manifestMap = Dictionary(uniqueKeysWithValues: manifestMapSequence)
         let successors: (GraphLoadingNode) -> [GraphLoadingNode] = { node in
             node.requiredDependencies().compactMap({ dependency in
-                let url = config.mirroredURL(forURL: dependency.declaration.url)
+                let url = mirrors.mirroredURL(forURL: dependency.declaration.url)
                 return manifestMap[PackageReference.computeIdentity(packageURL: url)].map { manifest in
                     GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
                 }
@@ -129,7 +129,7 @@ extension PackageGraph {
         // Resolve dependencies and create resolved packages.
         let resolvedPackages = createResolvedPackages(
             allManifests: allManifests,
-            config: config,
+            mirrors: mirrors,
             manifestToPackage: manifestToPackage,
             rootManifestSet: rootManifestSet,
             unsafeAllowedPackages: unsafeAllowedPackages,
@@ -187,7 +187,7 @@ private func checkAllDependenciesAreUsed(_ rootPackages: [ResolvedPackage], _ di
 /// Create resolved packages from the loaded packages.
 private func createResolvedPackages(
     allManifests: [GraphLoadingNode],
-    config: DependencyMirrors,
+    mirrors: DependencyMirrors,
     manifestToPackage: [Manifest: Package],
     // FIXME: This shouldn't be needed once <rdar://problem/33693433> is fixed.
     rootManifestSet: Set<Manifest>,
@@ -228,7 +228,7 @@ private func createResolvedPackages(
                 }
 
                 // Otherwise, look it up by its identity.
-                let url = config.mirroredURL(forURL: dependency.declaration.url)
+                let url = mirrors.mirroredURL(forURL: dependency.declaration.url)
                 let resolvedPackage = packageMapByIdentity[PackageReference.computeIdentity(packageURL: url)]
 
                 // We check that the explicit package dependency name matches the package name.
@@ -359,10 +359,10 @@ private func createResolvedPackages(
                     // explicitly reference the package containing the product, or for the product, package and
                     // dependency to share the same name. We don't check this in manifest loading for root-packages so
                     // we can provide a more detailed diagnostic here.
-                    let referencedPackageURL = config.mirroredURL(forURL: product.packageBuilder.package.manifest.url)
+                    let referencedPackageURL = mirrors.mirroredURL(forURL: product.packageBuilder.package.manifest.url)
                     let referencedPackageIdentity = PackageReference.computeIdentity(packageURL: referencedPackageURL)
                     let packageDependency = packageBuilder.package.manifest.dependencies.first { package in
-                        let packageURL = config.mirroredURL(forURL: package.url)
+                        let packageURL = mirrors.mirroredURL(forURL: package.url)
                         let packageIdentity = PackageReference.computeIdentity(packageURL: packageURL)
                         return packageIdentity == referencedPackageIdentity
                     }!

--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -59,7 +59,7 @@ public struct PackageGraphRoot {
         public let productFilter: ProductFilter
 
         /// Create the package reference object for the dependency.
-        public func createPackageRef(config: SwiftPMConfig) -> PackageReference {
+        public func createPackageRef(config: DependencyMirrors) -> PackageReference {
             let effectiveURL = config.mirroredURL(forURL: self.url)
             return PackageReference(
                 identity: PackageReference.computeIdentity(packageURL: effectiveURL),
@@ -128,7 +128,7 @@ public struct PackageGraphRoot {
     }
 
     /// Returns the constraints imposed by root manifests + dependencies.
-    public func constraints(config: SwiftPMConfig) -> [RepositoryPackageConstraint] {
+    public func constraints(config: DependencyMirrors) -> [RepositoryPackageConstraint] {
         let constraints = packageRefs.map({
             RepositoryPackageConstraint(container: $0, requirement: .unversioned, products: .everything)
         })

--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -59,8 +59,8 @@ public struct PackageGraphRoot {
         public let productFilter: ProductFilter
 
         /// Create the package reference object for the dependency.
-        public func createPackageRef(config: DependencyMirrors) -> PackageReference {
-            let effectiveURL = config.mirroredURL(forURL: self.url)
+        public func createPackageRef(mirrors: DependencyMirrors) -> PackageReference {
+            let effectiveURL = mirrors.mirroredURL(forURL: self.url)
             return PackageReference(
                 identity: PackageReference.computeIdentity(packageURL: effectiveURL),
                 path: effectiveURL,
@@ -128,13 +128,13 @@ public struct PackageGraphRoot {
     }
 
     /// Returns the constraints imposed by root manifests + dependencies.
-    public func constraints(config: DependencyMirrors) -> [RepositoryPackageConstraint] {
+    public func constraints(mirrors: DependencyMirrors) -> [RepositoryPackageConstraint] {
         let constraints = packageRefs.map({
             RepositoryPackageConstraint(container: $0, requirement: .unversioned, products: .everything)
         })
         return constraints + dependencies.map({
             RepositoryPackageConstraint(
-                container: $0.createPackageRef(config: config),
+                container: $0.createPackageRef(mirrors: mirrors),
                 requirement: $0.requirement.toConstraintRequirement(),
                 products: $0.productFilter
             )

--- a/Sources/PackageGraph/PackageModel+Extensions.swift
+++ b/Sources/PackageGraph/PackageModel+Extensions.swift
@@ -13,8 +13,8 @@ import SourceControl
 
 extension PackageDependencyDescription {
     /// Create the package reference object for the dependency.
-    public func createPackageRef(config: DependencyMirrors) -> PackageReference {
-        let effectiveURL = config.mirroredURL(forURL: self.url)
+    public func createPackageRef(mirrors: DependencyMirrors) -> PackageReference {
+        let effectiveURL = mirrors.mirroredURL(forURL: self.url)
         return PackageReference(
             identity: PackageReference.computeIdentity(packageURL: effectiveURL),
             path: effectiveURL,
@@ -25,10 +25,10 @@ extension PackageDependencyDescription {
 
 extension Manifest {
     /// Constructs constraints of the dependencies in the raw package.
-    public func dependencyConstraints(productFilter: ProductFilter, config: DependencyMirrors) -> [RepositoryPackageConstraint] {
+    public func dependencyConstraints(productFilter: ProductFilter, mirrors: DependencyMirrors) -> [RepositoryPackageConstraint] {
         return dependenciesRequired(for: productFilter).map({
             return RepositoryPackageConstraint(
-                container: $0.declaration.createPackageRef(config: config),
+                container: $0.declaration.createPackageRef(mirrors: mirrors),
                 requirement: $0.declaration.requirement.toConstraintRequirement(),
                 products: $0.productFilter)
         })

--- a/Sources/PackageGraph/PackageModel+Extensions.swift
+++ b/Sources/PackageGraph/PackageModel+Extensions.swift
@@ -13,7 +13,7 @@ import SourceControl
 
 extension PackageDependencyDescription {
     /// Create the package reference object for the dependency.
-    public func createPackageRef(config: SwiftPMConfig) -> PackageReference {
+    public func createPackageRef(config: DependencyMirrors) -> PackageReference {
         let effectiveURL = config.mirroredURL(forURL: self.url)
         return PackageReference(
             identity: PackageReference.computeIdentity(packageURL: effectiveURL),
@@ -25,7 +25,7 @@ extension PackageDependencyDescription {
 
 extension Manifest {
     /// Constructs constraints of the dependencies in the raw package.
-    public func dependencyConstraints(productFilter: ProductFilter, config: SwiftPMConfig) -> [RepositoryPackageConstraint] {
+    public func dependencyConstraints(productFilter: ProductFilter, config: DependencyMirrors) -> [RepositoryPackageConstraint] {
         return dependenciesRequired(for: productFilter).map({
             return RepositoryPackageConstraint(
                 container: $0.declaration.createPackageRef(config: config),

--- a/Sources/PackageGraph/RepositoryPackageContainer.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainer.swift
@@ -92,7 +92,7 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
 
     init(
         identifier: PackageReference,
-        config: SwiftPMConfig,
+        config: DependencyMirrors,
         repository: Repository,
         manifestLoader: ManifestLoaderProtocol,
         toolsVersionLoader: ToolsVersionLoaderProtocol,
@@ -293,7 +293,7 @@ public class RepositoryPackageContainer: BasePackageContainer, CustomStringConve
 public class RepositoryPackageContainerProvider: PackageContainerProvider {
     let repositoryManager: RepositoryManager
     let manifestLoader: ManifestLoaderProtocol
-    let config: SwiftPMConfig
+    let config: DependencyMirrors
 
     /// The tools version currently in use. Only the container versions less than and equal to this will be provided by
     /// the container.
@@ -314,7 +314,7 @@ public class RepositoryPackageContainerProvider: PackageContainerProvider {
     ///   - toolsVersionLoader: The tools version loader.
     public init(
         repositoryManager: RepositoryManager,
-        config: SwiftPMConfig = SwiftPMConfig(),
+        config: DependencyMirrors = DependencyMirrors(),
         manifestLoader: ManifestLoaderProtocol,
         currentToolsVersion: ToolsVersion = ToolsVersion.currentToolsVersion,
         toolsVersionLoader: ToolsVersionLoaderProtocol = ToolsVersionLoader()

--- a/Sources/SPMTestSupport/TestWorkspace.swift
+++ b/Sources/SPMTestSupport/TestWorkspace.swift
@@ -26,7 +26,7 @@ public final class TestWorkspace {
     public let checksumAlgorithm: MockHashAlgorithm
     let roots: [TestPackage]
     let packages: [TestPackage]
-    public let config: SwiftPMConfig
+    public let config: DependencyMirrors
     public var manifestLoader: MockManifestLoader
     public var repoProvider: InMemoryGitRepositoryProvider
     public let delegate = TestWorkspaceDelegate()
@@ -51,7 +51,7 @@ public final class TestWorkspace {
         self.downloader = downloader ?? MockDownloader(fileSystem: fs)
         self.archiver = archiver
         self.checksumAlgorithm = checksumAlgorithm
-        self.config = SwiftPMConfig(path: sandbox.appending(component: "swiftpm"), fs: fs)
+        self.config = DependencyMirrors(path: sandbox.appending(component: "swiftpm"), fs: fs)
         self.roots = roots
         self.packages = packages
 

--- a/Sources/SPMTestSupport/TestWorkspace.swift
+++ b/Sources/SPMTestSupport/TestWorkspace.swift
@@ -51,7 +51,7 @@ public final class TestWorkspace {
         self.downloader = downloader ?? MockDownloader(fileSystem: fs)
         self.archiver = archiver
         self.checksumAlgorithm = checksumAlgorithm
-        self.mirrors = DependencyMirrors(path: sandbox.appending(component: "swiftpm"), fs: fs)
+        self.mirrors = try DependencyMirrors(path: sandbox.appending(component: "swiftpm"), fs: fs)
         self.roots = roots
         self.packages = packages
 

--- a/Sources/SPMTestSupport/TestWorkspace.swift
+++ b/Sources/SPMTestSupport/TestWorkspace.swift
@@ -26,7 +26,7 @@ public final class TestWorkspace {
     public let checksumAlgorithm: MockHashAlgorithm
     let roots: [TestPackage]
     let packages: [TestPackage]
-    public let config: DependencyMirrors
+    public let mirrors: DependencyMirrors
     public var manifestLoader: MockManifestLoader
     public var repoProvider: InMemoryGitRepositoryProvider
     public let delegate = TestWorkspaceDelegate()
@@ -51,7 +51,7 @@ public final class TestWorkspace {
         self.downloader = downloader ?? MockDownloader(fileSystem: fs)
         self.archiver = archiver
         self.checksumAlgorithm = checksumAlgorithm
-        self.config = DependencyMirrors(path: sandbox.appending(component: "swiftpm"), fs: fs)
+        self.mirrors = DependencyMirrors(path: sandbox.appending(component: "swiftpm"), fs: fs)
         self.roots = roots
         self.packages = packages
 
@@ -165,7 +165,7 @@ public final class TestWorkspace {
             currentToolsVersion: toolsVersion,
             toolsVersionLoader: ToolsVersionLoader(),
             delegate: delegate,
-            config: config,
+            mirrors: mirrors,
             fileSystem: fs,
             repositoryProvider: repoProvider,
             downloader: downloader,

--- a/Sources/SourceControl/CMakeLists.txt
+++ b/Sources/SourceControl/CMakeLists.txt
@@ -7,11 +7,11 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(SourceControl
+  DependencyMirrors.swift
   GitRepository.swift
   InMemoryGitRepository.swift
   Repository.swift
-  RepositoryManager.swift
-  SwiftPMConfig.swift)
+  RepositoryManager.swift)
 
 target_link_libraries(SourceControl PUBLIC
   TSCBasic

--- a/Sources/SourceControl/DependencyMirrors.swift
+++ b/Sources/SourceControl/DependencyMirrors.swift
@@ -19,8 +19,14 @@ public final class DependencyMirrors {
         case mirrorNotFound
     }
 
+    /// The path to the mirrors file.
+    private let mirrorsFile: AbsolutePath?
+
+    /// The filesystem to manage the mirrors file on.
+    private var fileSystem: FileSystem?
+
     /// Persistence support.
-    let persistence: SimplePersistence?
+    private let persistence: SimplePersistence?
 
     /// The schema version of the mirrors file.
     ///
@@ -28,25 +34,35 @@ public final class DependencyMirrors {
     static let schemaVersion: Int = 1
 
     /// The mirrors.
-    private var mirrors: [String: Mirror]
+    private var mirrors: [String: Mirror] = [:]
 
-    public init(path: AbsolutePath, fs: FileSystem = localFileSystem) {
-        self.mirrors = [:]
-        self.persistence = SimplePersistence(
-            fileSystem: fs, schemaVersion: DependencyMirrors.schemaVersion,
-            statePath: path, prettyPrint: true
+    public init(path: AbsolutePath, fs: FileSystem = localFileSystem) throws {
+        self.mirrorsFile = path
+        self.fileSystem = fs
+        let persistence = SimplePersistence(
+            fileSystem: fs,
+            schemaVersion: DependencyMirrors.schemaVersion,
+            statePath: path,
+            prettyPrint: true
         )
+
+        do {
+            self.persistence = persistence
+            _ = try persistence.restoreState(self)
+        } catch SimplePersistence.Error.restoreFailure(_, let error) {
+            throw StringError("Configuration file is corrupted or malformed; fix or delete the file to continue: \(error)")
+        }
     }
 
     public init() {
-        self.mirrors = [:]
+        self.mirrorsFile = nil
+        self.fileSystem = nil
         self.persistence = nil
     }
 
     /// Set a mirror URL for the given URL.
-    public func set(mirrorURL: String, forURL url: String) throws {
+    public func set(mirrorURL: String, forURL url: String) {
         mirrors[url] = Mirror(original: url, mirror: mirrorURL)
-        try saveState()
     }
 
     /// Unset a mirror for the given URL.
@@ -60,7 +76,6 @@ public final class DependencyMirrors {
         } else {
             throw Error.mirrorNotFound
         }
-        try saveState()
     }
 
     /// Returns the mirror for the given specificer.
@@ -77,42 +92,54 @@ public final class DependencyMirrors {
     public func load() throws {
         _ = try self.persistence?.restoreState(self)
     }
-}
 
+    public func saveState() throws {
+        guard let persistence = self.persistence else { return }
+        if mirrors.isEmpty,
+           let fileSystem = self.fileSystem,
+           let mirrorsFile = self.mirrorsFile
+        {
+            // Remove the mirrors file if there are no mirrors to save.
+            return try fileSystem.removeFileTree(mirrorsFile)
+        }
+
+        try persistence.saveState(self)
+    }
+}
 
 extension DependencyMirrors: JSONSerializable {
     public func toJSON() -> JSON {
-        // FIXME: Find a way to avoid encode-decode dance here.
-        let jsonData = try! JSONEncoder().encode(mirrors.values.sorted(by: { $0.original < $1.mirror }))
-        return try! JSON(data: jsonData)
+        return mirrors.values.sorted(by: { $0.original < $1.mirror }).map { $0.toJSON() }.toJSON()
     }
 }
 
 extension DependencyMirrors: SimplePersistanceProtocol {
-
-    public func saveState() throws {
-        try self.persistence?.saveState(self)
-    }
-
     public func restore(from json: JSON) throws {
-        // FIXME: Find a way to avoid encode-decode dance here.
-        let data = Data(json.toBytes().contents)
-        let mirrorsData = try JSONDecoder().decode([Mirror].self, from: data)
-        self.mirrors = Dictionary(mirrorsData.map({ ($0.original, $0) }), uniquingKeysWith: { first, _ in first })
+        let mirrors = try json.getArray().map(Mirror.init(json:))
+        self.mirrors = Dictionary(mirrors.map({ ($0.original, $0) }), uniquingKeysWith: { first, _ in first })
     }
 }
 
 /// An individual repository mirror.
-fileprivate struct Mirror: Codable {
+fileprivate struct Mirror {
     /// The original repository path.
     let original: String
 
     /// The mirrored repository path.
     let mirror: String
+}
 
-    init(original: String, mirror: String) {
-        self.original = original
-        self.mirror = mirror
+extension Mirror: JSONMappable, JSONSerializable {
+    init(json: JSON) throws {
+        self.original = try json.get("original")
+        self.mirror = try json.get("mirror")
+    }
+
+    func toJSON() -> JSON {
+        .init([
+            "original": original,
+            "mirror": mirror
+        ])
     }
 }
 

--- a/Sources/SourceControl/DependencyMirrors.swift
+++ b/Sources/SourceControl/DependencyMirrors.swift
@@ -106,14 +106,14 @@ extension DependencyMirrors: SimplePersistanceProtocol {
 }
 
 /// An individual repository mirror.
-public struct Mirror: Codable {
+fileprivate struct Mirror: Codable {
     /// The original repository path.
-    public let original: String
+    let original: String
 
     /// The mirrored repository path.
-    public let mirror: String
+    let mirror: String
 
-    public init(original: String, mirror: String) {
+    init(original: String, mirror: String) {
         self.original = original
         self.mirror = mirror
     }

--- a/Sources/SourceControl/DependencyMirrors.swift
+++ b/Sources/SourceControl/DependencyMirrors.swift
@@ -84,7 +84,15 @@ public final class DependencyMirrors {
     }
 }
 
-// MARK: - Persistence.
+
+extension DependencyMirrors: JSONSerializable {
+    public func toJSON() -> JSON {
+        // FIXME: Find a way to avoid encode-decode dance here.
+        let jsonData = try! JSONEncoder().encode(mirrors.values.sorted(by: { $0.original < $1.mirror }))
+        return try! JSON(data: jsonData)
+    }
+}
+
 extension DependencyMirrors: SimplePersistanceProtocol {
 
     public func saveState() throws {
@@ -96,12 +104,6 @@ extension DependencyMirrors: SimplePersistanceProtocol {
         let data = Data(json.toBytes().contents)
         let mirrorsData = try JSONDecoder().decode([Mirror].self, from: data)
         self.mirrors = Dictionary(mirrorsData.map({ ($0.original, $0) }), uniquingKeysWith: { first, _ in first })
-    }
-
-    public func toJSON() -> JSON {
-        // FIXME: Find a way to avoid encode-decode dance here.
-        let jsonData = try! JSONEncoder().encode(mirrors.values.sorted(by: { $0.original < $1.mirror }))
-        return try! JSON(data: jsonData)
     }
 }
 

--- a/Sources/SourceControl/DependencyMirrors.swift
+++ b/Sources/SourceControl/DependencyMirrors.swift
@@ -27,7 +27,7 @@ public final class DependencyMirrors {
     /// Persistence support.
     let persistence: SimplePersistence?
 
-    /// The schema version of the config file.
+    /// The schema version of the mirrors file.
     ///
     /// * 1: Initial version.
     static let schemaVersion: Int = 1

--- a/Sources/SourceControl/DependencyMirrors.swift
+++ b/Sources/SourceControl/DependencyMirrors.swift
@@ -15,13 +15,8 @@ import TSCUtility
 
 /// Manages a package's configuration.
 public final class DependencyMirrors {
-
-    enum Error: Swift.Error, CustomStringConvertible {
+    public enum Error: Swift.Error {
         case mirrorNotFound
-
-        var description: String {
-            return "mirror not found"
-        }
     }
 
     /// Persistence support.
@@ -118,5 +113,14 @@ fileprivate struct Mirror: Codable {
     init(original: String, mirror: String) {
         self.original = original
         self.mirror = mirror
+    }
+}
+
+extension DependencyMirrors.Error: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .mirrorNotFound:
+            return "mirror not found"
+        }
     }
 }

--- a/Sources/SourceControl/DependencyMirrors.swift
+++ b/Sources/SourceControl/DependencyMirrors.swift
@@ -13,11 +13,8 @@ import Foundation
 import TSCBasic
 import TSCUtility
 
-// FIXME: We may want to move this class to some other layer once we start
-// supporting more things than just mirrors.
-//
 /// Manages a package's configuration.
-public final class SwiftPMConfig {
+public final class DependencyMirrors {
 
     enum Error: Swift.Error, CustomStringConvertible {
         case mirrorNotFound
@@ -41,7 +38,7 @@ public final class SwiftPMConfig {
     public init(path: AbsolutePath, fs: FileSystem = localFileSystem) {
         self.mirrors = [:]
         self.persistence = SimplePersistence(
-            fileSystem: fs, schemaVersion: SwiftPMConfig.schemaVersion,
+            fileSystem: fs, schemaVersion: DependencyMirrors.schemaVersion,
             statePath: path, prettyPrint: true
         )
     }
@@ -88,7 +85,7 @@ public final class SwiftPMConfig {
 }
 
 // MARK: - Persistence.
-extension SwiftPMConfig: SimplePersistanceProtocol {
+extension DependencyMirrors: SimplePersistanceProtocol {
 
     public func saveState() throws {
         try self.persistence?.saveState(self)

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -38,7 +38,7 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
     let dependencyManifests: Workspace.DependencyManifests
 
     /// The SwiftPM config.
-    let config: SwiftPMConfig
+    let config: DependencyMirrors
 
     /// The tools version currently in use.
     let currentToolsVersion: ToolsVersion
@@ -46,7 +46,7 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
     init(
         root: PackageGraphRoot,
         dependencyManifests: Workspace.DependencyManifests,
-        config: SwiftPMConfig,
+        config: DependencyMirrors,
         currentToolsVersion: ToolsVersion = ToolsVersion.currentToolsVersion
     ) {
         self.root = root
@@ -97,7 +97,7 @@ private struct LocalPackageContainer: PackageContainer {
     let manifest: Manifest
     /// The managed dependency if the package is not a root package.
     let dependency: ManagedDependency?
-    let config: SwiftPMConfig
+    let config: DependencyMirrors
     let currentToolsVersion: ToolsVersion
 
     // Gets the package reference from the managed dependency or computes it for root packages.

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -37,8 +37,8 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
     /// The managed manifests to make available to the resolver.
     let dependencyManifests: Workspace.DependencyManifests
 
-    /// The SwiftPM config.
-    let config: DependencyMirrors
+    /// The dependency mirrors.
+    let mirrors: DependencyMirrors
 
     /// The tools version currently in use.
     let currentToolsVersion: ToolsVersion
@@ -46,12 +46,12 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
     init(
         root: PackageGraphRoot,
         dependencyManifests: Workspace.DependencyManifests,
-        config: DependencyMirrors,
+        mirrors: DependencyMirrors,
         currentToolsVersion: ToolsVersion = ToolsVersion.currentToolsVersion
     ) {
         self.root = root
         self.dependencyManifests = dependencyManifests
-        self.config = config
+        self.mirrors = mirrors
         self.currentToolsVersion = currentToolsVersion
     }
 
@@ -66,7 +66,7 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
                 package: identifier,
                 manifest: manifest.manifest,
                 dependency: manifest.dependency,
-                config: config,
+                mirrors: mirrors,
                 currentToolsVersion: currentToolsVersion
             )
 
@@ -80,7 +80,7 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
                 package: identifier,
                 manifest: dependencyManifests.root.manifests[index],
                 dependency: nil,
-                config: config,
+                mirrors: mirrors,
                 currentToolsVersion: currentToolsVersion
             )
 
@@ -97,7 +97,7 @@ private struct LocalPackageContainer: PackageContainer {
     let manifest: Manifest
     /// The managed dependency if the package is not a root package.
     let dependency: ManagedDependency?
-    let config: DependencyMirrors
+    let mirrors: DependencyMirrors
     let currentToolsVersion: ToolsVersion
 
     // Gets the package reference from the managed dependency or computes it for root packages.
@@ -138,7 +138,7 @@ private struct LocalPackageContainer: PackageContainer {
     func getDependencies(at version: Version, productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
         // Because of the implementation of `reversedVersions`, we should only get the exact same version.
         precondition(dependency?.checkoutState?.version == version)
-        return manifest.dependencyConstraints(productFilter: productFilter, config: config)
+        return manifest.dependencyConstraints(productFilter: productFilter, mirrors: mirrors)
     }
 
     func getDependencies(at revision: String, productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
@@ -146,7 +146,7 @@ private struct LocalPackageContainer: PackageContainer {
         if let checkoutState = dependency?.checkoutState,
             checkoutState.version == nil,
             checkoutState.revision.identifier == revision {
-            return manifest.dependencyConstraints(productFilter: productFilter, config: config)
+            return manifest.dependencyConstraints(productFilter: productFilter, mirrors: mirrors)
         }
 
         throw ResolverPrecomputationError.differentRequirement(
@@ -166,7 +166,7 @@ private struct LocalPackageContainer: PackageContainer {
             )
         }
 
-        return manifest.dependencyConstraints(productFilter: productFilter, config: config)
+        return manifest.dependencyConstraints(productFilter: productFilter, mirrors: mirrors)
     }
 
     func getUpdatedIdentifier(at boundVersion: BoundVersion) throws -> PackageReference {

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -166,7 +166,7 @@ public class Workspace {
     public let dataPath: AbsolutePath
 
     /// The swiftpm config.
-    fileprivate let config: SwiftPMConfig
+    fileprivate let config: DependencyMirrors
 
     /// The current persisted state of the workspace.
     public let state: WorkspaceState
@@ -254,7 +254,7 @@ public class Workspace {
         currentToolsVersion: ToolsVersion = ToolsVersion.currentToolsVersion,
         toolsVersionLoader: ToolsVersionLoaderProtocol = ToolsVersionLoader(),
         delegate: WorkspaceDelegate? = nil,
-        config: SwiftPMConfig = SwiftPMConfig(),
+        config: DependencyMirrors = DependencyMirrors(),
         fileSystem: FileSystem = localFileSystem,
         repositoryProvider: RepositoryProvider = GitRepositoryProvider(),
         downloader: Downloader = FoundationDownloader(),

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -376,7 +376,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             TargetDescription(name: "Foo3", dependencies: ["Bar3"]),
         ]
 
-        let config = SwiftPMConfig()
+        let config = DependencyMirrors()
 
         let v5ProductMapping: [String: ProductFilter] = [
             "Bar1": .specific(["Bar1", "Bar3"]),

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -376,7 +376,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             TargetDescription(name: "Foo3", dependencies: ["Bar3"]),
         ]
 
-        let config = DependencyMirrors()
+        let mirrors = DependencyMirrors()
 
         let v5ProductMapping: [String: ProductFilter] = [
             "Bar1": .specific(["Bar1", "Bar3"]),
@@ -385,7 +385,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         ]
         let v5Constraints = dependencies.map({
             RepositoryPackageConstraint(
-                container: $0.createPackageRef(config: config),
+                container: $0.createPackageRef(mirrors: mirrors),
                 requirement: $0.requirement.toConstraintRequirement(),
                 products: v5ProductMapping[$0.name]!)
         })
@@ -396,7 +396,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         ]
         let v5_2Constraints = dependencies.map({
             RepositoryPackageConstraint(
-                container: $0.createPackageRef(config: config),
+                container: $0.createPackageRef(mirrors: mirrors),
                 requirement: $0.requirement.toConstraintRequirement(),
                 products: v5_2ProductMapping[$0.name]!)
         })
@@ -415,7 +415,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
 
             XCTAssertEqual(
                 manifest
-                    .dependencyConstraints(productFilter: .everything, config: config)
+                    .dependencyConstraints(productFilter: .everything, mirrors: mirrors)
                     .sorted(by: { $0.identifier.identity < $1.identifier.identity }),
                 [
                     v5Constraints[0],
@@ -439,7 +439,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
 
             XCTAssertEqual(
                 manifest
-                    .dependencyConstraints(productFilter: .everything, config: config)
+                    .dependencyConstraints(productFilter: .everything, mirrors: mirrors)
                     .sorted(by: { $0.identifier.identity < $1.identifier.identity }),
                 [
                     v5Constraints[0],
@@ -463,7 +463,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
 
             XCTAssertEqual(
                 manifest
-                    .dependencyConstraints(productFilter: .everything, config: config)
+                    .dependencyConstraints(productFilter: .everything, mirrors: mirrors)
                     .sorted(by: { $0.identifier.identity < $1.identifier.identity }),
                 [
                     v5_2Constraints[0],
@@ -487,7 +487,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
 
             XCTAssertEqual(
                 manifest
-                    .dependencyConstraints(productFilter: .specific(Set(products.map({ $0.name }))), config: config)
+                    .dependencyConstraints(productFilter: .specific(Set(products.map({ $0.name }))), mirrors: mirrors)
                     .sorted(by: { $0.identifier.identity < $1.identifier.identity }),
                 [
                     v5_2Constraints[0],

--- a/Tests/SourceControlTests/DependencyMirrorsTests.swift
+++ b/Tests/SourceControlTests/DependencyMirrorsTests.swift
@@ -1,0 +1,80 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+import TSCBasic
+import TSCUtility
+import SPMTestSupport
+import SourceControl
+import Workspace
+
+final class DependencyMirrorsTests: XCTestCase {
+    func testLoadingSchema1() throws {
+        let fs = InMemoryFileSystem()
+        let mirrorsFile = AbsolutePath("/mirrors.txt")
+
+        let originalURL = "https://github.com/apple/swift-argument-parser.git"
+        let mirrorURL = "https://github.com/mona/swift-argument-parser.git"
+
+        try fs.writeFileContents(mirrorsFile) {
+            $0 <<< """
+                {
+                  "object": [
+                    {
+                      "mirror": "\(mirrorURL)",
+                      "original": "\(originalURL)"
+                    }
+                  ],
+                  "version": 1
+                }
+                """
+        }
+
+        let mirrors = try DependencyMirrors(path: mirrorsFile, fs: fs)
+
+        XCTAssertEqual(mirrors.getMirror(forURL: "https://github.com/apple/swift-argument-parser.git"), "https://github.com/mona/swift-argument-parser.git")
+    }
+
+    func testThrowsMirrorNotFound() throws {
+        let fs = InMemoryFileSystem()
+        let mirrorsFile = AbsolutePath("/mirrors.txt")
+        let mirrors = try DependencyMirrors(path: mirrorsFile, fs: fs)
+
+        XCTAssertThrows(DependencyMirrors.Error.mirrorNotFound) {
+            try mirrors.unset(originalOrMirrorURL: "https://github.com/apple/swift-argument-parser.git")
+        }
+    }
+
+    func testEmptyMirrors() throws {
+        let fs = InMemoryFileSystem()
+        let mirrorsFile = AbsolutePath("/mirrors.txt")
+        let mirrors = try DependencyMirrors(path: mirrorsFile, fs: fs)
+
+        try mirrors.saveState()
+        XCTAssertFalse(fs.exists(mirrorsFile))
+
+        let originalURL = "https://github.com/apple/swift-argument-parser.git"
+        let mirrorURL = "https://github.com/mona/swift-argument-parser.git"
+        mirrors.set(mirrorURL: mirrorURL, forURL: originalURL)
+
+        XCTAssertFalse(fs.exists(mirrorsFile))
+
+        try mirrors.saveState()
+        XCTAssertTrue(fs.exists(mirrorsFile))
+
+        try mirrors.unset(originalOrMirrorURL: originalURL)
+
+        XCTAssertTrue(fs.exists(mirrorsFile))
+
+        try mirrors.saveState()
+        XCTAssertFalse(fs.exists(mirrorsFile))
+    }
+}

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3397,8 +3397,9 @@ final class WorkspaceTests: XCTestCase {
             result.check(notPresent: "Baz")
         }
 
-        try workspace.mirrors.set(mirrorURL: workspace.packagesDir.appending(component: "Baz").pathString, forURL: workspace.packagesDir.appending(component: "Bar").pathString)
-        try workspace.mirrors.set(mirrorURL: workspace.packagesDir.appending(component: "Baz").pathString, forURL: workspace.packagesDir.appending(component: "Bam").pathString)
+        workspace.mirrors.set(mirrorURL: workspace.packagesDir.appending(component: "Baz").pathString, forURL: workspace.packagesDir.appending(component: "Bar").pathString)
+        workspace.mirrors.set(mirrorURL: workspace.packagesDir.appending(component: "Baz").pathString, forURL: workspace.packagesDir.appending(component: "Bam").pathString)
+        try workspace.mirrors.saveState()
 
         let deps: [TestWorkspace.PackageDependency] = [
             .init(name: "Bam", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Bar"])),

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3397,8 +3397,8 @@ final class WorkspaceTests: XCTestCase {
             result.check(notPresent: "Baz")
         }
 
-        try workspace.config.set(mirrorURL: workspace.packagesDir.appending(component: "Baz").pathString, forURL: workspace.packagesDir.appending(component: "Bar").pathString)
-        try workspace.config.set(mirrorURL: workspace.packagesDir.appending(component: "Baz").pathString, forURL: workspace.packagesDir.appending(component: "Bam").pathString)
+        try workspace.mirrors.set(mirrorURL: workspace.packagesDir.appending(component: "Baz").pathString, forURL: workspace.packagesDir.appending(component: "Bar").pathString)
+        try workspace.mirrors.set(mirrorURL: workspace.packagesDir.appending(component: "Baz").pathString, forURL: workspace.packagesDir.appending(component: "Bam").pathString)
 
         let deps: [TestWorkspace.PackageDependency] = [
             .init(name: "Bam", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Bar"])),


### PR DESCRIPTION
The `SwiftPMConfig` type is responsible for getting and setting the mirrored URLs for dependencies. For example, if a package has a direct or transitive dependency on `https://github.com/apple/swift-argument-parser.git`, you can use a mirror to instead point all references to that package to a fork, say `https://github.com/mattt/swift-argument-parser`. This functionality was discussed on the Swift Forums [in this thread](https://forums.swift.org/t/dependency-mirroring-and-forking/13902).

The name `SwiftPMConfig` is vague, and makes it difficult to understand the significance of `config` properties and parameters that are passed around among the `PackageGraph`, `SourceControl`, and `Workspace` modules. In other contexts, the word "config" is used to describe `pkgConfig`, build configuration, or `xcconfig` files. 

[This comment](https://github.com/apple/swift-package-manager/blob/7afc6e22bb7b957b7d212fea31cf0f9132513bc0/Sources/SourceControl/SwiftPMConfig.swift#L16) indicates that the name was chosen in anticipation of the type being used to manage other concerns. However, since that hasn't happened yet, I think renaming it to something more descriptive would go a long way to helping comprehensibility.

I chose the name `DependencyMirrors`, but we can certainly bikeshed on that.

This PR also takes a further steps to resolve the existing [FIXME](https://github.com/apple/swift-package-manager/blob/7afc6e22bb7b957b7d212fea31cf0f9132513bc0/Sources/SourceControl/SwiftPMConfig.swift#L105) comments, as well as adding tests for DependencyMirrors that didn't previously exist. In the process of adding test coverage, I updated the implementation to more closely match that of `PinsStore`. These changes (38fa10cb77bfb908eca000c7bbfa85ed7557f322 ) are entirely severable from the rest of the PR, and can be dropped if you prefer.

This PR doesn't change the default file path for dependency mirror configuration (`.swiftpm/config`). We can punt on how or whether to migrate this until there's a strong reason to do so.
 