### PR TITLE
add missing CMake setup for Basics and PackageCollections

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -6,9 +6,11 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
+add_subdirectory(Basics)
 add_subdirectory(Build)
 add_subdirectory(Commands)
 add_subdirectory(LLBuildManifest)
+add_subdirectory(PackageCollections)
 add_subdirectory(PackageDescription)
 add_subdirectory(PackageGraph)
 add_subdirectory(PackageLoading)

--- a/Sources/PackageCollections/CMakeLists.txt
+++ b/Sources/PackageCollections/CMakeLists.txt
@@ -14,13 +14,16 @@ add_library(PackageCollections
   Model/Profile.swift
   Model/Search.swift
   Model/TargetListResult.swift
-  PackageCollectionProvider.swift
-  PackageCollections+Configuration.swift
-  PackageCollections+Storage.swift
-  PackageCollections+Vallidation.swift
-  PackageCollections.swift
+  Providers/JSONPackageCollectionProvider.swift
+  Providers/PackageCollectionProvider.swift
+  Providers/PackageMetadataProvider.swift
   Storage/PackageCollectionsProfileStorage.swift
   Storage/PackageCollectionsStorage.swift
+  API.swift
+  PackageCollections.swift
+  PackageCollections+Configuration.swift
+  PackageCollections+Storage.swift
+  PackageCollections+Validation.swift
   Utility.swift)
 target_link_libraries(PackageCollections PUBLIC
   TSCBasic


### PR DESCRIPTION
motivation: modules are not available for bootstrap

changes: add missing CMake indexes
