### PR TITLE
[PackageLoading] Fix inconsistent .systemLibrary's pkgBuild parsing

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1753,13 +1753,7 @@ public class BuildPlan {
         }
         let results = pkgConfigArgs(for: target, diagnostics: diagnostics)
         var ret: [(cFlags: [String], libs: [String])] = []
-        for resultW in results {
-            // Otherwise, get the result and cache it.
-            guard let result = resultW else {
-                ret.append(([], []))
-                continue
-            }
-
+        for result in results {
             // If there is no pc file on system and we have an available provider, emit a warning.
             if let provider = result.provider, result.couldNotFindConfigFile {
                 diagnostics.emit(.pkgConfigHint(pkgConfigName: result.pkgConfigName, installText: provider.installText))
@@ -1774,24 +1768,20 @@ public class BuildPlan {
         }
 
         // Build cache
-        var cflagsCache: [String] = []
+        var cflagsCache: OrderedSet<String> = []
         var libsCache: [String] = []
         for tuple in ret {
             // Avoid duplicates while merging
             for cFlag in tuple.cFlags {
-                if !cflagsCache.contains(cFlag) {
-                    cflagsCache.append(cFlag)
-                }
+                cflagsCache.append(cFlag)
             }
 
             for lib in tuple.libs {
-                if !libsCache.contains(lib) {
-                    libsCache.append(lib)
-                }
+                libsCache.append(lib)
             }
         }
 
-        pkgConfigCache[target] = (cflagsCache, libsCache)
+        pkgConfigCache[target] = ([String](cflagsCache), libsCache)
 
         return pkgConfigCache[target]!
     }

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1743,7 +1743,7 @@ public class BuildPlan {
     }
 
     /// Get pkgConfig arguments for a system library target.
-    private func pkgConfig(for target: SystemLibraryTarget) -> (cFlags: [String], libs: [String]) {
+    private func pkgConfig(for target: SystemLibraryTarget) -> (cFlags: OrderedSet<String>, libs: OrderedSet<String>) {
         // If we already have these flags, we're done.
         if let flags = pkgConfigCache[target] {
             return flags
@@ -1752,14 +1752,8 @@ public class BuildPlan {
             pkgConfigCache[target] = ([], [])
         }
         let results = pkgConfigArgs(for: target, diagnostics: diagnostics)
-        var ret: [(cFlags: [String], libs: [String])] = []
-        for resultW in results {
-            // Otherwise, get the result and cache it.
-            guard let result = resultW else {
-                ret.append(([], []))
-                continue
-            }
-
+        var ret: (cFlags: OrderedSet<String>, libs: OrderedSet<String>) = (cFlags: OrderedSet<String>(), libs: OrderedSet<String>())
+        for result in results {
             // If there is no pc file on system and we have an available provider, emit a warning.
             if let provider = result.provider, result.couldNotFindConfigFile {
                 diagnostics.emit(.pkgConfigHint(pkgConfigName: result.pkgConfigName, installText: provider.installText))
@@ -1770,28 +1764,16 @@ public class BuildPlan {
                 )
             }
 
-            ret.append((result.cFlags, result.libs))
-        }
-
-        // Build cache
-        var cflagsCache: [String] = []
-        var libsCache: [String] = []
-        for tuple in ret {
-            // Avoid duplicates while merging
-            for cFlag in tuple.cFlags {
-                if !cflagsCache.contains(cFlag) {
-                    cflagsCache.append(cFlag)
-                }
+            for cflag in result.cFlags {
+                ret.cFlags.append(cflag)
             }
 
-            for lib in tuple.libs {
-                if !libsCache.contains(lib) {
-                    libsCache.append(lib)
-                }
+            for lib in result.libs {
+                ret.libs.append(lib)
             }
         }
 
-        pkgConfigCache[target] = (cflagsCache, libsCache)
+        pkgConfigCache[target] = (ret.cFlags, ret.libs)
 
         return pkgConfigCache[target]!
     }
@@ -1831,7 +1813,7 @@ public class BuildPlan {
     }
 
     /// Cache for pkgConfig flags.
-    private var pkgConfigCache = [SystemLibraryTarget: (cFlags: [String], libs: [String])]()
+    private var pkgConfigCache = [SystemLibraryTarget: (cFlags: OrderedSet<String>, libs: OrderedSet<String>)]()
 
     /// Cache for xcframework library information.
     private var xcFrameworkCache = [BinaryTarget: LibraryInfo?]()

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1771,14 +1771,11 @@ public class BuildPlan {
         var cflagsCache: OrderedSet<String> = []
         var libsCache: [String] = []
         for tuple in ret {
-            // Avoid duplicates while merging
             for cFlag in tuple.cFlags {
                 cflagsCache.append(cFlag)
             }
 
-            for lib in tuple.libs {
-                libsCache.append(lib)
-            }
+            libsCache.append(contentsOf: tuple.libs)
         }
 
         pkgConfigCache[target] = ([String](cflagsCache), libsCache)

--- a/Sources/PackageLoading/Target+PkgConfig.swift
+++ b/Sources/PackageLoading/Target+PkgConfig.swift
@@ -55,45 +55,49 @@ public struct PkgConfigResult {
 }
 
 /// Get pkgConfig result for a system library target.
-public func pkgConfigArgs(for target: SystemLibraryTarget, diagnostics: DiagnosticsEngine, fileSystem: FileSystem = localFileSystem, brewPrefix: AbsolutePath? = nil) -> PkgConfigResult? {
+public func pkgConfigArgs(for target: SystemLibraryTarget, diagnostics: DiagnosticsEngine, fileSystem: FileSystem = localFileSystem, brewPrefix: AbsolutePath? = nil) -> [PkgConfigResult?] {
     // If there is no pkg config name defined, we're done.
-    guard let pkgConfigName = target.pkgConfig else { return nil }
+    guard let pkgConfigNames = target.pkgConfig else { return [] }
 
     // Compute additional search paths for the provider, if any.
     let provider = target.providers?.first { $0.isAvailable }
     let additionalSearchPaths = provider?.pkgConfigSearchPath(brewPrefixOverride: brewPrefix) ?? []
 
+   var ret: [PkgConfigResult] = []
     // Get the pkg config flags.
-    do {
-        let pkgConfig = try PkgConfig(
-            name: pkgConfigName,
-            additionalSearchPaths: additionalSearchPaths,
-            diagnostics: diagnostics,
-            fileSystem: fileSystem,
-            brewPrefix: brewPrefix)
+    for pkgConfigName in pkgConfigNames.components(separatedBy: " ") {
+        do {
+            let pkgConfig = try PkgConfig(
+                    name: pkgConfigName,
+                    additionalSearchPaths: additionalSearchPaths,
+                    diagnostics: diagnostics,
+                    fileSystem: fileSystem,
+                    brewPrefix: brewPrefix)
 
-        // Run the allow list checker.
-        let filtered = allowlist(pcFile: pkgConfigName, flags: (pkgConfig.cFlags, pkgConfig.libs))
+            // Run the allow list checker.
+            let filtered = allowlist(pcFile: pkgConfigName, flags: (pkgConfig.cFlags, pkgConfig.libs))
 
-        // Remove any default flags which compiler adds automatically.
-        let (cFlags, libs) = removeDefaultFlags(cFlags: filtered.cFlags, libs: filtered.libs)
+            // Remove any default flags which compiler adds automatically.
+            let (cFlags, libs) = removeDefaultFlags(cFlags: filtered.cFlags, libs: filtered.libs)
 
-        // Set the error if there are any unallowed flags.
-        var error: Swift.Error?
-        if !filtered.unallowed.isEmpty {
-            error = PkgConfigError.prohibitedFlags(filtered.unallowed.joined(separator: ", "))
+            // Set the error if there are any unallowed flags.
+            var error: Swift.Error?
+            if !filtered.unallowed.isEmpty {
+                error = PkgConfigError.prohibitedFlags(filtered.unallowed.joined(separator: ", "))
+            }
+
+            ret.append(PkgConfigResult(
+                    pkgConfigName: pkgConfigName,
+                    cFlags: cFlags,
+                    libs: libs,
+                    error: error,
+                    provider: provider
+            ))
+        } catch {
+            ret.append(PkgConfigResult(pkgConfigName: pkgConfigName, error: error, provider: provider))
         }
-
-        return PkgConfigResult(
-            pkgConfigName: pkgConfigName,
-            cFlags: cFlags,
-            libs: libs,
-            error: error,
-            provider: provider
-        )
-    } catch {
-        return PkgConfigResult(pkgConfigName: pkgConfigName, error: error, provider: provider)
     }
+    return ret
 }
 
 extension SystemPackageProviderDescription {

--- a/Sources/PackageLoading/Target+PkgConfig.swift
+++ b/Sources/PackageLoading/Target+PkgConfig.swift
@@ -19,10 +19,10 @@ public struct PkgConfigResult {
     public let pkgConfigName: String
 
     /// The cFlags from pkgConfig.
-    public let cFlags: OrderedSet<String>
+    public let cFlags: [String]
 
     /// The library flags from pkgConfig.
-    public let libs: OrderedSet<String>
+    public let libs: [String]
 
     /// Available provider, if any.
     public let provider: SystemPackageProviderDescription?
@@ -41,8 +41,8 @@ public struct PkgConfigResult {
     /// Create a result.
     fileprivate init(
         pkgConfigName: String,
-        cFlags: OrderedSet<String> = [],
-        libs: OrderedSet<String> = [],
+        cFlags: [String] = [],
+        libs: [String] = [],
         error: Swift.Error? = nil,
         provider: SystemPackageProviderDescription? = nil
     ) {
@@ -55,7 +55,7 @@ public struct PkgConfigResult {
 }
 
 /// Get pkgConfig result for a system library target.
-public func pkgConfigArgs(for target: SystemLibraryTarget, diagnostics: DiagnosticsEngine, fileSystem: FileSystem = localFileSystem, brewPrefix: AbsolutePath? = nil) -> [PkgConfigResult] {
+public func pkgConfigArgs(for target: SystemLibraryTarget, diagnostics: DiagnosticsEngine, fileSystem: FileSystem = localFileSystem, brewPrefix: AbsolutePath? = nil) -> [PkgConfigResult?] {
     // If there is no pkg config name defined, we're done.
     guard let pkgConfigNames = target.pkgConfig else { return [] }
 
@@ -216,7 +216,7 @@ public func allowlist(
 ///
 /// This behavior is similar to pkg-config cli tool and helps avoid conflicts between
 /// sdk and default search paths in macOS.
-public func removeDefaultFlags(cFlags: [String], libs: [String]) -> (OrderedSet<String>, OrderedSet<String>) {
+public func removeDefaultFlags(cFlags: [String], libs: [String]) -> ([String], [String]) {
     /// removes a flag from given array of flags.
     func remove(flag: (String, String), from flags: [String]) -> [String] {
         var result = [String]()
@@ -245,7 +245,7 @@ public func removeDefaultFlags(cFlags: [String], libs: [String]) -> (OrderedSet<
         }
         return result
     }
-    return (OrderedSet<String>(remove(flag: ("-I", "/usr/include"), from: cFlags)), OrderedSet<String>(remove(flag: ("-L", "/usr/lib"), from: libs)))
+    return (remove(flag: ("-I", "/usr/include"), from: cFlags), remove(flag: ("-L", "/usr/lib"), from: libs))
 }
 
 public struct PkgConfigDiagnosticLocation: DiagnosticLocation {

--- a/Sources/PackageLoading/Target+PkgConfig.swift
+++ b/Sources/PackageLoading/Target+PkgConfig.swift
@@ -55,7 +55,7 @@ public struct PkgConfigResult {
 }
 
 /// Get pkgConfig result for a system library target.
-public func pkgConfigArgs(for target: SystemLibraryTarget, diagnostics: DiagnosticsEngine, fileSystem: FileSystem = localFileSystem, brewPrefix: AbsolutePath? = nil) -> [PkgConfigResult?] {
+public func pkgConfigArgs(for target: SystemLibraryTarget, diagnostics: DiagnosticsEngine, fileSystem: FileSystem = localFileSystem, brewPrefix: AbsolutePath? = nil) -> [PkgConfigResult] {
     // If there is no pkg config name defined, we're done.
     guard let pkgConfigNames = target.pkgConfig else { return [] }
 

--- a/Sources/PackageLoading/Target+PkgConfig.swift
+++ b/Sources/PackageLoading/Target+PkgConfig.swift
@@ -19,10 +19,10 @@ public struct PkgConfigResult {
     public let pkgConfigName: String
 
     /// The cFlags from pkgConfig.
-    public let cFlags: [String]
+    public let cFlags: OrderedSet<String>
 
     /// The library flags from pkgConfig.
-    public let libs: [String]
+    public let libs: OrderedSet<String>
 
     /// Available provider, if any.
     public let provider: SystemPackageProviderDescription?
@@ -41,8 +41,8 @@ public struct PkgConfigResult {
     /// Create a result.
     fileprivate init(
         pkgConfigName: String,
-        cFlags: [String] = [],
-        libs: [String] = [],
+        cFlags: OrderedSet<String> = [],
+        libs: OrderedSet<String> = [],
         error: Swift.Error? = nil,
         provider: SystemPackageProviderDescription? = nil
     ) {
@@ -55,7 +55,7 @@ public struct PkgConfigResult {
 }
 
 /// Get pkgConfig result for a system library target.
-public func pkgConfigArgs(for target: SystemLibraryTarget, diagnostics: DiagnosticsEngine, fileSystem: FileSystem = localFileSystem, brewPrefix: AbsolutePath? = nil) -> [PkgConfigResult?] {
+public func pkgConfigArgs(for target: SystemLibraryTarget, diagnostics: DiagnosticsEngine, fileSystem: FileSystem = localFileSystem, brewPrefix: AbsolutePath? = nil) -> [PkgConfigResult] {
     // If there is no pkg config name defined, we're done.
     guard let pkgConfigNames = target.pkgConfig else { return [] }
 
@@ -216,7 +216,7 @@ public func allowlist(
 ///
 /// This behavior is similar to pkg-config cli tool and helps avoid conflicts between
 /// sdk and default search paths in macOS.
-public func removeDefaultFlags(cFlags: [String], libs: [String]) -> ([String], [String]) {
+public func removeDefaultFlags(cFlags: [String], libs: [String]) -> (OrderedSet<String>, OrderedSet<String>) {
     /// removes a flag from given array of flags.
     func remove(flag: (String, String), from flags: [String]) -> [String] {
         var result = [String]()
@@ -245,7 +245,7 @@ public func removeDefaultFlags(cFlags: [String], libs: [String]) -> ([String], [
         }
         return result
     }
-    return (remove(flag: ("-I", "/usr/include"), from: cFlags), remove(flag: ("-L", "/usr/lib"), from: libs))
+    return (OrderedSet<String>(remove(flag: ("-I", "/usr/include"), from: cFlags)), OrderedSet<String>(remove(flag: ("-L", "/usr/lib"), from: libs)))
 }
 
 public struct PkgConfigDiagnosticLocation: DiagnosticLocation {

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -671,8 +671,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         var impartedSettings = PIF.BuildSettings()
 
         var cFlags: [String] = []
-        for resultw in pkgConfigArgs(for: systemTarget, diagnostics: diagnostics, fileSystem: fileSystem) {
-            guard let result = resultw else { continue }
+        for result in pkgConfigArgs(for: systemTarget, diagnostics: diagnostics, fileSystem: fileSystem) {
             if let error = result.error {
                 let location = PkgConfigDiagnosticLocation(pcFile: result.pkgConfigName, target: target.name)
                 diagnostics.emit(warning: "\(error)", location: location)

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -671,7 +671,8 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         var impartedSettings = PIF.BuildSettings()
 
         var cFlags: [String] = []
-        if let result = pkgConfigArgs(for: systemTarget, diagnostics: diagnostics, fileSystem: fileSystem) {
+        for resultw in pkgConfigArgs(for: systemTarget, diagnostics: diagnostics, fileSystem: fileSystem) {
+            guard let result = resultw else { continue }
             if let error = result.error {
                 let location = PkgConfigDiagnosticLocation(pcFile: result.pkgConfigName, target: target.name)
                 diagnostics.emit(warning: "\(error)", location: location)

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -670,9 +670,8 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         // Impart the header search path to all direct and indirect clients.
         var impartedSettings = PIF.BuildSettings()
 
-        var cFlags: [String] = []
-        for resultw in pkgConfigArgs(for: systemTarget, diagnostics: diagnostics, fileSystem: fileSystem) {
-            guard let result = resultw else { continue }
+        var cFlags: OrderedSet<String> = []
+        for result in pkgConfigArgs(for: systemTarget, diagnostics: diagnostics, fileSystem: fileSystem) {
             if let error = result.error {
                 let location = PkgConfigDiagnosticLocation(pcFile: result.pkgConfigName, target: target.name)
                 diagnostics.emit(warning: "\(error)", location: location)

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -670,8 +670,9 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         // Impart the header search path to all direct and indirect clients.
         var impartedSettings = PIF.BuildSettings()
 
-        var cFlags: OrderedSet<String> = []
-        for result in pkgConfigArgs(for: systemTarget, diagnostics: diagnostics, fileSystem: fileSystem) {
+        var cFlags: [String] = []
+        for resultw in pkgConfigArgs(for: systemTarget, diagnostics: diagnostics, fileSystem: fileSystem) {
+            guard let result = resultw else { continue }
             if let error = result.error {
                 let location = PkgConfigDiagnosticLocation(pcFile: result.pkgConfigName, target: target.name)
                 diagnostics.emit(warning: "\(error)", location: location)

--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -507,10 +507,11 @@ public func xcodeProject(
             switch depModule.underlyingTarget {
               case let systemTarget as SystemLibraryTarget:
                 hdrInclPaths.append("$(SRCROOT)/\(systemTarget.path.relative(to: sourceRootDir).pathString)")
-                for pkgArgs in pkgConfigArgs(for: systemTarget, diagnostics: diagnostics) {
-                    targetSettings.common.OTHER_LDFLAGS += [String](pkgArgs.libs)
-                    targetSettings.common.OTHER_SWIFT_FLAGS += [String](pkgArgs.cFlags)
-                    targetSettings.common.OTHER_CFLAGS += [String](pkgArgs.cFlags)
+                for pkgArgsWrapped in pkgConfigArgs(for: systemTarget, diagnostics: diagnostics) {
+                    guard let pkgArgs = pkgArgsWrapped else { continue }
+                    targetSettings.common.OTHER_LDFLAGS += pkgArgs.libs
+                    targetSettings.common.OTHER_SWIFT_FLAGS += pkgArgs.cFlags
+                    targetSettings.common.OTHER_CFLAGS += pkgArgs.cFlags
                 }
             case let clangTarget as ClangTarget:
                 hdrInclPaths.append("$(SRCROOT)/\(clangTarget.includeDir.relative(to: sourceRootDir).pathString)")

--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -507,11 +507,10 @@ public func xcodeProject(
             switch depModule.underlyingTarget {
               case let systemTarget as SystemLibraryTarget:
                 hdrInclPaths.append("$(SRCROOT)/\(systemTarget.path.relative(to: sourceRootDir).pathString)")
-                for pkgArgsWrapped in pkgConfigArgs(for: systemTarget, diagnostics: diagnostics) {
-                    guard let pkgArgs = pkgArgsWrapped else { continue }
-                    targetSettings.common.OTHER_LDFLAGS += pkgArgs.libs
-                    targetSettings.common.OTHER_SWIFT_FLAGS += pkgArgs.cFlags
-                    targetSettings.common.OTHER_CFLAGS += pkgArgs.cFlags
+                for pkgArgs in pkgConfigArgs(for: systemTarget, diagnostics: diagnostics) {
+                    targetSettings.common.OTHER_LDFLAGS += [String](pkgArgs.libs)
+                    targetSettings.common.OTHER_SWIFT_FLAGS += [String](pkgArgs.cFlags)
+                    targetSettings.common.OTHER_CFLAGS += [String](pkgArgs.cFlags)
                 }
             case let clangTarget as ClangTarget:
                 hdrInclPaths.append("$(SRCROOT)/\(clangTarget.includeDir.relative(to: sourceRootDir).pathString)")

--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -507,7 +507,8 @@ public func xcodeProject(
             switch depModule.underlyingTarget {
               case let systemTarget as SystemLibraryTarget:
                 hdrInclPaths.append("$(SRCROOT)/\(systemTarget.path.relative(to: sourceRootDir).pathString)")
-                if let pkgArgs = pkgConfigArgs(for: systemTarget, diagnostics: diagnostics) {
+                for pkgArgsWrapped in pkgConfigArgs(for: systemTarget, diagnostics: diagnostics) {
+                    guard let pkgArgs = pkgArgsWrapped else { continue }
                     targetSettings.common.OTHER_LDFLAGS += pkgArgs.libs
                     targetSettings.common.OTHER_SWIFT_FLAGS += pkgArgs.cFlags
                     targetSettings.common.OTHER_CFLAGS += pkgArgs.cFlags

--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -507,8 +507,7 @@ public func xcodeProject(
             switch depModule.underlyingTarget {
               case let systemTarget as SystemLibraryTarget:
                 hdrInclPaths.append("$(SRCROOT)/\(systemTarget.path.relative(to: sourceRootDir).pathString)")
-                for pkgArgsWrapped in pkgConfigArgs(for: systemTarget, diagnostics: diagnostics) {
-                    guard let pkgArgs = pkgArgsWrapped else { continue }
+                for pkgArgs in pkgConfigArgs(for: systemTarget, diagnostics: diagnostics) {
                     targetSettings.common.OTHER_LDFLAGS += pkgArgs.libs
                     targetSettings.common.OTHER_SWIFT_FLAGS += pkgArgs.cFlags
                     targetSettings.common.OTHER_CFLAGS += pkgArgs.cFlags

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1534,7 +1534,7 @@ final class BuildPlanTests: XCTestCase {
         _ = try BuildPlan(buildParameters: mockBuildParameters(),
             graph: graph, diagnostics: diagnostics, fileSystem: fileSystem)
 
-       XCTAssertTrue(diagnostics.diagnostics.contains(where: { ($0.message.data is PkgConfigHintDiagnostic) }))
+       XCTAssertTrue(diagnostics.diagnostics.contains(where: { ($0.message.data is PkgConfigGenericDiagnostic) }))
     }
 
     func testPkgConfigGenericDiagnostic() throws {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1534,7 +1534,7 @@ final class BuildPlanTests: XCTestCase {
         _ = try BuildPlan(buildParameters: mockBuildParameters(),
             graph: graph, diagnostics: diagnostics, fileSystem: fileSystem)
 
-       XCTAssertTrue(diagnostics.diagnostics.contains(where: { ($0.message.data is PkgConfigGenericDiagnostic) }))
+       XCTAssertTrue(diagnostics.diagnostics.contains(where: { ($0.message.data is PkgConfigHintDiagnostic) }))
     }
 
     func testPkgConfigGenericDiagnostic() throws {

--- a/Tests/PackageLoadingTests/PkgConfigTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigTests.swift
@@ -35,7 +35,7 @@ class PkgConfigTests: XCTestCase {
         // No pkgConfig name.
         do {
             let result = pkgConfigArgs(for: SystemLibraryTarget(pkgConfig: ""), diagnostics: diagnostics)
-            XCTAssertNil(result)
+            XCTAssertTrue(result.isEmpty)
         }
 
         // No pc file.
@@ -48,9 +48,7 @@ class PkgConfigTests: XCTestCase {
                     .yum(["libFoo-devel"])
                 ]
             )
-            let results = pkgConfigArgs(for: target, diagnostics: diagnostics)
-            for wrappedResult in results {
-                let result = wrappedResult!
+            for result in pkgConfigArgs(for: target, diagnostics: diagnostics) {
                 XCTAssertEqual(result.pkgConfigName, "Foo")
                 XCTAssertEqual(result.cFlags, [])
                 XCTAssertEqual(result.libs, [])
@@ -75,9 +73,7 @@ class PkgConfigTests: XCTestCase {
 
         // Pc file.
         try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let results = pkgConfigArgs(for: SystemLibraryTarget(pkgConfig: "Foo"), diagnostics: diagnostics)
-            for wrappedResult in results {
-                let result = wrappedResult!
+            for result in pkgConfigArgs(for: SystemLibraryTarget(pkgConfig: "Foo"), diagnostics: diagnostics) {
                 XCTAssertEqual(result.pkgConfigName, "Foo")
                 XCTAssertEqual(result.cFlags, ["-I/path/to/inc", "-I\(inputsDir.pathString)"])
                 XCTAssertEqual(result.libs, ["-L/usr/da/lib", "-lSystemModule", "-lok"])
@@ -89,9 +85,7 @@ class PkgConfigTests: XCTestCase {
 
         // Pc file with prohibited flags.
         try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
-            let results = pkgConfigArgs(for: SystemLibraryTarget(pkgConfig: "Bar"), diagnostics: diagnostics)
-            for wrappedResult in results {
-                let result = wrappedResult!
+            for result in pkgConfigArgs(for: SystemLibraryTarget(pkgConfig: "Bar"), diagnostics: diagnostics) {
                 XCTAssertEqual(result.pkgConfigName, "Bar")
                 XCTAssertEqual(result.cFlags, ["-I/path/to/inc"])
                 XCTAssertEqual(result.libs, ["-L/usr/da/lib", "-lSystemModule", "-lok"])


### PR DESCRIPTION
_Parse pkgConfig (of .systemLibrary targets) in Swift Package Manager on all OS in the same way (in the way it is done on Ubuntu)_

### Motivation:

_On Arch Linux derrivatives, pkgConfig is parsed differently; and it can cause segfaults of SPM on some cases. The main example is [SwiftGtk](https://github.com/rhx/SwiftGtk) which cannot be built on Arch Linux. It recognizes in SwiftGLib's [package.swift](https://github.com/rhx/SwiftGLib/blob/master/Package.swift) "glib-2.0 gio-unix-2.0" as two files on Ubuntu ("glib-2.0.pc" and "gio-unix-2.0.pc") where on Arch it recognizes it as "glib-2.0 gio-unix-2.0.pc", that does not exists and will lead to a Segmentation fault when calling realpath (there is no pc files with this name)._

### Modifications:

_(Target+PkgConfig.swift) pkgConfigArgs now returns an array (since now, string is splitted in multiple packages)_
All other changes are adaptation to this change.

### Result:

_Fix SR-13424 and SR-13891_

#### Post scriptum: 

Tests are failing, I will fix this when you will review this.

This behaviour can be considered as a workaround, and I think that in the future, to avoid confusions, pkgConfig: String should be changed to pkgConfigs: [String] to ensure developer would use correct names.

Sorry if I did something wrong, it is my first contribution here, and english is not my native language.
