### PR TITLE
Add Basics to CMakeLists.txt

### DIFF
--- a/Sources/Build/CMakeLists.txt
+++ b/Sources/Build/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(Build
   SwiftCompilerOutputParser.swift
   XCFrameworkInfo.swift)
 target_link_libraries(Build PUBLIC
+  Basics
   TSCBasic
   PackageGraph
   LLBuildManifest

--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(Commands
   SymbolGraphExtract.swift
   WatchmanHelper.swift)
 target_link_libraries(Commands PUBLIC
+  Basics
   ArgumentParser
   Build
   PackageGraph

--- a/Sources/LLBuildManifest/CMakeLists.txt
+++ b/Sources/LLBuildManifest/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(LLBuildManifest
   Target.swift
   Tools.swift)
 target_link_libraries(LLBuildManifest PUBLIC
+  Basics
   TSCBasic)
 
 # NOTE(compnerd) workaround for CMake not setting up include flags yet

--- a/Sources/PackageCollections/CMakeLists.txt
+++ b/Sources/PackageCollections/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(PackageCollections
   PackageCollections+Validation.swift
   Utility.swift)
 target_link_libraries(PackageCollections PUBLIC
+  Basics
   TSCBasic
   TSCUtility
   PackageModel

--- a/Sources/PackageGraph/CMakeLists.txt
+++ b/Sources/PackageGraph/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(PackageGraph
   Version+Extensions.swift
   VersionSetSpecifier.swift)
 target_link_libraries(PackageGraph PUBLIC
+  Basics
   TSCBasic
   PackageLoading
   PackageModel

--- a/Sources/PackageLoading/CMakeLists.txt
+++ b/Sources/PackageLoading/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(PackageLoading
   ToolsVersionLoader.swift
   UserManifestResources.swift)
 target_link_libraries(PackageLoading PUBLIC
+  Basics
   TSCBasic
   PackageModel
   TSCUtility)

--- a/Sources/PackageModel/CMakeLists.txt
+++ b/Sources/PackageModel/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(PackageModel
   Target.swift
   ToolsVersion.swift)
 target_link_libraries(PackageModel PUBLIC
+  Basics
   TSCBasic
   TSCUtility)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet

--- a/Sources/SPMBuildCore/CMakeLists.txt
+++ b/Sources/SPMBuildCore/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(SPMBuildCore
 set_target_properties(SPMBuildCore PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_link_libraries(SPMBuildCore PUBLIC
+  Basics
   TSCBasic
   TSCUtility
   PackageGraph)

--- a/Sources/SPMLLBuild/CMakeLists.txt
+++ b/Sources/SPMLLBuild/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(SPMLLBuild
 set_target_properties(SPMLLBuild PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 target_link_libraries(SPMLLBuild PUBLIC
+  Basics
   TSCBasic
   TSCUtility
   llbuildSwift)

--- a/Sources/SourceControl/CMakeLists.txt
+++ b/Sources/SourceControl/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(SourceControl
   RepositoryManager.swift)
 
 target_link_libraries(SourceControl PUBLIC
+  Basics
   TSCBasic
   TSCUtility)
 

--- a/Sources/Workspace/CMakeLists.txt
+++ b/Sources/Workspace/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(Workspace
   WorkspaceState.swift
   WindowsToolchainInfo.swift)
 target_link_libraries(Workspace PUBLIC
+  Basics
   TSCBasic
   TSCUtility
   SPMBuildCore

--- a/Sources/Xcodeproj/CMakeLists.txt
+++ b/Sources/Xcodeproj/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(Xcodeproj
   XcodeProjectModel.swift
   XcodeProjectModelSerialization.swift)
 target_link_libraries(Xcodeproj PUBLIC
+  Basics
   TSCBasic
   PackageGraph)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet


### PR DESCRIPTION
Add Basics to CMakeLists.txt in `target_link_libraries`
### Motivation:
We need to link the library in order to use it in the smoke tests.

### Modifications
Add Basics to CMakeLists.txt in `target_link_libraries`

### Result:
CMake will link Basics to all of the modules using it
