### PR TITLE
improve error message when targets dependencies are not found

### DIFF
--- a/Tests/PackageLoadingTests/PD4LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4LoadingTests.swift
@@ -429,7 +429,7 @@ class PackageDescription4LoadingTests: PackageDescriptionLoadingTests {
             """
 
         XCTAssertManifestLoadThrows(stream.bytes) { _, diagnostics in
-            diagnostics.check(diagnostic: "target 'B' referenced in product 'Product' could not be found", behavior: .error)
+            diagnostics.check(diagnostic: "target 'B' referenced in product 'Product' could not be found; valid targets are: 'A'", behavior: .error)
         }
     }
 }

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -638,12 +638,14 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 ],
                 targets: [
                     .target(name: "A"),
+                    .target(name: "b"),
+                    .target(name: "C"),
                 ]
             )
             """
 
         XCTAssertManifestLoadThrows(stream.bytes) { _, diagnostics in
-            diagnostics.check(diagnostic: "target 'B' referenced in product 'Product' could not be found", behavior: .error)
+            diagnostics.check(diagnostic: "target 'B' referenced in product 'Product' could not be found; valid targets are: 'A', 'C', 'b'", behavior: .error)
         }
     }
 
@@ -673,7 +675,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             XCTFail("Unexpected success")
         } catch let error as StringError {
-            XCTAssertMatch(error.description, "target 'B' referenced in product 'Product' could not be found")
+            XCTAssertMatch(error.description, "target 'B' referenced in product 'Product' could not be found; valid targets are: 'A'")
         }
     }
 

--- a/Tests/PackageLoadingTests/PD5_3LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5_3LoadingTests.swift
@@ -212,7 +212,7 @@ class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
                 """
 
             XCTAssertManifestLoadThrows(stream.bytes) { _, diagnostics in
-                diagnostics.check(diagnostic: "invalid URL scheme for binary target 'Foo'; valid schemes are: https", behavior: .error)
+                diagnostics.check(diagnostic: "invalid URL scheme for binary target 'Foo'; valid schemes are: 'https'", behavior: .error)
             }
         }
 
@@ -232,7 +232,7 @@ class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
                 """
 
             XCTAssertManifestLoadThrows(stream.bytes) { _, diagnostics in
-                diagnostics.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: xcframework", behavior: .error)
+                diagnostics.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'xcframework'", behavior: .error)
             }
         }
 
@@ -255,7 +255,7 @@ class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
                 """
 
             XCTAssertManifestLoadThrows(stream.bytes) { _, diagnostics in
-                diagnostics.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: zip", behavior: .error)
+                diagnostics.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'zip'", behavior: .error)
             }
         }
 
@@ -275,7 +275,7 @@ class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
                 """
 
             XCTAssertManifestLoadThrows(stream.bytes) { _, diagnostics in
-                diagnostics.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: xcframework", behavior: .error)
+                diagnostics.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'xcframework'", behavior: .error)
             }
         }
 
@@ -298,7 +298,7 @@ class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
                 """
 
             XCTAssertManifestLoadThrows(stream.bytes) { _, diagnostics in
-                diagnostics.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: zip", behavior: .error)
+                diagnostics.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'zip'", behavior: .error)
             }
         }
     }


### PR DESCRIPTION
motivation: better diagnostics help uses be self sufficient

changes:
* update error message when target dependencies not found to include list of valid dependencies
* update error message when product refers to unknown target to include list of valid targets
* adjust tests