### PR TITLE
improve concurrency safety of pubgrub prefetch

### DIFF
--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -220,6 +220,7 @@ public class RepositoryManager {
 
         self.operationQueue = OperationQueue()
         self.operationQueue.name = "org.swift.swiftpm.repomanagerqueue-concurrent"
+        // FIXME: make this configurable and/or compute based on CPU count
         self.operationQueue.maxConcurrentOperationCount = 10
 
         self.persistence = SimplePersistence(


### PR DESCRIPTION
motivation: prevent potential deadlocks

changes:
* dont wait on prefetch sync, notify instead.
* use memoize on prefteches to avoid races / redundant prefetches
* replace switch with tryMap to improve code readability
* rename ContainerProvider::provider to ContainerProvider::underlying to improve code readability
* add some code comments
