### PR TITLE
Switch to using `JSONEncoder.makeWithDefaults()` for JSON output of `describe` command

### DIFF
--- a/Sources/Commands/Describe.swift
+++ b/Sources/Commands/Describe.swift
@@ -27,18 +27,8 @@ func describe(_ package: Package, in mode: DescribeMode, on stream: OutputByteSt
     let data: Data
     switch mode {
     case .json:
-        let encoder = JSONEncoder()
+        let encoder = JSONEncoder.makeWithDefaults()
         encoder.keyEncodingStrategy = .convertToSnakeCase
-        // FIXME: This should be extracted into somewhere reusable.
-        if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
-            encoder.outputFormatting = [.sortedKeys, .prettyPrinted, .withoutEscapingSlashes]
-        }
-        else if #available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
-            encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
-        }
-        else {
-            encoder.outputFormatting = [.prettyPrinted]
-        }
         data = try! encoder.encode(desc)
     case .text:
         var encoder = PlainTextEncoder()


### PR DESCRIPTION
Switch to using `JSONEncoder.makeWithDefaults()` for JSON output formatting of `describe` command, now that it exists.  No change in semantics, so no change to tests.

### Motivation:

This cleans up the code by adopting newly added convenience initializers.

### Modifications:

Use `JSONEncoder.makeWithDefaults()` in the implementation of the `describe` subcommand rather than the conditional code for the various SDK versions.

### Result:

No change in semantics, but cleaner code.
