### PR TITLE
make code more resilient when cache directories cannot be created 

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -480,22 +480,26 @@ public class SwiftTool {
             return explicitCachePath
         }
 
-        // Create the default cache directory.
-        let idiomaticCachePath = fileSystem.swiftPMCacheDirectory
-        if !fileSystem.exists(idiomaticCachePath) {
-            try fileSystem.createDirectory(idiomaticCachePath, recursive: true)
+        do {
+            // Create the default cache directory.
+            let idiomaticCachePath = fileSystem.swiftPMCacheDirectory
+            if !fileSystem.exists(idiomaticCachePath) {
+                try fileSystem.createDirectory(idiomaticCachePath, recursive: true)
+            }
+            // Create ~/.swiftpm if necessary
+            if !fileSystem.exists(fileSystem.dotSwiftPM) {
+                try fileSystem.createDirectory(fileSystem.dotSwiftPM, recursive: true)
+            }
+            // Create ~/.swiftpm/cache symlink if necessary
+            let dotSwiftPMCachesPath = fileSystem.dotSwiftPM.appending(component: "cache")
+            if !fileSystem.exists(dotSwiftPMCachesPath, followSymlink: false) {
+                try fileSystem.createSymbolicLink(dotSwiftPMCachesPath, pointingAt: idiomaticCachePath, relative: false)
+            }
+            return idiomaticCachePath
+        } catch {
+            self.diagnostics.emit(warning: "Failed creating default cache locations, \(error)")
+            return nil
         }
-        // Create ~/.swiftpm if necessary
-        if !fileSystem.exists(fileSystem.dotSwiftPM) {
-            try fileSystem.createDirectory(fileSystem.dotSwiftPM, recursive: true)
-        }
-        // Create ~/.swiftpm/cache symlink if necessary
-        let dotSwiftPMCachesPath = fileSystem.dotSwiftPM.appending(component: "cache")
-        if !fileSystem.exists(dotSwiftPMCachesPath, followSymlink: false) {
-            try fileSystem.createSymbolicLink(dotSwiftPMCachesPath, pointingAt: idiomaticCachePath, relative: false)
-        }
-
-        return idiomaticCachePath
     }
 
     /// Returns the currently active workspace.

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -472,6 +472,14 @@ public class SwiftTool {
     }
 
     private func getCachePath(fileSystem: FileSystem = localFileSystem) throws -> AbsolutePath? {
+        if options.skipCache {
+            return nil
+        }
+
+        if let explicitCachePath = options.cachePath {
+            return explicitCachePath
+        }
+
         // Create the default cache directory.
         let idiomaticCachePath = fileSystem.swiftPMCacheDirectory
         if !fileSystem.exists(idiomaticCachePath) {
@@ -487,7 +495,7 @@ public class SwiftTool {
             try fileSystem.createSymbolicLink(dotSwiftPMCachesPath, pointingAt: idiomaticCachePath, relative: false)
         }
 
-        return options.skipCache ? nil : options.cachePath ?? idiomaticCachePath
+        return idiomaticCachePath
     }
 
     /// Returns the currently active workspace.

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -477,6 +477,10 @@ public class SwiftTool {
         }
 
         if let explicitCachePath = options.cachePath {
+            // Create the explicit cache path if necessary
+            if !fileSystem.exists(explicitCachePath) {
+                try fileSystem.createDirectory(explicitCachePath, recursive: true)
+            }
             return explicitCachePath
         }
 


### PR DESCRIPTION
motivation: better reseliency

changes: catch file system errors when trying to create default cache locations and warn + disable cache instead of failing

follow up / replacement for https://github.com/apple/swift-package-manager/pull/3142