### PR TITLE
improve the error message when exausting attempts to resolve the depe…

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1781,7 +1781,8 @@ extension Workspace {
         forceResolution: Bool,
         extraConstraints: [PackageContainerConstraint] = [],
         diagnostics: DiagnosticsEngine,
-        retryOnPackagePathMismatch: Bool = true
+        retryOnPackagePathMismatch: Bool = true,
+        removeResolvedFile: Bool = true
     ) throws -> DependencyManifests {
 
         // Ensure the cache path exists and validate that edited dependencies.
@@ -1869,7 +1870,8 @@ extension Workspace {
         // resolved file has an outdated entry for a transitive dependency whose
         // URL was changed. For e.g., the resolved file could refer to a dependency
         // through a ssh url but its new reference is now changed to http.
-        if !updatedDependencyManifests.computePackageURLs().missing.isEmpty {
+        let missing = updatedDependencyManifests.computePackageURLs().missing
+        if !missing.isEmpty {
             // Check if an override package has a mismatching basename.
             if self.didDiagnosePackageOverrideBasenameMismatch(updatedDependencyManifests, diagnostics) {
                 return updatedDependencyManifests
@@ -1882,16 +1884,29 @@ extension Workspace {
                     forceResolution: forceResolution,
                     extraConstraints: extraConstraints,
                     diagnostics: diagnostics,
-                    retryOnPackagePathMismatch: false
+                    retryOnPackagePathMismatch: false,
+                    removeResolvedFile: removeResolvedFile
                 )
-            } else {
+            } else if removeResolvedFile, self.fileSystem.exists(self.resolvedFile) {
                 // If we weren't able to resolve properly even after a retry, it
                 // could mean that the dependency at fault has a different
                 // version of the manifest file which contains dependencies that
                 // have also changed their package references.
-
-                diagnostics.emit(error: "the Package.resolved file is most likely severely out-of-date and is preventing correct resolution; delete the resolved file and try again")
-
+                // TODO: is there a better/safer way to reset the resolved file?
+                try self.fileSystem.removeFileTree(self.resolvedFile)
+                return try self._resolve(
+                    root: root,
+                    explicitProduct: explicitProduct,
+                    forceResolution: forceResolution,
+                    extraConstraints: extraConstraints,
+                    diagnostics: diagnostics,
+                    retryOnPackagePathMismatch: false,
+                    removeResolvedFile: false
+                )
+            } else {
+                // give up
+                let missing = missing.map{ $0.description }
+                diagnostics.emit(error: "exhausted attempts to resolve the dependencies graph, with '\(missing.joined(separator: "', '"))' unresolved.")
                 return updatedDependencyManifests
             }
         }


### PR DESCRIPTION
…ndencies graph

motivation: current error message is confusing and non-actionable, replace it with one that is more accurate and actionable

changes:
* attempt to remove the Package.resolved file if it exists and rety as this could e one cause for such failure and we can automate the rmeoval instead of asking the user to do that
* improve the error message to be cleaerer and provide information about the unresolved dependencies

rdar://problem/69716855
