### PR TITLE
Modify skip condition for SourceControlTests.RepositoryManagerTests.testCache() to only skip on macOS < 11

### DIFF
--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -291,7 +291,13 @@ class RepositoryManagerTests: XCTestCase {
     }
 
     func testCache() throws {
-        try XCTSkipUnless(ProcessEnv.vars["SWIFTPM_ENABLE_FLAKY_REPOSITORYMANAGERTESTS"] == "1", "skipping test that sometimes crashes in CI")
+        if #available(macOS 11, *) {
+            // No need to skip the test.
+        }
+        else {
+            // Avoid a crasher that seems to happen only on macOS 10.15, but leave an environment variable for testing.
+            try XCTSkipUnless(ProcessEnv.vars["SWIFTPM_ENABLE_FLAKY_REPOSITORYMANAGERTESTS"] == "1", "skipping test that sometimes crashes in CI (rdar://70540298)")
+        }
         
         fixture(name: "DependencyResolution/External/Simple") { prefix in
             let cachePath = prefix.appending(component: "cache")


### PR DESCRIPTION
Modify skip condition for SourceControlTests.RepositoryManagerTests.testCache() to only skip on macOS < 11

### Motivation:

This allows the test to run in environments that aren't affected by the underlying bug.

### Modifications:

Changed the condition under which XCTSkip() is called.

rdar://72092379