### PR TITLE
fix thread safety issue in package collections

### DIFF
--- a/Sources/Basics/ConcurrencyHelpers.swift
+++ b/Sources/Basics/ConcurrencyHelpers.swift
@@ -67,6 +67,64 @@ public final class ThreadSafeKeyValueStore<Key, Value> where Key: Hashable {
     }
 }
 
+/// Thread-safe array like structure
+public final class ThreadSafeArrayStore<Value> {
+    private var underlying: [Value]
+    private let lock = Lock()
+
+    public init(_ seed: [Value] = []) {
+        self.underlying = seed
+    }
+
+    public subscript(index: Int) -> Value? {
+        self.lock.withLock {
+            self.underlying[index]
+        }
+    }
+
+    public func get() -> [Value] {
+        self.lock.withLock {
+            self.underlying
+        }
+    }
+
+    public func clear() {
+        self.lock.withLock {
+            self.underlying = []
+        }
+    }
+
+    public func append(_ item: Value) {
+        self.lock.withLock {
+            self.underlying.append(item)
+        }
+    }
+
+    public var count: Int {
+        self.lock.withLock {
+            self.underlying.count
+        }
+    }
+
+    public var isEmpty: Bool {
+        self.lock.withLock {
+            self.underlying.isEmpty
+        }
+    }
+
+    public func map<NewValue>(_ transform: (Value) -> NewValue) -> [NewValue] {
+        self.lock.withLock {
+            self.underlying.map(transform)
+        }
+    }
+
+    public func compactMap<NewValue>(_ transform: (Value) throws -> NewValue?) rethrows -> [NewValue] {
+        try self.lock.withLock {
+            try self.underlying.compactMap(transform)
+        }
+    }
+}
+
 /// Thread-safe value boxing  structure
 public final class ThreadSafeBox<Value> {
     private var underlying: Value?

--- a/Sources/PackageCollections/JSONModel/JSONCollection+v1.swift
+++ b/Sources/PackageCollections/JSONModel/JSONCollection+v1.swift
@@ -248,14 +248,14 @@ extension JSONPackageCollectionModel.V1 {
 extension JSONPackageCollectionModel.V1 {
     public struct Validator {
         public let configuration: Configuration
-        
+
         public init(configuration: Configuration = .init()) {
             self.configuration = configuration
         }
-        
+
         public func validate(collection: Collection) -> [ValidationMessage]? {
             var messages = [ValidationMessage]()
-            
+
             let packages = collection.packages
             // Stop validating if collection doesn't pass basic checks
             if packages.isEmpty {
@@ -265,24 +265,24 @@ extension JSONPackageCollectionModel.V1 {
             } else {
                 packages.forEach { self.validate(package: $0, messages: &messages) }
             }
-            
+
             guard messages.isEmpty else {
                 return messages
             }
-            
+
             return nil
         }
-        
+
         // TODO: validate package url?
         private func validate(package: Collection.Package, messages: inout [ValidationMessage]) {
             let packageID = PackageIdentity(url: package.url.absoluteString).description
-            
+
             // Check for duplicate versions
             let nonUniqueVersions = Dictionary(grouping: package.versions, by: { $0.version }).filter { $1.count > 1 }.keys
             if !nonUniqueVersions.isEmpty {
                 messages.append(.error("Duplicate version(s) found in package \(packageID): \(nonUniqueVersions).", property: "package.versions"))
             }
-            
+
             var nonSemanticVersions = [String]()
             let semanticVersions: [TSCUtility.Version] = package.versions.compactMap {
                 let semver = TSCUtility.Version(string: $0.version)
@@ -291,15 +291,15 @@ extension JSONPackageCollectionModel.V1 {
                 }
                 return semver
             }
-            
+
             guard nonSemanticVersions.isEmpty else {
                 messages.append(.error("Non semantic version(s) found in package \(packageID): \(nonSemanticVersions).", property: "package.versions"))
                 // The next part of validation requires sorting the semvers. Cannot continue if non-semver.
                 return
             }
-            
+
             let sortedVersions = semanticVersions.sorted(by: >)
-            
+
             var currentMajor: Int?
             var majorCount = 0
             var minorCount = 0
@@ -322,7 +322,7 @@ extension JSONPackageCollectionModel.V1 {
 
                 minorCount += 1
             }
-            
+
             package.versions.forEach { version in
                 if version.products.isEmpty {
                     messages.append(.error("Package \(packageID) version \(version.version) does not contain any products.", property: "version.products"))
@@ -332,13 +332,13 @@ extension JSONPackageCollectionModel.V1 {
                         messages.append(.error("Product \(product.name) of package \(packageID) version \(version.version) does not contain any targets.", property: "product.targets"))
                     }
                 }
-                
+
                 if version.targets.isEmpty {
                     messages.append(.error("Package \(packageID) version \(version.version) does not contain any targets.", property: "version.targets"))
                 }
             }
         }
-        
+
         public struct Configuration {
             public var maximumPackageCount: Int
             public var maximumMajorVersionCount: Int

--- a/Sources/PackageCollections/PackageCollections+Validation.swift
+++ b/Sources/PackageCollections/PackageCollections+Validation.swift
@@ -40,26 +40,26 @@ public struct ValidationMessage: Equatable, CustomStringConvertible {
     public let message: String
     public let level: Level
     public let property: String?
-    
+
     private init(_ message: String, level: Level, property: String? = nil) {
         self.message = message
         self.level = level
         self.property = property
     }
-    
+
     static func error(_ message: String, property: String? = nil) -> ValidationMessage {
         .init(message, level: .error, property: property)
     }
-    
+
     static func warning(_ message: String, property: String? = nil) -> ValidationMessage {
         .init(message, level: .warning, property: property)
     }
-    
+
     public enum Level: String, Equatable {
         case warning
         case error
     }
-    
+
     public var description: String {
         "[\(self.level)] \(self.property.map { "\($0): " } ?? "")\(self.message)"
     }
@@ -68,9 +68,9 @@ public struct ValidationMessage: Equatable, CustomStringConvertible {
 extension Array where Element == ValidationMessage {
     func errors(include levels: Set<ValidationMessage.Level> = [.error]) -> [ValidationError]? {
         let errors = self.filter { levels.contains($0.level) }
-        
+
         guard !errors.isEmpty else { return nil }
-        
+
         return errors.map {
             if let property = $0.property {
                 return ValidationError.property(name: property, message: $0.message)

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -48,8 +48,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
         let readmeURL = baseURL.appendingPathComponent("readme")
 
         let sync = DispatchGroup()
-        var results = [URL: Result<HTTPClientResponse, Error>]()
-        let resultsLock = Lock()
+        let results = ThreadSafeKeyValueStore<URL, Result<HTTPClientResponse, Error>>()
 
         // get the main data
         sync.enter()
@@ -58,34 +57,22 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
         let metadataOptions = self.makeRequestOptions(validResponseCodes: [200, 401, 403, 404])
         httpClient.get(metadataURL, headers: metadataHeaders, options: metadataOptions) { result in
             defer { sync.leave() }
-            resultsLock.withLock {
-                results[metadataURL] = result
-            }
+            results[metadataURL] = result
             if case .success(let response) = result {
                 let apiLimit = response.headers.get("X-RateLimit-Limit").first.flatMap(Int.init) ?? -1
                 let apiRemaining = response.headers.get("X-RateLimit-Remaining").first.flatMap(Int.init) ?? -1
                 switch (response.statusCode, metadataHeaders.contains("Authorization"), apiRemaining) {
                 case (_, _, 0):
                     self.diagnosticsEngine?.emit(warning: "Exceeded API limits on \(metadataURL.host ?? metadataURL.absoluteString) (\(apiRemaining)/\(apiLimit)), consider configuring an API token for this service.")
-                    resultsLock.withLock {
-                        results[metadataURL] = .failure(Errors.apiLimitsExceeded(metadataURL, apiLimit))
-                    }
+                    results[metadataURL] = .failure(Errors.apiLimitsExceeded(metadataURL, apiLimit))
                 case (401, true, _):
-                    resultsLock.withLock {
-                        results[metadataURL] = .failure(Errors.invalidAuthToken(metadataURL))
-                    }
+                    results[metadataURL] = .failure(Errors.invalidAuthToken(metadataURL))
                 case (401, false, _):
-                    resultsLock.withLock {
-                        results[metadataURL] = .failure(Errors.permissionDenied(metadataURL))
-                    }
+                    results[metadataURL] = .failure(Errors.permissionDenied(metadataURL))
                 case (403, _, _):
-                    resultsLock.withLock {
-                        results[metadataURL] = .failure(Errors.permissionDenied(metadataURL))
-                    }
+                    results[metadataURL] = .failure(Errors.permissionDenied(metadataURL))
                 case (404, _, _):
-                    resultsLock.withLock {
-                        results[metadataURL] = .failure(NotFoundError("\(baseURL)"))
-                    }
+                    results[metadataURL] = .failure(NotFoundError("\(baseURL)"))
                 case (200, _, _):
                     if apiRemaining < self.configuration.apiLimitWarningThreshold {
                         self.diagnosticsEngine?.emit(warning: "Approaching API limits on \(metadataURL.host ?? metadataURL.absoluteString) (\(apiRemaining)/\(apiLimit)), consider configuring an API token for this service.")
@@ -98,15 +85,11 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
                         let options = self.makeRequestOptions(validResponseCodes: [200])
                         self.httpClient.get(url, headers: headers, options: options) { result in
                             defer { sync.leave() }
-                            resultsLock.withLock {
-                                results[url] = result
-                            }
+                            results[url] = result
                         }
                     }
                 default:
-                    resultsLock.withLock {
-                        results[metadataURL] = .failure(Errors.invalidResponse(metadataURL, "Invalid status code: \(response.statusCode)"))
-                    }
+                    results[metadataURL] = .failure(Errors.invalidResponse(metadataURL, "Invalid status code: \(response.statusCode)"))
                 }
             }
         }


### PR DESCRIPTION
motivation: a failing test hinted to a thread safety issue, which was then diagnosed to an incorrect lock on an array. this prompted creating a thread safe utility for array to avoid such cases

changes:
* create a thread-safe utlitiy for array
* replace array + lock with the new utility
* add test
