### PR TITLE
Deprecate version-specific manifests

### DIFF
--- a/Examples/package-info/Sources/package-info/main.swift
+++ b/Examples/package-info/Sources/package-info/main.swift
@@ -31,7 +31,7 @@ let package = localFileSystem.currentWorkingDirectory!
 // There are several levels of information available.
 // Each takes longer to load than the level above it, but provides more detail.
 let diagnostics = DiagnosticsEngine()
-let manifest = try ManifestLoader.loadManifest(packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], packageKind: .local)
+let manifest = try ManifestLoader.loadManifest(packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], packageKind: .local, diagnostics: diagnostics)
 let loadedPackage = try PackageBuilder.loadPackage(packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], diagnostics: diagnostics)
 let graph = try Workspace.loadGraph(packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], diagnostics: diagnostics)
 

--- a/Sources/Commands/APIDigester.swift
+++ b/Sources/Commands/APIDigester.swift
@@ -92,7 +92,8 @@ struct APIDigesterBaselineDumper {
         let workspace = Workspace.create(
             forRootPackage: baselinePackageRoot,
             manifestLoader: manifestLoader,
-            repositoryManager: repositoryManager
+            repositoryManager: repositoryManager,
+            diagnostics: diags
         )
 
         let graph = try workspace.loadPackageGraph(

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -494,7 +494,7 @@ extension SwiftPackageTool {
             switch toolsVersionMode {
             case .display:
                 let toolsVersionLoader = ToolsVersionLoader()
-                let version = try toolsVersionLoader.load(at: pkg, fileSystem: localFileSystem)
+                let version = try toolsVersionLoader.load(at: pkg, packageKind: .root, fileSystem: localFileSystem, diagnostics: swiftTool.diagnostics)
                 print("\(version)")
 
             case .set(let value):

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -493,7 +493,8 @@ public class SwiftTool {
             isResolverPrefetchingEnabled: options.shouldEnableResolverPrefetching,
             skipUpdate: options.skipDependencyUpdate,
             enableResolverTrace: options.enableResolverTrace,
-            cachePath: cachePath
+            cachePath: cachePath,
+            diagnostics: diagnostics
         )
         _workspace = workspace
         return workspace

--- a/Sources/PackageGraph/LocalPackageContainer.swift
+++ b/Sources/PackageGraph/LocalPackageContainer.swift
@@ -28,6 +28,7 @@ public class LocalPackageContainer: PackageContainer {
     private let manifestLoader: ManifestLoaderProtocol
     private let toolsVersionLoader: ToolsVersionLoaderProtocol
     private let currentToolsVersion: ToolsVersion
+    private let diagnostics: DiagnosticsEngine?
     /// The file system that shoud be used to load this package.
     let fs: FileSystem
 
@@ -38,7 +39,7 @@ public class LocalPackageContainer: PackageContainer {
         }
 
         // Load the tools version.
-        let toolsVersion = try toolsVersionLoader.load(at: AbsolutePath(identifier.path), fileSystem: fs)
+        let toolsVersion = try toolsVersionLoader.load(at: AbsolutePath(identifier.path), packageKind: .local, fileSystem: fs, diagnostics: diagnostics)
 
         // Validate the tools version.
         try toolsVersion.validateToolsVersion(self.currentToolsVersion, packagePath: identifier.path)
@@ -70,7 +71,8 @@ public class LocalPackageContainer: PackageContainer {
         manifestLoader: ManifestLoaderProtocol,
         toolsVersionLoader: ToolsVersionLoaderProtocol,
         currentToolsVersion: ToolsVersion,
-        fs: FileSystem = localFileSystem
+        fs: FileSystem = localFileSystem,
+        diagnostics: DiagnosticsEngine? = nil
     ) {
         assert(URL.scheme(identifier.path) == nil, "unexpected scheme \(URL.scheme(identifier.path)!) in \(identifier.path)")
         self.identifier = identifier
@@ -79,6 +81,7 @@ public class LocalPackageContainer: PackageContainer {
         self.toolsVersionLoader = toolsVersionLoader
         self.currentToolsVersion = currentToolsVersion
         self.fs = fs
+        self.diagnostics = diagnostics
     }
     
     public func isToolsVersionCompatible(at version: Version) -> Bool {

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -208,12 +208,13 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         packagePath: AbsolutePath,
         swiftCompiler: AbsolutePath,
         swiftCompilerFlags: [String],
-        packageKind: PackageReference.Kind
+        packageKind: PackageReference.Kind,
+        diagnostics: DiagnosticsEngine
     ) throws -> Manifest {
         let fileSystem = localFileSystem
         let resources = try UserManifestResources(swiftCompiler: swiftCompiler, swiftCompilerFlags: swiftCompilerFlags)
         let loader = ManifestLoader(manifestResources: resources)
-        let toolsVersion = try ToolsVersionLoader().load(at: packagePath, fileSystem: fileSystem)
+        let toolsVersion = try ToolsVersionLoader().load(at: packagePath, packageKind: packageKind, fileSystem: fileSystem, diagnostics: diagnostics)
         return try loader.load(
             package: packagePath,
             baseURL: packagePath.pathString,
@@ -234,7 +235,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         diagnostics: DiagnosticsEngine? = nil
     ) throws -> Manifest {
         let fileSystem = fileSystem ?? localFileSystem
-        let manifestPath = try Manifest.path(atPackagePath: path, fileSystem: fileSystem)
+        let manifestPath = try Manifest.path(atPackagePath: path, packageKind: packageKind, fileSystem: fileSystem, diagnostics: diagnostics)
         let packageIdentity = PackageIdentity(url: baseURL)
         let cacheKey = try ManifestCacheKey(packageIdentity: packageIdentity,
                                             manifestPath: manifestPath,

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -292,7 +292,8 @@ public final class PackageBuilder {
             packagePath: packagePath,
             swiftCompiler: swiftCompiler,
             swiftCompilerFlags: swiftCompilerFlags,
-            packageKind: kind)
+            packageKind: kind,
+            diagnostics: diagnostics)
         let builder = PackageBuilder(
             manifest: manifest,
             productFilter: .everything,

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -351,7 +351,9 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                     bytes: bogusManifest)
             }
             // Check we can load the repository.
-            let manifest = try manifestLoader.load(package: root, baseURL: "/foo", toolsVersion: .v4_2, packageKind: .root, fileSystem: fs)
+            let diagnostics = DiagnosticsEngine()
+            let manifest = try manifestLoader.load(package: root, baseURL: "/foo", toolsVersion: .v4_2, packageKind: .root, fileSystem: fs, diagnostics: diagnostics)
+            XCTAssertEqual(diagnostics.diagnostics.map { $0.message.text }, ["Version-specific manifests will be deprecated soon, please use semantic versioning to support older clients."])
             XCTAssertEqual(manifest.name, "Trivial")
         }
     }
@@ -469,13 +471,16 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             func check(loader: ManifestLoader, expectCached: Bool) {
                 delegate.clear()
+                let diagnostics = DiagnosticsEngine()
                 let manifest = try! loader.load(
                     package: manifestPath.parentDirectory,
                     baseURL: manifestPath.pathString,
                     toolsVersion: .v4_2,
-                    packageKind: .local
+                    packageKind: .local,
+                    diagnostics: diagnostics
                 )
 
+                XCTAssertTrue(diagnostics.diagnostics.isEmpty)
                 XCTAssertEqual(delegate.loaded, [manifestPath])
                 XCTAssertEqual(delegate.parsed, expectCached ? [] : [manifestPath])
                 XCTAssertEqual(manifest.name, "Trivial")

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3785,7 +3785,7 @@ final class WorkspaceTests: XCTestCase {
         // From here the API should be simple and straightforward:
         let diagnostics = DiagnosticsEngine()
         let manifest = try ManifestLoader.loadManifest(
-            packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], packageKind: .local
+            packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], packageKind: .local, diagnostics: diagnostics
         )
         let loadedPackage = try PackageBuilder.loadPackage(
             packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], xcTestMinimumDeploymentTargets: [:], diagnostics: diagnostics


### PR DESCRIPTION
Emit a warning if any root package has version-specific manifests to make package authors aware of the deprecation.

rdar://71256931
