### PR TITLE
[bootstrap] Add a --skip-cmake-bootstrap flag to use a prebuilt swift-build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,24 +31,27 @@ endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 option(BUILD_SHARED_LIBS "Build shared libraries by default" YES)
+option(FIND_PM_DEPS "Search for all external Package Manager dependencies" YES)
 
 string(COMPARE EQUAL ${CMAKE_SYSTEM_NAME} Windows CMAKE_INSTALL_DEFAULT)
 option(USE_CMAKE_INSTALL
   "Install build products using cmake's install() instead of the bootstrap script's install()"
   ${CMAKE_INSTALL_DEFAULT})
 
-find_package(TSC CONFIG REQUIRED)
+if(FIND_PM_DEPS)
+  find_package(TSC CONFIG REQUIRED)
 
-find_package(LLBuild CONFIG)
-if(NOT LLBuild_FOUND)
-  find_package(LLBuild REQUIRED)
+  find_package(LLBuild CONFIG)
+  if(NOT LLBuild_FOUND)
+    find_package(LLBuild REQUIRED)
+  endif()
+
+  find_package(ArgumentParser CONFIG REQUIRED)
+  find_package(SwiftDriver CONFIG REQUIRED)
 endif()
 
 find_package(dispatch QUIET)
 find_package(Foundation QUIET)
-
-find_package(ArgumentParser CONFIG REQUIRED)
-find_package(SwiftDriver CONFIG REQUIRED)
 
 add_subdirectory(Sources)
 add_subdirectory(cmake/modules)

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -120,6 +120,10 @@ def add_build_args(parser):
         action="store_true",
         help="enables building SwiftPM in release mode")
     parser.add_argument(
+        "--skip-cmake-bootstrap",
+        action="store_true",
+        help="build with prebuilt package manager in toolchain if it exists")
+    parser.add_argument(
         "--libswiftpm-install-dir",
         metavar='PATH',
         help="where to install libSwiftPM")
@@ -198,6 +202,8 @@ def parse_build_args(args):
     args.bootstrap_dir = os.path.join(args.target_dir, "bootstrap")
     args.conf = 'release' if args.release else 'debug'
     args.bin_dir = os.path.join(args.target_dir, args.conf)
+    args.bootstrap = not args.skip_cmake_bootstrap or \
+                     not os.path.exists(os.path.join(os.path.split(args.swiftc_path)[0], "swift-build"))
 
 def parse_test_args(args):
     """Parses and cleans arguments necessary for the test action."""
@@ -296,10 +302,12 @@ def build(args):
     if not args.llbuild_build_dir:
         build_llbuild(args)
 
-    build_tsc(args)
-    build_yams(args)
-    build_swift_argument_parser(args)
-    build_swift_driver(args)
+    if args.bootstrap:
+        build_tsc(args)
+        build_yams(args)
+        build_swift_argument_parser(args)
+        build_swift_driver(args)
+
     build_swiftpm_with_cmake(args)
     build_swiftpm_with_swiftpm(args,integrated_swift_driver=False)
 
@@ -433,7 +441,7 @@ def install_binary(args, binary, dest_dir):
 # Build functions
 # -----------------------------------------------------------
 
-def build_with_cmake(args, cmake_args, source_path, build_dir):
+def build_with_cmake(args, cmake_args, source_path, build_dir, targets=[]):
     """Runs CMake if needed, then builds with Ninja."""
     cache_path = os.path.join(build_dir, "CMakeCache.txt")
     if args.reconfigure or not os.path.isfile(cache_path) or not args.swiftc_path in open(cache_path).read():
@@ -460,6 +468,8 @@ def build_with_cmake(args, cmake_args, source_path, build_dir):
 
     if args.verbose:
         ninja_cmd.append("-v")
+
+    ninja_cmd += targets
 
     call(ninja_cmd, cwd=build_dir, verbose=args.verbose)
 
@@ -558,19 +568,25 @@ def build_swiftpm_with_cmake(args):
     """Builds SwiftPM using CMake."""
     note("Building SwiftPM (with CMake)")
 
