### PR TITLE
clarfiy reveresedVersions/versions in pubgrub

### DIFF
--- a/Sources/PackageGraph/LocalPackageContainer.swift
+++ b/Sources/PackageGraph/LocalPackageContainer.swift
@@ -89,11 +89,11 @@ public class LocalPackageContainer: PackageContainer {
         fatalError("This should never be called")
     }
     
-    public func versions(filter isIncluded: (Version) -> Bool) throws -> AnySequence<Version> {
+    public func toolsVersionsAppropriateVersionsDescending() throws -> [Version] {
         fatalError("This should never be called")
     }
     
-    public func reversedVersions() throws -> [Version] {
+    public func versionsAscending() throws -> [Version] {
         fatalError("This should never be called")
     }
     

--- a/Sources/PackageGraph/PackageContainer.swift
+++ b/Sources/PackageGraph/PackageContainer.swift
@@ -49,10 +49,19 @@ public protocol PackageContainer {
     /// The list will be returned in sorted order, with the latest version *first*.
     /// All versions will not be requested at once. Resolver will request the next one only
     /// if the previous one did not satisfy all constraints.
-    func versions(filter isIncluded: (Version) -> Bool) throws -> AnySequence<Version>
+    func toolsVersionsAppropriateVersionsDescending() throws -> [Version]
+
+    /// Get the list of versions in the repository sorted in the ascending order, that is the earliest
+    /// version appears first.
+    func versionsAscending() throws -> [Version]
+
+    /// Get the list of versions in the repository sorted in the descending order, that is the latest
+    /// version appears first.
+    func versionsDescending() throws -> [Version]
 
     /// Get the list of versions in the repository sorted in the reverse order, that is the latest
     /// version appears first.
+    @available(*, deprecated, message: "use versionsDescending instead")
     func reversedVersions() throws -> [Version]
 
     // FIXME: We should perhaps define some particularly useful error codes
@@ -88,6 +97,17 @@ public protocol PackageContainer {
     /// after the container is available. The updated identifier is returned in result of the
     /// dependency resolution.
     func getUpdatedIdentifier(at boundVersion: BoundVersion) throws -> PackageReference
+}
+
+extension PackageContainer {
+    @available(*, deprecated, message: "use versionsDescending instead")
+    public func reversedVersions() throws -> [Version] {
+        try self.versionsDescending()
+    }
+
+    public func versionsDescending() throws -> [Version] {
+        try self.versionsAscending().reversed()
+    }
 }
 
 // MARK: -

--- a/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
@@ -1094,7 +1094,7 @@ private final class PubGrubPackageContainer {
         if let pinnedVersion = self.pinnedVersion, requirement.contains(pinnedVersion) {
             return 1
         }
-        return try self.underlying.reversedVersions().filter(requirement.contains).count
+        return try self.underlying.versionsDescending().filter(requirement.contains).count
     }
 
     /// Computes the bounds of the given range against the versions available in the package.
@@ -1105,7 +1105,7 @@ private final class PubGrubPackageContainer {
         var includeLowerBound = true
         var includeUpperBound = true
 
-        let versions = try self.underlying.reversedVersions()
+        let versions = try self.underlying.versionsDescending()
 
         if let last = versions.last, range.lowerBound < last {
             includeLowerBound = false
@@ -1131,13 +1131,13 @@ private final class PubGrubPackageContainer {
         }
 
         // Return the highest version that is allowed by the input requirement.
-        return try self.underlying.reversedVersions().first { versionSet.contains($0) }
+        return try self.underlying.versionsDescending().first { versionSet.contains($0) }
     }
 
     /// Compute the bounds of incompatible tools version starting from the given version.
     private func computeIncompatibleToolsVersionBounds(fromVersion: Version) throws -> VersionSetSpecifier {
         assert(!self.underlying.isToolsVersionCompatible(at: fromVersion))
-        let versions: [Version] = try self.underlying.reversedVersions().reversed()
+        let versions: [Version] = try self.underlying.versionsAscending()
 
         // This is guaranteed to be present.
         let idx = versions.firstIndex(of: fromVersion)!
@@ -1358,7 +1358,7 @@ private final class PubGrubPackageContainer {
             return result
         }
 
-        let versions: [Version] = try self.underlying.reversedVersions().reversed()
+        let versions: [Version] = try self.underlying.versionsAscending()
 
         guard let idx = versions.firstIndex(of: firstVersion) else {
             assertionFailure()

--- a/Sources/SPMTestSupport/MockPackageContainer.swift
+++ b/Sources/SPMTestSupport/MockPackageContainer.swift
@@ -38,11 +38,11 @@ public class MockPackageContainer: PackageContainer {
     }
 
     public let _versions: [Version]
-    public func versions(filter isIncluded: (Version) -> Bool) throws -> AnySequence<Version> {
-        return AnySequence(_versions.filter(isIncluded))
+    public func toolsVersionsAppropriateVersionsDescending() throws -> [Version] {
+        return try self.versionsDescending()
     }
 
-    public func reversedVersions() throws -> [Version] {
+    public func versionsAscending() throws -> [Version] {
         return _versions
     }
 
@@ -98,8 +98,7 @@ public class MockPackageContainer: PackageContainer {
         dependencies: [String: [Dependency]] = [:]
     ) {
         self.name = name
-        let versions = dependencies.keys.compactMap(Version.init(string:))
-        self._versions = versions.sorted().reversed()
+        self._versions = dependencies.keys.compactMap(Version.init(string:)).sorted()
         self.dependencies = dependencies
     }
 }

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -117,7 +117,7 @@ private struct LocalPackageContainer: PackageContainer {
         }
     }
 
-    func reversedVersions() throws -> [Version] {
+    func versionsAscending() throws -> [Version] {
         if let version = dependency?.state.checkout?.version {
             return [version]
         } else {
@@ -138,8 +138,8 @@ private struct LocalPackageContainer: PackageContainer {
         return currentToolsVersion
     }
 
-    func versions(filter isIncluded: (Version) -> Bool) throws -> AnySequence<Version> {
-        return AnySequence(try self.reversedVersions())
+    func toolsVersionsAppropriateVersionsDescending() throws -> [Version] {
+        return try self.versionsDescending()
     }
 
     func getDependencies(at version: Version, productFilter: ProductFilter) throws -> [PackageContainerConstraint] {

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2391,7 +2391,7 @@ extension Workspace {
             // FIXME: this should not block
             let container = try temp_await { containerProvider.getContainer(for: package, skipUpdate: true, on: self.queue, completion: $0) } as! RepositoryPackageContainer
             guard let tag = container.getTag(for: version) else {
-                throw StringError("Internal error: please file a bug at https://bugs.swift.org with this info -- unable to get tag for \(package) \(version); available versions \(try container.reversedVersions())")
+                throw StringError("Internal error: please file a bug at https://bugs.swift.org with this info -- unable to get tag for \(package) \(version); available versions \(try container.versionsDescending())")
             }
             let revision = try container.getRevision(forTag: tag)
             checkoutState = CheckoutState(revision: revision, version: version)

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -180,7 +180,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
 
         let ref = PackageReference(identity: PackageIdentity(path: repoPath), path: repoPath.pathString)
         let container = try provider.getContainer(for: ref, skipUpdate: false)
-        let v = try container.versions(filter: { _ in true }).map { $0 }
+        let v = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
         XCTAssertEqual(v, ["2.0.3", "1.0.3", "1.0.2", "1.0.1", "1.0.0"])
     }
 
@@ -235,7 +235,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             let provider = createProvider(ToolsVersion(version: "4.0.0"))
             let ref = PackageReference(identity: PackageIdentity(url: specifier.url), path: specifier.url)
             let container = try provider.getContainer(for: ref, skipUpdate: false)
-            let v = try container.versions(filter: { _ in true }).map { $0 }
+            let v = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
             XCTAssertEqual(v, ["1.0.1"])
         }
 
@@ -244,7 +244,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             let ref = PackageReference(identity: PackageIdentity(url: specifier.url), path: specifier.url)
             let container = try provider.getContainer(for: ref, skipUpdate: false) as! RepositoryPackageContainer
             XCTAssertTrue(container.validToolsVersionsCache.isEmpty)
-            let v = try container.versions(filter: { _ in true }).map { $0 }
+            let v = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
             XCTAssertEqual(container.validToolsVersionsCache["1.0.0"], false)
             XCTAssertEqual(container.validToolsVersionsCache["1.0.1"], true)
             XCTAssertEqual(container.validToolsVersionsCache["1.0.2"], true)
@@ -256,7 +256,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             let provider = createProvider(ToolsVersion(version: "3.0.0"))
             let ref = PackageReference(identity: PackageIdentity(url: specifier.url), path: specifier.url)
             let container = try provider.getContainer(for: ref, skipUpdate: false)
-            let v = try container.versions(filter: { _ in true }).map { $0 }
+            let v = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
             XCTAssertEqual(v, [])
         }
 
@@ -312,7 +312,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         )
         let ref = PackageReference(identity: PackageIdentity(path: repoPath), path: repoPath.pathString)
         let container = try provider.getContainer(for: ref, skipUpdate: false)
-        let v = try container.versions(filter: { _ in true }).map { $0 }
+        let v = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
         XCTAssertEqual(v, ["1.0.4-alpha", "1.0.2-dev.2", "1.0.2-dev", "1.0.1", "1.0.0", "1.0.0-beta.1", "1.0.0-alpha.1"])
     }
 
@@ -352,7 +352,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         )
         let ref = PackageReference(identity: PackageIdentity(path: repoPath), path: repoPath.pathString)
         let container = try provider.getContainer(for: ref, skipUpdate: false)
-        let v = try container.versions(filter: { _ in true }).map { $0 }
+        let v = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
         XCTAssertEqual(v, ["2.0.1", "1.0.4", "1.0.2", "1.0.1", "1.0.0"])
     }
 


### PR DESCRIPTION
motivation: easier to reason about code

changes:
* rename PacakgeContainer::reversedVersions to PackageContainer::versionsDescending
* add PacakgeContainer::versionsAscending to avoid the versionsDescending().reveresed() code
* rename PacakgeContainer::versions(filter) to PackageContainer::toolsVersionsAppropriateVersionsDescending to better reflect the true meaning
* remove filter from PackageContainer::toolsVersionsAppropriateVersionsDescending since its not used in practice
* adjust tests and mocks
