### PR TITLE
improved shared repositories cache location

### DIFF
--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -363,11 +363,11 @@ public class RepositoryManager {
         let isLocal = (try? AbsolutePath(validating: handle.repository.url)) != nil
         let shouldCacheLocalPackages = ProcessEnv.vars["SWIFTPM_TESTS_PACKAGECACHE"] == "1" || cacheLocalPackages
 
-        if let cachePath = cachePath, !(isLocal && !shouldCacheLocalPackages) {
+        if let cachePath = self.cachePath, !(isLocal && !shouldCacheLocalPackages) {
             let cachedRepositoryPath = cachePath.appending(component: handle.repository.fileSystemIdentifier)
             do {
+                try self.initializeCacheIfNeeded(cachePath: cachePath)
                 try fileSystem.withLock(on: cachePath, type: .shared) {
-                    try initalizeCacheIfNeeded(cachePath: cachePath)
                     try fileSystem.withLock(on: cachedRepositoryPath, type: .exclusive) {
                         // Fetch the repository into the cache.
                         if (fileSystem.exists(cachedRepositoryPath)) {
@@ -476,35 +476,20 @@ public class RepositoryManager {
     }
 
     /// Sets up the cache directories if they don't already exist.
-    public func initalizeCacheIfNeeded(cachePath: AbsolutePath) throws {
+    public func initializeCacheIfNeeded(cachePath: AbsolutePath) throws {
         // Create the supplied cache directory.
-        if !fileSystem.exists(cachePath) {
-            try fileSystem.createDirectory(cachePath, recursive: true)
-        }
-        // Create the default cache directory.
-        let defaultCachePath = fileSystem.swiftPMCacheDirectory.appending(component: "repositories")
-        if !fileSystem.exists(defaultCachePath) {
-            try fileSystem.createDirectory(defaultCachePath, recursive: true)
-        }
-        // Create .swiftpm directory.
-        if !fileSystem.exists(fileSystem.dotSwiftPM) {
-            try fileSystem.createDirectory(fileSystem.dotSwiftPM, recursive: true)
-        }
-        // Symlink the default cache path to .swiftpm/cache.
-        // Don't symlink the user supplied cache path since it might change.
-        let symlinkPath = fileSystem.dotSwiftPM.appending(component: "cache")
-        if !fileSystem.exists(symlinkPath, followSymlink: false) {
-            try fileSystem.createSymbolicLink(symlinkPath, pointingAt: defaultCachePath, relative: false)
+        if !self.fileSystem.exists(cachePath) {
+            try self.fileSystem.createDirectory(cachePath, recursive: true)
         }
     }
 
     /// Purges the cached repositories from the cache.
     public func purgeCache() throws {
-        guard let cachePath = cachePath else { return }
-        try fileSystem.withLock(on: cachePath, type: .exclusive) {
-            let cachedRepositories = try fileSystem.getDirectoryContents(cachePath)
+        guard let cachePath = self.cachePath else { return }
+        try self.fileSystem.withLock(on: cachePath, type: .exclusive) {
+            let cachedRepositories = try self.fileSystem.getDirectoryContents(cachePath)
             for repoPath in cachedRepositories {
-                try fileSystem.removeFileTree(cachePath.appending(component: repoPath))
+                try self.fileSystem.removeFileTree(cachePath.appending(component: repoPath))
             }
         }
     }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -209,9 +209,6 @@ public class Workspace {
     /// The path where packages which are put in edit mode are checked out.
     public let editablesPath: AbsolutePath
 
-    /// The path where repositories are globally cached by the `RepositoryManager`
-    private let cachePath: AbsolutePath?
-
     /// The file system on which the workspace will operate.
     fileprivate var fileSystem: FileSystem
 
@@ -314,17 +311,17 @@ public class Workspace {
         self.additionalFileRules = additionalFileRules
 
         let repositoriesPath = self.dataPath.appending(component: "repositories")
+        let repositoriesCachePath = cachePath.map { $0.appending(component: "repositories") }
         let repositoryManager = repositoryManager ?? RepositoryManager(
             path: repositoriesPath,
             provider: repositoryProvider,
             delegate: delegate.map(WorkspaceRepositoryManagerDelegate.init(workspaceDelegate:)),
             fileSystem: fileSystem,
-            cachePath: cachePath)
+            cachePath: repositoriesCachePath)
         self.repositoryManager = repositoryManager
 
         self.checkoutsPath = self.dataPath.appending(component: "checkouts")
         self.artifactsPath = self.dataPath.appending(component: "artifacts")
-        self.cachePath = cachePath
 
         self.containerProvider = RepositoryPackageContainerProvider(
             repositoryManager: repositoryManager,

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -163,15 +163,16 @@ final class PackageToolTests: XCTestCase {
     func testCache() throws {
         fixture(name: "DependencyResolution/External/Simple") { prefix in
             let packageRoot = prefix.appending(component: "Bar")
-            let cachePath = prefix.appending(component: "cache")
             let repositoriesPath = packageRoot.appending(components: ".build", "repositories")
+            let cachePath = prefix.appending(component: "cache")
+            let repositoriesCachePath = cachePath.appending(component: "repositories")
 
             // Perform an initial fetch and populate the cache
             _ = try execute(["resolve", "--cache-path", cachePath.pathString], packagePath: packageRoot)
-            // we have to check for the prefix here since the hash value changes becasue spm sees the `prefix`
+            // we have to check for the prefix here since the hash value changes because spm sees the `prefix`
             // directory `/var/...` as `/private/var/...`.
             XCTAssert(try localFileSystem.getDirectoryContents(repositoriesPath).contains { $0.hasPrefix("Foo-") })
-            XCTAssert(try localFileSystem.getDirectoryContents(cachePath).contains { $0.hasPrefix("Foo-") })
+            XCTAssert(try localFileSystem.getDirectoryContents(repositoriesCachePath).contains { $0.hasPrefix("Foo-") })
 
             // Remove .build folder
             _ = try execute(["reset"], packagePath: packageRoot)
@@ -187,7 +188,7 @@ final class PackageToolTests: XCTestCase {
             // Perfom another fetch
             _ = try execute(["resolve", "--cache-path", cachePath.pathString], packagePath: packageRoot)
             XCTAssert(try localFileSystem.getDirectoryContents(repositoriesPath).contains { $0.hasPrefix("Foo-") })
-            XCTAssert(try localFileSystem.getDirectoryContents(cachePath).contains { $0.hasPrefix("Foo-") })
+            XCTAssert(try localFileSystem.getDirectoryContents(repositoriesCachePath).contains { $0.hasPrefix("Foo-") })
         }
     }
 


### PR DESCRIPTION
motivation: current symblink is ~/.switpm/cache -> idiomatic-cache-location/repositories, this creates an issue for other types of caches

changes:
* refactor how cache directory is computed and defaults are created on disk, and move it to SwiftTool so it can be used across RepositoryManager and other parts of the code that need caches
* change the symlink of ~/.swift/cache to point to the top level cache not the repositories subdirectory
* adjust test

note: if you used the shared cache feature before you should delete ~/.swiftpm/cache since its pointing to the wrong place

