### PR TITLE
Revert "adjust tests to changes from TSC"

### DIFF
--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -324,7 +324,7 @@ final class BuildPlanTests: XCTestCase {
             XCTAssertMatch(linkedFileList.description, .contains("PkgLib"))
             XCTAssertNoMatch(linkedFileList.description, .contains("ExtLib"))
 
-            try testWithTemporaryDirectory { path in
+            mktmpdir { path in
                 let yaml = path.appending(component: "release.yaml")
                 let llbuild = LLBuildManifestBuilder(plan)
                 try llbuild.generateManifest(at: yaml)
@@ -350,7 +350,7 @@ final class BuildPlanTests: XCTestCase {
             XCTAssertNoMatch(linkedFileList.description, .contains("PkgLib"))
             XCTAssertNoMatch(linkedFileList.description, .contains("ExtLib"))
 
-            try testWithTemporaryDirectory { path in
+            mktmpdir { path in
                 let yaml = path.appending(component: "debug.yaml")
                 let llbuild = LLBuildManifestBuilder(plan)
                 try llbuild.generateManifest(at: yaml)
@@ -722,7 +722,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #endif
 
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             let yaml = path.appending(component: "debug.yaml")
             let llbuild = LLBuildManifestBuilder(plan)
             try llbuild.generateManifest(at: yaml)
@@ -2078,7 +2078,7 @@ final class BuildPlanTests: XCTestCase {
 
         let plan = try BuildPlan(buildParameters: mockBuildParameters(), graph: graph, diagnostics: diagnostics, fileSystem: fs)
 
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             let yaml = path.appending(component: "debug.yaml")
             let llbuild = LLBuildManifestBuilder(plan)
             try llbuild.generateManifest(at: yaml)
@@ -2130,7 +2130,7 @@ final class BuildPlanTests: XCTestCase {
           XCTAssertNoMatch(barTarget, [.anySequence, "-fmodule-map-file=/path/to/build/debug/Foo.build/module.modulemap", .anySequence])
         #endif
 
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             let yaml = path.appending(component: "debug.yaml")
             let llbuild = LLBuildManifestBuilder(plan)
             try llbuild.generateManifest(at: yaml)
@@ -2198,7 +2198,7 @@ final class BuildPlanTests: XCTestCase {
            XCTAssertNoMatch(barTarget, [.anySequence, "-fmodule-map-file=/path/to/build/debug/Foo.build/module.modulemap", .anySequence])
          #endif
 
-        try testWithTemporaryDirectory { path in
+         mktmpdir { path in
              let yaml = path.appending(component: "debug.yaml")
              let llbuild = LLBuildManifestBuilder(plan)
              try llbuild.generateManifest(at: yaml)
@@ -2267,7 +2267,7 @@ final class BuildPlanTests: XCTestCase {
            XCTAssertNoMatch(barTarget, [.anySequence, "-fmodule-map-file=/path/to/build/debug/Foo.build/module.modulemap", .anySequence])
          #endif
 
-        try testWithTemporaryDirectory { path in
+         mktmpdir { path in
              let yaml = path.appending(component: "debug.yaml")
              let llbuild = LLBuildManifestBuilder(plan)
              try llbuild.generateManifest(at: yaml)
@@ -2314,7 +2314,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertTrue(objects.contains(AbsolutePath("/path/to/build/debug/exe.build/exe.swiftmodule.o")), objects.description)
         XCTAssertTrue(objects.contains(AbsolutePath("/path/to/build/debug/lib.build/lib.swiftmodule.o")), objects.description)
 
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             let yaml = path.appending(component: "debug.yaml")
             let llbuild = LLBuildManifestBuilder(result.plan)
             try llbuild.generateManifest(at: yaml)

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -288,7 +288,7 @@ final class PackageToolTests: XCTestCase {
     }
 
     func testInitEmpty() throws {
-        try testWithTemporaryDirectory { tmpPath in
+        mktmpdir { tmpPath in
             let fs = localFileSystem
             let path = tmpPath.appending(component: "Foo")
             try fs.createDirectory(path)
@@ -301,7 +301,7 @@ final class PackageToolTests: XCTestCase {
     }
 
     func testInitExecutable() throws {
-        try testWithTemporaryDirectory { tmpPath in
+        mktmpdir { tmpPath in
             let fs = localFileSystem
             let path = tmpPath.appending(component: "Foo")
             try fs.createDirectory(path)
@@ -321,7 +321,7 @@ final class PackageToolTests: XCTestCase {
     }
 
     func testInitLibrary() throws {
-        try testWithTemporaryDirectory { tmpPath in
+        mktmpdir { tmpPath in
             let fs = localFileSystem
             let path = tmpPath.appending(component: "Foo")
             try fs.createDirectory(path)
@@ -336,7 +336,7 @@ final class PackageToolTests: XCTestCase {
     }
 
     func testInitCustomNameExecutable() throws {
-        try testWithTemporaryDirectory { tmpPath in
+        mktmpdir { tmpPath in
             let fs = localFileSystem
             let path = tmpPath.appending(component: "Foo")
             try fs.createDirectory(path)
@@ -609,8 +609,8 @@ final class PackageToolTests: XCTestCase {
         }
     }
 
-    func testSymlinkedDependency() throws {
-        try testWithTemporaryDirectory { path in
+    func testSymlinkedDependency() {
+        mktmpdir { path in
             let fs = localFileSystem
             let root = path.appending(components: "root")
             let dep = path.appending(components: "dep")
@@ -659,8 +659,8 @@ final class PackageToolTests: XCTestCase {
         }
     }
 
-    func testWatchmanXcodeprojgen() throws {
-        try testWithTemporaryDirectory { path in
+    func testWatchmanXcodeprojgen() {
+        mktmpdir { path in
             let fs = localFileSystem
             let diagnostics = DiagnosticsEngine()
 
@@ -690,8 +690,8 @@ final class PackageToolTests: XCTestCase {
         }
     }
 
-    func testMirrorConfig() throws {
-        try testWithTemporaryDirectory { prefix in
+    func testMirrorConfig() {
+        mktmpdir { prefix in
             let fs = localFileSystem
             let packageRoot = prefix.appending(component: "Foo")
             let configOverride = prefix.appending(component: "configoverride")
@@ -758,7 +758,7 @@ final class PackageToolTests: XCTestCase {
     func testPackageLoadingCommandPathResilience() throws {
       #if os(macOS)
         fixture(name: "ValidLayouts/SingleModule") { prefix in
-            try testWithTemporaryDirectory { tmpdir in
+            mktmpdir { tmpdir in
                 // Create fake `xcrun` and `sandbox-exec` commands.
                 let fakeBinDir = tmpdir
                 for fakeCmdName in ["xcrun", "sandbox-exec"] {

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -528,7 +528,7 @@ class MiscellaneousTestCase: XCTestCase {
             return
         }
 
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             let fs = localFileSystem
 
             let package = path.appending(component: "foo")

--- a/Tests/FunctionalTests/ToolsVersionTests.swift
+++ b/Tests/FunctionalTests/ToolsVersionTests.swift
@@ -21,7 +21,7 @@ import Workspace
 class ToolsVersionTests: XCTestCase {
 
     func testToolsVersion() throws {
-        try testWithTemporaryDirectory{ path in
+        mktmpdir { path in
             let fs = localFileSystem
 
             // Create a repo for the dependency to test against.

--- a/Tests/FunctionalTests/VersionSpecificTests.swift
+++ b/Tests/FunctionalTests/VersionSpecificTests.swift
@@ -19,7 +19,7 @@ import SPMTestSupport
 class VersionSpecificTests: XCTestCase {
     /// Functional tests of end-to-end support for version specific dependency resolution.
     func testEndToEndResolution() throws {
-        try testWithTemporaryDirectory{ path in
+        mktmpdir { path in
             let fs = localFileSystem
 
             // Create a repo for the dependency to test against.

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -503,8 +503,8 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
     }
     
     
-    func testMissingBranchDiagnostics() throws {
-        try testWithTemporaryDirectory { tmpDir in
+    func testMissingBranchDiagnostics() {
+        mktmpdir { tmpDir in
             // Create a repository.
             let packageDir = tmpDir.appending(component: "SomePackage")
             try localFileSystem.createDirectory(packageDir)

--- a/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
+++ b/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
@@ -17,22 +17,22 @@ import PackageLoading
 class ManifestLoadingPerfTests: XCTestCasePerf {
     let manifestLoader = ManifestLoader(manifestResources: Resources.default)
 
-    func write(_ bytes: ByteString, body: (AbsolutePath) -> ()) throws {
-        try testWithTemporaryDirectory { tmpdir in
-            let manifestFile = tmpdir.appending(component: "Package.swift")
+    func write(_ bytes: ByteString, body: (AbsolutePath) -> ()) {
+        mktmpdir { path in
+            let manifestFile = path.appending(component: "Package.swift")
             try localFileSystem.writeFileContents(manifestFile, bytes: bytes)
-            body(tmpdir)
+            body(path)
         }
     }
 
-    func testTrivialManifestLoading_X1() throws {
+    func testTrivialManifestLoading_X1() {
       #if os(macOS)
         let N = 1
         let trivialManifest = ByteString(encodingAsUTF8: ("""
             import PackageDescription
             let package = Package(name: "Trivial")
             """))
-        try write(trivialManifest) { path in
+        write(trivialManifest) { path in
             measure {
                 for _ in 0..<N {
                     let manifest = try! self.manifestLoader.load(
@@ -47,7 +47,7 @@ class ManifestLoadingPerfTests: XCTestCasePerf {
       #endif
     }
 
-    func testNonTrivialManifestLoading_X1() throws {
+    func testNonTrivialManifestLoading_X1() {
       #if os(macOS)
         let N = 1
         let manifest = ByteString(encodingAsUTF8: """
@@ -64,7 +64,7 @@ class ManifestLoadingPerfTests: XCTestCasePerf {
             )
             """)
 
-        try write(manifest) { path in
+        write(manifest) { path in
             measure {
                 for _ in 0..<N {
                     let manifest = try! self.manifestLoader.load(

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -443,8 +443,8 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
         }
     }
 
-    func testCacheInvalidationOnEnv() throws {
-        try testWithTemporaryDirectory { path in
+    func testCacheInvalidationOnEnv() {
+        mktmpdir { path in
             let fs = localFileSystem
 
             let manifestPath = path.appending(components: "pkg", "Package.swift")
@@ -499,8 +499,8 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
         }
     }
 
-    func testCaching() throws {
-        try testWithTemporaryDirectory { path in
+    func testCaching() {
+        mktmpdir { path in
             let fs = localFileSystem
 
             let manifestPath = path.appending(components: "pkg", "Package.swift")
@@ -579,7 +579,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testContentBasedCaching() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             let stream = BufferedOutputByteStream()
             stream <<< """
                 import PackageDescription

--- a/Tests/PackageLoadingTests/PD5LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5LoadingTests.swift
@@ -323,7 +323,7 @@ class PackageDescription5LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testSerializedDiagnostics() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             let fs = localFileSystem
 
             let manifestPath = path.appending(components: "pkg", "Package.swift")

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -56,7 +56,7 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testBrokenSymlink() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             let fs = localFileSystem
 
             let sources = path.appending(components: "Sources", "foo")
@@ -88,7 +88,7 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testSymlinkedSourcesDirectory() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             let fs = localFileSystem
 
             let sources = path.appending(components: "Sources")

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -30,7 +30,7 @@ class GitRepositoryTests: XCTestCase {
 
     /// Test the basic provider functions.
     func testProvider() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             let testRepoPath = path.appending(component: "test-repo")
             try! makeDirectories(testRepoPath)
             initGitRepo(testRepoPath, tag: "1.2.3")
@@ -94,7 +94,7 @@ class GitRepositoryTests: XCTestCase {
     /// `Inputs`, which has known commit hashes. See the `construct.sh` script
     /// contained within it for more information.
     func testRawRepository() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             // Unarchive the static test repository.
             let inputArchivePath = AbsolutePath(#file).parentDirectory.appending(components: "Inputs", "TestRepo.tgz")
             try systemQuietly(["tar", "-x", "-v", "-C", path.pathString, "-f", inputArchivePath.pathString])
@@ -142,7 +142,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testSubmoduleRead() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             let testRepoPath = path.appending(component: "test-repo")
             try makeDirectories(testRepoPath)
             initGitRepo(testRepoPath)
@@ -163,7 +163,7 @@ class GitRepositoryTests: XCTestCase {
 
     /// Test the Git file system view.
     func testGitFileView() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             let testRepoPath = path.appending(component: "test-repo")
             try makeDirectories(testRepoPath)
             initGitRepo(testRepoPath)
@@ -243,7 +243,7 @@ class GitRepositoryTests: XCTestCase {
 
     /// Test the handling of local checkouts.
     func testCheckouts() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             // Create a test repository.
             let testRepoPath = path.appending(component: "test-repo")
             try makeDirectories(testRepoPath)
@@ -289,7 +289,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testFetch() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             // Create a repo.
             let testRepoPath = path.appending(component: "test-repo")
             try makeDirectories(testRepoPath)
@@ -329,7 +329,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testHasUnpushedCommits() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             // Create a repo.
             let testRepoPath = path.appending(component: "test-repo")
             try makeDirectories(testRepoPath)
@@ -365,8 +365,8 @@ class GitRepositoryTests: XCTestCase {
         }
     }
 
-    func testSetRemote() throws {
-        try testWithTemporaryDirectory { path in
+    func testSetRemote() {
+        mktmpdir { path in
             // Create a repo.
             let testRepoPath = path.appending(component: "test-repo")
             try makeDirectories(testRepoPath)
@@ -396,7 +396,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testUncommitedChanges() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             // Create a repo.
             let testRepoPath = path.appending(component: "test-repo")
             try makeDirectories(testRepoPath)
@@ -423,7 +423,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testBranchOperations() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             // Create a repo.
             let testRepoPath = path.appending(component: "test-repo")
             try makeDirectories(testRepoPath)
@@ -453,7 +453,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testCheckoutRevision() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             // Create a repo.
             let testRepoPath = path.appending(component: "test-repo")
             try makeDirectories(testRepoPath)
@@ -496,7 +496,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testSubmodules() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             let provider = GitRepositoryProvider()
 
             // Create repos: foo and bar, foo will have bar as submodule and then later
@@ -577,7 +577,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testAlternativeObjectStoreValidation() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             // Create a repo.
             let testRepoPath = path.appending(component: "test-repo")
             try makeDirectories(testRepoPath)
@@ -608,7 +608,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testAreIgnored() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             // Create a repo.
             let testRepoPath = path.appending(component: "test_repo")
             try makeDirectories(testRepoPath)
@@ -629,7 +629,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testAreIgnoredWithSpaceInRepoPath() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             // Create a repo.
             let testRepoPath = path.appending(component: "test repo")
             try makeDirectories(testRepoPath)
@@ -645,7 +645,7 @@ class GitRepositoryTests: XCTestCase {
     }
 
     func testMissingDefaultBranch() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             // Create a repository.
             let testRepoPath = path.appending(component: "test-repo")
             try makeDirectories(testRepoPath)

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -155,7 +155,7 @@ private class DummyRepositoryManagerDelegate: RepositoryManagerDelegate {
 
 class RepositoryManagerTests: XCTestCase {
     func testBasics() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             let provider = DummyRepositoryProvider()
             let delegate = DummyRepositoryManagerDelegate()
             let manager = RepositoryManager(path: path, provider: provider, delegate: delegate)
@@ -236,7 +236,7 @@ class RepositoryManagerTests: XCTestCase {
     }
 
     func testReset() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             let repos = path.appending(component: "repo")
             let provider = DummyRepositoryProvider()
             let delegate = DummyRepositoryManagerDelegate()
@@ -257,8 +257,8 @@ class RepositoryManagerTests: XCTestCase {
     }
 
     /// Check that the manager is persistent.
-    func testPersistence() throws {
-        try testWithTemporaryDirectory { path in
+    func testPersistence() {
+        mktmpdir { path in
             let provider = DummyRepositoryProvider()
 
             // Do the initial fetch.
@@ -309,7 +309,7 @@ class RepositoryManagerTests: XCTestCase {
     }
 
     func testParallelLookups() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             let provider = DummyRepositoryProvider()
             let delegate = DummyRepositoryManagerDelegate()
             let manager = RepositoryManager(path: path, provider: provider, delegate: delegate)
@@ -342,7 +342,7 @@ class RepositoryManagerTests: XCTestCase {
     }
 
     func testSkipUpdate() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             let repos = path.appending(component: "repo")
             let provider = DummyRepositoryProvider()
             let delegate = DummyRepositoryManagerDelegate()
@@ -373,7 +373,7 @@ class RepositoryManagerTests: XCTestCase {
     }
 
     func testStateFileResilience() throws {
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             // Setup a dummy repository.
             let repos = path.appending(component: "repo")
             let provider = DummyRepositoryProvider()

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -20,7 +20,7 @@ class InitTests: XCTestCase {
     // MARK: TSCBasic package creation for each package type.
     
     func testInitPackageEmpty() throws {
-        try testWithTemporaryDirectory { tmpPath in
+        mktmpdir { tmpPath in
             let fs = localFileSystem
             let path = tmpPath.appending(component: "Foo")
             let name = path.basename
@@ -51,7 +51,7 @@ class InitTests: XCTestCase {
     }
     
     func testInitPackageExecutable() throws {
-        try testWithTemporaryDirectory { tmpPath in
+        mktmpdir { tmpPath in
             let fs = localFileSystem
             let path = tmpPath.appending(component: "Foo")
             let name = path.basename
@@ -96,7 +96,7 @@ class InitTests: XCTestCase {
     }
 
     func testInitPackageLibrary() throws {
-        try testWithTemporaryDirectory { tmpPath in
+        mktmpdir { tmpPath in
             let fs = localFileSystem
             let path = tmpPath.appending(component: "Foo")
             let name = path.basename
@@ -138,7 +138,7 @@ class InitTests: XCTestCase {
     }
     
     func testInitPackageSystemModule() throws {
-        try testWithTemporaryDirectory { tmpPath in
+        mktmpdir { tmpPath in
             let fs = localFileSystem
             let path = tmpPath.appending(component: "Foo")
             let name = path.basename
@@ -168,7 +168,7 @@ class InitTests: XCTestCase {
     }
 
     func testInitManifest() throws {
-        try testWithTemporaryDirectory { tmpPath in
+        mktmpdir { tmpPath in
             let fs = localFileSystem
             let path = tmpPath.appending(component: "Foo")
             let name = path.basename

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -127,7 +127,7 @@ final class WorkspaceTests: XCTestCase {
 
     func testInterpreterFlags() throws {
         let fs = localFileSystem
-        try testWithTemporaryDirectory { path in
+        mktmpdir { path in
             let foo = path.appending(component: "foo")
 
             func createWorkspace(withManifest manifest: (OutputByteStream) -> ()) throws -> Workspace {

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -26,9 +26,9 @@ class GenerateXcodeprojTests: XCTestCase {
         XCTAssertEqual(xcodeprojPath, expectedPath)
     }
 
-    func testXcodebuildCanParseIt() throws {
+    func testXcodebuildCanParseIt() {
       #if os(macOS)
-      try testWithTemporaryDirectory { dstdir in
+        mktmpdir { dstdir in
             let packagePath = dstdir.appending(component: "foo")
             let modulePath = packagePath.appending(components: "Sources", "DummyModuleName")
             try makeDirectories(modulePath)
@@ -80,7 +80,7 @@ class GenerateXcodeprojTests: XCTestCase {
     }
 
     func testXcconfigOverrideValidatesPath() throws {
-        try testWithTemporaryDirectory { dstdir in
+        mktmpdir { dstdir in
             let packagePath = dstdir.appending(component: "Bar")
             let modulePath = packagePath.appending(components: "Sources", "Bar")
             try makeDirectories(modulePath)
@@ -115,7 +115,7 @@ class GenerateXcodeprojTests: XCTestCase {
     }
 
     func testGenerateXcodeprojWithInvalidModuleNames() throws {
-        try testWithTemporaryDirectory { dstdir in
+        mktmpdir { dstdir in
             let packagePath = dstdir.appending(component: "Bar")
             let modulePath = packagePath.appending(components: "Sources", "Modules")
             try makeDirectories(modulePath)
@@ -148,8 +148,9 @@ class GenerateXcodeprojTests: XCTestCase {
         }
     }
 
-    func testGenerateXcodeprojWithoutGitRepo() throws {
-        try testWithTemporaryDirectory { dstdir in
+    func testGenerateXcodeprojWithoutGitRepo() {
+        mktmpdir { dstdir in
+
             let packagePath = dstdir.appending(component: "Foo")
             let modulePath = packagePath.appending(components: "Sources", "DummyModule")
             try makeDirectories(modulePath)
@@ -180,8 +181,8 @@ class GenerateXcodeprojTests: XCTestCase {
         }
     }
 
-    func testGenerateXcodeprojWithDotFiles() throws {
-        try testWithTemporaryDirectory { dstdir in
+    func testGenerateXcodeprojWithDotFiles() {
+        mktmpdir { dstdir in
 
             let packagePath = dstdir.appending(component: "Foo")
             let modulePath = packagePath.appending(components: "Sources", "DummyModule")
@@ -215,8 +216,9 @@ class GenerateXcodeprojTests: XCTestCase {
         }
     }
 
-    func testGenerateXcodeprojWithRootFiles() throws {
-        try testWithTemporaryDirectory { dstdir in
+    func testGenerateXcodeprojWithRootFiles() {
+        mktmpdir { dstdir in
+
             let packagePath = dstdir.appending(component: "Foo")
             let modulePath = packagePath.appending(components: "Sources", "DummyModule")
             try makeDirectories(modulePath)
@@ -252,10 +254,10 @@ class GenerateXcodeprojTests: XCTestCase {
         }
     }
 
-    func testGenerateXcodeprojWithNonSourceFilesInSourceDirectories() throws {
-        try testWithTemporaryDirectory { tmpdir in
+    func testGenerateXcodeprojWithNonSourceFilesInSourceDirectories() {
+        mktmpdir { dstdir in
 
-            let packagePath = tmpdir.appending(component: "Foo")
+            let packagePath = dstdir.appending(component: "Foo")
             let modulePath = packagePath.appending(components: "Sources", "DummyModule")
             try makeDirectories(modulePath)
             try localFileSystem.writeFileContents(modulePath.appending(component: "dummy.swift"), bytes: "dummy_data")
@@ -280,7 +282,7 @@ class GenerateXcodeprojTests: XCTestCase {
             XCTAssertNoDiagnostics(diagnostics)
 
             let projectName = "DummyProjectName"
-            let outpath = Xcodeproj.buildXcodeprojPath(outputDir: tmpdir, projectName: projectName)
+            let outpath = Xcodeproj.buildXcodeprojPath(outputDir: dstdir, projectName: projectName)
             let project = try Xcodeproj.generate(projectName: projectName, xcodeprojPath: outpath, graph: graph, options: XcodeprojOptions(), diagnostics: diagnostics)
 
             let sources = project.mainGroup.subitems[1] as? Xcode.Group
@@ -291,8 +293,8 @@ class GenerateXcodeprojTests: XCTestCase {
         }
     }
 
-    func testGenerateXcodeprojWithFilesIgnoredByGit() throws {
-        try testWithTemporaryDirectory { dstdir in
+    func testGenerateXcodeprojWithFilesIgnoredByGit() {
+        mktmpdir { dstdir in
 
             let packagePath = dstdir.appending(component: "Foo")
             let modulePath = packagePath.appending(components: "Sources", "DummyModule")
@@ -334,8 +336,8 @@ class GenerateXcodeprojTests: XCTestCase {
         }
     }
 
-    func testGenerateXcodeprojWarnsConditionalTargetDependencies() throws {
-        try testWithTemporaryDirectory { dstdir in
+    func testGenerateXcodeprojWarnsConditionalTargetDependencies() {
+        mktmpdir { dstdir in
             let fooPackagePath = dstdir.appending(component: "Foo")
             let fooTargetPath = fooPackagePath.appending(components: "Sources", "Foo")
             try makeDirectories(fooTargetPath)


### PR DESCRIPTION
Reverts apple/swift-package-manager#3008

Seeing failure in CI: 

https://ci.swift.org/job/oss-swift-pr-test/13664/console

```
22:55:23 [36/48] Compiling PackageLoadingPerformanceTests ManifestLoadingTests.swift
22:55:23 /Users/buildnode/jenkins/workspace/oss-swift-pr-test/swiftpm/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift:21:13: error: cannot find 'testWithTemporaryDirectory' in scope
22:55:23         try testWithTemporaryDirectory { tmpdir in
22:55:23             ^~~~~~~~~~~~~~~~~~~~~~~~~~
22:55:23 error: fatalError
```