### PR TITLE
HTTPClient Enhancements

### DIFF
--- a/Sources/Basics/HTPClient+URLSession.swift
+++ b/Sources/Basics/HTPClient+URLSession.swift
@@ -8,14 +8,14 @@ import struct TSCUtility.Versioning
 import FoundationNetworking
 #endif
 
-public struct URLSessionHTTPClient {
+public struct URLSessionHTTPClient: HTTPClientProtocol {
     private let configuration: URLSessionConfiguration
 
     public init(configuration: URLSessionConfiguration = .default) {
         self.configuration = configuration
     }
 
-    public func execute(request: HTTPClient.Request, callback: @escaping (Result<HTTPClient.Response, Error>) -> Void) {
+    public func execute(_ request: HTTPClient.Request, callback: @escaping (Result<HTTPClient.Response, Error>) -> Void) {
         let session = URLSession(configuration: self.configuration)
         let task = session.dataTask(with: request.urlRequest()) { data, response, error in
             if let error = error {

--- a/Sources/Basics/HTTPClient.swift
+++ b/Sources/Basics/HTTPClient.swift
@@ -359,6 +359,12 @@ public struct HTTPClientHeaders: Sequence, Equatable {
     }
 }
 
+extension HTTPClientHeaders: ExpressibleByDictionaryLiteral {
+    public init(dictionaryLiteral elements: (String, String)...) {
+        self.init(elements.map(Item.init))
+    }
+}
+
 public enum HTTPClientError: Error, Equatable {
     case invalidResponse
     case badResponseStatusCode(Int)

--- a/Sources/Basics/HTTPClient.swift
+++ b/Sources/Basics/HTTPClient.swift
@@ -24,9 +24,13 @@ import Glibc
 import CRT
 #endif
 
+public protocol HTTPClientProtocol {
+    func execute(_ request: HTTPClientRequest, callback: @escaping (Result<HTTPClientResponse, Error>) -> Void)
+}
+
 // MARK: - HTTPClient
 
-public struct HTTPClient {
+public struct HTTPClient: HTTPClientProtocol {
     public typealias Configuration = HTTPClientConfiguration
     public typealias Request = HTTPClientRequest
     public typealias Response = HTTPClientResponse


### PR DESCRIPTION
A couple of improvements to `HTTPClient` in support of the Swift package registry implementation (#3023). 

### Motivation:

I want to use `URLProtocol` to test the HTTP client that interacts against a mock package registry server. However, it's not currently possible to access the underlying `URLSession` of an `HTTPClient` to configure the URL protocol. 

### Modifications:

This PR introduces a `HTTPClientProtocol` protocol that provides the minimal amount of dependency injection necessary to make this work.

In addition, this PR conforms `HTTPClientHeaders` to be `ExpressibleByDictionaryLiteral` and reorganizes some declarations in `HTTPClient.swift`. These changes (8385b794c44b1cedde4d778c504ab4a65ef35087 and c5717b04167b6e27585c5ffe21ec009b5af032ab) are entirely severable, and you're welcome to ignore them. 

### Result:

As a result of merging this PR, we'll be able to test `HTTPClient` instances using mocked responses from custom `URLProtocol` subclasses.