### PR TITLE
more work towards performance improvements

### DIFF
--- a/Sources/PackageGraph/Pubgrub/PartialSolution.swift
+++ b/Sources/PackageGraph/Pubgrub/PartialSolution.swift
@@ -13,7 +13,7 @@ import TSCBasic
 
 /// The partial solution is a constantly updated solution used throughout the
 /// dependency resolution process, tracking know assignments.
-public final class PartialSolution {
+public struct PartialSolution {
     var root: DependencyResolutionNode?
 
     /// All known assigments.
@@ -50,7 +50,7 @@ public final class PartialSolution {
 
     /// Create a new derivation assignment and add it to the partial solution's
     /// list of known assignments.
-    public func derive(_ term: Term, cause: Incompatibility) {
+    mutating public func derive(_ term: Term, cause: Incompatibility) {
         let derivation = Assignment.derivation(term, cause: cause, decisionLevel: decisionLevel)
         self.assignments.append(derivation)
         register(derivation)
@@ -58,7 +58,7 @@ public final class PartialSolution {
 
     /// Create a new decision assignment and add it to the partial solution's
     /// list of known assignments.
-    public func decide(_ node: DependencyResolutionNode, at version: Version) {
+    mutating public func decide(_ node: DependencyResolutionNode, at version: Version) {
         decisions[node] = version
         let term = Term(node, .exact(version))
         let decision = Assignment.decision(term, decisionLevel: decisionLevel)
@@ -67,7 +67,7 @@ public final class PartialSolution {
     }
 
     /// Populates the _positive and _negative poperties with the assignment.
-    private func register(_ assignment: Assignment) {
+    mutating private func register(_ assignment: Assignment) {
         let term = assignment.term
         let pkg = term.node
 
@@ -107,7 +107,7 @@ public final class PartialSolution {
 
     /// Backtrack to a specific decision level by dropping all assignments with
     /// a decision level which is greater.
-    public func backtrack(toDecisionLevel decisionLevel: Int) {
+    mutating public func backtrack(toDecisionLevel decisionLevel: Int) {
         var toBeRemoved: [(Int, Assignment)] = []
 
         for (idx, assignment) in zip(0..., assignments) {

--- a/Sources/PackageGraph/Pubgrub/PartialSolution.swift
+++ b/Sources/PackageGraph/Pubgrub/PartialSolution.swift
@@ -50,7 +50,7 @@ public struct PartialSolution {
 
     /// Create a new derivation assignment and add it to the partial solution's
     /// list of known assignments.
-    mutating public func derive(_ term: Term, cause: Incompatibility) {
+    public mutating func derive(_ term: Term, cause: Incompatibility) {
         let derivation = Assignment.derivation(term, cause: cause, decisionLevel: decisionLevel)
         self.assignments.append(derivation)
         register(derivation)
@@ -58,7 +58,7 @@ public struct PartialSolution {
 
     /// Create a new decision assignment and add it to the partial solution's
     /// list of known assignments.
-    mutating public func decide(_ node: DependencyResolutionNode, at version: Version) {
+    public mutating func decide(_ node: DependencyResolutionNode, at version: Version) {
         decisions[node] = version
         let term = Term(node, .exact(version))
         let decision = Assignment.decision(term, decisionLevel: decisionLevel)
@@ -67,7 +67,7 @@ public struct PartialSolution {
     }
 
     /// Populates the _positive and _negative poperties with the assignment.
-    mutating private func register(_ assignment: Assignment) {
+    private mutating func register(_ assignment: Assignment) {
         let term = assignment.term
         let pkg = term.node
 
@@ -107,7 +107,7 @@ public struct PartialSolution {
 
     /// Backtrack to a specific decision level by dropping all assignments with
     /// a decision level which is greater.
-    mutating public func backtrack(toDecisionLevel decisionLevel: Int) {
+    public mutating func backtrack(toDecisionLevel decisionLevel: Int) {
         var toBeRemoved: [(Int, Assignment)] = []
 
         for (idx, assignment) in zip(0..., assignments) {

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -54,8 +54,8 @@ class DependencyResolverRealWorldPerfTests: XCTestCasePerf {
 
         measure {
             for _ in 0 ..< N {
-                let resolver = PubgrubDependencyResolver(provider)
-                switch resolver.solve(dependencies: graph.constraints) {
+                let resolver = PubgrubDependencyResolver(provider: provider)
+                switch resolver.solve(constraints: graph.constraints) {
                 case .success(let result):
                     let result: [(container: PackageReference, version: Version)] = result.compactMap {
                         guard case .version(let version) = $0.binding else {


### PR DESCRIPTION
motivation: make PubgrubDependencyResolver safer for concurrent work

changes:
* turn PubgrubDependencyResolver into a struct and get rid of it's state
* move all state into a new State abstraction that is thread-safe and can be passed around between funcations
* turn PartialSolution into a struct, highlighting which functions are mutating
* cleanup / move code around in PubgrubDependencyResolver so its easier to reason about
* adjust tests

no functional changes here, just code reorganization

⚠️ based on #3091 and #3092, so let merge those  first
