### PR TITLE
Allow generated Xcode projects to build for Mac Catalyst

### DIFF
--- a/Sources/Xcodeproj/XcodeProjectModel.swift
+++ b/Sources/Xcodeproj/XcodeProjectModel.swift
@@ -386,6 +386,7 @@ public struct Xcode {
             public var SDKROOT: String?
             public var SKIP_INSTALL: String?
             public var SUPPORTED_PLATFORMS: [String]?
+            public var SUPPORTS_MACCATALYST: String?
             public var SWIFT_ACTIVE_COMPILATION_CONDITIONS: [String]?
             public var SWIFT_FORCE_STATIC_LINK_STDLIB: String?
             public var SWIFT_FORCE_DYNAMIC_LINK_STDLIB: String?
@@ -433,6 +434,7 @@ public struct Xcode {
                 SDKROOT: String? = nil,
                 SKIP_INSTALL: String? = nil,
                 SUPPORTED_PLATFORMS: [String]? = nil,
+                SUPPORTS_MACCATALYST: String? = nil,
                 SWIFT_ACTIVE_COMPILATION_CONDITIONS: [String]? = nil,
                 SWIFT_FORCE_STATIC_LINK_STDLIB: String? = nil,
                 SWIFT_FORCE_DYNAMIC_LINK_STDLIB: String? = nil,
@@ -479,6 +481,7 @@ public struct Xcode {
                 self.SDKROOT = SDKROOT
                 self.SKIP_INSTALL = SKIP_INSTALL
                 self.SUPPORTED_PLATFORMS = SUPPORTED_PLATFORMS
+                self.SUPPORTS_MACCATALYST = SUPPORTS_MACCATALYST
                 self.SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_ACTIVE_COMPILATION_CONDITIONS
                 self.SWIFT_FORCE_STATIC_LINK_STDLIB = SWIFT_FORCE_STATIC_LINK_STDLIB
                 self.SWIFT_FORCE_DYNAMIC_LINK_STDLIB = SWIFT_FORCE_DYNAMIC_LINK_STDLIB

--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -108,15 +108,8 @@ public func xcodeProject(
     // Set the SUPPORTED_PLATFORMS to all platforms.
     // FIXME: This doesn't seem correct, but was what the old project generation
     // code did, so for now we do so too.
-    projectSettings.common.SUPPORTED_PLATFORMS = [
-        "macosx",
-        "iphoneos",
-        "iphonesimulator",
-        "appletvos",
-        "appletvsimulator",
-        "watchos",
-        "watchsimulator",
-    ]
+    projectSettings.common.SUPPORTED_PLATFORMS = ["$(AVAILABLE_PLATFORMS)"]
+    projectSettings.common.SUPPORTS_MACCATALYST = "YES"
 
     // Set the default `SDKROOT` to the latest macOS SDK.
     projectSettings.common.SDKROOT = "macosx"

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -107,7 +107,8 @@ class PackageGraphTests: XCTestCase {
             XCTAssertNil(project.buildSettings.xcconfigFileRef)
 
             XCTAssertEqual(project.buildSettings.common.SDKROOT, "macosx")
-            XCTAssertEqual(project.buildSettings.common.SUPPORTED_PLATFORMS!, ["macosx", "iphoneos", "iphonesimulator", "appletvos", "appletvsimulator", "watchos", "watchsimulator"])
+            XCTAssertEqual(project.buildSettings.common.SUPPORTED_PLATFORMS, ["$(AVAILABLE_PLATFORMS)"])
+            XCTAssertEqual(project.buildSettings.common.SUPPORTS_MACCATALYST, "YES")
             XCTAssertEqual(project.buildSettings.common.CLANG_ENABLE_OBJC_ARC, "YES")
             XCTAssertEqual(project.buildSettings.release.SWIFT_OPTIMIZATION_LEVEL, "-Owholemodule")
             XCTAssertEqual(project.buildSettings.debug.SWIFT_OPTIMIZATION_LEVEL, "-Onone")


### PR DESCRIPTION
Without SUPPORTS_MACCATALYST=YES, the Mac Catalyst build destination
will not be available, and therefore
`xcodebuild -destination 'platform=macOS,variant=Mac Catalyst'`
will fail to build the package.