### PR TITLE
HTTP Client abstraction 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -209,6 +209,9 @@ let package = Package(
         // MARK: SwiftPM tests
 
         .testTarget(
+            name: "BasicsTests",
+            dependencies: ["Basics", "SPMTestSupport"]),
+        .testTarget(
             name: "BuildTests",
             dependencies: ["Build", "SPMTestSupport"]),
         .testTarget(

--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -7,7 +7,10 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(Basics
-  FileSystem+Extensions.swift)
+  DispatchTimeInterval+Extensions.swift
+  FileSystem+Extensions.swift
+  HTPClient+URLSession.swift
+  HTTPClient.swift)
 target_link_libraries(Basics PUBLIC
   TSCBasic
   TSCUtility)

--- a/Sources/Basics/DispatchTimeInterval+Extensions.swift
+++ b/Sources/Basics/DispatchTimeInterval+Extensions.swift
@@ -1,0 +1,59 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Dispatch
+import struct Foundation.TimeInterval
+
+extension DispatchTimeInterval {
+    func timeInterval() -> TimeInterval? {
+        switch self {
+        case .seconds(let value):
+            return Double(value)
+        case .milliseconds(let value):
+            return Double(value) / 1000
+        case .microseconds(let value):
+            return Double(value) / 1_000_000
+        case .nanoseconds(let value):
+            return Double(value) / 1_000_000_000
+        default:
+            return nil
+        }
+    }
+
+    func milliseconds() -> Int? {
+        switch self {
+        case .seconds(let value):
+            return value.multipliedReportingOverflow(by: 1000).partialValue
+        case .milliseconds(let value):
+            return value
+        case .microseconds(let value):
+            return Int(Double(value) / 1000)
+        case .nanoseconds(let value):
+            return Int(Double(value) / 1_000_000)
+        default:
+            return nil
+        }
+    }
+
+    func seconds() -> Int? {
+        switch self {
+        case .seconds(let value):
+            return value
+        case .milliseconds(let value):
+            return Int(Double(value) / 1000)
+        case .microseconds(let value):
+            return Int(Double(value) / 1_000_000)
+        case .nanoseconds(let value):
+            return Int(Double(value) / 1_000_000_000)
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/Basics/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem+Extensions.swift
@@ -18,7 +18,7 @@ extension FileSystem {
 }
 
 extension FileSystem {
-    /// SwiftPM cache directory under usre's caches directory (if exists)
+    /// SwiftPM cache directory under user's caches directory (if exists)
     public var swiftPMCacheDirectory: AbsolutePath {
         if let cachesDirectory = self.cachesDirectory {
             return cachesDirectory.appending(component: "org.swift.swiftpm")

--- a/Sources/Basics/HTPClient+URLSession.swift
+++ b/Sources/Basics/HTPClient+URLSession.swift
@@ -1,0 +1,73 @@
+
+
+import Foundation
+import struct TSCUtility.Versioning
+#if canImport(FoundationNetworking)
+// TODO: this brings OpenSSL dependency` on Linux
+// need to decide how to best deal with that
+import FoundationNetworking
+#endif
+
+public struct URLSessionHTTPClient {
+    private let configuration: URLSessionConfiguration
+
+    public init(configuration: URLSessionConfiguration) {
+        self.configuration = configuration
+    }
+
+    public func execute(request: HTTPClient.Request, callback: @escaping (Result<HTTPClient.Response, Error>) -> Void) {
+        let session = URLSession(configuration: self.configuration)
+        let task = session.dataTask(with: request.urlRequest()) { data, response, error in
+            if let error = error {
+                callback(.failure(error))
+            } else if let response = response as? HTTPURLResponse {
+                callback(.success(response.response(body: data)))
+            } else {
+                callback(.failure(HTTPClientError.invalidResponse))
+            }
+        }
+        task.resume()
+    }
+}
+
+extension HTTPClient.Request {
+    func urlRequest() -> URLRequest {
+        var request = URLRequest(url: self.url)
+        request.httpMethod = self.methodString()
+        self.headers.forEach { header in
+            request.addValue(header.value, forHTTPHeaderField: header.name)
+        }
+        request.httpBody = self.body
+        if let interval = self.options.timeout?.timeInterval() {
+            request.timeoutInterval = interval
+        }
+        return request
+    }
+
+    func methodString() -> String {
+        switch self.method {
+        case .head:
+            return "HEAD"
+        case .get:
+            return "GET"
+        case .post:
+            return "POST"
+        case .put:
+            return "PUT"
+        case .delete:
+            return "DELETE"
+        }
+    }
+}
+
+extension HTTPURLResponse {
+    func response(body: Data?) -> HTTPClient.Response {
+        let headers = HTTPClientHeaders(self.allHeaderFields.map { header in
+            .init(name: "\(header.key)", value: "\(header.value)")
+        })
+        return HTTPClient.Response(statusCode: self.statusCode,
+                                   statusText: Self.localizedString(forStatusCode: self.statusCode),
+                                   headers: headers,
+                                   body: body)
+    }
+}

--- a/Sources/Basics/HTPClient+URLSession.swift
+++ b/Sources/Basics/HTPClient+URLSession.swift
@@ -3,7 +3,7 @@
 import Foundation
 import struct TSCUtility.Versioning
 #if canImport(FoundationNetworking)
-// TODO: this brings OpenSSL dependency` on Linux
+// FIXME: this brings OpenSSL dependency on Linux
 // need to decide how to best deal with that
 import FoundationNetworking
 #endif

--- a/Sources/Basics/HTTPClient.swift
+++ b/Sources/Basics/HTTPClient.swift
@@ -1,0 +1,308 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Dispatch
+import struct Foundation.Data
+import struct Foundation.Date
+import struct Foundation.URL
+import TSCBasic
+import TSCUtility
+
+// MARK: - HTTPClient
+
+public struct HTTPClient {
+    public typealias Configuration = HTTPClientConfiguration
+    public typealias Request = HTTPClientRequest
+    public typealias Response = HTTPClientResponse
+    public typealias Handler = (Request, @escaping (Result<Response, Error>) -> Void) -> Void
+
+    private let configuration: HTTPClientConfiguration
+    private let underlying: Handler
+
+    // static to share across instances of the http client
+    private static var hostsErrorsLock = Lock()
+    private static var hostsErrors = [String: [Date]]()
+
+    public init(configuration: HTTPClientConfiguration = .init(), handler: @escaping Handler) {
+        self.configuration = configuration
+        self.underlying = handler
+    }
+
+    public func execute(_ request: Request, callback: @escaping (Result<Response, Error>) -> Void) {
+        // merge configuration
+        var request = request
+        if request.options.callbackQueue == nil {
+            request.options.callbackQueue = self.configuration.callbackQueue
+        }
+        if request.options.retryStrategy == nil {
+            request.options.retryStrategy = self.configuration.retryStrategy
+        }
+        if request.options.circuitBreakerStrategy == nil {
+            request.options.circuitBreakerStrategy = self.configuration.circuitBreakerStrategy
+        }
+        if request.options.timeout == nil {
+            request.options.timeout = self.configuration.requestTimeout
+        }
+        // add additional headers
+        if let additionalHeaders = self.configuration.requestHeaders {
+            additionalHeaders.forEach {
+                request.headers.add($0)
+            }
+        }
+        if request.options.addUserAgent, !request.headers.contains("User-Agent") {
+            request.headers.add(name: "User-Agent", value: "SwiftPackageManager/\(Versioning.currentVersion.displayString)")
+        }
+        // execute
+        self._execute(request: request, requestNumber: 0) { result in
+            let callbackQueue = request.options.callbackQueue ?? self.configuration.callbackQueue
+            callbackQueue.async {
+                callback(result)
+            }
+        }
+    }
+
+    private func _execute(request: Request, requestNumber: Int, callback: @escaping (Result<Response, Error>) -> Void) {
+        if self.shouldCircuitBreak(request: request) {
+            return callback(.failure(HTTPClientError.circuitBreakerTriggered))
+        }
+
+        self.underlying(request) { result in
+            switch result {
+            case .failure(let error):
+                callback(.failure(error))
+            case .success(let response):
+                // record host errors for circuit breaker
+                self.recordErrorIfNecessary(response: response, request: request)
+                // handle retry strategy
+                if let retryDelay = self.shouldRetry(response: response, request: request, requestNumber: requestNumber), #available(OSX 10.15, *) {
+                    // TODO: dedicated retry queue?
+                    return DispatchQueue.global().asyncAfter(deadline: DispatchTime.now().advanced(by: retryDelay)) {
+                        self._execute(request: request, requestNumber: requestNumber + 1, callback: callback)
+                    }
+                }
+                // check for valid response codes
+                if let validResponseCodes = request.options.validResponseCodes, !validResponseCodes.contains(response.statusCode) {
+                    return callback(.failure(HTTPClientError.badResponseStatusCode(response.statusCode)))
+                }
+                callback(.success(response))
+            }
+        }
+    }
+
+    private func shouldRetry(response: Response, request: Request, requestNumber: Int) -> DispatchTimeInterval? {
+        guard let strategy = request.options.retryStrategy, response.statusCode >= 500 else {
+            return .none
+        }
+
+        switch strategy {
+        case .exponentialBackoff(let maxAttempts, let delay):
+            guard requestNumber < maxAttempts - 1 else {
+                return .none
+            }
+            let exponential = Int(min(pow(2.0, Double(requestNumber)), Double(Int.max)))
+            let delayMilli = exponential.multipliedReportingOverflow(by: delay.milliseconds() ?? 0).partialValue
+            let jitterMilli = Int.random(in: 1 ... 10)
+            return .milliseconds(delayMilli + jitterMilli)
+        }
+    }
+
+    private func recordErrorIfNecessary(response: Response, request: Request) {
+        guard request.options.circuitBreakerStrategy != nil, let host = request.url.host, response.statusCode >= 500 else {
+            return
+        }
+
+        Self.hostsErrorsLock.withLock {
+            // Avoid copy-on-write: remove entry from dictionary before mutating
+            var errors = Self.hostsErrors.removeValue(forKey: host) ?? []
+            errors.append(Date())
+            Self.hostsErrors[host] = errors
+        }
+    }
+
+    private func shouldCircuitBreak(request: Request) -> Bool {
+        guard let strategy = request.options.circuitBreakerStrategy, let host = request.url.host else {
+            return false
+        }
+
+        switch strategy {
+        case .hostErrors(let maxErrors, let age):
+            if let errors = (Self.hostsErrorsLock.withLock { Self.hostsErrors[host] }) {
+                if #available(OSX 10.15, *), errors.count >= maxErrors, let lastError = errors.last, let age = age.timeInterval(), lastError.distance(to: Date()) < age {
+                    return true
+                } else if errors.count >= maxErrors {
+                    // reset aged errors
+                    Self.hostsErrorsLock.withLock {
+                        Self.hostsErrors[host] = nil
+                    }
+                }
+            }
+            return false
+        }
+    }
+}
+
+extension HTTPClient {
+    func head(_ url: URL, headers: HTTPClientHeaders = .init(), options: Request.Options = .init(), callback: @escaping (Result<Response, Error>) -> Void) {
+        self.execute(Request(method: .head, url: url, headers: headers, body: nil, options: options), callback: callback)
+    }
+
+    func get(_ url: URL, headers: HTTPClientHeaders = .init(), options: Request.Options = .init(), callback: @escaping (Result<Response, Error>) -> Void) {
+        self.execute(Request(method: .get, url: url, headers: headers, body: nil, options: options), callback: callback)
+    }
+
+    func put(_ url: URL, body: Data?, headers: HTTPClientHeaders = .init(), options: Request.Options = .init(), callback: @escaping (Result<Response, Error>) -> Void) {
+        self.execute(Request(method: .put, url: url, headers: headers, body: body, options: options), callback: callback)
+    }
+
+    func post(_ url: URL, body: Data?, headers: HTTPClientHeaders = .init(), options: Request.Options = .init(), callback: @escaping (Result<Response, Error>) -> Void) {
+        self.execute(Request(method: .post, url: url, headers: headers, body: body, options: options), callback: callback)
+    }
+
+    func delete(_ url: URL, headers: HTTPClientHeaders = .init(), options: Request.Options = .init(), callback: @escaping (Result<Response, Error>) -> Void) {
+        self.execute(Request(method: .delete, url: url, headers: headers, body: nil, options: options), callback: callback)
+    }
+}
+
+public struct HTTPClientConfiguration {
+    var requestHeaders: HTTPClientHeaders?
+    var requestTimeout: DispatchTimeInterval?
+    var retryStrategy: HTTPClientRetryStrategy?
+    var circuitBreakerStrategy: HTTPClientCircuitBreakerStrategy?
+    var callbackQueue: DispatchQueue
+
+    public init() {
+        self.requestHeaders = .none
+        self.requestTimeout = .none
+        self.retryStrategy = .none
+        self.circuitBreakerStrategy = .none
+        self.callbackQueue = .global()
+    }
+}
+
+public enum HTTPClientRetryStrategy {
+    case exponentialBackoff(maxAttempts: Int, baseDelay: DispatchTimeInterval)
+}
+
+public enum HTTPClientCircuitBreakerStrategy {
+    case hostErrors(maxErrors: Int, age: DispatchTimeInterval)
+}
+
+public struct HTTPClientRequest {
+    let method: Method
+    let url: URL
+    var headers: HTTPClientHeaders
+    var body: Data?
+    var options: Options
+
+    public init(method: Method = .get,
+                url: URL,
+                headers: HTTPClientHeaders = .init(),
+                body: Data? = nil,
+                options: Options = .init()) {
+        self.method = method
+        self.url = url
+        self.headers = headers
+        self.body = body
+        self.options = options
+    }
+
+    public enum Method {
+        case head
+        case get
+        case post
+        case put
+        case delete
+    }
+
+    public struct Options {
+        var addUserAgent: Bool
+        var validResponseCodes: [Int]?
+        var timeout: DispatchTimeInterval?
+        var retryStrategy: HTTPClientRetryStrategy?
+        var circuitBreakerStrategy: HTTPClientCircuitBreakerStrategy?
+        var callbackQueue: DispatchQueue?
+
+        public init() {
+            self.addUserAgent = true
+            self.validResponseCodes = .none
+            self.timeout = .none
+            self.retryStrategy = .none
+            self.circuitBreakerStrategy = .none
+            self.callbackQueue = .none
+        }
+    }
+}
+
+public struct HTTPClientResponse {
+    let statusCode: Int
+    let statusText: String?
+    let headers: HTTPClientHeaders
+    let body: Data?
+
+    public init(statusCode: Int,
+                statusText: String? = nil,
+                headers: HTTPClientHeaders = .init(),
+                body: Data? = nil) {
+        self.statusCode = statusCode
+        self.statusText = statusText
+        self.headers = headers
+        self.body = body
+    }
+}
+
+public struct HTTPClientHeaders: Sequence, Equatable {
+    // TODO: optimize
+    private var headers: [Item]
+
+    public init(_ headers: [Item] = []) {
+        self.headers = headers
+    }
+
+    // TODO: optimize
+    public func contains(_ name: String) -> Bool {
+        self.headers.contains(where: { $0.name.lowercased() == name.lowercased() })
+    }
+
+    public var count: Int {
+        self.headers.count
+    }
+
+    public mutating func add(name: String, value: String) {
+        self.add(Item(name: name, value: value))
+    }
+
+    public mutating func add(_ item: Item) {
+        self.headers.append(item)
+    }
+
+    // TODO: optimize
+    public func get(name: String) -> [String] {
+        self.headers.filter { $0.name.lowercased() == name.lowercased() }.map { $0.value }
+    }
+
+    public func makeIterator() -> IndexingIterator<[Item]> {
+        self.headers.makeIterator()
+    }
+
+    public struct Item: Equatable {
+        let name: String
+        let value: String
+    }
+
+    public static func == (lhs: HTTPClientHeaders, rhs: HTTPClientHeaders) -> Bool {
+        lhs.headers == rhs.headers
+    }
+}
+
+public enum HTTPClientError: Error, Equatable {
+    case invalidResponse
+    case badResponseStatusCode(Int)
+    case circuitBreakerTriggered
+}

--- a/Sources/Basics/HTTPClient.swift
+++ b/Sources/Basics/HTTPClient.swift
@@ -296,17 +296,24 @@ public struct HTTPClientHeaders: Sequence, Equatable {
     }
 
     public mutating func add(_ item: Item) {
-        // Avoid copy-on-write: remove entry from dictionary before mutating
-        var values = self.headers.removeValue(forKey: item.name.lowercased()) ?? []
-        values.append(item.value)
-        self.headers[item.name.lowercased()] = values
-        self.items.append(item)
+        self.add([item])
+    }
+
+    public mutating func add(_ items: [Item]) {
+        for item in items {
+            if self.items.contains(item) {
+                continue
+            }
+            // Avoid copy-on-write: remove entry from dictionary before mutating
+            var values = self.headers.removeValue(forKey: item.name.lowercased()) ?? []
+            values.append(item.value)
+            self.headers[item.name.lowercased()] = values
+            self.items.append(item)
+        }
     }
 
     public mutating func merge(_ other: HTTPClientHeaders) {
-        other.forEach {
-            self.add($0)
-        }
+        self.add(other.items)
     }
 
     public func get(_ name: String) -> [String] {

--- a/Tests/BasicsTests/HTTPClientTests.swift
+++ b/Tests/BasicsTests/HTTPClientTests.swift
@@ -410,12 +410,35 @@ final class HTTPClientTest: XCTestCase {
         XCTAssertEqual(sync.wait(timeout: timeout), .success, "should not timeout")
     }
 
-    func assertRequestHeaders(_ headers: HTTPClientHeaders, expected: HTTPClientHeaders) {
+    func testHTTPClientHeaders() {
+        var headers = HTTPClientHeaders()
+
+        let items = (1 ... Int.random(in: 10 ... 20)).map { index in HTTPClientHeaders.Item(name: "header-\(index)", value: UUID().uuidString) }
+        headers.add(items)
+
+        XCTAssertEqual(headers.count, items.count, "headers count should match")
+        items.forEach { item in
+            XCTAssertEqual(headers.get(item.name).first, item.value, "headers value should match")
+        }
+
+        headers.add(items.first!)
+        XCTAssertEqual(headers.count, items.count, "headers count should match (no duplicates)")
+
+        let name = UUID().uuidString
+        let values = (1 ... Int.random(in: 10 ... 20)).map { "value-\($0)" }
+        values.forEach { value in
+            headers.add(name: name, value: value)
+        }
+        XCTAssertEqual(headers.count, items.count + 1, "headers count should match (no duplicates)")
+        XCTAssertEqual(values, headers.get(name), "multiple headers value should match")
+    }
+
+    private func assertRequestHeaders(_ headers: HTTPClientHeaders, expected: HTTPClientHeaders) {
         let noAgent = HTTPClientHeaders(headers.filter { $0.name != "User-Agent" })
         XCTAssertEqual(noAgent, expected, "expected headers to match")
     }
 
-    func assertResponseHeaders(_ headers: HTTPClientHeaders, expected: HTTPClientHeaders) {
+    private func assertResponseHeaders(_ headers: HTTPClientHeaders, expected: HTTPClientHeaders) {
         XCTAssertEqual(headers, expected, "expected headers to match")
     }
 }

--- a/Tests/BasicsTests/HTTPClientTests.swift
+++ b/Tests/BasicsTests/HTTPClientTests.swift
@@ -1,0 +1,387 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+@testable import Basics
+import TSCTestSupport
+import XCTest
+
+final class HTTPClientTest: XCTestCase {
+    func testHead() {
+        let url = URL(string: "http://test")!
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseStatus = Int.random(in: 201 ..< 500)
+        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseBody: Data? = nil
+
+        let handler = { (request: HTTPClient.Request, callback: @escaping (Result<HTTPClient.Response, Error>) -> Void) in
+            XCTAssertEqual(request.url, url, "url should match")
+            XCTAssertEqual(request.method, .head, "method should match")
+            self.assertRequestHeaders(request.headers, expected: requestHeaders)
+            callback(.success(HTTPClient.Response(statusCode: responseStatus, headers: responseHeaders, body: responseBody)))
+        }
+
+        let httpClient = HTTPClient(handler: handler)
+
+        let promise = XCTestExpectation(description: "completed")
+        httpClient.head(url, headers: requestHeaders) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("unexpected error \(error)")
+            case .success(let response):
+                XCTAssertEqual(response.statusCode, responseStatus, "statusCode should match")
+                self.assertResponseHeaders(response.headers, expected: responseHeaders)
+                XCTAssertEqual(response.body, responseBody, "body should match")
+            }
+            promise.fulfill()
+        }
+
+        wait(for: [promise], timeout: 1)
+    }
+
+    func testGet() {
+        let url = URL(string: "http://test")!
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseStatus = Int.random(in: 201 ..< 500)
+        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseBody = UUID().uuidString.data(using: .utf8)
+
+        let handler = { (request: HTTPClient.Request, callback: @escaping (Result<HTTPClient.Response, Error>) -> Void) in
+            XCTAssertEqual(request.url, url, "url should match")
+            XCTAssertEqual(request.method, .get, "method should match")
+            self.assertRequestHeaders(request.headers, expected: requestHeaders)
+            callback(.success(HTTPClient.Response(statusCode: responseStatus, headers: responseHeaders, body: responseBody)))
+        }
+
+        let httpClient = HTTPClient(handler: handler)
+
+        let promise = XCTestExpectation(description: "completed")
+        httpClient.get(url, headers: requestHeaders) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("unexpected error \(error)")
+            case .success(let response):
+                XCTAssertEqual(response.statusCode, responseStatus, "statusCode should match")
+                self.assertResponseHeaders(response.headers, expected: responseHeaders)
+                XCTAssertEqual(response.body, responseBody, "body should match")
+            }
+            promise.fulfill()
+        }
+
+        wait(for: [promise], timeout: 1)
+    }
+
+    func testPost() {
+        let url = URL(string: "http://test")!
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let requestBody = UUID().uuidString.data(using: .utf8)
+        let responseStatus = Int.random(in: 201 ..< 500)
+        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseBody = UUID().uuidString.data(using: .utf8)
+
+        let handler = { (request: HTTPClient.Request, callback: @escaping (Result<HTTPClient.Response, Error>) -> Void) in
+            XCTAssertEqual(request.url, url, "url should match")
+            XCTAssertEqual(request.method, .post, "method should match")
+            self.assertRequestHeaders(request.headers, expected: requestHeaders)
+            XCTAssertEqual(request.body, requestBody, "body should match")
+            callback(.success(HTTPClient.Response(statusCode: responseStatus, headers: responseHeaders, body: responseBody)))
+        }
+
+        let httpClient = HTTPClient(handler: handler)
+
+        let promise = XCTestExpectation(description: "completed")
+        httpClient.post(url, body: requestBody, headers: requestHeaders) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("unexpected error \(error)")
+            case .success(let response):
+                XCTAssertEqual(response.statusCode, responseStatus, "statusCode should match")
+                self.assertResponseHeaders(response.headers, expected: responseHeaders)
+                XCTAssertEqual(response.body, responseBody, "body should match")
+            }
+            promise.fulfill()
+        }
+
+        wait(for: [promise], timeout: 1)
+    }
+
+    func testPut() {
+        let url = URL(string: "http://test")!
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let requestBody = UUID().uuidString.data(using: .utf8)
+        let responseStatus = Int.random(in: 201 ..< 500)
+        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseBody = UUID().uuidString.data(using: .utf8)
+
+        let handler = { (request: HTTPClient.Request, callback: @escaping (Result<HTTPClient.Response, Error>) -> Void) in
+            XCTAssertEqual(request.url, url, "url should match")
+            XCTAssertEqual(request.method, .put, "method should match")
+            self.assertRequestHeaders(request.headers, expected: requestHeaders)
+            XCTAssertEqual(request.body, requestBody, "body should match")
+            callback(.success(HTTPClient.Response(statusCode: responseStatus, headers: responseHeaders, body: responseBody)))
+        }
+
+        let httpClient = HTTPClient(handler: handler)
+
+        let promise = XCTestExpectation(description: "completed")
+        httpClient.put(url, body: requestBody, headers: requestHeaders) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("unexpected error \(error)")
+            case .success(let response):
+                XCTAssertEqual(response.statusCode, responseStatus, "statusCode should match")
+                self.assertResponseHeaders(response.headers, expected: responseHeaders)
+                XCTAssertEqual(response.body, responseBody, "body should match")
+            }
+            promise.fulfill()
+        }
+
+        wait(for: [promise], timeout: 1)
+    }
+
+    func testDelete() {
+        let url = URL(string: "http://test")!
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseStatus = Int.random(in: 201 ..< 500)
+        let responseHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let responseBody = UUID().uuidString.data(using: .utf8)
+
+        let handler = { (request: HTTPClient.Request, callback: @escaping (Result<HTTPClient.Response, Error>) -> Void) in
+            XCTAssertEqual(request.url, url, "url should match")
+            XCTAssertEqual(request.method, .delete, "method should match")
+            self.assertRequestHeaders(request.headers, expected: requestHeaders)
+            callback(.success(HTTPClient.Response(statusCode: responseStatus, headers: responseHeaders, body: responseBody)))
+        }
+
+        let httpClient = HTTPClient(handler: handler)
+
+        let promise = XCTestExpectation(description: "completed")
+        httpClient.delete(url, headers: requestHeaders) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("unexpected error \(error)")
+            case .success(let response):
+                XCTAssertEqual(response.statusCode, responseStatus, "statusCode should match")
+                self.assertResponseHeaders(response.headers, expected: responseHeaders)
+                XCTAssertEqual(response.body, responseBody, "body should match")
+            }
+            promise.fulfill()
+        }
+
+        wait(for: [promise], timeout: 1)
+    }
+
+    func testUserAgent() {
+        let url = URL(string: "http://test")!
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+
+        let handler = { (request: HTTPClient.Request, callback: @escaping (Result<HTTPClient.Response, Error>) -> Void) in
+            XCTAssertTrue(request.headers.contains("User-Agent"), "expecting User-Agent")
+            self.assertRequestHeaders(request.headers, expected: requestHeaders)
+            callback(.success(HTTPClient.Response(statusCode: 200)))
+        }
+
+        let httpClient = HTTPClient(handler: handler)
+        var request = HTTPClient.Request(method: .get, url: url, headers: requestHeaders)
+        request.options.addUserAgent = true
+
+        let promise = XCTestExpectation(description: "completed")
+        httpClient.execute(request) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("unexpected error \(error)")
+            case .success(let response):
+                XCTAssertEqual(response.statusCode, 200, "statusCode should match")
+            }
+            promise.fulfill()
+        }
+
+        wait(for: [promise], timeout: 1)
+    }
+
+    func testNoUserAgent() {
+        let url = URL(string: "http://test")!
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+
+        let handler = { (request: HTTPClient.Request, callback: @escaping (Result<HTTPClient.Response, Error>) -> Void) in
+            XCTAssertFalse(request.headers.contains("User-Agent"), "expecting User-Agent")
+            self.assertRequestHeaders(request.headers, expected: requestHeaders)
+            callback(.success(HTTPClient.Response(statusCode: 200)))
+        }
+
+        let httpClient = HTTPClient(handler: handler)
+        var request = HTTPClient.Request(method: .get, url: url, headers: requestHeaders)
+        request.options.addUserAgent = false
+
+        let promise = XCTestExpectation(description: "completed")
+        httpClient.execute(request) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("unexpected error \(error)")
+            case .success(let response):
+                XCTAssertEqual(response.statusCode, 200, "statusCode should match")
+            }
+            promise.fulfill()
+        }
+
+        wait(for: [promise], timeout: 1)
+    }
+
+    func testExponentialBackoff() {
+        var count = 0
+        var lastCall: Date?
+        let maxAttempts = 5
+        let errorCode = Int.random(in: 500 ..< 600)
+        let delay = DispatchTimeInterval.milliseconds(100)
+
+        let brokenHandler = { (_: HTTPClient.Request, callback: @escaping (Result<HTTPClient.Response, Error>) -> Void) in
+            let expectedDelta = pow(2.0, Double(count - 1)) * delay.timeInterval()!
+            let delta = lastCall?.distance(to: Date()) ?? 0
+            XCTAssertEqual(delta, expectedDelta, accuracy: 0.1)
+
+            count += 1
+            lastCall = Date()
+            callback(.success(HTTPClient.Response(statusCode: errorCode)))
+        }
+
+        let httpClient = HTTPClient(handler: brokenHandler)
+        var request = HTTPClient.Request(method: .get, url: URL(string: "http://test")!)
+        request.options.retryStrategy = .exponentialBackoff(maxAttempts: maxAttempts, baseDelay: delay)
+
+        let promise = XCTestExpectation(description: "completed")
+        httpClient.execute(request) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("unexpected error \(error)")
+            case .success(let response):
+                XCTAssertEqual(response.statusCode, errorCode)
+                XCTAssertEqual(count, maxAttempts, "retries should match")
+            }
+            promise.fulfill()
+        }
+
+        let timeout = Double(Int(pow(2.0, Double(maxAttempts))) * delay.milliseconds()!) / 1000
+        wait(for: [promise], timeout: timeout)
+    }
+
+    func testValidResponseCodes() {
+        let statusCode = Int.random(in: 201 ..< 500)
+        let brokenHandler = { (_: HTTPClient.Request, callback: @escaping (Result<HTTPClient.Response, Error>) -> Void) in
+            callback(.success(HTTPClient.Response(statusCode: statusCode)))
+        }
+
+        let httpClient = HTTPClient(handler: brokenHandler)
+        var request = HTTPClient.Request(method: .get, url: URL(string: "http://test")!)
+        request.options.validResponseCodes = [200]
+
+        let promise = XCTestExpectation(description: "completed")
+        httpClient.execute(request) { result in
+            switch result {
+            case .failure(let error):
+                XCTAssertEqual(error as? HTTPClientError, .badResponseStatusCode(statusCode), "expected error to match")
+            case .success(let response):
+                XCTFail("unexpected success \(response)")
+            }
+            promise.fulfill()
+        }
+
+        wait(for: [promise], timeout: 1)
+    }
+
+    func testCircuitBreaker() {
+        var count = 0
+        let errorCode = Int.random(in: 500 ..< 600)
+        let maxErrors = 5
+        let age = DispatchTimeInterval.milliseconds(100)
+
+        let brokenHandler = { (_: HTTPClient.Request, callback: @escaping (Result<HTTPClient.Response, Error>) -> Void) in
+            count += 1
+            callback(.success(HTTPClient.Response(statusCode: errorCode)))
+        }
+
+        let httpClient = HTTPClient(handler: brokenHandler)
+
+        let sync = DispatchGroup()
+        (0 ... maxErrors * 2).forEach { index in
+            sync.enter()
+            var request = HTTPClient.Request(method: .get, url: URL(string: "http://test.com/\(index)/foo")!)
+            request.options.circuitBreakerStrategy = .hostErrors(maxErrors: maxErrors, age: age)
+            httpClient.execute(request) { result in
+                defer { sync.leave() }
+                switch result {
+                case .failure(let error):
+                    if index < maxErrors {
+                        XCTFail("unexpected error \(error)")
+                    } else {
+                        XCTAssertEqual(error as? HTTPClientError, .circuitBreakerTriggered, "expected error to match")
+                    }
+                case .success(let response):
+                    if index < maxErrors {
+                        XCTAssertEqual(response.statusCode, errorCode, "expected status code to match")
+                    } else {
+                        XCTFail("unexpected success \(response)")
+                    }
+                }
+            }
+        }
+
+        let timeout = DispatchTime.now() + .milliseconds(age.milliseconds()! * maxErrors)
+        XCTAssertEqual(sync.wait(timeout: timeout), .success, "should not timeout")
+    }
+
+    func testCircuitBreakerAging() {
+        var count = 0
+        let errorCode = Int.random(in: 500 ..< 600)
+        let maxErrors = 5
+        let age = DispatchTimeInterval.milliseconds(100)
+
+        let brokenHandler = { (_: HTTPClient.Request, callback: @escaping (Result<HTTPClient.Response, Error>) -> Void) in
+            count += 1
+            if count < maxErrors / 2 {
+                // immediate
+                callback(.success(HTTPClient.Response(statusCode: errorCode)))
+            } else {
+                // age it
+                DispatchQueue.global().asyncAfter(deadline: .now() + age) {
+                    callback(.success(HTTPClient.Response(statusCode: errorCode)))
+                }
+            }
+        }
+
+        let httpClient = HTTPClient(handler: brokenHandler)
+
+        let sync = DispatchGroup()
+        (0 ... maxErrors * 2).forEach { index in
+            sync.enter()
+            var request = HTTPClient.Request(method: .get, url: URL(string: "http://test.com/\(index)/foo")!)
+            request.options.circuitBreakerStrategy = .hostErrors(maxErrors: maxErrors, age: age)
+            httpClient.execute(request) { result in
+                defer { sync.leave() }
+                switch result {
+                case .failure(let error):
+                    XCTFail("unexpected error \(error)")
+                case .success(let response):
+                    XCTAssertEqual(response.statusCode, errorCode, "expected status code to match")
+                }
+            }
+        }
+
+        let timeout = DispatchTime.now() + .milliseconds(age.milliseconds()! * maxErrors)
+        XCTAssertEqual(sync.wait(timeout: timeout), .success, "should not timeout")
+    }
+
+    func assertRequestHeaders(_ headers: HTTPClientHeaders, expected: HTTPClientHeaders) {
+        let noAgent = HTTPClientHeaders(headers.filter { $0.name != "User-Agent" })
+        XCTAssertEqual(noAgent, expected, "expected headers to match")
+    }
+
+    func assertResponseHeaders(_ headers: HTTPClientHeaders, expected: HTTPClientHeaders) {
+        XCTAssertEqual(headers, expected, "expected headers to match")
+    }
+}

