### PR TITLE
Allow tests to link against executable targets

### DIFF
--- a/Fixtures/Miscellaneous/ExeTest/Sources/Exe/Other.swift
+++ b/Fixtures/Miscellaneous/ExeTest/Sources/Exe/Other.swift
@@ -1,0 +1,3 @@
+public func GetOtherString() -> String {
+    return "Other"
+}

--- a/Fixtures/Miscellaneous/ExeTest/Tests/ExeTests/ExeTests.swift
+++ b/Fixtures/Miscellaneous/ExeTest/Tests/ExeTests/ExeTests.swift
@@ -6,6 +6,7 @@ final class ExeTestTests: XCTestCase {
     func testExample() throws {
         // This is an example of a test case that tries to imports an executable target.
         XCTAssertEqual(Exe.GetGreeting(), "Hello")
+        XCTAssertEqual(Exe.GetOtherString(), "Hello")
     }
 
     static var allTests = [

--- a/Fixtures/Miscellaneous/TestableExe/Package.swift
+++ b/Fixtures/Miscellaneous/TestableExe/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "TestableExe",
+    targets: [
+        .target(
+            name: "TestableExe1"
+        ),
+        .target(
+            name: "TestableExe2"
+        ),
+        .target(
+            name: "TestableExe3"
+        ),
+        .testTarget(
+            name: "TestableExeTests",
+            dependencies: [
+                "TestableExe1",
+                "TestableExe2",
+                "TestableExe3",
+            ]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/TestableExe/Sources/TestableExe1/main.swift
+++ b/Fixtures/Miscellaneous/TestableExe/Sources/TestableExe1/main.swift
@@ -1,0 +1,5 @@
+public func GetGreeting1() -> String {
+    return "Hello, world"
+}
+
+print("\(GetGreeting1())!")

--- a/Fixtures/Miscellaneous/TestableExe/Sources/TestableExe2/main.swift
+++ b/Fixtures/Miscellaneous/TestableExe/Sources/TestableExe2/main.swift
@@ -1,0 +1,5 @@
+public func GetGreeting2() -> String {
+    return "Hello, planet"
+}
+
+print("\(GetGreeting2())!")

--- a/Fixtures/Miscellaneous/TestableExe/Sources/TestableExe3/include/TestableExe3.h
+++ b/Fixtures/Miscellaneous/TestableExe/Sources/TestableExe3/include/TestableExe3.h
@@ -1,0 +1,1 @@
+const char * GetGreeting3();

--- a/Fixtures/Miscellaneous/TestableExe/Sources/TestableExe3/main.c
+++ b/Fixtures/Miscellaneous/TestableExe/Sources/TestableExe3/main.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include "include/TestableExe3.h"
+
+const char * GetGreeting3() {
+    return "Hello, universe";
+}
+
+int main() {
+    printf("%s!\n", GetGreeting3());
+}

--- a/Fixtures/Miscellaneous/TestableExe/Tests/LinuxMain.swift
+++ b/Fixtures/Miscellaneous/TestableExe/Tests/LinuxMain.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+import TestableExeTests
+
+var tests = [XCTestCaseEntry]()
+tests += TestableExeTests.allTests()
+XCTMain(tests)

--- a/Fixtures/Miscellaneous/TestableExe/Tests/TestableExeTests/TestableExeTests.swift
+++ b/Fixtures/Miscellaneous/TestableExe/Tests/TestableExeTests/TestableExeTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+import TestableExe1
+import TestableExe2
+import TestableExe3
+import class Foundation.Bundle
+
+final class TestableExeTests: XCTestCase {
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+        
+        XCTAssertEqual(GetGreeting1(), "Hello, world")
+        XCTAssertEqual(GetGreeting2(), "Hello, planet")
+        XCTAssertEqual(String(cString: GetGreeting3()), "Hello, universe")
+
+        // Some of the APIs that we use below are available in macOS 10.13 and above.
+        guard #available(macOS 10.13, *) else {
+            return
+        }
+
+        let fooBinary = productsDirectory.appendingPathComponent("TestableExe1")
+
+        let process = Process()
+        process.executableURL = fooBinary
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8)
+
+        XCTAssertEqual(output, "Hello, world!\n")
+    }
+
+    /// Returns path to the built products directory.
+    var productsDirectory: URL {
+      #if os(macOS)
+        for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+            return bundle.bundleURL.deletingLastPathComponent()
+        }
+        fatalError("couldn't find the products directory")
+      #else
+        return Bundle.main.bundleURL
+      #endif
+    }
+
+    static var allTests = [
+        ("testExample", testExample),
+    ]
+}

