### PR TITLE
Updates to package collection models

### DIFF
--- a/Fixtures/Collections/GitHub/license.json
+++ b/Fixtures/Collections/GitHub/license.json
@@ -1,0 +1,25 @@
+{
+  "name": "LICENSE",
+  "path": "LICENSE",
+  "sha": "401c59dcc4570b954dd6d345e76199e1f4e76266",
+  "size": 1077,
+  "url": "https://api.github.com/repos/benbalter/gman/contents/LICENSE?ref=master",
+  "html_url": "https://github.com/benbalter/gman/blob/master/LICENSE",
+  "git_url": "https://api.github.com/repos/benbalter/gman/git/blobs/401c59dcc4570b954dd6d345e76199e1f4e76266",
+  "download_url": "https://raw.githubusercontent.com/benbalter/gman/master/LICENSE?lab=true",
+  "type": "file",
+  "content": "VGhlIE1JVCBMaWNlbnNlIChNSVQpCgpDb3B5cmlnaHQgKGMpIDIwMTMgQmVu\nIEJhbHRlcgoKUGVybWlzc2lvbiBpcyBoZXJlYnkgZ3JhbnRlZCwgZnJlZSBv\nZiBjaGFyZ2UsIHRvIGFueSBwZXJzb24gb2J0YWluaW5nIGEgY29weSBvZgp0\naGlzIHNvZnR3YXJlIGFuZCBhc3NvY2lhdGVkIGRvY3VtZW50YXRpb24gZmls\nZXMgKHRoZSAiU29mdHdhcmUiKSwgdG8gZGVhbCBpbgp0aGUgU29mdHdhcmUg\nd2l0aG91dCByZXN0cmljdGlvbiwgaW5jbHVkaW5nIHdpdGhvdXQgbGltaXRh\ndGlvbiB0aGUgcmlnaHRzIHRvCnVzZSwgY29weSwgbW9kaWZ5LCBtZXJnZSwg\ncHVibGlzaCwgZGlzdHJpYnV0ZSwgc3VibGljZW5zZSwgYW5kL29yIHNlbGwg\nY29waWVzIG9mCnRoZSBTb2Z0d2FyZSwgYW5kIHRvIHBlcm1pdCBwZXJzb25z\nIHRvIHdob20gdGhlIFNvZnR3YXJlIGlzIGZ1cm5pc2hlZCB0byBkbyBzbywK\nc3ViamVjdCB0byB0aGUgZm9sbG93aW5nIGNvbmRpdGlvbnM6CgpUaGUgYWJv\ndmUgY29weXJpZ2h0IG5vdGljZSBhbmQgdGhpcyBwZXJtaXNzaW9uIG5vdGlj\nZSBzaGFsbCBiZSBpbmNsdWRlZCBpbiBhbGwKY29waWVzIG9yIHN1YnN0YW50\naWFsIHBvcnRpb25zIG9mIHRoZSBTb2Z0d2FyZS4KClRIRSBTT0ZUV0FSRSBJ\nUyBQUk9WSURFRCAiQVMgSVMiLCBXSVRIT1VUIFdBUlJBTlRZIE9GIEFOWSBL\nSU5ELCBFWFBSRVNTIE9SCklNUExJRUQsIElOQ0xVRElORyBCVVQgTk9UIExJ\nTUlURUQgVE8gVEhFIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZLCBG\nSVRORVNTCkZPUiBBIFBBUlRJQ1VMQVIgUFVSUE9TRSBBTkQgTk9OSU5GUklO\nR0VNRU5ULiBJTiBOTyBFVkVOVCBTSEFMTCBUSEUgQVVUSE9SUyBPUgpDT1BZ\nUklHSFQgSE9MREVSUyBCRSBMSUFCTEUgRk9SIEFOWSBDTEFJTSwgREFNQUdF\nUyBPUiBPVEhFUiBMSUFCSUxJVFksIFdIRVRIRVIKSU4gQU4gQUNUSU9OIE9G\nIENPTlRSQUNULCBUT1JUIE9SIE9USEVSV0lTRSwgQVJJU0lORyBGUk9NLCBP\nVVQgT0YgT1IgSU4KQ09OTkVDVElPTiBXSVRIIFRIRSBTT0ZUV0FSRSBPUiBU\nSEUgVVNFIE9SIE9USEVSIERFQUxJTkdTIElOIFRIRSBTT0ZUV0FSRS4K\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/benbalter/gman/contents/LICENSE?ref=master",
+    "git": "https://api.github.com/repos/benbalter/gman/git/blobs/401c59dcc4570b954dd6d345e76199e1f4e76266",
+    "html": "https://github.com/benbalter/gman/blob/master/LICENSE"
+  },
+  "license": {
+    "key": "mit",
+    "name": "MIT License",
+    "spdx_id": "MIT",
+    "url": "https://api.github.com/licenses/mit",
+    "node_id": "MDc6TGljZW5zZW1pdA=="
+  }
+}

--- a/Fixtures/Collections/JSON/good.json
+++ b/Fixtures/Collections/JSON/good.json
@@ -14,6 +14,10 @@
       "summary": "Package One",
       "keywords": ["sample package"],
       "readmeURL": "https://www.example.com/repos/RepoOne/README",