-    cmake_flags = [
-        get_llbuild_cmake_arg(args),
-        "-DTSC_DIR=" + os.path.join(args.tsc_build_dir, "cmake/modules"),
-        "-DYams_DIR=" + os.path.join(args.yams_build_dir, "cmake/modules"),
-        "-DArgumentParser_DIR=" + os.path.join(args.swift_argument_parser_build_dir, "cmake/modules"),
-        "-DSwiftDriver_DIR=" + os.path.join(args.swift_driver_build_dir, "cmake/modules"),
-    ]
+    if args.bootstrap:
+        cmake_flags = [
+            get_llbuild_cmake_arg(args),
+            "-DTSC_DIR=" + os.path.join(args.tsc_build_dir, "cmake/modules"),
+            "-DYams_DIR=" + os.path.join(args.yams_build_dir, "cmake/modules"),
+            "-DArgumentParser_DIR=" + os.path.join(args.swift_argument_parser_build_dir, "cmake/modules"),
+            "-DSwiftDriver_DIR=" + os.path.join(args.swift_driver_build_dir, "cmake/modules"),
+            "-DFIND_PM_DEPS:BOOL=YES",
+        ]
+    else:
+        cmake_flags = [ "-DFIND_PM_DEPS:BOOL=NO" ]
 
     if platform.system() == 'Darwin':
         cmake_flags.append("-DCMAKE_C_FLAGS=-target %s%s" % (get_build_target(args), g_macos_deployment_target))
         cmake_flags.append("-DCMAKE_OSX_DEPLOYMENT_TARGET=%s" % g_macos_deployment_target)
 
-    build_with_cmake(args, cmake_flags, args.project_root, args.bootstrap_dir)
+    targets = [] if args.bootstrap else ["PD4", "PD4_2"]
+
+    build_with_cmake(args, cmake_flags, args.project_root, args.bootstrap_dir, targets)
 
     if args.llbuild_link_framework:
         add_rpath_for_cmake_build(args, args.llbuild_build_dir)
@@ -582,15 +598,22 @@ def build_swiftpm_with_cmake(args):
 
 def build_swiftpm_with_swiftpm(args, integrated_swift_driver):
     """Builds SwiftPM using the version of SwiftPM built with CMake."""
-    note("Building SwiftPM (with swift-build)")
 
     swiftpm_args = [
         "SWIFT_EXEC=" + args.swiftc_path,
         "SWIFT_DRIVER_SWIFT_EXEC=" + args.swiftc_path,
-        "SWIFTPM_PD_LIBS=" + os.path.join(args.bootstrap_dir, "pm"),
-        os.path.join(args.bootstrap_dir, "bin/swift-build"),
-        "--disable-sandbox",
     ]
+
+    if args.bootstrap:
+        note("Building SwiftPM (with a freshly built swift-build)")
+        swiftpm_args.append("SWIFTPM_PD_LIBS=" + os.path.join(args.bootstrap_dir, "pm"))
+        swiftpm_args.append(os.path.join(args.bootstrap_dir, "bin/swift-build"))
+    else:
+        note("Building SwiftPM (with a prebuilt swift-build)")
+        swiftpm_args.append(os.path.join(os.path.split(args.swiftc_path)[0], "swift-build"))
+
+    swiftpm_args.append("--disable-sandbox")
+
     if integrated_swift_driver:
         swiftpm_args.append("--use-integrated-swift-driver")
 
@@ -660,19 +683,20 @@ def get_swiftpm_env_cmd(args):
     env_cmd.append("SWIFTCI_USE_LOCAL_DEPS=1")
     env_cmd.append("SWIFTPM_MACOS_DEPLOYMENT_TARGET=%s" % g_macos_deployment_target)
 
-    libs_joined = ":".join([
-        os.path.join(args.bootstrap_dir, "lib"),
-        os.path.join(args.tsc_build_dir, "lib"),
-        os.path.join(args.llbuild_build_dir, "lib"),
-        os.path.join(args.yams_build_dir, "lib"),
-        os.path.join(args.swift_argument_parser_build_dir, "lib"),
-        os.path.join(args.swift_driver_build_dir, "lib"),
-    ] + args.target_info["paths"]["runtimeLibraryPaths"])
+    if args.bootstrap:
+        libs_joined = ":".join([
+            os.path.join(args.bootstrap_dir, "lib"),
+            os.path.join(args.tsc_build_dir, "lib"),
+            os.path.join(args.llbuild_build_dir, "lib"),
+            os.path.join(args.yams_build_dir, "lib"),
+            os.path.join(args.swift_argument_parser_build_dir, "lib"),
+            os.path.join(args.swift_driver_build_dir, "lib"),
+        ] + args.target_info["paths"]["runtimeLibraryPaths"])
 
