### PR TITLE
add diagnostics to package collections

### DIFF
--- a/Sources/Basics/HTTPClient.swift
+++ b/Sources/Basics/HTTPClient.swift
@@ -33,14 +33,16 @@ public struct HTTPClient {
     public typealias Handler = (Request, @escaping (Result<Response, Error>) -> Void) -> Void
 
     public var configuration: HTTPClientConfiguration
+    private let diagnosticsEngine: DiagnosticsEngine
     private let underlying: Handler
 
     // static to share across instances of the http client
     private static var hostsErrorsLock = Lock()
     private static var hostsErrors = [String: [Date]]()
 
-    public init(configuration: HTTPClientConfiguration = .init(), handler: Handler? = nil) {
+    public init(configuration: HTTPClientConfiguration = .init(), handler: Handler? = nil, diagnosticsEngine: DiagnosticsEngine = .init()) {
         self.configuration = configuration
+        self.diagnosticsEngine = diagnosticsEngine
         // FIXME: inject platform specific implementation here
         self.underlying = handler ?? URLSessionHTTPClient().execute
     }
@@ -80,6 +82,7 @@ public struct HTTPClient {
 
     private func _execute(request: Request, requestNumber: Int, callback: @escaping (Result<Response, Error>) -> Void) {
         if self.shouldCircuitBreak(request: request) {
+            diagnosticsEngine.emit(warning: "Circuit breaker triggered for \(request.url)")
             return callback(.failure(HTTPClientError.circuitBreakerTriggered))
         }
 
@@ -92,6 +95,7 @@ public struct HTTPClient {
                 self.recordErrorIfNecessary(response: response, request: request)
                 // handle retry strategy
                 if let retryDelay = self.shouldRetry(response: response, request: request, requestNumber: requestNumber) {
+                    diagnosticsEngine.emit(warning: "\(request.url) failed, retrying in \(retryDelay)")
                     // TODO: dedicated retry queue?
                     return DispatchQueue.global().asyncAfter(deadline: .now() + retryDelay) {
                         self._execute(request: request, requestNumber: requestNumber + 1, callback: callback)

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -14,6 +14,7 @@ import TSCBasic
 // TODO: is there a better name? this conflicts with the module name which is okay in this case but not ideal in Swift
 public struct PackageCollections: PackageCollectionsProtocol {
     private let configuration: Configuration
+    private let diagnosticsEngine: DiagnosticsEngine
     private let storageContainer: (storage: Storage, owned: Bool)
     private let collectionProviders: [Model.CollectionSourceType: PackageCollectionProvider]
     private let metadataProvider: PackageMetadataProvider
@@ -23,13 +24,14 @@ public struct PackageCollections: PackageCollectionsProtocol {
     }
 
     // initialize with defaults
-    public init(configuration: Configuration = .init()) {
-        let storage = Storage(sources: FilePackageCollectionsSourcesStorage(),
-                              collections: SQLitePackageCollectionsStorage())
-        let collectionProviders = [Model.CollectionSourceType.json: JSONPackageCollectionProvider()]
-        let metadataProvider = GitHubPackageMetadataProvider()
+    public init(configuration: Configuration = .init(), diagnosticsEngine: DiagnosticsEngine = .init()) {
+        let storage = Storage(sources: FilePackageCollectionsSourcesStorage(diagnosticsEngine: diagnosticsEngine),
+                              collections: SQLitePackageCollectionsStorage(diagnosticsEngine: diagnosticsEngine))
+        let collectionProviders = [Model.CollectionSourceType.json: JSONPackageCollectionProvider(diagnosticsEngine: diagnosticsEngine)]
+        let metadataProvider = GitHubPackageMetadataProvider(diagnosticsEngine: diagnosticsEngine)
 
         self.configuration = configuration
+        self.diagnosticsEngine = diagnosticsEngine
         self.storageContainer = (storage, true)
         self.collectionProviders = collectionProviders
         self.metadataProvider = metadataProvider
@@ -37,10 +39,12 @@ public struct PackageCollections: PackageCollectionsProtocol {
 
     // internal initializer for testing
     init(configuration: Configuration = .init(),
+         diagnosticsEngine: DiagnosticsEngine = .init(),
          storage: Storage,
          collectionProviders: [Model.CollectionSourceType: PackageCollectionProvider],
          metadataProvider: PackageMetadataProvider) {
         self.configuration = configuration
+        self.diagnosticsEngine = diagnosticsEngine
         self.storageContainer = (storage, false)
         self.collectionProviders = collectionProviders
         self.metadataProvider = metadataProvider
@@ -202,12 +206,14 @@ public struct PackageCollections: PackageCollectionsProtocol {
                 self.metadataProvider.get(reference) { result in
                     switch result {
                     case .failure(let error) where error is NotFoundError:
+                        self.diagnosticsEngine.emit(warning: "Failed fetching information about \(reference) from \(self.metadataProvider.name).")
                         let metadata = Model.PackageMetadata(
                             package: Self.mergedPackageMetadata(package: packageSearchResult.package, basicMetadata: nil),
                             collections: packageSearchResult.collections
                         )
                         callback(.success(metadata))
                     case .failure(let error):
+                        self.diagnosticsEngine.emit(error: "Failed fetching information about \(reference) from \(self.metadataProvider.name).")
                         callback(.failure(error))
                     case .success(let basicMetadata):
                         // finally merge the results

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -22,11 +22,11 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
     public var name: String = "GitHub"
 
     private let httpClient: HTTPClient
-    private let diagnosticsEngine: DiagnosticsEngine
+    private let diagnosticsEngine: DiagnosticsEngine?
     private let decoder: JSONDecoder
     private let queue: DispatchQueue
 
-    init(httpClient: HTTPClient? = nil, diagnosticsEngine: DiagnosticsEngine = .init()) {
+    init(httpClient: HTTPClient? = nil, diagnosticsEngine: DiagnosticsEngine? = nil) {
         self.httpClient = httpClient ?? Self.makeDefaultHTTPClient(diagnosticsEngine: diagnosticsEngine)
         self.diagnosticsEngine = diagnosticsEngine
         self.decoder = JSONDecoder.makeWithDefaults()
@@ -140,7 +140,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
         return options
     }
 
-    private static func makeDefaultHTTPClient(diagnosticsEngine: DiagnosticsEngine) -> HTTPClient {
+    private static func makeDefaultHTTPClient(diagnosticsEngine: DiagnosticsEngine?) -> HTTPClient {
         var client = HTTPClient(diagnosticsEngine: diagnosticsEngine)
         // TODO: make these defaults configurable?
         client.configuration.requestTimeout = .seconds(1)

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -19,12 +19,16 @@ import PackageModel
 import TSCBasic
 
 struct GitHubPackageMetadataProvider: PackageMetadataProvider {
-    let httpClient: HTTPClient
-    let decoder: JSONDecoder
-    let queue: DispatchQueue
+    public var name: String = "GitHub"
 
-    init(httpClient: HTTPClient? = nil) {
-        self.httpClient = httpClient ?? Self.makeDefaultHTTPClient()
+    private let httpClient: HTTPClient
+    private let diagnosticsEngine: DiagnosticsEngine
+    private let decoder: JSONDecoder
+    private let queue: DispatchQueue
+
+    init(httpClient: HTTPClient? = nil, diagnosticsEngine: DiagnosticsEngine = .init()) {
+        self.httpClient = httpClient ?? Self.makeDefaultHTTPClient(diagnosticsEngine: diagnosticsEngine)
+        self.diagnosticsEngine = diagnosticsEngine
         self.decoder = JSONDecoder.makeWithDefaults()
         self.queue = DispatchQueue(label: "org.swift.swiftpm.GitHubPackageMetadataProvider", attributes: .concurrent)
     }
@@ -95,6 +99,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
                     callback(.success(.init(
                         summary: metadata.description,
                         keywords: metadata.topics,
+                        // filters out non-semantic versioned tags
                         versions: tags.compactMap { TSCUtility.Version(string: $0.name) },
                         watchersCount: metadata.watchersCount,
                         readmeURL: readme?.downloadURL,
@@ -135,8 +140,8 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
         return options
     }
 
-    private static func makeDefaultHTTPClient() -> HTTPClient {
-        var client = HTTPClient()
+    private static func makeDefaultHTTPClient(diagnosticsEngine: DiagnosticsEngine) -> HTTPClient {
+        var client = HTTPClient(diagnosticsEngine: diagnosticsEngine)
         // TODO: make these defaults configurable?
         client.configuration.requestTimeout = .seconds(1)
         client.configuration.retryStrategy = .exponentialBackoff(maxAttempts: 3, baseDelay: .milliseconds(50))

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -21,11 +21,11 @@ private typealias JSONModel = JSONPackageCollectionModel.V1
 
 struct JSONPackageCollectionProvider: PackageCollectionProvider {
     private let configuration: Configuration
-    private let diagnosticsEngine: DiagnosticsEngine
+    private let diagnosticsEngine: DiagnosticsEngine?
     private let httpClient: HTTPClient
     private let decoder: JSONDecoder
 
-    init(configuration: Configuration = .init(), httpClient: HTTPClient? = nil, diagnosticsEngine: DiagnosticsEngine = .init()) {
+    init(configuration: Configuration = .init(), httpClient: HTTPClient? = nil, diagnosticsEngine: DiagnosticsEngine? = nil) {
         self.configuration = configuration
         self.diagnosticsEngine = diagnosticsEngine
         self.httpClient = httpClient ?? Self.makeDefaultHTTPClient(diagnosticsEngine: diagnosticsEngine)        
@@ -144,7 +144,7 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
             }
 
             if !serializationOkay {
-                self.diagnosticsEngine.emit(warning: "Some collection information could not be deserialized likely due to invalid format, contact the collection's author (\(collection.generatedBy?.name ?? "n/a")) to address this issue.")
+                self.diagnosticsEngine?.emit(warning: "Some of the information from \(collection.name) could not be deserialized correctly, likely due to invalid format. Contact the collection's author (\(collection.generatedBy?.name ?? "n/a")) to address this issue.")
             }
 
             return .success(.init(source: source,
@@ -165,7 +165,7 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
         return options
     }
 
-    private static func makeDefaultHTTPClient(diagnosticsEngine: DiagnosticsEngine) -> HTTPClient {
+    private static func makeDefaultHTTPClient(diagnosticsEngine: DiagnosticsEngine?) -> HTTPClient {
         var client = HTTPClient(diagnosticsEngine: diagnosticsEngine)
         // TODO: make these defaults configurable?
         client.configuration.requestTimeout = .seconds(1)

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -15,17 +15,20 @@ import class Foundation.JSONDecoder
 import struct Foundation.URL
 import PackageModel
 import SourceControl
+import TSCBasic
 
 private typealias JSONModel = JSONPackageCollectionModel.V1
 
 struct JSONPackageCollectionProvider: PackageCollectionProvider {
-    let configuration: Configuration
-    let httpClient: HTTPClient
-    let decoder: JSONDecoder
+    private let configuration: Configuration
+    private let diagnosticsEngine: DiagnosticsEngine
+    private let httpClient: HTTPClient
+    private let decoder: JSONDecoder
 
-    init(configuration: Configuration = .init(), httpClient: HTTPClient? = nil) {
+    init(configuration: Configuration = .init(), httpClient: HTTPClient? = nil, diagnosticsEngine: DiagnosticsEngine = .init()) {
         self.configuration = configuration
-        self.httpClient = httpClient ?? Self.makeDefaultHTTPClient()
+        self.diagnosticsEngine = diagnosticsEngine
+        self.httpClient = httpClient ?? Self.makeDefaultHTTPClient(diagnosticsEngine: diagnosticsEngine)        
         self.decoder = JSONDecoder.makeWithDefaults()
     }
 
@@ -84,6 +87,7 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
                 return .failure(Errors.invalidJSON(error))
             }
 
+            var serializationOkay = true
             let packages = collection.packages.map { package -> Model.Package in
                 let versions = package.versions.compactMap { version -> Model.Package.Version? in
                     // note this filters out / ignores missing / bad data in attempt to make the most out of the provided set
@@ -94,11 +98,27 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
                         return nil
                     }
                     let targets = version.targets.map { Model.Target(name: $0.name, moduleName: $0.moduleName) }
+                    if targets.count != version.targets.count {
+                        serializationOkay = false
+                    }
                     let products = version.products.compactMap { Model.Product(from: $0, packageTargets: targets) }
+                    if products.count != version.products.count {
+                        serializationOkay = false
+                    }
                     let minimumPlatformVersions: [PackageModel.SupportedPlatform]? = version.minimumPlatformVersions?.compactMap { PackageModel.SupportedPlatform(from: $0) }
+                    if minimumPlatformVersions?.count != version.minimumPlatformVersions?.count {
+                        serializationOkay = false
+                    }
                     let verifiedPlatforms: [PackageModel.Platform]? = version.verifiedPlatforms?.compactMap { PackageModel.Platform(from: $0) }
+                    if verifiedPlatforms?.count != version.verifiedPlatforms?.count {
+                        serializationOkay = false
+                    }
                     let verifiedSwiftVersions = version.verifiedSwiftVersions?.compactMap { SwiftLanguageVersion(string: $0) }
+                    if verifiedSwiftVersions?.count != version.verifiedSwiftVersions?.count {
+                        serializationOkay = false
+                    }
                     let license = version.license.flatMap { Model.License(from: $0) }
+
                     return .init(version: parsedVersion,
                                  packageName: version.packageName,
                                  targets: targets,
@@ -109,6 +129,10 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
                                  verifiedSwiftVersions: verifiedSwiftVersions,
                                  license: license)
                 }
+                if versions.count != package.versions.count {
+                    serializationOkay = false
+                }
+
                 return .init(repository: RepositorySpecifier(url: package.url.absoluteString),
                              summary: package.summary,
                              keywords: package.keywords,
@@ -118,6 +142,11 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
                              readmeURL: package.readmeURL,
                              authors: nil)
             }
+
+            if !serializationOkay {
+                self.diagnosticsEngine.emit(warning: "Some collection information could not be deserialized likely due to invalid format, contact the collection's author (\(collection.generatedBy?.name ?? "n/a")) to address this issue.")
+            }
+
             return .success(.init(source: source,
                                   name: collection.name,
                                   overview: collection.overview,
@@ -136,8 +165,8 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
         return options
     }
 
-    private static func makeDefaultHTTPClient() -> HTTPClient {
-        var client = HTTPClient()
+    private static func makeDefaultHTTPClient(diagnosticsEngine: DiagnosticsEngine) -> HTTPClient {
+        var client = HTTPClient(diagnosticsEngine: diagnosticsEngine)
         // TODO: make these defaults configurable?
         client.configuration.requestTimeout = .seconds(1)
         client.configuration.retryStrategy = .exponentialBackoff(maxAttempts: 3, baseDelay: .milliseconds(50))

--- a/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
@@ -15,6 +15,9 @@ import TSCUtility
 
 /// `PackageBasicMetadata` provider
 protocol PackageMetadataProvider {
+    /// The name of the provider
+    var name: String { get }
+
     /// Retrieves metadata for a package at the given repository address.
     ///
     /// - Parameters:

--- a/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
+++ b/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
@@ -20,17 +20,18 @@ struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
     let fileSystem: FileSystem
     let path: AbsolutePath
 
+    private let diagnosticsEngine: DiagnosticsEngine
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
 
     private let queue = DispatchQueue(label: "org.swift.swiftpm.FilePackageCollectionsSourcesStorage")
 
-    init(fileSystem: FileSystem = localFileSystem, path: AbsolutePath? = nil) {
+    init(fileSystem: FileSystem = localFileSystem, path: AbsolutePath? = nil, diagnosticsEngine: DiagnosticsEngine = .init()) {
         self.fileSystem = fileSystem
 
         let name = "collections"
         self.path = path ?? fileSystem.dotSwiftPM.appending(components: "config", "\(name).json")
-
+        self.diagnosticsEngine = diagnosticsEngine
         self.encoder = JSONEncoder.makeWithDefaults()        
         self.decoder = JSONDecoder.makeWithDefaults()
     }

--- a/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
+++ b/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
@@ -20,13 +20,13 @@ struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
     let fileSystem: FileSystem
     let path: AbsolutePath
 
-    private let diagnosticsEngine: DiagnosticsEngine
+    private let diagnosticsEngine: DiagnosticsEngine?
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
 
     private let queue = DispatchQueue(label: "org.swift.swiftpm.FilePackageCollectionsSourcesStorage")
 
-    init(fileSystem: FileSystem = localFileSystem, path: AbsolutePath? = nil, diagnosticsEngine: DiagnosticsEngine = .init()) {
+    init(fileSystem: FileSystem = localFileSystem, path: AbsolutePath? = nil, diagnosticsEngine: DiagnosticsEngine? = nil) {
         self.fileSystem = fileSystem
 
         let name = "collections"

--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -24,7 +24,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
     let fileSystem: FileSystem
     let location: SQLite.Location
 
-    private let diagnosticsEngine: DiagnosticsEngine
+    private let diagnosticsEngine: DiagnosticsEngine?
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
 
@@ -37,7 +37,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
     private var cache = [Model.CollectionIdentifier: Model.Collection]()
     private let cacheLock = Lock()
 
-    init(location: SQLite.Location? = nil, diagnosticsEngine: DiagnosticsEngine = .init()) {
+    init(location: SQLite.Location? = nil, diagnosticsEngine: DiagnosticsEngine? = nil) {
         self.location = location ?? .path(localFileSystem.swiftPMCacheDirectory.appending(components: "package-collection.db"))
         switch self.location {
         case .path, .temporary:
@@ -50,7 +50,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
         self.decoder = JSONDecoder.makeWithDefaults()
     }
 
-    convenience init(path: AbsolutePath, diagnosticsEngine: DiagnosticsEngine = .init()) {
+    convenience init(path: AbsolutePath, diagnosticsEngine: DiagnosticsEngine? = nil) {
         self.init(location: .path(path), diagnosticsEngine: diagnosticsEngine)
     }
 
@@ -213,7 +213,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                 }
 
                 if collections.count != blobs.count {
-                    self.diagnosticsEngine.emit(warning: "Some stored collections could not be deserialized. Please refresh the collections to resolve this issue.")
+                    self.diagnosticsEngine?.emit(warning: "Some stored collections could not be deserialized. Please refresh the collections to resolve this issue.")
                 }
 
                 callback(.success(collections))

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -931,6 +931,8 @@ final class PackageCollectionsTests: XCTestCase {
 
     func testFetchMetadataProviderError() throws {
         struct BrokenMetadataProvider: PackageMetadataProvider {
+            var name: String = "BrokenMetadataProvider"
+
             func get(_ reference: PackageReference, callback: @escaping (Result<PackageCollectionsModel.PackageBasicMetadata, Error>) -> Void) {
                 callback(.failure(TerribleThing()))
             }

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -28,7 +28,7 @@ func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: I
     let supportedPlatforms: [PackageModel.SupportedPlatform] = [
         .init(platform: .macOS, version: .init("10.15")),
         .init(platform: .iOS, version: .init("13")),
-        .init(platform: .watchOS, version: "6")
+        .init(platform: .watchOS, version: "6"),
     ]
 
     return (0 ..< count).map { collectionIndex in
@@ -113,6 +113,8 @@ struct MockCollectionsProvider: PackageCollectionProvider {
 }
 
 struct MockMetadataProvider: PackageMetadataProvider {
+    var name: String = "MockMetadataProvider"
+
     let packages: [PackageReference: PackageCollectionsModel.PackageBasicMetadata]
 
     init(_ packages: [PackageReference: PackageCollectionsModel.PackageBasicMetadata]) {


### PR DESCRIPTION
motivation: provide users with useful information when error condistions occur

changes:
* add DiagnosticEngine to relevant entities in PackageCollection and HTTPClient
* add few diagnostics messages in error cases where users may need to be informed or take action