+      "license": {
+        "name": "Apache-2.0",
+        "url": "https://www.example.com/repos/RepoOne/LICENSE"
+      },
       "versions": [
         {
           "version": "0.1.0",

--- a/Fixtures/Collections/JSON/good.json
+++ b/Fixtures/Collections/JSON/good.json
@@ -41,12 +41,20 @@
           "minimumPlatformVersions": [
             { "name": "macOS", "version": "10.15" }
           ],
-          "verifiedPlatforms": [
-            { "name": "macOS" },
-            { "name": "iOS" },
-            { "name": "Linux" }
+          "verifiedCompatibility": [
+            {
+              "platform": { "name": "macOS" },
+              "swiftVersion": "5.1"
+            },
+            {
+              "platform": { "name": "iOS" },
+              "swiftVersion": "5.1"
+            },
+            {
+              "platform": { "name": "Linux" },
+              "swiftVersion": "5.1"
+            }
           ],
-          "verifiedSwiftVersions": ["5.1"],
           "license": {
             "name": "Apache-2.0",
             "url": "https://www.example.com/repos/RepoOne/LICENSE"

--- a/Sources/Commands/SwiftPackageCollectionsTool.swift
+++ b/Sources/Commands/SwiftPackageCollectionsTool.swift
@@ -205,14 +205,16 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
             }
 
             let modules = version.targets.compactMap { $0.moduleName }.joined(separator: ", ")
-            let platforms = optionalRow("Verified Platforms", version.verifiedPlatforms?.map { $0.name }.joined(separator: ", "))
-            let swiftVersions = optionalRow("Verified Swift Versions", version.verifiedSwiftVersions?.map { $0.rawValue }.joined(separator: ", "))
+            let compatibility = optionalRow(
+                "Verified Compatibility (Platform, Swift Version)",
+                version.verifiedCompatibility?.map { "(\($0.platform.name), \($0.swiftVersion.rawValue))" }.joined(separator: ", ")
+            )
             let license = optionalRow("License", version.license?.type.description)
 
             return """
             \(version.version)
                 Package Name: \(version.packageName)
-                Modules: \(modules)\(platforms)\(swiftVersions)\(license)
+                Modules: \(modules)\(compatibility)\(license)
             """
         }
 

--- a/Sources/PackageCollections/JSONModel/JSONCollection+v1.swift
+++ b/Sources/PackageCollections/JSONModel/JSONCollection+v1.swift
@@ -138,11 +138,8 @@ extension JSONPackageCollectionModel.V1.Collection.Package {
         /// An array of the package version’s supported platforms specified in `Package.swift`.
         public let minimumPlatformVersions: [JSONPackageCollectionModel.V1.PlatformVersion]?
 
-        /// An array of platforms in which the package version has been tested and verified.
-        public let verifiedPlatforms: [JSONPackageCollectionModel.V1.Platform]?
-
-        /// An array of Swift versions that the package version has been tested and verified for.
-        public let verifiedSwiftVersions: [String]?
+        /// An array of compatible platforms and Swift versions that has been tested and verified for.
+        public let verifiedCompatibility: [JSONPackageCollectionModel.V1.Compatibility]?
 
         /// The package version's license.
         public let license: JSONPackageCollectionModel.V1.License?
@@ -155,8 +152,7 @@ extension JSONPackageCollectionModel.V1.Collection.Package {
             products: [JSONPackageCollectionModel.V1.Product],
             toolsVersion: String,
             minimumPlatformVersions: [JSONPackageCollectionModel.V1.PlatformVersion]?,
-            verifiedPlatforms: [JSONPackageCollectionModel.V1.Platform]?,
-            verifiedSwiftVersions: [String]?,
+            verifiedCompatibility: [JSONPackageCollectionModel.V1.Compatibility]?,
             license: JSONPackageCollectionModel.V1.License?
         ) {
             self.version = version
@@ -165,8 +161,7 @@ extension JSONPackageCollectionModel.V1.Collection.Package {
             self.products = products
             self.toolsVersion = toolsVersion
             self.minimumPlatformVersions = minimumPlatformVersions
-            self.verifiedPlatforms = verifiedPlatforms
-            self.verifiedSwiftVersions = verifiedSwiftVersions
+            self.verifiedCompatibility = verifiedCompatibility
             self.license = license
         }
     }
@@ -231,6 +226,15 @@ extension JSONPackageCollectionModel.V1 {
         public init(name: String) {
             self.name = name
         }
+    }
+    
+    /// Compatible platform and Swift version.
+    public struct Compatibility: Equatable, Codable {
+        /// The platform (e.g., macOS, Linux, etc.)
+        public let platform: Platform
+        
+        /// The Swift version
+        public let swiftVersion: String
     }
 
     public struct License: Equatable, Codable {

--- a/Sources/PackageCollections/JSONModel/JSONCollection+v1.swift
+++ b/Sources/PackageCollections/JSONModel/JSONCollection+v1.swift
@@ -235,13 +235,13 @@ extension JSONPackageCollectionModel.V1 {
 
     public struct License: Equatable, Codable {
         /// License name (e.g., Apache-2.0, MIT, etc.)
-        public let name: String
+        public let name: String?
 
         /// The URL of the license file.
         public let url: URL
 
         /// Creates a `License`
-        public init(name: String, url: URL) {
+        public init(name: String?, url: URL) {
             self.name = name
             self.url = url
         }

--- a/Sources/PackageCollections/JSONModel/JSONCollection+v1.swift
+++ b/Sources/PackageCollections/JSONModel/JSONCollection+v1.swift
@@ -95,7 +95,7 @@ extension JSONPackageCollectionModel.V1.Collection {
 
         /// The URL of the package's README.
         public let readmeURL: Foundation.URL?
-        
+
         /// The package's current license info
         public let license: JSONPackageCollectionModel.V1.License?
 
@@ -227,12 +227,12 @@ extension JSONPackageCollectionModel.V1 {
             self.name = name
         }
     }
-    
+
     /// Compatible platform and Swift version.
     public struct Compatibility: Equatable, Codable {
         /// The platform (e.g., macOS, Linux, etc.)
         public let platform: Platform
-        
+
         /// The Swift version
         public let swiftVersion: String
     }

--- a/Sources/PackageCollections/JSONModel/JSONCollection+v1.swift
+++ b/Sources/PackageCollections/JSONModel/JSONCollection+v1.swift
@@ -47,13 +47,13 @@ extension JSONPackageCollectionModel.V1 {
         /// Creates a `Collection`
         public init(
             name: String,
-            overview: String? = nil,
-            keywords: [String]? = nil,
+            overview: String?,
+            keywords: [String]?,
             packages: [JSONPackageCollectionModel.V1.Collection.Package],
             formatVersion: JSONPackageCollectionModel.FormatVersion,
-            revision: Int? = nil,
+            revision: Int?,
             generatedAt: Date = Date(),
-            generatedBy: Author? = nil
+            generatedBy: Author?
         ) {
             precondition(formatVersion == .v1_0, "Unsupported format version: \(formatVersion)")
 
@@ -95,20 +95,25 @@ extension JSONPackageCollectionModel.V1.Collection {
 
         /// The URL of the package's README.
         public let readmeURL: Foundation.URL?
+        
+        /// The package's current license info
+        public let license: JSONPackageCollectionModel.V1.License?
 
         /// Creates a `Package`
         public init(
             url: URL,
-            summary: String? = nil,
-            keywords: [String]? = nil,
+            summary: String?,
+            keywords: [String]?,
             versions: [JSONPackageCollectionModel.V1.Collection.Package.Version],
-            readmeURL: URL? = nil
+            readmeURL: URL?,
+            license: JSONPackageCollectionModel.V1.License?
         ) {
             self.url = url
             self.summary = summary
             self.keywords = keywords
             self.versions = versions
             self.readmeURL = readmeURL
+            self.license = license
         }
     }
 }
@@ -149,10 +154,10 @@ extension JSONPackageCollectionModel.V1.Collection.Package {
             targets: [JSONPackageCollectionModel.V1.Target],
             products: [JSONPackageCollectionModel.V1.Product],
             toolsVersion: String,
-            minimumPlatformVersions: [JSONPackageCollectionModel.V1.PlatformVersion]? = nil,
-            verifiedPlatforms: [JSONPackageCollectionModel.V1.Platform]? = nil,
-            verifiedSwiftVersions: [String]? = nil,
-            license: JSONPackageCollectionModel.V1.License? = nil
+            minimumPlatformVersions: [JSONPackageCollectionModel.V1.PlatformVersion]?,
+            verifiedPlatforms: [JSONPackageCollectionModel.V1.Platform]?,
+            verifiedSwiftVersions: [String]?,
+            license: JSONPackageCollectionModel.V1.License?
         ) {
             self.version = version
             self.packageName = packageName
@@ -176,7 +181,7 @@ extension JSONPackageCollectionModel.V1 {
         public let moduleName: String?
 
         /// Creates a `Target`
-        public init(name: String, moduleName: String? = nil) {
+        public init(name: String, moduleName: String?) {
             self.name = name
             self.moduleName = moduleName
         }

--- a/Sources/PackageCollections/Model/License.swift
+++ b/Sources/PackageCollections/Model/License.swift
@@ -101,7 +101,7 @@ extension PackageCollectionsModel {
     }
 }
 
-extension PackageCollectionsModel.LicenseType  {
+extension PackageCollectionsModel.LicenseType {
     public init(string: String?) {
         self = string.map { s in Self.allCases.first { $0.description.lowercased() == s.lowercased() } ?? .other(s) } ?? .other(nil)
     }

--- a/Sources/PackageCollections/Model/License.swift
+++ b/Sources/PackageCollections/Model/License.swift
@@ -101,6 +101,12 @@ extension PackageCollectionsModel {
     }
 }
 
+extension PackageCollectionsModel.LicenseType  {
+    public init(string: String) {
+        self = Self.allCases.first { $0.description.lowercased() == string.lowercased() } ?? .other(string)
+    }
+}
+
 extension PackageCollectionsModel.LicenseType: Codable {
     public enum DiscriminatorKeys: String, Codable {
         case Apache2_0

--- a/Sources/PackageCollections/Model/License.swift
+++ b/Sources/PackageCollections/Model/License.swift
@@ -61,7 +61,7 @@ extension PackageCollectionsModel {
         case EPL2_0
 
         /// Other license type
-        case other(String)
+        case other(String?)
 
         public var description: String {
             switch self {
@@ -90,7 +90,7 @@ extension PackageCollectionsModel {
             case .EPL2_0:
                 return "EPL-2.0"
             case .other(let name):
-                return name
+                return name ?? "other"
             }
         }
 
@@ -102,8 +102,8 @@ extension PackageCollectionsModel {
 }
 
 extension PackageCollectionsModel.LicenseType  {
-    public init(string: String) {
-        self = Self.allCases.first { $0.description.lowercased() == string.lowercased() } ?? .other(string)
+    public init(string: String?) {
+        self = string.map { s in Self.allCases.first { $0.description.lowercased() == s.lowercased() } ?? .other(s) } ?? .other(nil)
     }
 }
 

--- a/Sources/PackageCollections/Model/Package.swift
+++ b/Sources/PackageCollections/Model/Package.swift
@@ -129,6 +129,14 @@ extension PackageCollectionsModel.Package {
         /// The package version's supported platforms
         public let minimumPlatformVersions: [SupportedPlatform]?
         
+        // TODO: remove (replaced by verifiedCompatibility)
+        /// The package version's supported platforms verified to work
+        public var verifiedPlatforms: [PackageModel.Platform]? { nil }
+
+        // TODO: remove (replaced by verifiedCompatibility)
+        /// The package version's Swift versions verified to work
+        public var verifiedSwiftVersions: [SwiftLanguageVersion]? { nil }
+        
         /// An array of compatible platforms and Swift versions that has been tested and verified for.
         public let verifiedCompatibility: [PackageCollectionsModel.Compatibility]?
 

--- a/Sources/PackageCollections/Model/Package.swift
+++ b/Sources/PackageCollections/Model/Package.swift
@@ -128,12 +128,9 @@ extension PackageCollectionsModel.Package {
 
         /// The package version's supported platforms
         public let minimumPlatformVersions: [SupportedPlatform]?
-
-        /// The package version's supported platforms verified to work
-        public let verifiedPlatforms: [PackageModel.Platform]?
-
-        /// The package version's Swift versions verified to work
-        public let verifiedSwiftVersions: [SwiftLanguageVersion]?
+        
+        /// An array of compatible platforms and Swift versions that has been tested and verified for.
+        public let verifiedCompatibility: [PackageCollectionsModel.Compatibility]?
 
         /// The package version's license
         public let license: PackageCollectionsModel.License?
@@ -162,6 +159,17 @@ extension PackageCollectionsModel {
 
         /// The product's targets
         public let targets: [Target]
+    }
+}
+
+extension PackageCollectionsModel {
+    /// Compatible platform and Swift version.
+    public struct Compatibility: Equatable, Codable {
+        /// The platform (e.g., macOS, Linux, etc.)
+        public let platform: PackageModel.Platform
+        
+        /// The Swift version
+        public let swiftVersion: SwiftLanguageVersion
     }
 }
 

--- a/Sources/PackageCollections/Model/Package.swift
+++ b/Sources/PackageCollections/Model/Package.swift
@@ -58,11 +58,11 @@ extension PackageCollectionsModel {
         public var latestVersion: Version? {
             self.latestReleaseVersion ?? self.latestPrereleaseVersion
         }
-        
+
         public var latestReleaseVersion: Version? {
             self.versions.latestRelease
         }
-        
+
         public var latestPrereleaseVersion: Version? {
             self.versions.latestPrerelease
         }
@@ -128,7 +128,7 @@ extension PackageCollectionsModel.Package {
 
         /// The package version's supported platforms
         public let minimumPlatformVersions: [SupportedPlatform]?
-        
+
         // TODO: remove (replaced by verifiedCompatibility)
         /// The package version's supported platforms verified to work
         public var verifiedPlatforms: [PackageModel.Platform]? { nil }
@@ -136,7 +136,7 @@ extension PackageCollectionsModel.Package {
         // TODO: remove (replaced by verifiedCompatibility)
         /// The package version's Swift versions verified to work
         public var verifiedSwiftVersions: [SwiftLanguageVersion]? { nil }
-        
+
         /// An array of compatible platforms and Swift versions that has been tested and verified for.
         public let verifiedCompatibility: [PackageCollectionsModel.Compatibility]?
 
@@ -175,7 +175,7 @@ extension PackageCollectionsModel {
     public struct Compatibility: Equatable, Codable {
         /// The platform (e.g., macOS, Linux, etc.)
         public let platform: PackageModel.Platform
-        
+
         /// The Swift version
         public let swiftVersion: SwiftLanguageVersion
     }
@@ -219,7 +219,7 @@ extension Array where Element == PackageCollectionsModel.Package.Version {
             .sorted(by: >)
             .first
     }
-    
+
     var latestPrerelease: PackageCollectionsModel.Package.Version? {
         self.filter { !$0.version.prereleaseIdentifiers.isEmpty }
             .sorted(by: >)

--- a/Sources/PackageCollections/Model/Package.swift
+++ b/Sources/PackageCollections/Model/Package.swift
@@ -55,7 +55,17 @@ extension PackageCollectionsModel {
         ///     1.0.0-beta.1
         ///
         ///     Latest = 1.0.0-beta.3
-        public let latestVersion: Version?
+        public var latestVersion: Version? {
+            self.latestReleaseVersion ?? self.latestPrereleaseVersion
+        }
+        
+        public var latestReleaseVersion: Version? {
+            self.versions.latestRelease
+        }
+        
+        public var latestPrereleaseVersion: Version? {
+            self.versions.latestPrerelease
+        }
 
         /// Number of watchers
         public let watchersCount: Int?
@@ -72,7 +82,6 @@ extension PackageCollectionsModel {
             summary: String?,
             keywords: [String]?,
             versions: [Version],
-            latestVersion: Version?,
             watchersCount: Int?,
             readmeURL: URL?,
             authors: [Author]?
@@ -82,7 +91,6 @@ extension PackageCollectionsModel {
             self.summary = summary
             self.keywords = keywords
             self.versions = versions
-            self.latestVersion = latestVersion
             self.watchersCount = watchersCount
             self.readmeURL = readmeURL
             self.authors = authors
@@ -174,4 +182,26 @@ extension PackageCollectionsModel.Package {
 
 extension PackageCollectionsModel {
     public typealias PackageMetadata = (package: PackageCollectionsModel.Package, collections: [PackageCollectionsModel.CollectionIdentifier])
+}
+
+// MARK: - Utilities
+
+extension PackageCollectionsModel.Package.Version: Comparable {
+    public static func < (lhs: PackageCollectionsModel.Package.Version, rhs: PackageCollectionsModel.Package.Version) -> Bool {
+        lhs.version < rhs.version
+    }
+}
+
+extension Array where Element == PackageCollectionsModel.Package.Version {
+    var latestRelease: PackageCollectionsModel.Package.Version? {
+        self.filter { $0.version.prereleaseIdentifiers.isEmpty }
+            .sorted(by: >)
+            .first
+    }
+    
+    var latestPrerelease: PackageCollectionsModel.Package.Version? {
+        self.filter { !$0.version.prereleaseIdentifiers.isEmpty }
+            .sorted(by: >)
+            .first
+    }
 }

--- a/Sources/PackageCollections/Model/Package.swift
+++ b/Sources/PackageCollections/Model/Package.swift
@@ -73,6 +73,9 @@ extension PackageCollectionsModel {
         /// URL of the package's README
         public let readmeURL: URL?
 
+        /// The package's current license info
+        public let license: License?
+
         /// Package authors
         public let authors: [Author]?
 
@@ -84,6 +87,7 @@ extension PackageCollectionsModel {
             versions: [Version],
             watchersCount: Int?,
             readmeURL: URL?,
+            license: License?,
             authors: [Author]?
         ) {
             self.reference = .init(repository: repository)
@@ -93,6 +97,7 @@ extension PackageCollectionsModel {
             self.versions = versions
             self.watchersCount = watchersCount
             self.readmeURL = readmeURL
+            self.license = license
             self.authors = authors
         }
     }

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -363,13 +363,14 @@ public struct PackageCollections: PackageCollectionsProtocol {
         }
         versions.sort(by: >)
 
-        return .init(
+        return Model.Package(
             repository: package.repository,
             summary: basicMetadata?.summary ?? package.summary,
             keywords: basicMetadata?.keywords ?? package.keywords,
             versions: versions,
             watchersCount: basicMetadata?.watchersCount,
             readmeURL: basicMetadata?.readmeURL ?? package.readmeURL,
+            license: basicMetadata?.license ?? package.license,
             authors: basicMetadata?.authors
         )
     }

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -357,8 +357,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
                   products: packageVersion.products,
                   toolsVersion: packageVersion.toolsVersion,
                   minimumPlatformVersions: packageVersion.minimumPlatformVersions,
-                  verifiedPlatforms: packageVersion.verifiedPlatforms,
-                  verifiedSwiftVersions: packageVersion.verifiedSwiftVersions,
+                  verifiedCompatibility: packageVersion.verifiedCompatibility,
                   license: packageVersion.license)
         }
         versions.sort(by: >)

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -361,17 +361,13 @@ public struct PackageCollections: PackageCollectionsProtocol {
                   verifiedSwiftVersions: packageVersion.verifiedSwiftVersions,
                   license: packageVersion.license)
         }
-
-        // uses TSCUtility.Version comparator
-        versions.sort(by: { lhs, rhs in lhs.version > rhs.version })
-        let latestVersion = versions.first
+        versions.sort(by: >)
 
         return .init(
             repository: package.repository,
             summary: basicMetadata?.summary ?? package.summary,
             keywords: basicMetadata?.keywords ?? package.keywords,
             versions: versions,
-            latestVersion: latestVersion,
             watchersCount: basicMetadata?.watchersCount,
             readmeURL: basicMetadata?.readmeURL ?? package.readmeURL,
             authors: basicMetadata?.authors

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -46,6 +46,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
         let tagsURL = baseURL.appendingPathComponent("tags")
         let contributorsURL = baseURL.appendingPathComponent("contributors")
         let readmeURL = baseURL.appendingPathComponent("readme")
+        let licenseURL = baseURL.appendingPathComponent("license")
 
         let sync = DispatchGroup()
         let results = ThreadSafeKeyValueStore<URL, Result<HTTPClientResponse, Error>>()
@@ -78,7 +79,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
                         self.diagnosticsEngine?.emit(warning: "Approaching API limits on \(metadataURL.host ?? metadataURL.absoluteString) (\(apiRemaining)/\(apiLimit)), consider configuring an API token for this service.")
                     }
                     // if successful, fan out multiple API calls
-                    [tagsURL, contributorsURL, readmeURL].forEach { url in
+                    [tagsURL, contributorsURL, readmeURL, licenseURL].forEach { url in
                         sync.enter()
                         var headers = self.makeRequestHeaders(url)
                         headers.add(name: "Accept", value: "application/vnd.github.v3+json")
@@ -110,6 +111,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
                     let tags = try results[tagsURL]?.success?.decodeBody([Tag].self, using: self.decoder) ?? []
                     let contributors = try results[contributorsURL]?.success?.decodeBody([Contributor].self, using: self.decoder)
                     let readme = try results[readmeURL]?.success?.decodeBody(Readme.self, using: self.decoder)
+                    let license = try results[licenseURL]?.success?.decodeBody(License.self, using: self.decoder)
 
                     callback(.success(.init(
                         summary: metadata.description,
@@ -118,6 +120,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
                         versions: tags.compactMap { TSCUtility.Version(string: $0.name) },
                         watchersCount: metadata.watchersCount,
                         readmeURL: readme?.downloadURL,
+                        license: license.flatMap { .init(type: Model.LicenseType(string: $0.license.spdxID), url: $0.downloadURL) },
                         authors: contributors?.map { .init(username: $0.login, url: $0.url, service: .init(name: "GitHub")) },
                         processedAt: Date()
                     )))
@@ -208,7 +211,6 @@ extension GitHubPackageMetadataProvider {
         let tagsURL: Foundation.URL
         let contributorsURL: Foundation.URL
         let language: String?
-        let license: License?
         let watchersCount: Int
         let forksCount: Int
 
@@ -226,7 +228,6 @@ extension GitHubPackageMetadataProvider {
             case tagsURL = "tags_url"
             case contributorsURL = "contributors_url"
             case language
-            case license
             case watchersCount = "watchers_count"
             case forksCount = "forks_count"
         }
@@ -234,11 +235,6 @@ extension GitHubPackageMetadataProvider {
 }
 
 extension GitHubPackageMetadataProvider {
-    fileprivate struct License: Codable {
-        let key: String
-        let name: String
-    }
-
     fileprivate struct Tag: Codable {
         let name: String
         let tarballURL: Foundation.URL
@@ -271,6 +267,30 @@ extension GitHubPackageMetadataProvider {
             case url
             case htmlURL = "html_url"
             case downloadURL = "download_url"
+        }
+    }
+    
+    fileprivate struct License: Codable {
+        let url: Foundation.URL
+        let htmlURL: Foundation.URL
+        let downloadURL: Foundation.URL
+        let license: License
+        
+        private enum CodingKeys: String, CodingKey {
+            case url
+            case htmlURL = "html_url"
+            case downloadURL = "download_url"
+            case license
+        }
+        
+        fileprivate struct License: Codable {
+            let name: String
+            let spdxID: String
+            
+            private enum CodingKeys: String, CodingKey {
+                case name
+                case spdxID = "spdx_id"
+            }
         }
     }
 }

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -269,24 +269,24 @@ extension GitHubPackageMetadataProvider {
             case downloadURL = "download_url"
         }
     }
-    
+
     fileprivate struct License: Codable {
         let url: Foundation.URL
         let htmlURL: Foundation.URL
         let downloadURL: Foundation.URL
         let license: License
-        
+
         private enum CodingKeys: String, CodingKey {
             case url
             case htmlURL = "html_url"
             case downloadURL = "download_url"
             case license
         }
-        
+
         fileprivate struct License: Codable {
             let name: String
             let spdxID: String
-            
+
             private enum CodingKeys: String, CodingKey {
                 case name
                 case spdxID = "spdx_id"

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -137,7 +137,6 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
                              summary: package.summary,
                              keywords: package.keywords,
                              versions: versions,
-                             latestVersion: versions.first,
                              watchersCount: nil,
                              readmeURL: package.readmeURL,
                              authors: nil)

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -139,6 +139,7 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
                              versions: versions,
                              watchersCount: nil,
                              readmeURL: package.readmeURL,
+                             license: package.license.flatMap { Model.License(from: $0) },
                              authors: nil)
             }
 
@@ -239,7 +240,6 @@ extension PackageModel.Platform {
 
 extension Model.License {
     fileprivate init(from: JSONModel.License) {
-        let type = Model.LicenseType.allCases.first { $0.description.lowercased() == from.name.lowercased() } ?? .other(from.name)
-        self.init(type: type, url: from.url)
+        self.init(type: Model.LicenseType(string: from.name.lowercased()), url: from.url)
     }
 }

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -240,6 +240,6 @@ extension PackageModel.Platform {
 
 extension Model.License {
     fileprivate init(from: JSONModel.License) {
-        self.init(type: Model.LicenseType(string: from.name.lowercased()), url: from.url)
+        self.init(type: Model.LicenseType(string: from.name), url: from.url)
     }
 }

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -109,12 +109,8 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
                     if minimumPlatformVersions?.count != version.minimumPlatformVersions?.count {
                         serializationOkay = false
                     }
-                    let verifiedPlatforms: [PackageModel.Platform]? = version.verifiedPlatforms?.compactMap { PackageModel.Platform(from: $0) }
-                    if verifiedPlatforms?.count != version.verifiedPlatforms?.count {
-                        serializationOkay = false
-                    }
-                    let verifiedSwiftVersions = version.verifiedSwiftVersions?.compactMap { SwiftLanguageVersion(string: $0) }
-                    if verifiedSwiftVersions?.count != version.verifiedSwiftVersions?.count {
+                    let verifiedCompatibility = version.verifiedCompatibility?.compactMap { Model.Compatibility(from: $0) }
+                    if verifiedCompatibility?.count != version.verifiedCompatibility?.count {
                         serializationOkay = false
                     }
                     let license = version.license.flatMap { Model.License(from: $0) }
@@ -125,8 +121,7 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
                                  products: products,
                                  toolsVersion: toolsVersion,
                                  minimumPlatformVersions: minimumPlatformVersions,
-                                 verifiedPlatforms: verifiedPlatforms,
-                                 verifiedSwiftVersions: verifiedSwiftVersions,
+                                 verifiedCompatibility: verifiedCompatibility,
                                  license: license)
                 }
                 if versions.count != package.versions.count {
@@ -235,6 +230,16 @@ extension PackageModel.Platform {
         default:
             return nil
         }
+    }
+}
+
+extension Model.Compatibility {
+    fileprivate init?(from: JSONModel.Compatibility) {
+        guard let platform = PackageModel.Platform(from: from.platform),
+              let swiftVersion = SwiftLanguageVersion(string: from.swiftVersion) else {
+            return nil
+        }
+        self.init(platform: platform, swiftVersion: swiftVersion)
     }
 }
 

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -236,7 +236,7 @@ extension PackageModel.Platform {
 extension Model.Compatibility {
     fileprivate init?(from: JSONModel.Compatibility) {
         guard let platform = PackageModel.Platform(from: from.platform),
-              let swiftVersion = SwiftLanguageVersion(string: from.swiftVersion) else {
+            let swiftVersion = SwiftLanguageVersion(string: from.swiftVersion) else {
             return nil
         }
         self.init(platform: platform, swiftVersion: swiftVersion)

--- a/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
@@ -33,6 +33,7 @@ extension Model {
         let versions: [TSCUtility.Version]
         let watchersCount: Int?
         let readmeURL: Foundation.URL?
+        let license: PackageCollectionsModel.License?
         let authors: [PackageCollectionsModel.Package.Author]?
         let processedAt: Date
     }

--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -73,6 +73,12 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
                     callback(.success(.init(statusCode: 200,
                                             headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
                                             body: data)))
+                case (.get, apiURL.appendingPathComponent("license")):
+                    let path = directoryPath.appending(components: "GitHub", "license.json")
+                    let data = Data(try! localFileSystem.readFileContents(path).contents)
+                    callback(.success(.init(statusCode: 200,
+                                            headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
+                                            body: data)))
                 default:
                     XCTFail("method and url should match")
                 }
@@ -91,6 +97,8 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
                                                                                      url: URL(string: "https://api.github.com/users/octocat")!,
                                                                                      service: .init(name: "GitHub"))])
             XCTAssertEqual(metadata.readmeURL, URL(string: "https://raw.githubusercontent.com/octokit/octokit.rb/master/README.md"))
+            XCTAssertEqual(metadata.license?.type, PackageCollectionsModel.LicenseType.MIT)
+            XCTAssertEqual(metadata.license?.url, URL(string: "https://raw.githubusercontent.com/benbalter/gman/master/LICENSE?lab=true"))
             XCTAssertEqual(metadata.watchersCount, 80)
         }
     }
@@ -277,6 +285,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
             XCTAssertNotNil(metadata)
             XCTAssert(metadata.versions.count > 0)
             XCTAssert(metadata.keywords!.count > 0)
+            XCTAssertNotNil(metadata.license)
             XCTAssert(metadata.authors!.count > 0)
         }
     }

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionModelTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionModelTests.swift
@@ -31,8 +31,7 @@ class JSONPackageCollectionModelTests: XCTestCase {
                         products: [.init(name: "Bar", type: .library(.automatic), targets: ["Foo"])],
                         toolsVersion: "5.2",
                         minimumPlatformVersions: [.init(name: "macOS", version: "10.15")],
-                        verifiedPlatforms: [.init(name: "macOS")],
-                        verifiedSwiftVersions: ["5.2"],
+                        verifiedCompatibility: [Model.Compatibility(platform: Model.Platform(name: "macOS"), swiftVersion: "5.2")],
                         license: .init(name: "Apache-2.0", url: URL(string: "https://package-collection-tests.com/repos/foobar/LICENSE")!)
                     ),
                 ],
@@ -70,8 +69,7 @@ class JSONPackageCollectionModelTests: XCTestCase {
                         products: [.init(name: "Bar", type: .library(.automatic), targets: ["Foo"])],
                         toolsVersion: "5.2",
                         minimumPlatformVersions: nil,
-                        verifiedPlatforms: nil,
-                        verifiedSwiftVersions: nil,
+                        verifiedCompatibility: nil,
                         license: nil
                     ),
                 ],
@@ -130,8 +128,7 @@ class JSONPackageCollectionModelTests: XCTestCase {
                         products: [.init(name: "Bar", type: .library(.automatic), targets: ["Foo"])],
                         toolsVersion: "5.2",
                         minimumPlatformVersions: nil,
-                        verifiedPlatforms: nil,
-                        verifiedSwiftVersions: nil,
+                        verifiedCompatibility: nil,
                         license: nil
                     ),
                 ],
@@ -150,8 +147,7 @@ class JSONPackageCollectionModelTests: XCTestCase {
                         products: [.init(name: "Baz", type: .library(.automatic), targets: ["Foo"])],
                         toolsVersion: "5.2",
                         minimumPlatformVersions: nil,
-                        verifiedPlatforms: nil,
-                        verifiedSwiftVersions: nil,
+                        verifiedCompatibility: nil,
                         license: nil
                     ),
                 ],
@@ -194,8 +190,7 @@ class JSONPackageCollectionModelTests: XCTestCase {
                         products: [],
                         toolsVersion: "5.2",
                         minimumPlatformVersions: nil,
-                        verifiedPlatforms: nil,
-                        verifiedSwiftVersions: nil,
+                        verifiedCompatibility: nil,
                         license: nil
                     ),
                     Model.Collection.Package.Version(
@@ -205,8 +200,7 @@ class JSONPackageCollectionModelTests: XCTestCase {
                         products: [.init(name: "Bar", type: .library(.automatic), targets: ["Foo"])],
                         toolsVersion: "5.2",
                         minimumPlatformVersions: nil,
-                        verifiedPlatforms: nil,
-                        verifiedSwiftVersions: nil,
+                        verifiedCompatibility: nil,
                         license: nil
                     ),
                 ],
@@ -259,8 +253,7 @@ class JSONPackageCollectionModelTests: XCTestCase {
                         products: [.init(name: "Bar", type: .library(.automatic), targets: ["Foo"])],
                         toolsVersion: "5.2",
                         minimumPlatformVersions: nil,
-                        verifiedPlatforms: nil,
-                        verifiedSwiftVersions: nil,
+                        verifiedCompatibility: nil,
                         license: nil
                     ),
                 ],
@@ -303,8 +296,7 @@ class JSONPackageCollectionModelTests: XCTestCase {
                         products: [.init(name: "Bar", type: .library(.automatic), targets: ["Foo"])],
                         toolsVersion: "5.2",
                         minimumPlatformVersions: nil,
-                        verifiedPlatforms: nil,
-                        verifiedSwiftVersions: nil,
+                        verifiedCompatibility: nil,
                         license: nil
                     ),
                     Model.Collection.Package.Version(
@@ -314,8 +306,7 @@ class JSONPackageCollectionModelTests: XCTestCase {
                         products: [.init(name: "Bar", type: .library(.automatic), targets: ["Foo"])],
                         toolsVersion: "5.2",
                         minimumPlatformVersions: nil,
-                        verifiedPlatforms: nil,
-                        verifiedSwiftVersions: nil,
+                        verifiedCompatibility: nil,
                         license: nil
                     ),
                 ],
@@ -334,8 +325,7 @@ class JSONPackageCollectionModelTests: XCTestCase {
                         products: [.init(name: "Baz", type: .library(.automatic), targets: ["Foo"])],
                         toolsVersion: "5.2",
                         minimumPlatformVersions: nil,
-                        verifiedPlatforms: nil,
-                        verifiedSwiftVersions: nil,
+                        verifiedCompatibility: nil,
                         license: nil
                     ),
                     Model.Collection.Package.Version(
@@ -345,8 +335,7 @@ class JSONPackageCollectionModelTests: XCTestCase {
                         products: [.init(name: "Baz", type: .library(.automatic), targets: ["Foo"])],
                         toolsVersion: "5.2",
                         minimumPlatformVersions: nil,
-                        verifiedPlatforms: nil,
-                        verifiedSwiftVersions: nil,
+                        verifiedCompatibility: nil,
                         license: nil
                     ),
                 ],
@@ -394,8 +383,7 @@ class JSONPackageCollectionModelTests: XCTestCase {
                         products: [.init(name: "Bar", type: .library(.automatic), targets: [])],
                         toolsVersion: "5.2",
                         minimumPlatformVersions: nil,
-                        verifiedPlatforms: nil,
-                        verifiedSwiftVersions: nil,
+                        verifiedCompatibility: nil,
                         license: nil
                     ),
                 ],

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionModelTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionModelTests.swift
@@ -36,7 +36,8 @@ class JSONPackageCollectionModelTests: XCTestCase {
                         license: .init(name: "Apache-2.0", url: URL(string: "https://package-collection-tests.com/repos/foobar/LICENSE")!)
                     ),
                 ],
-                readmeURL: URL(string: "https://package-collection-tests.com/repos/foobar/README")!
+                readmeURL: URL(string: "https://package-collection-tests.com/repos/foobar/README")!,
+                license: .init(name: "Apache-2.0", url: URL(string: "https://package-collection-tests.com/repos/foobar/LICENSE")!)
             ),
         ]
         let collection = Model.Collection(
@@ -74,7 +75,8 @@ class JSONPackageCollectionModelTests: XCTestCase {
                         license: nil
                     ),
                 ],
-                readmeURL: nil
+                readmeURL: nil,
+                license: nil
             ),
         ]
         let collection = Model.Collection(
@@ -133,7 +135,8 @@ class JSONPackageCollectionModelTests: XCTestCase {
                         license: nil
                     ),
                 ],
-                readmeURL: URL(string: "https://package-collection-tests.com/repos/foobar/README")!
+                readmeURL: nil,
+                license: nil
             ),
             Model.Collection.Package(
                 url: URL(string: "https://package-collection-tests.com/repos/foobaz.git")!,
@@ -152,7 +155,8 @@ class JSONPackageCollectionModelTests: XCTestCase {
                         license: nil
                     ),
                 ],
-                readmeURL: nil
+                readmeURL: nil,
+                license: nil
             ),
         ]
         let collection = Model.Collection(
@@ -206,7 +210,8 @@ class JSONPackageCollectionModelTests: XCTestCase {
                         license: nil
                     ),
                 ],
-                readmeURL: nil
+                readmeURL: nil,
+                license: nil
             ),
         ]
         let collection = Model.Collection(
@@ -259,7 +264,8 @@ class JSONPackageCollectionModelTests: XCTestCase {
                         license: nil
                     ),
                 ],
-                readmeURL: URL(string: "https://package-collection-tests.com/repos/foobar/README")!
+                readmeURL: nil,
+                license: nil
             )
         ]
         let collection = Model.Collection(
@@ -313,7 +319,8 @@ class JSONPackageCollectionModelTests: XCTestCase {
                         license: nil
                     ),
                 ],
-                readmeURL: URL(string: "https://package-collection-tests.com/repos/foobar/README")!
+                readmeURL: nil,
+                license: nil
             ),
             Model.Collection.Package(
                 url: URL(string: "https://package-collection-tests.com/repos/foobaz.git")!,
@@ -343,7 +350,8 @@ class JSONPackageCollectionModelTests: XCTestCase {
                         license: nil
                     ),
                 ],
-                readmeURL: nil
+                readmeURL: nil,
+                license: nil
             ),
         ]
         let collection = Model.Collection(
@@ -391,7 +399,8 @@ class JSONPackageCollectionModelTests: XCTestCase {
                         license: nil
                     ),
                 ],
-                readmeURL: URL(string: "https://package-collection-tests.com/repos/foobar/README")!
+                readmeURL: nil,
+                license: nil
             )
         ]
         let collection = Model.Collection(

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -66,8 +66,9 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(version.products, [.init(name: "Foo", type: .library(.automatic), targets: [.init(name: "Foo", moduleName: "Foo")])])
             XCTAssertEqual(version.toolsVersion, ToolsVersion(string: "5.1")!)
             XCTAssertEqual(version.minimumPlatformVersions, [SupportedPlatform(platform: .macOS, version: .init("10.15"))])
-            XCTAssertEqual(version.verifiedSwiftVersions, [SwiftLanguageVersion(string: "5.1")!])
-            XCTAssertEqual(version.verifiedPlatforms, [.macOS, .iOS, .linux])
+            XCTAssertEqual(version.verifiedCompatibility?.count, 3)
+            XCTAssertEqual(version.verifiedCompatibility!.first!.platform, .macOS)
+            XCTAssertEqual(version.verifiedCompatibility!.first!.swiftVersion, SwiftLanguageVersion(string: "5.1")!)
             XCTAssertEqual(version.license, .init(type: .Apache2_0, url: URL(string: "https://www.example.com/repos/RepoOne/LICENSE")!))
         }
     }
