### PR TITLE
Update JSON package collection models

### DIFF
--- a/Fixtures/Collections/JSON/good.json
+++ b/Fixtures/Collections/JSON/good.json
@@ -1,6 +1,6 @@
 {
   "name": "Sample Package Collection",
-  "description": "This is a sample package collection listing made-up packages.",
+  "overview": "This is a sample package collection listing made-up packages.",
   "keywords": ["sample package collection"],
   "formatVersion": "1.0",
   "revision": 3,
@@ -11,7 +11,7 @@
   "packages": [
     {
       "url": "https://www.example.com/repos/RepoOne.git",
-      "description": "Package One",
+      "summary": "Package One",
       "keywords": ["sample package"],
       "readmeURL": "https://www.example.com/repos/RepoOne/README",
       "versions": [
@@ -52,7 +52,7 @@
     },
     {
       "url": "https://www.example.com/repos/RepoTwo.git",
-      "description": "Package Two",
+      "summary": "Package Two",
       "readmeURL": "https://www.example.com/repos/RepoTwo/README",
       "versions": [
         {

--- a/Fixtures/Collections/JSON/good.json
+++ b/Fixtures/Collections/JSON/good.json
@@ -5,10 +5,14 @@
   "formatVersion": "1.0",
   "revision": 3,
   "generatedAt": "2020-10-22T06:03:52Z",
+  "generatedBy": {
+    "name": "Jane Doe"
+  },
   "packages": [
     {
       "url": "https://www.example.com/repos/RepoOne.git",
       "description": "Package One",
+      "keywords": ["sample package"],
       "readmeURL": "https://www.example.com/repos/RepoOne/README",
       "versions": [
         {
@@ -30,6 +34,9 @@
             }
           ],
           "toolsVersion": "5.1",
+          "minimumPlatformVersions": [
+            { "name": "macOS", "version": "10.15" }
+          ],
           "verifiedPlatforms": [
             { "name": "macOS" },
             { "name": "iOS" },

--- a/Sources/PackageCollections/CMakeLists.txt
+++ b/Sources/PackageCollections/CMakeLists.txt
@@ -7,8 +7,10 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(PackageCollections
-  Model/CVE.swift
+  JSONModel/JSONCollection.swift
+  JSONModel/JSONCollection+v1.swift
   Model/Collection.swift
+  Model/CVE.swift
   Model/License.swift
   Model/Package.swift
   Model/Search.swift

--- a/Sources/PackageCollections/JSONModel/JSONCollection+v1.swift
+++ b/Sources/PackageCollections/JSONModel/JSONCollection+v1.swift
@@ -18,18 +18,18 @@ extension JSONPackageCollectionModel {
 }
 
 extension JSONPackageCollectionModel.V1 {
-    public struct PackageCollection: Equatable, Codable {
+    public struct Collection: Equatable, Codable {
         /// The name of the package collection, for display purposes only.
         public let name: String
 
         /// A description of the package collection.
-        public let _description: String?
+        public let overview: String?
 
         /// An array of keywords that the collection is associated with.
         public let keywords: [String]?
 
         /// An array of package metadata objects
-        public let packages: [JSONPackageCollectionModel.V1.PackageCollection.Package]
+        public let packages: [JSONPackageCollectionModel.V1.Collection.Package]
 
         /// The version of the format to which the collection conforms.
         public let formatVersion: JSONPackageCollectionModel.FormatVersion
@@ -43,12 +43,12 @@ extension JSONPackageCollectionModel.V1 {
         /// The author of this package collection.
         public let generatedBy: Author?
 
-        /// Creates a `PackageCollection`
+        /// Creates a `Collection`
         public init(
             name: String,
-            description: String? = nil,
+            overview: String? = nil,
             keywords: [String]? = nil,
-            packages: [JSONPackageCollectionModel.V1.PackageCollection.Package],
+            packages: [JSONPackageCollectionModel.V1.Collection.Package],
             formatVersion: JSONPackageCollectionModel.FormatVersion,
             revision: Int? = nil,
             generatedAt: Date = Date(),
@@ -57,24 +57,13 @@ extension JSONPackageCollectionModel.V1 {
             precondition(formatVersion == .v1_0, "Unsupported format version: \(formatVersion)")
 
             self.name = name
-            self._description = description
+            self.overview = overview
             self.keywords = keywords
             self.packages = packages
             self.formatVersion = formatVersion
             self.revision = revision
             self.generatedAt = generatedAt
             self.generatedBy = generatedBy
-        }
-
-        private enum CodingKeys: String, CodingKey {
-            case name
-            case _description = "description"
-            case keywords
-            case packages
-            case formatVersion
-            case revision
-            case generatedAt
-            case generatedBy
         }
 
         public struct Author: Equatable, Codable {
@@ -89,19 +78,19 @@ extension JSONPackageCollectionModel.V1 {
     }
 }
 
-extension JSONPackageCollectionModel.V1.PackageCollection {
+extension JSONPackageCollectionModel.V1.Collection {
     public struct Package: Equatable, Codable {
         /// The URL of the package. Currently only Git repository URLs are supported.
         public let url: Foundation.URL
 
         /// A description of the package.
-        public let _description: String?
+        public let summary: String?
 
         /// An array of keywords that the package is associated with.
         public let keywords: [String]?
 
         /// An array of version objects representing the most recent and/or relevant releases of the package.
-        public let versions: [JSONPackageCollectionModel.V1.PackageCollection.Package.Version]
+        public let versions: [JSONPackageCollectionModel.V1.Collection.Package.Version]
 
         /// The URL of the package's README.
         public let readmeURL: Foundation.URL?
@@ -109,29 +98,21 @@ extension JSONPackageCollectionModel.V1.PackageCollection {
         /// Creates a `Package`
         public init(
             url: URL,
-            description: String? = nil,
+            summary: String? = nil,
             keywords: [String]? = nil,
-            versions: [JSONPackageCollectionModel.V1.PackageCollection.Package.Version],
+            versions: [JSONPackageCollectionModel.V1.Collection.Package.Version],
             readmeURL: URL? = nil
         ) {
             self.url = url
-            self._description = description
+            self.summary = summary
             self.keywords = keywords
             self.versions = versions
             self.readmeURL = readmeURL
         }
-
-        private enum CodingKeys: String, CodingKey {
-            case url
-            case _description = "description"
-            case keywords
-            case versions
-            case readmeURL
-        }
     }
 }
 
-extension JSONPackageCollectionModel.V1.PackageCollection.Package {
+extension JSONPackageCollectionModel.V1.Collection.Package {
     public struct Version: Equatable, Codable {
         /// The semantic version string.
         public let version: String

--- a/Sources/PackageCollections/JSONModel/JSONCollection+v1.swift
+++ b/Sources/PackageCollections/JSONModel/JSONCollection+v1.swift
@@ -1,0 +1,262 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import struct Foundation.Date
+import struct Foundation.URL
+
+import PackageModel
+
+extension JSONPackageCollectionModel {
+    public enum V1 {}
+}
+
+extension JSONPackageCollectionModel.V1 {
+    public struct PackageCollection: Equatable, Codable {
+        /// The name of the package collection, for display purposes only.
+        public let name: String
+
+        /// A description of the package collection.
+        public let _description: String?
+
+        /// An array of keywords that the collection is associated with.
+        public let keywords: [String]?
+
+        /// An array of package metadata objects
+        public let packages: [JSONPackageCollectionModel.V1.PackageCollection.Package]
+
+        /// The version of the format to which the collection conforms.
+        public let formatVersion: JSONPackageCollectionModel.FormatVersion
+
+        /// The revision number of this package collection.
+        public let revision: Int?
+
+        /// The ISO 8601-formatted datetime string when the package collection was generated.
+        public let generatedAt: Date
+
+        /// The author of this package collection.
+        public let generatedBy: Author?
+
+        /// Creates a `PackageCollection`
+        public init(
+            name: String,
+            description: String? = nil,
+            keywords: [String]? = nil,
+            packages: [JSONPackageCollectionModel.V1.PackageCollection.Package],
+            formatVersion: JSONPackageCollectionModel.FormatVersion,
+            revision: Int? = nil,
+            generatedAt: Date = Date(),
+            generatedBy: Author? = nil
+        ) {
+            precondition(formatVersion == .v1_0, "Unsupported format version: \(formatVersion)")
+
+            self.name = name
+            self._description = description
+            self.keywords = keywords
+            self.packages = packages
+            self.formatVersion = formatVersion
+            self.revision = revision
+            self.generatedAt = generatedAt
+            self.generatedBy = generatedBy
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case name
+            case _description = "description"
+            case keywords
+            case packages
+            case formatVersion
+            case revision
+            case generatedAt
+            case generatedBy
+        }
+
+        public struct Author: Equatable, Codable {
+            /// The author name.
+            public let name: String
+
+            /// Creates an `Author`
+            public init(name: String) {
+                self.name = name
+            }
+        }
+    }
+}
+
+extension JSONPackageCollectionModel.V1.PackageCollection {
+    public struct Package: Equatable, Codable {
+        /// The URL of the package. Currently only Git repository URLs are supported.
+        public let url: Foundation.URL
+
+        /// A description of the package.
+        public let _description: String?
+
+        /// An array of keywords that the package is associated with.
+        public let keywords: [String]?
+
+        /// An array of version objects representing the most recent and/or relevant releases of the package.
+        public let versions: [JSONPackageCollectionModel.V1.PackageCollection.Package.Version]
+
+        /// The URL of the package's README.
+        public let readmeURL: Foundation.URL?
+
+        /// Creates a `Package`
+        public init(
+            url: URL,
+            description: String? = nil,
+            keywords: [String]? = nil,
+            versions: [JSONPackageCollectionModel.V1.PackageCollection.Package.Version],
+            readmeURL: URL? = nil
+        ) {
+            self.url = url
+            self._description = description
+            self.keywords = keywords
+            self.versions = versions
+            self.readmeURL = readmeURL
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case url
+            case _description = "description"
+            case keywords
+            case versions
+            case readmeURL
+        }
+    }
+}
+
+extension JSONPackageCollectionModel.V1.PackageCollection.Package {
+    public struct Version: Equatable, Codable {
+        /// The semantic version string.
+        public let version: String
+
+        /// The name of the package.
+        public let packageName: String
+
+        /// An array of the package version's targets.
+        public let targets: [JSONPackageCollectionModel.V1.Target]
+
+        /// An array of the package version's products.
+        public let products: [JSONPackageCollectionModel.V1.Product]
+
+        /// The tools (semantic) version specified in `Package.swift`.
+        public let toolsVersion: String
+
+        /// An array of the package version’s supported platforms specified in `Package.swift`.
+        public let minimumPlatformVersions: [JSONPackageCollectionModel.V1.PlatformVersion]?
+
+        /// An array of platforms in which the package version has been tested and verified.
+        public let verifiedPlatforms: [JSONPackageCollectionModel.V1.Platform]?
+
+        /// An array of Swift versions that the package version has been tested and verified for.
+        public let verifiedSwiftVersions: [String]?
+
+        /// The package version's license.
+        public let license: JSONPackageCollectionModel.V1.License?
+
+        /// Creates a `Version`
+        public init(
+            version: String,
+            packageName: String,
+            targets: [JSONPackageCollectionModel.V1.Target],
+            products: [JSONPackageCollectionModel.V1.Product],
+            toolsVersion: String,
+            minimumPlatformVersions: [JSONPackageCollectionModel.V1.PlatformVersion]? = nil,
+            verifiedPlatforms: [JSONPackageCollectionModel.V1.Platform]? = nil,
+            verifiedSwiftVersions: [String]? = nil,
+            license: JSONPackageCollectionModel.V1.License? = nil
+        ) {
+            self.version = version
+            self.packageName = packageName
+            self.targets = targets
+            self.products = products
+            self.toolsVersion = toolsVersion
+            self.minimumPlatformVersions = minimumPlatformVersions
+            self.verifiedPlatforms = verifiedPlatforms
+            self.verifiedSwiftVersions = verifiedSwiftVersions
+            self.license = license
+        }
+    }
+}
+
+extension JSONPackageCollectionModel.V1 {
+    public struct Target: Equatable, Codable {
+        /// The target name.
+        public let name: String
+
+        /// The module name if this target can be imported as a module.
+        public let moduleName: String?
+
+        /// Creates a `Target`
+        public init(name: String, moduleName: String? = nil) {
+            self.name = name
+            self.moduleName = moduleName
+        }
+    }
+
+    public struct Product: Equatable, Codable {
+        /// The product name.
+        public let name: String
+
+        /// The product type.
+        public let type: ProductType
+
+        /// An array of the product’s targets.
+        public let targets: [String]
+
+        /// Creates a `Product`
+        public init(
+            name: String,
+            type: ProductType,
+            targets: [String]
+        ) {
+            self.name = name
+            self.type = type
+            self.targets = targets
+        }
+    }
+
+    public struct PlatformVersion: Equatable, Codable {
+        /// The name of the platform (e.g., macOS, Linux, etc.).
+        public let name: String
+
+        /// The semantic version of the platform.
+        public let version: String
+
+        /// Creates a `PlatformVersion`
+        public init(name: String, version: String) {
+            self.name = name
+            self.version = version
+        }
+    }
+
+    public struct Platform: Equatable, Codable {
+        /// The name of the platform (e.g., macOS, Linux, etc.).
+        public let name: String
+
+        /// Creates a `Platform`
+        public init(name: String) {
+            self.name = name
+        }
+    }
+
+    public struct License: Equatable, Codable {
+        /// License name (e.g., Apache-2.0, MIT, etc.)
+        public let name: String
+
+        /// The URL of the license file.
+        public let url: URL
+
+        /// Creates a `License`
+        public init(name: String, url: URL) {
+            self.name = name
+            self.url = url
+        }
+    }
+}

--- a/Sources/PackageCollections/JSONModel/JSONCollection.swift
+++ b/Sources/PackageCollections/JSONModel/JSONCollection.swift
@@ -1,0 +1,18 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+public enum JSONPackageCollectionModel {}
+
+extension JSONPackageCollectionModel {
+    /// Representation of `PackageCollection` JSON schema version
+    public enum FormatVersion: String, Codable {
+        case v1_0 = "1.0"
+    }
+}

--- a/Sources/PackageCollections/Model/Collection.swift
+++ b/Sources/PackageCollections/Model/Collection.swift
@@ -22,6 +22,7 @@ extension PackageCollectionsModel {
     public struct Collection: Equatable, Codable {
         public typealias Identifier = CollectionIdentifier
         public typealias Source = CollectionSource
+        public typealias Author = CollectionAuthor
 
         /// The identifier of the collection
         public let identifier: Identifier
@@ -44,6 +45,9 @@ extension PackageCollectionsModel {
         /// When this collection was created/published by the source
         public let createdAt: Date
 
+        /// Who authored this collection
+        public let createdBy: Author?
+        
         /// When this collection was last processed locally
         public let lastProcessedAt: Date
 
@@ -55,6 +59,7 @@ extension PackageCollectionsModel {
             keywords: [String]?,
             packages: [Package],
             createdAt: Date,
+            createdBy: Author?,
             lastProcessedAt: Date = Date()
         ) {
             self.identifier = .init(from: source)
@@ -64,6 +69,7 @@ extension PackageCollectionsModel {
             self.keywords = keywords
             self.packages = packages
             self.createdAt = createdAt
+            self.createdBy = createdBy
             self.lastProcessedAt = lastProcessedAt
         }
     }
@@ -110,6 +116,14 @@ extension PackageCollectionsModel {
                 return lhs.absoluteString < rhs.absoluteString
             }
         }
+    }
+}
+
+extension PackageCollectionsModel {
+    /// Represents the author of a `PackageCollection`
+    public struct CollectionAuthor: Equatable, Codable {
+        /// The name of the author
+        public let name: String
     }
 }
 

--- a/Sources/PackageCollections/Model/Collection.swift
+++ b/Sources/PackageCollections/Model/Collection.swift
@@ -18,11 +18,10 @@ import TSCUtility
 public enum PackageCollectionsModel {}
 
 extension PackageCollectionsModel {
-    /// A `PackageCollection` is a collection of packages.
+    /// A `Collection` is a collection of packages.
     public struct Collection: Equatable, Codable {
         public typealias Identifier = CollectionIdentifier
         public typealias Source = CollectionSource
-        public typealias Author = CollectionAuthor
 
         /// The identifier of the collection
         public let identifier: Identifier
@@ -34,7 +33,7 @@ extension PackageCollectionsModel {
         public let name: String
 
         /// The description of the collection
-        public let description: String?
+        public let overview: String?
 
         /// Keywords for the collection
         public let keywords: [String]?
@@ -51,11 +50,11 @@ extension PackageCollectionsModel {
         /// When this collection was last processed locally
         public let lastProcessedAt: Date
 
-        /// Initializes a `PackageCollection`
+        /// Initializes a `Collection`
         init(
             source: Source,
             name: String,
-            description: String?,
+            overview: String?,
             keywords: [String]?,
             packages: [Package],
             createdAt: Date,
@@ -65,7 +64,7 @@ extension PackageCollectionsModel {
             self.identifier = .init(from: source)
             self.source = source
             self.name = name
-            self.description = description
+            self.overview = overview
             self.keywords = keywords
             self.packages = packages
             self.createdAt = createdAt
@@ -76,7 +75,7 @@ extension PackageCollectionsModel {
 }
 
 extension PackageCollectionsModel {
-    /// Represents the source of a `PackageCollection`
+    /// Represents the source of a `Collection`
     public struct CollectionSource: Equatable, Hashable, Codable {
         /// Source type
         public let type: CollectionSourceType
@@ -90,14 +89,14 @@ extension PackageCollectionsModel {
         }
     }
 
-    /// Represents the source type of a `PackageCollection`
+    /// Represents the source type of a `Collection`
     public enum CollectionSourceType: String, Codable, CaseIterable {
         case json
     }
 }
 
 extension PackageCollectionsModel {
-    /// Represents the identifier of a `PackageCollection`
+    /// Represents the identifier of a `Collection`
     public enum CollectionIdentifier: Hashable, Comparable {
         /// JSON based package collection at URL
         case json(URL)
@@ -116,14 +115,6 @@ extension PackageCollectionsModel {
                 return lhs.absoluteString < rhs.absoluteString
             }
         }
-    }
-}
-
-extension PackageCollectionsModel {
-    /// Represents the author of a `PackageCollection`
-    public struct CollectionAuthor: Equatable, Codable {
-        /// The name of the author
-        public let name: String
     }
 }
 
@@ -153,5 +144,13 @@ extension PackageCollectionsModel.CollectionIdentifier: Codable {
             try container.encode(DiscriminatorKeys.json, forKey: ._case)
             try container.encode(url, forKey: .url)
         }
+    }
+}
+
+extension PackageCollectionsModel.Collection {
+    /// Represents the author of a `Collection`
+    public struct Author: Equatable, Codable {
+        /// The name of the author
+        public let name: String
     }
 }

--- a/Sources/PackageCollections/Model/Package.swift
+++ b/Sources/PackageCollections/Model/Package.swift
@@ -90,7 +90,6 @@ extension PackageCollectionsModel {
     }
 }
 
-// FIXME: add minimumPlatformVersions
 extension PackageCollectionsModel.Package {
     /// A representation of package version
     public struct Version: Codable, Equatable {
@@ -113,6 +112,9 @@ extension PackageCollectionsModel.Package {
 
         /// The package version's Swift tools version
         public let toolsVersion: ToolsVersion
+        
+        /// The package version's supported platforms
+        public let minimumPlatformVersions: [SupportedPlatform]?
 
         /// The package version's supported platforms verified to work
         public let verifiedPlatforms: [PackageModel.Platform]?

--- a/Sources/PackageCollections/Model/Package.swift
+++ b/Sources/PackageCollections/Model/Package.swift
@@ -23,7 +23,7 @@ extension PackageCollectionsModel {
         public let repository: RepositorySpecifier
 
         /// Package description
-        public let description: String?
+        public let summary: String?
 
         /// Keywords for the package
         public let keywords: [String]?
@@ -69,7 +69,7 @@ extension PackageCollectionsModel {
         /// Initializes a `PackageMetadata`
         init(
             repository: RepositorySpecifier,
-            description: String?,
+            summary: String?,
             keywords: [String]?,
             versions: [Version],
             latestVersion: Version?,
@@ -79,7 +79,7 @@ extension PackageCollectionsModel {
         ) {
             self.reference = .init(repository: repository)
             self.repository = repository
-            self.description = description
+            self.summary = summary
             self.keywords = keywords
             self.versions = versions
             self.latestVersion = latestVersion

--- a/Sources/PackageCollections/Model/TargetListResult.swift
+++ b/Sources/PackageCollections/Model/TargetListResult.swift
@@ -36,7 +36,7 @@ extension PackageCollectionsModel.TargetListResult {
         public let repository: RepositorySpecifier
 
         /// Package description
-        public let description: String?
+        public let summary: String?
 
         /// Package versions that contain the target
         public let versions: [Version]

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -330,7 +330,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
                 .map { pair -> PackageCollectionsModel.TargetListResult.Package in
                     let versions = pair.package.versions.map { PackageCollectionsModel.TargetListResult.PackageVersion(version: $0.version, packageName: $0.packageName) }
                     return .init(repository: pair.package.repository,
-                                 description: pair.package.description,
+                                 summary: pair.package.summary,
                                  versions: versions,
                                  collections: Array(pair.collections))
                 }
@@ -359,7 +359,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
 
         return .init(
             repository: package.repository,
-            description: basicMetadata?.description ?? package.description,
+            summary: basicMetadata?.summary ?? package.summary,
             keywords: basicMetadata?.keywords ?? package.keywords,
             versions: versions,
             latestVersion: latestVersion,

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -347,6 +347,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
                   targets: packageVersion.targets,
                   products: packageVersion.products,
                   toolsVersion: packageVersion.toolsVersion,
+                  minimumPlatformVersions: packageVersion.minimumPlatformVersions,
                   verifiedPlatforms: packageVersion.verifiedPlatforms,
                   verifiedSwiftVersions: packageVersion.verifiedSwiftVersions,
                   license: packageVersion.license)

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -104,7 +104,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
                     let readme = try results[readmeURL]?.success?.decodeBody(Readme.self, using: self.decoder)
 
                     callback(.success(.init(
-                        description: metadata.description,
+                        summary: metadata.description,
                         keywords: metadata.topics,
                         versions: tags.compactMap { TSCUtility.Version(string: $0.name) },
                         watchersCount: metadata.watchersCount,

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -16,6 +16,8 @@ import struct Foundation.URL
 import PackageModel
 import SourceControl
 
+fileprivate typealias JSONModel = JSONPackageCollectionModel.V1
+
 struct JSONPackageCollectionProvider: PackageCollectionProvider {
     let configuration: Configuration
     let httpClient: HTTPClient
@@ -82,10 +84,10 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
         }
 
         func makeCollection(_ response: HTTPClientResponse) -> Result<PackageCollectionsModel.Collection, Error> {
-            let collection: CollectionV1
+            let collection: JSONModel.PackageCollection
             do {
                 // parse json
-                guard let decoded = try response.decodeBody(CollectionV1.self, using: self.decoder) else {
+                guard let decoded = try response.decodeBody(JSONModel.PackageCollection.self, using: self.decoder) else {
                     throw Errors.invalidResponse("Invalid body")
                 }
                 collection = decoded
@@ -104,6 +106,7 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
                     }
                     let targets = version.targets.map { PackageCollectionsModel.Target(name: $0.name, moduleName: $0.moduleName) }
                     let products = version.products.compactMap { PackageCollectionsModel.Product(from: $0, packageTargets: targets) }
+                    let minimumPlatformVersions: [PackageModel.SupportedPlatform]? = version.minimumPlatformVersions?.compactMap { PackageModel.SupportedPlatform(from: $0) }
                     let verifiedPlatforms: [PackageModel.Platform]? = version.verifiedPlatforms?.compactMap { PackageModel.Platform(from: $0) }
                     let verifiedSwiftVersions = version.verifiedSwiftVersions?.compactMap { SwiftLanguageVersion(string: $0) }
                     let license = version.license.flatMap { PackageCollectionsModel.License(from: $0) }
@@ -112,25 +115,27 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
                                  targets: targets,
                                  products: products,
                                  toolsVersion: toolsVersion,
+                                 minimumPlatformVersions: minimumPlatformVersions,
                                  verifiedPlatforms: verifiedPlatforms,
                                  verifiedSwiftVersions: verifiedSwiftVersions,
                                  license: license)
                 }
-                return .init(repository: RepositorySpecifier(url: package.url),
-                             description: package.description,
+                return .init(repository: RepositorySpecifier(url: package.url.absoluteString),
+                             description: package._description,
                              keywords: package.keywords,
                              versions: versions,
                              latestVersion: versions.first,
                              watchersCount: nil,
-                             readmeURL: package.readmeURL.flatMap { Foundation.URL(string: $0) },
+                             readmeURL: package.readmeURL,
                              authors: nil)
             }
             return .success(.init(source: source,
                                   name: collection.name,
-                                  description: collection.description,
+                                  description: collection._description,
                                   keywords: collection.keywords,
                                   packages: packages,
                                   createdAt: collection.generatedAt,
+                                  createdBy: collection.generatedBy.flatMap { PackageCollectionsModel.CollectionAuthor(name: $0.name) },
                                   lastProcessedAt: Date()))
         }
     }
@@ -168,79 +173,32 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
     }
 }
 
-// MARK: - JSON Models
-
-extension JSONPackageCollectionProvider {
-    fileprivate struct CollectionV1: Decodable {
-        let name: String
-        let description: String?
-        let keywords: [String]?
-        let formatVersion: String
-        let revision: Int?
-        let packages: [Package]
-        let generatedAt: Date
-        let generatedBy: Author?
-    }
-}
-
-extension JSONPackageCollectionProvider.CollectionV1 {
-    fileprivate struct Package: Decodable {
-        let url: String
-        let description: String?
-        let keywords: [String]?
-        let versions: [Version]
-        let readmeURL: String?
-    }
-
-    fileprivate struct Version: Decodable {
-        let version: String
-        let packageName: String
-        let toolsVersion: String
-        let targets: [Target]
-        let products: [Product]
-        let minimumPlatformVersions: [PlatformVersion]?
-        let verifiedPlatforms: [Platform]?
-        let verifiedSwiftVersions: [String]?
-        let license: License?
-    }
-
-    fileprivate struct Target: Decodable {
-        let name: String
-        let moduleName: String?
-    }
-
-    fileprivate struct Product: Decodable {
-        let name: String
-        let type: ProductType
-        let targets: [String]
-    }
-
-    fileprivate struct Platform: Decodable {
-        let name: String
-    }
-
-    fileprivate struct License: Decodable {
-        let name: String
-        let url: String
-    }
-
-    fileprivate struct Author: Decodable {
-        let name: String
-    }
-}
-
 // MARK: - Extensions for mapping from JSON to PackageCollectionsModel
 
 extension PackageCollectionsModel.Product {
-    fileprivate init?(from: JSONPackageCollectionProvider.CollectionV1.Product, packageTargets: [PackageCollectionsModel.Target]) {
+    fileprivate init(from: JSONModel.Product, packageTargets: [PackageCollectionsModel.Target]) {
         let targets = packageTargets.filter { from.targets.map { $0.lowercased() }.contains($0.name.lowercased()) }
         self = .init(name: from.name, type: from.type, targets: targets)
     }
 }
 
+extension PackageModel.SupportedPlatform {
+    fileprivate init?(from: JSONModel.PlatformVersion) {
+        guard let platform = Platform(name: from.name) else {
+            return nil
+        }
+        let version = PlatformVersion(from.version)
+        self.init(platform: platform, version: version)
+    }
+}
+
 extension PackageModel.Platform {
-    fileprivate init?(from: JSONPackageCollectionProvider.CollectionV1.Platform) {
-        switch from.name.lowercased() {
+    fileprivate init?(from: JSONModel.Platform) {
+        self.init(name: from.name)
+    }
+    
+    fileprivate init?(name: String) {
+        switch name.lowercased() {
         case let name where name.contains("macos"):
             self = PackageModel.Platform.macOS
         case let name where name.contains("ios"):
@@ -264,11 +222,8 @@ extension PackageModel.Platform {
 }
 
 extension PackageCollectionsModel.License {
-    fileprivate init?(from: JSONPackageCollectionProvider.CollectionV1.License) {
+    fileprivate init(from: JSONModel.License) {
         let type = PackageCollectionsModel.LicenseType.allCases.first { $0.description.lowercased() == from.name.lowercased() } ?? .other(from.name)
-        guard let url = Foundation.URL(string: from.url) else {
-            return nil
-        }
-        self.init(type: type, url: url)
+        self.init(type: type, url: from.url)
     }
 }

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -84,10 +84,10 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
         }
 
         func makeCollection(_ response: HTTPClientResponse) -> Result<PackageCollectionsModel.Collection, Error> {
-            let collection: JSONModel.PackageCollection
+            let collection: JSONModel.Collection
             do {
                 // parse json
-                guard let decoded = try response.decodeBody(JSONModel.PackageCollection.self, using: self.decoder) else {
+                guard let decoded = try response.decodeBody(JSONModel.Collection.self, using: self.decoder) else {
                     throw Errors.invalidResponse("Invalid body")
                 }
                 collection = decoded
@@ -121,7 +121,7 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
                                  license: license)
                 }
                 return .init(repository: RepositorySpecifier(url: package.url.absoluteString),
-                             description: package._description,
+                             summary: package.summary,
                              keywords: package.keywords,
                              versions: versions,
                              latestVersion: versions.first,
@@ -131,11 +131,11 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
             }
             return .success(.init(source: source,
                                   name: collection.name,
-                                  description: collection._description,
+                                  overview: collection.overview,
                                   keywords: collection.keywords,
                                   packages: packages,
                                   createdAt: collection.generatedAt,
-                                  createdBy: collection.generatedBy.flatMap { PackageCollectionsModel.CollectionAuthor(name: $0.name) },
+                                  createdBy: collection.generatedBy.flatMap { PackageCollectionsModel.Collection.Author(name: $0.name) },
                                   lastProcessedAt: Date()))
         }
     }

--- a/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
@@ -25,7 +25,7 @@ protocol PackageMetadataProvider {
 
 extension PackageCollectionsModel {
     struct PackageBasicMetadata: Equatable {
-        let description: String?
+        let summary: String?
         let keywords: [String]?
         let versions: [TSCUtility.Version]
         let watchersCount: Int?

--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -233,7 +233,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                     var map = partial
                     map[collection.identifier] = collection.packages.filter { package in
                         if package.repository.url.lowercased().contains(queryString) { return true }
-                        if let description = package.description, description.lowercased().contains(queryString) { return true }
+                        if let summary = package.summary, summary.lowercased().contains(queryString) { return true }
                         if let keywords = package.keywords, (keywords.map { $0.lowercased() }).contains(queryString) { return true }
                         return package.versions.contains(where: { version in
                             if version.packageName.lowercased().contains(queryString) { return true }
@@ -351,7 +351,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                         .map { pair -> PackageCollectionsModel.TargetListItem.Package in
                             let versions = pair.package.versions.map { PackageCollectionsModel.TargetListItem.Package.Version(version: $0.version, packageName: $0.packageName) }
                             return PackageCollectionsModel.TargetListItem.Package(repository: pair.package.repository,
-                                                                                  description: pair.package.description,
+                                                                                  summary: pair.package.summary,
                                                                                   versions: versions,
                                                                                   collections: Array(pair.collections))
                         }

--- a/Sources/PackageModel/Platform.swift
+++ b/Sources/PackageModel/Platform.swift
@@ -37,7 +37,7 @@ public struct Platform: Equatable, Hashable, Codable {
 }
 
 /// Represents a platform supported by a target.
-public struct SupportedPlatform: Codable {
+public struct SupportedPlatform: Equatable, Codable {
     /// The platform.
     public let platform: Platform
 

--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -76,7 +76,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
             let reference = PackageReference(repository: RepositorySpecifier(url: repoURL))
             let metadata = try tsc_await { callback in provider.get(reference, callback: callback) }
 
-            XCTAssertEqual(metadata.description, "This your first repo!")
+            XCTAssertEqual(metadata.summary, "This your first repo!")
             XCTAssertEqual(metadata.versions, [TSCUtility.Version("0.1.0")])
             XCTAssertEqual(metadata.authors, [PackageCollectionsModel.Package.Author(username: "octocat",
                                                                                      url: URL(string: "https://api.github.com/users/octocat")!,
@@ -130,7 +130,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
             let reference = PackageReference(repository: RepositorySpecifier(url: repoURL))
             let metadata = try tsc_await { callback in provider.get(reference, callback: callback) }
 
-            XCTAssertEqual(metadata.description, "This your first repo!")
+            XCTAssertEqual(metadata.summary, "This your first repo!")
             XCTAssertEqual(metadata.versions, [])
             XCTAssertNil(metadata.authors)
             XCTAssertNil(metadata.readmeURL)

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionModelTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionModelTests.swift
@@ -1,0 +1,57 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Foundation
+import XCTest
+
+@testable import PackageCollections
+import PackageModel
+
+class JSONPackageCollectionModelTests: XCTestCase {
+    typealias Model = JSONPackageCollectionModel.V1
+
+    func testCodable() throws {
+        let packages = [
+            Model.PackageCollection.Package(
+                url: URL(string: "https://package-collection-tests.com/repos/foobar.git")!,
+                description: "Package Foobar",
+                keywords: ["test package"],
+                versions: [
+                    Model.PackageCollection.Package.Version(
+                        version: "1.3.2",
+                        packageName: "Foobar",
+                        targets: [.init(name: "Foo", moduleName: "Foo")],
+                        products: [.init(name: "Bar", type: .library(.automatic), targets: ["Foo"])],
+                        toolsVersion: "5.2",
+                        minimumPlatformVersions: [.init(name: "macOS", version: "10.15")],
+                        verifiedPlatforms: [.init(name: "macOS")],
+                        verifiedSwiftVersions: ["5.2"],
+                        license: .init(name: "Apache-2.0", url: URL(string: "https://package-collection-tests.com/repos/foobar/LICENSE")!)
+                    ),
+                ],
+                readmeURL: URL(string: "https://package-collection-tests.com/repos/foobar/README")!
+            ),
+        ]
+        let packageCollection = Model.PackageCollection(
+            name: "Test Package Collection",
+            description: "A test package collection",
+            keywords: ["swift packages"],
+            packages: packages,
+            formatVersion: .v1_0,
+            revision: 3,
+            generatedAt: Date(),
+            generatedBy: .init(name: "Jane Doe")
+        )
+
+        let data = try JSONEncoder().encode(packageCollection)
+        let decoded = try JSONDecoder().decode(Model.PackageCollection.self, from: data)
+        XCTAssertEqual(packageCollection, decoded)
+    }
+}

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionModelTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionModelTests.swift
@@ -19,12 +19,12 @@ class JSONPackageCollectionModelTests: XCTestCase {
 
     func testCodable() throws {
         let packages = [
-            Model.PackageCollection.Package(
+            Model.Collection.Package(
                 url: URL(string: "https://package-collection-tests.com/repos/foobar.git")!,
-                description: "Package Foobar",
+                summary: "Package Foobar",
                 keywords: ["test package"],
                 versions: [
-                    Model.PackageCollection.Package.Version(
+                    Model.Collection.Package.Version(
                         version: "1.3.2",
                         packageName: "Foobar",
                         targets: [.init(name: "Foo", moduleName: "Foo")],
@@ -39,9 +39,9 @@ class JSONPackageCollectionModelTests: XCTestCase {
                 readmeURL: URL(string: "https://package-collection-tests.com/repos/foobar/README")!
             ),
         ]
-        let packageCollection = Model.PackageCollection(
+        let packageCollection = Model.Collection(
             name: "Test Package Collection",
-            description: "A test package collection",
+            overview: "A test package collection",
             keywords: ["swift packages"],
             packages: packages,
             formatVersion: .v1_0,
@@ -51,7 +51,7 @@ class JSONPackageCollectionModelTests: XCTestCase {
         )
 
         let data = try JSONEncoder().encode(packageCollection)
-        let decoded = try JSONDecoder().decode(Model.PackageCollection.self, from: data)
+        let decoded = try JSONDecoder().decode(Model.Collection.self, from: data)
         XCTAssertEqual(packageCollection, decoded)
     }
 }

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -49,13 +49,13 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             let collection = try tsc_await { callback in provider.get(source, callback: callback) }
 
             XCTAssertEqual(collection.name, "Sample Package Collection")
-            XCTAssertEqual(collection.description, "This is a sample package collection listing made-up packages.")
+            XCTAssertEqual(collection.overview, "This is a sample package collection listing made-up packages.")
             XCTAssertEqual(collection.keywords, ["sample package collection"])
             XCTAssertEqual(collection.createdBy?.name, "Jane Doe")
             XCTAssertEqual(collection.packages.count, 2)
             let package = collection.packages.first!
             XCTAssertEqual(package.repository, .init(url: "https://www.example.com/repos/RepoOne.git"))
-            XCTAssertEqual(package.description, "Package One")
+            XCTAssertEqual(package.summary, "Package One")
             XCTAssertEqual(package.keywords, ["sample package"])
             XCTAssertEqual(package.readmeURL, URL(string: "https://www.example.com/repos/RepoOne/README")!)
             XCTAssertEqual(package.versions.count, 1)
@@ -99,13 +99,13 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             let collection = try tsc_await { callback in provider.get(source, callback: callback) }
 
             XCTAssertEqual(collection.name, "Sample Package Collection")
-            XCTAssertEqual(collection.description, "This is a sample package collection listing made-up packages.")
+            XCTAssertEqual(collection.overview, "This is a sample package collection listing made-up packages.")
             XCTAssertEqual(collection.keywords, ["sample package collection"])
             XCTAssertEqual(collection.createdBy?.name, "Jane Doe")
             XCTAssertEqual(collection.packages.count, 2)
             let package = collection.packages.first!
             XCTAssertEqual(package.repository, .init(url: "https://www.example.com/repos/RepoOne.git"))
-            XCTAssertEqual(package.description, "Package One")
+            XCTAssertEqual(package.summary, "Package One")
             XCTAssertEqual(package.keywords, ["sample package"])
             XCTAssertEqual(package.readmeURL, URL(string: "https://www.example.com/repos/RepoOne/README")!)
             XCTAssertEqual(package.versions.count, 1)

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -51,10 +51,12 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(collection.name, "Sample Package Collection")
             XCTAssertEqual(collection.description, "This is a sample package collection listing made-up packages.")
             XCTAssertEqual(collection.keywords, ["sample package collection"])
+            XCTAssertEqual(collection.createdBy?.name, "Jane Doe")
             XCTAssertEqual(collection.packages.count, 2)
             let package = collection.packages.first!
             XCTAssertEqual(package.repository, .init(url: "https://www.example.com/repos/RepoOne.git"))
             XCTAssertEqual(package.description, "Package One")
+            XCTAssertEqual(package.keywords, ["sample package"])
             XCTAssertEqual(package.readmeURL, URL(string: "https://www.example.com/repos/RepoOne/README")!)
             XCTAssertEqual(package.versions.count, 1)
             let version = package.versions.first!
@@ -62,6 +64,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(version.targets, [.init(name: "Foo", moduleName: "Foo")])
             XCTAssertEqual(version.products, [.init(name: "Foo", type: .library(.automatic), targets: [.init(name: "Foo", moduleName: "Foo")])])
             XCTAssertEqual(version.toolsVersion, ToolsVersion(string: "5.1")!)
+            XCTAssertEqual(version.minimumPlatformVersions, [SupportedPlatform(platform: .macOS, version: .init("10.15"))])
             XCTAssertEqual(version.verifiedSwiftVersions, [SwiftLanguageVersion(string: "5.1")!])
             XCTAssertEqual(version.verifiedPlatforms, [.macOS, .iOS, .linux])
             XCTAssertEqual(version.license, .init(type: .Apache2_0, url: URL(string: "https://www.example.com/repos/RepoOne/LICENSE")!))
@@ -98,10 +101,12 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(collection.name, "Sample Package Collection")
             XCTAssertEqual(collection.description, "This is a sample package collection listing made-up packages.")
             XCTAssertEqual(collection.keywords, ["sample package collection"])
+            XCTAssertEqual(collection.createdBy?.name, "Jane Doe")
             XCTAssertEqual(collection.packages.count, 2)
             let package = collection.packages.first!
             XCTAssertEqual(package.repository, .init(url: "https://www.example.com/repos/RepoOne.git"))
             XCTAssertEqual(package.description, "Package One")
+            XCTAssertEqual(package.keywords, ["sample package"])
             XCTAssertEqual(package.readmeURL, URL(string: "https://www.example.com/repos/RepoOne/README")!)
             XCTAssertEqual(package.versions.count, 1)
             let version = package.versions.first!
@@ -109,6 +114,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(version.targets, [.init(name: "Foo", moduleName: "Foo")])
             XCTAssertEqual(version.products, [.init(name: "Foo", type: .library(.automatic), targets: [.init(name: "Foo", moduleName: "Foo")])])
             XCTAssertEqual(version.toolsVersion, ToolsVersion(string: "5.1")!)
+            XCTAssertEqual(version.minimumPlatformVersions, [SupportedPlatform(platform: .macOS, version: .init("10.15"))])
             XCTAssertEqual(version.verifiedSwiftVersions, [SwiftLanguageVersion(string: "5.1")!])
             XCTAssertEqual(version.verifiedPlatforms, [.macOS, .iOS, .linux])
             XCTAssertEqual(version.license, .init(type: .Apache2_0, url: URL(string: "https://www.example.com/repos/RepoOne/LICENSE")!))

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -378,7 +378,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                                   license: nil)
 
         let mockPackage = PackageCollectionsModel.Package(repository: .init(url: "https://packages.mock/\(UUID().uuidString)"),
-                                                          description: UUID().uuidString,
+                                                          summary: UUID().uuidString,
                                                           keywords: [UUID().uuidString, UUID().uuidString],
                                                           versions: [mockVersion],
                                                           latestVersion: mockVersion,
@@ -388,7 +388,7 @@ final class PackageCollectionsTests: XCTestCase {
 
         let mockCollection = PackageCollectionsModel.Collection(source: .init(type: .json, url: URL(string: "https://feed.mock/\(UUID().uuidString)")!),
                                                                 name: UUID().uuidString,
-                                                                description: UUID().uuidString,
+                                                                overview: UUID().uuidString,
                                                                 keywords: [UUID().uuidString, UUID().uuidString],
                                                                 packages: [mockPackage],
                                                                 createdAt: Date(),
@@ -396,7 +396,7 @@ final class PackageCollectionsTests: XCTestCase {
 
         let mockCollection2 = PackageCollectionsModel.Collection(source: .init(type: .json, url: URL(string: "https://feed.mock/\(UUID().uuidString)")!),
                                                                  name: UUID().uuidString,
-                                                                 description: UUID().uuidString,
+                                                                 overview: UUID().uuidString,
                                                                  keywords: [UUID().uuidString, UUID().uuidString],
                                                                  packages: [mockPackage],
                                                                  createdAt: Date(),
@@ -423,8 +423,8 @@ final class PackageCollectionsTests: XCTestCase {
         }
 
         do {
-            // search by package description
-            let searchResult = try tsc_await { callback in packageCollections.findPackages(mockPackage.description!, callback: callback) }
+            // search by package description/summary
+            let searchResult = try tsc_await { callback in packageCollections.findPackages(mockPackage.summary!, callback: callback) }
             XCTAssertEqual(searchResult.items.count, 1, "list count should match")
             XCTAssertEqual(searchResult.items.first?.collections.sorted(), expectedCollectionsIdentifiers, "list count should match")
         }
@@ -529,7 +529,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                                   license: nil)
 
         let mockPackage = PackageCollectionsModel.Package(repository: RepositorySpecifier(url: "https://packages.mock/\(UUID().uuidString)"),
-                                                          description: UUID().uuidString,
+                                                          summary: UUID().uuidString,
                                                           keywords: [UUID().uuidString, UUID().uuidString],
                                                           versions: [mockVersion],
                                                           latestVersion: mockVersion,
@@ -539,7 +539,7 @@ final class PackageCollectionsTests: XCTestCase {
 
         let mockCollection = PackageCollectionsModel.Collection(source: .init(type: .json, url: URL(string: "https://feed.mock/\(UUID().uuidString)")!),
                                                                 name: UUID().uuidString,
-                                                                description: UUID().uuidString,
+                                                                overview: UUID().uuidString,
                                                                 keywords: [UUID().uuidString, UUID().uuidString],
                                                                 packages: [mockPackage],
                                                                 createdAt: Date(),
@@ -547,7 +547,7 @@ final class PackageCollectionsTests: XCTestCase {
 
         let mockCollection2 = PackageCollectionsModel.Collection(source: .init(type: .json, url: URL(string: "https://feed.mock/\(UUID().uuidString)")!),
                                                                  name: UUID().uuidString,
-                                                                 description: UUID().uuidString,
+                                                                 overview: UUID().uuidString,
                                                                  keywords: [UUID().uuidString, UUID().uuidString],
                                                                  packages: [mockPackage],
                                                                  createdAt: Date(),
@@ -656,7 +656,7 @@ final class PackageCollectionsTests: XCTestCase {
                 if self.brokenSources.contains(source) {
                     callback(.failure(self.error))
                 } else {
-                    callback(.success(PackageCollectionsModel.Collection(source: source, name: "", description: nil, keywords: nil, packages: [], createdAt: Date(), createdBy: nil)))
+                    callback(.success(PackageCollectionsModel.Collection(source: source, name: "", overview: nil, keywords: nil, packages: [], createdAt: Date(), createdBy: nil)))
                 }
             }
         }
@@ -833,7 +833,7 @@ final class PackageCollectionsTests: XCTestCase {
         }
 
         let mockPackage = PackageCollectionsModel.Package(repository: RepositorySpecifier(url: "https://package-\(packageId)"),
-                                                          description: "package \(packageId) description",
+                                                          summary: "package \(packageId) description",
                                                           keywords: [UUID().uuidString],
                                                           versions: versions,
                                                           latestVersion: versions.first,
@@ -841,7 +841,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                           readmeURL: URL(string: "https://package-\(packageId)-readme")!,
                                                           authors: (0 ..< Int.random(in: 1 ... 10)).map { .init(username: "\($0)", url: nil, service: nil) })
 
-        let mockMetadata = PackageCollectionsModel.PackageBasicMetadata(description: "\(mockPackage.description!) 2",
+        let mockMetadata = PackageCollectionsModel.PackageBasicMetadata(summary: "\(mockPackage.summary!) 2",
                                                                         keywords: mockPackage.keywords.flatMap { $0.map { "\($0)-2" } },
                                                                         versions: mockPackage.versions.map { TSCUtility.Version($0.version.major, 1, 0) },
                                                                         watchersCount: mockPackage.watchersCount! + 1,
@@ -853,7 +853,7 @@ final class PackageCollectionsTests: XCTestCase {
 
         XCTAssertEqual(metadata.reference, mockPackage.reference, "reference should match")
         XCTAssertEqual(metadata.repository, mockPackage.repository, "repository should match")
-        XCTAssertEqual(metadata.description, mockMetadata.description, "description should match")
+        XCTAssertEqual(metadata.summary, mockMetadata.summary, "summary should match")
         XCTAssertEqual(metadata.keywords, mockMetadata.keywords, "keywords should match")
         mockPackage.versions.forEach { version in
             let metadataVersion = metadata.versions.first(where: { $0.version == version.version })

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -372,6 +372,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                                   targets: mockTargets,
                                                                   products: mockProducts,
                                                                   toolsVersion: .currentToolsVersion,
+                                                                  minimumPlatformVersions: nil,
                                                                   verifiedPlatforms: nil,
                                                                   verifiedSwiftVersions: nil,
                                                                   license: nil)
@@ -390,14 +391,16 @@ final class PackageCollectionsTests: XCTestCase {
                                                                 description: UUID().uuidString,
                                                                 keywords: [UUID().uuidString, UUID().uuidString],
                                                                 packages: [mockPackage],
-                                                                createdAt: Date())
+                                                                createdAt: Date(),
+                                                                createdBy: nil)
 
         let mockCollection2 = PackageCollectionsModel.Collection(source: .init(type: .json, url: URL(string: "https://feed.mock/\(UUID().uuidString)")!),
                                                                  name: UUID().uuidString,
                                                                  description: UUID().uuidString,
                                                                  keywords: [UUID().uuidString, UUID().uuidString],
                                                                  packages: [mockPackage],
-                                                                 createdAt: Date())
+                                                                 createdAt: Date(),
+                                                                 createdBy: nil)
 
         let expectedCollections = [mockCollection, mockCollection2]
         let expectedCollectionsIdentifiers = expectedCollections.map { $0.identifier }.sorted()
@@ -520,13 +523,14 @@ final class PackageCollectionsTests: XCTestCase {
                                                                   targets: mockTargets,
                                                                   products: mockProducts,
                                                                   toolsVersion: .currentToolsVersion,
+                                                                  minimumPlatformVersions: nil,
                                                                   verifiedPlatforms: nil,
                                                                   verifiedSwiftVersions: nil,
                                                                   license: nil)
 
         let mockPackage = PackageCollectionsModel.Package(repository: RepositorySpecifier(url: "https://packages.mock/\(UUID().uuidString)"),
                                                           description: UUID().uuidString,
-                                                          keywords: nil,
+                                                          keywords: [UUID().uuidString, UUID().uuidString],
                                                           versions: [mockVersion],
                                                           latestVersion: mockVersion,
                                                           watchersCount: nil,
@@ -538,14 +542,16 @@ final class PackageCollectionsTests: XCTestCase {
                                                                 description: UUID().uuidString,
                                                                 keywords: [UUID().uuidString, UUID().uuidString],
                                                                 packages: [mockPackage],
-                                                                createdAt: Date())
+                                                                createdAt: Date(),
+                                                                createdBy: nil)
 
         let mockCollection2 = PackageCollectionsModel.Collection(source: .init(type: .json, url: URL(string: "https://feed.mock/\(UUID().uuidString)")!),
                                                                  name: UUID().uuidString,
                                                                  description: UUID().uuidString,
                                                                  keywords: [UUID().uuidString, UUID().uuidString],
                                                                  packages: [mockPackage],
-                                                                 createdAt: Date())
+                                                                 createdAt: Date(),
+                                                                 createdBy: nil)
 
         let expectedCollections = [mockCollection, mockCollection2]
         let expectedCollectionsIdentifiers = expectedCollections.map { $0.identifier }.sorted()
@@ -650,7 +656,7 @@ final class PackageCollectionsTests: XCTestCase {
                 if self.brokenSources.contains(source) {
                     callback(.failure(self.error))
                 } else {
-                    callback(.success(PackageCollectionsModel.Collection(source: source, name: "", description: nil, keywords: nil, packages: [], createdAt: Date())))
+                    callback(.success(PackageCollectionsModel.Collection(source: source, name: "", description: nil, keywords: nil, packages: [], createdAt: Date(), createdBy: nil)))
                 }
             }
         }
@@ -820,6 +826,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                     targets: targets,
                                                     products: products,
                                                     toolsVersion: .currentToolsVersion,
+                                                    minimumPlatformVersions: [.init(platform: .macOS, version: .init("10.15"))],
                                                     verifiedPlatforms: [.iOS, .linux],
                                                     verifiedSwiftVersions: SwiftLanguageVersion.knownSwiftLanguageVersions,
                                                     license: PackageCollectionsModel.License(type: .Apache2_0, url: URL(string: "http://apache.license")!))
@@ -856,6 +863,7 @@ final class PackageCollectionsTests: XCTestCase {
             XCTAssertEqual(version.targets, metadataVersion?.targets, "targets should match")
             XCTAssertEqual(version.products, metadataVersion?.products, "products should match")
             XCTAssertEqual(version.toolsVersion, metadataVersion?.toolsVersion, "toolsVersion should match")
+            XCTAssertEqual(version.minimumPlatformVersions, metadataVersion?.minimumPlatformVersions, "minimumPlatformVersions should match")
             XCTAssertEqual(version.verifiedPlatforms, metadataVersion?.verifiedPlatforms, "verifiedPlatforms should match")
             XCTAssertEqual(version.verifiedSwiftVersions, metadataVersion?.verifiedSwiftVersions, "verifiedSwiftVersions should match")
             XCTAssertEqual(version.license, metadataVersion?.license, "license should match")

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -25,6 +25,11 @@ func makeMockSources(count: Int = Int.random(in: 5 ... 10)) -> [PackageCollectio
 
 func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: Int = 50) -> [PackageCollectionsModel.Collection] {
     let platforms: [PackageModel.Platform] = [.macOS, .iOS, .tvOS, .watchOS, .linux, .android, .windows, .wasi]
+    let supportedPlatforms: [PackageModel.SupportedPlatform] = [
+        .init(platform: .macOS, version: .init("10.15")),
+        .init(platform: .iOS, version: .init("13")),
+        .init(platform: .watchOS, version: "6")
+    ]
 
     return (0 ..< count).map { collectionIndex in
         let packages = (0 ..< Int.random(in: min(5, maxPackages) ... maxPackages)).map { packageIndex -> PackageCollectionsModel.Package in
@@ -38,6 +43,7 @@ func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: I
                                                     type: .executable,
                                                     targets: targets)
                 }
+                let minimumPlatformVersions = (0 ..< Int.random(in: 1 ... 2)).map { _ in supportedPlatforms.randomElement()! }
                 let verifiedPlatforms = (0 ..< Int.random(in: 1 ... 3)).map { _ in platforms.randomElement()! }
                 let verifiedSwiftVersions = (0 ..< Int.random(in: 1 ... 3)).map { _ in SwiftLanguageVersion.knownSwiftLanguageVersions.randomElement()! }
                 let licenseType = PackageCollectionsModel.LicenseType.allCases.randomElement()!
@@ -48,6 +54,7 @@ func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: I
                                                                targets: targets,
                                                                products: products,
                                                                toolsVersion: .currentToolsVersion,
+                                                               minimumPlatformVersions: minimumPlatformVersions,
                                                                verifiedPlatforms: verifiedPlatforms,
                                                                verifiedSwiftVersions: verifiedSwiftVersions,
                                                                license: license)
@@ -66,9 +73,10 @@ func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: I
         return PackageCollectionsModel.Collection(source: .init(type: .json, url: URL(string: "https://feed-\(collectionIndex)")!),
                                                   name: "collection \(collectionIndex)",
                                                   description: "collection \(collectionIndex) description",
-                                                  keywords: nil,
+                                                  keywords: (0 ..< Int.random(in: 1 ... 3)).map { "keyword \($0)" },
                                                   packages: packages,
-                                                  createdAt: Date())
+                                                  createdAt: Date(),
+                                                  createdBy: PackageCollectionsModel.Collection.Author(name: "Jane Doe"))
     }
 }
 

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -61,7 +61,7 @@ func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: I
             }
 
             return PackageCollectionsModel.Package(repository: RepositorySpecifier(url: "https://package-\(packageIndex)"),
-                                                   description: "package \(packageIndex) description",
+                                                   summary: "package \(packageIndex) description",
                                                    keywords: (0 ..< Int.random(in: 1 ... 3)).map { "keyword \($0)" },
                                                    versions: versions,
                                                    latestVersion: versions.first,
@@ -72,7 +72,7 @@ func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: I
 
         return PackageCollectionsModel.Collection(source: .init(type: .json, url: URL(string: "https://feed-\(collectionIndex)")!),
                                                   name: "collection \(collectionIndex)",
-                                                  description: "collection \(collectionIndex) description",
+                                                  overview: "collection \(collectionIndex) description",
                                                   keywords: (0 ..< Int.random(in: 1 ... 3)).map { "keyword \($0)" },
                                                   packages: packages,
                                                   createdAt: Date(),
@@ -81,7 +81,7 @@ func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: I
 }
 
 func makeMockPackageBasicMetadata() -> PackageCollectionsModel.PackageBasicMetadata {
-    return .init(description: UUID().uuidString,
+    return .init(summary: UUID().uuidString,
                  keywords: (0 ..< Int.random(in: 1 ... 3)).map { "keyword \($0)" },
                  versions: (0 ..< Int.random(in: 1 ... 10)).map { TSCUtility.Version($0, 0, 0) },
                  watchersCount: Int.random(in: 0 ... 50),


### PR DESCRIPTION
According to https://forums.swift.org/t/package-collection-format/42071

- Rename `summary` and `title` to `description` and `name`, respectively
- Add `keywords` to `PackageCollection.Package`
- Add `minimumPlatformVersions` to `PackageCollection.Package.Version`
- Add `createdBy` to `PackageCollection`

API models and tests are updated as well.

