### PR TITLE
Reference latest supported version of Xcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Swift Package Manager is a tool for managing distribution of source code, ai
 
 We’ve designed the system to make it easy to share packages on services like GitHub, but packages are also great for private personal development, sharing code within a team, or at any other granularity.
 
-Swift Package Manager includes a build system that can build for macOS and Linux. Xcode 11 integrates with libSwiftPM to provide support for iOS, watchOS, and tvOS platforms.
+Swift Package Manager includes a build system that can build for macOS and Linux. Xcode 12 integrates with libSwiftPM to provide support for iOS, watchOS, and tvOS platforms.
 
 The [SourceKit-LSP](https://github.com/apple/sourcekit-lsp) project leverages libSwiftPM and provides [Language Server Protocol](https://langserver.org/) implementation for editors that support LSP.
 


### PR DESCRIPTION
Reference latest supported version of Xcode in documentation

### Motivation:

Because current version referenced is old.

### Modifications:

Documentation

### Result:

It references the current version
