### PR TITLE
Better error messages when trying to import executable targets

### DIFF
--- a/Fixtures/Miscellaneous/ExeTest/Package.swift
+++ b/Fixtures/Miscellaneous/ExeTest/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "ExeTest",
+    targets: [
+        .target(
+            name: "Exe",
+            dependencies: []
+        ),
+        .testTarget(
+            name: "ExeTests",
+            dependencies: ["Exe"]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/ExeTest/Sources/Exe/main.swift
+++ b/Fixtures/Miscellaneous/ExeTest/Sources/Exe/main.swift
@@ -1,0 +1,5 @@
+public func GetGreeting() -> String {
+    return "Hello"
+}
+
+print("\(GetGreeting()), world!")

--- a/Fixtures/Miscellaneous/ExeTest/Tests/ExeTests/ExeTests.swift
+++ b/Fixtures/Miscellaneous/ExeTest/Tests/ExeTests/ExeTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+import Exe
+
+final class ExeTestTests: XCTestCase {
+    
+    func testExample() throws {
+        // This is an example of a test case that tries to imports an executable target.
+        XCTAssertEqual(Exe.GetGreeting(), "Hello")
+    }
+
+    static var allTests = [
+        ("testExample", testExample),
+    ]
+}

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -502,7 +502,8 @@ public final class SwiftTargetBuildDescription {
 
     /// The path to the swiftmodule file after compilation.
     var moduleOutputPath: AbsolutePath {
-        return buildParameters.buildPath.appending(component: target.c99name + ".swiftmodule")
+        let dirPath = (target.type == .executable) ? tempsPath : buildParameters.buildPath
+        return dirPath.appending(component: target.c99name + ".swiftmodule")
     }
 
     /// The path to the wrapped swift module which is created using the modulewrap tool. This is required

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -143,7 +143,7 @@ final class BuildPlanTests: XCTestCase {
             "@/path/to/build/debug/exe.product/Objects.LinkFileList",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift/macosx",
             "-target", "x86_64-apple-macosx10.10", "-Xlinker", "-add_ast_path",
-            "-Xlinker", "/path/to/build/debug/exe.swiftmodule", "-Xlinker", "-add_ast_path",
+            "-Xlinker", "/path/to/build/debug/exe.build/exe.swiftmodule", "-Xlinker", "-add_ast_path",
             "-Xlinker", "/path/to/build/debug/lib.swiftmodule",
         ]
       #else
@@ -784,7 +784,7 @@ final class BuildPlanTests: XCTestCase {
             "@/path/to/build/debug/exe.product/Objects.LinkFileList",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift/macosx",
             "-target", "x86_64-apple-macosx10.10",
-            "-Xlinker", "-add_ast_path", "-Xlinker", "/path/to/build/debug/exe.swiftmodule",
+            "-Xlinker", "-add_ast_path", "-Xlinker", "/path/to/build/debug/exe.build/exe.swiftmodule",
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
@@ -994,7 +994,7 @@ final class BuildPlanTests: XCTestCase {
             "@/path/to/build/debug/exe.product/Objects.LinkFileList",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift/macosx",
             "-target", "x86_64-apple-macosx10.10",
-            "-Xlinker", "-add_ast_path", "-Xlinker", "/path/to/build/debug/exe.swiftmodule",
+            "-Xlinker", "-add_ast_path", "-Xlinker", "/path/to/build/debug/exe.build/exe.swiftmodule",
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
@@ -1092,7 +1092,7 @@ final class BuildPlanTests: XCTestCase {
             "@/path/to/build/debug/Foo.product/Objects.LinkFileList",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift/macosx",
             "-target", "x86_64-apple-macosx10.10",
-            "-Xlinker", "-add_ast_path", "-Xlinker", "/path/to/build/debug/Foo.swiftmodule"
+            "-Xlinker", "-add_ast_path", "-Xlinker", "/path/to/build/debug/Foo.build/Foo.swiftmodule"
         ])
 
         XCTAssertEqual(barLinkArgs, [
@@ -2339,10 +2339,10 @@ final class BuildPlanTests: XCTestCase {
             XCTAssertMatch(contents, .contains("""
                   "/path/to/build/debug/exe.build/exe.swiftmodule.o":
                     tool: shell
-                    inputs: ["/path/to/build/debug/exe.swiftmodule"]
+                    inputs: ["/path/to/build/debug/exe.build/exe.swiftmodule"]
                     outputs: ["/path/to/build/debug/exe.build/exe.swiftmodule.o"]
                     description: "Wrapping AST for exe for debugging"
-                    args: ["/fake/path/to/swiftc","-modulewrap","/path/to/build/debug/exe.swiftmodule","-o","/path/to/build/debug/exe.build/exe.swiftmodule.o","-target","x86_64-unknown-linux-gnu"]
+                    args: ["/fake/path/to/swiftc","-modulewrap","/path/to/build/debug/exe.build/exe.swiftmodule","-o","/path/to/build/debug/exe.build/exe.swiftmodule.o","-target","x86_64-unknown-linux-gnu"]
                 """))
             XCTAssertMatch(contents, .contains("""
                   "/path/to/build/debug/lib.build/lib.swiftmodule.o":

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -513,4 +513,26 @@ class MiscellaneousTestCase: XCTestCase {
             XCTAssertMatch(stderr, .contains("warning: '--generate-linuxmain' option is deprecated"))
         }
     }
+    
+    func testErrorMessageWhenTestLinksExecutable() {
+        fixture(name: "Miscellaneous/ExeTest") { prefix in
+            do {
+                try executeSwiftTest(prefix)
+                XCTFail()
+            } catch SwiftPMProductError.executionFailure(let error, let output, let stderr) {
+                XCTAssertMatch(stderr + output, .contains("Compiling Exe main.swift"))
+                XCTAssertMatch(stderr + output, .contains("Compiling ExeTests ExeTests.swift"))
+                XCTAssertMatch(stderr + output, .regex("error: no such module 'Exe'"))
+
+                if case ProcessResult.Error.nonZeroExit(let result) = error {
+                    // if our code crashes we'll get an exit code of 256
+                    XCTAssertEqual(result.exitStatus, .terminated(code: 1))
+                } else {
+                    XCTFail("\(stderr + output)")
+                }
+            } catch {
+                XCTFail()
+            }
+        }
+    }
 }

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -90,7 +90,7 @@ class InitTests: XCTestCase {
             let triple = Resources.default.toolchain.triple
             let binPath = path.appending(components: ".build", triple.tripleString, "debug")
             XCTAssertFileExists(binPath.appending(component: "Foo"))
-            XCTAssertFileExists(binPath.appending(component: "Foo.swiftmodule"))
+            XCTAssertFileExists(binPath.appending(components: "Foo.build", "Foo.swiftmodule"))
         }
     }
 


### PR DESCRIPTION
Improves the error messages that result from trying to import and link against executable targets.  This is an interim step while working on support for testing executable targets.

### Motivation:

When a unit test (or another target) imports the module for an executable target, the error emitted is quite bad.  This is because the module for the executable target is actually emitted into a directory where the compiler finds it, but then the linking fails because the corresponding object files aren't passed to the linker (which is because of symbol name collisions — see below).  So the result is a linker error complaining about missing symbols, rather than at least a module import error and ideally a specific message about why the module isn't available.

### Discussion:

Ideally, tests should be able to import executable modules and test the code in them.  There are some complications with that, because the `.o` file for an executable target has a `_main` symbol, which collides with the one for the test itself on non-Darwin platforms (tests are bundles on Darwin platforms but executables on other platforms).  This makes them unsuitable to be linked into the test executable in their current form.

### Modifications:

Until that is addressed, the error message that is shown when trying to import an executable module should at least be improved.  The first commit changes where modules for non-library compiled targets (currently executables and targets) are emitted so that the compiler doesn't see them.

A later commit will add more specific error messages indicating specifically that executable modules can't be imported or linked against by other kinds of targets.

Later, when the issue with the `_main` collision has been addressed, the module for the executable target can be moved to the main build directory again.

### Result:

Better error messages when trying to import executable or test targets.

This is a work in progress, which still needs:
- customized diagnostics based on looking at the failure message and the name of the module imported
