### PR TITLE
Improve the error message that's shown when a target tries to import an executable module

### DIFF
--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -523,6 +523,7 @@ class MiscellaneousTestCase: XCTestCase {
                 XCTAssertMatch(stderr + output, .contains("Compiling Exe main.swift"))
                 XCTAssertMatch(stderr + output, .contains("Compiling ExeTests ExeTests.swift"))
                 XCTAssertMatch(stderr + output, .regex("error: no such module 'Exe'"))
+                XCTAssertMatch(stderr + output, .regex("note: module 'Exe' is the main module of an executable, and cannot be imported by tests and other targets"))
 
                 if case ProcessResult.Error.nonZeroExit(let result) = error {
                     // if our code crashes we'll get an exit code of 256


### PR DESCRIPTION
Improve the error message that's shown when a target tries to import an executable module.  This machinery can also be used for other kinds of errors in the future.  Currently only supports Swift targets that link against executables (either C or Swift).

### Motivation:

This adds a check for the common case of a target trying to import an executable target, and provides an additional note to the error message.

### Modifications:

Add a way for the BuildOperation to react to build command failures by looking at the build plan and providing more tailored output.

### Result:

Better diagnostics when a target (typically a test) tries to link against an executable module.