--- a/Fixtures/Miscellaneous/TestableExe/Tests/TestableExeTests/XCTestManifests.swift
+++ b/Fixtures/Miscellaneous/TestableExe/Tests/TestableExeTests/XCTestManifests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+#if !canImport(ObjectiveC)
+public func allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(TestableExeTests.allTests),
+    ]
+}
+#endif

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -143,7 +143,7 @@ final class BuildPlanTests: XCTestCase {
             "@/path/to/build/debug/exe.product/Objects.LinkFileList",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift/macosx",
             "-target", "x86_64-apple-macosx10.10", "-Xlinker", "-add_ast_path",
-            "-Xlinker", "/path/to/build/debug/exe.build/exe.swiftmodule", "-Xlinker", "-add_ast_path",
+            "-Xlinker", "/path/to/build/debug/exe.swiftmodule", "-Xlinker", "-add_ast_path",
             "-Xlinker", "/path/to/build/debug/lib.swiftmodule",
         ]
       #else
@@ -784,7 +784,7 @@ final class BuildPlanTests: XCTestCase {
             "@/path/to/build/debug/exe.product/Objects.LinkFileList",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift/macosx",
             "-target", "x86_64-apple-macosx10.10",
-            "-Xlinker", "-add_ast_path", "-Xlinker", "/path/to/build/debug/exe.build/exe.swiftmodule",
+            "-Xlinker", "-add_ast_path", "-Xlinker", "/path/to/build/debug/exe.swiftmodule",
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
@@ -994,7 +994,7 @@ final class BuildPlanTests: XCTestCase {
             "@/path/to/build/debug/exe.product/Objects.LinkFileList",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift/macosx",
             "-target", "x86_64-apple-macosx10.10",
-            "-Xlinker", "-add_ast_path", "-Xlinker", "/path/to/build/debug/exe.build/exe.swiftmodule",
+            "-Xlinker", "-add_ast_path", "-Xlinker", "/path/to/build/debug/exe.swiftmodule",
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
@@ -1092,7 +1092,7 @@ final class BuildPlanTests: XCTestCase {
             "@/path/to/build/debug/Foo.product/Objects.LinkFileList",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift/macosx",
             "-target", "x86_64-apple-macosx10.10",
-            "-Xlinker", "-add_ast_path", "-Xlinker", "/path/to/build/debug/Foo.build/Foo.swiftmodule"
+            "-Xlinker", "-add_ast_path", "-Xlinker", "/path/to/build/debug/Foo.swiftmodule"
         ])
 
         XCTAssertEqual(barLinkArgs, [
@@ -2339,10 +2339,10 @@ final class BuildPlanTests: XCTestCase {
             XCTAssertMatch(contents, .contains("""
                   "/path/to/build/debug/exe.build/exe.swiftmodule.o":
                     tool: shell
-                    inputs: ["/path/to/build/debug/exe.build/exe.swiftmodule"]
+                    inputs: ["/path/to/build/debug/exe.swiftmodule"]
                     outputs: ["/path/to/build/debug/exe.build/exe.swiftmodule.o"]
                     description: "Wrapping AST for exe for debugging"
-                    args: ["/fake/path/to/swiftc","-modulewrap","/path/to/build/debug/exe.build/exe.swiftmodule","-o","/path/to/build/debug/exe.build/exe.swiftmodule.o","-target","x86_64-unknown-linux-gnu"]
+                    args: ["/fake/path/to/swiftc","-modulewrap","/path/to/build/debug/exe.swiftmodule","-o","/path/to/build/debug/exe.build/exe.swiftmodule.o","-target","x86_64-unknown-linux-gnu"]
                 """))
             XCTAssertMatch(contents, .contains("""
                   "/path/to/build/debug/lib.build/lib.swiftmodule.o":

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -523,7 +523,7 @@ class MiscellaneousTestCase: XCTestCase {
                 XCTAssertMatch(stdout, .contains("Eliding symbols from Exe_main.swift.o"))
                 XCTAssertMatch(stdout, .contains("Linking ExeTestPackageTests"))
             } catch {
-                XCTFail()
+                XCTFail("\(error)")
             }
         }
     }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -514,23 +514,14 @@ class MiscellaneousTestCase: XCTestCase {
         }
     }
     
-    func testErrorMessageWhenTestLinksExecutable() {
+    func testTestsCanLinkAgainstExecutable() {
         fixture(name: "Miscellaneous/ExeTest") { prefix in
             do {
-                try executeSwiftTest(prefix)
-                XCTFail()
-            } catch SwiftPMProductError.executionFailure(let error, let output, let stderr) {
-                XCTAssertMatch(stderr + output, .contains("Compiling Exe main.swift"))
-                XCTAssertMatch(stderr + output, .contains("Compiling ExeTests ExeTests.swift"))
-                XCTAssertMatch(stderr + output, .regex("error: no such module 'Exe'"))
-                XCTAssertMatch(stderr + output, .regex("note: module 'Exe' is the main module of an executable, and cannot be imported by tests and other targets"))
-
-                if case ProcessResult.Error.nonZeroExit(let result) = error {
-                    // if our code crashes we'll get an exit code of 256
-                    XCTAssertEqual(result.exitStatus, .terminated(code: 1))
-                } else {
-                    XCTFail("\(stderr + output)")
-                }
+                let (stdout, _) = try executeSwiftTest(prefix)
+                XCTAssertMatch(stdout, .contains("Compiling Exe main.swift"))
+                XCTAssertMatch(stdout, .contains("Compiling ExeTests ExeTests.swift"))
+                XCTAssertMatch(stdout, .contains("Eliding symbols from Exe_main.swift.o"))
+                XCTAssertMatch(stdout, .contains("Linking ExeTestPackageTests"))
             } catch {
                 XCTFail()
             }

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -90,7 +90,7 @@ class InitTests: XCTestCase {
             let triple = Resources.default.toolchain.triple
             let binPath = path.appending(components: ".build", triple.tripleString, "debug")
             XCTAssertFileExists(binPath.appending(component: "Foo"))
-            XCTAssertFileExists(binPath.appending(components: "Foo.build", "Foo.swiftmodule"))
+            XCTAssertFileExists(binPath.appending(component: "Foo.swiftmodule"))
         }
     }
 


### PR DESCRIPTION
Experimental changes to allow test products to link against both Swift and Clang executable targets.  This allows them to test everything except the main function in those targets without having to run the executable as a subprocess.

### Motivation:

Many package authors don’t want to split their code into executable targets vs library targets, but still want to test data structures and algorithms in their executables.

### Modifications:

This is experimental and not suitable for merging yet.  It uses `nmedit` to elide the `_main` symbols from .o files from executables when a test product links them.  This only works on Darwin; on Linux and Windows, the `strip` tool should usable but that hasn’t yet been tried.

There are several issues to address:
- this isn’t particularly portable, since different implementations are required on different platforms; currently only Darwin is supported
- it isn’t great from a performance perspective to have to create custom versions of the .o files from the executables
- there isn’t any way for a unit test that depends on an executable to indicate whether it just wants a build-time dependency on the product or whether it wants to link against it
- there’s something a bit conceptually shady about treating executables as libraries, so we will likely want to limit the types of targets that are allowed to link against executables to just unit tests
- whatever tool is invoked on a particular platform should be found using the toolchain using a proper accessor
- there are numerous FIXMEs in the code, especially related to the support for Clang executables
- the test fixture isn’t yet being used

In the long run it would be better to have Swift and Clang changes to conditionally emit any `_main` symbol to a separate .o file that could be either included or excluded from a particular link command.

### Result:

Unit tests that declare dependencies on executable targets will link against that code as well.  We will need to consider the compatibility impacts of this, and might need to tie it to a tools version.

rdar://58122395