### PR TITLE
Re-enable target-based dependency resolution

### DIFF
--- a/IntegrationTests/Tests/IntegrationTests/XCBuildTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/XCBuildTests.swift
@@ -94,25 +94,6 @@ final class XCBuildTests: XCTestCase {
             XCTAssertFileExists(releasePath.appending(component: "bar"))
             XCTAssertNoSuchPath(releasePath.appending(component: "cbar"))
         }
-
-        fixture(name: "XCBuild/ExecutableProducts") { path in
-            let fooPath = path.appending(component: "Foo")
-            let binaryPath = fooPath.appending(components: ".build", "apple", "Products")
-
-            try sh(swiftBuild, "--package-path", fooPath, "--build-system", "xcode", "--target", "cbar")
-            let debugPath = binaryPath.appending(component: "Debug")
-            XCTAssertNoSuchPath(debugPath.appending(component: "foo"))
-            XCTAssertNoSuchPath(debugPath.appending(component: "cfoo"))
-            XCTAssertNoSuchPath(debugPath.appending(component: "bar"))
-            XCTAssertFileExists(debugPath.appending(component: "cbar"))
-
-            try sh(swiftBuild, "--package-path", fooPath, "--build-system", "xcode", "--target", "cbar", "-c", "release")
-            let releasePath = binaryPath.appending(component: "Release")
-            XCTAssertNoSuchPath(releasePath.appending(component: "foo"))
-            XCTAssertNoSuchPath(releasePath.appending(component: "cfoo"))
-            XCTAssertNoSuchPath(releasePath.appending(component: "bar"))
-            XCTAssertFileExists(releasePath.appending(component: "cbar"))
-        }
     }
 
     func testTestProducts() throws {

--- a/Sources/PackageGraph/DependencyResolutionNode.swift
+++ b/Sources/PackageGraph/DependencyResolutionNode.swift
@@ -78,7 +78,6 @@ public enum DependencyResolutionNode {
 
     /// Assembles the product filter to use on the manifest for this node to determine its dependencies.
     public var productFilter: ProductFilter {
-        #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
         switch self {
         case .empty:
             return .specific([])
@@ -87,9 +86,6 @@ public enum DependencyResolutionNode {
         case .root:
             return .everything
         }
-        #else
-        return .everything
-        #endif
     }
 
     /// Returns the dependency that a product has on its own package, if relevant.

--- a/Sources/PackageGraph/RepositoryPackageContainer.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainer.swift
@@ -222,6 +222,7 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
         productFilter: ProductFilter
     ) throws -> (Manifest, [Constraint]) {
         let manifest = try self.loadManifest(at: revision, version: version)
+        let productFilter = manifest.toolsVersion < ToolsVersion.v5_2 ? ProductFilter.everything : productFilter
         return (manifest, manifest.dependencyConstraints(productFilter: productFilter, mirrors: mirrors))
     }
 

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -130,7 +130,6 @@ public final class Manifest: ObjectIdentifierProtocol {
 
     /// Returns the targets required for a particular product filter.
     public func targetsRequired(for productFilter: ProductFilter) -> [TargetDescription] {
-        #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
         // If we have already calcualted it, returned the cached value.
         if let targets = _requiredTargets[productFilter] {
             return targets
@@ -147,9 +146,6 @@ public final class Manifest: ObjectIdentifierProtocol {
             _requiredTargets[productFilter] = targets
             return targets
         }
-        #else
-        return self.targets
-        #endif
     }
 
     /// Returns the package dependencies required for a particular products filter.
@@ -215,7 +211,6 @@ public final class Manifest: ObjectIdentifierProtocol {
         }
 
         return dependencies.compactMap { dependency in
-            #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
             if let filter = associations[dependency.name] {
                 return dependency.filtered(by: filter)
             } else if keepUnused {
@@ -225,9 +220,6 @@ public final class Manifest: ObjectIdentifierProtocol {
                 // Dependencies known to not have any relevant products are discarded.
                 return nil
             }
-            #else
-            return dependency.filtered(by: .everything)
-            #endif
         }
     }
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1314,25 +1314,18 @@ final class BuildPlanTests: XCTestCase {
             ]
         )
 
-        #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
         XCTAssertEqual(diagnostics.diagnostics.count, 1)
         let firstDiagnostic = diagnostics.diagnostics.first.map({ $0.message.text })
         XCTAssert(
             firstDiagnostic == "dependency 'C' is not used by any target",
             "Unexpected diagnostic: " + (firstDiagnostic ?? "[none]")
         )
-        #endif
 
         let graphResult = PackageGraphResult(graph)
         graphResult.check(reachableProducts: "aexec", "BLibrary")
         graphResult.check(reachableTargets: "ATarget", "BTarget1")
-        #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
         graphResult.check(products: "aexec", "BLibrary")
         graphResult.check(targets: "ATarget", "BTarget1")
-        #else
-        graphResult.check(products: "BLibrary", "bexec", "aexec", "cexec")
-        graphResult.check(targets: "ATarget", "BTarget1", "BTarget2", "CTarget")
-        #endif
 
         let planResult = BuildPlanResult(plan: try BuildPlan(
             buildParameters: mockBuildParameters(),
@@ -1341,13 +1334,8 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fileSystem
         ))
 
-        #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
         planResult.checkProductsCount(2)
         planResult.checkTargetsCount(2)
-        #else
-        planResult.checkProductsCount(4)
-        planResult.checkTargetsCount(4)
-        #endif
     }
 
     func testReachableBuildProductsAndTargets() throws {

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -739,9 +739,7 @@ class PackageGraphTests: XCTestCase {
 
         DiagnosticsEngineTester(diagnostics) { result in
             result.check(diagnostic: "dependency 'Baz' is not used by any target", behavior: .warning)
-            #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
             result.check(diagnostic: "dependency 'Biz' is not used by any target", behavior: .warning)
-            #endif
         }
     }
 
@@ -1080,11 +1078,6 @@ class PackageGraphTests: XCTestCase {
     }
 
     func testUnreachableProductsSkipped() throws {
-        #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
-        #else
-        try XCTSkipIf(true)
-        #endif
-
         let fs = InMemoryFileSystem(emptyFiles:
             "/Root/Sources/Root/Root.swift",
             "/Immediate/Sources/ImmediateUsed/ImmediateUsed.swift",

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -1062,11 +1062,6 @@ final class PubgrubTests: XCTestCase {
     }
 
     func testUnreachableProductsSkipped() throws {
-        #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
-        #else
-        try XCTSkipIf(true)
-        #endif
-
         builder.serve("root", at: .unversioned, with: [
             "root": ["immediate": (.versionSet(v1Range), .specific(["ImmediateUsed"]))]
         ])

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -357,11 +357,6 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
     }
 
     func testDependencyConstraints() throws {
-        #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
-        #else
-        try XCTSkipIf(true)
-        #endif
-
         let dependencies = [
             PackageDependencyDescription(name: "Bar1", url: "/Bar1", requirement: .upToNextMajor(from: "1.0.0")),
             PackageDependencyDescription(name: "Bar2", url: "/Bar2", requirement: .upToNextMajor(from: "1.0.0")),
@@ -627,10 +622,8 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
 
             let forNothing = try container.getDependencies(at: version, productFilter: .specific([]))
             let forProduct = try container.getDependencies(at: version, productFilter: .specific(["Product"]))
-            #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
-              // If the cache overlaps (incorrectly), these will be the same.
-              XCTAssertNotEqual(forNothing, forProduct)
-            #endif
+            // If the cache overlaps (incorrectly), these will be the same.
+            XCTAssertNotEqual(forNothing, forProduct)
         }
     }
 }

--- a/Tests/PackageModelTests/ManifestTests.swift
+++ b/Tests/PackageModelTests/ManifestTests.swift
@@ -56,13 +56,11 @@ class ManifestTests: XCTestCase {
                 targets: targets
             )
 
-            #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
             XCTAssertEqual(manifest.targetsRequired(for: .specific(["Foo", "Bar"])).map({ $0.name }).sorted(), [
                 "Bar",
                 "Baz",
                 "Foo",
             ])
-            #endif
         }
     }
 
@@ -152,13 +150,11 @@ class ManifestTests: XCTestCase {
                 targets: targets
             )
 
-            #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
             XCTAssertEqual(manifest.dependenciesRequired(for: .specific(["Foo"])).map({ $0.name }).sorted(), [
                 "Bar1", // Foo → Foo1 → Bar1
                 "Bar2", // Foo → Foo1 → Foo2 → Bar2
                 // (Bar3 is unreachable.)
             ])
-            #endif
         }
     }
 }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -2087,7 +2087,7 @@ final class WorkspaceTests: XCTestCase {
 
         workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("Foo[Foo] 1.0.0..<2.0.0"), behavior: .error)
