### PR TITLE
Call artifacts download delegate final method

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1608,6 +1608,7 @@ extension Workspace {
         let tempDiagnostics = DiagnosticsEngine()
 
         var authProvider: AuthorizationProviding? = nil
+        var didDownloadAnyArtifact = false
         #if os(macOS)
         // Netrc feature currently only supported on macOS 10.13+ due to dependency
         // on NSTextCheckingResult.range(with:)
@@ -1636,7 +1637,7 @@ extension Workspace {
             }
             let archivePath = parentDirectory.appending(component: parsedURL.lastPathComponent)
 
-
+            didDownloadAnyArtifact = true
             downloader.downloadFile(
                 at: parsedURL,
                 to: archivePath,
@@ -1684,7 +1685,10 @@ extension Workspace {
         }
 
         group.wait()
-        delegate?.didDownloadBinaryArtifacts()
+
+        if didDownloadAnyArtifact {
+            delegate?.didDownloadBinaryArtifacts()
+        }
 
         for diagnostic in tempDiagnostics.diagnostics {
             diagnostics.emit(diagnostic.message, location: diagnostic.location)


### PR DESCRIPTION
Call atrifacts download delegate final method only if we ever try to download an artifact.

### Motivation:

`WorkspaceDelegate.didDownloadBinaryArtifacts` is called despite there's nothing to download, nor we even tried to download anything. Given the name "did download" it should be called only if there was a download (attempt).

### Modifications:

Check with flag whether any download happened.
