### PR TITLE
Temporarily disable target-based dependency resolution

### DIFF
--- a/Sources/PackageGraph/DependencyResolutionNode.swift
+++ b/Sources/PackageGraph/DependencyResolutionNode.swift
@@ -78,6 +78,7 @@ public enum DependencyResolutionNode {
 
     /// Assembles the product filter to use on the manifest for this node to determine its dependencies.
     public var productFilter: ProductFilter {
+        #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
         switch self {
         case .empty:
             return .specific([])
@@ -86,6 +87,9 @@ public enum DependencyResolutionNode {
         case .root:
             return .everything
         }
+        #else
+        return .everything
+        #endif
     }
 
     /// Returns the dependency that a product has on its own package, if relevant.

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -131,6 +131,7 @@ public final class Manifest: ObjectIdentifierProtocol {
 
     /// Returns the targets required for a particular product filter.
     public func targetsRequired(for productFilter: ProductFilter) -> [TargetDescription] {
+        #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
         // If we have already calcualted it, returned the cached value.
         if let targets = _requiredTargets[productFilter] {
             return targets
@@ -147,6 +148,9 @@ public final class Manifest: ObjectIdentifierProtocol {
             _requiredTargets[productFilter] = targets
             return targets
         }
+        #else
+        return self.targets
+        #endif
     }
 
     /// Returns the package dependencies required for a particular products filter.
@@ -212,6 +216,7 @@ public final class Manifest: ObjectIdentifierProtocol {
         }
 
         return dependencies.compactMap { dependency in
+            #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
             if let filter = associations[dependency.name] {
                 return FilteredDependencyDescription(declaration: dependency, productFilter: filter)
             } else if keepUnused {
@@ -221,6 +226,9 @@ public final class Manifest: ObjectIdentifierProtocol {
                 // Dependencies known to not have any relevant products are discarded.
                 return nil
             }
+            #else
+            return FilteredDependencyDescription(declaration: dependency, productFilter: .everything)
+            #endif
         }
     }
 

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -739,7 +739,9 @@ class PackageGraphTests: XCTestCase {
 
         DiagnosticsEngineTester(diagnostics) { result in
             result.check(diagnostic: "dependency 'Baz' is not used by any target", behavior: .warning)
+            #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
             result.check(diagnostic: "dependency 'Biz' is not used by any target", behavior: .warning)
+            #endif
         }
     }
 
@@ -1077,7 +1079,12 @@ class PackageGraphTests: XCTestCase {
         }
     }
 
-    func testUnreachableProductsSkipped() {
+    func testUnreachableProductsSkipped() throws {
+        #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
+        #else
+        try XCTSkipIf(true)
+        #endif
+
         let fs = InMemoryFileSystem(emptyFiles:
             "/Root/Sources/Root/Root.swift",
             "/Immediate/Sources/ImmediateUsed/ImmediateUsed.swift",

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -1058,7 +1058,12 @@ final class PubgrubTests: XCTestCase {
         ])
     }
 
-    func testUnreachableProductsSkipped() {
+    func testUnreachableProductsSkipped() throws {
+        #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
+        #else
+        try XCTSkipIf(true)
+        #endif
+
         builder.serve("root", at: .unversioned, with: [
             "root": ["immediate": (.versionSet(v1Range), .specific(["ImmediateUsed"]))]
         ])

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -360,6 +360,11 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
     }
 
     func testDependencyConstraints() throws {
+        #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
+        #else
+        try XCTSkipIf(true)
+        #endif
+
         let dependencies = [
             PackageDependencyDescription(name: "Bar1", url: "/Bar1", requirement: .upToNextMajor(from: "1.0.0")),
             PackageDependencyDescription(name: "Bar2", url: "/Bar2", requirement: .upToNextMajor(from: "1.0.0")),

--- a/Tests/PackageModelTests/ManifestTests.swift
+++ b/Tests/PackageModelTests/ManifestTests.swift
@@ -56,11 +56,13 @@ class ManifestTests: XCTestCase {
                 targets: targets
             )
 
+            #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
             XCTAssertEqual(manifest.targetsRequired(for: .specific(["Foo", "Bar"])).map({ $0.name }).sorted(), [
                 "Bar",
                 "Baz",
                 "Foo",
             ])
+            #endif
         }
     }
 
@@ -150,11 +152,13 @@ class ManifestTests: XCTestCase {
                 targets: targets
             )
 
+            #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
             XCTAssertEqual(manifest.dependenciesRequired(for: .specific(["Foo"])).map({ $0.declaration.name }).sorted(), [
                 "Bar1", // Foo → Foo1 → Bar1
                 "Bar2", // Foo → Foo1 → Foo2 → Bar2
                 // (Bar3 is unreachable.)
             ])
+            #endif
         }
     }
 }

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -86,11 +86,20 @@ class PIFBuilderTests: XCTestCase {
             let targetAExeDependencies = pif.workspace.projects[0].targets[0].dependencies
             XCTAssertEqual(targetAExeDependencies.map{ $0.targetGUID }, ["PACKAGE-PRODUCT:blib", "PACKAGE-TARGET:A2", "PACKAGE-TARGET:A3"])
             let projectBTargetNames = pif.workspace.projects[1].targets.map({ $0.name })
+            #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
             XCTAssertEqual(projectBTargetNames, ["blib", "B2"])
+            #else
+            XCTAssertEqual(projectBTargetNames, ["bexe", "blib", "B2"])
+            #endif
         }
     }
 
-    func testProject() {
+    func testProject() throws {
+        #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
+        #else
+        try XCTSkipIf(true)
+        #endif
+
         let fs = InMemoryFileSystem(emptyFiles:
             "/Foo/Sources/foo/main.swift",
             "/Foo/Tests/FooTests/tests.swift",
@@ -675,7 +684,12 @@ class PIFBuilderTests: XCTestCase {
         }
     }
 
-    func testTestProducts() {
+    func testTestProducts() throws {
+        #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
+        #else
+        try XCTSkipIf(true)
+        #endif
+
         let fs = InMemoryFileSystem(emptyFiles:
             "/Foo/Sources/FooTests/FooTests.swift",
             "/Foo/Sources/CFooTests/CFooTests.m",


### PR DESCRIPTION
We are seeing some issues with the full implementation of target-based dependency resolution done in #2749 and need to temporarily disable it to unblock affected projects. The changes are still available behind a compile-time define `ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION` and the tests have been modified accordingly to work in both cases (some tests are skipped by default for now and only enabled when enabling target-based dependency resolution).

I haven't yet distilled the issues into test cases, but once I have I'll start a branch of re-enabling this again.

rdar://problem/65284674