--- a/Tests/BasicsTests/URLSessionHTTPClientTests.swift
+++ b/Tests/BasicsTests/URLSessionHTTPClientTests.swift
@@ -9,6 +9,12 @@
  */
 
 @testable import Basics
+import Foundation
+#if canImport(FoundationNetworking)
+// TODO: this brings OpenSSL dependency` on Linux
+// need to decide how to best deal with that
+import FoundationNetworking
+#endif
 import TSCBasic
 import TSCTestSupport
 import XCTest
@@ -190,18 +196,14 @@ final class URLSessionHTTPClientTest: XCTestCase {
     }
 
     private func assertRequestHeaders(_ headers: [String: String]?, expected: HTTPClientHeaders) {
-        let filtered = headers?.filter { $0.key != "User-Agent" && $0.key != "Content-Length" }
-        XCTAssertEqual(filtered?.count, expected.count, "expected size to match")
-        expected.forEach { header in
-            XCTAssertEqual(header.value, headers?[header.name], "expected value to match")
-        }
+        let headers = (headers?.filter { $0.key != "User-Agent" && $0.key != "Content-Length" } ?? [])
+            .flatMap { HTTPClientHeaders($0.map { .init(name: $0.key, value: $0.value) }) } ?? .init()
+        XCTAssertEqual(headers, expected)
     }
 
     private func assertResponseHeaders(_ headers: HTTPClientHeaders, expected: [String: String]) {
-        XCTAssertEqual(headers.count, expected.count, "expected size to match")
-        headers.forEach { header in
-            XCTAssertEqual(header.value, expected[header.name], "expected value to match")
-        }
+        let expected = HTTPClientHeaders(expected.map { .init(name: $0.key, value: $0.value) })
+        XCTAssertEqual(headers, expected)
     }
 }
 

