### PR TITLE
Workspace: allow passing extra swiftc flags via Info.plist

### DIFF
--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -218,6 +218,7 @@ public final class UserToolchain: Toolchain {
                 if let SDKROOT = ProcessEnv.vars["SDKROOT"], let root = try? AbsolutePath(validating: SDKROOT) {
                     var runtime: [String] = []
                     var xctest: [String] = []
+                    var extraSwiftCFlags: [String] = []
 
                     if let settings = WindowsSDKSettings(reading: root.appending(component: "SDKSettings.plist"),
                                                          diagnostics: nil, filesystem: localFileSystem) {
@@ -247,10 +248,12 @@ public final class UserToolchain: Toolchain {
                                 "-I", path.appending(RelativePath("usr/lib/swift/windows/\(triple.arch)")).pathString,
                                 "-L", path.appending(RelativePath("usr/lib/swift/windows")).pathString,
                             ]
+
+                            extraSwiftCFlags = info.defaults.extraSwiftCFlags ??  []
                         }
                     }
 
-                    return [ "-sdk", root.pathString, ] + runtime + xctest
+                    return [ "-sdk", root.pathString, ] + runtime + xctest + extraSwiftCFlags
                 }
             }
 

--- a/Sources/Workspace/WindowsToolchainInfo.swift
+++ b/Sources/Workspace/WindowsToolchainInfo.swift
@@ -74,6 +74,10 @@ public struct WindowsPlatformInfo {
         /// XCTEST_VERSION
         /// specifies the version string of the bundled XCTest.
         public let xctestVersion: String
+
+        /// SWIFTC_FLAGS
+        /// Specifies extra flags to pass to swiftc from Swift Package Manager.
+        public let extraSwiftCFlags: [String]?
     }
 
     public let defaults: DefaultProperties
@@ -82,6 +86,7 @@ public struct WindowsPlatformInfo {
 extension WindowsPlatformInfo.DefaultProperties: Decodable {
     enum CodingKeys: String, CodingKey {
     case xctestVersion = "XCTEST_VERSION"
+    case extraSwiftCFlags = "SWIFTC_FLAGS"
     }
 }
 


### PR DESCRIPTION
Add the support for the platform to specify extra flags to the Swift
compiler.  This is intended to be used for Windows to pass `-use-ld=lld`
by default when building SPM.  The reason to prefer this the
configuration is that using the native tools is preferable normally,
however, when building with SPM, the AST wrapping and debug info
generation tends to confuse link.exe sometimes.  Additionally, extra
flags are required for using link which are not required when using lld
(namely, `/incremental:no` to avoid incremental linking which will add
padding to the metadata which the runtime does not expect).