### PR TITLE
Add swift package archive-source subcommand

### DIFF
--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -56,7 +56,7 @@ public struct SwiftPackageTool: ParsableCommand {
             ToolsVersionCommand.self,
             GenerateXcodeProject.self,
             ComputeChecksum.self,
-            Archive.self,
+            ArchiveSource.self,
             CompletionTool.self,
         ],
         helpNames: [.short, .long, .customLong("help", withSingleDash: true)])
@@ -541,8 +541,9 @@ extension SwiftPackageTool {
         }
     }
 
-    struct Archive: SwiftCommand {
+    struct ArchiveSource: SwiftCommand {
         static let configuration = CommandConfiguration(
+            commandName: "archive-source",
             abstract: "Create a source archive for the package"
         )
 

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -56,6 +56,7 @@ public struct SwiftPackageTool: ParsableCommand {
             ToolsVersionCommand.self,
             GenerateXcodeProject.self,
             ComputeChecksum.self,
+            Archive.self,
             CompletionTool.self,
         ],
         helpNames: [.short, .long, .customLong("help", withSingleDash: true)])
@@ -536,6 +537,46 @@ extension SwiftPackageTool {
             }
 
             stdoutStream <<< checksum <<< "\n"
+            stdoutStream.flush()
+        }
+    }
+
+    struct Archive: SwiftCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Create a source archive for the package"
+        )
+
+        @OptionGroup()
+        var swiftOptions: SwiftToolOptions
+
+        @Option(
+            name: [.short, .long],
+            help: "The absolute or relative path for the generated source archive"
+        )
+        var output: AbsolutePath?
+
+        func run(_ swiftTool: SwiftTool) throws {
+            let packageRoot = try swiftOptions.packagePath ?? swiftTool.getPackageRoot()
+            let repository = GitRepository(path: packageRoot)
+
+            let destination: AbsolutePath
+            if let output = output {
+                destination = output
+            } else {
+                let graph = try swiftTool.loadPackageGraph()
+                let packageName = graph.rootPackages[0].name
+                destination = packageRoot.appending(component: "\(packageName).zip")
+            }
+
+            try repository.archive(to: destination)
+
+            if destination.contains(packageRoot) {
+                let relativePath = destination.relative(to: packageRoot)
+                stdoutStream <<< "Created \(relativePath.pathString)" <<< "\n"
+            } else {
+                stdoutStream <<< "Created \(destination.pathString)" <<< "\n"
+            }
+
             stdoutStream.flush()
         }
     }

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -447,6 +447,19 @@ public final class GitRepository: Repository, WorkingCheckout {
         }
     }
 
