### PR TITLE
build_ubuntu_cross_compilation_toolchain URL Fix

### DIFF
--- a/Utilities/build_ubuntu_cross_compilation_toolchain
+++ b/Utilities/build_ubuntu_cross_compilation_toolchain
@@ -99,7 +99,7 @@ test -f "$macos_swift_pkg"
 test -f "$linux_swift_pkg"
 
 # config
-blocks_h_url="https://raw.githubusercontent.com/apple/swift-corelibs-libdispatch/master/src/BlocksRuntime/Block.h"
+blocks_h_url="https://raw.githubusercontent.com/apple/swift-corelibs-libdispatch/main/src/BlocksRuntime/Block.h"
 xc_tc_name="swift.xctoolchain"
 linux_sdk_name="ubuntu-xenial.sdk"
 cross_tc_basename="cross-toolchain"


### PR DESCRIPTION
The core libs files branch is now called main and not master, the script build_ubuntu_cross_compilation_toolchain fails silently because it can't find the file https://raw.githubusercontent.com/apple/swift-corelibs-libdispatch/master/src/BlocksRuntime/Block.h. 
### Motivation:

The script no longer works, and I'd like it to work again 😊

### Modifications:

Update of the url to https://raw.githubusercontent.com/apple/swift-corelibs-libdispatch/main/src/BlocksRuntime/Block.h

### Result:

The script completes successfully again.
