### PR TITLE
add Core module to place common utilities such as FileSystem extensions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -100,54 +100,58 @@ let package = Package(
         // MARK: SwiftPM specific support libraries
 
         .target(
+            name: "Basics",
+            dependencies: ["SwiftToolsSupport-auto"]),
+
+        .target(
             /** The llbuild manifest model */
             name: "LLBuildManifest",
-            dependencies: ["SwiftToolsSupport-auto"]),
+            dependencies: ["SwiftToolsSupport-auto", "Basics"]),
 
         .target(
             /** Source control operations */
             name: "SourceControl",
-            dependencies: ["SwiftToolsSupport-auto"]),
+            dependencies: ["SwiftToolsSupport-auto", "Basics"]),
         .target(
             /** Shim for llbuild library */
             name: "SPMLLBuild",
-            dependencies: ["SwiftToolsSupport-auto"]),
+            dependencies: ["SwiftToolsSupport-auto", "Basics"]),
 
         // MARK: Project Model
 
         .target(
             /** Primitive Package model objects */
             name: "PackageModel",
-            dependencies: ["SwiftToolsSupport-auto"]),
+            dependencies: ["SwiftToolsSupport-auto", "Basics"]),
         .target(
             /** Package model conventions and loading support */
             name: "PackageLoading",
-            dependencies: ["SwiftToolsSupport-auto", "PackageModel"]),
+            dependencies: ["SwiftToolsSupport-auto", "Basics", "PackageModel"]),
 
         // MARK: Package Dependency Resolution
 
         .target(
             /** Data structures and support for complete package graphs */
             name: "PackageGraph",
-            dependencies: ["SwiftToolsSupport-auto", "PackageLoading", "PackageModel", "SourceControl"]),
-        
+            dependencies: ["SwiftToolsSupport-auto", "Basics", "PackageLoading", "PackageModel", "SourceControl"]),
+
         // MARK: Package Collections
 
         .target(
             /** Data structures and support for package collections */
             name: "PackageCollections",
-            dependencies: ["SwiftToolsSupport-auto", "PackageModel", "SourceControl"]),
+            dependencies: ["SwiftToolsSupport-auto", "Basics", "PackageModel", "SourceControl"]),
 
         // MARK: Package Manager Functionality
 
         .target(
             /** Builds Modules and Products */
             name: "SPMBuildCore",
-            dependencies: ["SwiftToolsSupport-auto", "PackageGraph"]),
+            dependencies: ["SwiftToolsSupport-auto", "Basics", "PackageGraph"]),
         .target(
             /** Builds Modules and Products */
             name: "Build",
-            dependencies: ["SwiftToolsSupport-auto", "SPMBuildCore", "PackageGraph", "LLBuildManifest", "SwiftDriver", "SPMLLBuild"]),
+            dependencies: ["SwiftToolsSupport-auto", "Basics", "SPMBuildCore", "PackageGraph", "LLBuildManifest", "SwiftDriver", "SPMLLBuild"]),
         .target(
             /** Support for building using Xcode's build system */
             name: "XCBuildSupport",
@@ -156,18 +160,18 @@ let package = Package(
         .target(
             /** Generates Xcode projects */
             name: "Xcodeproj",
-            dependencies: ["SwiftToolsSupport-auto", "PackageGraph"]),
+            dependencies: ["SwiftToolsSupport-auto", "Basics", "PackageGraph"]),
         .target(
             /** High level functionality */
             name: "Workspace",
-            dependencies: ["SwiftToolsSupport-auto", "SPMBuildCore", "PackageGraph", "PackageModel", "SourceControl", "Xcodeproj"]),
+            dependencies: ["SwiftToolsSupport-auto", "Basics", "SPMBuildCore", "PackageGraph", "PackageModel", "SourceControl", "Xcodeproj"]),
 
         // MARK: Commands
 
         .target(
             /** High-level commands */
             name: "Commands",
-            dependencies: ["SwiftToolsSupport-auto", "Build", "PackageGraph", "SourceControl", "Xcodeproj", "Workspace", "XCBuildSupport", "ArgumentParser"]),
+            dependencies: ["SwiftToolsSupport-auto", "Basics", "Build", "PackageGraph", "SourceControl", "Xcodeproj", "Workspace", "XCBuildSupport", "ArgumentParser"]),
         .target(
             /** The main executable provided by SwiftPM */
             name: "swift-package",
@@ -197,7 +201,7 @@ let package = Package(
         .target(
             /** SwiftPM test support library */
             name: "SPMTestSupport",
-            dependencies: ["SwiftToolsSupport-auto", "TSCTestSupport", "PackageGraph", "PackageLoading", "SourceControl", "Commands", "XCBuildSupport"]),
+            dependencies: ["SwiftToolsSupport-auto", "Basics", "TSCTestSupport", "PackageGraph", "PackageLoading", "SourceControl", "Commands", "XCBuildSupport"]),
 
         // MARK: SwiftPM tests
 

--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -1,0 +1,24 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_library(Basics
+  FileSystem+Extensions.swift)
+target_link_libraries(Basics PUBLIC
+  TSCBasic
+  TSCUtility)
+# NOTE(compnerd) workaround for CMake not setting up include flags yet
+set_target_properties(Basics PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+if(USE_CMAKE_INSTALL)
+install(TARGETS Basics
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
+endif()
+set_property(GLOBAL APPEND PROPERTY SwiftPM_EXPORTS Basics)

--- a/Sources/Basics/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem+Extensions.swift
@@ -1,0 +1,29 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import TSCBasic
+
+extension FileSystem {
+    /// SwiftPM directory under user's home directory (~/.swiftpm)
+    public var dotSwiftPM: AbsolutePath {
+        return self.homeDirectory.appending(component: ".swiftpm")
+    }
+}
+
+extension FileSystem {
+    /// SwiftPM cache directory under usre's caches directory (if exists)
+    public var swiftPMCacheDirectory: AbsolutePath {
+        if let cachesDirectory = self.cachesDirectory {
+            return cachesDirectory.appending(component: "org.swift.swiftpm")
+        } else {
+            return self.dotSwiftPM.appending(component: "cache")
+        }
+    }
+}


### PR DESCRIPTION
motivation: with the introduction of TSC there is no more room for common SwiftPM utilities such as FS extensions

changes:
* add Core module that dependends on TSC and make everything depend on it
* add FS extensions for getting ~/.swiftm and SwiftPM's cache directory
* adjust code to latest TSC FS changes