### PR TITLE
Move InMemoryGitRepository to SPMTestSupport

### DIFF
--- a/Sources/SPMTestSupport/InMemoryGitRepository.swift
+++ b/Sources/SPMTestSupport/InMemoryGitRepository.swift
@@ -9,8 +9,9 @@
 */
 
 import TSCBasic
-import Dispatch
 import TSCUtility
+import SourceControl
+import Dispatch
 import class Foundation.NSUUID
 
 /// The error encountered during in memory git repository operations.

--- a/Sources/SourceControl/CMakeLists.txt
+++ b/Sources/SourceControl/CMakeLists.txt
@@ -8,7 +8,6 @@
 
 add_library(SourceControl
   GitRepository.swift
-  InMemoryGitRepository.swift
   Repository.swift
   RepositoryManager.swift
   SwiftPMConfig.swift)


### PR DESCRIPTION
`InMemoryGitRepository` is currently located in the `SourceControl` module, but is used exclusively for testing. This PR moves it to the `SPMTestSupport` module, to clarify the scope and nature of its use.