### PR TITLE
Workspace delegate weak property

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -304,6 +304,7 @@ public class SwiftTool {
     /// workspace is not needed, infact it would be an error to ask for the workspace object
     /// for package init because the Manifest file should *not* present.
     private var _workspace: Workspace?
+    private var _workspaceDelegate: ToolWorkspaceDelegate?
 
     /// Create an instance of this tool.
     ///
@@ -514,6 +515,7 @@ public class SwiftTool {
             cachePath: try self.getCachePath()
         )
         _workspace = workspace
+        _workspaceDelegate = delegate
         return workspace
     }
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -183,7 +183,7 @@ private class WorkspaceRepositoryManagerDelegate: RepositoryManagerDelegate {
 /// This class does *not* support concurrent operations.
 public class Workspace {
     /// The delegate interface.
-    public let delegate: WorkspaceDelegate?
+    public weak var delegate: WorkspaceDelegate?
 
     /// The path of the workspace data.
     public let dataPath: AbsolutePath


### PR DESCRIPTION
Make the `Workspace.delegate` property weak optional. It doesn't have to be captured with strong reference (It's unlike for delegate pattern to retain)

### Motivation:

Initialize the `Workspace.delegate` separately at any point. Ref: https://bugs.swift.org/browse/SR-4402

### Modifications:

`Workspace.delegate` is weak property now. That means if any code relies on the retain, need update.