### PR TITLE
Rewrite spm-manifest-tool using swift-argument-parser and the updated SPMPackageEditor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -316,5 +316,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] != nil {
               dependencies: ["Workspace", "PackageModel", "PackageLoading",
                              "SourceControl", "SwiftSyntax", "SwiftToolsSupport-auto"]),
       .testTarget(name: "SPMPackageEditorTests", dependencies: ["SPMPackageEditor", "SPMTestSupport"]),
+      .target(name: "swiftpm-manifest-tool",
+              dependencies: ["SPMPackageEditor", "ArgumentParser"])
   ]
 }

--- a/Package.swift
+++ b/Package.swift
@@ -305,3 +305,16 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(path: "../swift-driver"),
     ]
 }
+
+// Because SwiftSyntax is closely tied to the compiler, only attempt to build
+// the package editor library if we're in a build-script environment and can
+// assume we're using a just-built compiler and SwiftSyntax library.
+if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] != nil {
+    package.dependencies += [.package(path: "../swift-syntax")]
+    package.targets += [
+      .target(name: "SPMPackageEditor",
+              dependencies: ["Workspace", "PackageModel", "PackageLoading",
+                             "SourceControl", "SwiftSyntax", "SwiftToolsSupport-auto"]),
+      .testTarget(name: "SPMPackageEditorTests", dependencies: ["SPMPackageEditor", "SPMTestSupport"]),
+  ]
+}

