### PR TITLE
Fix Linux builds

### DIFF
--- a/Sources/Basics/HTTPClient.swift
+++ b/Sources/Basics/HTTPClient.swift
@@ -95,7 +95,7 @@ public struct HTTPClient {
                 self.recordErrorIfNecessary(response: response, request: request)
                 // handle retry strategy
                 if let retryDelay = self.shouldRetry(response: response, request: request, requestNumber: requestNumber) {
-                    diagnosticsEngine?.emit(warning: "\(request.url) failed, retrying in \(retryDelay)")
+                    self.diagnosticsEngine?.emit(warning: "\(request.url) failed, retrying in \(retryDelay)")
                     // TODO: dedicated retry queue?
                     return DispatchQueue.global().asyncAfter(deadline: .now() + retryDelay) {
                         self._execute(request: request, requestNumber: requestNumber + 1, callback: callback)

--- a/Sources/Basics/JSON+Extensions.swift
+++ b/Sources/Basics/JSON+Extensions.swift
@@ -89,9 +89,8 @@ extension JSONEncoder {
             } else {
                 encoder.outputFormatting = [.prettyPrinted]
             }
-            // `.withoutEscapingSlashes` is not in 5.3 on non-Darwin platforms
-//            #elseif compiler(>=5.3)
-//            encoder.outputFormatting = [.sortedKeys, .prettyPrinted, .withoutEscapingSlashes]
+            #elseif compiler(>=5.3)
+            encoder.outputFormatting = [.sortedKeys, .prettyPrinted, .withoutEscapingSlashes]
             #else
             encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
             #endif

--- a/Sources/Basics/JSON+Extensions.swift
+++ b/Sources/Basics/JSON+Extensions.swift
@@ -89,8 +89,9 @@ extension JSONEncoder {
             } else {
                 encoder.outputFormatting = [.prettyPrinted]
             }
-            #elseif compiler(>=5.3)
-            encoder.outputFormatting = [.sortedKeys, .prettyPrinted, .withoutEscapingSlashes]
+            // `.withoutEscapingSlashes` is not in 5.3 on non-Darwin platforms
+//            #elseif compiler(>=5.3)
+//            encoder.outputFormatting = [.sortedKeys, .prettyPrinted, .withoutEscapingSlashes]
             #else
             encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
             #endif

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -96,7 +96,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
                         var headers = self.makeRequestHeaders(url)
                         headers.add(name: "Accept", value: "application/vnd.github.v3+json")
                         let options = self.makeRequestOptions(validResponseCodes: [200])
-                        httpClient.get(url, headers: headers, options: options) { result in
+                        self.httpClient.get(url, headers: headers, options: options) { result in
                             defer { sync.leave() }
                             resultsLock.withLock {
                                 results[url] = result


### PR DESCRIPTION
Motivation:
I was building another project that depends on this repo in docker:
- Swift 5.2 build failing with `requires explicit 'self.'` at a couple of places.
- Swift 5.3 build failing with `'JSONEncoder.OutputFormatting' has no member 'withoutEscapingSlashes'`

Modifications:
Add `self.` where appropriate.
Remove `.withoutEscapingSlashes` for non-Apple platforms.

Result:
Linux builds complete successful with Swift 5.2 and 5.3.
