### PR TITLE
Fix build on Windows: add dependencies in CMake script

### DIFF
--- a/Sources/Build/CMakeLists.txt
+++ b/Sources/Build/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(Build
   XCFrameworkInfo.swift)
 target_link_libraries(Build PUBLIC
   TSCBasic
+  Basics
   PackageGraph
   LLBuildManifest
   SPMBuildCore

--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(Commands
   WatchmanHelper.swift)
 target_link_libraries(Commands PUBLIC
   ArgumentParser
+  Basics
   Build
   PackageGraph
   SourceControl

--- a/Sources/LLBuildManifest/CMakeLists.txt
+++ b/Sources/LLBuildManifest/CMakeLists.txt
@@ -15,7 +15,8 @@ add_library(LLBuildManifest
   Target.swift
   Tools.swift)
 target_link_libraries(LLBuildManifest PUBLIC
-  TSCBasic)
+  TSCBasic
+  Basics)
 
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(LLBuildManifest PROPERTIES

--- a/Sources/PackageCollections/CMakeLists.txt
+++ b/Sources/PackageCollections/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(PackageCollections
 target_link_libraries(PackageCollections PUBLIC
   TSCBasic
   TSCUtility
+  Basics
   PackageModel
   SourceControl)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet

--- a/Sources/PackageGraph/CMakeLists.txt
+++ b/Sources/PackageGraph/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(PackageGraph
   VersionSetSpecifier.swift)
 target_link_libraries(PackageGraph PUBLIC
   TSCBasic
+  Basics
   PackageLoading
   PackageModel
   SourceControl

--- a/Sources/PackageLoading/CMakeLists.txt
+++ b/Sources/PackageLoading/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(PackageLoading
   UserManifestResources.swift)
 target_link_libraries(PackageLoading PUBLIC
   TSCBasic
+  Basics
   PackageModel
   TSCUtility)
 if(Foundation_FOUND)

--- a/Sources/PackageModel/CMakeLists.txt
+++ b/Sources/PackageModel/CMakeLists.txt
@@ -34,7 +34,8 @@ add_library(PackageModel
   ToolsVersion.swift)
 target_link_libraries(PackageModel PUBLIC
   TSCBasic
-  TSCUtility)
+  TSCUtility
+  Basics)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(PackageModel PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/SPMBuildCore/CMakeLists.txt
+++ b/Sources/SPMBuildCore/CMakeLists.txt
@@ -18,6 +18,7 @@ set_target_properties(SPMBuildCore PROPERTIES
 target_link_libraries(SPMBuildCore PUBLIC
   TSCBasic
   TSCUtility
+  Basics
   PackageGraph)
 
 

--- a/Sources/SPMLLBuild/CMakeLists.txt
+++ b/Sources/SPMLLBuild/CMakeLists.txt
@@ -14,6 +14,7 @@ set_target_properties(SPMLLBuild PROPERTIES
 target_link_libraries(SPMLLBuild PUBLIC
   TSCBasic
   TSCUtility
+  Basics
   llbuildSwift)
 
 if(USE_CMAKE_INSTALL)

--- a/Sources/SourceControl/CMakeLists.txt
+++ b/Sources/SourceControl/CMakeLists.txt
@@ -13,7 +13,8 @@ add_library(SourceControl
 
 target_link_libraries(SourceControl PUBLIC
   TSCBasic
-  TSCUtility)
+  TSCUtility
+  Basics)
 
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(SourceControl PROPERTIES

--- a/Sources/Workspace/CMakeLists.txt
+++ b/Sources/Workspace/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(Workspace
 target_link_libraries(Workspace PUBLIC
   TSCBasic
   TSCUtility
+  Basics
   SPMBuildCore
   PackageGraph
   PackageLoading

--- a/Sources/Xcodeproj/CMakeLists.txt
+++ b/Sources/Xcodeproj/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(Xcodeproj
   XcodeProjectModelSerialization.swift)
 target_link_libraries(Xcodeproj PUBLIC
   TSCBasic
+  Basics
   PackageGraph)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(Xcodeproj PROPERTIES


### PR DESCRIPTION
### Motivation:

A build error sometimes occurs when building SwiftPM with CMake, because the dependencies on `Basics` target are missing for some other targets. The error might happen or not, depending on the order in which CMake builds the targets.

### Modifications:

This change adds the missing dependencies.

### Result:

The CMake build succeeds after this change.
