### PR TITLE
[5.3] The llbuild dependency should reference the 5.3 release branch

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -233,7 +233,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         package.dependencies += [
-            .package(url: "https://github.com/apple/swift-llbuild.git", .branch("master")),
+            .package(url: "https://github.com/apple/swift-llbuild.git", .branch("release/5.3")),
         ]
     } else {
         // In Swift CI, use a local path to llbuild to interoperate with tools

--- a/Package.swift
+++ b/Package.swift
@@ -230,7 +230,7 @@ let package = Package(
 // this right now.
 
 /// When not using local dependencies, the branch to use for llbuild and TSC repositories
-let relatedDependenciesBranch = ProcessInfo.processInfo.environment["SWIFTPM_DEPS_BRANCH"] ?? "release/5.3"
+let relatedDependenciesBranch = "release/5.3"
 
 if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {

--- a/Package.swift
+++ b/Package.swift
@@ -229,11 +229,13 @@ let package = Package(
 // package dependency like this but there is no other good way of expressing
 // this right now.
 
+/// When not using local dependencies, the branch to use for llbuild and TSC repositories
+let relatedDependenciesBranch = ProcessInfo.processInfo.environment["SWIFTPM_DEPS_BRANCH"] ?? "release/5.3"
 
 if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         package.dependencies += [
-            .package(url: "https://github.com/apple/swift-llbuild.git", .branch("release/5.3")),
+            .package(url: "https://github.com/apple/swift-llbuild.git", .branch(relatedDependenciesBranch)),
         ]
     } else {
         // In Swift CI, use a local path to llbuild to interoperate with tools
@@ -247,7 +249,7 @@ if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
 
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("release/5.3")),
+        .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch(relatedDependenciesBranch)),
     ]
 } else {
     package.dependencies += [


### PR DESCRIPTION
Fixes non-CI builds of SPM 5.3