### PR TITLE
Make Platform/SupportedPlatform types Equatable

### DIFF
--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -10,7 +10,7 @@
 
 /// A platform that usually corresponds to an operating system such as
 /// iOS, macOS, or Linux.
-public struct Platform: Encodable {
+public struct Platform: Encodable, Equatable {
 
     /// The name of the platform.
     fileprivate let name: String
@@ -64,7 +64,7 @@ public struct Platform: Encodable {
 /// with the top-level package’s deployment version. The deployment
 /// target of a package's dependencies must be lower than or equal to the top-level package's
 /// deployment target version for a particular platform.
-public struct SupportedPlatform: Encodable {
+public struct SupportedPlatform: Encodable, Equatable {
 
     /// The platform.
     let platform: Platform


### PR DESCRIPTION
As reported by @broadwaylamb in SR-13813:

>In my project, I want to only build a SwiftPM target when the platform I'm building for is *not* `.wasi`. For that, I wrote the following code in my `Package.swift`:

```swift
// This list should be updated whenever SwiftPM adds support for a new platform.
let supportedPlatforms: [Platform] = [
    .macOS,
    .iOS,
    .watchOS,
    .tvOS,
    .linux,
    .android,
    .windows,
    .wasi,
]

extension Array where Element: Equatable {
    func except(_ exceptions: [Element]) -> [Element] {
        return filter { platform in
            !exceptions.contains(platform)
        }
    }
}
```

>I expected that I could write:
```swift
.target(name: "WASIIncompatibleTarget",
        condition: .when(platforms: supportedPlatforms.except([.wasi])))
```

>However, that didn't work because `Platform` is not `Equatable. I see no reason why it shouldn't conform to that protocol, and propose that we fix it.