### PR TITLE
performance improvements

### DIFF
--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(Basics
   ConcurrencyHelpers.swift
   Dictionary+Extensions.swift
   DispatchTimeInterval+Extensions.swift
+  Errors.swift
   FileSystem+Extensions.swift
   HTPClient+URLSession.swift
   HTTPClient.swift

--- a/Sources/Basics/ConcurrencyHelpers.swift
+++ b/Sources/Basics/ConcurrencyHelpers.swift
@@ -41,6 +41,12 @@ public final class ThreadSafeKeyValueStore<Key, Value> where Key: Hashable {
             self.underlying.removeAll()
         }
     }
+
+    public var isEmpty: Bool {
+        self.lock.withLock {
+            self.underlying.isEmpty
+        }
+    }
 }
 
 /// Thread-safe value boxing  structure
@@ -75,7 +81,7 @@ public final class ThreadSafeBox<Value> {
     }
 }
 
-@available(*, deprecated, message: "use non-blocking version instead")
+@available(*, deprecated, message: "replace with async/await when available")
 public func temp_await<T, ErrorType>(_ body: (@escaping (Result<T, ErrorType>) -> Void) -> Void) throws -> T {
     return try tsc_await(body)
 }

--- a/Sources/Basics/ConcurrencyHelpers.swift
+++ b/Sources/Basics/ConcurrencyHelpers.swift
@@ -47,6 +47,12 @@ public final class ThreadSafeKeyValueStore<Key, Value> where Key: Hashable {
             self.underlying.isEmpty
         }
     }
+
+    public func contains(_ key: Key) -> Bool {
+        self.lock.withLock {
+            self.underlying.keys.contains(key)
+        }
+    }
 }
 
 /// Thread-safe value boxing  structure

--- a/Sources/Basics/ConcurrencyHelpers.swift
+++ b/Sources/Basics/ConcurrencyHelpers.swift
@@ -81,7 +81,9 @@ public final class ThreadSafeBox<Value> {
     }
 }
 
-@available(*, deprecated, message: "replace with async/await when available")
+// FIXME: mark as deprecated once async/await is available
+//@available(*, deprecated, message: "replace with async/await when available")
+@inlinable
 public func temp_await<T, ErrorType>(_ body: (@escaping (Result<T, ErrorType>) -> Void) -> Void) throws -> T {
     return try tsc_await(body)
 }