--- a/Sources/SPMPackageEditor/PackageEditor.swift
+++ b/Sources/SPMPackageEditor/PackageEditor.swift
@@ -26,8 +26,12 @@ public final class PackageEditor {
     let context: PackageEditorContext
 
     /// Create a package editor instance.
-    public convenience init(buildDir: AbsolutePath, toolchain: UserToolchain) throws {
-        self.init(context: try PackageEditorContext(buildDir: buildDir, toolchain: toolchain))
+    public convenience init(manifestPath: AbsolutePath,
+                            buildDir: AbsolutePath,
+                            toolchain: UserToolchain) throws {
+        self.init(context: try PackageEditorContext(manifestPath: manifestPath,
+                                                    buildDir: buildDir,
+                                                    toolchain: toolchain))
     }
 
     /// Create a package editor instance.
@@ -41,41 +45,40 @@ public final class PackageEditor {
     }
 
     /// Add a package dependency.
-    public func addPackageDependency(options: Options.AddPackageDependency) throws {
-        var options = options
-
+    public func addPackageDependency(url: String, requirement: PackageDependencyRequirement?) throws {
+      var requirement = requirement
+        let manifestPath = context.manifestPath
         // Validate that the package doesn't already contain this dependency.
         // FIXME: We need to handle version-specific manifests.
-        let loadedManifest = try context.loadManifest(at: options.manifestPath.parentDirectory)
+        let loadedManifest = try context.loadManifest(at: context.manifestPath.parentDirectory)
         let containsDependency = loadedManifest.dependencies.contains {
-            return PackageReference.computeIdentity(packageURL: options.url) == PackageReference.computeIdentity(packageURL: $0.url)
+            return PackageReference.computeIdentity(packageURL: url) == PackageReference.computeIdentity(packageURL: $0.url)
         }
         guard !containsDependency else {
-            throw StringError("Already has dependency \(options.url)")
+            throw StringError("Already has dependency \(url)")
         }
 
         // If the input URL is a path, force the requirement to be a local package.
-        if TSCUtility.URL.scheme(options.url) == nil {
-            assert(options.requirement == nil || options.requirement == .localPackage)
-            options.requirement = .localPackage
+        if TSCUtility.URL.scheme(url) == nil {
+            assert(requirement == nil || requirement == .localPackage)
+            requirement = .localPackage
         }
 
         // Load the dependency manifest depending on the inputs.
         let dependencyManifest: Manifest
-        let requirement: PackageDependencyRequirement
-        if options.requirement == .localPackage {
+        if requirement == .localPackage {
             // For local packages, load the manifest and get the first library product name.
-            let path = AbsolutePath(options.url, relativeTo: fs.currentWorkingDirectory!)
+            let path = AbsolutePath(url, relativeTo: fs.currentWorkingDirectory!)
             dependencyManifest = try context.loadManifest(at: path)
             requirement = .localPackage
         } else {
             // Otherwise, first lookup the dependency.
-            let spec = RepositorySpecifier(url: options.url)
+            let spec = RepositorySpecifier(url: url)
             let handle = try await{ context.repositoryManager.lookup(repository: spec, completion: $0) }
             let repo = try handle.open()
 
             // Compute the requirement.
-            if let inputRequirement = options.requirement {
+            if let inputRequirement = requirement {
                 requirement = inputRequirement
             } else {
                 // Use the latest version or the master branch.
@@ -85,15 +88,15 @@ public final class PackageEditor {
             }
 
             // Load the manifest.
-            let revision = try repo.resolveRevision(identifier: requirement.ref!)
+            let revision = try repo.resolveRevision(identifier: requirement!.ref!)
             let repoFS = try repo.openFileView(revision: revision)
             dependencyManifest = try context.loadManifest(at: .root, fs: repoFS)
         }
 
         // Add the package dependency.
-        let manifestContents = try fs.readFileContents(options.manifestPath).cString
+        let manifestContents = try fs.readFileContents(manifestPath).cString
         let editor = try ManifestRewriter(manifestContents)
-        try editor.addPackageDependency(url: options.url, requirement: requirement)
+        try editor.addPackageDependency(url: url, requirement: requirement!)
 
         // Add the product in the first regular target, if possible.
         let productName = dependencyManifest.products.filter{ $0.type.isLibrary }.map{ $0.name }.first
@@ -105,40 +108,39 @@ public final class PackageEditor {
         }
 
         // FIXME: We should verify our edits by loading the edited manifest before writing it to disk.
-        try fs.writeFileContents(options.manifestPath, bytes: ByteString(encodingAsUTF8: editor.editedManifest))
+        try fs.writeFileContents(manifestPath, bytes: ByteString(encodingAsUTF8: editor.editedManifest))
     }
 
     /// Add a new target.
-    public func addTarget(options: Options.AddTarget) throws {
-        let manifest = options.manifestPath
-        let targetName = options.targetName
+    public func addTarget(name targetName: String, type targetType: TargetType?) throws {
+        let manifestPath = context.manifestPath
         let testTargetName = targetName + "Tests"
 
         // Validate that the package doesn't already contain this dependency.
         // FIXME: We need to handle version-specific manifests.
-        let loadedManifest = try context.loadManifest(at: options.manifestPath.parentDirectory)
+        let loadedManifest = try context.loadManifest(at: manifestPath.parentDirectory)
         if loadedManifest.targets.contains(where: { $0.name == targetName }) {
             throw StringError("Already has a target named \(targetName)")
         }
 
-        let manifestContents = try fs.readFileContents(options.manifestPath).cString
+        let manifestContents = try fs.readFileContents(manifestPath).cString
         let editor = try ManifestRewriter(manifestContents)
         try editor.addTarget(targetName: targetName)
         try editor.addTarget(targetName: testTargetName, type: .test)
         try editor.addTargetDependency(target: testTargetName, dependency: targetName)
 
         // FIXME: We should verify our edits by loading the edited manifest before writing it to disk.
-        try fs.writeFileContents(manifest, bytes: ByteString(encodingAsUTF8: editor.editedManifest))
+        try fs.writeFileContents(manifestPath, bytes: ByteString(encodingAsUTF8: editor.editedManifest))
 
         // Write template files.
-        let targetPath = manifest.parentDirectory.appending(components: "Sources", targetName)
+        let targetPath = manifestPath.parentDirectory.appending(components: "Sources", targetName)
         if !localFileSystem.exists(targetPath) {
             let file = targetPath.appending(components: targetName + ".swift")
             try fs.createDirectory(targetPath)
             try fs.writeFileContents(file, bytes: "")
         }
 
-        let testTargetPath = manifest.parentDirectory.appending(components: "Tests", testTargetName)
+        let testTargetPath = manifestPath.parentDirectory.appending(components: "Tests", testTargetName)
         if !fs.exists(testTargetPath) {
             let file = testTargetPath.appending(components: testTargetName + ".swift")
             try fs.createDirectory(testTargetPath)
@@ -204,40 +206,6 @@ public enum PackageDependencyRequirement: Equatable {
     }
 }
 
-public enum Options {
-    public struct AddPackageDependency {
-        public var manifestPath: AbsolutePath
-        public var url: String
-        public var requirement: PackageDependencyRequirement?
-
-        public init(
-            manifestPath: AbsolutePath,
-            url: String,
-            requirement: PackageDependencyRequirement? = nil
-        ) {
-            self.manifestPath = manifestPath
-            self.url = url
-            self.requirement = requirement
-        }
-    }
-
-    public struct AddTarget {
-        public var manifestPath: AbsolutePath
-        public var targetName: String
-        public var targetType: TargetType
-
-        public init(
-            manifestPath: AbsolutePath,
-            targetName: String,
-            targetType: TargetType = .regular
-        ) {
-            self.manifestPath = manifestPath
-            self.targetName = targetName
-            self.targetType = targetType
-        }
-    }
-}
-
 extension ProductType {
     var isLibrary: Bool {
         switch self {
@@ -251,6 +219,8 @@ extension ProductType {
 
 /// The global context for package editor.
 public final class PackageEditorContext {
+    /// Path to the package manifest.
+    let manifestPath: AbsolutePath
 
     /// Path to the build directory of the package.
     let buildDir: AbsolutePath
@@ -264,7 +234,11 @@ public final class PackageEditorContext {
     /// The file system in use.
     let fs: FileSystem
 
-    public init(buildDir: AbsolutePath, toolchain: UserToolchain, fs: FileSystem = localFileSystem) throws {
+    public init(manifestPath: AbsolutePath,
+                buildDir: AbsolutePath,
+                toolchain: UserToolchain,
+                fs: FileSystem = localFileSystem) throws {
+        self.manifestPath = manifestPath
         self.buildDir = buildDir
         self.fs = fs
 

--- a/Sources/swiftpm-manifest-tool/main.swift
+++ b/Sources/swiftpm-manifest-tool/main.swift
@@ -1,135 +1,150 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2019 Apple Inc. and the Swift project authors
+ Copyright (c) 2019-2020 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-import TSCBasic
-import TSCUtility
-import func POSIX.exit
-
 import SPMPackageEditor
-import class PackageModel.Manifest
+import Workspace
+import PackageModel
 
-enum ToolError: Error {
-    case error(String)
-    case noManifest
+import ArgumentParser
+
+/// The root manifest editor command.
+struct ManifestTool: ParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "swiftpm-manifest-tool",
+        abstract: "Mechanically edit SwiftPM manifests.",
+        subcommands: [AddPackageDependency.self, AddTarget.self])
 }
 
-enum Mode: String {
-    case addPackageDependency = "add-package"
-    case addTarget = "add-target"
-    case help
+ManifestTool.main()
+
+// MARK: - Subcommands
+
+/// Options shared by manifest editing subcommands.
+struct ManifestToolOptions: ParsableArguments {
+    @Option
+    var buildPath: AbsolutePath?
 }
 
-struct Options {
-    struct AddPackageDependency {
-        let url: String
+/// Implements the add-package-dependency subcommand.
+struct AddPackageDependency: ParsableCommand {
+
+    @Argument
+    var dependencyURL: String
+
+    @OptionGroup
+    var manifestToolOptions: ManifestToolOptions
+
+    mutating func run() throws {
+        guard let cwd = localFileSystem.currentWorkingDirectory else {
+            throw ValidationError("error: couldn't determine the current working directory")
+        }
+        guard let packageRoot = findPackageRoot() else {
+            throw ValidationError("error: couldn't find a package manifest")
+        }
+        let buildPath = getEnvBuildPath(workingDir: cwd) ??
+            manifestToolOptions.buildPath ??
+            packageRoot.appending(component: ".build")
+        let editor = try PackageEditor(manifestPath: packageRoot.appending(component: Manifest.filename),
+                                       buildDir: buildPath,
+                                       toolchain: UserToolchain(destination: try Destination.hostDestination()))
+        try editor.addPackageDependency(url: dependencyURL, requirement: nil)
     }
-    struct AddTarget {
-        let name: String
-    }
-    var dataPath: AbsolutePath = AbsolutePath("/tmp")
-    var addPackageDependency: AddPackageDependency?
-    var addTarget: AddTarget?
-    var mode = Mode.help
 }
 
-/// Finds the Package.swift manifest file in the current working directory.
-func findPackageManifest() -> AbsolutePath? {
-    guard let cwd = localFileSystem.currentWorkingDirectory else {
+struct AddTarget: ParsableCommand {
+
+    @Argument
+    var targetName: String
+
+    @Option
+    var targetType: TargetType?
+
+    @OptionGroup
+    var manifestToolOptions: ManifestToolOptions
+
+    mutating func run() throws {
+        guard let cwd = localFileSystem.currentWorkingDirectory else {
+            throw ValidationError("error: couldn't determine the current working directory")
+        }
+        guard let packageRoot = findPackageRoot() else {
+            throw ValidationError("error: couldn't find a package manifest")
+        }
+        let buildPath = getEnvBuildPath(workingDir: cwd) ??
+            manifestToolOptions.buildPath ??
+            packageRoot.appending(component: ".build")
+        let editor = try PackageEditor(manifestPath: packageRoot.appending(component: Manifest.filename),
+                                       buildDir: buildPath,
+                                       toolchain: UserToolchain(destination: try Destination.hostDestination()))
+        try editor.addTarget(name: targetName, type: targetType)
+    }
+}
+
+// MARK: - Utilities
+
+/// Returns path of the nearest directory containing the manifest file w.r.t
+/// current working directory.
+fileprivate func findPackageRoot() -> AbsolutePath? {
+    guard var root = localFileSystem.currentWorkingDirectory else {
         return nil
     }
-
-    let manifestPath = cwd.appending(component: Manifest.filename)
-    return localFileSystem.isFile(manifestPath) ? manifestPath : nil
-}
-
-final class PackageIndex {
-
-    struct Entry: Codable {
-        let name: String
-        let url: String
-    }
-
-    // Name -> URL
-    private(set) var index: [String: String]
-
-    init() throws {
-        index = [:]
-
-        let indexFile = localFileSystem.homeDirectory.appending(components: ".swiftpm", "package-mapping.json")
-        guard localFileSystem.isFile(indexFile) else {
-            return
+    // FIXME: It would be nice to move this to a generalized method which takes path and predicate and
+    // finds the lowest path for which the predicate is true.
+    while !localFileSystem.isFile(root.appending(component: Manifest.filename)) {
+        root = root.parentDirectory
+        guard !root.isRoot else {
+            return nil
         }
+    }
+    return root
+}
 
-        let bytes = try localFileSystem.readFileContents(indexFile).contents
-        let entries = try JSONDecoder().decode(Array<Entry>.self, from: Data(bytes: bytes, count: bytes.count))
+/// Returns the build path from the environment, if present.
+fileprivate func getEnvBuildPath(workingDir: AbsolutePath) -> AbsolutePath? {
+    // Don't rely on build path from env for SwiftPM's own tests.
+    guard ProcessEnv.vars["SWIFTPM_TESTS_MODULECACHE"] == nil else { return nil }
+    guard let env = ProcessEnv.vars["SWIFTPM_BUILD_DIR"] else { return nil }
+    return AbsolutePath(env, relativeTo: workingDir)
+}
 
-        index = Dictionary(uniqueKeysWithValues: entries.map{($0.name, $0.url)})
+extension AbsolutePath: ExpressibleByArgument {
+    public init?(argument: String) {
+        if let cwd = localFileSystem.currentWorkingDirectory {
+            self.init(argument, relativeTo: cwd)
+        } else {
+            guard let path = try? AbsolutePath(validating: argument) else {
+                return nil
+            }
+            self = path
+        }
+    }
+
+    public static var defaultCompletionKind: CompletionKind {
+        // This type is most commonly used to select a directory, not a file.
+        // Specify '.file()' in an argument declaration when necessary.
+        .directory
     }
 }
 
-do {
-    let binder = ArgumentBinder<Options>()
-
-    let parser = ArgumentParser(
-        usage: "subcommand",
-        overview: "Tool for editing the Package.swift manifest file")
-
-    // Add package dependency.
-    let packageDependencyParser = parser.add(subparser: Mode.addPackageDependency.rawValue, overview: "Add a new package dependency")
-    binder.bind(
-        positional: packageDependencyParser.add(positional: "package-url", kind: String.self, usage: "Dependency URL"),
-        to: { $0.addPackageDependency = Options.AddPackageDependency(url: $1) })
-
-    // Add Target.
-    let addTargetParser = parser.add(subparser: Mode.addTarget.rawValue, overview: "Add a new target")
-    binder.bind(
-        positional: addTargetParser.add(positional: "target-name", kind: String.self, usage: "Target name"),
-        to: { $0.addTarget = Options.AddTarget(name: $1) })
-
-    // Bind the mode.
-    binder.bind(
-        parser: parser,
-        to: { $0.mode = Mode(rawValue: $1)! })
-
-    // Parse the options.
-    var options = Options()
-    let result = try parser.parse(Array(CommandLine.arguments.dropFirst()))
-    try binder.fill(parseResult: result, into: &options)
-
-    // Find the Package.swift file in cwd.
-    guard let manifest = findPackageManifest() else {
-        throw ToolError.noManifest
-    }
-    options.dataPath = (localFileSystem.currentWorkingDirectory ?? AbsolutePath("/tmp")).appending(component: ".build")
-
-    switch options.mode {
-    case .addPackageDependency:
-        var url = options.addPackageDependency!.url
-        url = try PackageIndex().index[url] ?? url
-
-        let editor = try PackageEditor(buildDir: options.dataPath)
-        try editor.addPackageDependency(options: .init(manifestPath: manifest, url: url, requirement: nil))
-
-    case .addTarget:
-        let targetOptions = options.addTarget!
-
-        let editor = try PackageEditor(buildDir: options.dataPath)
-        try editor.addTarget(options: .init(manifestPath: manifest, targetName: targetOptions.name, targetType: .regular))
-
-    case .help:
-        parser.printUsage(on: stdoutStream)
+extension TargetType: ExpressibleByArgument {
+    public init?(argument: String) {
+        switch argument {
+        case "regular":
+            self = .regular
+        case "test":
+            self = .test
+        default:
+            return nil
+        }
     }
 
-} catch {
-    stderrStream <<< String(describing: error) <<< "\n"
-    stderrStream.flush()
-    POSIX.exit(1)
+    public static var defaultCompletionKind: CompletionKind {
+        .list(["regular", "test"])
+    }
 }

--- a/Tests/SPMPackageEditorTests/PackageEditorTests.swift
+++ b/Tests/SPMPackageEditorTests/PackageEditorTests.swift
@@ -50,16 +50,15 @@ final class PackageEditorTests: XCTestCase {
         try fs.writeFileContents(manifestPath) { $0 <<< manifest }
 
         let context = try PackageEditorContext(
+            manifestPath: AbsolutePath("/pkg/Package.swift"),
             buildDir: AbsolutePath("/pkg/foo"), toolchain: Resources.default.toolchain, fs: fs)
         let editor = PackageEditor(context: context)
 
         XCTAssertThrows(StringError("Already has a target named foo")) {
-            try editor.addTarget(options:
-                .init(manifestPath: manifestPath, targetName: "foo"))
+            try editor.addTarget(name: "foo", type: .regular)
         }
 
-        try editor.addTarget(options:
-            .init(manifestPath: manifestPath, targetName: "baz"))
+        try editor.addTarget(name: "baz", type: .regular)
 
         let newManifest = try fs.readFileContents(manifestPath).cString
         XCTAssertEqual(newManifest, """

--- a/Tests/SPMPackageEditorTests/PackageEditorTests.swift
+++ b/Tests/SPMPackageEditorTests/PackageEditorTests.swift
@@ -50,7 +50,7 @@ final class PackageEditorTests: XCTestCase {
         try fs.writeFileContents(manifestPath) { $0 <<< manifest }
 
         let context = try PackageEditorContext(
-            buildDir: AbsolutePath("/pkg/foo"), fs: fs)
+            buildDir: AbsolutePath("/pkg/foo"), toolchain: Resources.default.toolchain, fs: fs)
         let editor = PackageEditor(context: context)
 
         XCTAssertThrows(StringError("Already has a target named foo")) {


### PR DESCRIPTION
This builds on https://github.com/apple/swift-package-manager/pull/3034, so only the second commit is new. In addition to rewriting the command line tool to use ArgumentParser, I made a few minor API updates to SPMPackageEditor. The changes to main.swift include a few small utilities copied over from the Commands target so they wouldn't need to be marked public.