--- a/Tests/BasicsTests/URLSessionHTTPClientTests.swift
+++ b/Tests/BasicsTests/URLSessionHTTPClientTests.swift
@@ -1,0 +1,329 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+@testable import Basics
+import TSCBasic
+import TSCTestSupport
+import XCTest
+
+final class URLSessionHTTPClientTest: XCTestCase {
+    func testHead() {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let urlSession = URLSessionHTTPClient(configuration: configuration)
+        let httpClient = HTTPClient(handler: urlSession.execute)
+
+        let url = URL(string: "http://test")!
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+
+        let responseStatus = 200
+        let responseHeaders = [UUID().uuidString: UUID().uuidString]
+        let responseBody = UUID().uuidString.data(using: .utf8)
+
+        MockURLProtocol.onRequest("HEAD", url) { request in
+            self.assertRequestHeaders(request.allHTTPHeaderFields, expected: requestHeaders)
+            MockURLProtocol.respond(request, statusCode: responseStatus, headers: responseHeaders, body: responseBody)
+        }
+
+        let promise = XCTestExpectation(description: "completed")
+        httpClient.head(url, headers: requestHeaders) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("unexpected error \(error)")
+            case .success(let response):
+                XCTAssertEqual(response.statusCode, responseStatus)
+                self.assertResponseHeaders(response.headers, expected: responseHeaders)
+                XCTAssertEqual(response.body, responseBody)
+            }
+            promise.fulfill()
+        }
+
+        wait(for: [promise], timeout: 1.0)
+    }
+
+    func testGet() {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let urlSession = URLSessionHTTPClient(configuration: configuration)
+        let httpClient = HTTPClient(handler: urlSession.execute)
+
+        let url = URL(string: "http://test")!
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+
+        let responseStatus = 200
+        let responseHeaders = [UUID().uuidString: UUID().uuidString]
+        let responseBody = UUID().uuidString.data(using: .utf8)
+
+        MockURLProtocol.onRequest("GET", url) { request in
+            self.assertRequestHeaders(request.allHTTPHeaderFields, expected: requestHeaders)
+            MockURLProtocol.respond(request, statusCode: responseStatus, headers: responseHeaders, body: responseBody)
+        }
+
+        let promise = XCTestExpectation(description: "completed")
+        httpClient.get(url, headers: requestHeaders) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("unexpected error \(error)")
+            case .success(let response):
+                XCTAssertEqual(response.statusCode, responseStatus)
+                self.assertResponseHeaders(response.headers, expected: responseHeaders)
+                XCTAssertEqual(response.body, responseBody)
+            }
+            promise.fulfill()
+        }
+
+        wait(for: [promise], timeout: 1.0)
+    }
+
+    func testPost() {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let urlSession = URLSessionHTTPClient(configuration: configuration)
+        let httpClient = HTTPClient(handler: urlSession.execute)
+
+        let url = URL(string: "http://test")!
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let requestBody = UUID().uuidString.data(using: .utf8)
+
+        let responseStatus = 200
+        let responseHeaders = [UUID().uuidString: UUID().uuidString]
+        let responseBody = UUID().uuidString.data(using: .utf8)
+
+        MockURLProtocol.onRequest("POST", url) { request in
+            // FIXME:
+            XCTAssertEqual(request.httpBody, requestBody)
+            self.assertRequestHeaders(request.allHTTPHeaderFields, expected: requestHeaders)
+            MockURLProtocol.respond(request, statusCode: responseStatus, headers: responseHeaders, body: responseBody)
+        }
+
+        let promise = XCTestExpectation(description: "completed")
+        httpClient.post(url, body: requestBody, headers: requestHeaders) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("unexpected error \(error)")
+            case .success(let response):
+                XCTAssertEqual(response.statusCode, responseStatus)
+                self.assertResponseHeaders(response.headers, expected: responseHeaders)
+                XCTAssertEqual(response.body, responseBody)
+            }
+            promise.fulfill()
+        }
+
+        wait(for: [promise], timeout: 1.0)
+    }
+
+    func testPut() {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let urlSession = URLSessionHTTPClient(configuration: configuration)
+        let httpClient = HTTPClient(handler: urlSession.execute)
+
+        let url = URL(string: "http://test")!
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+        let requestBody = UUID().uuidString.data(using: .utf8)
+
+        let responseStatus = 200
+        let responseHeaders = [UUID().uuidString: UUID().uuidString]
+        let responseBody = UUID().uuidString.data(using: .utf8)
+
+        MockURLProtocol.onRequest("PUT", url) { request in
+            XCTAssertEqual(request.httpBody, requestBody)
+            self.assertRequestHeaders(request.allHTTPHeaderFields, expected: requestHeaders)
+            MockURLProtocol.respond(request, statusCode: responseStatus, headers: responseHeaders, body: responseBody)
+        }
+
+        let promise = XCTestExpectation(description: "completed")
+        httpClient.put(url, body: requestBody, headers: requestHeaders) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("unexpected error \(error)")
+            case .success(let response):
+                XCTAssertEqual(response.statusCode, responseStatus)
+                self.assertResponseHeaders(response.headers, expected: responseHeaders)
+                XCTAssertEqual(response.body, responseBody)
+            }
+            promise.fulfill()
+        }
+
+        wait(for: [promise], timeout: 1.0)
+    }
+
+    func testDelete() {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let urlSession = URLSessionHTTPClient(configuration: configuration)
+        let httpClient = HTTPClient(handler: urlSession.execute)
+
+        let url = URL(string: "http://test")!
+        let requestHeaders = HTTPClientHeaders([HTTPClientHeaders.Item(name: UUID().uuidString, value: UUID().uuidString)])
+
+        let responseStatus = 200
+        let responseHeaders = [UUID().uuidString: UUID().uuidString]
+        let responseBody = UUID().uuidString.data(using: .utf8)
+
+        MockURLProtocol.onRequest("DELETE", url) { request in
+            self.assertRequestHeaders(request.allHTTPHeaderFields, expected: requestHeaders)
+            MockURLProtocol.respond(request, statusCode: responseStatus, headers: responseHeaders, body: responseBody)
+        }
+
+        let promise = XCTestExpectation(description: "completed")
+        httpClient.delete(url, headers: requestHeaders) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("unexpected error \(error)")
+            case .success(let response):
+                XCTAssertEqual(response.statusCode, responseStatus)
+                self.assertResponseHeaders(response.headers, expected: responseHeaders)
+                XCTAssertEqual(response.body, responseBody)
+            }
+            promise.fulfill()
+        }
+
+        wait(for: [promise], timeout: 1.0)
+    }
+
+    private func assertRequestHeaders(_ headers: [String: String]?, expected: HTTPClientHeaders) {
+        let filtered = headers?.filter { $0.key != "User-Agent" && $0.key != "Content-Length" }
+        XCTAssertEqual(filtered?.count, expected.count, "expected size to match")
+        expected.forEach { header in
+            XCTAssertEqual(header.value, headers?[header.name], "expected value to match")
+        }
+    }
+
+    private func assertResponseHeaders(_ headers: HTTPClientHeaders, expected: [String: String]) {
+        XCTAssertEqual(headers.count, expected.count, "expected size to match")
+        headers.forEach { header in
+            XCTAssertEqual(header.value, expected[header.name], "expected value to match")
+        }
+    }
+}
+
+private class MockURLProtocol: URLProtocol {
+    typealias Action = (URLRequest) -> Void
+
+    private static var lock = Lock()
+    private static var observers: [Key: Action] = [:]
+    private static var requests: [Key: URLProtocol] = [:]
+
+    static func onRequest(_ method: String, _ url: URL, completion: @escaping Action) {
+        let key = Key(url, method)
+        self.lock.withLock { () -> Void in
+            guard !self.observers.keys.contains(key) else {
+                return XCTFail("does not support multiple observers for the same url")
+            }
+            self.observers[key] = completion
+        }
+    }
+
+    static func respond(_ request: URLRequest, statusCode: Int, headers: [String: String]? = nil, body: Data? = nil) {
+        self.respond(request.httpMethod!, request.url!, statusCode: statusCode, headers: headers, body: body)
+    }
+
+    static func respond(_ method: String, _ url: URL, statusCode: Int, headers: [String: String]? = nil, body: Data? = nil) {
+        let key = Key(url, method)
+        let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: "1.1", headerFields: headers)!
+        self.sendResponse(response, for: key)
+        if let data = body {
+            self.sendData(data, for: key)
+        }
+        self.sendCompletion(for: key)
+    }
+
+    private static func sendResponse(_ response: URLResponse, for key: Key) {
+        guard let request = (self.lock.withLock { self.requests[key] }) else {
+            return XCTFail("url did not start loading")
+        }
+        request.client?.urlProtocol(request, didReceive: response, cacheStoragePolicy: .notAllowed)
+    }
+
+    private static func sendData(_ data: Data, for key: Key) {
+        guard let request = (self.lock.withLock { self.requests[key] }) else {
+            return XCTFail("url did not start loading")
+        }
+        request.client?.urlProtocol(request, didLoad: data)
+    }
+
+    private static func sendCompletion(for key: Key) {
+        guard let request = (self.lock.withLock { self.requests[key] }) else {
+            return XCTFail("url did not start loading")
+        }
+        request.client?.urlProtocolDidFinishLoading(request)
+    }
+
+    private static func sendError(_ error: Error, for key: Key) {
+        guard let request = (self.lock.withLock { self.requests[key] }) else {
+            return XCTFail("url did not start loading")
+        }
+        request.client?.urlProtocol(request, didFailWithError: error)
+    }
+
+    private struct Key: Hashable {
+        let url: URL
+        let method: String
+
+        init(_ url: URL, _ method: String) {
+            self.url = url
+            self.method = method
+        }
+    }
+
+    // MARK: - URLProtocol
+
+    override class func canInit(with _: URLRequest) -> Bool {
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    override func startLoading() {
+        if let url = self.request.url, let method = self.request.httpMethod {
+            let key = Key(url, method)
+
+            Self.lock.withLock {
+                Self.requests[key] = self
+            }
+
+            guard let action = (Self.lock.withLock { Self.observers[key] }) else {
+                return
+            }
+
+            // read body if available
+            var request = self.request
+            if let bodyStream = self.request.httpBodyStream {
+                bodyStream.open()
+                defer { bodyStream.close() }
+                let bufferSize: Int = 1024
+                let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+                var data = Data()
+                while bodyStream.hasBytesAvailable {
+                    let read = bodyStream.read(buffer, maxLength: bufferSize)
+                    data.append(buffer, count: read)
+                }
+                buffer.deallocate()
+                request.httpBody = data
+            }
+
+            DispatchQueue.main.async {
+                action(request)
+            }
+        }
+    }
+
+    override func stopLoading() {
+        if let url = self.request.url, let method = self.request.httpMethod {
+            let key = Key(url, method)
+            Self.lock.withLock {
+                Self.requests[key] = nil
+            }
+        }
+    }
+}


### PR DESCRIPTION
motivation: incoming features use HTTP to access remote resources: package collection and package registry. we should abstract given complexy around error handling and non-apple platform support

changes:
* create HTTPClient utility in Basics modules
* implement URLSession based backend
* implment exponential backoff
* implement (naive) circuit breaker
* add tests

TODO:
⚠️   discuss our approach to non-apple platforms (given FoundationNetworking dependency on OpenSSL)
