### PR TITLE
Temporarily skipping failing integration test until it can be investigated

### DIFF
--- a/IntegrationTests/Tests/IntegrationTests/XCBuildTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/XCBuildTests.swift
@@ -116,6 +116,8 @@ final class XCBuildTests: XCTestCase {
     }
 
     func testTestProducts() throws {
+        try XCTSkip("Temporarily skipping failing test")
+
         #if !os(macOS)
             try XCTSkip("Test requires macOS")
         #endif


### PR DESCRIPTION
Temporarily skipping failing integration test until it can be investigated.  This was newly added (#3088) but is failing.

### Motivation:

This is blocking PR builds.