@@ -117,8 +118,9 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(version.products, [.init(name: "Foo", type: .library(.automatic), targets: [.init(name: "Foo", moduleName: "Foo")])])
             XCTAssertEqual(version.toolsVersion, ToolsVersion(string: "5.1")!)
             XCTAssertEqual(version.minimumPlatformVersions, [SupportedPlatform(platform: .macOS, version: .init("10.15"))])
-            XCTAssertEqual(version.verifiedSwiftVersions, [SwiftLanguageVersion(string: "5.1")!])
-            XCTAssertEqual(version.verifiedPlatforms, [.macOS, .iOS, .linux])
+            XCTAssertEqual(version.verifiedCompatibility?.count, 3)
+            XCTAssertEqual(version.verifiedCompatibility!.first!.platform, .macOS)
+            XCTAssertEqual(version.verifiedCompatibility!.first!.swiftVersion, SwiftLanguageVersion(string: "5.1")!)
             XCTAssertEqual(version.license, .init(type: .Apache2_0, url: URL(string: "https://www.example.com/repos/RepoOne/LICENSE")!))
         }
     }

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -58,6 +58,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(package.summary, "Package One")
             XCTAssertEqual(package.keywords, ["sample package"])
             XCTAssertEqual(package.readmeURL, URL(string: "https://www.example.com/repos/RepoOne/README")!)
