### PR TITLE
add deprecation warning to 'generate-xcodeproj'

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -534,7 +534,7 @@ extension SwiftPackageTool {
     struct GenerateXcodeProject: SwiftCommand {
         static let configuration = CommandConfiguration(
             commandName: "generate-xcodeproj",
-            abstract: "Generates an Xcode project")
+            abstract: "Generates an Xcode project. This command will be deprecated soon.")
 
         struct Options: ParsableArguments {
             @Option(help: "Path to xcconfig file", completion: .file())
@@ -573,6 +573,8 @@ extension SwiftPackageTool {
         }
 
         func run(_ swiftTool: SwiftTool) throws {
+            swiftTool.diagnostics.emit(.warning("Xcode supports Swift Packages directly. 'generate-xcodeproj' is no longer needed and will be deprecated soon."))
+
             let graph = try swiftTool.loadPackageGraph()
 
             let projectName: String

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -573,7 +573,7 @@ extension SwiftPackageTool {
         }
 
         func run(_ swiftTool: SwiftTool) throws {
-            swiftTool.diagnostics.emit(.warning("Xcode supports Swift Packages directly. 'generate-xcodeproj' is no longer needed and will be deprecated soon."))
+            swiftTool.diagnostics.emit(.warning("Xcode can open and build Swift Packages directly. 'generate-xcodeproj' is no longer needed and will be deprecated soon."))
 
             let graph = try swiftTool.loadPackageGraph()
 

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -399,4 +399,11 @@ class GenerateXcodeprojTests: XCTestCase {
             }
         }
     }
+
+    func testGenerateXcodeprojDeprecation() {
+            fixture(name: "DependencyResolution/External/Simple/Foo") { path in
+                let (_, stderr) = try SwiftPMProduct.SwiftPackage.execute(["generate-xcodeproj"], packagePath: path)
+                XCTAssertMatch(stderr, .contains("'generate-xcodeproj' is no longer needed and will be deprecated soon"))
+            }
+        }
 }


### PR DESCRIPTION
motivation: Starting Xcode 11, packages are directly supported by Xcode and the generate-xcodeproj command is no longer needed

changes:
* add deprecation warning that generate-xcodeproj will be deprecated soon
* add test

rdar://problem/65633238
