### PR TITLE
Add public initializer to `Profile`

### DIFF
--- a/Sources/PackageCollections/Model/Profile.swift
+++ b/Sources/PackageCollections/Model/Profile.swift
@@ -16,5 +16,9 @@ extension PackageCollectionsModel {
 
         /// Profile name
         public let name: String
+
+        public init(name: String) {
+            self.name = name
+        }
     }
 }


### PR DESCRIPTION
It is expected that clients have to construct `Profile` objects themselves, so there should be a public initializer.
