### PR TITLE
Remove print statement

### DIFF
--- a/Sources/SPMTestSupport/XCTAssertHelpers.swift
+++ b/Sources/SPMTestSupport/XCTAssertHelpers.swift
@@ -32,7 +32,6 @@ public func XCTAssertBuilds(
 ) {
     for conf in configurations {
         do {
-            print("    Building \(conf)")
             _ = try executeSwiftBuild(
                 path,
                 configuration: conf,


### PR DESCRIPTION
This ends up polluting the output of `swift test` quite a bit and doesn't seem very useful. I am assuming it was just accidentally left there.