### PR TITLE
Revert "dependency resolution performance improvements (#3106)"

### DIFF
--- a/Sources/Basics/ConcurrencyHelpers.swift
+++ b/Sources/Basics/ConcurrencyHelpers.swift
@@ -42,12 +42,6 @@ public final class ThreadSafeKeyValueStore<Key, Value> where Key: Hashable {
         }
     }
 
-    public var count: Int {
-        self.lock.withLock {
-            self.underlying.count
-        }
-    }
-
     public var isEmpty: Bool {
         self.lock.withLock {
             self.underlying.isEmpty
@@ -59,12 +53,6 @@ public final class ThreadSafeKeyValueStore<Key, Value> where Key: Hashable {
             self.underlying.keys.contains(key)
         }
     }
-
-    public func mapValues<T>(_ transform: (Value) throws -> T) rethrows -> [Key : T] {
-        try self.lock.withLock {
-            try self.underlying.mapValues(transform)
-        }
-    }
 }
 
 /// Thread-safe value boxing  structure
@@ -73,10 +61,6 @@ public final class ThreadSafeBox<Value> {
     private let lock = Lock()
 
     public init() {}
-
-    public init(_ seed: Value) {
-        self.underlying = seed
-    }
 
     @discardableResult
     public func memoize(body: () throws -> Value) rethrows -> Value {
@@ -99,12 +83,6 @@ public final class ThreadSafeBox<Value> {
     public func get() -> Value? {
         self.lock.withLock {
             self.underlying
-        }
-    }
-
-    public func put(_ newValue: Value) {
-        self.lock.withLock {
-            self.underlying = newValue
         }
     }
 }

--- a/Sources/PackageGraph/Pubgrub/Term.swift
+++ b/Sources/PackageGraph/Pubgrub/Term.swift
@@ -104,8 +104,9 @@ public struct Term: Equatable, Hashable {
         return true
     }
 
-    // From: https://github.com/dart-lang/pub/blob/master/lib/src/solver/term.dart
     public func relation(with other: Term) -> SetRelation {
+        // From: https://github.com/dart-lang/pub/blob/master/lib/src/solver/term.dart
+
         if self.node != other.node {
             fatalError("attempting to compute relation between different packages \(self) \(other)")
         }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -148,16 +148,17 @@ public protocol ManifestLoaderDelegate {
 /// serialized form of the manifest (as implemented by `PackageDescription`'s
 /// `atexit()` handler) which is then deserialized and loaded.
 public final class ManifestLoader: ManifestLoaderProtocol {
-    private let resources: ManifestResourceProvider
-    private let serializedDiagnostics: Bool
-    private let isManifestSandboxEnabled: Bool
-    private let delegate: ManifestLoaderDelegate?
-    private let extraManifestFlags: [String]
 
-    private let databaseCacheDir: AbsolutePath!
-    private var databaseCache: PersistentCacheProtocol?
-    private let memoryCache = ThreadSafeKeyValueStore<ManifestCacheKey, Manifest>()
-    private let useInMemoryCache: Bool
+    let resources: ManifestResourceProvider
+    let serializedDiagnostics: Bool
+    let isManifestSandboxEnabled: Bool
+    var isManifestCachingEnabled: Bool {
+        return cacheDir != nil
+    }
+    let cacheDir: AbsolutePath!
+    let delegate: ManifestLoaderDelegate?
+    private(set) var cache: PersistentCacheProtocol?
+    private let extraManifestFlags: [String]
     
     private let jsonEncoder: JSONEncoder
     private let jsonDecoder: JSONDecoder
@@ -167,7 +168,6 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         serializedDiagnostics: Bool = false,
         isManifestSandboxEnabled: Bool = true,
         cacheDir: AbsolutePath? = nil,
-        useInMemoryCache: Bool = true,
         delegate: ManifestLoaderDelegate? = nil,
         extraManifestFlags: [String] = []
     ) {
@@ -177,16 +177,24 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         self.delegate = delegate
         self.extraManifestFlags = extraManifestFlags
 
+        // Resolve symlinks since we can't use them in sandbox profiles.
+        if let cacheDir = cacheDir {
+            try? localFileSystem.createDirectory(cacheDir, recursive: true)
+        }
+        self.cacheDir = cacheDir.map(resolveSymlinks)
         self.jsonEncoder = JSONEncoder.makeWithDefaults()
         self.jsonDecoder = JSONDecoder.makeWithDefaults()
-
-        self.useInMemoryCache = useInMemoryCache
-        self.databaseCacheDir = cacheDir.map(resolveSymlinks)
     }
 
     @available(*, deprecated)
-    public convenience init(resources: ManifestResourceProvider, isManifestSandboxEnabled: Bool = true) {
-        self.init(manifestResources: resources, isManifestSandboxEnabled: isManifestSandboxEnabled)
+    public convenience init(
+        resources: ManifestResourceProvider,
+        isManifestSandboxEnabled: Bool = true
+    ) {
+        self.init(
+            manifestResources: resources,
+            isManifestSandboxEnabled: isManifestSandboxEnabled
+       )
     }
 
     /// Loads a manifest from a package repository using the resources associated with a particular `swiftc` executable.
@@ -202,16 +210,14 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         swiftCompilerFlags: [String],
         packageKind: PackageReference.Kind
     ) throws -> Manifest {
-        let fileSystem = localFileSystem
         let resources = try UserManifestResources(swiftCompiler: swiftCompiler, swiftCompilerFlags: swiftCompilerFlags)
         let loader = ManifestLoader(manifestResources: resources)
-        let toolsVersion = try ToolsVersionLoader().load(at: packagePath, fileSystem: fileSystem)
+        let toolsVersion = try ToolsVersionLoader().load(at: packagePath, fileSystem: localFileSystem)
         return try loader.load(
             package: packagePath,
             baseURL: packagePath.pathString,
             toolsVersion: toolsVersion,
-            packageKind: packageKind,
-            fileSystem: fileSystem
+            packageKind: packageKind
         )
     }
 
@@ -225,39 +231,16 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         fileSystem: FileSystem? = nil,
         diagnostics: DiagnosticsEngine? = nil
     ) throws -> Manifest {
-        let fileSystem = fileSystem ?? localFileSystem
-        let manifestPath = try Manifest.path(atPackagePath: path, fileSystem: fileSystem)
-        let packageIdentity = PackageIdentity(url: baseURL)
-        let cacheKey = try ManifestCacheKey(packageIdentity: packageIdentity,
-                                            manifestPath: manifestPath,
-                                            toolsVersion: toolsVersion,
-                                            env: ProcessEnv.vars,
-                                            swiftpmVersion: Versioning.currentVersion.displayString,
-                                            fileSystem: fileSystem)
-
-        if self.useInMemoryCache, let manifest = self.memoryCache[cacheKey] {
-            // Inform the delegate (backwards compatibility)
-            self.delegate?.willLoad(manifest: manifestPath)
-            return manifest
-        }
-
-        let manifest = try self.loadFile(
-            manifestPath: manifestPath,
+        return try loadFile(
+            path: Manifest.path(atPackagePath: path, fileSystem: fileSystem ?? localFileSystem),
             baseURL: baseURL,
             version: version,
             revision: revision,
             toolsVersion: toolsVersion,
-            packageIdentity: packageIdentity,
             packageKind: packageKind,
             fileSystem: fileSystem,
             diagnostics: diagnostics
         )
-
-        if self.useInMemoryCache {
-            self.memoryCache[cacheKey] = manifest
-        }
-
-        return manifest
     }
 
     /// Create a manifest by loading a specific manifest file from the given `path`.
@@ -269,33 +252,34 @@ public final class ManifestLoader: ManifestLoaderProtocol {
     ///   - revision: The revision the manifest is from, if known.
     ///   - kind: The kind of package the manifest is from.
     ///   - fileSystem: If given, the file system to load from (otherwise load from the local file system).
-    private func loadFile(
-        manifestPath: AbsolutePath,
+    func loadFile(
+        path inputPath: AbsolutePath,
         baseURL: String,
         version: Version?,
         revision: String?,
         toolsVersion: ToolsVersion,
-        packageIdentity: PackageIdentity,
         packageKind: PackageReference.Kind,
-        fileSystem: FileSystem,
+        fileSystem: FileSystem? = nil,
         diagnostics: DiagnosticsEngine? = nil
     ) throws -> Manifest {
+        try self.createCacheIfNeeded()
+
         // Inform the delegate.
-        self.delegate?.willLoad(manifest: manifestPath)
+        self.delegate?.willLoad(manifest: inputPath)
 
         // Validate that the file exists.
-        guard fileSystem.isFile(manifestPath) else {
+        guard (fileSystem ?? localFileSystem).isFile(inputPath) else {
             throw PackageModel.Package.Error.noManifest(
                 baseURL: baseURL, version: version?.description)
         }
 
         // Get the JSON string for the manifest.
-
-        let jsonString = try self.loadJSONString(
-            path: manifestPath,
+        let identity = PackageIdentity(url: baseURL)
+        let jsonString = try loadJSONString(
+            path: inputPath,
             toolsVersion: toolsVersion,
-            packageIdentity: packageIdentity,
-            fileSystem: fileSystem,
+            packageIdentity: identity,
+            fs: fileSystem,
             diagnostics: diagnostics
         )
 
@@ -304,7 +288,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         var manifestBuilder = ManifestBuilder(
             toolsVersion: toolsVersion,
             baseURL: baseURL,
-            fileSystem: fileSystem
+            fileSystem: fileSystem ?? localFileSystem
         )
         try manifestBuilder.build(v4: json, toolsVersion: toolsVersion)
 
@@ -317,7 +301,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         var products =  manifestBuilder.products
         var targets = manifestBuilder.targets
         if products.isEmpty, targets.isEmpty,
-            fileSystem.isFile(manifestPath.parentDirectory.appending(component: moduleMapFilename)) {
+            (fileSystem ?? localFileSystem).isFile(inputPath.parentDirectory.appending(component: moduleMapFilename)) {
                 products.append(ProductDescription(
                 name: manifestBuilder.name,
                 type: .library(.automatic),
@@ -336,7 +320,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             name: manifestBuilder.name,
             defaultLocalization: manifestBuilder.defaultLocalization,
             platforms: manifestBuilder.platforms,
-            path: manifestPath,
+            path: inputPath,
             url: baseURL,
             version: version,
             revision: revision,
@@ -352,7 +336,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             targets: targets
         )
 
-        try self.validate(manifest, toolsVersion: toolsVersion, diagnostics: diagnostics)
+        try validate(manifest, toolsVersion: toolsVersion, diagnostics: diagnostics)
 
         if let diagnostics = diagnostics, diagnostics.hasErrors {
             throw Diagnostics.fatalError
@@ -363,14 +347,14 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
     /// Validate the provided manifest.
     private func validate(_ manifest: Manifest, toolsVersion: ToolsVersion, diagnostics: DiagnosticsEngine?) throws {
-        try self.validateTargets(manifest, diagnostics: diagnostics)
-        try self.validateProducts(manifest, diagnostics: diagnostics)
-        try self.validateDependencies(manifest, toolsVersion: toolsVersion, diagnostics: diagnostics)
+        try validateTargets(manifest, diagnostics: diagnostics)
+        try validateProducts(manifest, diagnostics: diagnostics)
+        try validateDependencies(manifest, toolsVersion: toolsVersion, diagnostics: diagnostics)
 
         // Checks reserved for tools version 5.2 features
         if toolsVersion >= .v5_2 {
-            try self.validateTargetDependencyReferences(manifest, diagnostics: diagnostics)
-            try self.validateBinaryTargets(manifest, diagnostics: diagnostics)
+            try validateTargetDependencyReferences(manifest, diagnostics: diagnostics)
+            try validateBinaryTargets(manifest, diagnostics: diagnostics)
         }
     }
 
@@ -498,38 +482,40 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
     /// Load the JSON string for the given manifest.
     private func loadJSONString(
-        path manifestPath: AbsolutePath,
+        path inputPath: AbsolutePath,
         toolsVersion: ToolsVersion,
         packageIdentity: PackageIdentity,
-        fileSystem: FileSystem,
+        fs: FileSystem? = nil,
         diagnostics: DiagnosticsEngine? = nil
     ) throws -> String {
         let result: ManifestParseResult
+        let pathOrContents: ManifestPathOrContents
 
-        let cacheKey = try ManifestCacheKey(
-            packageIdentity: packageIdentity,
-            manifestPath: manifestPath,
-            toolsVersion: toolsVersion,
-            env: ProcessEnv.vars,
-            swiftpmVersion: Versioning.currentVersion.displayString,
-            fileSystem: fileSystem
-        )
-
-        // Resolve symlinks since we can't use them in sandbox profiles.
-        try self.createCacheIfNeeded()
-        if let cache = self.databaseCache {
-            result = try self.loadManifestFromCache(key: cacheKey, cache: cache)
+        if let fs = fs {
+            let contents = try fs.readFileContents(inputPath).contents
+            pathOrContents = .contents(contents)
         } else {
-            result = self.parse(
+            pathOrContents = .path(inputPath)
+        }
+
+        if let cache = self.cache {
+            let key = ManifestCacheKey(
                 packageIdentity: packageIdentity,
-                manifestPath: cacheKey.manifestPath,
-                manifestContents: cacheKey.manifestContents,
-                toolsVersion: toolsVersion)
+                pathOrContents: pathOrContents,
+                toolsVersion: toolsVersion,
+                env: ProcessEnv.vars,
+                swiftpmVersion: Versioning.currentVersion.displayString
+            )
+           result = try loadManifestFromCache(key: key, cache: cache)
+        } else {
+            result = parse(
+                packageIdentity: packageIdentity,
+                pathOrContents: pathOrContents, toolsVersion: toolsVersion)
         }
 
         // Throw now if we weren't able to parse the manifest.
         guard let parsedManifest = result.parsedManifest else {
-            let errors = result.errorOutput ?? result.compilerOutput ?? "Unknown error parsing manifest for \(packageIdentity)"
+            let errors = result.errorOutput ?? result.compilerOutput ?? "<unknown>"
             throw ManifestParseError.invalidManifestFormat(errors, diagnosticFile: result.diagnosticFile)
         }
 
@@ -559,10 +545,9 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             return result
         }
 
-        let result = self.parse(
+        let result = parse(
             packageIdentity: key.packageIdentity,
-            manifestPath: key.manifestPath,
-            manifestContents: key.manifestContents,
+            pathOrContents: key.pathOrContents,
             toolsVersion: key.toolsVersion
         )
 
@@ -573,51 +558,31 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         return result
     }
 
-    fileprivate struct ManifestCacheKey: Hashable {
+    fileprivate struct ManifestCacheKey {
         let packageIdentity: PackageIdentity
-        let manifestPath: AbsolutePath
-        let manifestContents: [UInt8]
+        let pathOrContents: ManifestPathOrContents
         let toolsVersion: ToolsVersion
         let env: [String: String]
         let swiftpmVersion: String
 
-        init (packageIdentity: PackageIdentity,
-              manifestPath: AbsolutePath,
-              toolsVersion: ToolsVersion,
-              env: [String: String],
-              swiftpmVersion: String,
-              fileSystem: FileSystem
-        ) throws {
-            self.packageIdentity = packageIdentity
-            self.manifestPath = manifestPath
-            self.manifestContents = try fileSystem.readFileContents(manifestPath).contents
-            self.toolsVersion = toolsVersion
-            self.env = env
-            self.swiftpmVersion = swiftpmVersion
-        }
-
-        // TODO: is there a way to avoid the dual hashing?
-        func hash(into hasher: inout Hasher) {
-            hasher.combine(self.packageIdentity)
-            hasher.combine(self.manifestContents)
-            hasher.combine(self.toolsVersion.description)
-            for key in self.env.keys.sorted(by: >) {
-                hasher.combine(key)
-                hasher.combine(env[key]!)
-            }
-            hasher.combine(self.swiftpmVersion)
-        }
-
-        // TODO: is there a way to avoid the dual hashing?
         func computeHash() throws -> ByteString {
             let stream = BufferedOutputByteStream()
-            stream <<< self.packageIdentity
-            stream <<< self.manifestContents
-            stream <<< self.toolsVersion.description
-            for key in self.env.keys.sorted(by: >) {
+            stream <<< packageIdentity
+
+            switch pathOrContents {
+            case .path(let path):
+                stream <<< (try localFileSystem.readFileContents(path))
+            case .contents(let contents):
+                stream <<< contents
+            }
+
+            stream <<< toolsVersion.description
+
+            for key in env.keys.sorted(by: >) {
                 stream <<< key <<< env[key]!
             }
-            stream <<< self.swiftpmVersion
+            stream <<< swiftpmVersion
+
             return SHA256().hash(stream.bytes)
         }
     }
@@ -656,10 +621,10 @@ public final class ManifestLoader: ManifestLoaderProtocol {
     /// Parse the manifest at the given path to JSON.
     fileprivate func parse(
         packageIdentity: PackageIdentity,
-        manifestPath: AbsolutePath,
-        manifestContents: [UInt8],
+        pathOrContents: ManifestPathOrContents,
         toolsVersion: ToolsVersion
     ) -> ManifestParseResult {
+
         /// Helper method for parsing the manifest.
         func _parse(
             path manifestPath: AbsolutePath,
@@ -738,8 +703,8 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             }
 
             // Add the arguments for emitting serialized diagnostics, if requested.
-            if self.serializedDiagnostics, self.databaseCacheDir != nil {
-                let diaDir = self.databaseCacheDir.appending(component: "ManifestLoading")
+            if serializedDiagnostics, cacheDir != nil {
+                let diaDir = cacheDir.appending(component: "ManifestLoading")
                 let diagnosticFile = diaDir.appending(component: "\(packageIdentity).dia")
                 try localFileSystem.createDirectory(diaDir, recursive: true)
                 cmd += ["-Xfrontend", "-serialize-diagnostics-path", "-Xfrontend", diagnosticFile.pathString]
@@ -792,7 +757,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                 // the permissions which are absolutely necessary for manifest parsing.
                 if isManifestSandboxEnabled {
                     let cacheDirectories = [
-                        self.databaseCacheDir,
+                        cacheDir,
                         moduleCachePath.map({ AbsolutePath($0) })
                     ].compactMap({ $0 })
                     let profile = sandboxProfile(toolsVersion: toolsVersion, cacheDirectories: cacheDirectories)
@@ -830,20 +795,21 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
         var manifestParseResult = ManifestParseResult()
         do {
-            if localFileSystem.isFile(manifestPath) {
+            switch pathOrContents {
+            case .path(let path):
                 try _parse(
-                    path: manifestPath,
+                    path: path,
                     toolsVersion: toolsVersion,
                     manifestParseResult: &manifestParseResult
                 )
-            } else {
+            case .contents(let contents):
                 try withTemporaryFile(suffix: ".swift") { tempFile in
-                    try localFileSystem.writeFileContents(tempFile.path, bytes: ByteString(manifestContents))
-                    try _parse(
-                        path: tempFile.path,
-                        toolsVersion: toolsVersion,
-                        manifestParseResult: &manifestParseResult
-                    )
+                  try localFileSystem.writeFileContents(tempFile.path, bytes: ByteString(contents))
+                  try _parse(
+                      path: tempFile.path,
+                      toolsVersion: toolsVersion,
+                      manifestParseResult: &manifestParseResult
+                  )
                 }
             }
         } catch {
@@ -905,22 +871,14 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
     func createCacheIfNeeded() throws {
         // Return if we have already created the cache.
-        guard self.databaseCache == nil else {
-            return
-        }
-        guard let manifestCacheDBPath = self.databaseCacheDir.flatMap({ Self.manifestCacheDBPath($0) }) else {
-            return
-        }
-        try localFileSystem.createDirectory(self.databaseCacheDir, recursive: true)
-        self.databaseCache = try SQLiteBackedPersistentCache(cacheFilePath: manifestCacheDBPath)
+        guard self.cache == nil else { return }
+        guard let manifestCacheDBPath = cacheDir.flatMap({ Self.manifestCacheDBPath($0) }) else { return }
+        self.cache = try SQLiteBackedPersistentCache(cacheFilePath: manifestCacheDBPath)
     }
 
     public func resetCache() throws {
-        self.memoryCache.clear()
-        guard let manifestCacheDBPath = self.databaseCacheDir.flatMap({ Self.manifestCacheDBPath($0) }) else {
-            return
-        }
-        self.databaseCache = nil
+        guard let manifestCacheDBPath = cacheDir.flatMap({ Self.manifestCacheDBPath($0) }) else { return }
+        self.cache = nil
         // Also remove the database file from disk.
         try localFileSystem.removeFileTree(manifestCacheDBPath)
     }
@@ -955,6 +913,12 @@ private func sandboxProfile(toolsVersion: ToolsVersion, cacheDirectories: [Absol
     }
 
     return stream.bytes.description
+}
+
+/// Enum to represent either the manifest path or its content.
+private enum ManifestPathOrContents {
+    case path(AbsolutePath)
+    case contents([UInt8])
 }
 
 extension TSCBasic.Diagnostic.Message {

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -104,7 +104,7 @@ extension Manifest {
     }
 }
 
-public struct ToolsVersionLoader: ToolsVersionLoaderProtocol {
+public class ToolsVersionLoader: ToolsVersionLoaderProtocol {
     
     // FIXME: Remove this property and the initializer?
     // Arbitrary tools versions are used only in `ToolsVersionLoaderTests.testVersionSpecificManifestFallbacks()`.

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -257,8 +257,6 @@ public class Workspace {
 
     fileprivate let additionalFileRules: [FileRuleDescription]
 
-    private let queue = DispatchQueue(label: "org.swift.swiftpm.workspace", attributes: .concurrent)
-
     /// Create a new package workspace.
     ///
     /// This will automatically load the persisted state for the package, if
@@ -733,20 +731,9 @@ extension Workspace {
         packages: [AbsolutePath],
         diagnostics: DiagnosticsEngine
     ) -> [Manifest] {
-
-        let lock = Lock()
-        let sync = DispatchGroup()
-        var rootManifests = [Manifest]()
-        packages.forEach { package in
-            self.queue.async(group: sync) {
-                if let manifest = self.loadManifest(packagePath: package, url: package.pathString, packageKind: .root, diagnostics: diagnostics) {
-                    lock.withLock {
-                        rootManifests.append(manifest)
-                    }
-                }
-            }
-        }
-        sync.wait()
+        let rootManifests = packages.compactMap({ package -> Manifest? in
+            loadManifest(packagePath: package, url: package.pathString, packageKind: .root, diagnostics: diagnostics)
+        })
 
         // Check for duplicate root packages.
         let duplicateRoots = rootManifests.spm_findDuplicateElements(by: \.name)
@@ -856,7 +843,7 @@ extension Workspace {
             // Get handle to the repository.
             // TODO: replace with async/await when available
             let handle = try temp_await {
-                repositoryManager.lookup(repository: dependency.packageRef.repository, skipUpdate: true, on: self.queue, completion: $0)
+                repositoryManager.lookup(repository: dependency.packageRef.repository, skipUpdate: true, on: .global(), completion: $0)
             }
             let repo = try handle.open()
 
@@ -1647,7 +1634,7 @@ extension Workspace {
         let pins = pinsStore.pins.map({ $0 })
         DispatchQueue.concurrentPerform(iterations: pins.count) { idx in
             _ = try? temp_await {
-                containerProvider.getContainer(for: pins[idx].packageRef, skipUpdate: true, on: self.queue, completion: $0)
+                containerProvider.getContainer(for: pins[idx].packageRef, skipUpdate: true, on: .global(), completion: $0)
             }
         }
 
@@ -2090,7 +2077,7 @@ extension Workspace {
                 // Get the latest revision from the container.
                 // TODO: replace with async/await when available
                 let container = try temp_await {
-                    containerProvider.getContainer(for: packageRef, skipUpdate: true, on: self.queue, completion: $0)
+                    containerProvider.getContainer(for: packageRef, skipUpdate: true, on: .global(), completion: $0)
                 } as! RepositoryPackageContainer
                 var revision = try container.getRevision(forIdentifier: identifier)
                 let branch = branch ?? (identifier == revision.identifier ? nil : identifier)
@@ -2318,7 +2305,7 @@ extension Workspace {
         // If not, we need to get the repository from the checkouts.
         // FIXME: this should not block
         let handle = try temp_await {
-            repositoryManager.lookup(repository: package.repository, skipUpdate: true, on: self.queue, completion: $0)
+            repositoryManager.lookup(repository: package.repository, skipUpdate: true, on: .global(), completion: $0)
         }
 
         // Clone the repository into the checkouts.
@@ -2389,7 +2376,7 @@ extension Workspace {
             // annoying. Maybe we should make an SPI on the provider for
             // this?
             // FIXME: this should not block
-            let container = try temp_await { containerProvider.getContainer(for: package, skipUpdate: true, on: self.queue, completion: $0) } as! RepositoryPackageContainer
+            let container = try temp_await { containerProvider.getContainer(for: package, skipUpdate: true, on: .global(), completion: $0) } as! RepositoryPackageContainer
             guard let tag = container.getTag(for: version) else {
                 throw StringError("Internal error: please file a bug at https://bugs.swift.org with this info -- unable to get tag for \(package) \(version); available versions \(try container.versionsDescending())")
             }

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -566,7 +566,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             }
 
             let noCacheLoader = ManifestLoader(
-                manifestResources: Resources.default, useInMemoryCache: false, delegate: delegate)
+                manifestResources: Resources.default, delegate: delegate)
             for _ in 0..<2 {
                 check(loader: noCacheLoader, expectCached: false)
             }


### PR DESCRIPTION
This reverts commit bfde016c44acc43c27eb3b7a0545a0662a181502.

We are seeing issues like "error: database is locked" when using SwiftPM with this commit, let's do a speculative revert.

See also https://ci.swift.org/job/oss-swift-pr-test/15882/consoleText