### PR TITLE
Add optional delegate perameter to Workspace.create()

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -346,14 +346,16 @@ public class Workspace {
     public static func create(
         forRootPackage packagePath: AbsolutePath,
         manifestLoader: ManifestLoaderProtocol,
-        repositoryManager: RepositoryManager? = nil
+        repositoryManager: RepositoryManager? = nil,
+        delegate: WorkspaceDelegate? = nil
     ) -> Workspace {
         return Workspace(
             dataPath: packagePath.appending(component: ".build"),
             editablesPath: packagePath.appending(component: "Packages"),
             pinsFile: packagePath.appending(component: "Package.resolved"),
             manifestLoader: manifestLoader,
-            repositoryManager: repositoryManager
+            repositoryManager: repositoryManager,
+            delegate: delegate
         )
     }
 }


### PR DESCRIPTION
Add optional delegate parameter to `Workspace.create()`

### Motivation:

`Workspace.create` is a convenient way to instantiate a `Workspace` instance. However can't use it if want to use `WorkspaceDelegate` - that is unfortunate. `Workspace.delegate` is a `let` property, hence it can't be set after initialization.

### Modifications:

Add optional delegate perameter to Workspace.create()


Ref https://bugs.swift.org/browse/SR-4402