+            XCTAssertEqual(package.license, .init(type: .Apache2_0, url: URL(string: "https://www.example.com/repos/RepoOne/LICENSE")!))
             XCTAssertEqual(package.versions.count, 1)
             let version = package.versions.first!
             XCTAssertEqual(version.packageName, "PackageOne")
@@ -108,6 +109,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(package.summary, "Package One")
             XCTAssertEqual(package.keywords, ["sample package"])
             XCTAssertEqual(package.readmeURL, URL(string: "https://www.example.com/repos/RepoOne/README")!)
+            XCTAssertEqual(package.license, .init(type: .Apache2_0, url: URL(string: "https://www.example.com/repos/RepoOne/LICENSE")!))
             XCTAssertEqual(package.versions.count, 1)
             let version = package.versions.first!
             XCTAssertEqual(version.packageName, "PackageOne")

--- a/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
@@ -21,23 +21,23 @@ final class PackageCollectionsModelTests: XCTestCase {
         let versions: [PackageCollectionsModel.Package.Version] = [
             .init(
                 version: .init(stringLiteral: "1.2.0"), packageName: "FooBar", targets: targets, products: products,
-                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedPlatforms: nil, verifiedSwiftVersions: nil, license: nil
+                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedCompatibility: nil, license: nil
             ),
             .init(
                 version: .init(stringLiteral: "2.0.1"), packageName: "FooBar", targets: targets, products: products,
-                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedPlatforms: nil, verifiedSwiftVersions: nil, license: nil
+                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedCompatibility: nil, license: nil
             ),
             .init(
                 version: .init(stringLiteral: "2.1.0-beta.3"), packageName: "FooBar", targets: targets, products: products,
-                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedPlatforms: nil, verifiedSwiftVersions: nil, license: nil
+                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedCompatibility: nil, license: nil
             ),
             .init(
                 version: .init(stringLiteral: "2.1.0"), packageName: "FooBar", targets: targets, products: products,
-                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedPlatforms: nil, verifiedSwiftVersions: nil, license: nil
+                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedCompatibility: nil, license: nil
             ),
             .init(
                 version: .init(stringLiteral: "3.0.0-beta.1"), packageName: "FooBar", targets: targets, products: products,
-                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedPlatforms: nil, verifiedSwiftVersions: nil, license: nil
+                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedCompatibility: nil, license: nil
             ),
         ]
         
@@ -52,11 +52,11 @@ final class PackageCollectionsModelTests: XCTestCase {
         let versions: [PackageCollectionsModel.Package.Version] = [
             .init(
                 version: .init(stringLiteral: "2.1.0-beta.3"), packageName: "FooBar", targets: targets, products: products,
-                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedPlatforms: nil, verifiedSwiftVersions: nil, license: nil
+                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedCompatibility: nil, license: nil
             ),
             .init(
                 version: .init(stringLiteral: "3.0.0-beta.1"), packageName: "FooBar", targets: targets, products: products,
-                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedPlatforms: nil, verifiedSwiftVersions: nil, license: nil
+                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedCompatibility: nil, license: nil
             ),
         ]
         
@@ -71,15 +71,15 @@ final class PackageCollectionsModelTests: XCTestCase {
         let versions: [PackageCollectionsModel.Package.Version] = [
             .init(
                 version: .init(stringLiteral: "1.2.0"), packageName: "FooBar", targets: targets, products: products,
-                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedPlatforms: nil, verifiedSwiftVersions: nil, license: nil
+                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedCompatibility: nil, license: nil
             ),
             .init(
                 version: .init(stringLiteral: "2.0.1"), packageName: "FooBar", targets: targets, products: products,
-                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedPlatforms: nil, verifiedSwiftVersions: nil, license: nil
+                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedCompatibility: nil, license: nil
             ),
             .init(
                 version: .init(stringLiteral: "2.1.0"), packageName: "FooBar", targets: targets, products: products,
-                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedPlatforms: nil, verifiedSwiftVersions: nil, license: nil
+                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedCompatibility: nil, license: nil
             ),
         ]
         

--- a/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
@@ -1,0 +1,89 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import XCTest
+
+@testable import PackageCollections
+@testable import PackageModel
+
+final class PackageCollectionsModelTests: XCTestCase {
+    func testLatestVersions() {
+        let targets = [PackageCollectionsModel.Target(name: "Foo", moduleName: "Foo")]
+        let products = [PackageCollectionsModel.Product(name: "Foo", type: .library(.automatic), targets: targets)]
+        let toolsVersion = ToolsVersion(string: "5.2")!
+        let versions: [PackageCollectionsModel.Package.Version] = [
+            .init(
+                version: .init(stringLiteral: "1.2.0"), packageName: "FooBar", targets: targets, products: products,
+                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedPlatforms: nil, verifiedSwiftVersions: nil, license: nil
+            ),
+            .init(
+                version: .init(stringLiteral: "2.0.1"), packageName: "FooBar", targets: targets, products: products,
+                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedPlatforms: nil, verifiedSwiftVersions: nil, license: nil
+            ),
+            .init(
+                version: .init(stringLiteral: "2.1.0-beta.3"), packageName: "FooBar", targets: targets, products: products,
+                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedPlatforms: nil, verifiedSwiftVersions: nil, license: nil
+            ),
+            .init(
+                version: .init(stringLiteral: "2.1.0"), packageName: "FooBar", targets: targets, products: products,
+                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedPlatforms: nil, verifiedSwiftVersions: nil, license: nil
+            ),
+            .init(
+                version: .init(stringLiteral: "3.0.0-beta.1"), packageName: "FooBar", targets: targets, products: products,
+                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedPlatforms: nil, verifiedSwiftVersions: nil, license: nil
+            ),
+        ]
+        
+        XCTAssertEqual("2.1.0", versions.latestRelease?.version.description)
+        XCTAssertEqual("3.0.0-beta.1", versions.latestPrerelease?.version.description)
+    }
+    
+    func testNoLatestReleaseVersion() {
+        let targets = [PackageCollectionsModel.Target(name: "Foo", moduleName: "Foo")]
+        let products = [PackageCollectionsModel.Product(name: "Foo", type: .library(.automatic), targets: targets)]
+        let toolsVersion = ToolsVersion(string: "5.2")!
+        let versions: [PackageCollectionsModel.Package.Version] = [
+            .init(
+                version: .init(stringLiteral: "2.1.0-beta.3"), packageName: "FooBar", targets: targets, products: products,
+                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedPlatforms: nil, verifiedSwiftVersions: nil, license: nil
+            ),
+            .init(
+                version: .init(stringLiteral: "3.0.0-beta.1"), packageName: "FooBar", targets: targets, products: products,
+                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedPlatforms: nil, verifiedSwiftVersions: nil, license: nil
+            ),
+        ]
+        
+        XCTAssertNil(versions.latestRelease)
+        XCTAssertEqual("3.0.0-beta.1", versions.latestPrerelease?.version.description)
+    }
+    
+    func testNoLatestPrereleaseVersion() {
+        let targets = [PackageCollectionsModel.Target(name: "Foo", moduleName: "Foo")]
+        let products = [PackageCollectionsModel.Product(name: "Foo", type: .library(.automatic), targets: targets)]
+        let toolsVersion = ToolsVersion(string: "5.2")!
+        let versions: [PackageCollectionsModel.Package.Version] = [
+            .init(
+                version: .init(stringLiteral: "1.2.0"), packageName: "FooBar", targets: targets, products: products,
+                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedPlatforms: nil, verifiedSwiftVersions: nil, license: nil
+            ),
+            .init(
+                version: .init(stringLiteral: "2.0.1"), packageName: "FooBar", targets: targets, products: products,
+                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedPlatforms: nil, verifiedSwiftVersions: nil, license: nil
+            ),
+            .init(
+                version: .init(stringLiteral: "2.1.0"), packageName: "FooBar", targets: targets, products: products,
+                toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedPlatforms: nil, verifiedSwiftVersions: nil, license: nil
+            ),
+        ]
+        
+        XCTAssertEqual("2.1.0", versions.latestRelease?.version.description)
+        XCTAssertNil(versions.latestPrerelease)
+    }
+}

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -381,7 +381,6 @@ final class PackageCollectionsTests: XCTestCase {
                                                           summary: UUID().uuidString,
                                                           keywords: [UUID().uuidString, UUID().uuidString],
                                                           versions: [mockVersion],
-                                                          latestVersion: mockVersion,
                                                           watchersCount: nil,
                                                           readmeURL: nil,
                                                           authors: nil)
@@ -532,7 +531,6 @@ final class PackageCollectionsTests: XCTestCase {
                                                           summary: UUID().uuidString,
                                                           keywords: [UUID().uuidString, UUID().uuidString],
                                                           versions: [mockVersion],
-                                                          latestVersion: mockVersion,
                                                           watchersCount: nil,
                                                           readmeURL: nil,
                                                           authors: nil)
@@ -836,7 +834,6 @@ final class PackageCollectionsTests: XCTestCase {
                                                           summary: "package \(packageId) description",
                                                           keywords: [UUID().uuidString],
                                                           versions: versions,
-                                                          latestVersion: versions.first,
                                                           watchersCount: Int.random(in: 0 ... 50),
                                                           readmeURL: URL(string: "https://package-\(packageId)-readme")!,
                                                           authors: (0 ..< Int.random(in: 1 ... 10)).map { .init(username: "\($0)", url: nil, service: nil) })

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -383,6 +383,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                           versions: [mockVersion],
                                                           watchersCount: nil,
                                                           readmeURL: nil,
+                                                          license: nil,
                                                           authors: nil)
 
         let mockCollection = PackageCollectionsModel.Collection(source: .init(type: .json, url: URL(string: "https://feed.mock/\(UUID().uuidString)")!),
@@ -533,6 +534,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                           versions: [mockVersion],
                                                           watchersCount: nil,
                                                           readmeURL: nil,
+                                                          license: nil,
                                                           authors: nil)
 
         let mockCollection = PackageCollectionsModel.Collection(source: .init(type: .json, url: URL(string: "https://feed.mock/\(UUID().uuidString)")!),
@@ -836,6 +838,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                           versions: versions,
                                                           watchersCount: Int.random(in: 0 ... 50),
                                                           readmeURL: URL(string: "https://package-\(packageId)-readme")!,
+                                                          license: PackageCollectionsModel.License(type: .Apache2_0, url: URL(string: "http://apache.license")!),
                                                           authors: (0 ..< Int.random(in: 1 ... 10)).map { .init(username: "\($0)", url: nil, service: nil) })
 
         let mockMetadata = PackageCollectionsModel.PackageBasicMetadata(summary: "\(mockPackage.summary!) 2",
@@ -843,6 +846,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                                         versions: mockPackage.versions.map { TSCUtility.Version($0.version.major, 1, 0) },
                                                                         watchersCount: mockPackage.watchersCount! + 1,
                                                                         readmeURL: URL(string: "\(mockPackage.readmeURL!.absoluteString)-2")!,
+                                                                        license: PackageCollectionsModel.License(type: .Apache2_0, url: URL(string: "\(mockPackage.license!.url.absoluteString)-2")!),
                                                                         authors: mockPackage.authors.flatMap { $0.map { .init(username: "\($0.username + "2")", url: nil, service: nil) } },
                                                                         processedAt: Date())
 
@@ -869,6 +873,7 @@ final class PackageCollectionsTests: XCTestCase {
         XCTAssertEqual(metadata.latestVersion?.version, versions.last?.version, "latestVersion should match")
         XCTAssertEqual(metadata.watchersCount, mockMetadata.watchersCount, "watchersCount should match")
         XCTAssertEqual(metadata.readmeURL, mockMetadata.readmeURL, "readmeURL should match")
+        XCTAssertEqual(metadata.license, mockMetadata.license, "license should match")
         XCTAssertEqual(metadata.authors, mockMetadata.authors, "authors should match")
     }
 

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -373,8 +373,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                                   products: mockProducts,
                                                                   toolsVersion: .currentToolsVersion,
                                                                   minimumPlatformVersions: nil,
-                                                                  verifiedPlatforms: nil,
-                                                                  verifiedSwiftVersions: nil,
+                                                                  verifiedCompatibility: nil,
                                                                   license: nil)
 
         let mockPackage = PackageCollectionsModel.Package(repository: .init(url: "https://packages.mock/\(UUID().uuidString)"),
@@ -524,8 +523,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                                   products: mockProducts,
                                                                   toolsVersion: .currentToolsVersion,
                                                                   minimumPlatformVersions: nil,
-                                                                  verifiedPlatforms: nil,
-                                                                  verifiedSwiftVersions: nil,
+                                                                  verifiedCompatibility: nil,
                                                                   license: nil)
 
         let mockPackage = PackageCollectionsModel.Package(repository: RepositorySpecifier(url: "https://packages.mock/\(UUID().uuidString)"),
@@ -827,8 +825,10 @@ final class PackageCollectionsTests: XCTestCase {
                                                     products: products,
                                                     toolsVersion: .currentToolsVersion,
                                                     minimumPlatformVersions: [.init(platform: .macOS, version: .init("10.15"))],
-                                                    verifiedPlatforms: [.iOS, .linux],
-                                                    verifiedSwiftVersions: SwiftLanguageVersion.knownSwiftLanguageVersions,
+                                                    verifiedCompatibility: [
+                                                        .init(platform: .iOS, swiftVersion: SwiftLanguageVersion.knownSwiftLanguageVersions.randomElement()!),
+                                                        .init(platform: .linux, swiftVersion: SwiftLanguageVersion.knownSwiftLanguageVersions.randomElement()!),
+                                                    ],
                                                     license: PackageCollectionsModel.License(type: .Apache2_0, url: URL(string: "http://apache.license")!))
         }
 
@@ -865,8 +865,7 @@ final class PackageCollectionsTests: XCTestCase {
             XCTAssertEqual(version.products, metadataVersion?.products, "products should match")
             XCTAssertEqual(version.toolsVersion, metadataVersion?.toolsVersion, "toolsVersion should match")
             XCTAssertEqual(version.minimumPlatformVersions, metadataVersion?.minimumPlatformVersions, "minimumPlatformVersions should match")
-            XCTAssertEqual(version.verifiedPlatforms, metadataVersion?.verifiedPlatforms, "verifiedPlatforms should match")
-            XCTAssertEqual(version.verifiedSwiftVersions, metadataVersion?.verifiedSwiftVersions, "verifiedSwiftVersions should match")
+            XCTAssertEqual(version.verifiedCompatibility, metadataVersion?.verifiedCompatibility, "verifiedCompatibility should match")
             XCTAssertEqual(version.license, metadataVersion?.license, "license should match")
         }
         XCTAssertEqual(metadata.latestVersion, metadata.versions.first, "versions should be sorted")

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -66,6 +66,7 @@ func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: I
                                                    versions: versions,
                                                    watchersCount: Int.random(in: 1 ... 1000),
                                                    readmeURL: URL(string: "https://package-\(packageIndex)-readme")!,
+                                                   license: PackageCollectionsModel.License(type: .Apache2_0, url: URL(string: "https://\(packageIndex).license")!),
                                                    authors: nil)
         }
 
