### PR TITLE
performance: shared manifests cache

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -175,12 +175,12 @@ public struct SwiftToolOptions: ParsableArguments {
 
     /// Disables manifest caching.
     @Option(name: .customLong("manifest-caching"), help: "Caching of Package.swift manifests")
-    var manifestCachingMode: ManifestCachingMode = .system
+    var manifestCachingMode: ManifestCachingMode = .shared
 
     enum ManifestCachingMode: String, ExpressibleByArgument {
         case none
         case local
-        case system
+        case shared
 
         init?(argument: String) {
             self.init(rawValue: argument)

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -170,8 +170,22 @@ public struct SwiftToolOptions: ParsableArguments {
     var shouldDisableSandbox: Bool = false
 
     /// Disables manifest caching.
-    @Flag(name: .customLong("disable-package-manifest-caching"), help: "Disable caching Package.swift manifests")
+    @Flag(name: .customLong("disable-package-manifest-caching"), help: .hidden)
     var shouldDisableManifestCaching: Bool = false
+
+    /// Disables manifest caching.
+    @Option(name: .customLong("manifest-caching"), help: "Caching of Package.swift manifests")
+    var manifestCachingMode: ManifestCachingMode = .system
+
+    enum ManifestCachingMode: String, ExpressibleByArgument {
+        case none
+        case local
+        case system
+
+        init?(argument: String) {
+            self.init(rawValue: argument)
+        }
+    }
 
     /// Path to the compilation destination describing JSON file.
     @Option(name: .customLong("destination"), completion: .file())

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -650,6 +650,7 @@ public class SwiftTool {
     func buildParameters() throws -> BuildParameters {
         return try _buildParameters.get()
     }
+
     private lazy var _buildParameters: Result<BuildParameters, Swift.Error> = {
         return Result(catching: {
             let toolchain = try self.getToolchain()
@@ -742,11 +743,12 @@ public class SwiftTool {
 
     private lazy var _manifestLoader: Result<ManifestLoader, Swift.Error> = {
         return Result(catching: {
-            try ManifestLoader(
+            let cachePath = try self.getCachePath().map{ $0.appending(component: "manifests") } ?? self.buildPath
+            return try ManifestLoader(
                 // Always use the host toolchain's resources for parsing manifest.
                 manifestResources: self._hostToolchain.get().manifestResources,
                 isManifestSandboxEnabled: !self.options.shouldDisableSandbox,
-                cacheDir: self.options.shouldDisableManifestCaching ? nil : self.buildPath,
+                cacheDir: self.options.shouldDisableManifestCaching ? nil : cachePath,
                 extraManifestFlags: self.options.manifestFlags
             )
         })

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -754,9 +754,9 @@ public class SwiftTool {
                 cachePath = nil
             case (false, .none):
                 cachePath = nil
-            case (false,.local):
+            case (false, .local):
                 cachePath = self.buildPath
-            case (false, .system):
+            case (false, .shared):
                 cachePath = try self.getCachePath().map{ $0.appending(component: "manifests") }
             }
             return try ManifestLoader(

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -163,17 +163,14 @@ public final class ManifestLoader: ManifestLoaderProtocol {
     private let extraManifestFlags: [String]
 
     private let databaseCacheDir: AbsolutePath?
-    private var databaseCache: PersistentCacheProtocol?
-    private let databaseCacheLock = Lock()
+    //private var databaseCache: SQLiteBackedPersistentCache?
+    //private let databaseCacheLock = Lock()
 
     private let useInMemoryCache: Bool
     private let memoryCache = ThreadSafeKeyValueStore<ManifestCacheKey, Manifest>()
 
     // Cache storage for computed sdk path.
     private var sdkRootCache = ThreadSafeBox<AbsolutePath>()
-
-    private let jsonEncoder: JSONEncoder
-    private let jsonDecoder: JSONDecoder
 
     private let operationQueue: OperationQueue
 
@@ -191,9 +188,6 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         self.isManifestSandboxEnabled = isManifestSandboxEnabled
         self.delegate = delegate
         self.extraManifestFlags = extraManifestFlags
-
-        self.jsonEncoder = JSONEncoder.makeWithDefaults()
-        self.jsonDecoder = JSONDecoder.makeWithDefaults()
 
         self.useInMemoryCache = useInMemoryCache
         self.databaseCacheDir = cacheDir.map(resolveSymlinks)
@@ -375,7 +369,6 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                 }
 
                 // Get the JSON string for the manifest.
-
                 let jsonString = try self.loadJSONString(
                     path: manifestPath,
                     toolsVersion: toolsVersion,
@@ -600,9 +593,8 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         toolsVersion: ToolsVersion,
         packageIdentity: PackageIdentity,
         fileSystem: FileSystem,
-        diagnostics: DiagnosticsEngine? = nil
+        diagnostics: DiagnosticsEngine?
     ) throws -> String {
-        let result: ManifestParseResult
 
         let cacheKey = try ManifestCacheKey(
             packageIdentity: packageIdentity,
@@ -613,18 +605,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             fileSystem: fileSystem
         )
 
-        // Resolve symlinks since we can't use them in sandbox profiles.
-
-        if let cache = try self.createCacheIfNeeded() {
-            result = try self.loadManifestFromCache(key: cacheKey, cache: cache)
-        } else {
-            result = self.parse(
-                packageIdentity: packageIdentity,
-                manifestPath: cacheKey.manifestPath,
-                manifestContents: cacheKey.manifestContents,
-                toolsVersion: toolsVersion)
-        }
-
+        let result = try self.parseAndCacheManifest(key: cacheKey, diagnostics: diagnostics)
         // Throw now if we weren't able to parse the manifest.
         guard let parsedManifest = result.parsedManifest else {
             let errors = result.errorOutput ?? result.compilerOutput ?? "Unknown error parsing manifest for \(packageIdentity)"
@@ -643,33 +624,28 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         return parsedManifest
     }
 
-    fileprivate func loadManifestFromCache(
-        key: ManifestCacheKey,
-        cache: PersistentCacheProtocol
-    ) throws -> ManifestParseResult {
-        let keyHash = try key.computeHash()
-        let cacheHit = try keyHash.withData {
-            try cache.get(key: $0)
-        }.flatMap {
-            try? self.jsonDecoder.decode(ManifestParseResult.self, from: $0)
+    fileprivate func parseAndCacheManifest(key: ManifestCacheKey, diagnostics: DiagnosticsEngine?) throws -> ManifestParseResult {
+        let cache = self.databaseCacheDir.map { cacheDir -> SQLiteManifestCache in
+            let path = Self.manifestCacheDBPath(cacheDir)
+            return SQLiteManifestCache(location: .path(path), diagnosticsEngine: diagnostics)
         }
-        if let result = cacheHit {
+
+        // FIXME
+        defer { try? cache?.close() }
+
+        if let result = try cache?.get(key: key) {
             return result
         }
 
-        let result = self.parse(
-            packageIdentity: key.packageIdentity,
-            manifestPath: key.manifestPath,
-            manifestContents: key.manifestContents,
-            toolsVersion: key.toolsVersion
-        )
+        let result = self.parse(packageIdentity: key.packageIdentity,
+                                manifestPath: key.manifestPath,
+                                manifestContents: key.manifestContents,
+                                toolsVersion: key.toolsVersion)
 
         // only cache successfully parsed manifests,
         // this is important for swift-pm development
         if !result.hasErrors {
-            try keyHash.withData {
-                try cache.put(key: $0, value: self.jsonEncoder.encode(result))
-            }
+            try cache?.put(key: key, manifest: result)
         }
 
         return result
@@ -1002,30 +978,9 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         return cacheDir.appending(component: "manifest.db")
     }
 
-    func createCacheIfNeeded() throws -> PersistentCacheProtocol? {
-        try self.databaseCacheLock.withLock {
-            // Return if we have already created the cache.
-            if let cache = self.databaseCache {
-                return cache
-            }
-            guard let databaseCacheDir = self.databaseCacheDir else {
-                return nil
-            }
-            try localFileSystem.createDirectory(databaseCacheDir, recursive: true)
-            let manifestCacheDBPath = Self.manifestCacheDBPath(databaseCacheDir)
-            self.databaseCache = try SQLiteBackedPersistentCache(cacheFilePath: manifestCacheDBPath)
-            return self.databaseCache
-        }
-    }
-
     public func purgeCache() throws {
         self.memoryCache.clear()
-        try self.databaseCacheLock.withLock {
-            self.databaseCache = nil
-            // Also remove the database file from disk.
-            guard let manifestCacheDBPath = self.databaseCacheDir.flatMap({ Self.manifestCacheDBPath($0) }) else {
-                return
-            }
+        if let manifestCacheDBPath = self.databaseCacheDir.flatMap({ Self.manifestCacheDBPath($0) }) {
             try localFileSystem.removeFileTree(manifestCacheDBPath)
         }
     }
@@ -1112,5 +1067,152 @@ extension TSCBasic.Diagnostic.Message {
             invalid language tag '\(languageTag)'; the pattern for language tags is groups of latin characters and \
             digits separated by hyphens
             """)
+    }
+}
+
+/// SQLite backed persistent cache.
+private final class SQLiteManifestCache: Closable {
+    let fileSystem: FileSystem
+    let location: SQLite.Location
+
+    private var state = State.idle
+    private let stateLock = Lock()
+
+    private let diagnosticsEngine: DiagnosticsEngine?
+    private let jsonEncoder: JSONEncoder
+    private let jsonDecoder: JSONDecoder
+
+    init(location: SQLite.Location, diagnosticsEngine: DiagnosticsEngine? = nil) {
+        self.location = location
+        switch self.location {
+        case .path, .temporary:
+            self.fileSystem = localFileSystem
+        case .memory:
+            self.fileSystem = InMemoryFileSystem()
+        }
+        self.diagnosticsEngine = diagnosticsEngine
+        self.jsonEncoder = JSONEncoder.makeWithDefaults()
+        self.jsonDecoder = JSONDecoder.makeWithDefaults()
+    }
+
+    convenience init(path: AbsolutePath, diagnosticsEngine: DiagnosticsEngine? = nil) {
+        self.init(location: .path(path), diagnosticsEngine: diagnosticsEngine)
+    }
+
+    deinit {
+        guard case .disconnected = (self.stateLock.withLock { self.state }) else {
+            return assertionFailure("db should be closed")
+        }
+    }
+
+    func close() throws {
+        try self.stateLock.withLock {
+            if case .connected(let db) = self.state {
+                try db.close()
+            }
+            self.state = .disconnected
+        }
+    }
+
+    func put(key: ManifestLoader.ManifestCacheKey, manifest: ManifestLoader.ManifestParseResult) throws {
+        let query = "INSERT OR IGNORE INTO MANIFEST_CACHE VALUES (?, ?);"        
+        try self.executeStatement(query) { statement -> Void in
+            let keyHash = try key.computeHash()
+            let data = try self.jsonEncoder.encode(manifest)
+            let bindings: [SQLite.SQLiteValue] = [
+                .string(keyHash.cString),
+                .blob(data),
+            ]
+            try statement.bind(bindings)
+            try statement.step()
+        }
+    }
+
+    func get(key: ManifestLoader.ManifestCacheKey) throws -> ManifestLoader.ManifestParseResult? {
+        let query = "SELECT value FROM MANIFEST_CACHE WHERE key == ? LIMIT 1;"
+        return try self.executeStatement(query) { statement ->  ManifestLoader.ManifestParseResult? in
+            let keyHash = try key.computeHash()
+            try statement.bind([.string(keyHash.cString)])
+            let data = try statement.step()?.blob(at: 0)
+            return try data.flatMap {
+                try self.jsonDecoder.decode(ManifestLoader.ManifestParseResult.self, from: $0)
+            }
+        }
+    }
+
+    private func executeStatement<T>(_ query: String, _ body: (SQLite.PreparedStatement) throws -> T) throws -> T {
+        try self.withDB { db in
+            let result: Result<T, Error>
+            let statement = try db.prepare(query: query)
+            do {
+                result = .success(try body(statement))
+            } catch {
+                result = .failure(error)
+            }
+            try statement.finalize()
+            switch result {
+            case .failure(let error):
+                throw error
+            case .success(let value):
+                return value
+            }
+        }
+    }
+
+    private func withDB<T>(_ body: (SQLite) throws -> T) throws -> T {
+        let createDB = { () throws -> SQLite in
+            // FIXME: fix TSC as its mixing milliseconds with seconds
+            var configuration = SQLite.Configuration()
+            configuration.busyTimeoutSeconds = 1000
+            let db = try SQLite(location: self.location, configuration: configuration)
+            try self.createSchemaIfNecessary(db: db)
+            return db
+        }
+
+        let db = try stateLock.withLock { () -> SQLite in
+            let db: SQLite
+            switch (self.location, self.state) {
+            case (.path(let path), .connected(let database)):
+                if self.fileSystem.exists(path) {
+                    db = database
+                } else {
+                    try database.close()
+                    try self.fileSystem.createDirectory(path.parentDirectory, recursive: true)
+                    db = try createDB()
+                }
+            case (.path(let path), _):
+                if !self.fileSystem.exists(path) {
+                    try self.fileSystem.createDirectory(path.parentDirectory, recursive: true)
+                }
+                db = try createDB()
+            case (_, .connected(let database)):
+                db = database
+            case (_, _):
+                db = try createDB()
+            }
+            self.state = .connected(db)
+            return db
+        }
+
+        return try body(db)
+    }
+
+    private func createSchemaIfNecessary(db: SQLite) throws {
+        let table = """
+            CREATE TABLE IF NOT EXISTS MANIFEST_CACHE (
+                key STRING PRIMARY KEY NOT NULL,
+                value BLOB NOT NULL
+            );
+        """
+
+        try db.exec(query: table)
+        try db.exec(query: "PRAGMA journal_mode=WAL;")
+    }
+
+    private enum State {
+        case idle
+        case connected(SQLite)
+        case disconnected
+        case error
     }
 }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -976,7 +976,6 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         return cacheDir.appending(component: "manifest.db")
     }
 
-
     /// reset internal cache
     public func resetCache() throws {
         self.memoryCache.clear()
@@ -1172,7 +1171,7 @@ private final class SQLiteManifestCache: Closable {
         let createDB = { () throws -> SQLite in
             // see https://www.sqlite.org/c3ref/busy_timeout.html
             var configuration = SQLite.Configuration()
-            configuration.busyTimeoutMilliseconds = 5000
+            configuration.busyTimeoutMilliseconds = 10_000
             let db = try SQLite(location: self.location, configuration: configuration)
             try self.createSchemaIfNecessary(db: db)
             return db

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -163,14 +163,11 @@ public final class ManifestLoader: ManifestLoaderProtocol {
     private let extraManifestFlags: [String]
 
     private let databaseCacheDir: AbsolutePath?
-    //private var databaseCache: SQLiteBackedPersistentCache?
-    //private let databaseCacheLock = Lock()
 
     private let useInMemoryCache: Bool
     private let memoryCache = ThreadSafeKeyValueStore<ManifestCacheKey, Manifest>()
 
-    // Cache storage for computed sdk path.
-    private var sdkRootCache = ThreadSafeBox<AbsolutePath>()
+    private let sdkRootCache = ThreadSafeBox<AbsolutePath>()
 
     private let operationQueue: OperationQueue
 
@@ -1161,9 +1158,9 @@ private final class SQLiteManifestCache: Closable {
 
     private func withDB<T>(_ body: (SQLite) throws -> T) throws -> T {
         let createDB = { () throws -> SQLite in
-            // FIXME: fix TSC as its mixing milliseconds with seconds
+            // see https://www.sqlite.org/c3ref/busy_timeout.html
             var configuration = SQLite.Configuration()
-            configuration.busyTimeoutSeconds = 1000
+            configuration.busyTimeoutMilliseconds = 5000
             let db = try SQLite(location: self.location, configuration: configuration)
             try self.createSchemaIfNecessary(db: db)
             return db

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -1117,7 +1117,7 @@ private final class SQLiteManifestCache: Closable {
             let keyHash = try key.computeHash()
             let data = try self.jsonEncoder.encode(manifest)
             let bindings: [SQLite.SQLiteValue] = [
-                .string(keyHash.cString),
+                .string(keyHash.hexadecimalRepresentation),
                 .blob(data),
             ]
             try statement.bind(bindings)
@@ -1129,7 +1129,7 @@ private final class SQLiteManifestCache: Closable {
         let query = "SELECT value FROM MANIFEST_CACHE WHERE key == ? LIMIT 1;"
         return try self.executeStatement(query) { statement ->  ManifestLoader.ManifestParseResult? in
             let keyHash = try key.computeHash()
-            try statement.bind([.string(keyHash.cString)])
+            try statement.bind([.string(keyHash.hexadecimalRepresentation)])
             let data = try statement.step()?.blob(at: 0)
             return try data.flatMap {
                 try self.jsonDecoder.decode(ManifestLoader.ManifestParseResult.self, from: $0)

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -96,7 +96,7 @@ public protocol ManifestLoaderProtocol {
     )
 
     /// Reset any internal cache held by the manifest loader.
-    func resetCache() throws
+    func purgeCache() throws
 }
 
 extension ManifestLoaderProtocol {
@@ -137,8 +137,7 @@ extension ManifestLoaderProtocol {
         )
     }
 
-    public func resetCache() throws {
-    }
+    public func purgeCache() throws {}
 }
 
 public protocol ManifestLoaderDelegate {
@@ -1019,7 +1018,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         }
     }
 
-    public func resetCache() throws {
+    public func purgeCache() throws {
         self.memoryCache.clear()
         try self.databaseCacheLock.withLock {
             self.databaseCache = nil

--- a/Sources/SPMTestSupport/MockManifestLoader.swift
+++ b/Sources/SPMTestSupport/MockManifestLoader.swift
@@ -69,6 +69,9 @@ public final class MockManifestLoader: ManifestLoaderProtocol {
             }
         }
     }
+
+    public func resetCache() throws {}
+    public func purgeCache() throws {}
 }
 
 extension ManifestLoader {

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -509,7 +509,10 @@ extension Workspace {
     ///     - diagnostics: The diagnostics engine that reports errors, warnings
     ///       and notes.
     public func purgeCache(with diagnostics: DiagnosticsEngine) {
-        diagnostics.wrap { try repositoryManager.purgeCache() }
+        diagnostics.wrap {
+            try repositoryManager.purgeCache()
+            try manifestLoader.purgeCache()
+        }
     }
 
     /// Resets the entire workspace by removing the data directory.
@@ -525,9 +528,7 @@ extension Workspace {
         })
 
         guard removed else { return }
-
         repositoryManager.reset()
-        try? manifestLoader.resetCache()
         try? fileSystem.removeFileTree(dataPath)
     }
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -521,14 +521,15 @@ extension Workspace {
     ///     - diagnostics: The diagnostics engine that reports errors, warnings
     ///       and notes.
     public func reset(with diagnostics: DiagnosticsEngine) {
-        let removed = diagnostics.wrap({
+        let removed = diagnostics.wrap {
             try fileSystem.chmod(.userWritable, path: checkoutsPath, options: [.recursive, .onlyFiles])
             // Reset state.
             try state.reset()
-        })
+        }
 
         guard removed else { return }
         repositoryManager.reset()
+        try? manifestLoader.resetCache()
         try? fileSystem.removeFileTree(dataPath)
     }
 

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -573,7 +573,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             // Resetting the cache should allow us to remove the cache
             // directory without triggering assertions in sqlite.
-            try manifestLoader.resetCache()
+            try manifestLoader.purgeCache()
             try localFileSystem.removeFileTree(path)
         }
     }


### PR DESCRIPTION
motivation: manifest cache improves performance by caching a parsable version of the menifest, making the cache global improve performance across different build which use similar dependencies

changes:
* change the default manifest cache location from local .build to shared SwifPM cache directory
* change purgeCache to include manifest cache, instead of workspace reset