### PR TITLE
Keep revision from resolved file during resolution

### DIFF
--- a/Sources/PackageGraph/BoundVersion.swift
+++ b/Sources/PackageGraph/BoundVersion.swift
@@ -26,7 +26,7 @@ public enum BoundVersion: Equatable, Hashable {
     case unversioned
 
     /// The package assignment is this revision.
-    case revision(String)
+    case revision(String, branch: String? = nil)
 }
 
 extension BoundVersion: CustomStringConvertible {
@@ -38,7 +38,7 @@ extension BoundVersion: CustomStringConvertible {
             return version.description
         case .unversioned:
             return "unversioned"
-        case .revision(let identifier):
+        case .revision(let identifier, _):
             return identifier
         }
     }

--- a/Sources/PackageGraph/RepositoryPackageContainer.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainer.swift
@@ -243,7 +243,7 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
             }
             version = v
             revision = try repository.resolveRevision(tag: tag)
-        case .revision(let identifier):
+        case .revision(let identifier, _):
             revision = try repository.resolveRevision(identifier: identifier)
         case .unversioned, .excluded:
             assertionFailure("Unexpected type requirement \(boundVersion)")

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2070,13 +2070,13 @@ extension Workspace {
                     packageStateChanges[packageRef.path] = (packageRef, .added(newState))
                 }
 
-            case .revision(let identifier):
+            case .revision(let identifier, let branch):
                 // Get the latest revision from the container.
                 let container = try tsc_await {
                     containerProvider.getContainer(for: packageRef, skipUpdate: true, completion: $0)
                 } as! RepositoryPackageContainer
                 var revision = try container.getRevision(forIdentifier: identifier)
-                let branch = identifier == revision.identifier ? nil : identifier
+                let branch = branch ?? (identifier == revision.identifier ? nil : identifier)
 
                 // If we have a branch and we shouldn't be updating the
                 // branches, use the revision from pin instead (if present).

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -1040,8 +1040,8 @@ final class PubgrubTests: XCTestCase {
         let result = resolver.solve(constraints: dependencies)
 
         AssertResult(result, [
-            ("a", .revision("develop")),
-            ("b", .revision("master")),
+            ("a", .revision("develop-sha-1", branch: "develop")),
+            ("b", .revision("master-sha-2", branch: "master")),
         ])
     }
 


### PR DESCRIPTION
### Motivation:

It looks like the pubgrub resolver did not actually keep the revision of branch-based dependencies around during resolution. I found this when testing individual `swift package update` when branch-based dependencies were involved, but there might be more cases where this lead to us updating the resolved file unconditionally. In particular, it seems as if the recorded revision was used to determine dependencies which could have potentially caused inconsistencies when not actually using that revision in practice.

### Modifications:

- add an optional `branch` parameter to `BoundVersion` to represent a particular revision of a branch-based dependency
- use this to keep the revision from `pinsMap` in `PubgrubDependencyResolver` if needed
- adjusted expected result of `testBranchedBasedPin`, this was testing exactly this scenario, but it seems as if the expected results were wrong, since they were expecting branches instead of the actual revisions

### Result:

Keep revision from resolved file during resolution which fixes `swift package update $package-name` in cases with any branch-based dependencies. Might also fix other issues were we were eagerly updating branch-based dependencies without cause.

rdar://64230888
