### PR TITLE
Enable explicitly declared executable targets by default, now that SE-0294 has been accepted

### DIFF
--- a/Documentation/PackageDescription.md
+++ b/Documentation/PackageDescription.md
@@ -492,11 +492,49 @@ A target may depend on other targets within the same package and on products ven
 ## Methods
 
 ```swift
-/// Creates a library or executable target.
+/// Creates a regular target.
 ///
-/// A target can contain either Swift or C-family source files, but not both. The Swift Package Manager
-/// considers a target to be an executable target if its directory contains a `main.swift`, `main.m`, `main.c`,
-/// or `main.cpp` file. The Swift Package Manager considers all other targets to be library targets.
+/// A target can contain either Swift or C-family source files, but not both. It contains code that is built as
+/// a regular module that can be included in a library or executable product, but that cannot itself be used as
+/// the main target of an executable product.
+///
+/// - Parameters:
+///   - name: The name of the target.
+///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
+///   - path: The custom path for the target. By default, the Swift Package Manager requires a target's sources to reside at predefined search paths;
+///       for example, `[PackageRoot]/Sources/[TargetName]`.
+///       Don't escape the package root; for example, values like `../Foo` or `/Foo` are invalid.
+///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
+///       A path is relative to the target's directory.
+///       This parameter has precedence over the `sources` parameter.
+///   - sources: An explicit list of source files. If you provide a path to a directory,
+///       the Swift Package Manager searches for valid source files recursively.
+///   - resources: An explicit list of resources files.
+///   - publicHeadersPath: The directory containing public headers of a C-family library target.
+///   - cSettings: The C settings for this target.
+///   - cxxSettings: The C++ settings for this target.
+///   - swiftSettings: The Swift settings for this target.
+///   - linkerSettings: The linker settings for this target.
+static func target(
+    name: String,
+    dependencies: [Target.Dependency] = [],
+    path: String? = nil,
+    exclude: [String] = [],
+    sources: [String]? = nil,
+    resources: [Resource]? = nil,
+    publicHeadersPath: String? = nil,
+    cSettings: [CSetting]? = nil,
+    cxxSettings: [CXXSetting]? = nil,
+    swiftSettings: [SwiftSetting]? = nil,
+    linkerSettings: [LinkerSetting]? = nil
+) -> Target
+
+/// Creates an executable target.
+///
+/// An executable target can contain either Swift or C-family source files, but not both. It contains code that
+/// is built as an executable module that can be used as the main target of an executable product. The target
+/// is expected to either have a source file named `main.swift`, `main.m`, `main.c`, or `main.cpp`, or a source
+/// file that contains the `@main` keyword.
 ///
 /// - Parameters:
 ///   - name: The name of the target.

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -380,9 +380,9 @@ public final class Target {
     /// Creates an executable target.
     ///
     /// An executable target can contain either Swift or C-family source files, but not both. It contains code that
-    /// is built as an executable module that can be used as the main target of an executable product.  The target
+    /// is built as an executable module that can be used as the main target of an executable product. The target
     /// is expected to either have a source file named `main.swift`, `main.m`, `main.c`, or `main.cpp`, or a source
-    ///  file that contains the `@main` keyword.
+    /// file that contains the `@main` keyword.
     ///
     /// - Parameters:
     ///   - name: The name of the target.

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -256,7 +256,7 @@ public final class PackageBuilder {
         fileSystem: FileSystem = localFileSystem,
         diagnostics: DiagnosticsEngine,
         shouldCreateMultipleTestProducts: Bool = false,
-        warnAboutImplicitExecutableTargets: Bool = (ProcessEnv.vars["SWIFTPM_ENABLE_EXECUTABLE_TARGETS"] == "1"),
+        warnAboutImplicitExecutableTargets: Bool = true,
         createREPLProduct: Bool = false
     ) {
         self.manifest = manifest


### PR DESCRIPTION
Enable explicitly declared executable targets by default, now that SE-0294 has been accepted, and adjust the PackageDescription documentation.