### PR TITLE
Support for `executableTarget` in the manifest, to allow use of `@main` in package targets

### DIFF
--- a/Fixtures/Miscellaneous/AtMainSupport/Package.swift
+++ b/Fixtures/Miscellaneous/AtMainSupport/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version:999.0
+import PackageDescription
+
+let package = Package(
+    name: "AtMainSupport",
+    products: [
+        .executable(name: "ClangExec", targets: ["ClangExec"]),
+        .executable(name: "SwiftExec", targets: ["SwiftExec"]),
+    ],
+    targets: [
+        .executableTarget(name: "ClangExec"),
+        .executableTarget(name: "SwiftExec"),
+    ]
+)

--- a/Fixtures/Miscellaneous/AtMainSupport/Sources/ClangExec/NotMain.c
+++ b/Fixtures/Miscellaneous/AtMainSupport/Sources/ClangExec/NotMain.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+int main() {
+    printf("Hello, C.");
+  }

--- a/Fixtures/Miscellaneous/AtMainSupport/Sources/SwiftExec/NotMain.swift
+++ b/Fixtures/Miscellaneous/AtMainSupport/Sources/SwiftExec/NotMain.swift
@@ -1,0 +1,6 @@
+@main 
+struct MyProgram {
+    static func main() {
+        print("Hello, Swift.")
+    }
+}

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2018 Apple Inc. and the Swift project authors
+ Copyright (c) 2018 - 2020 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -22,6 +22,8 @@ public final class Target {
     public enum TargetType: String, Encodable {
         /// A target that contains code for the Swift package’s functionality.
         case regular
+        /// A target that contains code for an executable's main module.
+        case executable
         /// A target that contains tests for the Swift package’s other targets.
         case test
         /// A target that adapts a library on the system to work with Swift packages.
@@ -196,7 +198,7 @@ public final class Target {
         self._checksum = checksum
 
         switch type {
-        case .regular, .test:
+        case .regular, .executable, .test:
             precondition(
                 url == nil &&
                 pkgConfig == nil &&
@@ -322,11 +324,11 @@ public final class Target {
         )
     }
 
-    /// Creates a library or executable target.
+    /// Creates a regular target.
     ///
-    /// A target can contain either Swift or C-family source files, but not both. The Swift Package Manager
-    /// considers a target to be an executable target if its directory contains a `main.swift`, `main.m`, `main.c`,
-    /// or `main.cpp` file. The Swift Package Manager considers all other targets to be library targets.
+    /// A target can contain either Swift or C-family source files, but not both. It contains code that is built as
+    /// a regular module that can be included in a library or executable product, but that cannot itself be used as
+    /// the main target of an executable product.
     ///
     /// - Parameters:
     ///   - name: The name of the target.
@@ -375,6 +377,60 @@ public final class Target {
         )
     }
 
+    /// Creates an executable target.
+    ///
+    /// An executable target can contain either Swift or C-family source files, but not both. It contains code that
+    /// is built as an executable module that can be used as the main target of an executable product.  The target
+    /// is expected to either have a source file named `main.swift`, `main.m`, `main.c`, or `main.cpp`, or a source
+    ///  file that contains the `@main` keyword.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the target.
+    ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
+    ///   - path: The custom path for the target. By default, the Swift Package Manager requires a target's sources to reside at predefined search paths;
+    ///       for example, `[PackageRoot]/Sources/[TargetName]`.
+    ///       Don't escape the package root; for example, values like `../Foo` or `/Foo` are invalid.
+    ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
+    ///       A path is relative to the target's directory.
+    ///       This parameter has precedence over the `sources` parameter.
+    ///   - sources: An explicit list of source files. If you provide a path to a directory,
+    ///       the Swift Package Manager searches for valid source files recursively.
+    ///   - resources: An explicit list of resources files.
+    ///   - publicHeadersPath: The directory containing public headers of a C-family library target.
+    ///   - cSettings: The C settings for this target.
+    ///   - cxxSettings: The C++ settings for this target.
+    ///   - swiftSettings: The Swift settings for this target.
+    ///   - linkerSettings: The linker settings for this target.
+    @available(_PackageDescription, introduced: 999.0)
+    public static func executableTarget(
+       name: String,
+       dependencies: [Dependency] = [],
+       path: String? = nil,
+       exclude: [String] = [],
+       sources: [String]? = nil,
+       resources: [Resource]? = nil,
+       publicHeadersPath: String? = nil,
+       cSettings: [CSetting]? = nil,
+       cxxSettings: [CXXSetting]? = nil,
+       swiftSettings: [SwiftSetting]? = nil,
+       linkerSettings: [LinkerSetting]? = nil
+    ) -> Target {
+       return Target(
+           name: name,
+           dependencies: dependencies,
+           path: path,
+           exclude: exclude,
+           sources: sources,
+           resources: resources,
+           publicHeadersPath: publicHeadersPath,
+           type: .executable,
+           cSettings: cSettings,
+           cxxSettings: cxxSettings,
+           swiftSettings: swiftSettings,
+           linkerSettings: linkerSettings
+       )
+    }
+    
     /// Creates a test target.
     ///
     /// Write test targets using the XCTest testing framework.

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -223,6 +223,9 @@ public final class PackageBuilder {
     /// If set to true, one test product will be created for each test target.
     private let shouldCreateMultipleTestProducts: Bool
 
+    /// Temporary parameter controlling whether to warn about implicit executable targets when tools version is vNext
+    private let warnAboutImplicitExecutableTargets: Bool
+
     /// Create the special REPL product for this package.
     private let createREPLProduct: Bool
 
@@ -252,6 +255,7 @@ public final class PackageBuilder {
         fileSystem: FileSystem = localFileSystem,
         diagnostics: DiagnosticsEngine,
         shouldCreateMultipleTestProducts: Bool = false,
+        warnAboutImplicitExecutableTargets: Bool = (ProcessEnv.vars["SWIFTPM_ENABLE_EXECUTABLE_TARGETS"] == "1"),
         createREPLProduct: Bool = false
     ) {
         self.manifest = manifest
@@ -264,6 +268,7 @@ public final class PackageBuilder {
         self.diagnostics = diagnostics
         self.shouldCreateMultipleTestProducts = shouldCreateMultipleTestProducts
         self.createREPLProduct = createREPLProduct
+        self.warnAboutImplicitExecutableTargets = warnAboutImplicitExecutableTargets
     }
 
     /// Loads a package from a package repository using the resources associated with a particular `swiftc` executable.
@@ -738,7 +743,7 @@ public final class PackageBuilder {
             targetType = .executable
         default:
             targetType = sources.computeTargetType()
-            if targetType == .executable && manifest.toolsVersion >= .vNext {
+            if targetType == .executable && manifest.toolsVersion >= .vNext && warnAboutImplicitExecutableTargets {
                 diagnostics.emit(warning: "in tools version \(ToolsVersion.vNext) and later, use 'executableTarget()' to declare executable targets")
             }
         }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -728,7 +728,18 @@ public final class PackageBuilder {
             return nil
         }
         try validateSourcesOverlapping(forTarget: potentialModule.name, sources: sources.paths)
-
+        
+        /// Determine the target's type, or leave nil to check the source directory.
+        let targetType: Target.Kind?
+        switch potentialModule.type {
+        case .test:
+            targetType = .test
+        case .executable:
+            targetType = .executable
+        default:
+            targetType = (manifest.toolsVersion >= .vNext) ? .library : nil
+        }
+        
         // Create and return the right kind of target depending on what kind of sources we found.
         if sources.hasSwiftSources {
             return SwiftTarget(
@@ -736,7 +747,7 @@ public final class PackageBuilder {
                 bundleName: bundleName,
                 defaultLocalization: manifest.defaultLocalization,
                 platforms: self.platforms(isTest: potentialModule.isTest),
-                isTest: potentialModule.isTest,
+                type: targetType,
                 sources: sources,
                 resources: resources,
                 dependencies: dependencies,
@@ -767,7 +778,7 @@ public final class PackageBuilder {
                 includeDir: publicHeadersPath,
                 moduleMapType: moduleMapType,
                 headers: headers,
-                isTest: potentialModule.isTest,
+                type: targetType,
                 sources: sources,
                 resources: resources,
                 dependencies: dependencies,

--- a/Sources/PackageLoading/PackageDescription4Loader.swift
+++ b/Sources/PackageLoading/PackageDescription4Loader.swift
@@ -333,6 +333,8 @@ extension TargetDescription.TargetType {
         switch string {
         case "regular":
             self = .regular
+        case "executable":
+            self = .executable
         case "test":
             self = .test
         case "system":

--- a/Sources/PackageModel/Manifest/TargetDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetDescription.swift
@@ -14,6 +14,7 @@ public struct TargetDescription: Equatable, Codable {
     /// The target type.
     public enum TargetType: String, Equatable, Codable {
         case regular
+        case executable
         case test
         case system
         case binary
@@ -124,7 +125,7 @@ public struct TargetDescription: Equatable, Codable {
         checksum: String? = nil
     ) {
         switch type {
-        case .regular, .test:
+        case .regular, .executable, .test:
             precondition(
                 url == nil &&
                 pkgConfig == nil &&

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -234,6 +234,8 @@ fileprivate extension SourceCodeFragment {
         switch target.type {
         case .regular:
             self.init(enum: "target", subnodes: params, multiline: true)
+        case .executable:
+            self.init(enum: "executableTarget", subnodes: params, multiline: true)
         case .test:
             self.init(enum: "testTarget", subnodes: params, multiline: true)
         case .system:

--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -225,7 +225,7 @@ public final class SwiftTarget: Target {
         bundleName: String? = nil,
         defaultLocalization: String? = nil,
         platforms: [SupportedPlatform] = [],
-        type: Kind? = nil,
+        type: Kind,
         sources: Sources,
         resources: [Resource] = [],
         dependencies: [Target.Dependency] = [],
@@ -238,7 +238,7 @@ public final class SwiftTarget: Target {
             bundleName: bundleName,
             defaultLocalization: defaultLocalization,
             platforms: platforms,
-            type: type ?? sources.computeTargetType(),
+            type: type,
             sources: sources,
             resources: resources,
             dependencies: dependencies,
@@ -389,7 +389,7 @@ public final class ClangTarget: Target {
         includeDir: AbsolutePath,
         moduleMapType: ModuleMapType,
         headers: [AbsolutePath] = [],
-        type: Kind? = nil,
+        type: Kind,
         sources: Sources,
         resources: [Resource] = [],
         dependencies: [Target.Dependency] = [],
@@ -407,7 +407,7 @@ public final class ClangTarget: Target {
             bundleName: bundleName,
             defaultLocalization: defaultLocalization,
             platforms: platforms,
-            type: type ?? sources.computeTargetType(),
+            type: type,
             sources: sources,
             resources: resources,
             dependencies: dependencies,
@@ -524,17 +524,5 @@ public final class BinaryTarget: Target {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.artifactSource = try container.decode(ArtifactSource.self, forKey: .artifactSource)
         try super.init(from: decoder)
-    }
-}
-
-extension Sources {
-    /// Determine target type based on the sources.
-    fileprivate func computeTargetType() -> Target.Kind {
-        let isLibrary = !relativePaths.contains { path in
-            let file = path.basename.lowercased()
-            // Look for a main.xxx file avoiding cases like main.xxx.xxx
-            return file.hasPrefix("main.") && String(file.filter({$0 == "."})).count == 1
-        }
-        return isLibrary ? .library : .executable
     }
 }

--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -225,21 +225,20 @@ public final class SwiftTarget: Target {
         bundleName: String? = nil,
         defaultLocalization: String? = nil,
         platforms: [SupportedPlatform] = [],
-        isTest: Bool = false,
+        type: Kind? = nil,
         sources: Sources,
         resources: [Resource] = [],
         dependencies: [Target.Dependency] = [],
         swiftVersion: SwiftLanguageVersion,
         buildSettings: BuildSettings.AssignmentTable = .init()
     ) {
-        let type: Kind = isTest ? .test : sources.computeTargetType()
         self.swiftVersion = swiftVersion
         super.init(
             name: name,
             bundleName: bundleName,
             defaultLocalization: defaultLocalization,
             platforms: platforms,
-            type: type,
+            type: type ?? sources.computeTargetType(),
             sources: sources,
             resources: resources,
             dependencies: dependencies,
@@ -390,14 +389,13 @@ public final class ClangTarget: Target {
         includeDir: AbsolutePath,
         moduleMapType: ModuleMapType,
         headers: [AbsolutePath] = [],
-        isTest: Bool = false,
+        type: Kind? = nil,
         sources: Sources,
         resources: [Resource] = [],
         dependencies: [Target.Dependency] = [],
         buildSettings: BuildSettings.AssignmentTable = .init()
     ) {
         assert(includeDir.contains(sources.root), "\(includeDir) should be contained in the source root \(sources.root)")
-        let type: Kind = isTest ? .test : sources.computeTargetType()
         self.isCXX = sources.containsCXXFiles
         self.cLanguageStandard = cLanguageStandard
         self.cxxLanguageStandard = cxxLanguageStandard
@@ -409,7 +407,7 @@ public final class ClangTarget: Target {
             bundleName: bundleName,
             defaultLocalization: defaultLocalization,
             platforms: platforms,
-            type: type,
+            type: type ?? sources.computeTargetType(),
             sources: sources,
             resources: resources,
             dependencies: dependencies,

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -168,6 +168,25 @@ final class BuildToolTests: XCTestCase {
             }
         }
     }
+    
+    func testAtMainSupport() {
+        fixture(name: "Miscellaneous/AtMainSupport") { path in
+            let fullPath = resolveSymlinks(path)
+            do {
+                let result = try build(["--product", "ClangExec"], packagePath: fullPath)
+                XCTAssert(result.binContents.contains("ClangExec"))
+            } catch SwiftPMProductError.executionFailure(_, let stdout, let stderr) {
+                XCTFail(stdout + "\n" + stderr)
+            }
+
+            do {
+                let result = try build(["--product", "SwiftExec"], packagePath: fullPath)
+                XCTAssert(result.binContents.contains("SwiftExec"))
+            } catch SwiftPMProductError.executionFailure(_, let stdout, let stderr) {
+                XCTFail(stdout + "\n" + stderr)
+            }
+        }
+    }
 
     func testNonReachableProductsAndTargetsFunctional() {
         fixture(name: "Miscellaneous/UnreachableTargets") { path in

--- a/Tests/PackageGraphTests/TargetTests.swift
+++ b/Tests/PackageGraphTests/TargetTests.swift
@@ -18,7 +18,7 @@ private extension ResolvedTarget {
     convenience init(name: String, deps: ResolvedTarget...) {
         self.init(
             target: SwiftTarget(
-                name: name, type: nil, 
+                name: name, type: .library, 
                 sources: Sources(paths: [], root: AbsolutePath("/")), dependencies: [], swiftVersion: .v4),
             dependencies: deps.map { .target($0, conditions: []) })
     }

--- a/Tests/PackageGraphTests/TargetTests.swift
+++ b/Tests/PackageGraphTests/TargetTests.swift
@@ -18,7 +18,7 @@ private extension ResolvedTarget {
     convenience init(name: String, deps: ResolvedTarget...) {
         self.init(
             target: SwiftTarget(
-                name: name, isTest: false, 
+                name: name, type: nil, 
                 sources: Sources(paths: [], root: AbsolutePath("/")), dependencies: [], swiftVersion: .v4),
             dependencies: deps.map { .target($0, conditions: []) })
     }

--- a/Tests/PackageLoadingTests/PD5_3LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5_3LoadingTests.swift
@@ -16,7 +16,7 @@ import SPMTestSupport
 import PackageModel
 import PackageLoading
 
-class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
+class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .v5_3
     }

--- a/Tests/PackageLoadingTests/PDNextVersionLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDNextVersionLoadingTests.swift
@@ -1,0 +1,42 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+import TSCBasic
+import TSCUtility
+import SPMTestSupport
+import PackageModel
+import PackageLoading
+
+class PackageDescriptionNextVersionLoadingTests: PackageDescriptionLoadingTests {
+    override var toolsVersion: ToolsVersion {
+        .vNext
+    }
+
+    func testExecutableTargets() throws {
+        let stream = BufferedOutputByteStream()
+        stream <<< """
+            import PackageDescription
+            let package = Package(
+               name: "Foo",
+               targets: [
+                   .executableTarget(
+                       name: "Foo"
+                    ),
+               ]
+            )
+            """
+
+        loadManifest(stream.bytes) { manifest in
+            XCTAssertEqual(manifest.targets[0].type, .executable)
+        }
+    }
+}

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -2207,6 +2207,7 @@ final class PackageBuilderTester {
                 fileSystem: fs,
                 diagnostics: diagnostics,
                 shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts,
+                warnAboutImplicitExecutableTargets: true,
                 createREPLProduct: createREPLProduct)
             let loadedPackage = try builder.construct()
             result = .package(loadedPackage)

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -385,66 +385,108 @@ class PackageBuilderTests: XCTestCase {
     }
 
     func testExecutableTargets() {
-        // Check that executable targets are supported.
         let fs = InMemoryFileSystem(emptyFiles:
-            "/Sources/exec/exec.swift",
-            "/Sources/foo/main.swift"
+            "/Sources/exec1/exec.swift",
+            "/Sources/exec2/main.swift",
+            "/Sources/lib/lib.swift"
         )
-
+        
+        // Check that an explicitly declared target without a main source file works.
         var manifest = Manifest.createV4Manifest(
             name: "pkg",
             toolsVersion: .vNext,
             products: [
-                ProductDescription(name: "exec", type: .executable, targets: ["exec", "foo"]),
+                ProductDescription(name: "exec1", type: .executable, targets: ["exec1", "lib"]),
             ],
             targets: [
-                TargetDescription(name: "foo"),
-                TargetDescription(name: "exec", type: .executable),
+                TargetDescription(name: "exec1", type: .executable),
+                TargetDescription(name: "lib"),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
-            package.checkModule("foo") { _ in }
-            package.checkModule("exec") { _ in }
-            package.checkProduct("exec") { product in
-                product.check(type: .executable, targets: ["exec", "foo"])
+            package.checkModule("lib") { _ in }
+            package.checkModule("exec1") { _ in }
+            package.checkProduct("exec1") { product in
+                product.check(type: .executable, targets: ["exec1", "lib"])
             }
         }
 
+        // Check that products are inferred for explicitly declared executable targets.
         manifest = Manifest.createV4Manifest(
             name: "pkg",
             toolsVersion: .vNext,
             products: [],
             targets: [
-                TargetDescription(name: "foo"),
-                TargetDescription(name: "exec", type: .executable),
+                TargetDescription(name: "exec1", type: .executable),
+                TargetDescription(name: "lib"),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
-            package.checkModule("foo") { _ in }
-            package.checkModule("exec") { _ in }
-            package.checkProduct("exec") { product in
-                product.check(type: .executable, targets: ["exec"])
+            package.checkModule("lib") { _ in }
+            package.checkModule("exec1") { _ in }
+            package.checkProduct("exec1") { product in
+                product.check(type: .executable, targets: ["exec1"])
             }
         }
 
-        // If we already have an explicit product, we shouldn't create an
-        // implicit one.
+        // Check that products are not inferred if there is an explicit executable product.
         manifest = Manifest.createV4Manifest(
             name: "pkg",
             toolsVersion: .vNext,
             products: [
-                ProductDescription(name: "exec", type: .executable, targets: ["exec"]),
+                ProductDescription(name: "exec1", type: .executable, targets: ["exec1"]),
             ],
             targets: [
-                TargetDescription(name: "foo"),
-                TargetDescription(name: "exec", type: .executable),
+                TargetDescription(name: "lib"),
+                TargetDescription(name: "exec1", type: .executable),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
-            package.checkModule("foo") { _ in }
-            package.checkModule("exec") { _ in }
-            package.checkProduct("exec") { product in
-                product.check(type: .executable, targets: ["exec"])
+            package.checkModule("lib") { _ in }
+            package.checkModule("exec1") { _ in }
+            package.checkProduct("exec1") { product in
+                product.check(type: .executable, targets: ["exec1"])
+            }
+        }
+
+        // Check that an explicitly declared target with a main source file still works.
+        manifest = Manifest.createV4Manifest(
+            name: "pkg",
+            toolsVersion: .vNext,
+            products: [
+                ProductDescription(name: "exec1", type: .executable, targets: ["exec1"]),
+            ],
+            targets: [
+                TargetDescription(name: "lib"),
+                TargetDescription(name: "exec1", type: .executable),
+            ]
+        )
+        PackageBuilderTester(manifest, in: fs) { package, _ in
+            package.checkModule("lib") { _ in }
+            package.checkModule("exec1") { _ in }
+            package.checkProduct("exec1") { product in
+                product.check(type: .executable, targets: ["exec1"])
+            }
+        }
+
+        // Check that a inferred target with a main source file still works but yields a warning.
+        manifest = Manifest.createV4Manifest(
+            name: "pkg",
+            toolsVersion: .vNext,
+            products: [
+                ProductDescription(name: "exec2", type: .executable, targets: ["exec2"]),
+            ],
+            targets: [
+                TargetDescription(name: "lib"),
+                TargetDescription(name: "exec2"),
+            ]
+        )
+        PackageBuilderTester(manifest, in: fs) { package, diagnostics in
+            diagnostics.check(diagnostic: "in tools version 999.0.0 and later, use 'executableTarget()' to declare executable targets", behavior: .warning)
+            package.checkModule("lib") { _ in }
+            package.checkModule("exec2") { _ in }
+            package.checkProduct("exec2") { product in
+                product.check(type: .executable, targets: ["exec2"])
             }
         }
     }


### PR DESCRIPTION
Implementation of support for `executableTarget` in the manifest.  This allows use of `@main` by having targets be explicitly declared as executable rather than by looking for particular file names.

One preliminary change compared with the evolution proposal is that, in order to make the upgrading from tools version 5.3 smoother, regular targets containing `main.swift` etc are still supported but cause a warning that the target declaration should be changed to `executableTarget` if the tools version is newer than 5.3.  This is a bit more clear than silently treating the target as a library once the tools version is upgraded.

### Motivation:

See https://forums.swift.org/t/se-0294-declaring-executable-targets-in-package-manifests/42404

### Changes:

Implements the evolution proposal (including the warning mentioned above) but temporarily adds a guard on the environment variable SWIFTPM_ENABLE_EXECUTABLE_TARGETS until the proposal has been accepted.