### PR TITLE
Package collections: trie for search

### DIFF
--- a/Sources/PackageCollections/CMakeLists.txt
+++ b/Sources/PackageCollections/CMakeLists.txt
@@ -19,6 +19,9 @@ add_library(PackageCollections
   Providers/JSONPackageCollectionProvider.swift
   Providers/PackageCollectionProvider.swift
   Providers/PackageMetadataProvider.swift
+  Search/InMemoryPackageCollectionsSearch.swift
+  Search/PackageCollectionsSearch.swift
+  Search/Trie.swift
   Storage/FilePackageCollectionsSourcesStorage.swift
   Storage/PackageCollectionsSourcesStorage.swift
   Storage/PackageCollectionsStorage.swift

--- a/Sources/PackageCollections/Model/TargetListResult.swift
+++ b/Sources/PackageCollections/Model/TargetListResult.swift
@@ -48,11 +48,15 @@ extension PackageCollectionsModel.TargetListResult {
 
 extension PackageCollectionsModel.TargetListResult {
     /// Represents a package version
-    public struct PackageVersion: Hashable {
+    public struct PackageVersion: Hashable, Comparable {
         /// The version
         public let version: TSCUtility.Version
 
         /// Package name
         public let packageName: String
+        
+        public static func < (lhs: PackageVersion, rhs: PackageVersion) -> Bool {
+            lhs.version < rhs.version
+        }
     }
 }

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -105,7 +105,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
                 sources.forEach { source in
                     self.refreshCollectionFromSource(source: source) { refreshResult in
                         lock.withLock { refreshResults.append(refreshResult) }
-                        if refreshResults.count == (lock.withLock { sources.count }) {
+                        if sources.count == (lock.withLock { refreshResults.count }) {
                             let errors = refreshResults.compactMap { $0.failure }
                             callback(errors.isEmpty ? .success(sources) : .failure(MultipleErrors(errors)))
                         }

--- a/Sources/PackageCollections/Search/InMemoryPackageCollectionsSearch.swift
+++ b/Sources/PackageCollections/Search/InMemoryPackageCollectionsSearch.swift
@@ -1,0 +1,361 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Dispatch
+import TSCBasic
+
+import PackageModel
+
+final class InMemoryPackageCollectionsSearch: PackageCollectionsSearch {
+    let configuration: Configuration
+
+    private let packageTrie: Trie<CollectionPackage>
+    private let targetTrie: Trie<CollectionPackage>
+    
+    private var cache = [Model.CollectionIdentifier: Model.Collection]()
+    private let cacheLock = Lock()
+    
+    private let tokenizer: Tokenizer = WordBoundaryTokenizer()
+    
+    // For indexing and executing queries
+    private let queue = DispatchQueue(label: "org.swift.swiftpm.InMemoryPackageCollectionsSearch", attributes: .concurrent)
+    
+    init(configuration: Configuration = .init()) {
+        self.configuration = configuration
+        self.packageTrie = Trie<CollectionPackage>()
+        self.targetTrie = Trie<CollectionPackage>()
+    }
+    
+    func index(collection: Model.Collection,
+               callback: @escaping (Result<Void, Error>) -> Void) {
+        self.queue.async {
+            let group = DispatchGroup()
+            
+            collection.packages.forEach { package in
+                group.enter()
+                
+                self.queue.async {
+                    defer { group.leave() }
+                    
+                    let document = CollectionPackage(collection: collection.identifier, package: package.reference.identity)
+        
+                    // This breaks up the URL into tokens because it contains punctuations, so when the
+                    // search query is a repository URL it will need to be tokenized the same way.
+                    // `searchPackages` does this, but not sure this is a good thing? We don't provide
+                    // options to NOT tokenize query string.
+                    self.index(text: package.repository.url, foundIn: document, to: self.packageTrie)
+                    // Index package identity without any transformation for `findPackage`
+                    self.index(text: package.reference.identity.description, foundIn: document, to: self.packageTrie, analyze: false)
+
+                    if let summary = package.summary {
+                        self.index(text: summary, foundIn: document, to: self.packageTrie)
+                    }
+                    if let keywords = package.keywords {
+                        keywords.forEach {
+                            self.index(text: $0, foundIn: document, to: self.packageTrie)
+                        }
+                    }
+                    package.versions.forEach { version in
+                        self.index(text: version.packageName, foundIn: document, to: self.packageTrie)
+                        version.products.forEach {
+                            self.index(text: $0.name, foundIn: document, to: self.packageTrie)
+                        }
+                        version.targets.forEach {
+                            self.index(text: $0.name, foundIn: document, to: self.packageTrie)
+                            // Target search is not tokenized - it's either exact match or prefix match
+                            self.index(text: $0.name, foundIn: document, to: self.targetTrie, analyze: false)
+                        }
+                    }
+                }
+            }
+            
+            group.notify(queue: self.queue) {
+                self.cacheLock.withLock {
+                    self.cache[collection.identifier] = collection
+                }
+                callback(.success(()))
+            }
+        }
+    }
+    
+    private func index(text: String, foundIn document: CollectionPackage, to trie: Trie<CollectionPackage>, analyze: Bool = true) {
+        if analyze {
+            let tokens = self.analyze(text: text)
+            tokens.forEach { trie.insert(word: $0, foundIn: document) }
+        } else {
+            trie.insert(word: text.lowercased(), foundIn: document)
+        }
+    }
+    
+    func remove(identifier: Model.CollectionIdentifier,
+                callback: @escaping (Result<Void, Error>) -> Void) {
+        self.queue.async {
+            guard let collection = self.cacheLock.withLock({ self.cache.removeValue(forKey: identifier) }) else {
+                return callback(.success(()))
+            }
+            
+            let group = DispatchGroup()
+
+            collection.packages.forEach { package in
+                group.enter()
+                
+                self.queue.async {
+                    defer { group.leave() }
+                    
+                    let document = CollectionPackage(collection: identifier, package: package.reference.identity)
+                    self.packageTrie.remove(document: document)
+                    self.targetTrie.remove(document: document)
+                }
+            }
+            
+            group.notify(queue: self.queue) {
+                callback(.success(()))
+            }
+        }
+    }
+    
+    func findPackage(identifier: PackageIdentity,
+                     collectionIdentifiers: [Model.CollectionIdentifier]? = nil,
+                     callback: @escaping (Result<Model.PackageSearchResult.Item, Error>) -> Void) {
+        self.queue.async {
+            let documents: Set<CollectionPackage>
+            do {
+                documents = try self.packageTrie.find(word: identifier.description)
+            } catch { // This includes `NotFoundError`
+                return callback(.failure(error))
+            }
+
+            let collectionIdentifiers: Set<Model.CollectionIdentifier>? = collectionIdentifiers.flatMap { Set($0) }
+            let collections = documents.filter { collectionIdentifiers?.contains($0.collection) ?? true }
+                .compactMap { collectionPackage in self.cacheLock.withLock { self.cache[collectionPackage.collection] } }
+                // Sort collections by processing date so the latest metadata is first
+                .sorted(by: { lhs, rhs in lhs.lastProcessedAt > rhs.lastProcessedAt })
+            
+            guard let package = collections.compactMap({ $0.packages.first { $0.reference.identity == identifier } }).first else {
+                return callback(.failure(NotFoundError("\(identifier)")))
+            }
+
+            callback(.success(.init(package: package, collections: collections.map { $0.identifier })))
+        }
+    }
+    
+    func searchPackages(identifiers: [Model.CollectionIdentifier]? = nil,
+                        query: String,
+                        callback: @escaping (Result<Model.PackageSearchResult, Error>) -> Void) {
+        self.queue.async {
+            // Clean and break up query string into tokens
+            let queryTokens = self.analyze(text: query)
+    
+            var queryResults = [String: Result<Set<CollectionPackage>, Error>]()
+            let queryResultsLock = Lock()
+
+            let group = DispatchGroup()
+
+            queryTokens.forEach { token in
+                group.enter()
+                
+                self.queue.async {
+                    defer { group.leave() }
+
+                    do {
+                        let matches = try self.packageTrie.find(word: token)
+                        queryResultsLock.withLock { queryResults[token] = .success(matches) }
+                    } catch {
+                        queryResultsLock.withLock { queryResults[token] = .failure(error) }
+                    }
+                }
+            }
+
+            group.notify(queue: self.queue) {
+                let errors = queryResults.values.compactMap { $0.failure }.filter { !($0 is NotFoundError) }
+                guard errors.isEmpty else {
+                    return callback(.failure(MultipleErrors(errors)))
+                }
+                
+                // We only want `CollectionPackage`s that match *all* tokens
+                let collectionIdentifiers: Set<Model.CollectionIdentifier>? = identifiers.flatMap { Set($0) }
+                let matchingCollectionPackages = queryResults.values
+                    .compactMap { $0.success }
+                    .reduce(into: [CollectionPackage: Int]()) { result, documents in
+                        // Count matches for each `CollectionPackage`
+                        documents.forEach {
+                            result[$0] = (result[$0] ?? 0) + 1
+                        }
+                    }
+                    .filter { collectionPackage, score in
+                        // Qualified results must contain all query tokens
+                        score == queryTokens.count && collectionIdentifiers?.contains(collectionPackage.collection) ?? true
+                    }
+                    .keys
+
+                // Construct the result
+                let packageCollections = matchingCollectionPackages
+                    .reduce(into: [PackageIdentity: (package: Model.Package, collections: Set<Model.CollectionIdentifier>)]()) { result, collectionPackage in
+                        var entry = result.removeValue(forKey: collectionPackage.package)
+                        if entry == nil {
+                            guard let package = self.cacheLock.withLock({
+                                self.cache[collectionPackage.collection].flatMap { collection in
+                                    collection.packages.first { $0.reference.identity == collectionPackage.package }
+                                }
+                            }) else {
+                                return
+                            }
+                            entry = (package, .init())
+                        }
+                        
+                        if var entry = entry {
+                            entry.collections.insert(collectionPackage.collection)
+                            result[collectionPackage.package] = entry
+                        }
+                    }
+                
+                let result = Model.PackageSearchResult(items: packageCollections.map { entry in
+                    .init(package: entry.value.package, collections: Array(entry.value.collections))
+                })
+                callback(.success(result))
+            }
+        }
+    }
+    
+    func searchTargets(identifiers: [Model.CollectionIdentifier]? = nil,
+                       query: String,
+                       type: Model.TargetSearchType,
+                       callback: @escaping (Result<Model.TargetSearchResult, Error>) -> Void) {
+        self.queue.async {
+            let matches: [String: Set<CollectionPackage>]
+            do {
+                switch type {
+                case .exactMatch:
+                    matches = [query.lowercased(): try self.targetTrie.find(word: query)]
+                case .prefix:
+                    matches = try self.targetTrie.findWithPrefix(query)
+                }
+            } catch is NotFoundError {
+                matches = [:]
+            } catch {
+                return callback(.failure(error))
+            }
+
+            let collectionIdentifiers: Set<Model.CollectionIdentifier>? = identifiers.flatMap { Set($0) }
+            
+            var packageCollections = [PackageIdentity: (package: Model.Package, collections: Set<Model.CollectionIdentifier>)]()
+            var targetPackageVersions = [Model.Target: [PackageIdentity: Set<Model.TargetListResult.PackageVersion>]]()
+            
+            // Group `CollectionPackage`s by packages
+            // For each matching target name, find the containing package version(s)
+            matches.forEach { targetName, collectionPackages in
+                collectionPackages.filter { collectionIdentifiers?.contains($0.collection) ?? true }.forEach { collectionPackage in
+                    var packageEntry = packageCollections.removeValue(forKey: collectionPackage.package)
+                    if packageEntry == nil {
+                        guard let package = self.cacheLock.withLock({
+                            self.cache[collectionPackage.collection].flatMap { collection in
+                                collection.packages.first { $0.reference.identity == collectionPackage.package }
+                            }
+                        }) else {
+                            return
+                        }
+                        packageEntry = (package, .init())
+                    }
+
+                    if var packageEntry = packageEntry {
+                        packageEntry.collections.insert(collectionPackage.collection)
+                        packageCollections[collectionPackage.package] = packageEntry
+
+                        packageEntry.package.versions.forEach { version in
+                            let targets = version.targets.filter { $0.name.lowercased() == targetName }
+                            targets.forEach { target in
+                                var targetEntry = targetPackageVersions.removeValue(forKey: target) ?? [:]
+                                var targetPackageEntry = targetEntry.removeValue(forKey: packageEntry.package.reference.identity) ?? .init()
+                                targetPackageEntry.insert(.init(version: version.version, packageName: version.packageName))
+                                targetEntry[packageEntry.package.reference.identity] = targetPackageEntry
+                                targetPackageVersions[target] = targetEntry
+                            }
+                        }
+                    }
+                }
+            }
+
+            let result = Model.TargetSearchResult(items: targetPackageVersions.map { target, packageVersions in
+                let targetPackages: [Model.TargetListItem.Package] = packageVersions.compactMap { reference, versions in
+                    guard let packageEntry = packageCollections[reference] else {
+                        return nil
+                    }
+                    return Model.TargetListItem.Package(
+                        repository: packageEntry.package.repository,
+                        summary: packageEntry.package.summary,
+                        versions: Array(versions).sorted(by: >),
+                        collections: Array(packageEntry.collections)
+                    )
+                }
+                return Model.TargetListItem(target: target, packages: targetPackages)
+            })
+            callback(.success(result))
+        }
+    }
+    
+    func analyze(text: String) -> [String] {
+        var tokens = self.tokenizer.tokenize(text: text)
+        tokens = TokenFilters.lowercase(tokens: tokens)
+        tokens = TokenFilters.stopwords(tokens: tokens, stopwords: self.configuration.stopwords)
+        return tokens
+    }
+
+    private struct CollectionPackage: Hashable, CustomStringConvertible {
+        let collection: Model.CollectionIdentifier
+        let package: PackageIdentity
+        
+        var description: String {
+            "\(collection): \(package)"
+        }
+    }
+    
+    struct Configuration {
+        // https://www.link-assistant.com/seo-stop-words.html
+        static let stopwords: Set<String> = [
+            "a", "am", "an", "and", "also", "are", "b", "be", "been", "being", "but",
+            "c", "can", "cannot", "could", "d", "did", "do", "does", "doing", "done", "e",
+            "f", "for", "from", "g", "h", "had", "has", "have", "he", "her", "hers", "him", "his", "how", "however",
+            "i", "if", "in", "is", "it", "its", "j", "just", "k", "l", "let",
+            "m", "may", "me", "might", "mine", "must", "my", "n", "not", "o", "of", "on", "or", "our", "ours",
+            "p", "q", "r", "re", "s", "shall", "she", "should", "so",
+            "t", "that", "the", "their", "theirs", "them", "then", "there", "these", "they", "this", "those", "to", "too",
+            "u", "un", "us", "v",
+            "w", "was", "we", "were", "what", "when", "where", "which", "while", "who", "whom", "whose", "why", "will", "with", "would",
+            "x", "y", "yes", "yet", "you", "your", "yours", "z"
+        ]
+        
+        var stopwords: Set<String>
+        
+        init(stopwords: Set<String>? = nil) {
+            self.stopwords = stopwords ?? Self.stopwords
+        }
+    }
+}
+
+protocol Tokenizer {
+    func tokenize(text: String) -> [String]
+}
+
+struct WordBoundaryTokenizer: Tokenizer {
+    func tokenize(text: String) -> [String] {
+        // Split on any character that is not a letter or a number
+        text.split { !$0.isLetter && !$0.isNumber }.map(String.init)
+    }
+}
+
+enum TokenFilters {
+    static func lowercase(tokens: [String]) -> [String] {
+        tokens.map { $0.lowercased() }
+    }
+    
+    static func stopwords(tokens: [String], stopwords: Set<String> = []) -> [String] {
+        tokens.filter { !stopwords.contains($0) }
+    }
+}

--- a/Sources/PackageCollections/Search/PackageCollectionsSearch.swift
+++ b/Sources/PackageCollections/Search/PackageCollectionsSearch.swift
@@ -1,0 +1,61 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import PackageModel
+
+protocol PackageCollectionsSearch {
+    /// Adds the given `PackageCollectionsModel.Collection` to the search index.
+    ///
+    /// - Parameters:
+    ///   - collection: The `PackageCollectionsModel.Collection` to index
+    ///   - callback: The closure to invoke when result becomes available
+    func index(collection: Model.Collection,
+               callback: @escaping (Result<Void, Error>) -> Void)
+    
+    /// Removes the `PackageCollectionsModel.Collection` from the search index.
+    ///
+    /// - Parameters:
+    ///   - identifier: The identifier of the `PackageCollectionsModel.Collection` to remove
+    ///   - callback: The closure to invoke when result becomes available
+    func remove(identifier: Model.CollectionIdentifier,
+                callback: @escaping (Result<Void, Error>) -> Void)
+    
+    /// Returns `PackageSearchResult.Item` for the given package identity.
+    ///
+    /// - Parameters:
+    ///   - identifier: The package identifier
+    ///   - collectionIdentifiers: Optional. The identifiers of the `PackageCollectionsModel.Collection`s to search under.
+    ///   - callback: The closure to invoke when result becomes available
+    func findPackage(identifier: PackageIdentity,
+                     collectionIdentifiers: [Model.CollectionIdentifier]?,
+                     callback: @escaping (Result<Model.PackageSearchResult.Item, Error>) -> Void)
+    
+    /// Returns `PackageSearchResult` for the given search criteria.
+    ///
+    /// - Parameters:
+    ///   - identifiers: Optional. The identifiers of the `PackageCollectionsModel.Collection`s to search under.
+    ///   - query: The search query expression
+    ///   - callback: The closure to invoke when result becomes available
+    func searchPackages(identifiers: [Model.CollectionIdentifier]?,
+                        query: String,
+                        callback: @escaping (Result<Model.PackageSearchResult, Error>) -> Void)
+    
+    /// Returns `TargetSearchResult` for the given search criteria.
+    ///
+    /// - Parameters:
+    ///   - identifiers: Optional. The identifiers of the `PackageCollectionsModel.Collection`s  to search under.
+    ///   - query: The search query expression
+    ///   - type: The search type
+    ///   - callback: The closure to invoke when result becomes available
+    func searchTargets(identifiers: [Model.CollectionIdentifier]?,
+                       query: String,
+                       type: Model.TargetSearchType,
+                       callback: @escaping (Result<Model.TargetSearchResult, Error>) -> Void)
+}

--- a/Sources/PackageCollections/Search/Trie.swift
+++ b/Sources/PackageCollections/Search/Trie.swift
@@ -1,0 +1,220 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import TSCBasic
+
+import PackageModel
+
+final class Trie<Document: Hashable> {
+    private typealias Node = TrieNode<Character, Document>
+    
+    private let root: Node
+    
+    init() {
+        self.root = Node()
+    }
+    
+    /// Inserts a word and its document to the trie.
+    func insert(word: String, foundIn document: Document) {
+        guard !word.isEmpty else { return }
+        
+        var currentNode = self.root
+        // Check if word already exists otherwise creates the node path
+        for character in word.lowercased() {
+            if let child = currentNode.children[character] {
+                currentNode = child
+            } else {
+                currentNode = currentNode.add(value: character)
+            }
+        }
+        
+        currentNode.add(document: document)
+    }
+    
+    /// Removes word occurrences found in the given document.
+    func remove(document: Document) {
+        func removeInSubTrie(root: Node, document: Document) {
+            if root.isTerminating {
+                root.remove(document: document)
+            }
+            
+            // Clean up sub-tries
+            root.children.values.forEach {
+                removeInSubTrie(root: $0, document: document)
+            }
+            
+            root.children.forEach { value, node in
+                // If a child node doesn't have children (i.e., there are no words under it),
+                // and itself is not a word, delete it since its path has become a deadend.
+                if node.isLeaf, !node.isTerminating {
+                    root.remove(value: value)
+                }
+            }
+        }
+        
+        removeInSubTrie(root: self.root, document: document)
+    }
+    
+    /// Checks if the trie contains the exact word or words with matching prefix.
+    func contains(word: String, prefixMatch: Bool = false) -> Bool {
+        guard let node = self.findLastNodeOf(word: word) else {
+            return false
+        }
+        return prefixMatch || node.isTerminating
+    }
+    
+    /// Finds the word in this trie and returns its documents.
+    func find(word: String) throws -> Set<Document> {
+        guard let node = self.findLastNodeOf(word: word), node.isTerminating else {
+            throw NotFoundError(word)
+        }
+        return node.documents
+    }
+    
+    /// Finds words with matching prefix in this trie and returns their documents.
+    func findWithPrefix(_ prefix: String) throws -> [String: Set<Document>] {
+        guard let node = self.findLastNodeOf(word: prefix) else {
+            throw NotFoundError(prefix)
+        }
+                
+        func wordsInSubTrie(root: Node, prefix: String) -> [String: Set<Document>] {
+            precondition(root.value != nil, "Sub-trie root's value should not be nil")
+            
+            var subTrieWords = [String: Set<Document>]()
+            
+            // Construct the new prefix by adding the sub-trie root's character
+            var previousCharacters = prefix
+            previousCharacters.append(root.value!.lowercased()) // !-safe; see precondition
+            
+            // The root actually forms a word
+            if root.isTerminating {
+                subTrieWords[previousCharacters] = root.documents
+            }
+            
+            // Collect all words under this sub-trie
+            root.children.values.forEach {
+                let childWords = wordsInSubTrie(root: $0, prefix: previousCharacters)
+                subTrieWords.merge(childWords, uniquingKeysWith: { _, child in child })
+            }
+            
+            return subTrieWords
+        }
+        
+        var words = [String: Set<Document>]()
+        
+        let prefix = prefix.lowercased()
+        // The prefix is actually a word
+        if node.isTerminating {
+            words[prefix] = node.documents
+        }
+        
+        node.children.values.forEach {
+            let childWords = wordsInSubTrie(root: $0, prefix: prefix)
+            words.merge(childWords, uniquingKeysWith: { _, child in child })
+        }
+        
+        return words
+    }
+    
+    /// Finds the last node in the path of the given word if it exists in this trie.
+    private func findLastNodeOf(word: String) -> Node? {
+        guard !word.isEmpty else { return nil }
+        
+        var currentNode = self.root
+        // Traverse down the trie as far as we can
+        for character in word.lowercased() {
+            guard let child = currentNode.children[character] else {
+                return nil
+            }
+            currentNode = child
+        }
+        return currentNode
+    }
+}
+
+private final class TrieNode<T: Hashable, Document: Hashable> {
+    /// The value (i.e., character) that this node stores. `nil` if root.
+    let value: T?
+    
+    /// The parent of this node. `nil` if root.
+    private weak var parent: TrieNode<T, Document>?
+    
+    /// The children of this node identified by their corresponding value.
+    private var _children = [T: TrieNode<T, Document>]()
+    private let childrenLock = Lock()
+    
+    /// If the path to this node forms a valid word, these are the documents where the word can be found.
+    private var _documents = Set<Document>()
+    private let documentsLock = Lock()
+    
+    var isLeaf: Bool {
+        self.childrenLock.withLock {
+            self._children.isEmpty
+        }
+    }
+    
+    /// `true` indicates the path to this node forms a valid word.
+    var isTerminating: Bool {
+        self.documentsLock.withLock {
+            !self._documents.isEmpty
+        }
+    }
+    
+    var children: [T: TrieNode<T, Document>] {
+        self.childrenLock.withLock {
+            self._children
+        }
+    }
+    
+    var documents: Set<Document> {
+        self.documentsLock.withLock {
+            self._documents
+        }
+    }
+    
+    init(value: T? = nil, parent: TrieNode<T, Document>? = nil) {
+        self.value = value
+        self.parent = parent
+    }
+    
+    /// Adds a subpath under this node.
+    func add(value: T) -> TrieNode<T, Document> {
+        self.childrenLock.withLock {
+            if let existing = self._children[value] {
+                return existing
+            }
+            
+            let child = TrieNode<T, Document>(value: value, parent: self)
+            self._children[value] = child
+            return child
+        }
+    }
+    
+    /// Removes a subpath from this node.
+    func remove(value: T) {
+        _ = self.childrenLock.withLock {
+            self._children.removeValue(forKey: value)
+        }
+    }
+    
+    /// Adds a document in which the word formed by path leading to this node can be found.
+    func add(document: Document) {
+        _ = self.documentsLock.withLock {
+            self._documents.insert(document)
+        }
+    }
+    
+    /// Removes a referenced document.
+    func remove(document: Document) {
+        _ = self.documentsLock.withLock {
+            self._documents.remove(document)
+        }
+    }
+}

--- a/Sources/PackageCollections/Storage/PackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/PackageCollectionsStorage.swift
@@ -53,7 +53,7 @@ public protocol PackageCollectionsStorage {
                         query: String,
                         callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult, Error>) -> Void)
 
-    /// Returns optional `PackageSearchResult.Item` for the given package identity.
+    /// Returns `PackageSearchResult.Item` for the given package identity.
     ///
     /// - Parameters:
     ///   - identifier: The package identifier

--- a/Tests/PackageCollectionsTests/InMemoryPackageCollectionsSearchTests.swift
+++ b/Tests/PackageCollectionsTests/InMemoryPackageCollectionsSearchTests.swift
@@ -1,0 +1,438 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Dispatch
+import Foundation
+import TSCBasic
+import TSCUtility
+import XCTest
+
+@testable import PackageCollections
+import SourceControl
+
+class InMemoryPackageCollectionsSearchTests: XCTestCase {
+    func testAnalyze() {
+        let search = InMemoryPackageCollectionsSearch()
+        let text = "The quick brown fox jumps over the lazy dog, for the lazy dog has blocked its way for far too long."
+        let tokens = search.analyze(text: text)
+        XCTAssertEqual(["quick", "brown", "fox", "jumps", "over", "lazy", "dog", "lazy", "dog", "blocked", "way", "far", "long"], tokens)
+    }
+    
+    func testRemove() throws {
+        let search = InMemoryPackageCollectionsSearch()
+
+        let mockTargets = [UUID().uuidString, UUID().uuidString].map {
+            PackageCollectionsModel.Target(name: $0, moduleName: $0)
+        }
+
+        let mockProducts = [PackageCollectionsModel.Product(name: UUID().uuidString, type: .executable, targets: [mockTargets.first!]),
+                            PackageCollectionsModel.Product(name: UUID().uuidString, type: .executable, targets: mockTargets)]
+
+        let mockVersion = PackageCollectionsModel.Package.Version(version: TSCUtility.Version(1, 0, 0),
+                                                                  packageName: UUID().uuidString,
+                                                                  targets: mockTargets,
+                                                                  products: mockProducts,
+                                                                  toolsVersion: .currentToolsVersion,
+                                                                  minimumPlatformVersions: nil,
+                                                                  verifiedPlatforms: nil,
+                                                                  verifiedSwiftVersions: nil,
+                                                                  license: nil)
+
+        let mockPackage = PackageCollectionsModel.Package(repository: .init(url: "https://packages.mock/\(UUID().uuidString)"),
+                                                          summary: UUID().uuidString,
+                                                          keywords: [UUID().uuidString, UUID().uuidString],
+                                                          versions: [mockVersion],
+                                                          latestVersion: mockVersion,
+                                                          watchersCount: nil,
+                                                          readmeURL: nil,
+                                                          authors: nil)
+
+        let mockCollection = PackageCollectionsModel.Collection(source: .init(type: .json, url: URL(string: "https://feed.mock/\(UUID().uuidString)")!),
+                                                                name: UUID().uuidString,
+                                                                overview: UUID().uuidString,
+                                                                keywords: [UUID().uuidString, UUID().uuidString],
+                                                                packages: [mockPackage],
+                                                                createdAt: Date(),
+                                                                createdBy: nil)
+
+        let mockCollection2 = PackageCollectionsModel.Collection(source: .init(type: .json, url: URL(string: "https://feed.mock/\(UUID().uuidString)")!),
+                                                                 name: UUID().uuidString,
+                                                                 overview: UUID().uuidString,
+                                                                 keywords: [UUID().uuidString, UUID().uuidString],
+                                                                 packages: [mockPackage],
+                                                                 createdAt: Date(),
+                                                                 createdBy: nil)
+
+        let mockCollections = [mockCollection, mockCollection2]
+        
+        try mockCollections.forEach { collection in
+            try tsc_await { callback in search.index(collection: collection, callback: callback) }
+        }
+        
+        do {
+            // search by package name
+            let searchResult = try tsc_await { callback in search.searchPackages(query: mockVersion.packageName, callback: callback) }
+            XCTAssertEqual(searchResult.items.count, 1, "list count should match")
+            XCTAssertEqual(searchResult.items.first?.collections.sorted(), mockCollections.map { $0.identifier }.sorted(), "list count should match")
+        }
+        
+        // Remove a collection
+        try tsc_await { callback in search.remove(identifier: mockCollection.identifier, callback: callback) }
+        
+        // It should no longer show up in results
+        do {
+            // search by package name
+            let searchResult = try tsc_await { callback in search.searchPackages(query: mockVersion.packageName, callback: callback) }
+            XCTAssertEqual(searchResult.items.count, 1, "list count should match")
+            XCTAssertEqual(searchResult.items.first?.collections, [mockCollection2.identifier], "list count should match")
+        }
+    }
+    
+    func testFindPackage() throws {
+        let search = InMemoryPackageCollectionsSearch()
+        
+        let mockCollections = makeMockCollections()
+        let expectedPackage = mockCollections.last!.packages.last!
+
+        let group = DispatchGroup()
+        mockCollections.forEach { collection in
+            group.enter()
+            search.index(collection: collection) { _ in group.leave() }
+        }
+        group.wait()
+
+        let metadata = try tsc_await { callback in search.findPackage(identifier: expectedPackage.reference.identity, callback: callback) }
+
+        let expectedCollections = Set(mockCollections.filter { $0.packages.map { $0.reference }.contains(expectedPackage.reference) }.map { $0.identifier })
+        XCTAssertEqual(Set(metadata.collections), expectedCollections, "collections should match")
+
+        XCTAssertEqual(metadata.package, expectedPackage, "package should match")
+    }
+    
+    func testFindPackage_notFound() throws {
+        let search = InMemoryPackageCollectionsSearch()
+        let expectedPackage = makeMockCollections().first!.packages.first!
+
+        XCTAssertThrowsError(try tsc_await { callback in search.findPackage(identifier: expectedPackage.reference.identity, callback: callback) }, "expected error") { error in
+            XCTAssert(error is NotFoundError)
+        }
+    }
+    
+    func testFindPackage_mostRecentFirst() throws {
+        let search = InMemoryPackageCollectionsSearch()
+
+        var date = Date()
+        let mockCollections: [Model.Collection] = makeMockCollections(count: 2).map {
+            date.addTimeInterval(-1)
+            return Model.Collection(
+                source: $0.source,
+                name: $0.name,
+                overview: $0.overview,
+                keywords: $0.keywords,
+                packages: $0.packages,
+                createdAt: $0.createdAt,
+                createdBy: $0.createdBy,
+                lastProcessedAt: date
+            )
+        }
+        // Most recent lastProcessedAt
+        let expectedPackage = mockCollections.first!.packages.first!
+
+        try mockCollections.forEach { collection in
+            try tsc_await { callback in search.index(collection: collection, callback: callback) }
+        }
+
+        let metadata = try tsc_await { callback in search.findPackage(identifier: expectedPackage.reference.identity, callback: callback) }
+
+        let expectedCollections = Set(mockCollections.filter { $0.packages.map { $0.reference }.contains(expectedPackage.reference) }.map { $0.identifier })
+        XCTAssertEqual(Set(metadata.collections), expectedCollections, "collections should match")
+
+        XCTAssertEqual(metadata.package, expectedPackage, "package should match")
+    }
+    
+    func testFindPackagePerformance() throws {
+        #if ENABLE_COLLECTION_PERF_TESTS
+        #else
+        try XCTSkipIf(true)
+        #endif
+        
+        let search = InMemoryPackageCollectionsSearch()
+
+        let mockCollections = makeMockCollections(count: 1000)
+        let expectedPackage = mockCollections.last!.packages.last!
+
+        let group = DispatchGroup()
+        mockCollections.forEach { collection in
+            group.enter()
+            search.index(collection: collection) { _ in group.leave() }
+        }
+        group.wait()
+
+        let start = Date()
+        let metadata = try tsc_await { callback in search.findPackage(identifier: expectedPackage.reference.identity, callback: callback) }
+        XCTAssertNotNil(metadata)
+        let delta = Date().timeIntervalSince(start)
+        XCTAssert(delta < 1.0, "should fetch quickly, took \(delta)")
+    }
+
+    // This is an equivalent of PackageCollectionsTests.testPackageSearch
+    func testSearchPackages() throws {
+        let search = InMemoryPackageCollectionsSearch()
+
+        var mockCollections = makeMockCollections()
+
+        let mockTargets = [UUID().uuidString, UUID().uuidString].map {
+            PackageCollectionsModel.Target(name: $0, moduleName: $0)
+        }
+
+        let mockProducts = [PackageCollectionsModel.Product(name: UUID().uuidString, type: .executable, targets: [mockTargets.first!]),
+                            PackageCollectionsModel.Product(name: UUID().uuidString, type: .executable, targets: mockTargets)]
+
+        let mockVersion = PackageCollectionsModel.Package.Version(version: TSCUtility.Version(1, 0, 0),
+                                                                  packageName: UUID().uuidString,
+                                                                  targets: mockTargets,
+                                                                  products: mockProducts,
+                                                                  toolsVersion: .currentToolsVersion,
+                                                                  minimumPlatformVersions: nil,
+                                                                  verifiedPlatforms: nil,
+                                                                  verifiedSwiftVersions: nil,
+                                                                  license: nil)
+
+        let mockPackage = PackageCollectionsModel.Package(repository: .init(url: "https://packages.mock/\(UUID().uuidString)"),
+                                                          summary: UUID().uuidString,
+                                                          keywords: [UUID().uuidString, UUID().uuidString],
+                                                          versions: [mockVersion],
+                                                          latestVersion: mockVersion,
+                                                          watchersCount: nil,
+                                                          readmeURL: nil,
+                                                          authors: nil)
+
+        let mockCollection = PackageCollectionsModel.Collection(source: .init(type: .json, url: URL(string: "https://feed.mock/\(UUID().uuidString)")!),
+                                                                name: UUID().uuidString,
+                                                                overview: UUID().uuidString,
+                                                                keywords: [UUID().uuidString, UUID().uuidString],
+                                                                packages: [mockPackage],
+                                                                createdAt: Date(),
+                                                                createdBy: nil)
+
+        let mockCollection2 = PackageCollectionsModel.Collection(source: .init(type: .json, url: URL(string: "https://feed.mock/\(UUID().uuidString)")!),
+                                                                 name: UUID().uuidString,
+                                                                 overview: UUID().uuidString,
+                                                                 keywords: [UUID().uuidString, UUID().uuidString],
+                                                                 packages: [mockPackage],
+                                                                 createdAt: Date(),
+                                                                 createdBy: nil)
+
+        let expectedCollections = [mockCollection, mockCollection2]
+        let expectedCollectionsIdentifiers = expectedCollections.map { $0.identifier }.sorted()
+
+        mockCollections.append(contentsOf: expectedCollections)
+        
+        let group = DispatchGroup()
+        mockCollections.forEach { collection in
+            group.enter()
+            search.index(collection: collection) { _ in group.leave() }
+        }
+        group.wait()
+        
+        do {
+            // search by package name
+            let searchResult = try tsc_await { callback in search.searchPackages(query: mockVersion.packageName, callback: callback) }
+            XCTAssertEqual(searchResult.items.count, 1, "list count should match")
+            XCTAssertEqual(searchResult.items.first?.collections.sorted(), expectedCollectionsIdentifiers, "list count should match")
+        }
+        
+        do {
+            // search by package description/summary
+            let searchResult = try tsc_await { callback in search.searchPackages(query: mockPackage.summary!, callback: callback) }
+            XCTAssertEqual(searchResult.items.count, 1, "list count should match")
+            XCTAssertEqual(searchResult.items.first?.collections.sorted(), expectedCollectionsIdentifiers, "list count should match")
+        }
+        
+        do {
+            // search by package keywords
+            let searchResult = try tsc_await { callback in search.searchPackages(query: mockPackage.keywords!.first!, callback: callback) }
+            XCTAssertEqual(searchResult.items.count, 1, "list count should match")
+            XCTAssertEqual(searchResult.items.first?.collections.sorted(), expectedCollectionsIdentifiers, "list count should match")
+        }
+        
+        // FIXME: the code tokenizes the query (i.e., URL) which might not be desired?
+        do {
+            // search by package repository url
+            let searchResult = try tsc_await { callback in search.searchPackages(query: mockPackage.repository.url, callback: callback) }
+            XCTAssertEqual(searchResult.items.count, 1, "list count should match")
+            XCTAssertEqual(searchResult.items.first?.collections.sorted(), expectedCollectionsIdentifiers, "collections should match")
+        }
+        
+        do {
+            // search by package repository url base name
+            let searchResult = try tsc_await { callback in search.searchPackages(query: mockPackage.repository.basename, callback: callback) }
+            XCTAssertEqual(searchResult.items.count, 1, "list count should match")
+            XCTAssertEqual(searchResult.items.first?.collections.sorted(), expectedCollectionsIdentifiers, "collections should match")
+        }
+        
+        do {
+            // search by product name
+            let searchResult = try tsc_await { callback in search.searchPackages(query: mockProducts.first!.name, callback: callback) }
+            XCTAssertEqual(searchResult.items.count, 1, "list count should match")
+            XCTAssertEqual(searchResult.items.first?.collections.sorted(), expectedCollectionsIdentifiers, "list count should match")
+        }
+        
+        do {
+            // search by target name
+            let searchResult = try tsc_await { callback in search.searchPackages(query: mockTargets.first!.name, callback: callback) }
+            XCTAssertEqual(searchResult.items.count, 1, "list count should match")
+            XCTAssertEqual(searchResult.items.first?.collections.sorted(), expectedCollectionsIdentifiers, "collections should match")
+        }
+        
+        do {
+            // empty search
+            let searchResult = try tsc_await { callback in search.searchPackages(query: UUID().uuidString, callback: callback) }
+            XCTAssertEqual(searchResult.items.count, 0, "list count should match")
+        }
+    }
+    
+    // This is an equivalent of PackageCollectionsTests.testPackageSearchPerformance
+    func testSearchPackagesPerformance() throws {
+        #if ENABLE_COLLECTION_PERF_TESTS
+        #else
+        try XCTSkipIf(true)
+        #endif
+
+        let search = InMemoryPackageCollectionsSearch()
+
+        let mockCollections = makeMockCollections(count: 1000, maxPackages: 20)
+
+        let group = DispatchGroup()
+        mockCollections.forEach { collection in
+            group.enter()
+            search.index(collection: collection) { _ in group.leave() }
+        }
+        group.wait()
+        
+        // search by package name
+        let start = Date()
+        let repoName = mockCollections.last!.packages.last!.repository.basename
+        let searchResult = try tsc_await { callback in search.searchPackages(query: repoName, callback: callback) }
+        XCTAssert(searchResult.items.count > 0, "should get results")
+        let delta = Date().timeIntervalSince(start)
+        XCTAssert(delta < 1.0, "should search quickly, took \(delta)")
+    }
+    
+    // This is an equivalent of PackageCollectionsTests.testTargetsSearch
+    func testSearchTargets() throws {
+        let search = InMemoryPackageCollectionsSearch()
+        
+        var mockCollections = makeMockCollections()
+
+        let mockTargets = [UUID().uuidString, UUID().uuidString].map {
+            PackageCollectionsModel.Target(name: $0, moduleName: $0)
+        }
+
+        let mockProducts = [PackageCollectionsModel.Product(name: UUID().uuidString, type: .executable, targets: [mockTargets.first!]),
+                            PackageCollectionsModel.Product(name: UUID().uuidString, type: .executable, targets: mockTargets)]
+
+        let mockVersion = PackageCollectionsModel.Package.Version(version: TSCUtility.Version(1, 0, 0),
+                                                                  packageName: UUID().uuidString,
+                                                                  targets: mockTargets,
+                                                                  products: mockProducts,
+                                                                  toolsVersion: .currentToolsVersion,
+                                                                  minimumPlatformVersions: nil,
+                                                                  verifiedPlatforms: nil,
+                                                                  verifiedSwiftVersions: nil,
+                                                                  license: nil)
+
+        let mockPackage = PackageCollectionsModel.Package(repository: RepositorySpecifier(url: "https://packages.mock/\(UUID().uuidString)"),
+                                                          summary: UUID().uuidString,
+                                                          keywords: [UUID().uuidString, UUID().uuidString],
+                                                          versions: [mockVersion],
+                                                          latestVersion: mockVersion,
+                                                          watchersCount: nil,
+                                                          readmeURL: nil,
+                                                          authors: nil)
+
+        let mockCollection = PackageCollectionsModel.Collection(source: .init(type: .json, url: URL(string: "https://feed.mock/\(UUID().uuidString)")!),
+                                                                name: UUID().uuidString,
+                                                                overview: UUID().uuidString,
+                                                                keywords: [UUID().uuidString, UUID().uuidString],
+                                                                packages: [mockPackage],
+                                                                createdAt: Date(),
+                                                                createdBy: nil)
+
+        let mockCollection2 = PackageCollectionsModel.Collection(source: .init(type: .json, url: URL(string: "https://feed.mock/\(UUID().uuidString)")!),
+                                                                 name: UUID().uuidString,
+                                                                 overview: UUID().uuidString,
+                                                                 keywords: [UUID().uuidString, UUID().uuidString],
+                                                                 packages: [mockPackage],
+                                                                 createdAt: Date(),
+                                                                 createdBy: nil)
+
+        let expectedCollections = [mockCollection, mockCollection2]
+        let expectedCollectionsIdentifiers = expectedCollections.map { $0.identifier }.sorted()
+
+        mockCollections.append(contentsOf: expectedCollections)
+
+        let group = DispatchGroup()
+        mockCollections.forEach { collection in
+            group.enter()
+            search.index(collection: collection) { _ in group.leave() }
+        }
+        group.wait()
+
+        do {
+            // search by exact target name
+            let searchResult = try tsc_await { callback in search.searchTargets(query: mockTargets.first!.name, type: .exactMatch, callback: callback) }
+            XCTAssertEqual(searchResult.items.count, 1, "list count should match")
+            XCTAssertEqual(searchResult.items.first?.packages.map { $0.repository }, [mockPackage.repository], "packages should match")
+            XCTAssertEqual(searchResult.items.first?.packages.flatMap { $0.collections }.sorted(), expectedCollectionsIdentifiers, "collections should match")
+        }
+
+        do {
+            // search by prefix target name
+            let searchResult = try tsc_await { callback in search.searchTargets(query: String(mockTargets.first!.name.prefix(mockTargets.first!.name.count - 1)), type: .prefix, callback: callback) }
+            XCTAssertEqual(searchResult.items.count, 1, "list count should match")
+            XCTAssertEqual(searchResult.items.first?.packages.map { $0.repository }, [mockPackage.repository], "packages should match")
+            XCTAssertEqual(searchResult.items.first?.packages.flatMap { $0.collections }.sorted(), expectedCollectionsIdentifiers, "collections should match")
+        }
+
+        do {
+            // empty search
+            let searchResult = try tsc_await { callback in search.searchTargets(query: UUID().uuidString, type: .exactMatch, callback: callback) }
+            XCTAssertEqual(searchResult.items.count, 0, "list count should match")
+        }
+    }
+    
+    // This is an equivalent of PackageCollectionsTests.testTargetsSearchPerformance
+    func testSearchTargetsPerformance() throws {
+        #if ENABLE_COLLECTION_PERF_TESTS
+        #else
+        try XCTSkipIf(true)
+        #endif
+
+        let search = InMemoryPackageCollectionsSearch()
+
+        let mockCollections = makeMockCollections(count: 1000)
+
+        let group = DispatchGroup()
+        mockCollections.forEach { collection in
+            group.enter()
+            search.index(collection: collection) { _ in group.leave() }
+        }
+        group.wait()
+
+        // search by target name
+        let start = Date()
+        let targetName = mockCollections.last!.packages.last!.versions.last!.targets.last!.name
+        let searchResult = try tsc_await { callback in search.searchTargets(query: targetName, type: .exactMatch, callback: callback) }
+        XCTAssert(searchResult.items.count > 0, "should get results")
+        let delta = Date().timeIntervalSince(start)
+        XCTAssert(delta < 1.0, "should search quickly, took \(delta)")
+    }
+}

--- a/Tests/PackageCollectionsTests/TrieTests.swift
+++ b/Tests/PackageCollectionsTests/TrieTests.swift
@@ -1,0 +1,133 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import XCTest
+
+@testable import PackageCollections
+
+class TrieTests: XCTestCase {
+    func testContains() {
+        let trie = Trie<Int>()
+        
+        let doc1 = "THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG"
+        self.indexDocument(id: 1, contents: doc1, trie: trie)
+        
+        // Whole word match
+        XCTAssertTrue(trie.contains(word: "brown", prefixMatch: false))
+        XCTAssertTrue(trie.contains(word: "Fox", prefixMatch: false))
+        XCTAssertFalse(trie.contains(word: "foobar", prefixMatch: false))
+        
+        // Prefix match
+        XCTAssertTrue(trie.contains(word: "d", prefixMatch: true))
+        XCTAssertTrue(trie.contains(word: "Do", prefixMatch: true))
+        XCTAssertFalse(trie.contains(word: "doo", prefixMatch: true))
+    }
+    
+    func testFind() {
+        let trie = Trie<Int>()
+        
+        let doc1 = "the quick brown fox jumps over the lazy dog and the dog does not notice the fox jumps over it"
+        let doc2 = "the quick brown fox jumps over the lazy dog for the lazy dog has blocked its way for far too long"
+        self.indexDocument(id: 1, contents: doc1, trie: trie)
+        self.indexDocument(id: 2, contents: doc2, trie: trie)
+        
+        XCTAssertEqual(try trie.find(word: "brown"), [1, 2])
+        XCTAssertEqual(try trie.find(word: "blocked"), [2])
+        XCTAssertThrowsError(try trie.find(word: "fo"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+    }
+
+    func testFindWithPrefix() {
+        let trie = Trie<Int>()
+        
+        let doc1 = "the quick brown fox jumps over the lazy dog and the dog does not notice the fox jumps over it"
+        let doc2 = "the quick brown fox jumps over the lazy dog for the lazy dog has blocked its way for far too long"
+        self.indexDocument(id: 1, contents: doc1, trie: trie)
+        self.indexDocument(id: 2, contents: doc2, trie: trie)
+        
+        XCTAssertEqual(try trie.findWithPrefix("f"), ["fox": [1, 2], "for": [2], "far": [2]])
+        XCTAssertEqual(try trie.findWithPrefix("fo"), ["fox": [1, 2], "for": [2]])
+        XCTAssertEqual(try trie.findWithPrefix("far"), ["far": [2]])
+        XCTAssertThrowsError(try trie.findWithPrefix("foo"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+    }
+
+    func testRemoveDocument() {
+        let trie = Trie<Int>()
+        
+        let doc1 = "the quick brown fox jumps over the lazy dog"
+        let doc2 = "the dog does not notice the fox jumps over it"
+        let doc3 = "it has blocked the fox for far too long"
+        self.indexDocument(id: 1, contents: doc1, trie: trie)
+        self.indexDocument(id: 2, contents: doc2, trie: trie)
+        self.indexDocument(id: 3, contents: doc3, trie: trie)
+        
+        XCTAssertEqual(try trie.find(word: "fox"), [1, 2, 3])
+        XCTAssertEqual(try trie.find(word: "dog"), [1, 2])
+        XCTAssertEqual(try trie.find(word: "it"), [2, 3])
+        XCTAssertEqual(try trie.find(word: "lazy"), [1])
+        XCTAssertEqual(try trie.find(word: "notice"), [2])
+        XCTAssertEqual(try trie.find(word: "blocked"), [3])
+
+        trie.remove(document: 3)
+
+        XCTAssertEqual(try trie.find(word: "fox"), [1, 2])
+        XCTAssertEqual(try trie.find(word: "dog"), [1, 2])
+        XCTAssertEqual(try trie.find(word: "it"), [2])
+        XCTAssertEqual(try trie.find(word: "lazy"), [1])
+        XCTAssertEqual(try trie.find(word: "notice"), [2])
+        XCTAssertThrowsError(try trie.find(word: "blocked"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+
+        trie.remove(document: 1)
+
+        XCTAssertEqual(try trie.find(word: "fox"), [2])
+        XCTAssertEqual(try trie.find(word: "dog"), [2])
+        XCTAssertEqual(try trie.find(word: "it"), [2])
+        XCTAssertThrowsError(try trie.find(word: "lazy"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+        XCTAssertEqual(try trie.find(word: "notice"), [2])
+        XCTAssertThrowsError(try trie.find(word: "blocked"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+
+        trie.remove(document: 2)
+        
+        XCTAssertThrowsError(try trie.find(word: "fox"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+        XCTAssertThrowsError(try trie.find(word: "dog"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+        XCTAssertThrowsError(try trie.find(word: "it"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+        XCTAssertThrowsError(try trie.find(word: "lazy"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+        XCTAssertThrowsError(try trie.find(word: "notice"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+        XCTAssertThrowsError(try trie.find(word: "blocked"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+    }
+    
+    private func indexDocument(id: Int, contents: String, trie: Trie<Int>) {
+        let words = contents.components(separatedBy: " ")
+        words.forEach { word in
+            trie.insert(word: word, foundIn: id)
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
Currently to support search for package collections API we read and deserialize collection blobs from SQLite then perform string matchings on individual properties in memory (e.g., `package.summary.contains("foobar")`). This can be optimized.

Modifications:
Introduce `InMemoryPackageCollectionsSearch`, which uses `Trie`s as underlying search indexes.

`InMemoryPackageCollectionsSearch` contains the same `findPackage`, `searchPackages`, and `searchTargets` method signatures as
`SQLitePackageCollectionsStorage`. This PR only intends to show `InMemoryPackageCollectionsSearch` working standalone, and the next step is to weave `InMemoryPackageCollectionsSearch` into the existing business logic. This might mean using `InMemoryPackageCollectionsSearch` instead of `SQLitePackageCollectionsStorage` for search, or combining the two. We will also need to be able to de/serialize the indexes (tries) to avoid rebuilding them each time and to reduce "warm up" time.

Result:
A search index for package collections API that based on performance tests, yield better timings that current search strategy.