@@ -85,6 +86,7 @@ func makeMockPackageBasicMetadata() -> PackageCollectionsModel.PackageBasicMetad
                  versions: (0 ..< Int.random(in: 1 ... 10)).map { TSCUtility.Version($0, 0, 0) },
                  watchersCount: Int.random(in: 0 ... 50),
                  readmeURL: URL(string: "https://package-readme")!,
+                 license: PackageCollectionsModel.License(type: .Apache2_0, url: URL(string: "https://package-license")!),
                  authors: (0 ..< Int.random(in: 1 ... 10)).map { .init(username: "\($0)", url: nil, service: nil) },
                  processedAt: Date())
 }

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -64,7 +64,6 @@ func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: I
                                                    summary: "package \(packageIndex) description",
                                                    keywords: (0 ..< Int.random(in: 1 ... 3)).map { "keyword \($0)" },
                                                    versions: versions,
-                                                   latestVersion: versions.first,
                                                    watchersCount: Int.random(in: 1 ... 1000),
                                                    readmeURL: URL(string: "https://package-\(packageIndex)-readme")!,
                                                    authors: nil)

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -44,8 +44,12 @@ func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: I
                                                     targets: targets)
                 }
                 let minimumPlatformVersions = (0 ..< Int.random(in: 1 ... 2)).map { _ in supportedPlatforms.randomElement()! }
