### PR TITLE
Add JSONPackageCollectionModel validator

### DIFF
--- a/Sources/PackageCollections/JSONModel/JSONCollection+v1.swift
+++ b/Sources/PackageCollections/JSONModel/JSONCollection+v1.swift
@@ -261,7 +261,7 @@ extension JSONPackageCollectionModel.V1 {
             if packages.isEmpty {
                 messages.append(.error("A collection must contain at least one package.", property: "packages"))
             } else if packages.count > self.configuration.maximumPackageCount {
-                messages.append(.warning("The collection has (\(packages.count)) packages, which is more than the recommended maximum (\(self.configuration.maximumPackageCount)) and may impact the performance of certain operations.", property: "packages"))
+                messages.append(.warning("The collection has (\(packages.count)) packages, which is more than the recommended maximum (\(self.configuration.maximumPackageCount)) and extra data might be ignored.", property: "packages"))
             } else {
                 packages.forEach { self.validate(package: $0, messages: &messages) }
             }

--- a/Sources/PackageCollections/JSONModel/JSONCollection+v1.swift
+++ b/Sources/PackageCollections/JSONModel/JSONCollection+v1.swift
@@ -275,7 +275,7 @@ extension JSONPackageCollectionModel.V1 {
         
         // TODO: validate package url?
         private func validate(package: Collection.Package, messages: inout [ValidationMessage]) {
-            let packageID = package.url.absoluteString
+            let packageID = PackageIdentity(url: package.url.absoluteString).description
             
             // Check for duplicate versions
             let nonUniqueVersions = Dictionary(grouping: package.versions, by: { $0.version }).filter { $1.count > 1 }.keys

--- a/Sources/PackageCollections/PackageCollections+Configuration.swift
+++ b/Sources/PackageCollections/PackageCollections+Configuration.swift
@@ -11,7 +11,9 @@
 // TODO: how do we read default config values? ENV variables? user settings?
 extension PackageCollections {
     public struct Configuration {
-        // TODO: add configuration like mx size of feed, retries, etc
+        // TODO: add configuration including:
+        // JSONPackageCollectionProvider: maximumSizeInBytes
+        // JSONPackageCollectionValidator: maximumPackageCount, maximumMajorVersionCount, maximumMinorVersionCount
 
         /// Auth tokens for the collections or metadata provider
         public var authTokens: [AuthTokenType: String]?

--- a/Sources/PackageCollections/PackageCollections+Validation.swift
+++ b/Sources/PackageCollections/PackageCollections+Validation.swift
@@ -11,13 +11,13 @@
 import TSCBasic
 
 extension Model.CollectionSource {
-    func validate() -> [ValidationError]? {
-        var errors: [ValidationError]?
-        let appendError = { (error: ValidationError) in
-            if errors == nil {
-                errors = .init()
+    func validate() -> [ValidationMessage]? {
+        var messages: [ValidationMessage]?
+        let appendMessage = { (message: ValidationMessage) in
+            if messages == nil {
+                messages = .init()
             }
-            errors?.append(error)
+            messages?.append(message)
         }
 
         let allowedSchemes = Set(["https", "file"])
@@ -26,26 +26,71 @@ extension Model.CollectionSource {
         case .json:
             let scheme = url.scheme?.lowercased() ?? ""
             if !allowedSchemes.contains(scheme) {
-                appendError(.other(description: "Schema not allowed: \(url.absoluteString)"))
+                appendMessage(.error("Schema not allowed: \(url.absoluteString)"))
             } else if scheme == "file", !localFileSystem.exists(AbsolutePath(self.url.path)) {
-                appendError(.other(description: "Non-local files not allowed: \(url.absoluteString)"))
+                appendMessage(.error("Non-local files not allowed: \(url.absoluteString)"))
             }
         }
 
-        return errors
+        return messages
+    }
+}
+
+public struct ValidationMessage: Equatable, CustomStringConvertible {
+    public let message: String
+    public let level: Level
+    public let property: String?
+    
+    private init(_ message: String, level: Level, property: String? = nil) {
+        self.message = message
+        self.level = level
+        self.property = property
+    }
+    
+    static func error(_ message: String, property: String? = nil) -> ValidationMessage {
+        .init(message, level: .error, property: property)
+    }
+    
+    static func warning(_ message: String, property: String? = nil) -> ValidationMessage {
+        .init(message, level: .warning, property: property)
+    }
+    
+    public enum Level: String, Equatable {
+        case warning
+        case error
+    }
+    
+    public var description: String {
+        "[\(self.level)] \(self.property.map { "\($0): " } ?? "")\(self.message)"
+    }
+}
+
+extension Array where Element == ValidationMessage {
+    func errors(include levels: Set<ValidationMessage.Level> = [.error]) -> [ValidationError]? {
+        let errors = self.filter { levels.contains($0.level) }
+        
+        guard !errors.isEmpty else { return nil }
+        
+        return errors.map {
+            if let property = $0.property {
+                return ValidationError.property(name: property, message: $0.message)
+            } else {
+                return ValidationError.other(message: $0.message)
+            }
+        }
     }
 }
 
 public enum ValidationError: Error, Equatable, CustomStringConvertible {
-    case property(name: String, description: String)
-    case other(description: String)
+    case property(name: String, message: String)
+    case other(message: String)
 
     public var description: String {
         switch self {
-        case .property(let name, let description):
-            return "\(name): \(description)"
-        case .other(let description):
-            return description
+        case .property(let name, let message):
+            return "\(name): \(message)"
+        case .other(let message):
+            return message
         }
     }
 }

--- a/Sources/PackageCollections/PackageCollections+Validation.swift
+++ b/Sources/PackageCollections/PackageCollections+Validation.swift
@@ -36,7 +36,7 @@ extension Model.CollectionSource {
     }
 }
 
-internal enum ValidationError: Error, Equatable, CustomStringConvertible {
+public enum ValidationError: Error, Equatable, CustomStringConvertible {
     case property(name: String, description: String)
     case other(description: String)
 

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -118,7 +118,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
     public func addCollection(_ source: PackageCollectionsModel.CollectionSource,
                               order: Int? = nil,
                               callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void) {
-        if let errors = source.validate() {
+        if let errors = source.validate()?.errors() {
             return callback(.failure(MultipleErrors(errors)))
         }
 
@@ -157,7 +157,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
     // If not found locally (storage), the collection will be fetched from the source.
     public func getCollection(_ source: PackageCollectionsModel.CollectionSource,
                               callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void) {
-        if let errors = source.validate() {
+        if let errors = source.validate()?.errors() {
             return callback(.failure(MultipleErrors(errors)))
         }
 
@@ -277,7 +277,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
     private func refreshCollectionFromSource(source: PackageCollectionsModel.CollectionSource,
                                              order _: Int? = nil,
                                              callback: @escaping (Result<Model.Collection, Error>) -> Void) {
-        if let errors = source.validate() {
+        if let errors = source.validate()?.errors() {
             return callback(.failure(MultipleErrors(errors)))
         }
         guard let provider = self.collectionProviders[source.type] else {

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -37,7 +37,7 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
             preconditionFailure("JSONPackageCollectionProvider can only be used for fetching 'json' package collections")
         }
 
-        if let errors = source.validate() {
+        if let errors = source.validate()?.errors() {
             return callback(.failure(MultipleErrors(errors)))
         }
 

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionModelTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionModelTests.swift
@@ -55,7 +55,7 @@ class JSONPackageCollectionModelTests: XCTestCase {
         XCTAssertEqual(collection, decoded)
     }
     
-    func test_noValidationError() throws {
+    func test_validationOK() throws {
         let packages = [
             Model.Collection.Package(
                 url: URL(string: "https://package-collection-tests.com/repos/foobar.git")!,
@@ -92,7 +92,7 @@ class JSONPackageCollectionModelTests: XCTestCase {
         XCTAssertNil(validator.validate(collection: collection))
     }
     
-    func test_validationError_noPackages() throws {
+    func test_validationFailed_noPackages() throws {
         let collection = Model.Collection(
             name: "Test Package Collection",
             overview: "A test package collection",
@@ -105,16 +105,16 @@ class JSONPackageCollectionModelTests: XCTestCase {
         )
 
         let validator = Model.Validator()
-        let errors = validator.validate(collection: collection)!
-        XCTAssertEqual(1, errors.count)
+        let messages = validator.validate(collection: collection)!
+        XCTAssertEqual(1, messages.count)
         
-        guard case .property(_, let description) = errors.first else {
-            return XCTFail("Expected .property error")
+        guard case .error = messages[0].level else {
+            return XCTFail("Expected .error")
         }
-        XCTAssertTrue(description.contains("contain at least one package"))
+        XCTAssertTrue(messages[0].message.contains("contain at least one package"))
     }
     
-    func test_validationError_tooManyPackages() throws {
+    func test_validationFailed_tooManyPackages() throws {
         let packages = [
             Model.Collection.Package(
                 url: URL(string: "https://package-collection-tests.com/repos/foobar.git")!,
@@ -167,16 +167,16 @@ class JSONPackageCollectionModelTests: XCTestCase {
         )
 
         let validator = Model.Validator(configuration: .init(maximumPackageCount: 1))
-        let errors = validator.validate(collection: collection)!
-        XCTAssertEqual(1, errors.count)
+        let messages = validator.validate(collection: collection)!
+        XCTAssertEqual(1, messages.count)
         
-        guard case .property(_, let description) = errors.first else {
-            return XCTFail("Expected .property error")
+        guard case .warning = messages[0].level else {
+            return XCTFail("Expected .warning")
         }
-        XCTAssertNotNil(description.range(of: "too many packages", options: .caseInsensitive))
+        XCTAssertNotNil(messages[0].message.range(of: "more than the recommended", options: .caseInsensitive))
     }
     
-    func test_validationError_duplicateVersions_emptyProductsAndTargets() throws {
+    func test_validationFailed_duplicateVersions_emptyProductsAndTargets() throws {
         let packages = [
             Model.Collection.Package(
                 url: URL(string: "https://package-collection-tests.com/repos/foobar.git")!,
@@ -221,26 +221,26 @@ class JSONPackageCollectionModelTests: XCTestCase {
         )
 
         let validator = Model.Validator()
-        let errors = validator.validate(collection: collection)!
-        XCTAssertEqual(3, errors.count)
+        let messages = validator.validate(collection: collection)!
+        XCTAssertEqual(3, messages.count)
         
-        guard case .property(_, let desc0) = errors[0] else {
-            return XCTFail("Expected .property error")
+        guard case .error = messages[0].level else {
+            return XCTFail("Expected .error")
         }
-        XCTAssertNotNil(desc0.range(of: "duplicate version(s)", options: .caseInsensitive))
+        XCTAssertNotNil(messages[0].message.range(of: "duplicate version(s)", options: .caseInsensitive))
         
-        guard case .property(_, let desc1) = errors[1] else {
-            return XCTFail("Expected .property error")
+        guard case .error = messages[1].level else {
+            return XCTFail("Expected .error")
         }
-        XCTAssertNotNil(desc1.range(of: "does not contain any products", options: .caseInsensitive))
+        XCTAssertNotNil(messages[1].message.range(of: "does not contain any products", options: .caseInsensitive))
         
-        guard case .property(_, let desc2) = errors[2] else {
-            return XCTFail("Expected .property error")
+        guard case .error = messages[2].level else {
+            return XCTFail("Expected .error")
         }
-        XCTAssertNotNil(desc2.range(of: "does not contain any targets", options: .caseInsensitive))
+        XCTAssertNotNil(messages[2].message.range(of: "does not contain any targets", options: .caseInsensitive))
     }
     
-    func test_validationError_nonSemanticVersion() throws {
+    func test_validationFailed_nonSemanticVersion() throws {
         let packages = [
             Model.Collection.Package(
                 url: URL(string: "https://package-collection-tests.com/repos/foobar.git")!,
@@ -274,16 +274,16 @@ class JSONPackageCollectionModelTests: XCTestCase {
         )
 
         let validator = Model.Validator()
-        let errors = validator.validate(collection: collection)!
-        XCTAssertEqual(1, errors.count)
+        let messages = validator.validate(collection: collection)!
+        XCTAssertEqual(1, messages.count)
         
-        guard case .property(_, let description) = errors.first else {
-            return XCTFail("Expected .property error")
+        guard case .error = messages[0].level else {
+            return XCTFail("Expected .error")
         }
-        XCTAssertNotNil(description.range(of: "non semantic version(s)", options: .caseInsensitive))
+        XCTAssertNotNil(messages[0].message.range(of: "non semantic version(s)", options: .caseInsensitive))
     }
     
-    func test_validationError_tooManyMajorsAndMinors() throws {
+    func test_validationFailed_tooManyMajorsAndMinors() throws {
         let packages = [
             Model.Collection.Package(
                 url: URL(string: "https://package-collection-tests.com/repos/foobar.git")!,
@@ -358,21 +358,21 @@ class JSONPackageCollectionModelTests: XCTestCase {
         )
 
         let validator = Model.Validator(configuration: .init(maximumMajorVersionCount: 1, maximumMinorVersionCount: 1))
-        let errors = validator.validate(collection: collection)!
-        XCTAssertEqual(2, errors.count)
+        let messages = validator.validate(collection: collection)!
+        XCTAssertEqual(2, messages.count)
         
-        guard case .property(_, let desc0) = errors[0] else {
-            return XCTFail("Expected .property error")
+        guard case .warning = messages[0].level else {
+            return XCTFail("Expected .warning")
         }
-        XCTAssertNotNil(desc0.range(of: "too many major versions", options: .caseInsensitive))
+        XCTAssertNotNil(messages[0].message.range(of: "too many major versions", options: .caseInsensitive))
         
-        guard case .property(_, let desc1) = errors[1] else {
-            return XCTFail("Expected .property error")
+        guard case .warning = messages[1].level else {
+            return XCTFail("Expected .warning")
         }
-        XCTAssertNotNil(desc1.range(of: "too many minor versions", options: .caseInsensitive))
+        XCTAssertNotNil(messages[1].message.range(of: "too many minor versions", options: .caseInsensitive))
     }
     
-    func test_validationError_versionProductNoTargets() throws {
+    func test_validationFailed_versionProductNoTargets() throws {
         let packages = [
             Model.Collection.Package(
                 url: URL(string: "https://package-collection-tests.com/repos/foobar.git")!,
@@ -406,12 +406,12 @@ class JSONPackageCollectionModelTests: XCTestCase {
         )
 
         let validator = Model.Validator()
-        let errors = validator.validate(collection: collection)!
-        XCTAssertEqual(1, errors.count)
+        let messages = validator.validate(collection: collection)!
+        XCTAssertEqual(1, messages.count)
         
-        guard case .property(_, let description) = errors.first else {
-            return XCTFail("Expected .property error")
+        guard case .error = messages[0].level else {
+            return XCTFail("Expected .error")
         }
-        XCTAssertNotNil(description.range(of: "does not contain any targets", options: .caseInsensitive))
+        XCTAssertNotNil(messages[0].message.range(of: "does not contain any targets", options: .caseInsensitive))
     }
 }

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -132,7 +132,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             guard let internalError = (error as? MultipleErrors)?.errors.first else {
                 return XCTFail("invalid error \(error)")
             }
-            XCTAssertEqual(internalError as? ValidationError, ValidationError.other(description: "Schema not allowed: \(url.absoluteString)"))
+            XCTAssertEqual(internalError as? ValidationError, ValidationError.other(message: "Schema not allowed: \(url.absoluteString)"))
         })
     }
 

--- a/Tests/PackageCollectionsTests/ValidationMessageTests.swift
+++ b/Tests/PackageCollectionsTests/ValidationMessageTests.swift
@@ -1,0 +1,53 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import XCTest
+
+@testable import PackageCollections
+
+class ValidationMessageTests: XCTestCase {
+    func testMessageToError() {
+        let warningWithProperty = ValidationMessage.warning("warning with property", property: "foo")
+        let warning = ValidationMessage.warning("warning")
+        let errorWithProperty = ValidationMessage.error("error with property", property: "bar")
+        let error = ValidationMessage.error("error")
+        
+        let messages = [warningWithProperty, errorWithProperty, warning, error]
+        
+        do {
+            let errors = messages.errors(include: [.warning])!
+            XCTAssertEqual(2, errors.count)
+            
+            guard case .property(_, let m0) = errors[0], m0 == warningWithProperty.message else {
+                return XCTFail("Expected .property error")
+            }
+            guard case .other(let m1) = errors[1], m1 == warning.message else {
+                return XCTFail("Expected .other error")
+            }
+        }
+        
+        do {
+            let errors = messages.errors(include: [.error])!
+            XCTAssertEqual(2, errors.count)
+            
+            guard case .property(_, let m0) = errors[0], m0 == errorWithProperty.message else {
+                return XCTFail("Expected .property error")
+            }
+            guard case .other(let m1) = errors[1], m1 == error.message else {
+                return XCTFail("Expected .other error")
+            }
+        }
+        
+        do {
+            let errors = messages.errors(include: [.warning, .error])!
+            XCTAssertEqual(4, errors.count)
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
JSON collection needs to be validated before it gets saved to local
storage. We also plan to add a tool for validating JSON collections in
case someone decides to generate them without using the provided
generator.

Modifications:
Implement a validator for `JSONPackageCollectionModel.V1` models to
check for number packages, versions, etc.
