### PR TITLE
manifest loading performance improvements

### DIFF
--- a/Sources/Basics/ConcurrencyHelpers.swift
+++ b/Sources/Basics/ConcurrencyHelpers.swift
@@ -60,7 +60,7 @@ public final class ThreadSafeKeyValueStore<Key, Value> where Key: Hashable {
         }
     }
 
-    public func mapValues<T>(_ transform: (Value) throws -> T) rethrows -> [Key : T] {
+    public func mapValues<T>(_ transform: (Value) throws -> T) rethrows -> [Key: T] {
         try self.lock.withLock {
             try self.underlying.mapValues(transform)
         }
@@ -117,8 +117,15 @@ public enum Concurrency {
 }
 
 // FIXME: mark as deprecated once async/await is available
-//@available(*, deprecated, message: "replace with async/await when available")
+// @available(*, deprecated, message: "replace with async/await when available")
 @inlinable
 public func temp_await<T, ErrorType>(_ body: (@escaping (Result<T, ErrorType>) -> Void) -> Void) throws -> T {
     return try tsc_await(body)
+}
+
+// FIXME: mark as deprecated once async/await is available
+// @available(*, deprecated, message: "replace with async/await when available")
+@inlinable
+public func temp_await<T>(_ body: (@escaping (T) -> Void) -> Void) -> T {
+    return tsc_await(body)
 }

--- a/Sources/Basics/Errors.swift
+++ b/Sources/Basics/Errors.swift
@@ -12,6 +12,6 @@ public struct InternalError: Error {
     private let description: String
     public init(_ description: String) {
         assertionFailure(description)
-        self.description = "Internal error. Please file a bug at https://bugs.swift.org with this info. \(description)" 
+        self.description = "Internal error. Please file a bug at https://bugs.swift.org with this info. \(description)"
     }
 }

--- a/Sources/Basics/HTTPClient.swift
+++ b/Sources/Basics/HTTPClient.swift
@@ -107,7 +107,7 @@ public struct HTTPClient: HTTPClientProtocol {
                 if let retryDelay = self.shouldRetry(response: response, request: request, requestNumber: requestNumber) {
                     self.diagnosticsEngine?.emit(warning: "\(request.url) failed, retrying in \(retryDelay)")
                     // TODO: dedicated retry queue?
-                    return DispatchQueue.global().asyncAfter(deadline: .now() + retryDelay) {
+                    return self.configuration.callbackQueue.asyncAfter(deadline: .now() + retryDelay) {
                         self._execute(request: request, requestNumber: requestNumber + 1, callback: callback)
                     }
                 }
@@ -239,8 +239,7 @@ public struct HTTPClientRequest {
                 url: URL,
                 headers: HTTPClientHeaders = .init(),
                 body: Data? = nil,
-                options: Options = .init())
-    {
+                options: Options = .init()) {
         self.method = method
         self.url = url
         self.headers = headers
@@ -286,8 +285,7 @@ public struct HTTPClientResponse {
     public init(statusCode: Int,
                 statusText: String? = nil,
                 headers: HTTPClientHeaders = .init(),
-                body: Data? = nil)
-    {
+                body: Data? = nil) {
         self.statusCode = statusCode
         self.statusText = statusText
         self.headers = headers

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -166,9 +166,10 @@ extension SwiftPackageTool {
         func run(_ swiftTool: SwiftTool) throws {
             let workspace = try swiftTool.getActiveWorkspace()
             let root = try swiftTool.getWorkspaceRoot()
-            
-            let manifests = workspace.loadRootManifests(
-                packages: root.packages, diagnostics: swiftTool.diagnostics)
+
+            let manifests = try temp_await {
+                workspace.loadRootManifests(packages: root.packages, diagnostics: swiftTool.diagnostics, completion: $0)
+            }
             guard let manifest = manifests.first else { return }
 
             let builder = PackageBuilder(
@@ -233,8 +234,9 @@ extension SwiftPackageTool {
             // Get the root package.
             let workspace = try swiftTool.getActiveWorkspace()
             let root = try swiftTool.getWorkspaceRoot()
-            let manifest = workspace.loadRootManifests(
-                packages: root.packages, diagnostics: swiftTool.diagnostics)[0]
+            let manifest = try temp_await {
+                workspace.loadRootManifests(packages: root.packages, diagnostics: swiftTool.diagnostics, completion: $0)
+            }[0]
 
             let builder = PackageBuilder(
                 manifest: manifest,
@@ -360,9 +362,10 @@ extension SwiftPackageTool {
         func run(_ swiftTool: SwiftTool) throws {
             let workspace = try swiftTool.getActiveWorkspace()
             let root = try swiftTool.getWorkspaceRoot()
-            
-            let manifests = workspace.loadRootManifests(
-                packages: root.packages, diagnostics: swiftTool.diagnostics)
+
+            let manifests = try temp_await {
+                workspace.loadRootManifests(packages: root.packages, diagnostics: swiftTool.diagnostics, completion: $0)
+            }
             guard let manifest = manifests.first else { return }
 
             let encoder = JSONEncoder.makeWithDefaults()

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -224,7 +224,9 @@ public struct SwiftTestTool: SwiftCommand {
         case .codeCovPath:
             let workspace = try swiftTool.getActiveWorkspace()
             let root = try swiftTool.getWorkspaceRoot()
-            let rootManifest = workspace.loadRootManifests(packages: root.packages, diagnostics: swiftTool.diagnostics)[0]
+            let rootManifest = try temp_await {
+                workspace.loadRootManifests(packages: root.packages, diagnostics: swiftTool.diagnostics, completion: $0)                
+            }[0]
             let buildParameters = try swiftTool.buildParametersForTest()
             print(codeCovAsJSONPath(buildParameters: buildParameters, packageName: rootManifest.name))
 

--- a/Sources/PackageGraph/PackageContainer.swift
+++ b/Sources/PackageGraph/PackageContainer.swift
@@ -61,6 +61,7 @@ public protocol PackageContainer {
 
     /// Get the list of versions in the repository sorted in the reverse order, that is the latest
     /// version appears first.
+    // FIXME: deprecated 12/2020, remove once clients migrate
     @available(*, deprecated, message: "use versionsDescending instead")
     func reversedVersions() throws -> [Version]
 
@@ -100,7 +101,6 @@ public protocol PackageContainer {
 }
 
 extension PackageContainer {
-    @available(*, deprecated, message: "use versionsDescending instead")
     public func reversedVersions() throws -> [Version] {
         try self.versionsDescending()
     }

--- a/Sources/PackageGraph/RepositoryPackageContainer.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainer.swift
@@ -279,13 +279,17 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
                 self.currentToolsVersion, version: revision.identifier, packagePath: packageURL)
 
             // Load the manifest.
-            return try manifestLoader.load(
-                package: AbsolutePath.root,
-                baseURL: packageURL,
-                version: version,
-                toolsVersion: toolsVersion,
-                packageKind: identifier.kind,
-                fileSystem: fs)
+            // FIXME: this should not block
+            return try temp_await {
+                manifestLoader.load(package: AbsolutePath.root,
+                                    baseURL: packageURL,
+                                    version: version,
+                                    toolsVersion: toolsVersion,
+                                    packageKind: identifier.kind,
+                                    fileSystem: fs,
+                                    on: .global(),
+                                    completion: $0)
+            }
         }
     }
 

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -320,7 +320,7 @@ public final class MockWorkspace {
         let pinsStore = try workspace.pinsStore.load()
 
         let rootInput = PackageGraphRootInput(packages: rootPaths(for: roots.map { $0.name }), dependencies: [])
-        let rootManifests = workspace.loadRootManifests(packages: rootInput.packages, diagnostics: diagnostics)
+        let rootManifests = try temp_await { workspace.loadRootManifests(packages: rootInput.packages, diagnostics: diagnostics, completion: $0) }
         let root = PackageGraphRoot(input: rootInput, manifests: rootManifests)
 
         let dependencyManifests = try workspace.loadDependencyManifests(root: root, diagnostics: diagnostics)
@@ -474,7 +474,7 @@ public final class MockWorkspace {
         let rootInput = PackageGraphRootInput(
             packages: rootPaths(for: roots), dependencies: dependencies
         )
-        let rootManifests = workspace.loadRootManifests(packages: rootInput.packages, diagnostics: diagnostics)
+        let rootManifests = try tsc_await { workspace.loadRootManifests(packages: rootInput.packages, diagnostics: diagnostics, completion: $0) }
         let graphRoot = PackageGraphRoot(input: rootInput, manifests: rootManifests)
         let manifests = try workspace.loadDependencyManifests(root: graphRoot, diagnostics: diagnostics)
         result(manifests, diagnostics)

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -616,14 +616,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             )
 
             let packageReference = PackageReference(identity: PackageIdentity(path: packageDirectory), path: packageDirectory.pathString)
-            let container = try tsc_await { completion in
-                containerProvider.getContainer(
-                    for: packageReference,
-                    skipUpdate: false,
-                    on: .global(),
-                    completion: completion
-                )
-            }
+            let container = try containerProvider.getContainer(for: packageReference, skipUpdate: false)
 
             let forNothing = try container.getDependencies(at: version, productFilter: .specific([]))
             let forProduct = try container.getDependencies(at: version, productFilter: .specific(["Product"]))

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -22,13 +22,13 @@ class ManifestSourceGenerationTests: XCTestCase {
             // Write the original manifest file contents, and load it.
             try fs.writeFileContents(packageDir.appending(component: Manifest.filename), bytes: ByteString(encodingAsUTF8: manifestContents))
             let manifestLoader = ManifestLoader(manifestResources: Resources.default)
-            let manifest = try manifestLoader.load(package: packageDir, baseURL: packageDir.pathString, toolsVersion: toolsVersion, packageKind: .root)
+            let manifest = try tsc_await { manifestLoader.load(package: packageDir, baseURL: packageDir.pathString, toolsVersion: toolsVersion, packageKind: .root, on: .global(), completion: $0) }
 
             // Generate source code for the loaded manifest, write it out to replace the manifest file contents, and load it again.
             let newContents = manifest.generatedManifestFileContents
             try fs.writeFileContents(packageDir.appending(component: Manifest.filename), bytes: ByteString(encodingAsUTF8: newContents))
             print(newContents)
-            let newManifest = try manifestLoader.load(package: packageDir, baseURL: packageDir.pathString, toolsVersion: toolsVersion, packageKind: .root)
+            let newManifest = try tsc_await { manifestLoader.load(package: packageDir, baseURL: packageDir.pathString, toolsVersion: toolsVersion, packageKind: .root, on: .global(), completion: $0) }
             
             // Check that all the relevant properties survived.
             XCTAssertEqual(newManifest.toolsVersion, manifest.toolsVersion)

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3784,12 +3784,14 @@ final class WorkspaceTests: XCTestCase {
 
         // From here the API should be simple and straightforward:
         let diagnostics = DiagnosticsEngine()
-        let manifest = try ManifestLoader.loadManifest(
-            packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], packageKind: .local
-        )
-        let loadedPackage = try PackageBuilder.loadPackage(
-            packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], xcTestMinimumDeploymentTargets: [:], diagnostics: diagnostics
-        )
+        let manifest = try tsc_await {
+            ManifestLoader.loadManifest(packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], packageKind: .local, on: .global(), completion: $0)
+        }
+
+        let loadedPackage = try tsc_await {
+            PackageBuilder.loadPackage(packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], xcTestMinimumDeploymentTargets: [:], diagnostics: diagnostics, on: .global(), completion: $0)
+        }
+
         let graph = try Workspace.loadGraph(
             packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], diagnostics: diagnostics
         )


### PR DESCRIPTION
motivation: better performance for dependency resolution

changes:
* make the loadManifest function asynchronous
* move the operation queue into ManifestLoader instead of Workspace
* load root manifest asynchronous
* adjust call sites
* adjust test
* replace some queue.wait with queue.notify
* tested with TSAN