### PR TITLE
[Incremental] Update DriverExecutor protocol to be consistent with swift-driver

### DIFF
--- a/Sources/Build/SPMSwiftDriverExecutor.swift
+++ b/Sources/Build/SPMSwiftDriverExecutor.swift
@@ -57,8 +57,7 @@ final class SPMSwiftDriverExecutor: DriverExecutor {
     return try process.waitUntilExit()
   }
 
-  func execute(jobs: [Job],
-               incrementalCompilationState: IncrementalCompilationState?,
+  func execute(workload: DriverExecutorWorkload,
                delegate: JobExecutionDelegate,
                numParallelJobs: Int, forceResponseFiles: Bool,
                recordedInputModificationDates: [TypedVirtualPath : Date]) throws {

--- a/Sources/Build/SPMSwiftDriverExecutor.swift
+++ b/Sources/Build/SPMSwiftDriverExecutor.swift
@@ -57,7 +57,9 @@ final class SPMSwiftDriverExecutor: DriverExecutor {
     return try process.waitUntilExit()
   }
 
-  func execute(jobs: [Job], delegate: JobExecutionDelegate,
+  func execute(jobs: [Job],
+               incrementalCompilationState: IncrementalCompilationState?,
+               delegate: JobExecutionDelegate,
                numParallelJobs: Int, forceResponseFiles: Bool,
                recordedInputModificationDates: [TypedVirtualPath : Date]) throws {
     fatalError("Multi-job build plans should be lifted into the SPM build graph.")


### PR DESCRIPTION
In order to implement interleaved waves for incremental builds in swift-driver, the `DriverExecutor` protocol was changed. Update `SPMSSwiftDriverExecutor` to conform. 

Requires: https://github.com/apple/swift-driver/pull/351