### PR TITLE
Don't require .git suffix in repo URL

### DIFF
--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -39,7 +39,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
             return callback(.failure(Errors.invalidReferenceType(reference)))
         }
         guard let baseURL = self.apiURL(reference.path) else {
-            return callback(.failure(Errors.invalidGitUrl(reference.path)))
+            return callback(.failure(Errors.invalidGitURL(reference.path)))
         }
 
         let metadataURL = baseURL
@@ -147,7 +147,14 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
 
     internal func apiURL(_ url: String) -> Foundation.URL? {
         do {
-            let regex = try NSRegularExpression(pattern: #"([^/@]+)[:/]([^:/]+)/([^/]+)\.git$"#, options: .caseInsensitive)
+            var url = url.lowercased()
+            
+            let gitSuffix = ".git"
+            if url.hasSuffix(gitSuffix) {
+                url.removeLast(gitSuffix.count)
+            }
+            
+            let regex = try NSRegularExpression(pattern: #"([^/@]+)[:/]([^:/]+)/([^/]+)$"#, options: .caseInsensitive)
             if let match = regex.firstMatch(in: url, options: [], range: NSRange(location: 0, length: url.count)) {
                 if let hostRange = Range(match.range(at: 1), in: url),
                     let ownerRange = Range(match.range(at: 2), in: url),
@@ -202,7 +209,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
 
     enum Errors: Error, Equatable {
         case invalidReferenceType(PackageReference)
-        case invalidGitUrl(String)
+        case invalidGitURL(String)
         case invalidResponse(URL, String)
         case permissionDenied(URL)
         case invalidAuthToken(URL)

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -147,14 +147,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
 
     internal func apiURL(_ url: String) -> Foundation.URL? {
         do {
-            var url = url.lowercased()
-            
-            let gitSuffix = ".git"
-            if url.hasSuffix(gitSuffix) {
-                url.removeLast(gitSuffix.count)
-            }
-            
-            let regex = try NSRegularExpression(pattern: #"([^/@]+)[:/]([^:/]+)/([^/]+)$"#, options: .caseInsensitive)
+            let regex = try NSRegularExpression(pattern: #"([^/@]+)[:/]([^:/]+)/([^/.]+)(\.git)?$"#, options: .caseInsensitive)
             if let match = regex.firstMatch(in: url, options: [], range: NSRange(location: 0, length: url.count)) {
                 if let hostRange = Range(match.range(at: 1), in: url),
                     let ownerRange = Range(match.range(at: 2), in: url),

--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -20,22 +20,31 @@ import TSCBasic
 import TSCUtility
 
 class GitHubPackageMetadataProviderTests: XCTestCase {
-    func testBaseRL() throws {
-        let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")
-
+    func testBaseURL() throws {
+        let apiURL = URL(string: "https://api.github.com/repos/octocat/hello-world")
         let provider = GitHubPackageMetadataProvider()
-        let sshURLRetVal = provider.apiURL("git@github.com:octocat/Hello-World.git")
-        XCTAssertEqual(apiURL, sshURLRetVal)
+        
+        do {
+            let sshURLRetVal = provider.apiURL("git@github.com:octocat/Hello-World.git")
+            XCTAssertEqual(apiURL, sshURLRetVal)
+        }
 
-        let httpsURLRetVal = provider.apiURL("https://github.com/octocat/Hello-World.git")
-        XCTAssertEqual(apiURL, httpsURLRetVal)
+        do {
+            let httpsURLRetVal = provider.apiURL("https://github.com/octocat/Hello-World.git")
+            XCTAssertEqual(apiURL, httpsURLRetVal)
+        }
+        
+        do {
+            let httpsURLRetVal = provider.apiURL("https://github.com/octocat/Hello-World")
+            XCTAssertEqual(apiURL, httpsURLRetVal)
+        }
 
         XCTAssertNil(provider.apiURL("bad/Hello-World.git"))
     }
 
     func testGood() throws {
         let repoURL = "https://github.com/octocat/Hello-World.git"
-        let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
+        let apiURL = URL(string: "https://api.github.com/repos/octocat/hello-world")!
 
         fixture(name: "Collections") { directoryPath in
             let handler = { (request: HTTPClient.Request, callback: @escaping (Result<HTTPClient.Response, Error>) -> Void) in
@@ -105,7 +114,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
 
     func testOthersNotFound() throws {
         let repoURL = "https://github.com/octocat/Hello-World.git"
-        let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
+        let apiURL = URL(string: "https://api.github.com/repos/octocat/hello-world")!
 
         fixture(name: "Collections") { directoryPath in
             let path = directoryPath.appending(components: "GitHub", "metadata.json")
@@ -138,7 +147,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
 
     func testPermissionDenied() throws {
         let repoURL = "https://github.com/octocat/Hello-World.git"
-        let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
+        let apiURL = URL(string: "https://api.github.com/repos/octocat/hello-world")!
 
         let handler = { (_: HTTPClient.Request, callback: @escaping (Result<HTTPClient.Response, Error>) -> Void) in
             callback(.success(.init(statusCode: 401)))
@@ -156,7 +165,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
 
     func testInvalidAuthToken() throws {
         let repoURL = "https://github.com/octocat/Hello-World.git"
-        let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
+        let apiURL = URL(string: "https://api.github.com/repos/octocat/hello-world")!
         let authTokens = [AuthTokenType.github("api.github.com"): "foo"]
 
         let handler = { (request: HTTPClient.Request, callback: @escaping (Result<HTTPClient.Response, Error>) -> Void) in
@@ -181,7 +190,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
 
     func testAPILimit() throws {
         let repoURL = "https://github.com/octocat/Hello-World.git"
-        let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
+        let apiURL = URL(string: "https://api.github.com/repos/octocat/hello-world")!
 
         let total = 5
         var remaining = total
@@ -228,7 +237,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
             let provider = GitHubPackageMetadataProvider()
             let reference = PackageReference(repository: RepositorySpecifier(url: UUID().uuidString))
             XCTAssertThrowsError(try tsc_await { callback in provider.get(reference, callback: callback) }, "should throw error") { error in
-                XCTAssertEqual(error as? GitHubPackageMetadataProvider.Errors, .invalidGitUrl(reference.path))
+                XCTAssertEqual(error as? GitHubPackageMetadataProvider.Errors, .invalidGitURL(reference.path))
             }
         }
     }

--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -21,7 +21,7 @@ import TSCUtility
 
 class GitHubPackageMetadataProviderTests: XCTestCase {
     func testBaseURL() throws {
-        let apiURL = URL(string: "https://api.github.com/repos/octocat/hello-world")
+        let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")
         let provider = GitHubPackageMetadataProvider()
         
         do {
@@ -44,7 +44,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
 
     func testGood() throws {
         let repoURL = "https://github.com/octocat/Hello-World.git"
-        let apiURL = URL(string: "https://api.github.com/repos/octocat/hello-world")!
+        let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
 
         fixture(name: "Collections") { directoryPath in
             let handler = { (request: HTTPClient.Request, callback: @escaping (Result<HTTPClient.Response, Error>) -> Void) in
@@ -114,7 +114,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
 
     func testOthersNotFound() throws {
         let repoURL = "https://github.com/octocat/Hello-World.git"
-        let apiURL = URL(string: "https://api.github.com/repos/octocat/hello-world")!
+        let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
 
         fixture(name: "Collections") { directoryPath in
             let path = directoryPath.appending(components: "GitHub", "metadata.json")
@@ -147,7 +147,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
 
     func testPermissionDenied() throws {
         let repoURL = "https://github.com/octocat/Hello-World.git"
-        let apiURL = URL(string: "https://api.github.com/repos/octocat/hello-world")!
+        let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
 
         let handler = { (_: HTTPClient.Request, callback: @escaping (Result<HTTPClient.Response, Error>) -> Void) in
             callback(.success(.init(statusCode: 401)))
@@ -165,7 +165,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
 
     func testInvalidAuthToken() throws {
         let repoURL = "https://github.com/octocat/Hello-World.git"
-        let apiURL = URL(string: "https://api.github.com/repos/octocat/hello-world")!
+        let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
         let authTokens = [AuthTokenType.github("api.github.com"): "foo"]
 
         let handler = { (request: HTTPClient.Request, callback: @escaping (Result<HTTPClient.Response, Error>) -> Void) in
@@ -190,7 +190,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
 
     func testAPILimit() throws {
         let repoURL = "https://github.com/octocat/Hello-World.git"
-        let apiURL = URL(string: "https://api.github.com/repos/octocat/hello-world")!
+        let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
 
         let total = 5
         var remaining = total


### PR DESCRIPTION
Motivation:
Git URLs don't always include `.git` suffix, but the logic for constructing GitHub API URL incorrectly requires it.

Modification:
Convert git URL to lowercase and remove `.git` suffix before pattern matching.

Result:
Git URLs with or without `.git` suffix are accepted.