-    if platform.system() == 'Darwin':
-        env_cmd.append("DYLD_LIBRARY_PATH=%s" % libs_joined)
-    else:
-        env_cmd.append("LD_LIBRARY_PATH=%s" % libs_joined)
+        if platform.system() == 'Darwin':
+            env_cmd.append("DYLD_LIBRARY_PATH=%s" % libs_joined)
+        else:
+            env_cmd.append("LD_LIBRARY_PATH=%s" % libs_joined)
 
     return env_cmd
 


### PR DESCRIPTION
Rather than building with CMake and then using that freshly built swift-build to build it with itself, add this flag to check for a prebuilt swift-build next to swiftc and use that instead if it's there. The PackageDescription libraries are still built using CMake, as this repo's Package.swift only builds the latest 4_2 version.

This is part of [my patches to cross-compile the corelibs and SPM for Android using the official prebuilt Swift toolchain for Ubuntu](https://github.com/termux/termux-packages/tree/master/packages/swift), as it doesn't make sense to rebuild a native SPM before cross-compiling it, since the official toolchain already has a native swift-build.

I tested this pull with the Oct. 22 source snapshot and official prebuilt snapshot toolchain after applying this small patch to build-script in the main Swift repo:
```
diff --git a/utils/build-script b/utils/build-script
index 639f790fe3..2d208781e1 100755
--- a/utils/build-script
+++ b/utils/build-script
@@ -321,7 +321,7 @@ def apply_default_arguments(toolchain, args):
     # SwiftPM and XCTest have a dependency on Foundation.
     # On OS X, Foundation is built automatically using xcodebuild.
     # On Linux, we must ensure that it is built manually.
-    if ((args.build_swiftpm or args.build_xctest) and
+    if ((args.build_swift or args.build_xctest) and
             platform.system() != "Darwin"):
         args.build_foundation = True
 
diff --git a/utils/build-script-impl b/utils/build-script-impl
index 185f6bf555..d6a4e01fd0 100755
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2456,7 +2456,7 @@ for host in "${ALL_HOSTS[@]}"; do
         # some LLVM tools like TableGen. In the LLVM configure rules
         # above, a small subset of LLVM build_targets are selected
         # when SKIP_BUILD is set.
-        if [[ $(not ${SKIP_BUILD}) || "${product}" == "llvm" ]]; then
+        if [[ $(not ${SKIP_BUILD}) && "${product}" != "llvm" ]]; then
             if [[ "${CMAKE_GENERATOR}" == "Xcode" ]] ; then
                 # Xcode generator uses "ALL_BUILD" instead of "all".
                 # Also, xcodebuild uses -target instead of bare names.
diff --git a/utils/swift_build_support/swift_build_support/products/swiftpm.py b/utils/swift_build_support/swift_build_support/products/swiftpm.py
index 25e982e23f..18b626f3be 100644
--- a/utils/swift_build_support/swift_build_support/products/swiftpm.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftpm.py
@@ -60,7 +60,7 @@ class SwiftPM(product.Product):
             helper_cmd.append("--release")
 
         helper_cmd += [
-            "--swiftc-path", swiftc,
+            #"--swiftc-path", swiftc,
             "--clang-path", self.toolchain.cc,
             "--cmake-path", self.toolchain.cmake,
             "--ninja-path", self.toolchain.ninja,
```
The first two were not strictly necessary, but allowed me to skip building LLVM and corelibs targets that aren't needed. I then added the prebuilt Swift to my path and built, tested, and installed SPM without bootstrapping without a problem, similar to how I did the same with the corelibs in apple/swift#32922:
```
export PATH=/home/butta/swift/swift-DEVELOPMENT-SNAPSHOT-2020-10-22-a-ubuntu20.04/usr/bin:$PATH

./swift/utils/build-script -R --no-assertions --skip-build-cmark --skip-build-llvm --skip-build-swift -p -T --install-swiftpm
```
I~t might make sense to~ added a flag to ~dis~enable this, ~and force~defaulting to a bootstrap build even if a prebuilt swift-build is found, say if you made some changes to the SPM source that require bootstrapping with a modified SPM. I will submit a pull next so that a prebuilt Swift toolchain can be passed to the build-script and the single needed build-script patch above won't be.

Since some of this pull just avoids dependencies in the CMake build that are no longer needed when only building the PackageDescription libraries with CMake, it might be better to get the other PD library built with Package.swift and the prebuilt SPM instead, but I don't know if that's possible or why it isn't already done.