### PR TITLE
Improve robustness of XCBuild output parser

### DIFF
--- a/Sources/XCBuildSupport/XCBuildDelegate.swift
+++ b/Sources/XCBuildSupport/XCBuildDelegate.swift
@@ -50,7 +50,7 @@ extension XCBuildDelegate: XCBuildOutputParserDelegate {
         case .taskStarted(let info):
             queue.async {
                 self.didEmitProgressOutput = true
-                let text = self.isVerbose ? info.executionDescription + "\n" + info.commandLineDisplayString : info.executionDescription
+                let text = self.isVerbose ? [info.executionDescription, info.commandLineDisplayString].compactMap { $0 }.joined(separator: "\n") : info.executionDescription
                 self.progressAnimation.update(step: self.percentComplete, total: 100, text: text)
             }
         case .taskOutput(let info):


### PR DESCRIPTION
If we fail to parse a message, throw an Error instead of crashing. Also,
mark a few fields which actually can be nil, as optional.

rdar://70919533