### PR TITLE
Rename "await" to "tsc_await"

### DIFF
--- a/swift-tools-support-core/Sources/TSCBasic/Await.swift
+++ b/swift-tools-support-core/Sources/TSCBasic/Await.swift
@@ -14,11 +14,11 @@
 ///                   should be passed to the async method's completion handler.
 /// - Returns: The value wrapped by the async method's result.
 /// - Throws: The error wrapped by the async method's result
-public func await<T, ErrorType>(_ body: (@escaping (Result<T, ErrorType>) -> Void) -> Void) throws -> T {
-    return try await(body).get()
+public func tsc_await<T, ErrorType>(_ body: (@escaping (Result<T, ErrorType>) -> Void) -> Void) throws -> T {
+    return try tsc_await(body).get()
 }
 
-public func await<T>(_ body: (@escaping (T) -> Void) -> Void) -> T {
+public func tsc_await<T>(_ body: (@escaping (T) -> Void) -> Void) -> T {
     let condition = Condition()
     var result: T? = nil
     body { theResult in
@@ -33,4 +33,14 @@ public func await<T>(_ body: (@escaping (T) -> Void) -> Void) -> T {
         }
     }
     return result!
+}
+
+@available(*, deprecated, renamed: "tsc_await")
+public func await<T, ErrorType>(_ body: (@escaping (Result<T, ErrorType>) -> Void) -> Void) throws -> T {
+    return try tsc_await(body).get()
+}
+
+@available(*, deprecated, renamed: "tsc_await")
+public func await<T>(_ body: (@escaping (T) -> Void) -> Void) -> T {
+  return tsc_await(body)
 }

--- a/swift-tools-support-core/Tests/TSCBasicTests/AwaitTests.swift
+++ b/swift-tools-support-core/Tests/TSCBasicTests/AwaitTests.swift
@@ -32,11 +32,11 @@ class AwaitTests: XCTestCase {
     }
 
     func testBasics() throws {
-        let value = try await { async("Hi", $0) }
+        let value = try tsc_await { async("Hi", $0) }
         XCTAssertEqual("Hi", value)
 
         do {
-            let value = try await { throwingAsync("Hi", $0) }
+            let value = try tsc_await { throwingAsync("Hi", $0) }
             XCTFail("Unexpected success \(value)")
         } catch {
             XCTAssertEqual(error as? DummyError, DummyError.error)


### PR DESCRIPTION
To aid with (further) source compatibility testing, rename `await` to
`tsc_await` to get it out of the way of the use of the `await` keyword
in Swift's Concurrency design. Leave the `await` here as deprecated
entry points so we don't break any code in the process.