### PR TITLE
Fix a build failure resulting from a race condition between two PRs.

### DIFF
--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -12,7 +12,6 @@ import class Foundation.NSDate
 import class Foundation.Thread
 import func XCTest.XCTFail
 
-import Commands
 import PackageGraph
 import PackageModel
 import SourceControl


### PR DESCRIPTION
Each passed successfully but one unintentionally restored an import that the other had removed.

These were https://github.com/apple/swift-package-manager/pull/3029 and https://github.com/apple/swift-package-manager/pull/3019