### PR TITLE
Export "PackageCollections" module to clients

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
             targets: [
                 "SourceControl",
                 "SPMLLBuild",
-		"PackageCollections",
+                "PackageCollections",
                 "LLBuildManifest",
                 "PackageModel",
                 "PackageLoading",

--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,7 @@ let package = Package(
             targets: [
                 "SourceControl",
                 "SPMLLBuild",
+		"PackageCollections",
                 "LLBuildManifest",
                 "PackageModel",
                 "PackageLoading",
@@ -53,6 +54,7 @@ let package = Package(
                 "SourceControl",
                 "SPMLLBuild",
                 "LLBuildManifest",
+                "PackageCollections",
                 "PackageModel",
                 "PackageLoading",
                 "PackageGraph",
@@ -66,6 +68,7 @@ let package = Package(
             type: .dynamic,
             targets: [
                 "SourceControl",
+                "PackageCollections",
                 "PackageModel",
                 "PackageLoading",
                 "PackageGraph",


### PR DESCRIPTION
To make the new module available to clients of the various versions of libSwiftPM, we need to add it to the corresponding products.
