### PR TITLE
Sort targets for outputting to xcodeproj.

### DIFF
--- a/Sources/Xcodeproj/SchemesGenerator.swift
+++ b/Sources/Xcodeproj/SchemesGenerator.swift
@@ -116,7 +116,7 @@ public final class SchemesGenerator {
             """
 
         // Create buildable references for non-test targets.
-        for target in scheme.regularTargets {
+        for target in scheme.regularTargets.sorted(by: { $0.name < $1.name }) {
             stream <<< """
                       <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
                         <BuildableReference
@@ -148,7 +148,7 @@ public final class SchemesGenerator {
             """
 
         // Create testable references.
-        for target in scheme.testTargets {
+        for target in scheme.testTargets.sorted(by: { $0.name < $1.name }) {
             stream <<< """
                         <TestableReference
                           skipped = "NO">

--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -385,7 +385,7 @@ public func xcodeProject(
     // Go through all the targets, creating targets and adding file references
     // to the group tree (the specific top-level group under which they are
     // added depends on whether or not the target is a test target).
-    for target in targets {
+    for target in targets.sorted(by: { $0.name < $1.name }) {
         // Determine the appropriate product type based on the kind of target.
         // FIXME: We should factor this out.
         let productType: Xcode.Target.ProductType


### PR DESCRIPTION
Motivation:
Repeated runs of generate-xcodeproj generate different results
as Set is used to store targets which is ordered by hash.
Hash is randomly seeded between runs making the set be differently
ordered on each run.

Having the output reordered on rerun makes comparison very difficult
and is particularly annoying if the generated project is to be stored
in revision control or similar.

Change:
Sort the targets before output, removing the major
source of differences between runs.