### PR TITLE
Disable `testRepositoryCacheDoesNotDerailResolution`

### DIFF
--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -67,6 +67,7 @@ class DependencyResolutionTests: XCTestCase {
     }
 
     func testRepositoryCacheDoesNotDerailResolution() throws {
+        try XCTSkipIf(true)
         // From rdar://problem/65284674
         // RepositoryPackageContainer used to erroneously cache dependencies based only on version,
         // storing the result of the first product filter and then continually returning it for other filters too.


### PR DESCRIPTION
This tests seems to access remote dependencies, we should change it so that it can work without network access. This disables it for now.