--- a/Sources/Basics/Dictionary+Extensions.swift
+++ b/Sources/Basics/Dictionary+Extensions.swift
@@ -11,14 +11,12 @@ import TSCBasic
 extension Dictionary {
     @inlinable
     @discardableResult
-    public mutating func memoize(key: Key, lock: Lock, body: () throws -> Value) rethrows -> Value {
-        if let value = (lock.withLock { self[key] }) {
+    public mutating func memoize(key: Key, body: () throws -> Value) rethrows -> Value {
+        if let value = self[key] {
             return value
         }
         let value = try body()
-        lock.withLock {
-            self[key] = value
-        }
+        self[key] = value
         return value
     }
 }

--- a/Sources/Basics/Errors.swift
+++ b/Sources/Basics/Errors.swift
@@ -1,0 +1,16 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+public struct InternalError: Error {
+    private let description: String
+    public init(_ description: String) {
+        self.description = description
+    }
+}

--- a/Sources/PackageGraph/PackageContainer.swift
+++ b/Sources/PackageGraph/PackageContainer.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+import Dispatch
 import PackageLoading
 import PackageModel
 import SourceControl
@@ -132,6 +133,7 @@ public protocol PackageContainerProvider {
     func getContainer(
         for identifier: PackageReference,
         skipUpdate: Bool,
+        on queue: DispatchQueue,
         completion: @escaping (Result<PackageContainer, Swift.Error>) -> Void
     )
 }

--- a/Sources/PackageGraph/RepositoryPackageContainer.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainer.swift
@@ -73,7 +73,7 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
 
     /// This is used to remember if tools version of a particular version is
     /// valid or not.
-    public private(set) var validToolsVersionsCache: [Version: Bool] = [:]
+    internal var validToolsVersionsCache = ThreadSafeKeyValueStore<Version, Bool>()
 
     init(
         identifier: PackageReference,

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basics
 import TSCBasic
 import TSCUtility
 import Foundation
@@ -83,10 +84,10 @@ public final class Manifest: ObjectIdentifierProtocol {
     public let providers: [SystemPackageProviderDescription]?
 
     /// Targets required for building particular product filters.
-    private var _requiredTargets: [ProductFilter: [TargetDescription]]
+    private var _requiredTargets = ThreadSafeKeyValueStore<ProductFilter, [TargetDescription]>()
 
     /// Dependencies required for building particular product filters.
-    private var _requiredDependencies: [ProductFilter: [PackageDependencyDescription]]
+    private var _requiredDependencies = ThreadSafeKeyValueStore<ProductFilter, [PackageDependencyDescription]>()
 
     public init(
         name: String,
@@ -125,8 +126,6 @@ public final class Manifest: ObjectIdentifierProtocol {
         self.products = products
         self.targets = targets
         self.targetMap = Dictionary(targets.lazy.map({ ($0.name, $0) }), uniquingKeysWith: { $1 })
-        self._requiredTargets = [:]
-        self._requiredDependencies = [:]
     }
 
     /// Returns the targets required for a particular product filter.
@@ -344,6 +343,12 @@ extension Manifest: CustomStringConvertible {
 }
 
 extension Manifest: Codable {
+    private enum CodingKeys: CodingKey {
+         case name, path, url, version, targetMap, toolsVersion,
+              pkgConfig,providers, cLanguageStandard, cxxLanguageStandard, swiftLanguageVersions,
+              dependencies, products, targets, platforms, packageKind, revision,
+              defaultLocalization
+    }
     /// Coding user info key for dump-package command.
     ///
     /// Presence of this key will hide some keys when encoding the Manifest object.

--- a/Sources/SPMPackageEditor/PackageEditor.swift
+++ b/Sources/SPMPackageEditor/PackageEditor.swift
@@ -71,7 +71,7 @@ public final class PackageEditor {
         } else {
             // Otherwise, first lookup the dependency.
             let spec = RepositorySpecifier(url: options.url)
-            let handle = try tsc_await{ context.repositoryManager.lookup(repository: spec, completion: $0) }
+            let handle = try temp_await{ context.repositoryManager.lookup(repository: spec, completion: $0) }
             let repo = try handle.open()
 
             // Compute the requirement.

--- a/Sources/SPMTestSupport/MockPackageContainer.swift
+++ b/Sources/SPMTestSupport/MockPackageContainer.swift
@@ -116,10 +116,11 @@ public struct MockPackageContainerProvider: PackageContainerProvider {
     public func getContainer(
         for identifier: PackageReference,
         skipUpdate: Bool,
+        on queue: DispatchQueue,
         completion: @escaping (Result<PackageContainer, Swift.Error>
         ) -> Void
     ) {
-        DispatchQueue.global().async {
+        queue.async {
             completion(self.containersByIdentifier[identifier].map { .success($0) } ??
                 .failure(StringError("unknown module \(identifier)")))
         }

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -542,47 +542,66 @@ public final class MockWorkspace {
 }
 
 public final class MockWorkspaceDelegate: WorkspaceDelegate {
-    public var events = [String]()
+    private let lock = Lock()
+    public var _events = [String]()
 
     public init() {}
 
     public func repositoryWillUpdate(_ repository: String) {
-        self.events.append("updating repo: \(repository)")
+        self.append("updating repo: \(repository)")
     }
 
     public func dependenciesUpToDate() {
-        self.events.append("Everything is already up-to-date")
+        self.append("Everything is already up-to-date")
     }
 
     public func fetchingWillBegin(repository: String, fetchDetails: RepositoryManager.FetchDetails?) {
-        self.events.append("fetching repo: \(repository)")
+        self.append("fetching repo: \(repository)")
     }
 
     public func fetchingDidFinish(repository: String, fetchDetails: RepositoryManager.FetchDetails?, diagnostic: Diagnostic?) {
-        self.events.append("finished fetching repo: \(repository)")
+        self.append("finished fetching repo: \(repository)")
     }
 
     public func cloning(repository: String) {
-        self.events.append("cloning repo: \(repository)")
+        self.append("cloning repo: \(repository)")
     }
 
     public func checkingOut(repository: String, atReference reference: String, to path: AbsolutePath) {
-        self.events.append("checking out repo: \(repository)")
+        self.append("checking out repo: \(repository)")
     }
 
     public func removing(repository: String) {
-        self.events.append("removing repo: \(repository)")
+        self.append("removing repo: \(repository)")
     }
 
     public func willResolveDependencies(reason: WorkspaceResolveReason) {
-        self.events.append("will resolve dependencies")
+        self.append("will resolve dependencies")
     }
 
     public func willLoadManifest(packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind) {
-        self.events.append("will load manifest for \(packageKind) package: \(url)")
+        self.append("will load manifest for \(packageKind) package: \(url)")
     }
 
     public func didLoadManifest(packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Diagnostic]) {
-        self.events.append("did load manifest for \(packageKind) package: \(url)")
+        self.append("did load manifest for \(packageKind) package: \(url)")
+    }
+
+    private func append(_ event: String) {
+        self.lock.withLock {
+            self._events.append(event)
+        }
+    }
+
+    public var events: [String] {
+        self.lock.withLock {
+            self._events
+        }
+    }
+
+    public func clear() {
+        self.lock.withLock {
+            self._events = []
+        }
     }
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basics
 import TSCBasic
 import TSCUtility
 import Foundation
@@ -840,8 +841,8 @@ extension Workspace {
             // Otherwise, create a checkout at the destination from our repository store.
             //
             // Get handle to the repository.
-            // FIXE: this should not block
-            let handle = try tsc_await {
+            // TODO: replace with async/await when available
+            let handle = try temp_await {
                 repositoryManager.lookup(repository: dependency.packageRef.repository, skipUpdate: true, on: .global(), completion: $0)
             }
             let repo = try handle.open()
@@ -1629,10 +1630,10 @@ extension Workspace {
         //
         // We just request the packages here, repository manager will
         // automatically manage the parallelism.
+        // FIXME: this should not block
         let pins = pinsStore.pins.map({ $0 })
-        // FIXE: this should not block
         DispatchQueue.concurrentPerform(iterations: pins.count) { idx in
-            _ = try? tsc_await {
+            _ = try? temp_await {
                 containerProvider.getContainer(for: pins[idx].packageRef, skipUpdate: true, on: .global(), completion: $0)
             }
         }
@@ -2074,8 +2075,8 @@ extension Workspace {
 
             case .revision(let identifier, let branch):
                 // Get the latest revision from the container.
-                // FIXME: this should not block
-                let container = try tsc_await {
+                // TODO: replace with async/await when available
+                let container = try temp_await {
                     containerProvider.getContainer(for: packageRef, skipUpdate: true, on: .global(), completion: $0)
                 } as! RepositoryPackageContainer
                 var revision = try container.getRevision(forIdentifier: identifier)
@@ -2302,8 +2303,8 @@ extension Workspace {
         }
 
         // If not, we need to get the repository from the checkouts.
-        // FIXE: this should not block
-        let handle = try tsc_await {
+        // FIXME: this should not block
+        let handle = try temp_await {
             repositoryManager.lookup(repository: package.repository, skipUpdate: true, on: .global(), completion: $0)
         }
 
@@ -2374,8 +2375,8 @@ extension Workspace {
             // way to get it back out of the resolver which is very
             // annoying. Maybe we should make an SPI on the provider for
             // this?
-            // FIXE: this should not block
-            let container = try tsc_await { containerProvider.getContainer(for: package, skipUpdate: true, on: .global(), completion: $0) } as! RepositoryPackageContainer
+            // FIXME: this should not block
+            let container = try temp_await { containerProvider.getContainer(for: package, skipUpdate: true, on: .global(), completion: $0) } as! RepositoryPackageContainer
             guard let tag = container.getTag(for: version) else {
                 throw StringError("Internal error: please file a bug at https://bugs.swift.org with this info -- unable to get tag for \(package) \(version); available versions \(try container.reversedVersions())")
             }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -840,8 +840,9 @@ extension Workspace {
             // Otherwise, create a checkout at the destination from our repository store.
             //
             // Get handle to the repository.
+            // FIXE: this should not block
             let handle = try tsc_await {
-                repositoryManager.lookup(repository: dependency.packageRef.repository, skipUpdate: true, completion: $0)
+                repositoryManager.lookup(repository: dependency.packageRef.repository, skipUpdate: true, on: .global(), completion: $0)
             }
             let repo = try handle.open()
 
@@ -1629,9 +1630,10 @@ extension Workspace {
         // We just request the packages here, repository manager will
         // automatically manage the parallelism.
         let pins = pinsStore.pins.map({ $0 })
+        // FIXE: this should not block
         DispatchQueue.concurrentPerform(iterations: pins.count) { idx in
             _ = try? tsc_await {
-                containerProvider.getContainer(for: pins[idx].packageRef, skipUpdate: true, completion: $0)
+                containerProvider.getContainer(for: pins[idx].packageRef, skipUpdate: true, on: .global(), completion: $0)
             }
         }
 
@@ -2072,8 +2074,9 @@ extension Workspace {
 
             case .revision(let identifier, let branch):
                 // Get the latest revision from the container.
+                // FIXME: this should not block
                 let container = try tsc_await {
-                    containerProvider.getContainer(for: packageRef, skipUpdate: true, completion: $0)
+                    containerProvider.getContainer(for: packageRef, skipUpdate: true, on: .global(), completion: $0)
                 } as! RepositoryPackageContainer
                 var revision = try container.getRevision(forIdentifier: identifier)
                 let branch = branch ?? (identifier == revision.identifier ? nil : identifier)
@@ -2299,8 +2302,9 @@ extension Workspace {
         }
 
         // If not, we need to get the repository from the checkouts.
+        // FIXE: this should not block
         let handle = try tsc_await {
-            repositoryManager.lookup(repository: package.repository, skipUpdate: true, completion: $0)
+            repositoryManager.lookup(repository: package.repository, skipUpdate: true, on: .global(), completion: $0)
         }
 
         // Clone the repository into the checkouts.
@@ -2370,7 +2374,8 @@ extension Workspace {
             // way to get it back out of the resolver which is very
             // annoying. Maybe we should make an SPI on the provider for
             // this?
-            let container = try tsc_await { containerProvider.getContainer(for: package, skipUpdate: true, completion: $0) } as! RepositoryPackageContainer
+            // FIXE: this should not block
+            let container = try tsc_await { containerProvider.getContainer(for: package, skipUpdate: true, on: .global(), completion: $0) } as! RepositoryPackageContainer
             guard let tag = container.getTag(for: version) else {
                 throw StringError("Internal error: please file a bug at https://bugs.swift.org with this info -- unable to get tag for \(package) \(version); available versions \(try container.reversedVersions())")
             }

--- a/Tests/BasicsTests/ConcurrencyHelpersTests.swift
+++ b/Tests/BasicsTests/ConcurrencyHelpersTests.swift
@@ -23,7 +23,7 @@ final class ConcurrencyHelpersTest: XCTestCase {
             var expected = [Int: Int]()
             let lock = Lock()
 
-            var cache = ThreadSafeKeyValueStore<Int, Int>()
+            let cache = ThreadSafeKeyValueStore<Int, Int>()
             for index in 0 ..< 1000 {
                 self.queue.async(group: sync) {
                     usleep(UInt32.random(in: 100 ... 300))
@@ -60,7 +60,7 @@ final class ConcurrencyHelpersTest: XCTestCase {
 
             let serial = DispatchQueue(label: "testThreadSafeBoxSerial")
 
-            var cache = ThreadSafeBox<Int>()
+            let cache = ThreadSafeBox<Int>()
             for index in 0 ..< 1000 {
                 self.queue.async(group: sync) {
                     usleep(UInt32.random(in: 100 ... 300))

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -334,12 +334,12 @@ final class PubgrubTests: XCTestCase {
         XCTAssertThrowsError(try solver1.resolve(state: state1, conflict: notRoot))
     }
 
-    func testResolverDecisionMaking() {
+    func testResolverDecisionMaking() throws {
         let solver1 = PubgrubDependencyResolver(provider: emptyProvider)
         let state1 = PubgrubDependencyResolver.State(root: rootNode)
 
         // No decision can be made if no unsatisfied terms are available.
-        XCTAssertNil(try solver1.makeDecision(state: state1))
+        XCTAssertNil(try tsc_await { solver1.makeDecision(state: state1, completion: $0) })
 
         let a = MockContainer(name: aRef, dependenciesByVersion: [
             "0.0.0": [:],
@@ -355,7 +355,7 @@ final class PubgrubTests: XCTestCase {
 
         XCTAssertEqual(state2.incompatibilities.count, 0)
 
-        let decision = try! solver2.makeDecision(state: state2)
+        let decision = try tsc_await { solver2.makeDecision(state: state2, completion: $0) }
         XCTAssertEqual(decision, .product("a", package: "a"))
 
         XCTAssertEqual(state2.incompatibilities.count, 3)

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -10,7 +10,8 @@
 
 import XCTest
 
-import PackageGraph
+import Basics
+@testable import PackageGraph
 import PackageLoading
 import PackageModel
 import SourceControl
@@ -241,10 +242,13 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         do {
             let provider = createProvider(ToolsVersion(version: "4.2.0"))
             let ref = PackageReference(identity: PackageIdentity(url: specifier.url), path: specifier.url)
-            let container = try provider.getContainer(for: ref, skipUpdate: false)
-            XCTAssertEqual((container as! RepositoryPackageContainer).validToolsVersionsCache, [:])
+            let container = try provider.getContainer(for: ref, skipUpdate: false) as! RepositoryPackageContainer
+            XCTAssertTrue(container.validToolsVersionsCache.isEmpty)
             let v = try container.versions(filter: { _ in true }).map { $0 }
-            XCTAssertEqual((container as! RepositoryPackageContainer).validToolsVersionsCache, ["1.0.1": true, "1.0.0": false, "1.0.3": true, "1.0.2": true])
+            XCTAssertEqual(container.validToolsVersionsCache["1.0.0"], false)
+            XCTAssertEqual(container.validToolsVersionsCache["1.0.1"], true)
+            XCTAssertEqual(container.validToolsVersionsCache["1.0.2"], true)
+            XCTAssertEqual(container.validToolsVersionsCache["1.0.3"], true)
             XCTAssertEqual(v, ["1.0.3", "1.0.2", "1.0.1"])
         }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -596,7 +596,7 @@ final class WorkspaceTests: XCTestCase {
         XCTAssertMatch(workspace.delegate.events, [.equal("will resolve dependencies")])
 
         // Now load with Baz as a root package.
-        workspace.delegate.events = []
+        workspace.delegate.clear()
         workspace.checkPackageGraph(roots: ["Foo", "Baz"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "Baz", "Foo")
@@ -2791,7 +2791,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkUpdate(roots: ["Root"]) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
-        workspace.delegate.events = []
+        workspace.delegate.clear()
 
         // Check we don't have updating Foo event.
         workspace.checkUpdate(roots: ["Root"]) { diagnostics in
@@ -4054,7 +4054,7 @@ final class WorkspaceTests: XCTestCase {
             workspace.manifestLoader.manifests[editedFooKey] = manifest
         }
         XCTAssertMatch(workspace.delegate.events, [.equal("will resolve dependencies")])
-        workspace.delegate.events.removeAll()
+        workspace.delegate.clear()
 
         workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)


### PR DESCRIPTION
motivation: improve performance of dependency resolution

changes:
* pubgrub manages a concurrent queue that is passed to the container providers
* start prefetching dependencies as soon as we discover them 
* refractor pubgrub to do work in parallel where possible (e.g. version counts and bound calculation)
* serialize writing to output stream in SwifTool since now delegate callbacks can be concurrent 

⚠️ Interesting parts highlighted with 👀 
⚠️  This PR already improve performance, but there is more that can be done which I'd like to do after this is merged