### PR TITLE
replace more usage of fatalError with throwing an error

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -305,7 +305,9 @@ extension BuildSubset {
                 )
                 return LLBuildManifestBuilder.TargetKind.main.targetName
             }
-            return product.getLLBuildTargetName(config: config)
+            return diagnostics.wrap {
+                try product.getLLBuildTargetName(config: config)
+            }
         case .target(let targetName):
             guard let target = graph.allTargets.first(where: { $0.name == targetName }) else {
                 diagnostics.emit(error: "no target named '\(targetName)'")

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1091,7 +1091,7 @@ public final class ProductBuildDescription {
 
         switch product.type {
         case .library(.automatic):
-            fatalError()
+            throw InternalError("automatic library not supported")
         case .library(.static):
             // No arguments for static libraries.
             return []

--- a/Sources/Build/ManifestBuilder.swift
+++ b/Sources/Build/ManifestBuilder.swift
@@ -774,7 +774,7 @@ extension LLBuildManifestBuilder {
 
 extension LLBuildManifestBuilder {
     private func createProductCommand(_ buildProduct: ProductBuildDescription) throws {
-        let cmdName = buildProduct.product.getCommandName(config: buildConfig)
+        let cmdName = try buildProduct.product.getCommandName(config: buildConfig)
 
         // Create archive tool for static library and shell tool for rest of the products.
         if buildProduct.product.type == .library(.static) {
@@ -796,7 +796,7 @@ extension LLBuildManifestBuilder {
         }
 
         // Create a phony node to represent the entire target.
-        let targetName = buildProduct.product.getLLBuildTargetName(config: buildConfig)
+        let targetName = try buildProduct.product.getLLBuildTargetName(config: buildConfig)
         let output: Node = .virtual(targetName)
 
         manifest.addNode(output, toTarget: targetName)
@@ -830,7 +830,7 @@ extension ResolvedTarget {
 }
 
 extension ResolvedProduct {
-    public func getLLBuildTargetName(config: String) -> String {
+    public func getLLBuildTargetName(config: String) throws -> String {
         switch type {
         case .library(.dynamic):
             return "\(name)-\(config).dylib"
@@ -839,14 +839,14 @@ extension ResolvedProduct {
         case .library(.static):
             return "\(name)-\(config).a"
         case .library(.automatic):
-            fatalError()
+            throw InternalError("automatic library not supported")
         case .executable:
             return "\(name)-\(config).exe"
         }
     }
 
-    public func getCommandName(config: String) -> String {
-        return "C." + getLLBuildTargetName(config: config)
+    public func getCommandName(config: String) throws -> String {
+        return try "C." + self.getLLBuildTargetName(config: config)
     }
 }
 

--- a/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
@@ -572,7 +572,7 @@ public struct PubgrubDependencyResolver {
             }
 
             guard let _mostRecentSatisfier = mostRecentSatisfier else {
-                fatalError()
+                throw InternalError("mostRecentSatisfier not set")
             }
 
             if previousSatisfierLevel < _mostRecentSatisfier.decisionLevel || _mostRecentSatisfier.cause == nil {

--- a/Sources/PackageLoading/PackageDescription4Loader.swift
+++ b/Sources/PackageLoading/PackageDescription4Loader.swift
@@ -216,7 +216,7 @@ extension SystemPackageProviderDescription {
         case "apt":
             self = .apt(value)
         default:
-            fatalError()
+            throw InternalError("invalid provider \(name)")
         }
     }
 }
@@ -241,7 +241,7 @@ extension PackageModel.ProductType {
             case nil:
                 libraryType = .automatic
             default:
-                fatalError()
+                throw InternalError("invalid product type \(productType)")
             }
 
             self = .library(libraryType)
@@ -285,7 +285,7 @@ extension PackageDependencyDescription.Requirement {
             self = .localPackage
 
         default:
-            fatalError()
+            throw InternalError("invalid dependency \(type)")
         }
     }
 }
@@ -343,7 +343,7 @@ extension TargetDescription.TargetType {
         case "binary":
             self = .binary
         default:
-            fatalError()
+            throw InternalError("invalid target \(string)")
         }
     }
 }
@@ -365,7 +365,7 @@ extension TargetDescription.Dependency {
             self = try .byName(name: json.get("name"), condition: condition)
 
         default:
-            fatalError()
+            throw InternalError("invalid type \(type)")
         }
     }
 }

--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -391,7 +391,7 @@ public func xcodeProject(
         case .test:
             productType = .unitTest
         case .systemModule, .binary:
-            fatalError()
+            throw InternalError("\(target.type) not supported")
         }
 
         // Warn if the target name is invalid.


### PR DESCRIPTION
motivation: less crashes, happier users

changes: replace a few more cases of using fatalError with throwing an InternalError which asserts in development mode
