### PR TITLE
Use tsc_await rather than await

### DIFF
--- a/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
@@ -1357,7 +1357,7 @@ private final class ContainerProvider {
             }
 
             // Otherwise, fetch the container synchronously.
-            let container = try await { provider.getContainer(for: identifier, skipUpdate: skipUpdate, completion: $0) }
+            let container = try tsc_await { provider.getContainer(for: identifier, skipUpdate: skipUpdate, completion: $0) }
             let pubGrubContainer = PubGrubPackageContainer(container, pinsMap: pinsMap)
             self._fetchedContainers[identifier] = .success(pubGrubContainer)
             return pubGrubContainer

--- a/Sources/SPMPackageEditor/PackageEditor.swift
+++ b/Sources/SPMPackageEditor/PackageEditor.swift
@@ -71,7 +71,7 @@ public final class PackageEditor {
         } else {
             // Otherwise, first lookup the dependency.
             let spec = RepositorySpecifier(url: options.url)
-            let handle = try await{ context.repositoryManager.lookup(repository: spec, completion: $0) }
+            let handle = try tsc_await{ context.repositoryManager.lookup(repository: spec, completion: $0) }
             let repo = try handle.open()
 
             // Compute the requirement.

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -803,7 +803,7 @@ extension Workspace {
             // Otherwise, create a checkout at the destination from our repository store.
             //
             // Get handle to the repository.
-            let handle = try await {
+            let handle = try tsc_await {
                 repositoryManager.lookup(repository: dependency.packageRef.repository, skipUpdate: true, completion: $0)
             }
             let repo = try handle.open()
@@ -1579,7 +1579,7 @@ extension Workspace {
         // automatically manage the parallelism.
         let pins = pinsStore.pins.map({ $0 })
         DispatchQueue.concurrentPerform(iterations: pins.count) { idx in
-            _ = try? await {
+            _ = try? tsc_await {
                 containerProvider.getContainer(for: pins[idx].packageRef, skipUpdate: true, completion: $0)
             }
         }
@@ -2022,7 +2022,7 @@ extension Workspace {
 
             case .revision(let identifier):
                 // Get the latest revision from the container.
-                let container = try await {
+                let container = try tsc_await {
                     containerProvider.getContainer(for: packageRef, skipUpdate: true, completion: $0)
                 } as! RepositoryPackageContainer
                 var revision = try container.getRevision(forIdentifier: identifier)
@@ -2249,7 +2249,7 @@ extension Workspace {
         }
 
         // If not, we need to get the repository from the checkouts.
-        let handle = try await {
+        let handle = try tsc_await {
             repositoryManager.lookup(repository: package.repository, skipUpdate: true, completion: $0)
         }
 
@@ -2320,7 +2320,7 @@ extension Workspace {
             // way to get it back out of the resolver which is very
             // annoying. Maybe we should make an SPI on the provider for
             // this?
-            let container = try await { containerProvider.getContainer(for: package, skipUpdate: true, completion: $0) } as! RepositoryPackageContainer
+            let container = try tsc_await { containerProvider.getContainer(for: package, skipUpdate: true, completion: $0) } as! RepositoryPackageContainer
             guard let tag = container.getTag(for: version) else {
                 throw StringError("Internal error: please file a bug at https://bugs.swift.org with this info -- unable to get tag for \(package) \(version); available versions \(container.reversedVersions)")
             }

--- a/Tests/PackageCollectionsTests/PackageCollectionsProfileStorageTest.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsProfileStorageTest.swift
@@ -43,43 +43,43 @@ final class PackageCollectionProfileStorageTest: XCTestCase {
         let sources = makeMockSources()
 
         try sources.forEach { source in
-            _ = try await { callback in storage.add(source: source, order: nil, to: .default, callback: callback) }
+            _ = try tsc_await { callback in storage.add(source: source, order: nil, to: .default, callback: callback) }
         }
 
-        let profiles = try await { callback in storage.listProfiles(callback: callback) }
+        let profiles = try tsc_await { callback in storage.listProfiles(callback: callback) }
         XCTAssertEqual(profiles.count, 1, "profiles should match")
 
         do {
-            let list = try await { callback in storage.listSources(in: .default, callback: callback) }
+            let list = try tsc_await { callback in storage.listSources(in: .default, callback: callback) }
             XCTAssertEqual(list.count, sources.count, "collections should match")
         }
 
         let remove = sources.enumerated().filter { index, _ in index % 2 == 0 }.map { $1 }
         try remove.forEach { source in
-            _ = try await { callback in storage.remove(source: source, from: .default, callback: callback) }
+            _ = try tsc_await { callback in storage.remove(source: source, from: .default, callback: callback) }
         }
 
         do {
-            let list = try await { callback in storage.listSources(in: .default, callback: callback) }
+            let list = try tsc_await { callback in storage.listSources(in: .default, callback: callback) }
             XCTAssertEqual(list.count, sources.count - remove.count, "collections should match")
         }
 
         let remaining = sources.filter { !remove.contains($0) }
         try sources.forEach { source in
-            XCTAssertEqual(try await { callback in storage.exists(source: source, in: .default, callback: callback) }, remaining.contains(source))
-            XCTAssertEqual(try await { callback in storage.exists(source: source, in: nil, callback: callback) }, remaining.contains(source))
+            XCTAssertEqual(try tsc_await { callback in storage.exists(source: source, in: .default, callback: callback) }, remaining.contains(source))
+            XCTAssertEqual(try tsc_await { callback in storage.exists(source: source, in: nil, callback: callback) }, remaining.contains(source))
         }
 
         do {
-            _ = try await { callback in storage.move(source: remaining.last!, to: 0, in: .default, callback: callback) }
-            let list = try await { callback in storage.listSources(in: .default, callback: callback) }
+            _ = try tsc_await { callback in storage.move(source: remaining.last!, to: 0, in: .default, callback: callback) }
+            let list = try tsc_await { callback in storage.listSources(in: .default, callback: callback) }
             XCTAssertEqual(list.count, remaining.count, "collections should match")
             XCTAssertEqual(list.first, remaining.last, "item should match")
         }
 
         do {
-            _ = try await { callback in storage.move(source: remaining.last!, to: remaining.count - 1, in: .default, callback: callback) }
-            let list = try await { callback in storage.listSources(in: .default, callback: callback) }
+            _ = try tsc_await { callback in storage.move(source: remaining.last!, to: remaining.count - 1, in: .default, callback: callback) }
+            let list = try tsc_await { callback in storage.listSources(in: .default, callback: callback) }
             XCTAssertEqual(list.count, remaining.count, "collections should match")
             XCTAssertEqual(list.last, remaining.last, "item should match")
         }
@@ -92,11 +92,11 @@ final class PackageCollectionProfileStorageTest: XCTestCase {
         let sources = makeMockSources()
 
         try sources.forEach { source in
-            _ = try await { callback in storage.add(source: source, order: nil, to: .default, callback: callback) }
+            _ = try tsc_await { callback in storage.add(source: source, order: nil, to: .default, callback: callback) }
         }
 
         do {
-            let list = try await { callback in storage.listSources(in: .default, callback: callback) }
+            let list = try tsc_await { callback in storage.listSources(in: .default, callback: callback) }
             XCTAssertEqual(list.count, sources.count, "collections should match")
         }
 
@@ -104,7 +104,7 @@ final class PackageCollectionProfileStorageTest: XCTestCase {
         XCTAssertFalse(mockFileSystem.exists(storage.path), "expected file to be deleted")
 
         do {
-            let list = try await { callback in storage.listSources(in: .default, callback: callback) }
+            let list = try tsc_await { callback in storage.listSources(in: .default, callback: callback) }
             XCTAssertEqual(list.count, 0, "collections should match")
         }
     }
@@ -116,11 +116,11 @@ final class PackageCollectionProfileStorageTest: XCTestCase {
         let sources = makeMockSources()
 
         try sources.forEach { source in
-            _ = try await { callback in storage.add(source: source, order: nil, to: .default, callback: callback) }
+            _ = try tsc_await { callback in storage.add(source: source, order: nil, to: .default, callback: callback) }
         }
 
         do {
-            let list = try await { callback in storage.listSources(in: .default, callback: callback) }
+            let list = try tsc_await { callback in storage.listSources(in: .default, callback: callback) }
             XCTAssertEqual(list.count, sources.count, "collections should match")
         }
 
@@ -129,7 +129,7 @@ final class PackageCollectionProfileStorageTest: XCTestCase {
         XCTAssertEqual(buffer.count, 0, "expected file to be empty")
 
         do {
-            let list = try await { callback in storage.listSources(in: .default, callback: callback) }
+            let list = try tsc_await { callback in storage.listSources(in: .default, callback: callback) }
             XCTAssertEqual(list.count, 0, "collections should match")
         }
     }
@@ -141,10 +141,10 @@ final class PackageCollectionProfileStorageTest: XCTestCase {
         let sources = makeMockSources()
 
         try sources.forEach { source in
-            _ = try await { callback in storage.add(source: source, order: nil, to: .default, callback: callback) }
+            _ = try tsc_await { callback in storage.add(source: source, order: nil, to: .default, callback: callback) }
         }
 
-        let list = try await { callback in storage.listSources(in: .default, callback: callback) }
+        let list = try tsc_await { callback in storage.listSources(in: .default, callback: callback) }
         XCTAssertEqual(list.count, sources.count, "collections should match")
 
         try mockFileSystem.writeFileContents(storage.path, bytes: ByteString("{".utf8))
@@ -153,7 +153,7 @@ final class PackageCollectionProfileStorageTest: XCTestCase {
         XCTAssertNotEqual(buffer.count, 0, "expected file to be written")
         print(buffer)
 
-        XCTAssertThrowsError(try await { callback in storage.listSources(in: .default, callback: callback) }, "expected an error", { error in
+        XCTAssertThrowsError(try tsc_await { callback in storage.listSources(in: .default, callback: callback) }, "expected an error", { error in
             XCTAssert(error is DecodingError, "expected error to match")
         })
     }
@@ -166,30 +166,30 @@ final class PackageCollectionProfileStorageTest: XCTestCase {
         let sources = makeMockSources()
 
         try sources.forEach { source in
-            _ = try await { callback in storage.add(source: source, order: nil, to: profile, callback: callback) }
+            _ = try tsc_await { callback in storage.add(source: source, order: nil, to: profile, callback: callback) }
         }
 
-        let profiles = try await { callback in storage.listProfiles(callback: callback) }
+        let profiles = try tsc_await { callback in storage.listProfiles(callback: callback) }
         XCTAssertEqual(profiles.count, 1, "profiles should match")
 
         do {
-            let list = try await { callback in storage.listSources(in: profile, callback: callback) }
+            let list = try tsc_await { callback in storage.listSources(in: profile, callback: callback) }
             XCTAssertEqual(list.count, sources.count, "sources should match")
         }
 
         let remove = sources.enumerated().filter { index, _ in index % 2 == 0 }.map { $1 }
         try remove.forEach { source in
-            _ = try await { callback in storage.remove(source: source, from: profile, callback: callback) }
+            _ = try tsc_await { callback in storage.remove(source: source, from: profile, callback: callback) }
         }
 
         do {
-            let list = try await { callback in storage.listSources(in: profile, callback: callback) }
+            let list = try tsc_await { callback in storage.listSources(in: profile, callback: callback) }
             XCTAssertEqual(list.count, sources.count - remove.count, "sources should match")
         }
 
         try sources.forEach { source in
-            XCTAssertEqual(try await { callback in storage.exists(source: source, in: profile, callback: callback) }, !remove.contains(source))
-            XCTAssertEqual(try await { callback in storage.exists(source: source, in: nil, callback: callback) }, !remove.contains(source))
+            XCTAssertEqual(try tsc_await { callback in storage.exists(source: source, in: profile, callback: callback) }, !remove.contains(source))
+            XCTAssertEqual(try tsc_await { callback in storage.exists(source: source, in: nil, callback: callback) }, !remove.contains(source))
         }
 
         let buffer = try mockFileSystem.readFileContents(storage.path)
@@ -207,15 +207,15 @@ final class PackageCollectionProfileStorageTest: XCTestCase {
 
         try sources.enumerated().forEach { index, source in
             let profile = index % 2 == 0 ? Array(profiles.keys)[0] : Array(profiles.keys)[1]
-            _ = try await { callback in storage.add(source: source, order: nil, to: profile, callback: callback) }
+            _ = try tsc_await { callback in storage.add(source: source, order: nil, to: profile, callback: callback) }
             profiles[profile]?.append(source)
         }
 
-        let list = try await { callback in storage.listProfiles(callback: callback) }
+        let list = try tsc_await { callback in storage.listProfiles(callback: callback) }
         XCTAssertEqual(list.count, profiles.count, "list count should match")
 
         try profiles.forEach { profile, profileCollections in
-            let list = try await { callback in storage.listSources(in: profile, callback: callback) }
+            let list = try tsc_await { callback in storage.listSources(in: profile, callback: callback) }
             XCTAssertEqual(list.count, profileCollections.count, "list count should match")
         }
 

--- a/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
@@ -22,39 +22,39 @@ class PackageCollectionsStorageTests: XCTestCase {
 
             let mockSources = makeMockSources()
             try mockSources.forEach { source in
-                XCTAssertThrowsError(try await { callback in storage.get(identifier: .init(source: source), callback: callback) }, "expected error", { error in
+                XCTAssertThrowsError(try tsc_await { callback in storage.get(identifier: .init(source: source), callback: callback) }, "expected error", { error in
                     XCTAssert(error is NotFoundError, "Expected NotFoundError")
                 })
             }
 
             let mockCollections = makeMockCollections(count: 50)
             try mockCollections.forEach { collection in
-                _ = try await { callback in storage.put(collection: collection, callback: callback) }
+                _ = try tsc_await { callback in storage.put(collection: collection, callback: callback) }
             }
 
             try mockCollections.forEach { collection in
-                let retVal = try await { callback in storage.get(identifier: collection.identifier, callback: callback) }
+                let retVal = try tsc_await { callback in storage.get(identifier: collection.identifier, callback: callback) }
                 XCTAssertEqual(retVal.identifier, collection.identifier)
             }
 
             do {
-                let list = try await { callback in storage.list(callback: callback) }
+                let list = try tsc_await { callback in storage.list(callback: callback) }
                 XCTAssertEqual(list.count, mockCollections.count)
             }
 
             do {
                 let count = Int.random(in: 1 ..< mockCollections.count)
-                let list = try await { callback in storage.list(identifiers: mockCollections.prefix(count).map { $0.identifier }, callback: callback) }
+                let list = try tsc_await { callback in storage.list(identifiers: mockCollections.prefix(count).map { $0.identifier }, callback: callback) }
                 XCTAssertEqual(list.count, count)
             }
 
             do {
-                _ = try await { callback in storage.remove(identifier: mockCollections.first!.identifier, callback: callback) }
-                let list = try await { callback in storage.list(callback: callback) }
+                _ = try tsc_await { callback in storage.remove(identifier: mockCollections.first!.identifier, callback: callback) }
+                let list = try tsc_await { callback in storage.list(callback: callback) }
                 XCTAssertEqual(list.count, mockCollections.count - 1)
             }
 
-            XCTAssertThrowsError(try await { callback in storage.get(identifier: mockCollections.first!.identifier, callback: callback) }, "expected error", { error in
+            XCTAssertThrowsError(try tsc_await { callback in storage.get(identifier: mockCollections.first!.identifier, callback: callback) }, "expected error", { error in
                 XCTAssert(error is NotFoundError, "Expected NotFoundError")
             })
 
@@ -74,11 +74,11 @@ class PackageCollectionsStorageTests: XCTestCase {
 
             let mockCollections = makeMockCollections()
             try mockCollections.forEach { collection in
-                _ = try await { callback in storage.put(collection: collection, callback: callback) }
+                _ = try tsc_await { callback in storage.put(collection: collection, callback: callback) }
             }
 
             try mockCollections.forEach { collection in
-                let retVal = try await { callback in storage.get(identifier: collection.identifier, callback: callback) }
+                let retVal = try tsc_await { callback in storage.get(identifier: collection.identifier, callback: callback) }
                 XCTAssertEqual(retVal.identifier, collection.identifier)
             }
 
@@ -90,12 +90,12 @@ class PackageCollectionsStorageTests: XCTestCase {
 
             try storage.fileSystem.removeFileTree(storagePath)
 
-            XCTAssertThrowsError(try await { callback in storage.get(identifier: mockCollections.first!.identifier, callback: callback) }, "expected error", { error in
+            XCTAssertThrowsError(try tsc_await { callback in storage.get(identifier: mockCollections.first!.identifier, callback: callback) }, "expected error", { error in
                 XCTAssert(error is NotFoundError, "Expected NotFoundError")
             })
 
-            XCTAssertNoThrow(try await { callback in storage.put(collection: mockCollections.first!, callback: callback) })
-            let retVal = try await { callback in storage.get(identifier: mockCollections.first!.identifier, callback: callback) }
+            XCTAssertNoThrow(try tsc_await { callback in storage.put(collection: mockCollections.first!, callback: callback) })
+            let retVal = try tsc_await { callback in storage.get(identifier: mockCollections.first!.identifier, callback: callback) }
             XCTAssertEqual(retVal.identifier, mockCollections.first!.identifier)
 
             XCTAssertTrue(storage.fileSystem.exists(storagePath), "expected file to exist at \(storagePath)")
@@ -110,11 +110,11 @@ class PackageCollectionsStorageTests: XCTestCase {
 
             let mockCollections = makeMockCollections()
             try mockCollections.forEach { collection in
-                _ = try await { callback in storage.put(collection: collection, callback: callback) }
+                _ = try tsc_await { callback in storage.put(collection: collection, callback: callback) }
             }
 
             try mockCollections.forEach { collection in
-                let retVal = try await { callback in storage.get(identifier: collection.identifier, callback: callback) }
+                let retVal = try tsc_await { callback in storage.get(identifier: collection.identifier, callback: callback) }
                 XCTAssertEqual(retVal.identifier, collection.identifier)
             }
 
@@ -127,11 +127,11 @@ class PackageCollectionsStorageTests: XCTestCase {
             XCTAssertTrue(storage.fileSystem.exists(storagePath), "expected file to exist at \(path)")
             try storage.fileSystem.writeFileContents(storagePath, bytes: ByteString("blah".utf8))
 
-            XCTAssertThrowsError(try await { callback in storage.get(identifier: mockCollections.first!.identifier, callback: callback) }, "expected error", { error in
+            XCTAssertThrowsError(try tsc_await { callback in storage.get(identifier: mockCollections.first!.identifier, callback: callback) }, "expected error", { error in
                 XCTAssert("\(error)".contains("is not a database"), "Expected file is not a database error")
             })
 
-            XCTAssertThrowsError(try await { callback in storage.put(collection: mockCollections.first!, callback: callback) }, "expected error", { error in
+            XCTAssertThrowsError(try tsc_await { callback in storage.put(collection: mockCollections.first!, callback: callback) }, "expected error", { error in
                 XCTAssert("\(error)".contains("is not a database"), "Expected file is not a database error")
             })
         }
@@ -144,10 +144,10 @@ class PackageCollectionsStorageTests: XCTestCase {
         let count = SQLitePackageCollectionsStorage.batchSize / 2
         let mockCollections = makeMockCollections(count: count)
         try mockCollections.forEach { collection in
-            _ = try await { callback in storage.put(collection: collection, callback: callback) }
+            _ = try tsc_await { callback in storage.put(collection: collection, callback: callback) }
         }
 
-        let list = try await { callback in storage.list(callback: callback) }
+        let list = try tsc_await { callback in storage.list(callback: callback) }
         XCTAssertEqual(list.count, mockCollections.count)
     }
 
@@ -158,10 +158,10 @@ class PackageCollectionsStorageTests: XCTestCase {
         let count = Int(Double(SQLitePackageCollectionsStorage.batchSize) * 2.5)
         let mockCollections = makeMockCollections(count: count)
         try mockCollections.forEach { collection in
-            _ = try await { callback in storage.put(collection: collection, callback: callback) }
+            _ = try tsc_await { callback in storage.put(collection: collection, callback: callback) }
         }
 
-        let list = try await { callback in storage.list(callback: callback) }
+        let list = try tsc_await { callback in storage.list(callback: callback) }
         XCTAssertEqual(list.count, mockCollections.count)
     }
 
@@ -172,10 +172,10 @@ class PackageCollectionsStorageTests: XCTestCase {
         let count = Int(Double(SQLitePackageCollectionsStorage.batchSize) * 2.5)
         let mockCollections = makeMockCollections(count: count)
         try mockCollections.forEach { collection in
-            _ = try await { callback in storage.put(collection: collection, callback: callback) }
+            _ = try tsc_await { callback in storage.put(collection: collection, callback: callback) }
         }
 
-        let list = try await { callback in storage.list(identifiers: mockCollections.map { $0.identifier }, callback: callback) }
+        let list = try tsc_await { callback in storage.list(identifiers: mockCollections.map { $0.identifier }, callback: callback) }
         XCTAssertEqual(list.count, mockCollections.count)
     }
 }

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -191,7 +191,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             manifestLoader: MockManifestLoader(manifests: [:])
         )
         let ref = PackageReference(identity: "foo", path: repoPath.pathString)
-        let container = try await { provider.getContainer(for: ref, skipUpdate: false, completion: $0) }
+        let container = try tsc_await { provider.getContainer(for: ref, skipUpdate: false, completion: $0) }
         let v = container.versions(filter: { _ in true }).map { $0 }
         XCTAssertEqual(v, ["2.0.3", "1.0.3", "1.0.2", "1.0.1", "1.0.0"])
     }
@@ -246,7 +246,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         do {
             let provider = createProvider(ToolsVersion(version: "4.0.0"))
             let ref = PackageReference(identity: "foo", path: specifier.url)
-            let container = try await { provider.getContainer(for: ref, skipUpdate: false, completion: $0) }
+            let container = try tsc_await { provider.getContainer(for: ref, skipUpdate: false, completion: $0) }
             let v = container.versions(filter: { _ in true }).map { $0 }
             XCTAssertEqual(v, ["1.0.1"])
         }
@@ -254,7 +254,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         do {
             let provider = createProvider(ToolsVersion(version: "4.2.0"))
             let ref = PackageReference(identity: "foo", path: specifier.url)
-            let container = try await { provider.getContainer(for: ref, skipUpdate: false, completion: $0) }
+            let container = try tsc_await { provider.getContainer(for: ref, skipUpdate: false, completion: $0) }
             XCTAssertEqual((container as! RepositoryPackageContainer).validToolsVersionsCache, [:])
             let v = container.versions(filter: { _ in true }).map { $0 }
             XCTAssertEqual((container as! RepositoryPackageContainer).validToolsVersionsCache, ["1.0.1": true, "1.0.0": false, "1.0.3": true, "1.0.2": true])
@@ -264,7 +264,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         do {
             let provider = createProvider(ToolsVersion(version: "3.0.0"))
             let ref = PackageReference(identity: "foo", path: specifier.url)
-            let container = try await { provider.getContainer(for: ref, skipUpdate: false, completion: $0) }
+            let container = try tsc_await { provider.getContainer(for: ref, skipUpdate: false, completion: $0) }
             let v = container.versions(filter: { _ in true }).map { $0 }
             XCTAssertEqual(v, [])
         }
@@ -273,7 +273,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         do {
             let provider = createProvider(ToolsVersion(version: "4.0.0"))
             let ref = PackageReference(identity: "foo", path: specifier.url)
-            let container = try await { provider.getContainer(for: ref, skipUpdate: false, completion: $0) } as! RepositoryPackageContainer
+            let container = try tsc_await { provider.getContainer(for: ref, skipUpdate: false, completion: $0) } as! RepositoryPackageContainer
             let revision = try container.getRevision(forTag: "1.0.0")
             do {
                 _ = try container.getDependencies(at: revision.identifier, productFilter: .nothing)
@@ -320,7 +320,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             manifestLoader: MockManifestLoader(manifests: [:])
         )
         let ref = PackageReference(identity: "foo", path: repoPath.pathString)
-        let container = try await { provider.getContainer(for: ref, skipUpdate: false, completion: $0) }
+        let container = try tsc_await { provider.getContainer(for: ref, skipUpdate: false, completion: $0) }
         let v = container.versions(filter: { _ in true }).map { $0 }
         XCTAssertEqual(v, ["1.0.4-alpha", "1.0.2-dev.2", "1.0.2-dev", "1.0.1", "1.0.0", "1.0.0-beta.1", "1.0.0-alpha.1"])
     }
@@ -360,7 +360,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             manifestLoader: MockManifestLoader(manifests: [:])
         )
         let ref = PackageReference(identity: "foo", path: repoPath.pathString)
-        let container = try await { provider.getContainer(for: ref, skipUpdate: false, completion: $0) }
+        let container = try tsc_await { provider.getContainer(for: ref, skipUpdate: false, completion: $0) }
         let v = container.versions(filter: { _ in true }).map { $0 }
         XCTAssertEqual(v, ["2.0.1", "1.0.4", "1.0.2", "1.0.1", "1.0.0"])
     }
@@ -548,7 +548,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
 
             // Get a hold of the container for the test package.
             let packageRef = PackageReference(identity: "somepackage", path: packageDir.pathString)
-            let container = try await { containerProvider.getContainer(for: packageRef, skipUpdate: false, completion: $0) } as! RepositoryPackageContainer
+            let container = try tsc_await { containerProvider.getContainer(for: packageRef, skipUpdate: false, completion: $0) } as! RepositoryPackageContainer
 
             // Simulate accessing a fictitious dependency on the `master` branch, and check that we get back the expected error.
             do { _ = try container.getDependencies(at: "master", productFilter: .everything) }

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -17,7 +17,7 @@ import SPMTestSupport
 
 extension RepositoryManager {
     fileprivate func lookupSynchronously(repository: RepositorySpecifier) throws -> RepositoryHandle {
-        return try await { self.lookup(repository: repository, completion: $0) }
+        return try tsc_await { self.lookup(repository: repository, completion: $0) }
     }
 }
 
@@ -351,20 +351,20 @@ class RepositoryManagerTests: XCTestCase {
             let manager = RepositoryManager(path: repos, provider: provider, delegate: delegate)
             let dummyRepo = RepositorySpecifier(url: "dummy")
 
-            _ = try await { manager.lookup(repository: dummyRepo, completion: $0) }
+            _ = try tsc_await { manager.lookup(repository: dummyRepo, completion: $0) }
             XCTAssertEqual(delegate.willFetch.count, 1)
             XCTAssertEqual(delegate.didFetch.count, 1)
             XCTAssertEqual(delegate.willUpdate.count, 0)
             XCTAssertEqual(delegate.didUpdate.count, 0)
 
-            _ = try await { manager.lookup(repository: dummyRepo, completion: $0) }
-            _ = try await { manager.lookup(repository: dummyRepo, completion: $0) }
+            _ = try tsc_await { manager.lookup(repository: dummyRepo, completion: $0) }
+            _ = try tsc_await { manager.lookup(repository: dummyRepo, completion: $0) }
             XCTAssertEqual(delegate.willFetch.count, 1)
             XCTAssertEqual(delegate.didFetch.count, 1)
             XCTAssertEqual(delegate.willUpdate.count, 2)
             XCTAssertEqual(delegate.didUpdate.count, 2)
 
-            _ = try await { manager.lookup(repository: dummyRepo, skipUpdate: true, completion: $0) }
+            _ = try tsc_await { manager.lookup(repository: dummyRepo, skipUpdate: true, completion: $0) }
             XCTAssertEqual(delegate.willFetch.count, 1)
             XCTAssertEqual(delegate.didFetch.count, 1)
             XCTAssertEqual(delegate.willUpdate.count, 2)


### PR DESCRIPTION
This is the follow-on to https://github.com/apple/swift-package-manager/pull/3036, adopting the new swift-tools-support-core and using `tsc_await` in lieu of `await`.