+                result.check(diagnostic: .contains("no versions of 'Foo' match the requirement 1.0.1..<2.0.0 and 'Foo' 1.0.0 contains incompatible tools version"), behavior: .error)
             }
         }
     }
@@ -2923,7 +2923,7 @@ final class WorkspaceTests: XCTestCase {
                 result.check(targets: "Foo")
             }
             DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: .contains("Bar[Bar] {1.0.0..<1.5.0, 1.5.1..<2.0.0} is forbidden"), behavior: .error)
+                result.check(diagnostic: .contains("package 'bar' is required using a stable-version but 'bar' depends on an unstable-version package 'baz'."), behavior: .error)
             }
         }
     }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -1524,11 +1524,7 @@ final class WorkspaceTests: XCTestCase {
         // Run update.
         workspace.checkUpdateDryRun(roots: ["Root"]) { changes, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
-            #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
             let stateChange = Workspace.PackageStateChange.updated(.init(requirement: .version(Version("1.5.0")), products: .specific(["Foo"])))
-            #else
-            let stateChange = Workspace.PackageStateChange.updated(.init(requirement: .version(Version("1.5.0")), products: .everything))
-            #endif
 
             let path = AbsolutePath("/tmp/ws/pkgs/Foo")
             let expectedChange = (
@@ -2089,13 +2085,11 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
         workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(diagnostic: .contains("Foo[Foo] 1.0.0..<2.0.0"), behavior: .error)
             }
         }
-        #endif
     }
 
     func testToolsVersionRootPackages() throws {
@@ -2928,11 +2922,9 @@ final class WorkspaceTests: XCTestCase {
                 result.check(packages: "Foo")
                 result.check(targets: "Foo")
             }
-            #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(diagnostic: .contains("Bar[Bar] {1.0.0..<1.5.0, 1.5.1..<2.0.0} is forbidden"), behavior: .error)
             }
