### PR TITLE
Improve FileSystemError by adding associated path

### DIFF
--- a/Sources/SPMTestSupport/InMemoryGitRepository.swift
+++ b/Sources/SPMTestSupport/InMemoryGitRepository.swift
@@ -211,7 +211,7 @@ extension InMemoryGitRepository: FileSystem {
     }
 
     public func changeCurrentWorkingDirectory(to path: AbsolutePath) throws {
-        throw FileSystemError.unsupported
+        throw FileSystemError(.unsupported, path)
     }
 
     public var homeDirectory: AbsolutePath {
@@ -231,7 +231,7 @@ extension InMemoryGitRepository: FileSystem {
     }
     
     public func createSymbolicLink(_ path: AbsolutePath, pointingAt destination: AbsolutePath, relative: Bool) throws {
-        throw FileSystemError.unsupported
+        throw FileSystemError(.unsupported, path)
     }
 
     public func readFileContents(_ path: AbsolutePath) throws -> ByteString {

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -638,13 +638,15 @@ private class GitFileSystemView: FileSystem {
         // Walk the components resolving the tree (starting with a synthetic
         // root entry).
         var current: Tree.Entry = Tree.Entry(hash: root, type: .tree, name: "/")
+        var currentPath = AbsolutePath.root
         for component in path.components.dropFirst(1) {
             // Skip the root pseudo-component.
             if component == "/" { continue }
 
+            currentPath = currentPath.appending(component: component)
             // We have a component to resolve, so the current entry must be a tree.
             guard current.type == .tree else {
-                throw FileSystemError.notDirectory
+                throw FileSystemError(.notDirectory, currentPath)
             }
 
             // Fetch the tree.
@@ -733,10 +735,10 @@ private class GitFileSystemView: FileSystem {
 
     func getDirectoryContents(_ path: AbsolutePath) throws -> [String] {
         guard let entry = try getEntry(path) else {
-            throw FileSystemError.noEntry
+            throw FileSystemError(.noEntry, path)
         }
         guard entry.type == .tree else {
-            throw FileSystemError.notDirectory
+            throw FileSystemError(.notDirectory, path)
         }
 
         return try getTree(entry.hash).contents.map({ $0.name })
@@ -744,10 +746,10 @@ private class GitFileSystemView: FileSystem {
 
     func readFileContents(_ path: AbsolutePath) throws -> ByteString {
         guard let entry = try getEntry(path) else {
-            throw FileSystemError.noEntry
+            throw FileSystemError(.noEntry, path)
         }
         guard entry.type != .tree else {
-            throw FileSystemError.isDirectory
+            throw FileSystemError(.isDirectory, path)
         }
         guard entry.type != .symlink else {
             fatalError("FIXME: not implemented")
@@ -766,27 +768,27 @@ private class GitFileSystemView: FileSystem {
     }
 
     func createDirectory(_ path: AbsolutePath) throws {
-        throw FileSystemError.unsupported
+        throw FileSystemError(.unsupported, path)
     }
 
     func createDirectory(_ path: AbsolutePath, recursive: Bool) throws {
-        throw FileSystemError.unsupported
+        throw FileSystemError(.unsupported, path)
     }
     
     func createSymbolicLink(_ path: AbsolutePath, pointingAt destination: AbsolutePath, relative: Bool) throws {
-        throw FileSystemError.unsupported
+        throw FileSystemError(.unsupported, path)
     }
 
     func writeFileContents(_ path: AbsolutePath, bytes: ByteString) throws {
-        throw FileSystemError.unsupported
+        throw FileSystemError(.unsupported, path)
     }
 
     func removeFileTree(_ path: AbsolutePath) throws {
-        throw FileSystemError.unsupported
+        throw FileSystemError(.unsupported, path)
     }
 
     func chmod(_ mode: FileMode, path: AbsolutePath, options: Set<FileMode.Option>) throws {
-        throw FileSystemError.unsupported
+        throw FileSystemError(.unsupported, path)
     }
 
     func copy(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -158,23 +158,44 @@ extension Diagnostic.Message {
 extension FileSystemError: CustomStringConvertible {
     
     public var description: String {
-        switch self {
+        guard let path = path else {
+            switch self.kind {
+            case .invalidAccess:
+                return "invalid access"
+            case .ioError:
+                return "encountered I/O error"
+            case .isDirectory:
+                return "is a directory"
+            case .noEntry:
+                return "doesn't exist in file system"
+            case .notDirectory:
+                return "is not a directory"
+            case .unsupported:
+                return "unsupported operation"
+            case .unknownOSError:
+                return "unknown system error"
+            case .alreadyExistsAtDestination:
+                return "already exists in file system"
+            }
+        }
+
+        switch self.kind {
         case .invalidAccess:
-            return "invalid access"
+            return "invalid access to \(path)"
         case .ioError:
-            return "encountered I/O error"
+            return "encountered an I/O error while reading \(path)"
         case .isDirectory:
-            return "is a directory"
+            return "\(path) is a directory"
         case .noEntry:
-            return "doesn't exist in file system"
+            return "\(path) doesn't exist in file system"
         case .notDirectory:
-            return "is not a directory"
+            return "\(path) is not a directory"
         case .unsupported:
-            return "unsupported operation"
+            return "unsupported operation on \(path)"
         case .unknownOSError:
-            return "unknown system error"
+            return "unknown system error while operating on \(path)"
         case .alreadyExistsAtDestination:
-            return "already exists in file system"
+            return "\(path) already exists in file system"
         }
     }
 }

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -208,31 +208,36 @@ class GitRepositoryTests: XCTestCase {
             XCTAssert(view.isExecutableFile(AbsolutePath("/test-file-3.sh")))
 
             // Check read of a directory.
+            let subdirPath = AbsolutePath("/subdir")
             XCTAssertEqual(try view.getDirectoryContents(AbsolutePath("/")).sorted(), ["file.swift", "subdir", "test-file-1.txt", "test-file-3.sh"])
-            XCTAssertEqual(try view.getDirectoryContents(AbsolutePath("/subdir")).sorted(), ["test-file-2.txt"])
-            XCTAssertThrows(FileSystemError.isDirectory) {
-                _ = try view.readFileContents(AbsolutePath("/subdir"))
+            XCTAssertEqual(try view.getDirectoryContents(subdirPath).sorted(), ["test-file-2.txt"])
+            XCTAssertThrows(FileSystemError(.isDirectory, subdirPath)) {
+                _ = try view.readFileContents(subdirPath)
             }
 
             // Check read versus root.
-            XCTAssertThrows(FileSystemError.isDirectory) {
-                _ = try view.readFileContents(AbsolutePath("/"))
+            XCTAssertThrows(FileSystemError(.isDirectory, .root)) {
+                _ = try view.readFileContents(.root)
             }
 
             // Check read through a non-directory.
-            XCTAssertThrows(FileSystemError.notDirectory) {
-                _ = try view.getDirectoryContents(AbsolutePath("/test-file-1.txt"))
+            let notDirectoryPath1 = AbsolutePath("/test-file-1.txt")
+            XCTAssertThrows(FileSystemError(.notDirectory, notDirectoryPath1)) {
+                _ = try view.getDirectoryContents(notDirectoryPath1)
             }
-            XCTAssertThrows(FileSystemError.notDirectory) {
-                _ = try view.readFileContents(AbsolutePath("/test-file-1.txt/thing"))
+            let notDirectoryPath2 = AbsolutePath("/test-file-1.txt/thing")
+            XCTAssertThrows(FileSystemError(.notDirectory, notDirectoryPath2)) {
+                _ = try view.readFileContents(notDirectoryPath2)
             }
 
             // Check read/write into a missing directory.
-            XCTAssertThrows(FileSystemError.noEntry) {
-                _ = try view.getDirectoryContents(AbsolutePath("/does-not-exist"))
+            let noEntryPath1 = AbsolutePath("/does-not-exist")
+            XCTAssertThrows(FileSystemError(.noEntry, noEntryPath1)) {
+                _ = try view.getDirectoryContents(noEntryPath1)
             }
-            XCTAssertThrows(FileSystemError.noEntry) {
-                _ = try view.readFileContents(AbsolutePath("/does/not/exist"))
+            let noEntryPath2 = AbsolutePath("/does/not/exist")
+            XCTAssertThrows(FileSystemError(.noEntry, noEntryPath2)) {
+                _ = try view.readFileContents(noEntryPath2)
             }
 
             // Check read of a file.

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3030,7 +3030,7 @@ final class WorkspaceTests: XCTestCase {
                 result.check(targets: "Foo")
             }
             DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("the package at '/tmp/ws/pkgs/Bar' cannot be accessed (doesn't exist in file system"), behavior: .error)
+                result.check(diagnostic: .contains("the package at '/tmp/ws/pkgs/Bar' cannot be accessed (/tmp/ws/pkgs/Bar doesn't exist in file system"), behavior: .error)
             }
         }
     }

--- a/swift-tools-support-core/Sources/TSCBasic/FileSystem.swift
+++ b/swift-tools-support-core/Sources/TSCBasic/FileSystem.swift
@@ -12,74 +12,87 @@ import TSCLibc
 import Foundation
 import Dispatch
 
-public enum FileSystemError: Swift.Error {
-    /// Access to the path is denied.
-    ///
-    /// This is used when an operation cannot be completed because a component of
-    /// the path cannot be accessed.
-    ///
-    /// Used in situations that correspond to the POSIX EACCES error code.
-    case invalidAccess
+public struct FileSystemError: Swift.Error, Equatable {
+    public enum Kind: Equatable {
+        /// Access to the path is denied.
+        ///
+        /// This is used when an operation cannot be completed because a component of
+        /// the path cannot be accessed.
+        ///
+        /// Used in situations that correspond to the POSIX EACCES error code.
+        case invalidAccess
 
-    /// IO Error encoding
-    ///
-    /// This is used when an operation cannot be completed due to an otherwise
-    /// unspecified IO error.
-    case ioError
+        /// IO Error encoding
+        ///
+        /// This is used when an operation cannot be completed due to an otherwise
+        /// unspecified IO error.
+        case ioError(code: Int32)
 
-    /// Is a directory
-    ///
-    /// This is used when an operation cannot be completed because a component
-    /// of the path which was expected to be a file was not.
-    ///
-    /// Used in situations that correspond to the POSIX EISDIR error code.
-    case isDirectory
+        /// Is a directory
+        ///
+        /// This is used when an operation cannot be completed because a component
+        /// of the path which was expected to be a file was not.
+        ///
+        /// Used in situations that correspond to the POSIX EISDIR error code.
+        case isDirectory
 
-    /// No such path exists.
-    ///
-    /// This is used when a path specified does not exist, but it was expected
-    /// to.
-    ///
-    /// Used in situations that correspond to the POSIX ENOENT error code.
-    case noEntry
+        /// No such path exists.
+        ///
+        /// This is used when a path specified does not exist, but it was expected
+        /// to.
+        ///
+        /// Used in situations that correspond to the POSIX ENOENT error code.
+        case noEntry
 
-    /// Not a directory
-    ///
-    /// This is used when an operation cannot be completed because a component
-    /// of the path which was expected to be a directory was not.
-    ///
-    /// Used in situations that correspond to the POSIX ENOTDIR error code.
-    case notDirectory
+        /// Not a directory
+        ///
+        /// This is used when an operation cannot be completed because a component
+        /// of the path which was expected to be a directory was not.
+        ///
+        /// Used in situations that correspond to the POSIX ENOTDIR error code.
+        case notDirectory
 
-    /// Unsupported operation
-    ///
-    /// This is used when an operation is not supported by the concrete file
-    /// system implementation.
-    case unsupported
+        /// Unsupported operation
+        ///
+        /// This is used when an operation is not supported by the concrete file
+        /// system implementation.
+        case unsupported
 
-    /// An unspecific operating system error.
-    case unknownOSError
+        /// An unspecific operating system error at a given path.
+        case unknownOSError
 
-    /// File or folder already exists at destination.
-    ///
-    /// This is thrown when copying or moving a file or directory but the destination
-    /// path already contains a file or folder.
-    case alreadyExistsAtDestination
+        /// File or folder already exists at destination.
+        ///
+        /// This is thrown when copying or moving a file or directory but the destination
+        /// path already contains a file or folder.
+        case alreadyExistsAtDestination
+    }
+
+    /// The kind of the error being raised.
+    public let kind: Kind
+
+    /// The absolute path to the file associated with the error, if available.
+    public let path: AbsolutePath?
+
+    public init(_ kind: Kind, _ path: AbsolutePath? = nil) {
+        self.kind = kind
+        self.path = path
+    }
 }
 
 public extension FileSystemError {
-    init(errno: Int32) {
+    init(errno: Int32, _ path: AbsolutePath) {
         switch errno {
         case TSCLibc.EACCES:
-            self = .invalidAccess
+            self.init(.invalidAccess, path)
         case TSCLibc.EISDIR:
-            self = .isDirectory
+            self.init(.isDirectory, path)
         case TSCLibc.ENOENT:
-            self = .noEntry
+            self.init(.noEntry, path)
         case TSCLibc.ENOTDIR:
-            self = .notDirectory
+            self.init(.notDirectory, path)
         default:
-            self = .unknownOSError
+            self.init(.unknownOSError, path)
         }
     }
 }
@@ -238,7 +251,7 @@ public extension FileSystem {
     // if `atomically` is `true`, otherwise fall back to whatever implementation already exists.
     func writeFileContents(_ path: AbsolutePath, bytes: ByteString, atomically: Bool) throws {
         guard !atomically else {
-            throw FileSystemError.unsupported
+            throw FileSystemError(.unsupported, path)
         }
         try writeFileContents(path, bytes: bytes)
     }
@@ -252,11 +265,11 @@ public extension FileSystem {
     }
 
     func getFileInfo(_ path: AbsolutePath) throws -> FileInfo {
-        throw FileSystemError.unsupported
+        throw FileSystemError(.unsupported, path)
     }
 
     func withLock<T>(on path: AbsolutePath, type: FileLock.LockType, _ body: () throws -> T) throws -> T {
-        throw FileSystemError.unsupported
+        throw FileSystemError(.unsupported, path)
     }
 }
 
@@ -316,11 +329,11 @@ private class LocalFileSystem: FileSystem {
 
     func changeCurrentWorkingDirectory(to path: AbsolutePath) throws {
         guard isDirectory(path) else {
-            throw FileSystemError.notDirectory
+            throw FileSystemError(.notDirectory, path)
         }
 
         guard FileManager.default.changeCurrentDirectoryPath(path.pathString) else {
-            throw FileSystemError.unknownOSError
+            throw FileSystemError(.unknownOSError, path)
         }
     }
 
@@ -366,7 +379,7 @@ private class LocalFileSystem: FileSystem {
         // Open the file.
         let fp = fopen(path.pathString, "rb")
         if fp == nil {
-            throw FileSystemError(errno: errno)
+            throw FileSystemError(errno: errno, path)
         }
         defer { fclose(fp) }
 
@@ -377,11 +390,12 @@ private class LocalFileSystem: FileSystem {
             let n = fread(&tmpBuffer, 1, tmpBuffer.count, fp)
             if n < 0 {
                 if errno == EINTR { continue }
-                throw FileSystemError.ioError
+                throw FileSystemError(.ioError(code: errno), path)
             }
             if n == 0 {
-                if ferror(fp) != 0 {
-                    throw FileSystemError.ioError
+                let errno = ferror(fp)
+                if errno != 0 {
+                    throw FileSystemError(.ioError(code: errno), path)
                 }
                 break
             }
@@ -395,7 +409,7 @@ private class LocalFileSystem: FileSystem {
         // Open the file.
         let fp = fopen(path.pathString, "wb")
         if fp == nil {
-            throw FileSystemError(errno: errno)
+            throw FileSystemError(errno: errno, path)
         }
         defer { fclose(fp) }
 
@@ -405,10 +419,10 @@ private class LocalFileSystem: FileSystem {
             let n = fwrite(&contents, 1, contents.count, fp)
             if n < 0 {
                 if errno == EINTR { continue }
-                throw FileSystemError.ioError
+                throw FileSystemError(.ioError(code: errno), path)
             }
             if n != contents.count {
-                throw FileSystemError.ioError
+                throw FileSystemError(.unknownOSError, path)
             }
             break
         }
@@ -454,7 +468,7 @@ private class LocalFileSystem: FileSystem {
         guard let traverse = FileManager.default.enumerator(
                 at: URL(fileURLWithPath: path.pathString),
                 includingPropertiesForKeys: nil) else {
-            throw FileSystemError.noEntry
+            throw FileSystemError(.noEntry, path)
         }
 
         if !options.contains(.recursive) {
@@ -467,14 +481,16 @@ private class LocalFileSystem: FileSystem {
     }
 
     func copy(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
-        guard exists(sourcePath) else { throw FileSystemError.noEntry }
-        guard !exists(destinationPath) else { throw FileSystemError.alreadyExistsAtDestination }
+        guard exists(sourcePath) else { throw FileSystemError(.noEntry, sourcePath) }
+        guard !exists(destinationPath)
+        else { throw FileSystemError(.alreadyExistsAtDestination, destinationPath) }
         try FileManager.default.copyItem(at: sourcePath.asURL, to: destinationPath.asURL)
     }
 
     func move(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
-        guard exists(sourcePath) else { throw FileSystemError.noEntry }
-        guard !exists(destinationPath) else { throw FileSystemError.alreadyExistsAtDestination }
+        guard exists(sourcePath) else { throw FileSystemError(.noEntry, sourcePath) }
+        guard !exists(destinationPath)
+        else { throw FileSystemError(.alreadyExistsAtDestination, destinationPath) }
         try FileManager.default.moveItem(at: sourcePath.asURL, to: destinationPath.asURL)
     }
 
@@ -488,6 +504,9 @@ private class LocalFileSystem: FileSystem {
 //
 /// Concrete FileSystem implementation which simulates an empty disk.
 public class InMemoryFileSystem: FileSystem {
+    
+    /// Private internal representation of a file system node.
+    /// Not threadsafe.
     private class Node {
         /// The actual node data.
         let contents: NodeContents
@@ -501,6 +520,9 @@ public class InMemoryFileSystem: FileSystem {
            return Node(contents.copy())
         }
     }
+
+    /// Private internal representation the contents of a file system node.
+    /// Not threadsafe.
     private enum NodeContents {
         case file(ByteString)
         case directory(DirectoryContents)
@@ -518,6 +540,9 @@ public class InMemoryFileSystem: FileSystem {
             }
         }
     }
+    
+    /// Private internal representation the contents of a directory.
+    /// Not threadsafe.
     private class DirectoryContents {
         var entries: [String: Node]
 
@@ -535,10 +560,28 @@ public class InMemoryFileSystem: FileSystem {
         }
     }
 
-    /// The root filesytem.
+    /// The root node of the filesytem.
     private var root: Node
+    
+    /// Protects `root` and everything underneath it.
+    /// FIXME: Using a single lock for this is a performance problem, but in
+    /// reality, the only practical use for InMemoryFileSystem is for unit
+    /// tests.
+    private let lock = Lock()
+    /// A map that keeps weak references to all locked files.
+    private var lockFiles = Dictionary<AbsolutePath, WeakReference<DispatchQueue>>()
     /// Used to access lockFiles in a thread safe manner.
     private let lockFilesLock = Lock()
+    
+    /// Exclusive file system lock vended to clients through `withLock()`.
+    // Used to ensure that DispatchQueues are releassed when they are no longer in use.
+    private struct WeakReference<Value: AnyObject> {
+        weak var reference: Value?
+
+        init(_ value: Value?) {
+            self.reference = value
+        }
+    }
 
     public init() {
         root = Node(.directory(DirectoryContents()))
@@ -546,12 +589,15 @@ public class InMemoryFileSystem: FileSystem {
 
     /// Creates deep copy of the object.
     public func copy() -> InMemoryFileSystem {
-        let fs = InMemoryFileSystem()
-        fs.root = root.copy()
-        return fs
+        return lock.withLock {
+            let fs = InMemoryFileSystem()
+            fs.root = root.copy()
+            return fs
+        }
     }
 
-    /// Get the node corresponding to the given path.
+    /// Private function to look up the node corresponding to a path.
+    /// Not threadsafe.
     private func getNode(_ path: AbsolutePath, followSymlink: Bool = true) throws -> Node? {
         func getNodeInternal(_ path: AbsolutePath) throws -> Node? {
             // If this is the root node, return it.
@@ -566,7 +612,7 @@ public class InMemoryFileSystem: FileSystem {
 
             // If we didn't find a directory, this is an error.
             guard case .directory(let contents) = parent.contents else {
-                throw FileSystemError.notDirectory
+                throw FileSystemError(.notDirectory, path.parentDirectory)
             }
 
             // Return the directory entry.
@@ -590,46 +636,54 @@ public class InMemoryFileSystem: FileSystem {
     // MARK: FileSystem Implementation
 
     public func exists(_ path: AbsolutePath, followSymlink: Bool) -> Bool {
-        do {
-            switch try getNode(path, followSymlink: followSymlink)?.contents {
-            case .file, .directory, .symlink: return true
-            case .none: return false
+        return lock.withLock {
+            do {
+                switch try getNode(path, followSymlink: followSymlink)?.contents {
+                case .file, .directory, .symlink: return true
+                case .none: return false
+                }
+            } catch {
+                return false
             }
-        } catch {
-            return false
         }
     }
 
     public func isDirectory(_ path: AbsolutePath) -> Bool {
-        do {
-            if case .directory? = try getNode(path)?.contents {
-                return true
+        return lock.withLock {
+            do {
+                if case .directory? = try getNode(path)?.contents {
+                    return true
+                }
+                return false
+            } catch {
+                return false
             }
-            return false
-        } catch {
-            return false
         }
     }
 
     public func isFile(_ path: AbsolutePath) -> Bool {
-        do {
-            if case .file? = try getNode(path)?.contents {
-                return true
+        return lock.withLock {
+            do {
+                if case .file? = try getNode(path)?.contents {
+                    return true
+                }
+                return false
+            } catch {
+                return false
             }
-            return false
-        } catch {
-            return false
         }
     }
 
     public func isSymlink(_ path: AbsolutePath) -> Bool {
-        do {
-            if case .symlink? = try getNode(path, followSymlink: false)?.contents {
-                return true
+        return lock.withLock {
+            do {
+                if case .symlink? = try getNode(path, followSymlink: false)?.contents {
+                    return true
+                }
+                return false
+            } catch {
+                return false
             }
-            return false
-        } catch {
-            return false
         }
     }
 
@@ -645,7 +699,7 @@ public class InMemoryFileSystem: FileSystem {
     }
 
     public func changeCurrentWorkingDirectory(to path: AbsolutePath) throws {
-        throw FileSystemError.unsupported
+        throw FileSystemError(.unsupported, path)
     }
 
     public var homeDirectory: AbsolutePath {
@@ -658,18 +712,21 @@ public class InMemoryFileSystem: FileSystem {
     }
 
     public func getDirectoryContents(_ path: AbsolutePath) throws -> [String] {
-        guard let node = try getNode(path) else {
-            throw FileSystemError.noEntry
-        }
-        guard case .directory(let contents) = node.contents else {
-            throw FileSystemError.notDirectory
-        }
+        return try lock.withLock {
+            guard let node = try getNode(path) else {
+                throw FileSystemError(.noEntry, path)
+            }
+            guard case .directory(let contents) = node.contents else {
+                throw FileSystemError(.notDirectory, path)
+            }
 
-        // FIXME: Perhaps we should change the protocol to allow lazy behavior.
-        return [String](contents.entries.keys)
+            // FIXME: Perhaps we should change the protocol to allow lazy behavior.
+            return [String](contents.entries.keys)
+        }
     }
-
-    public func createDirectory(_ path: AbsolutePath, recursive: Bool) throws {
+    
+    /// Not threadsafe.
+    private func _createDirectory(_ path: AbsolutePath, recursive: Bool) throws {
         // Ignore if client passes root.
         guard !path.isRoot else {
             return
@@ -681,20 +738,20 @@ public class InMemoryFileSystem: FileSystem {
             // to create the parent and retry.
             if recursive && path != parentPath {
                 // Attempt to create the parent.
-                try createDirectory(parentPath, recursive: true)
+                try _createDirectory(parentPath, recursive: true)
 
                 // Re-attempt creation, non-recursively.
-                return try createDirectory(path, recursive: false)
+                return try _createDirectory(path, recursive: false)
             } else {
                 // Otherwise, we failed.
-                throw FileSystemError.noEntry
+                throw FileSystemError(.noEntry, parentPath)
             }
         }
 
         // Check that the parent is a directory.
         guard case .directory(let contents) = parent.contents else {
             // The parent isn't a directory, this is an error.
-            throw FileSystemError.notDirectory
+            throw FileSystemError(.notDirectory, parentPath)
         }
 
         // Check if the node already exists.
@@ -702,7 +759,7 @@ public class InMemoryFileSystem: FileSystem {
             // Verify it is a directory.
             guard case .directory = node.contents else {
                 // The path itself isn't a directory, this is an error.
-                throw FileSystemError.notDirectory
+                throw FileSystemError(.notDirectory, path)
             }
 
             // We are done.
@@ -713,71 +770,83 @@ public class InMemoryFileSystem: FileSystem {
         contents.entries[path.basename] = Node(.directory(DirectoryContents()))
     }
 
+    public func createDirectory(_ path: AbsolutePath, recursive: Bool) throws {
+        return try lock.withLock {
+            try _createDirectory(path, recursive: recursive)
+        }
+    }
+
     public func createSymbolicLink(_ path: AbsolutePath, pointingAt destination: AbsolutePath, relative: Bool) throws {
-        // Create directory to destination parent.
-        guard let destinationParent = try getNode(path.parentDirectory) else {
-            throw FileSystemError.noEntry
+        return try lock.withLock {
+            // Create directory to destination parent.
+            guard let destinationParent = try getNode(path.parentDirectory) else {
+                throw FileSystemError(.noEntry, path.parentDirectory)
+            }
+
+            // Check that the parent is a directory.
+            guard case .directory(let contents) = destinationParent.contents else {
+                throw FileSystemError(.notDirectory, path.parentDirectory)
+            }
+
+            guard contents.entries[path.basename] == nil else {
+                throw FileSystemError(.alreadyExistsAtDestination, path)
+            }
+
+            let destination = relative ? destination.relative(to: path.parentDirectory).pathString : destination.pathString
+
+            contents.entries[path.basename] = Node(.symlink(destination))
         }
-
-        // Check that the parent is a directory.
-        guard case .directory(let contents) = destinationParent.contents else {
-            throw FileSystemError.notDirectory
-        }
-
-        guard contents.entries[path.basename] == nil else {
-            throw FileSystemError.alreadyExistsAtDestination
-        }
-
-        let destination = relative ? destination.relative(to: path.parentDirectory).pathString : destination.pathString
-
-        contents.entries[path.basename] = Node(.symlink(destination))
     }
 
     public func readFileContents(_ path: AbsolutePath) throws -> ByteString {
-        // Get the node.
-        guard let node = try getNode(path) else {
-            throw FileSystemError.noEntry
-        }
+        return try lock.withLock {
+            // Get the node.
+            guard let node = try getNode(path) else {
+                throw FileSystemError(.noEntry, path)
+            }
 
-        // Check that the node is a file.
-        guard case .file(let contents) = node.contents else {
-            // The path is a directory, this is an error.
-            throw FileSystemError.isDirectory
-        }
+            // Check that the node is a file.
+            guard case .file(let contents) = node.contents else {
+                // The path is a directory, this is an error.
+                throw FileSystemError(.isDirectory, path)
+            }
 
-        // Return the file contents.
-        return contents
+            // Return the file contents.
+            return contents
+        }
     }
 
     public func writeFileContents(_ path: AbsolutePath, bytes: ByteString) throws {
-        // It is an error if this is the root node.
-        let parentPath = path.parentDirectory
-        guard path != parentPath else {
-            throw FileSystemError.isDirectory
-        }
-
-        // Get the parent node.
-        guard let parent = try getNode(parentPath) else {
-            throw FileSystemError.noEntry
-        }
-
-        // Check that the parent is a directory.
-        guard case .directory(let contents) = parent.contents else {
-            // The parent isn't a directory, this is an error.
-            throw FileSystemError.notDirectory
-        }
-
-        // Check if the node exists.
-        if let node = contents.entries[path.basename] {
-            // Verify it is a file.
-            guard case .file = node.contents else {
-                // The path is a directory, this is an error.
-                throw FileSystemError.isDirectory
+        return try lock.withLock {
+            // It is an error if this is the root node.
+            let parentPath = path.parentDirectory
+            guard path != parentPath else {
+                throw FileSystemError(.isDirectory, path)
             }
-        }
 
-        // Write the file.
-        contents.entries[path.basename] = Node(.file(bytes))
+            // Get the parent node.
+            guard let parent = try getNode(parentPath) else {
+                throw FileSystemError(.noEntry, parentPath)
+            }
+
+            // Check that the parent is a directory.
+            guard case .directory(let contents) = parent.contents else {
+                // The parent isn't a directory, this is an error.
+                throw FileSystemError(.notDirectory, parentPath)
+            }
+
+            // Check if the node exists.
+            if let node = contents.entries[path.basename] {
+                // Verify it is a file.
+                guard case .file = node.contents else {
+                    // The path is a directory, this is an error.
+                    throw FileSystemError(.isDirectory, path)
+                }
+            }
+
+            // Write the file.
+            contents.entries[path.basename] = Node(.file(bytes))
+        }
     }
 
     public func writeFileContents(_ path: AbsolutePath, bytes: ByteString, atomically: Bool) throws {
@@ -787,62 +856,91 @@ public class InMemoryFileSystem: FileSystem {
     }
 
     public func removeFileTree(_ path: AbsolutePath) throws {
-        // Ignore root and get the parent node's content if its a directory.
-        guard !path.isRoot,
-              let parent = try? getNode(path.parentDirectory),
-            case .directory(let contents) = parent.contents else {
-            return
+        return lock.withLock {
+            // Ignore root and get the parent node's content if its a directory.
+            guard !path.isRoot,
+                  let parent = try? getNode(path.parentDirectory),
+                case .directory(let contents) = parent.contents else {
+                return
+            }
+            // Set it to nil to release the contents.
+            contents.entries[path.basename] = nil
         }
-        // Set it to nil to release the contents.
-        contents.entries[path.basename] = nil
     }
 
     public func chmod(_ mode: FileMode, path: AbsolutePath, options: Set<FileMode.Option>) throws {
         // FIXME: We don't have these semantics in InMemoryFileSystem.
     }
-
-    public func copy(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
+    
+    /// Private implementation of core copying function.
+    /// Not threadsafe.
+    private func _copy(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
         // Get the source node.
         guard let source = try getNode(sourcePath) else {
-            throw FileSystemError.noEntry
+            throw FileSystemError(.noEntry, sourcePath)
         }
 
         // Create directory to destination parent.
         guard let destinationParent = try getNode(destinationPath.parentDirectory) else {
-            throw FileSystemError.noEntry
+            throw FileSystemError(.noEntry, destinationPath.parentDirectory)
         }
 
         // Check that the parent is a directory.
         guard case .directory(let contents) = destinationParent.contents else {
-            throw FileSystemError.notDirectory
+            throw FileSystemError(.notDirectory, destinationPath.parentDirectory)
         }
 
         guard contents.entries[destinationPath.basename] == nil else {
-            throw FileSystemError.alreadyExistsAtDestination
+            throw FileSystemError(.alreadyExistsAtDestination, destinationPath)
         }
 
         contents.entries[destinationPath.basename] = source
     }
 
+    public func copy(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
+        return try lock.withLock {
+            try _copy(from: sourcePath, to: destinationPath)
+        }
+    }
+
     public func move(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
-        // Get the source parent node.
-        guard let sourceParent = try getNode(sourcePath.parentDirectory) else {
-            throw FileSystemError.noEntry
+        return try lock.withLock {
+            // Get the source parent node.
+            guard let sourceParent = try getNode(sourcePath.parentDirectory) else {
+                throw FileSystemError(.noEntry, sourcePath.parentDirectory)
+            }
+
+            // Check that the parent is a directory.
+            guard case .directory(let contents) = sourceParent.contents else {
+                throw FileSystemError(.notDirectory, sourcePath.parentDirectory)
+            }
+
+            try _copy(from: sourcePath, to: destinationPath)
+
+            contents.entries[sourcePath.basename] = nil
         }
-
-        // Check that the parent is a directory.
-        guard case .directory(let contents) = sourceParent.contents else {
-            throw FileSystemError.notDirectory
-        }
-
-        try copy(from: sourcePath, to: destinationPath)
-
-        contents.entries[sourcePath.basename] = nil
     }
 
     public func withLock<T>(on path: AbsolutePath, type: FileLock.LockType = .exclusive, _ body: () throws -> T) throws -> T {
-        // FIXME: Lock individual files once resolving symlinks is thread-safe.
-        return try lockFilesLock.withLock(body)
+        let resolvedPath: AbsolutePath = try lock.withLock {
+            if case let .symlink(destination) = try getNode(path)?.contents {
+                return  AbsolutePath(destination, relativeTo: path.parentDirectory)
+            } else {
+                return path
+            }
+        }
+
+        let fileQueue: DispatchQueue = lockFilesLock.withLock {
+            if let queueReference = lockFiles[resolvedPath], let queue = queueReference.reference {
+                return queue
+            } else {
+                let queue = DispatchQueue(label: "org.swift.swiftpm.in-memory-file-system.file-queue", attributes: .concurrent)
+                lockFiles[resolvedPath] = WeakReference(queue)
+                return queue
+            }
+        }
+
+        return try fileQueue.sync(flags: type == .exclusive ? .barrier : .init() , execute: body)
     }
 }
 
@@ -908,7 +1006,7 @@ public class RerootedFileSystemView: FileSystem {
     }
 
     public func changeCurrentWorkingDirectory(to path: AbsolutePath) throws {
-        throw FileSystemError.unsupported
+        throw FileSystemError(.unsupported, path)
     }
 
     public var homeDirectory: AbsolutePath {

--- a/swift-tools-support-core/Sources/TSCBasic/Lock.swift
+++ b/swift-tools-support-core/Sources/TSCBasic/Lock.swift
@@ -110,7 +110,7 @@ public final class FileLock {
         if fileDescriptor == nil {
             let fd = TSCLibc.open(lockFile.pathString, O_WRONLY | O_CREAT | O_CLOEXEC, 0o666)
             if fd == -1 {
-                throw FileSystemError(errno: errno)
+                throw FileSystemError(errno: errno, lockFile)
             }
             self.fileDescriptor = fd
         }

--- a/swift-tools-support-core/Sources/TSCBasic/WritableByteStream.swift
+++ b/swift-tools-support-core/Sources/TSCBasic/WritableByteStream.swift
@@ -672,16 +672,20 @@ public final class LocalFileOutputByteStream: FileOutputByteStream {
     /// The pointer to the file.
     let filePointer: UnsafeMutablePointer<FILE>
 
-    /// True if there were any IO error during writing.
-    private var error: Bool = false
+    /// Set to an error value if there were any IO error during writing.
+    private var error: FileSystemError?
 
     /// Closes the file on deinit if true.
     private var closeOnDeinit: Bool
+
+    /// Path to the file this stream should operate on.
+    private let path: AbsolutePath?
 
     /// Instantiate using the file pointer.
     public init(filePointer: UnsafeMutablePointer<FILE>, closeOnDeinit: Bool = true, buffered: Bool = true) throws {
         self.filePointer = filePointer
         self.closeOnDeinit = closeOnDeinit
+        self.path = nil
         super.init(buffered: buffered)
     }
 
@@ -700,8 +704,9 @@ public final class LocalFileOutputByteStream: FileOutputByteStream {
     /// - Throws: FileSystemError
     public init(_ path: AbsolutePath, closeOnDeinit: Bool = true, buffered: Bool = true) throws {
         guard let filePointer = fopen(path.pathString, "wb") else {
-            throw FileSystemError(errno: errno)
+            throw FileSystemError(errno: errno, path)
         }
+        self.path = path
         self.filePointer = filePointer
         self.closeOnDeinit = closeOnDeinit
         super.init(buffered: buffered)
@@ -713,8 +718,12 @@ public final class LocalFileOutputByteStream: FileOutputByteStream {
         }
     }
 
-    func errorDetected() {
-        error = true
+    func errorDetected(code: Int32?) {
+        if let code = code {
+            error = .init(.ioError(code: code), path)
+        } else {
+            error = .init(.unknownOSError, path)
+        }
     }
 
     override final func writeImpl<C: Collection>(_ bytes: C) where C.Iterator.Element == UInt8 {
@@ -724,9 +733,9 @@ public final class LocalFileOutputByteStream: FileOutputByteStream {
             let n = fwrite(&contents, 1, contents.count, filePointer)
             if n < 0 {
                 if errno == EINTR { continue }
-                errorDetected()
+                errorDetected(code: errno)
             } else if n != contents.count {
-                errorDetected()
+                errorDetected(code: nil)
             }
             break
         }
@@ -738,9 +747,9 @@ public final class LocalFileOutputByteStream: FileOutputByteStream {
                 let n = fwrite(bytesPtr.baseAddress, 1, bytesPtr.count, filePointer)
                 if n < 0 {
                     if errno == EINTR { continue }
-                    errorDetected()
+                    errorDetected(code: errno)
                 } else if n != bytesPtr.count {
-                    errorDetected()
+                    errorDetected(code: nil)
                 }
                 break
             }
@@ -758,8 +767,8 @@ public final class LocalFileOutputByteStream: FileOutputByteStream {
             closeOnDeinit = false
         }
         // Throw if errors were found during writing.
-        if error {
-            throw FileSystemError.ioError
+        if let error = error {
+            throw error
         }
     }
 }

--- a/swift-tools-support-core/Sources/TSCUtility/Archiver.swift
+++ b/swift-tools-support-core/Sources/TSCUtility/Archiver.swift
@@ -51,12 +51,12 @@ public struct ZipArchiver: Archiver {
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         guard fileSystem.exists(archivePath) else {
-            completion(.failure(FileSystemError.noEntry))
+            completion(.failure(FileSystemError(.noEntry, archivePath)))
             return
         }
 
         guard fileSystem.isDirectory(destinationPath) else {
-            completion(.failure(FileSystemError.notDirectory))
+            completion(.failure(FileSystemError(.notDirectory, destinationPath)))
             return
         }
 

--- a/swift-tools-support-core/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/swift-tools-support-core/Tests/TSCBasicTests/FileSystemTests.swift
@@ -245,42 +245,45 @@ class FileSystemTests: XCTestCase {
             XCTAssertEqual(try! fs.readFileContents(filePath), "Hello, new world!")
 
             // Check read/write of a directory.
-            XCTAssertThrows(FileSystemError.ioError) {
+            XCTAssertThrows(FileSystemError(.ioError(code: TSCLibc.EPERM), filePath.parentDirectory)) {
                 _ = try fs.readFileContents(filePath.parentDirectory)
             }
-            XCTAssertThrows(FileSystemError.isDirectory) {
+            XCTAssertThrows(FileSystemError(.isDirectory, filePath.parentDirectory)) {
                 try fs.writeFileContents(filePath.parentDirectory, bytes: [])
             }
             XCTAssertEqual(try! fs.readFileContents(filePath), "Hello, new world!")
 
             // Check read/write against root.
-            XCTAssertThrows(FileSystemError.ioError) {
-              #if os(Android)
-                _ = try fs.readFileContents(AbsolutePath("/system/"))
-              #else
-                _ = try fs.readFileContents(AbsolutePath("/"))
-              #endif
+            #if os(Android)
+            let root = AbsolutePath("/system/")
+            #else
+            let root = AbsolutePath("/")
+            #endif
+            XCTAssertThrows(FileSystemError(.ioError(code: TSCLibc.EPERM), root)) {
+                _ = try fs.readFileContents(root)
+
             }
-            XCTAssertThrows(FileSystemError.isDirectory) {
-                try fs.writeFileContents(AbsolutePath("/"), bytes: [])
+            XCTAssertThrows(FileSystemError(.isDirectory, root)) {
+                try fs.writeFileContents(root, bytes: [])
             }
             XCTAssert(fs.exists(filePath))
 
             // Check read/write into a non-directory.
-            XCTAssertThrows(FileSystemError.notDirectory) {
-                _ = try fs.readFileContents(filePath.appending(component: "not-possible"))
+            let notDirectoryPath = filePath.appending(component: "not-possible")
+            XCTAssertThrows(FileSystemError(.notDirectory, notDirectoryPath)) {
+                _ = try fs.readFileContents(notDirectoryPath)
             }
-            XCTAssertThrows(FileSystemError.notDirectory) {
+            XCTAssertThrows(FileSystemError(.notDirectory, notDirectoryPath)) {
                 try fs.writeFileContents(filePath.appending(component: "not-possible"), bytes: [])
             }
             XCTAssert(fs.exists(filePath))
 
             // Check read/write into a missing directory.
             let missingDir = tmpDirPath.appending(components: "does", "not", "exist")
-            XCTAssertThrows(FileSystemError.noEntry) {
+            XCTAssertThrows(FileSystemError(.noEntry, missingDir)) {
                 _ = try fs.readFileContents(missingDir)
             }
-            XCTAssertThrows(FileSystemError.noEntry) {
+            XCTAssertThrows(FileSystemError(.noEntry, missingDir)) {
                 try fs.writeFileContents(missingDir, bytes: [])
             }
             XCTAssert(!fs.exists(missingDir))
@@ -302,10 +305,10 @@ class FileSystemTests: XCTestCase {
 
             // Copy with no source
 
-            XCTAssertThrows(FileSystemError.noEntry) {
+            XCTAssertThrows(FileSystemError(.noEntry, source)) {
                 try fs.copy(from: source, to: destination)
             }
-            XCTAssertThrows(FileSystemError.noEntry) {
+            XCTAssertThrows(FileSystemError(.noEntry, source)) {
                 try fs.move(from: source, to: destination)
             }
 
@@ -314,10 +317,10 @@ class FileSystemTests: XCTestCase {
             try fs.writeFileContents(source, bytes: "source1")
             try fs.writeFileContents(destination, bytes: "destination")
 
-            XCTAssertThrows(FileSystemError.alreadyExistsAtDestination) {
+            XCTAssertThrows(FileSystemError(.alreadyExistsAtDestination, destination)) {
                 try fs.copy(from: source, to: destination)
             }
-            XCTAssertThrows(FileSystemError.alreadyExistsAtDestination) {
+            XCTAssertThrows(FileSystemError(.alreadyExistsAtDestination, destination)) {
                 try fs.move(from: source, to: destination)
             }
 
@@ -373,22 +376,23 @@ class FileSystemTests: XCTestCase {
 
     func testInMemoryBasics() throws {
         let fs = InMemoryFileSystem()
+        let doesNotExist = AbsolutePath("/does-not-exist")
 
         // exists()
-        XCTAssert(!fs.exists(AbsolutePath("/does-not-exist")))
+        XCTAssert(!fs.exists(doesNotExist))
 
         // isDirectory()
-        XCTAssert(!fs.isDirectory(AbsolutePath("/does-not-exist")))
+        XCTAssert(!fs.isDirectory(doesNotExist))
 
         // isFile()
-        XCTAssert(!fs.isFile(AbsolutePath("/does-not-exist")))
+        XCTAssert(!fs.isFile(doesNotExist))
 
         // isSymlink()
-        XCTAssert(!fs.isSymlink(AbsolutePath("/does-not-exist")))
+        XCTAssert(!fs.isSymlink(doesNotExist))
 
         // getDirectoryContents()
-        XCTAssertThrows(FileSystemError.noEntry) {
-            _ = try fs.getDirectoryContents(AbsolutePath("/does-not-exist"))
+        XCTAssertThrows(FileSystemError(.noEntry, doesNotExist)) {
+            _ = try fs.getDirectoryContents(doesNotExist)
         }
 
         // createDirectory()
@@ -422,9 +426,10 @@ class FileSystemTests: XCTestCase {
         XCTAssert(fs.isDirectory(subsubdir))
 
         // Check non-recursive failing subdir case.
-        let newsubdir = AbsolutePath("/very-new-dir/subdir")
+        let veryNewDir = AbsolutePath("/very-new-dir")
+        let newsubdir = veryNewDir.appending(component: "subdir")
         XCTAssert(!fs.isDirectory(newsubdir))
-        XCTAssertThrows(FileSystemError.noEntry) {
+        XCTAssertThrows(FileSystemError(.noEntry, veryNewDir)) {
             try fs.createDirectory(newsubdir, recursive: false)
         }
         XCTAssert(!fs.isDirectory(newsubdir))
@@ -433,10 +438,10 @@ class FileSystemTests: XCTestCase {
         let filePath = AbsolutePath("/mach_kernel")
         try! fs.writeFileContents(filePath, bytes: [0xCD, 0x0D])
         XCTAssert(fs.exists(filePath) && !fs.isDirectory(filePath))
-        XCTAssertThrows(FileSystemError.notDirectory) {
+        XCTAssertThrows(FileSystemError(.notDirectory, filePath)) {
             try fs.createDirectory(filePath, recursive: true)
         }
-        XCTAssertThrows(FileSystemError.notDirectory) {
+        XCTAssertThrows(FileSystemError(.notDirectory, filePath)) {
             try fs.createDirectory(filePath.appending(component: "not-possible"), recursive: true)
         }
         XCTAssert(fs.exists(filePath) && !fs.isDirectory(filePath))
@@ -493,42 +498,45 @@ class FileSystemTests: XCTestCase {
         XCTAssertEqual(try! fs.readFileContents(filePath), "Hello, new world!")
 
         // Check read/write of a directory.
-        XCTAssertThrows(FileSystemError.isDirectory) {
+        XCTAssertThrows(FileSystemError(.isDirectory, filePath.parentDirectory)) {
             _ = try fs.readFileContents(filePath.parentDirectory)
         }
-        XCTAssertThrows(FileSystemError.isDirectory) {
+        XCTAssertThrows(FileSystemError(.isDirectory, filePath.parentDirectory)) {
             try fs.writeFileContents(filePath.parentDirectory, bytes: [])
         }
         XCTAssertEqual(try! fs.readFileContents(filePath), "Hello, new world!")
 
         // Check read/write against root.
-        XCTAssertThrows(FileSystemError.isDirectory) {
-            _ = try fs.readFileContents(AbsolutePath("/"))
+        let root = AbsolutePath("/")
+        XCTAssertThrows(FileSystemError(.isDirectory, root)) {
+            _ = try fs.readFileContents(root)
         }
-        XCTAssertThrows(FileSystemError.isDirectory) {
-            try fs.writeFileContents(AbsolutePath("/"), bytes: [])
+        XCTAssertThrows(FileSystemError(.isDirectory, root)) {
+            try fs.writeFileContents(root, bytes: [])
         }
         XCTAssert(fs.exists(filePath))
         XCTAssertTrue(fs.isFile(filePath))
 
         // Check read/write into a non-directory.
-        XCTAssertThrows(FileSystemError.notDirectory) {
-            _ = try fs.readFileContents(filePath.appending(component: "not-possible"))
+        let notDirectory = filePath.appending(component: "not-possible")
+        XCTAssertThrows(FileSystemError(.notDirectory, filePath)) {
+            _ = try fs.readFileContents(notDirectory)
         }
-        XCTAssertThrows(FileSystemError.notDirectory) {
-            try fs.writeFileContents(filePath.appending(component: "not-possible"), bytes: [])
+        XCTAssertThrows(FileSystemError(.notDirectory, filePath)) {
+            try fs.writeFileContents(notDirectory, bytes: [])
         }
         XCTAssert(fs.exists(filePath))
 
         // Check read/write into a missing directory.
-        let missingDir = AbsolutePath("/does/not/exist")
-        XCTAssertThrows(FileSystemError.noEntry) {
-            _ = try fs.readFileContents(missingDir)
+        let missingParent = AbsolutePath("/does/not")
+        let missingFile = missingParent.appending(component: "exist")
+        XCTAssertThrows(FileSystemError(.noEntry, missingFile)) {
+            _ = try fs.readFileContents(missingFile)
         }
-        XCTAssertThrows(FileSystemError.noEntry) {
-            try fs.writeFileContents(missingDir, bytes: [])
+        XCTAssertThrows(FileSystemError(.noEntry, missingParent)) {
+            try fs.writeFileContents(missingFile, bytes: [])
         }
-        XCTAssert(!fs.exists(missingDir))
+        XCTAssert(!fs.exists(missingFile))
     }
 
     func testInMemoryFsCopy() throws {
@@ -560,10 +568,10 @@ class FileSystemTests: XCTestCase {
 
         // Copy with no source
 
-        XCTAssertThrows(FileSystemError.noEntry) {
+        XCTAssertThrows(FileSystemError(.noEntry, source)) {
             try fs.copy(from: source, to: destination)
         }
-        XCTAssertThrows(FileSystemError.noEntry) {
+        XCTAssertThrows(FileSystemError(.noEntry, source)) {
             try fs.move(from: source, to: destination)
         }
 
@@ -572,10 +580,10 @@ class FileSystemTests: XCTestCase {
         try fs.writeFileContents(source, bytes: "source1")
         try fs.writeFileContents(destination, bytes: "destination")
 
-        XCTAssertThrows(FileSystemError.alreadyExistsAtDestination) {
+        XCTAssertThrows(FileSystemError(.alreadyExistsAtDestination, destination)) {
             try fs.copy(from: source, to: destination)
         }
-        XCTAssertThrows(FileSystemError.alreadyExistsAtDestination) {
+        XCTAssertThrows(FileSystemError(.alreadyExistsAtDestination, destination)) {
             try fs.move(from: source, to: destination)
         }
 
@@ -703,13 +711,13 @@ class FileSystemTests: XCTestCase {
 
             // Set foo to unwritable.
             try fs.chmod(.userUnWritable, path: foo)
-            XCTAssertThrows(FileSystemError.invalidAccess) {
+            XCTAssertThrows(FileSystemError(.invalidAccess, foo)) {
                 try fs.writeFileContents(foo, bytes: "test")
             }
 
             // Set the directory as unwritable.
             try fs.chmod(.userUnWritable, path: dir, options: [.recursive, .onlyFiles])
-            XCTAssertThrows(FileSystemError.invalidAccess) {
+            XCTAssertThrows(FileSystemError(.invalidAccess, bar)) {
                 try fs.writeFileContents(bar, bytes: "test")
             }
 
@@ -721,8 +729,9 @@ class FileSystemTests: XCTestCase {
 
             // But not anymore.
             try fs.chmod(.userUnWritable, path: dir, options: [.recursive])
-            XCTAssertThrows(FileSystemError.invalidAccess) {
-                try fs.writeFileContents(dir.appending(component: "new2"), bytes: "")
+            let newFile = dir.appending(component: "new2")
+            XCTAssertThrows(FileSystemError(.invalidAccess, newFile)) {
+                try fs.writeFileContents(newFile, bytes: "")
             }
 
             try? fs.removeFileTree(bar)

--- a/swift-tools-support-core/Tests/TSCUtilityTests/ArchiverTests.swift
+++ b/swift-tools-support-core/Tests/TSCUtilityTests/ArchiverTests.swift
@@ -40,8 +40,9 @@ class ArchiverTests: XCTestCase {
 
         let fileSystem = InMemoryFileSystem()
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        archiver.extract(from: AbsolutePath("/archive.zip"), to: AbsolutePath("/"), completion: { result in
-            XCTAssertResultFailure(result, equals: FileSystemError.noEntry)
+        let archive = AbsolutePath("/archive.zip")
+        archiver.extract(from: archive, to: AbsolutePath("/"), completion: { result in
+            XCTAssertResultFailure(result, equals: FileSystemError(.noEntry, archive))
             expectation.fulfill()
         })
 
@@ -53,8 +54,9 @@ class ArchiverTests: XCTestCase {
 
         let fileSystem = InMemoryFileSystem(emptyFiles: "/archive.zip")
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        archiver.extract(from: AbsolutePath("/archive.zip"), to: AbsolutePath("/destination"), completion: { result in
-            XCTAssertResultFailure(result, equals: FileSystemError.notDirectory)
+        let destination = AbsolutePath("/destination")
+        archiver.extract(from: AbsolutePath("/archive.zip"), to: destination, completion: { result in
+            XCTAssertResultFailure(result, equals: FileSystemError(.notDirectory, destination))
             expectation.fulfill()
         })
 
@@ -66,8 +68,9 @@ class ArchiverTests: XCTestCase {
 
         let fileSystem = InMemoryFileSystem(emptyFiles: "/archive.zip", "/destination")
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        archiver.extract(from: AbsolutePath("/archive.zip"), to: AbsolutePath("/destination"), completion: { result in
-            XCTAssertResultFailure(result, equals: FileSystemError.notDirectory)
+        let destination = AbsolutePath("/destination")
+        archiver.extract(from: AbsolutePath("/archive.zip"), to: destination, completion: { result in
+            XCTAssertResultFailure(result, equals: FileSystemError(.notDirectory, destination))
             expectation.fulfill()
         })
 


### PR DESCRIPTION
Mirrors https://github.com/apple/swift-tools-support-core/pull/167 change to the TSC package.

I've recently stumbled upon this error when running `swift build`:

```
error: noEntry
```

This is the exact and only output of this `swift build` invocation. Unfortunately, I think it's impossible to diagnose without an attached debugger. It's also hard to pinpoint where exactly the error comes from in the source code, since `FileSystemError.noEntry` is thrown from multiple places.

In my opinion, for an error value to be helpful it should have associated information attached to it. In this case, it would make sense for almost all cases of `FileSystemError` to have an associated `AbsolutePath` value.

`FileSystemError` now also has to be explicitly declared `Equatable` to make the tests compile, but previously it was `Equatable` anyway, although implicitly by virtue of being an enum with no associated values.
