### PR TITLE
Wasm executables should have .wasm extension

### DIFF
--- a/swift-tools-support-core/Sources/TSCUtility/Triple.swift
+++ b/swift-tools-support-core/Sources/TSCUtility/Triple.swift
@@ -187,7 +187,7 @@ extension Triple {
       case .linux:
         return ""
       case .wasi:
-        return ""
+        return ".wasm"
       case .windows:
         return ".exe"
       }


### PR DESCRIPTION
Mirrors https://github.com/apple/swift-tools-support-core/pull/153.