### PR TITLE
Rename the `tags()` functions of Repository and of WorkingCheckout to `getTags()`

### DIFF
--- a/Sources/PackageGraph/RepositoryPackageContainer.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainer.swift
@@ -94,7 +94,7 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
     // Compute the map of known versions.
     private func knownVersions() throws -> [Version: String] {
         try self.knownVersionsCache.memoize() {
-            let knownVersionsWithDuplicates = Git.convertTagsToVersionMap(try repository.tags())
+            let knownVersionsWithDuplicates = Git.convertTagsToVersionMap(try repository.getTags())
 
             return knownVersionsWithDuplicates.mapValues({ tags -> String in
                 if tags.count == 2 {

--- a/Sources/SPMTestSupport/InMemoryGitRepository.swift
+++ b/Sources/SPMTestSupport/InMemoryGitRepository.swift
@@ -57,7 +57,7 @@ public final class InMemoryGitRepository {
     fileprivate var tagsMap: [String: RevisionIdentifier] = [:]
 
     /// The array of current tags in the repository.
-    public func tags() throws -> [String] {
+    public func getTags() throws -> [String] {
         return Array(tagsMap.keys)
     }
 

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -320,7 +320,7 @@ public final class GitRepository: Repository, WorkingCheckout {
     // MARK: Repository Interface
 
     /// Returns the tags present in repository.
-    public func tags() throws -> [String] {
+    public func getTags() throws -> [String] {
         // Get the contents using `ls-tree`.
         try self.cachedTags.memoize {
             try self.queue.sync {

--- a/Sources/SourceControl/Repository.swift
+++ b/Sources/SourceControl/Repository.swift
@@ -157,7 +157,7 @@ extension RepositoryProvider {
 /// an inconsistency can be detected.
 public protocol Repository {
     /// Get the list of tags in the repository.
-    func tags() throws -> [String]
+    func getTags() throws -> [String]
 
     /// Resolve the revision for a specific tag.
     ///
@@ -201,7 +201,7 @@ public protocol Repository {
 /// system.
 public protocol WorkingCheckout {
     /// Get the list of tags in the repository.
-    func tags() throws -> [String]
+    func getTags() throws -> [String]
 
     /// Get the current revision.
     func getCurrentRevision() throws -> Revision

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -136,7 +136,7 @@ final class PackageToolTests: XCTestCase {
             // Check that `resolve` works.
             _ = try execute(["resolve"], packagePath: packageRoot)
             let path = try SwiftPMProduct.packagePath(for: "Foo", packageRoot: packageRoot)
-            XCTAssertEqual(try GitRepository(path: path).tags(), ["1.2.3"])
+            XCTAssertEqual(try GitRepository(path: path).getTags(), ["1.2.3"])
         }
     }
 
@@ -147,7 +147,7 @@ final class PackageToolTests: XCTestCase {
             // Perform an initial fetch.
             _ = try execute(["resolve"], packagePath: packageRoot)
             var path = try SwiftPMProduct.packagePath(for: "Foo", packageRoot: packageRoot)
-            XCTAssertEqual(try GitRepository(path: path).tags(), ["1.2.3"])
+            XCTAssertEqual(try GitRepository(path: path).getTags(), ["1.2.3"])
 
             // Retag the dependency, and update.
             let repo = GitRepository(path: prefix.appending(component: "Foo"))
@@ -156,7 +156,7 @@ final class PackageToolTests: XCTestCase {
 
             // We shouldn't assume package path will be same after an update so ask again for it.
             path = try SwiftPMProduct.packagePath(for: "Foo", packageRoot: packageRoot)
-            XCTAssertEqual(try GitRepository(path: path).tags(), ["1.2.3", "1.2.4"])
+            XCTAssertEqual(try GitRepository(path: path).getTags(), ["1.2.3", "1.2.4"])
         }
     }
 

--- a/Tests/FunctionalTests/CFamilyTargetTests.swift
+++ b/Tests/FunctionalTests/CFamilyTargetTests.swift
@@ -50,7 +50,7 @@ class CFamilyTargetTestCase: XCTestCase {
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Sea.c.o")
             XCTAssertDirectoryContainsFile(dir: debugPath, filename: "Foo.c.o")
             let path = try SwiftPMProduct.packagePath(for: "Foo", packageRoot: packageRoot)
-            XCTAssertEqual(try GitRepository(path: path).tags(), ["1.2.3"])
+            XCTAssertEqual(try GitRepository(path: path).getTags(), ["1.2.3"])
         }
     }
 

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -54,7 +54,7 @@ class DependencyResolutionTests: XCTestCase {
             XCTAssertBuilds(packageRoot)
             XCTAssertFileExists(prefix.appending(components: "Bar", ".build", Resources.default.toolchain.triple.tripleString, "debug", "Bar"))
             let path = try SwiftPMProduct.packagePath(for: "Foo", packageRoot: packageRoot)
-            XCTAssert(try GitRepository(path: path).tags().contains("1.2.3"))
+            XCTAssert(try GitRepository(path: path).getTags().contains("1.2.3"))
         }
     }
 

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -42,7 +42,7 @@ private class MockRepository: Repository {
         return PackageReference(identity: PackageIdentity(url: self.url), path: self.url)
     }
 
-    func tags() throws -> [String] {
+    func getTags() throws -> [String] {
         return self.versions.keys.map { String(describing: $0) }
     }
 

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -47,8 +47,8 @@ class GitRepositoryTests: XCTestCase {
 
             // Test the repository interface.
             let repository = provider.open(repository: repoSpec, at: testCheckoutPath)
-            let tags = try repository.tags()
-            XCTAssertEqual(try repository.tags(), ["1.2.3"])
+            let tags = try repository.getTags()
+            XCTAssertEqual(try repository.getTags(), ["1.2.3"])
 
             let revision = try repository.resolveRevision(tag: tags.first ?? "<invalid>")
             // FIXME: It would be nice if we had a deterministic hash here...
@@ -300,7 +300,7 @@ class GitRepositoryTests: XCTestCase {
             try makeDirectories(testRepoPath)
             initGitRepo(testRepoPath, tag: "1.2.3")
             let repo = GitRepository(path: testRepoPath)
-            XCTAssertEqual(try repo.tags(), ["1.2.3"])
+            XCTAssertEqual(try repo.getTags(), ["1.2.3"])
 
             // Clone it somewhere.
             let testClonePath = path.appending(component: "clone")
@@ -308,13 +308,13 @@ class GitRepositoryTests: XCTestCase {
             let repoSpec = RepositorySpecifier(url: testRepoPath.pathString)
             try provider.fetch(repository: repoSpec, to: testClonePath)
             let clonedRepo = provider.open(repository: repoSpec, at: testClonePath)
-            XCTAssertEqual(try clonedRepo.tags(), ["1.2.3"])
+            XCTAssertEqual(try clonedRepo.getTags(), ["1.2.3"])
 
             // Clone off a checkout.
             let checkoutPath = path.appending(component: "checkout")
             try provider.cloneCheckout(repository: repoSpec, at: testClonePath, to: checkoutPath, editable: false)
             let checkoutRepo = try provider.openCheckout(at: checkoutPath)
-            XCTAssertEqual(try checkoutRepo.tags(), ["1.2.3"])
+            XCTAssertEqual(try checkoutRepo.getTags(), ["1.2.3"])
 
             // Add a new file to original repo.
             try localFileSystem.writeFileContents(testRepoPath.appending(component: "test.txt"), bytes: "Hi")
@@ -325,11 +325,11 @@ class GitRepositoryTests: XCTestCase {
 
             // Update the cloned repo.
             try clonedRepo.fetch()
-            XCTAssertEqual(try clonedRepo.tags().sorted(), ["1.2.3", "2.0.0"])
+            XCTAssertEqual(try clonedRepo.getTags().sorted(), ["1.2.3", "2.0.0"])
 
             // Update the checkout.
             try checkoutRepo.fetch()
-            XCTAssertEqual(try checkoutRepo.tags().sorted(), ["1.2.3", "2.0.0"])
+            XCTAssertEqual(try checkoutRepo.getTags().sorted(), ["1.2.3", "2.0.0"])
         }
     }
 
@@ -588,7 +588,7 @@ class GitRepositoryTests: XCTestCase {
             try makeDirectories(testRepoPath)
             initGitRepo(testRepoPath, tag: "1.2.3")
             let repo = GitRepository(path: testRepoPath)
-            XCTAssertEqual(try repo.tags(), ["1.2.3"])
+            XCTAssertEqual(try repo.getTags(), ["1.2.3"])
 
             // Clone it somewhere.
             let testClonePath = path.appending(component: "clone")
@@ -596,7 +596,7 @@ class GitRepositoryTests: XCTestCase {
             let repoSpec = RepositorySpecifier(url: testRepoPath.pathString)
             try provider.fetch(repository: repoSpec, to: testClonePath)
             let clonedRepo = provider.open(repository: repoSpec, at: testClonePath)
-            XCTAssertEqual(try clonedRepo.tags(), ["1.2.3"])
+            XCTAssertEqual(try clonedRepo.getTags(), ["1.2.3"])
 
             // Clone off a checkout.
             let checkoutPath = path.appending(component: "checkout")
@@ -670,7 +670,7 @@ class GitRepositoryTests: XCTestCase {
             let repoSpec = RepositorySpecifier(url: testRepoPath.pathString)
             try provider.fetch(repository: repoSpec, to: testClonePath)
             let clonedRepo = provider.open(repository: repoSpec, at: testClonePath)
-            XCTAssertEqual(try clonedRepo.tags(), [])
+            XCTAssertEqual(try clonedRepo.getTags(), [])
 
             // Clone off a checkout.
             let checkoutPath = path.appending(component: "checkout")

--- a/Tests/SourceControlTests/InMemoryGitRepositoryTests.swift
+++ b/Tests/SourceControlTests/InMemoryGitRepositoryTests.swift
@@ -56,9 +56,9 @@ class InMemoryGitRepositoryTests: XCTestCase {
         XCTAssertTrue(!repo.hasUncommittedChanges())
         XCTAssertEqual(try repo.readFileContents(filePath), "two")
 
-        XCTAssert(try repo.tags().isEmpty)
+        XCTAssert(try repo.getTags().isEmpty)
         try repo.tag(name: "2.0.0")
-        XCTAssertEqual(try repo.tags(), ["2.0.0"])
+        XCTAssertEqual(try repo.getTags(), ["2.0.0"])
         XCTAssertTrue(!repo.hasUncommittedChanges())
         XCTAssertEqual(try repo.readFileContents(filePath), "two")
         XCTAssertEqual(try fs.readFileContents(filePath), "two")
@@ -96,7 +96,7 @@ class InMemoryGitRepositoryTests: XCTestCase {
 
         // Adding a new tag in original repo shouldn't show up in fetched repo.
         try repo.tag(name: "random")
-        XCTAssertEqual(try fooRepo.tags().sorted(), [v1, v2])
+        XCTAssertEqual(try fooRepo.getTags().sorted(), [v1, v2])
         XCTAssert(fooRepo.exists(revision: try fooRepo.resolveRevision(tag: v1)))
 
         let fooCheckoutPath = AbsolutePath("/fooCheckout")
@@ -105,7 +105,7 @@ class InMemoryGitRepositoryTests: XCTestCase {
         XCTAssertTrue(try provider.checkoutExists(at: fooCheckoutPath))
         let fooCheckout = try provider.openCheckout(at: fooCheckoutPath)
 
-        XCTAssertEqual(try fooCheckout.tags().sorted(), [v1, v2])
+        XCTAssertEqual(try fooCheckout.getTags().sorted(), [v1, v2])
         XCTAssert(fooCheckout.exists(revision: try fooCheckout.getCurrentRevision()))
         let checkoutRepo = provider.openRepo(at: fooCheckoutPath)
 

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -32,7 +32,7 @@ private class DummyRepository: Repository {
         self.provider = provider
     }
     
-    func tags() throws -> [String] {
+    func getTags() throws -> [String] {
         ["1.0.0"]
     }
 
@@ -191,7 +191,7 @@ class RepositoryManagerTests: XCTestCase {
             
                 // Open the repository.
                 let repository = try! handle.open()
-                XCTAssertEqual(try! repository.tags(), ["1.0.0"])
+                XCTAssertEqual(try! repository.getTags(), ["1.0.0"])
 
                 // Create a checkout of the repository.
                 let checkoutPath = path.appending(component: "checkout")


### PR DESCRIPTION
Rename the `tags()` functions of Repository and of WorkingCheckout to `getTags()`.  Until recently this was a property called `tags`, but now that it’s a function it makes more sense to call it `getTags()`.

### Motivation:

This makes it more consistent with all the other functions, which have a verb at the start (including the `getCurrentRevision()` function), but more importantly this makes it easier for clients to adopt to the change (having a property change to a method without changing name makes it difficult for a type that adopts the protocol to conform to both).

### Modifications:

Renamed the function in protocols and clients.

### Result:

No change in functionality but more consistent naming and easier transition for clients.