### PR TITLE
Improve integration test failure messages

### DIFF
--- a/IntegrationTests/Tests/IntegrationTests/XCBuildTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/XCBuildTests.swift
@@ -116,7 +116,7 @@ final class XCBuildTests: XCTestCase {
     }
 
     func testTestProducts() throws {
-        try XCTSkip("Temporarily skipping failing test")
+        try XCTSkip("FIXME: /.../XCBuild_TestProducts.551ajO/Foo/.build/apple/Intermediates.noindex/GeneratedModuleMaps/macosx/FooLib.modulemap:2:12: error: header 'FooLib-Swift.h' not found")
 
         #if !os(macOS)
             try XCTSkip("Test requires macOS")


### PR DESCRIPTION
Improve integration test failure messages, as the current text sometimes doesn't include enough information to diagnose the issue.

### Motivation:

The integration tests were enabled in #3088 but [one started failing](https://ci.swift.org/job/swift-package-manager-with-xcode-self-hosted-PR-osx/1257/console) soon thereafter with this uninformative message:

> 22:57:59 Test Case '-[IntegrationTests.XCBuildTests testTestProducts]' started.
> 22:57:59 
/Users/buildnode/jenkins/workspace/swift-package-manager-with-xcode-self-hosted-PR-osx/branch-main/swiftpm/IntegrationTests/Tests/IntegrationTests/XCBuildTests.swift:146: error: -[IntegrationTests.XCBuildTests testTestProducts] : XCTAssertEqual failed: ("terminated(code: 1)") is not equal to ("terminated(code: 0)")
> 22:57:59 /Users/buildnode/jenkins/workspace/swift-package-manager-with-xcode-self-hosted-PR-osx/branch-main/swiftpm/IntegrationTests/Tests/IntegrationTests/XCBuildTests.swift:184: error: -[IntegrationTests.XCBuildTests testTestProducts] : XCTAssertEqual failed: ("terminated(code: 1)") is not equal to ("terminated(code: 0)")

Since console output on Jenkins is the primary way we view results for these tests, we need more information printed there to be able to figure out why a given test is failing.

### Modifications:

Include diagnostic text in the command failure message — test invocation, stdout, and stderr.
