### PR TITLE
[NFC] Use extended delimiters for regex strings

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -758,13 +758,13 @@ private func sandboxProfile(allowedDirectories: [AbsolutePath]) -> String {
     stream <<< "(allow file-write*" <<< "\n"
     for directory in Platform.darwinCacheDirectories() {
         // For compiler module cache.
-        stream <<< "    (regex #\"^\(directory.pathString)/org\\.llvm\\.clang.*\")" <<< "\n"
+        stream <<< ##"    (regex #"^\##(directory.pathString)/org\.llvm\.clang.*")"## <<< "\n"
         // For archive tool.
-        stream <<< "    (regex #\"^\(directory.pathString)/ar.*\")" <<< "\n"
+        stream <<< ##"    (regex #"^\##(directory.pathString)/ar.*")"## <<< "\n"
         // For xcrun cache.
-        stream <<< "    (regex #\"^\(directory.pathString)/xcrun.*\")" <<< "\n"
+        stream <<< ##"    (regex #"^\##(directory.pathString)/xcrun.*")"## <<< "\n"
         // For autolink files.
-        stream <<< "    (regex #\"^\(directory.pathString)/.*\\.(swift|c)-[0-9a-f]+\\.autolink\")" <<< "\n"
+        stream <<< ##"    (regex #"^\##(directory.pathString)/.*\.(swift|c)-[0-9a-f]+\.autolink")"## <<< "\n"
     }
     for directory in allowedDirectories {
         stream <<< "    (subpath \"\(directory.pathString)\")" <<< "\n"

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -121,7 +121,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
 
     internal func apiURL(_ url: String) -> Foundation.URL? {
         do {
-            let regex = try NSRegularExpression(pattern: "([^/@]+)[:/]([^:/]+)/([^/]+)\\.git$", options: .caseInsensitive)
+            let regex = try NSRegularExpression(pattern: #"([^/@]+)[:/]([^:/]+)/([^/]+)\.git$"#, options: .caseInsensitive)
             if let match = regex.firstMatch(in: url, options: [], range: NSRange(location: 0, length: url.count)) {
                 if let hostRange = Range(match.range(at: 1), in: url),
                     let ownerRange = Range(match.range(at: 2), in: url),

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -905,7 +905,7 @@ private func sandboxProfile(toolsVersion: ToolsVersion, cacheDirectories: [Absol
         // Allow writing in temporary locations.
         stream <<< "(allow file-write*" <<< "\n"
         for directory in Platform.darwinCacheDirectories() {
-            stream <<< "    (regex #\"^\(directory.pathString)/org\\.llvm\\.clang.*\")" <<< "\n"
+            stream <<< ##"    (regex #"^\##(directory.pathString)/org\.llvm\.clang.*")"## <<< "\n"
         }
         for directory in cacheDirectories {
             stream <<< "    (subpath \"\(directory.pathString)\")" <<< "\n"

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -67,7 +67,7 @@ extension Manifest {
         do { contents = try fileSystem.getDirectoryContents(packagePath) } catch {
             throw ToolsVersionLoader.Error.inaccessiblePackage(path: packagePath, reason: String(describing: error))
         }
-        let regex = try! RegEx(pattern: "^Package@swift-(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?.swift$")
+        let regex = try! RegEx(pattern: #"^Package@swift-(\d+)(?:\.(\d+))?(?:\.(\d+))?.swift$"#)
 
         // Collect all version-specific manifests at the given package path.
         let versionSpecificManifests = Dictionary(contents.compactMap{ file -> (ToolsVersion, String)? in

--- a/Sources/PackageModel/SwiftLanguageVersion.swift
+++ b/Sources/PackageModel/SwiftLanguageVersion.swift
@@ -57,7 +57,7 @@ public struct SwiftLanguageVersion {
     }
 
     /// Regex for parsing the Swift language version.
-    private static let regex = try! RegEx(pattern: "^(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?$")
+    private static let regex = try! RegEx(pattern: #"^(\d+)(?:\.(\d+))?(?:\.(\d+))?$"#)
 
     /// Create an instance of Swift language version from the given string.
     ///

--- a/Sources/PackageModel/ToolsVersion.swift
+++ b/Sources/PackageModel/ToolsVersion.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -36,12 +36,12 @@ public struct ToolsVersion: Equatable, Hashable, Codable {
     /// Regex pattern to parse tools version. The format is SemVer 2.0 with an
     /// addition that specifying the patch version is optional.
     static let toolsVersionRegex = try! NSRegularExpression(pattern: "^" +
-        "(\\d+)\\.(\\d+)(?:\\.(\\d+))?" +
+        #"(\d+)\.(\d+)(?:\.(\d+))?"# +
         "(" +
-            "\\-[A-Za-z\\d]+(?:\\.[A-Za-z\\d]+)*" +
+            #"\-[A-Za-z\d]+(?:\.[A-Za-z\d]+)*"# +
         ")?" +
         "(" +
-            "\\+[A-Za-z\\d]+(?:\\.[A-Za-z\\d]+)*" +
+            #"\+[A-Za-z\d]+(?:\.[A-Za-z\d]+)*"# +
         ")?$", options: [])
 
     /// The major version number.

--- a/Sources/PackageModel/ToolsVersion.swift
+++ b/Sources/PackageModel/ToolsVersion.swift
@@ -35,14 +35,20 @@ public struct ToolsVersion: Equatable, Hashable, Codable {
 
     /// Regex pattern to parse tools version. The format is SemVer 2.0 with an
     /// addition that specifying the patch version is optional.
-    static let toolsVersionRegex = try! NSRegularExpression(pattern: "^" +
-        #"(\d+)\.(\d+)(?:\.(\d+))?"# +
-        "(" +
-            #"\-[A-Za-z\d]+(?:\.[A-Za-z\d]+)*"# +
-        ")?" +
-        "(" +
-            #"\+[A-Za-z\d]+(?:\.[A-Za-z\d]+)*"# +
-        ")?$", options: [])
+    static let toolsVersionRegex = try! NSRegularExpression(
+        pattern: #"""
+                 ^
+                 (\d+)\.(\d+)(?:\.(\d+))?
+                 (
+                     \-[A-Za-z\d]+(?:\.[A-Za-z\d]+)*
+                 )?
+                 (
+                     \+[A-Za-z\d]+(?:\.[A-Za-z\d]+)*
+                 )?
+                 $
+                 """#,
+        options: [.allowCommentsAndWhitespace]
+    )
 
     /// The major version number.
     public var major: Int {


### PR DESCRIPTION
Use `#"extended delimiters"#` for regex strings.

### Motivation:

This removes a lot of backslashes and make the strings more readable.

### Modifications:

Replaced the normal delimiters with extended delimiters for regex strings.

### Result:

No functional change.