### PR TITLE
RFC: prevent false positive cyclic dependency when root directory name clashes with a dependency name

### DIFF
--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -380,3 +380,21 @@ extension Manifest: Codable {
         try container.encode(packageKind, forKey: .packageKind)
     }
 }
+
+extension Manifest {
+    fileprivate static let pid = getpid()
+
+    public static func urlFor(packageKind: PackageReference.Kind, baseUrl: String) -> String {
+        if .root != packageKind {
+            return baseUrl
+        }
+
+        // reduce collision space
+        let suffix = ".switpm_\(Self.pid)_root"
+        var url = baseUrl
+        if !url.hasSuffix(suffix) {
+            url += suffix
+        }
+        return url
+    }
+}

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -54,7 +54,7 @@ public final class MockWorkspace {
         self.roots = roots
         self.packages = packages
 
-        self.manifestLoader = MockManifestLoader(manifests: [:])
+        self.manifestLoader = MockManifestLoader()
         self.repoProvider = InMemoryGitRepositoryProvider()
         self.toolsVersion = toolsVersion
         self.skipUpdate = skipUpdate
@@ -92,7 +92,7 @@ public final class MockWorkspace {
         try self.fs.createDirectory(self.rootsDir)
         try self.fs.createDirectory(self.packagesDir)
 
-        var manifests: [MockManifestLoader.Key: Manifest] = [:]
+        var manifests = [Manifest]()
 
         func create(package: MockPackage, basePath: AbsolutePath, packageKind: PackageReference.Kind) throws {
             let packagePath = basePath.appending(RelativePath(package.path ?? package.name))
@@ -118,7 +118,7 @@ public final class MockWorkspace {
             let manifestPath = packagePath.appending(component: Manifest.filename)
             for version in versions {
                 let v = version.flatMap(Version.init(string:))
-                manifests[.init(url: url, version: v)] = Manifest(
+                let manifest = Manifest(
                     name: package.name,
                     platforms: package.platforms,
                     path: manifestPath,
@@ -130,6 +130,7 @@ public final class MockWorkspace {
                     products: package.products.map { ProductDescription(name: $0.name, type: .library(.automatic), targets: $0.targets) },
                     targets: package.targets.map { $0.convert() }
                 )
+                manifests.append(manifest)
                 if let version = version {
                     try repo.tag(name: version)
                 }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -352,8 +352,8 @@ final class WorkspaceTests: XCTestCase {
 
         // Add entry for the Bar.git package.
         do {
-            let barKey = MockManifestLoader.Key(url: "/tmp/ws/pkgs/Bar", version: "1.0.0")
-            let barGitKey = MockManifestLoader.Key(url: "/tmp/ws/pkgs/Bar.git", version: "1.0.0")
+            let barKey = MockManifestLoader.makeKey(packageKind: .remote, url: "/tmp/ws/pkgs/Bar", version: "1.0.0")
+            let barGitKey = MockManifestLoader.makeKey(packageKind: .remote, url: "/tmp/ws/pkgs/Bar.git", version: "1.0.0")
             let manifest = workspace.manifestLoader.manifests[barKey]!
             workspace.manifestLoader.manifests[barGitKey] = manifest.with(url: "/tmp/ws/pkgs/Bar.git")
         }
@@ -2465,8 +2465,8 @@ final class WorkspaceTests: XCTestCase {
 
         // Add entry for the edited package.
         do {
-            let barKey = MockManifestLoader.Key(url: "/tmp/ws/pkgs/Bar")
-            let editedBarKey = MockManifestLoader.Key(url: "/tmp/ws/edits/Bar")
+            let barKey = MockManifestLoader.makeKey(packageKind: .remote, url: "/tmp/ws/pkgs/Bar")
+            let editedBarKey = MockManifestLoader.makeKey(packageKind: .remote, url: "/tmp/ws/edits/Bar")
             let manifest = workspace.manifestLoader.manifests[barKey]!
             workspace.manifestLoader.manifests[editedBarKey] = manifest
         }
@@ -2646,7 +2646,7 @@ final class WorkspaceTests: XCTestCase {
         // Check that changing the requirement to 1.5.0 triggers re-resolution.
         //
         // FIXME: Find a cleaner way to change a dependency requirement.
-        let fooKey = MockManifestLoader.Key(url: "/tmp/ws/roots/Foo")
+        let fooKey = MockManifestLoader.makeKey(packageKind: .root, url: "/tmp/ws/roots/Foo")
         let manifest = workspace.manifestLoader.manifests[fooKey]!
         workspace.manifestLoader.manifests[fooKey] = Manifest(
             name: manifest.name,
@@ -2731,8 +2731,8 @@ final class WorkspaceTests: XCTestCase {
 
         // Add entry for the edited package.
         do {
-            let fooKey = MockManifestLoader.Key(url: "/tmp/ws/pkgs/Foo")
-            let editedFooKey = MockManifestLoader.Key(url: "/tmp/ws/edits/Foo")
+            let fooKey = MockManifestLoader.makeKey(packageKind: .remote, url: "/tmp/ws/pkgs/Foo")
+            let editedFooKey = MockManifestLoader.makeKey(packageKind: .remote, url: "/tmp/ws/edits/Foo")
             let manifest = workspace.manifestLoader.manifests[fooKey]!
             workspace.manifestLoader.manifests[editedFooKey] = manifest
         }
@@ -4045,8 +4045,8 @@ final class WorkspaceTests: XCTestCase {
 
         // Add entry for the edited package.
         do {
-            let fooKey = MockManifestLoader.Key(url: "/tmp/ws/pkgs/Foo")
-            let editedFooKey = MockManifestLoader.Key(url: "/tmp/ws/edits/Foo")
+            let fooKey = MockManifestLoader.makeKey(packageKind: .remote, url: "/tmp/ws/pkgs/Foo")
+            let editedFooKey = MockManifestLoader.makeKey(packageKind: .remote, url: "/tmp/ws/edits/Foo")
             let manifest = workspace.manifestLoader.manifests[fooKey]!
             workspace.manifestLoader.manifests[editedFooKey] = manifest
         }


### PR DESCRIPTION
motivation: improve dependency resolution correctness

changes:

The real fix for this would be to replace the identity with something more unique than names

Until that time, we are appending a suffix to root manifests identities. This help differentiate them from dependencies with the same name as the directory in which the project resides and avoid incorrect cycle detections

⚠️  the solution in this PR is far from ideal, but hopefully this can trigger discussion that will bring a solution until the identity issue is resolved in a more comprehensive way