+    public func archive(to path: AbsolutePath) throws {
+        precondition(self.isWorkingRepo, "This operation is only valid in a working repository")
+
+        try self.queue.sync(flags: .barrier) {
+            try callGit("archive",
+                        "--format", "zip",
+                        "--output", path.pathString,
+                        "HEAD",
+                        failureMessage: "Couldn’t create an archive")
+            return
+        }
+    }
+
     /// Returns true if there is an alternative object store in the repository and it is valid.
     public func isAlternateObjectStoreValid() -> Bool {
         let objectStoreFile = self.path.appending(components: ".git", "objects", "info", "alternates")

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -941,13 +941,13 @@ final class PackageToolTests: XCTestCase {
       #endif
     }
 
-    func testArchive() throws {
+    func testArchiveSource() throws {
         fixture(name: "DependencyResolution/External/Simple") { prefix in
             let packageRoot = prefix.appending(component: "Bar")
 
             // Running without arguments or options
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive"], packagePath: packageRoot)
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive-source"], packagePath: packageRoot)
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
 
                 let stdoutOutput = try result.utf8Output()
@@ -955,7 +955,7 @@ final class PackageToolTests: XCTestCase {
 
                 // Running without arguments or options again, overwriting existing archive
                 do {
-                    let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive"], packagePath: packageRoot)
+                    let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive-source"], packagePath: packageRoot)
                     XCTAssertEqual(result.exitStatus, .terminated(code: 0))
 
                     let stdoutOutput = try result.utf8Output()
@@ -966,7 +966,7 @@ final class PackageToolTests: XCTestCase {
             // Runnning with output as absolute path within package root
             do {
                 let destination = packageRoot.appending(component: "Bar-1.2.3.zip")
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive", "--output", destination.pathString], packagePath: packageRoot)
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive-source", "--output", destination.pathString], packagePath: packageRoot)
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
 
                 let stdoutOutput = try result.utf8Output()
@@ -977,7 +977,7 @@ final class PackageToolTests: XCTestCase {
             // which in execution context is outside package root
             do {
                 let destination = RelativePath("Bar-1.2.3.zip")
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive", "--output", destination.pathString], packagePath: packageRoot)
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive-source", "--output", destination.pathString], packagePath: packageRoot)
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
 
                 let stdoutOutput = try result.utf8Output()
@@ -987,7 +987,7 @@ final class PackageToolTests: XCTestCase {
 
             // Running without arguments or options in non-package directory
             do {
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive"], packagePath: prefix)
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive-source"], packagePath: prefix)
                 XCTAssertEqual(result.exitStatus, .terminated(code: 1))
 
                 let stderrOutput = try result.utf8stderrOutput()
@@ -997,7 +997,7 @@ final class PackageToolTests: XCTestCase {
             // Runnning with output as absolute path to existing directory
             do {
                 let destination = AbsolutePath.root
-                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive", "--output", destination.pathString], packagePath: packageRoot)
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive-source", "--output", destination.pathString], packagePath: packageRoot)
                 XCTAssertEqual(result.exitStatus, .terminated(code: 1))
 
                 let stderrOutput = try result.utf8stderrOutput()

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -940,4 +940,72 @@ final class PackageToolTests: XCTestCase {
         }
       #endif
     }
+
+    func testArchive() throws {
+        fixture(name: "DependencyResolution/External/Simple") { prefix in
+            let packageRoot = prefix.appending(component: "Bar")
+
+            // Running without arguments or options
+            do {
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive"], packagePath: packageRoot)
+                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
+
+                let stdoutOutput = try result.utf8Output()
+                XCTAssert(stdoutOutput.contains("Created Bar.zip"), #"actual: "\#(stdoutOutput)""#)
+
+                // Running without arguments or options again, overwriting existing archive
+                do {
+                    let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive"], packagePath: packageRoot)
+                    XCTAssertEqual(result.exitStatus, .terminated(code: 0))
+
+                    let stdoutOutput = try result.utf8Output()
+                    XCTAssert(stdoutOutput.contains("Created Bar.zip"), #"actual: "\#(stdoutOutput)""#)
+                }
+            }
+
+            // Runnning with output as absolute path within package root
+            do {
+                let destination = packageRoot.appending(component: "Bar-1.2.3.zip")
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive", "--output", destination.pathString], packagePath: packageRoot)
+                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
+
+                let stdoutOutput = try result.utf8Output()
+                XCTAssert(stdoutOutput.contains("Created Bar-1.2.3.zip"), #"actual: "\#(stdoutOutput)""#)
+            }
+
+            // Runnning with output as relative path,
+            // which in execution context is outside package root
+            do {
+                let destination = RelativePath("Bar-1.2.3.zip")
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive", "--output", destination.pathString], packagePath: packageRoot)
+                XCTAssertEqual(result.exitStatus, .terminated(code: 0))
+
+                let stdoutOutput = try result.utf8Output()
+                XCTAssert(stdoutOutput.contains("Created /private/tmp/Bar-1.2.3.zip"), #"actual: "\#(stdoutOutput)""#)
+            }
+
+            // Running without arguments or options in non-package directory
+            do {
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive"], packagePath: prefix)
+                XCTAssertEqual(result.exitStatus, .terminated(code: 1))
+
+                let stderrOutput = try result.utf8stderrOutput()
+                XCTAssert(stderrOutput.contains("error: root manifest not found"), #"actual: "\#(stderrOutput)""#)
+            }
+
+            // Runnning with output as absolute path to existing directory
+            do {
+                let destination = AbsolutePath("/private/tmp")
+                let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive", "--output", destination.pathString], packagePath: packageRoot)
+                XCTAssertEqual(result.exitStatus, .terminated(code: 1))
+
+                let stderrOutput = try result.utf8stderrOutput()
+                XCTAssert(
+                    stderrOutput.contains("error: Couldn’t create an archive:") &&
+                        stderrOutput.contains("fatal: could not create archive file '/private/tmp': Is a directory"),
+                    #"actual: "\#(stderrOutput)""#
+                )
+            }
+        }
+    }
 }

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -981,7 +981,8 @@ final class PackageToolTests: XCTestCase {
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
 
                 let stdoutOutput = try result.utf8Output()
-                XCTAssert(stdoutOutput.contains("Created /private/tmp/Bar-1.2.3.zip"), #"actual: "\#(stdoutOutput)""#)
+                XCTAssert(stdoutOutput.hasPrefix("Created /"), #"actual: "\#(stdoutOutput)""#)
+                XCTAssert(stdoutOutput.contains("Bar-1.2.3.zip"), #"actual: "\#(stdoutOutput)""#)
             }
 
             // Running without arguments or options in non-package directory
@@ -995,14 +996,14 @@ final class PackageToolTests: XCTestCase {
 
             // Runnning with output as absolute path to existing directory
             do {
-                let destination = AbsolutePath("/private/tmp")
+                let destination = AbsolutePath.root
                 let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive", "--output", destination.pathString], packagePath: packageRoot)
                 XCTAssertEqual(result.exitStatus, .terminated(code: 1))
 
                 let stderrOutput = try result.utf8stderrOutput()
                 XCTAssert(
                     stderrOutput.contains("error: Couldn’t create an archive:") &&
-                        stderrOutput.contains("fatal: could not create archive file '/private/tmp': Is a directory"),
+                        stderrOutput.contains("fatal: could not create archive file '/': Is a directory"),
                     #"actual: "\#(stderrOutput)""#
                 )
             }


### PR DESCRIPTION
```
OVERVIEW: Create a source archive for the package

USAGE: swift package archive <options>

OPTIONS:
  -o, --output <output>   The absolute or relative path for the generated source archive 
```

### Motivation:

The Package Registry Service proposal ([SE-0292](https://github.com/apple/swift-evolution/blob/main/proposals/0292-package-registry-service.md)) describes a new [`swift package archive` subcommand](https://github.com/apple/swift-evolution/blob/main/proposals/0292-package-registry-service.md#archive-subcommand). This tool provides an authoritative method for generating source archives for package releases, which is important for generating and validating integrity checksums.

### Modifications:

- [x] Added an `archive(to:)` instance method to `GitRepository`
- [x] Added an `Archive` subtype to `SwiftPackageTool`
- [x] Added `testArchive` to `PackageToolTests` 

### Result:

The `swift package` command will have a new `archive` subcommand.

> **Note**: This feature is orthogonal to the package registry client implementation (#3023) and doesn't, for example, require the `--enable-package-registry` feature flag in order to be used.