-                let verifiedPlatforms = (0 ..< Int.random(in: 1 ... 3)).map { _ in platforms.randomElement()! }
-                let verifiedSwiftVersions = (0 ..< Int.random(in: 1 ... 3)).map { _ in SwiftLanguageVersion.knownSwiftLanguageVersions.randomElement()! }
+                let verifiedCompatibility = (0 ..< Int.random(in: 1 ... 3)).map { _ in
+                    PackageCollectionsModel.Compatibility(
+                        platform: platforms.randomElement()!,
+                        swiftVersion: SwiftLanguageVersion.knownSwiftLanguageVersions.randomElement()!
+                    )
+                }
                 let licenseType = PackageCollectionsModel.LicenseType.allCases.randomElement()!
                 let license = PackageCollectionsModel.License(type: licenseType, url: URL(string: "http://\(licenseType).license")!)
 
@@ -55,8 +59,7 @@ func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: I
                                                                products: products,
                                                                toolsVersion: .currentToolsVersion,
                                                                minimumPlatformVersions: minimumPlatformVersions,
-                                                               verifiedPlatforms: verifiedPlatforms,
-                                                               verifiedSwiftVersions: verifiedSwiftVersions,
+                                                               verifiedCompatibility: verifiedCompatibility,
                                                                license: license)
             }
 


