### PR TITLE
Temporarily disable a test that is crashing only in CI

### DIFF
--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -291,6 +291,8 @@ class RepositoryManagerTests: XCTestCase {
     }
 
     func testCache() throws {
+        try XCTSkipUnless(ProcessEnv.vars["SWIFTPM_ENABLE_FLAKY_REPOSITORYMANAGERTESTS"] == "1", "skipping test that sometimes crashes in CI")
+        
         fixture(name: "DependencyResolution/External/Simple") { prefix in
             let cachePath = prefix.appending(component: "cache")
             let repositoriesPath = prefix.appending(component: "repositories")


### PR DESCRIPTION
Temporarily disable a test that is crashing only in CI, but leave an environment variable to reenable it for testing.  The crash is being investigated.