-            #endif
         }
     }
 
@@ -4065,11 +4057,6 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testTargetBasedDependency() throws {
-        #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
-        #else
-        try XCTSkipIf(true)
-        #endif
-
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -86,20 +86,11 @@ class PIFBuilderTests: XCTestCase {
             let targetAExeDependencies = pif.workspace.projects[0].targets[0].dependencies
             XCTAssertEqual(targetAExeDependencies.map{ $0.targetGUID }, ["PACKAGE-PRODUCT:blib", "PACKAGE-TARGET:A2", "PACKAGE-TARGET:A3"])
             let projectBTargetNames = pif.workspace.projects[1].targets.map({ $0.name })
-            #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
             XCTAssertEqual(projectBTargetNames, ["blib", "B2"])
-            #else
-            XCTAssertEqual(projectBTargetNames, ["bexe", "blib", "B2"])
-            #endif
         }
     }
 
     func testProject() throws {
-        #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
-        #else
-        try XCTSkipIf(true)
-        #endif
-
         let fs = InMemoryFileSystem(emptyFiles:
             "/Foo/Sources/foo/main.swift",
             "/Foo/Tests/FooTests/tests.swift",
@@ -685,11 +676,6 @@ class PIFBuilderTests: XCTestCase {
     }
 
     func testTestProducts() throws {
-        #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
-        #else
-        try XCTSkipIf(true)
-        #endif
-
         let fs = InMemoryFileSystem(emptyFiles:
             "/Foo/Sources/FooTests/FooTests.swift",
             "/Foo/Sources/CFooTests/CFooTests.m",


### PR DESCRIPTION
Looks like we were not necessarily fetching dependencies of packages with pre-5.2 tools versions during resolution. It seems correct to not consider the product filter during dependency resolution for pre-5.2 packages, since it won't be correct for them by definition.

rdar://70633425