### PR TITLE
reduce the max concurrent operation performed when loading manifests

### DIFF
--- a/Sources/Basics/ConcurrencyHelpers.swift
+++ b/Sources/Basics/ConcurrencyHelpers.swift
@@ -109,6 +109,13 @@ public final class ThreadSafeBox<Value> {
     }
 }
 
+public enum Concurrency {
+    public static var maxOperations: Int {
+        // TODO: compute this by the number of CPUs
+        return (try? ProcessEnv.vars["SWIFTPM_MAX_CONCURRENT_OPERATIONS"].map(Int.init)) ?? 25
+    }
+}
+
 // FIXME: mark as deprecated once async/await is available
 //@available(*, deprecated, message: "replace with async/await when available")
 @inlinable

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -220,8 +220,7 @@ public class RepositoryManager {
 
         self.operationQueue = OperationQueue()
         self.operationQueue.name = "org.swift.swiftpm.repomanagerqueue-concurrent"
-        // FIXME: make this configurable and/or compute based on CPU count
-        self.operationQueue.maxConcurrentOperationCount = 10
+        self.operationQueue.maxConcurrentOperationCount = Concurrency.maxOperations
 
         self.persistence = SimplePersistence(
             fileSystem: fileSystem,

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1400,7 +1400,7 @@ extension Workspace {
         // this is allot of boilerplate code but its is important for performance
         let operationQueue = OperationQueue()
         operationQueue.name = self.queue.label + "-root-manifest-loading"
-        operationQueue.maxConcurrentOperationCount = (try? ProcessEnv.vars["SWIFTPM_MANIFEST_LOADING_MAX_CONCURRENCY"].map(Int.init)) ?? 100
+        operationQueue.maxConcurrentOperationCount = Concurrency.maxOperations
 
         let lock = Lock()
         let sync = DispatchGroup()


### PR DESCRIPTION
motivation: manifest loading concurrency tests sometime crash when they blow the threads limits in dispatch

changes:
* centralize max operation into a helper
* use the max concurrent operations limit for both manifest loading and repository lookup
