### PR TITLE
only cache successfully parsed manifets

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -665,8 +665,12 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             toolsVersion: key.toolsVersion
         )
 
-        try keyHash.withData {
-            try cache.put(key: $0, value: self.jsonEncoder.encode(result))
+        // only cache successfully parsed manifests,
+        // this is important for swift-pm development
+        if !result.hasErrors {
+            try keyHash.withData {
+                try cache.put(key: $0, value: self.jsonEncoder.encode(result))
+            }
         }
 
         return result


### PR DESCRIPTION
motivation: caching manifests that fail to parse makes development of swift-pm harder, and is not meaningful from a perfoamnce pov

changes: only cache manifests if they have no parse errors
