### PR TITLE
Remove instructions to use make in libSwiftPM example.

### DIFF
--- a/Documentation/libSwiftPM.md
+++ b/Documentation/libSwiftPM.md
@@ -17,11 +17,5 @@ package:
 ```sh
 $ git clone https://github.com/apple/swift-package-manager
 $ cd swift-package-manager/Examples/package-info
-$ make build
 $ swift run
 ```
-
-The Makefile in the example package contains commands to build the runtime
-libraries that are required for loading the `Package.swift` manifest files of
-Swift packages. The runtime libraries require (re)building only when the SwiftPM
-checkout is changed.


### PR DESCRIPTION
The Makefile doesn't appear to have existed for some time and the
example appears to run fine without it.