### PR DESCRIPTION
### Motivation:

Updating package collection models based on [feedback](https://forums.swift.org/t/package-collection-format/42071).

### Modifications:

- Add new computed properties `latestReleaseVersion` and `latestPrereleaseVersion` to `Package.Version`; convert existing `latestVersion` to be a computed property. (https://github.com/apple/swift-package-manager/commit/b7de686f26b85953514fcf6ca11d2e1086c70369)
- Add optional `license` to `Package` so that it can hold _current_ license info. Currently only `Package.Version` has `license` and that's only suitable for snapshot data. (https://github.com/apple/swift-package-manager/commit/c7c2b453988453eb8d3778879b6a600f84bd49bc)
- It might not always be possible to determine license name. Instead of forcing people to use values such as `"unknown"`, `""` for `license.name`, it might be better to allow `nil` instead. (https://github.com/apple/swift-package-manager/commit/bab101ef7c9dfe807d4dfef8fa732002c3f8bd1d)
- Matrix is a better representation of compatibility info, therefore we are combining `verifiedPlatforms` and `verifiedSwiftVersions` into a single `verifiedCompatibility` array, with each item having platform and Swift version. (https://github.com/apple/swift-package-manager/commit/e80034ae4359d8efe415c856335da909826bda50)

### Result:

This PR includes all the feedback we've collected so far. 

I will update documentation and https://github.com/apple/swift-package-collection-generator accordingly. 
