### PR TITLE
Make SPMTestSupport not require the command line tools (so it can be used for libSwiftPMDataModel)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -201,7 +201,7 @@ let package = Package(
         .target(
             /** SwiftPM test support library */
             name: "SPMTestSupport",
-            dependencies: ["SwiftToolsSupport-auto", "Basics", "TSCTestSupport", "PackageGraph", "PackageLoading", "SourceControl", "Commands", "XCBuildSupport"]),
+            dependencies: ["SwiftToolsSupport-auto", "Basics", "TSCTestSupport", "PackageGraph", "PackageLoading", "SourceControl", "Workspace", "Xcodeproj", "XCBuildSupport"]),
 
         // MARK: SwiftPM tests
 

--- a/Sources/SPMTestSupport/Resources.swift
+++ b/Sources/SPMTestSupport/Resources.swift
@@ -9,9 +9,8 @@
 */
 
 import TSCBasic
-import Build
+import SPMBuildCore
 import Foundation
-import Commands
 import PackageLoading
 import Workspace
 

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -18,7 +18,6 @@ import PackageModel
 import SourceControl
 import TSCUtility
 import Workspace
-import Commands
 
 @_exported import TSCTestSupport
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -2572,22 +2572,6 @@ final class BuildPlanTests: XCTestCase {
         try testBinaryTargets(platform: "macos", arch: "arm64e", destinationTriple: arm64eTriple)
     }
 
-    func testCreatingSanitizers() throws {
-        for sanitizer in Sanitizer.allCases {
-            XCTAssertEqual(sanitizer, try Sanitizer(argument: sanitizer.shortName))
-        }
-    }
-
-    func testInvalidSanitizer() throws {
-        do {
-            _ = try Sanitizer(argument: "invalid")
-            XCTFail("Should have failed to create Sanitizer")
-        } catch let error as ArgumentConversionError {
-            XCTAssertEqual(
-                error.description, "valid sanitizers: address, thread, undefined, scudo")
-        }
-    }
-
     func testAddressSanitizer() throws {
         try sanitizerTest(.address, expectedName: "address")
     }

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -12,6 +12,7 @@ import XCTest
 
 import SPMTestSupport
 import TSCBasic
+import SPMBuildCore
 import Commands
 import Workspace
 
@@ -49,6 +50,22 @@ final class BuildToolTests: XCTestCase {
 
     func testVersion() throws {
         XCTAssert(try execute(["--version"]).stdout.contains("Swift Package Manager"))
+    }
+
+    func testCreatingSanitizers() throws {
+        for sanitizer in Sanitizer.allCases {
+            XCTAssertEqual(sanitizer, try Sanitizer(argument: sanitizer.shortName))
+        }
+    }
+
+    func testInvalidSanitizer() throws {
+        do {
+            _ = try Sanitizer(argument: "invalid")
+            XCTFail("Should have failed to create Sanitizer")
+        } catch let error as ArgumentConversionError {
+            XCTAssertEqual(
+                error.description, "valid sanitizers: address, thread, undefined, scudo")
+        }
     }
 
     func testBinPathAndSymlink() throws {

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -13,7 +13,6 @@ import SPMTestSupport
 import TSCBasic
 import PackageModel
 import Workspace
-import Commands
 
 class InitTests: XCTestCase {
 

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -13,7 +13,7 @@ import TSCBasic
 import TSCUtility
 import PackageModel
 import PackageGraph
-import Build
+import SPMBuildCore
 import XCBuildSupport
 import SPMTestSupport
 

--- a/Tests/XCBuildSupportTests/PIFTests.swift
+++ b/Tests/XCBuildSupportTests/PIFTests.swift
@@ -12,7 +12,7 @@ import XCTest
 import TSCBasic
 import TSCUtility
 import PackageModel
-import Build
+import SPMBuildCore
 import XCBuildSupport
 import SPMTestSupport
 

--- a/Tests/XcodeprojTests/FunctionalTests.swift
+++ b/Tests/XcodeprojTests/FunctionalTests.swift
@@ -11,7 +11,6 @@
 import XCTest
 
 import TSCBasic
-import Commands
 import SPMTestSupport
 import PackageModel
 import TSCUtility


### PR DESCRIPTION
Remove a dependency of the SPMTestSupport target on the Command target, which in turn depends on Build, etc.  This lets the subset of unit tests that doesn't actually require the command line tools to still be used to test libSwiftPMDataModel.

The only real code change needed is to move two tests that are actually testing handling of command line arguments of the `swift-build` tool from BuildPlanTests to BuildToolTests.  This is where it belonged anyway, architecturally, since it's testing command line arguments.