### PR TITLE
improve correctness by using identity more broadly throughout the code

### DIFF
--- a/Sources/Commands/SwiftPackageCollectionsTool.swift
+++ b/Sources/Commands/SwiftPackageCollectionsTool.swift
@@ -217,8 +217,8 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
         }
 
         mutating func run() throws {
-            let identity = PackageIdentity(url: packageUrl)
-            let reference = PackageReference(identity: identity, path: packageUrl)
+            let identity = PackageIdentity(url: self.packageUrl)
+            let reference = PackageReference.remote(identity: identity, location: self.packageUrl)
             
             do { // assume URL is for a package
                 let result = try with { collections in

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -910,11 +910,11 @@ fileprivate func logPackageChanges(changes: [(PackageReference, Workspace.Packag
         let currentVersion = pins.pinsMap[package.identity]?.state.description ?? ""
         switch change {
         case let .added(state):
-            stream <<< "+ \(package.name) \(state.requirement.prettyPrinted)"
+            stream <<< "+ \(package.identity) \(state.requirement.prettyPrinted)"
         case let .updated(state):
-            stream <<< "~ \(package.name) \(currentVersion) -> \(package.name) \(state.requirement.prettyPrinted)"
+            stream <<< "~ \(package.identity) \(currentVersion) -> \(package.identity) \(state.requirement.prettyPrinted)"
         case .removed:
-            stream <<< "- \(package.name) \(currentVersion)"
+            stream <<< "- \(package.identity) \(currentVersion)"
         case .unchanged:
             continue
         }

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -141,7 +141,7 @@ private class ToolWorkspaceDelegate: WorkspaceDelegate {
                 let dependencies = packages.lazy.map({ "'\($0.path)'" }).joined(separator: ", ")
                 self.stdoutStream <<< "the following dependencies were added: \(dependencies)"
             case .packageRequirementChange(let package, let state, let requirement):
-                self.stdoutStream <<< "dependency '\(package.name)' was "
+                self.stdoutStream <<< "dependency '\(package.identity)' was "
 
                 switch state {
                 case .checkout(let checkoutState)?:

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -138,7 +138,7 @@ private class ToolWorkspaceDelegate: WorkspaceDelegate {
             case .forced:
                 self.stdoutStream <<< "it was forced"
             case .newPackages(let packages):
-                let dependencies = packages.lazy.map({ "'\($0.path)'" }).joined(separator: ", ")
+                let dependencies = packages.lazy.map({ "'\($0.location)'" }).joined(separator: ", ")
                 self.stdoutStream <<< "the following dependencies were added: \(dependencies)"
             case .packageRequirementChange(let package, let state, let requirement):
                 self.stdoutStream <<< "dependency '\(package.identity)' was "

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -38,8 +38,8 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
         guard reference.kind == .remote else {
             return callback(.failure(Errors.invalidReferenceType(reference)))
         }
-        guard let baseURL = self.apiURL(reference.path) else {
-            return callback(.failure(Errors.invalidGitURL(reference.path)))
+        guard let baseURL = self.apiURL(reference.location) else {
+            return callback(.failure(Errors.invalidGitURL(reference.location)))
         }
 
         let metadataURL = baseURL

--- a/Sources/PackageCollections/Utility.swift
+++ b/Sources/PackageCollections/Utility.swift
@@ -54,8 +54,8 @@ extension PackageReference {
     init(repository: RepositorySpecifier, kind: PackageReference.Kind = .remote) {
         self.init(
             identity: PackageIdentity(url: repository.url),
-            path: repository.url,
-            kind: kind
+            kind: kind,
+            location: repository.url
         )
     }
 }

--- a/Sources/PackageGraph/DependencyResolutionNode.swift
+++ b/Sources/PackageGraph/DependencyResolutionNode.swift
@@ -134,6 +134,6 @@ extension DependencyResolutionNode: Hashable {
 
 extension DependencyResolutionNode: CustomStringConvertible {
     public var description: String {
-        return "\(package.name)\(productFilter)"
+        return "\(self.package.identity)\(productFilter)"
     }
 }

--- a/Sources/PackageGraph/DependencyResolutionNode.swift
+++ b/Sources/PackageGraph/DependencyResolutionNode.swift
@@ -99,7 +99,7 @@ public enum DependencyResolutionNode {
         // Don’t create a version lock for anything but a product.
         guard specificProduct != nil else { return nil }
         return PackageContainerConstraint(
-            container: package,
+            package: package,
             versionRequirement: .exact(version),
             products: .specific([])
         )
@@ -112,7 +112,7 @@ public enum DependencyResolutionNode {
         // Don’t create a revision lock for anything but a product.
         guard specificProduct != nil else { return nil }
         return PackageContainerConstraint(
-            container: package,
+            package: self.package,
             requirement: .revision(revision),
             products: .specific([])
         )
@@ -127,13 +127,13 @@ extension DependencyResolutionNode: Equatable {
 
 extension DependencyResolutionNode: Hashable {
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(package)
-        hasher.combine(specificProduct)
+        hasher.combine(self.package)
+        hasher.combine(self.specificProduct)
     }
 }
 
 extension DependencyResolutionNode: CustomStringConvertible {
     public var description: String {
-        return "\(self.package.identity)\(productFilter)"
+        return "\(self.package.identity)\(self.productFilter)"
     }
 }

--- a/Sources/PackageGraph/DependencyResolver.swift
+++ b/Sources/PackageGraph/DependencyResolver.swift
@@ -13,7 +13,7 @@ import PackageModel
 
 public enum DependencyResolverError: Error, Equatable {
      /// A revision-based dependency contains a local package dependency.
-    case revisionDependencyContainsLocalPackage(dependency: String, localPackage: String)
+    case revisionDependencyContainsLocalPackage(dependency: PackageIdentity, localPackage: PackageIdentity)
 }
 
 public class DependencyResolver {

--- a/Sources/PackageGraph/LocalPackageContainer.swift
+++ b/Sources/PackageGraph/LocalPackageContainer.swift
@@ -66,7 +66,7 @@ public final class LocalPackageContainer: PackageContainer {
     public func getUpdatedIdentifier(at boundVersion: BoundVersion) throws -> PackageReference {
         assert(boundVersion == .unversioned, "Unexpected bound version \(boundVersion)")
         let manifest = try loadManifest()
-        return identifier.with(newName: manifest.name)
+        return identifier.with(alternateIdentity: PackageIdentity(name: manifest.name))
     }
 
     public init(

--- a/Sources/PackageGraph/LocalPackageContainer.swift
+++ b/Sources/PackageGraph/LocalPackageContainer.swift
@@ -24,14 +24,14 @@ import TSCUtility
 /// should be used as-is. Infact, they might not even have a git repository.
 /// Examples: Root packages, local dependencies, edited packages.
 public final class LocalPackageContainer: PackageContainer {
-    public let identifier: PackageReference
+    public let package: PackageReference
     private let mirrors: DependencyMirrors
     private let manifestLoader: ManifestLoaderProtocol
     private let toolsVersionLoader: ToolsVersionLoaderProtocol
     private let currentToolsVersion: ToolsVersion
 
     /// The file system that shoud be used to load this package.
-    private let fs: FileSystem
+    private let fileSystem: FileSystem
 
     /// cached version of the manifest
     private let manifest = ThreadSafeBox<Manifest>()
@@ -39,20 +39,20 @@ public final class LocalPackageContainer: PackageContainer {
     private func loadManifest() throws -> Manifest {
         try manifest.memoize() {
             // Load the tools version.
-            let toolsVersion = try toolsVersionLoader.load(at: AbsolutePath(identifier.path), fileSystem: fs)
+            let toolsVersion = try toolsVersionLoader.load(at: AbsolutePath(self.package.location), fileSystem: self.fileSystem)
 
             // Validate the tools version.
-            try toolsVersion.validateToolsVersion(self.currentToolsVersion, packagePath: identifier.path)
+            try toolsVersion.validateToolsVersion(self.currentToolsVersion, packagePath: self.package.location)
 
             // Load the manifest.
             // FIXME: this should not block
             return try temp_await {
-                manifestLoader.load(package: AbsolutePath(identifier.path),
-                                    baseURL: identifier.path,
+                manifestLoader.load(package: AbsolutePath(self.package.location),
+                                    baseURL: self.package.location,
                                     version: nil,
                                     toolsVersion: toolsVersion,
-                                    packageKind: identifier.kind,
-                                    fileSystem: fs,
+                                    packageKind: self.package.kind,
+                                    fileSystem: self.fileSystem,
                                     on: .global(),
                                     completion: $0)
             }
@@ -60,30 +60,30 @@ public final class LocalPackageContainer: PackageContainer {
     }
 
     public func getUnversionedDependencies(productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
-        return try loadManifest().dependencyConstraints(productFilter: productFilter, mirrors: mirrors)
+        return try self.loadManifest().dependencyConstraints(productFilter: productFilter, mirrors: mirrors)
     }
 
     public func getUpdatedIdentifier(at boundVersion: BoundVersion) throws -> PackageReference {
         assert(boundVersion == .unversioned, "Unexpected bound version \(boundVersion)")
-        let manifest = try loadManifest()
-        return identifier.with(alternateIdentity: PackageIdentity(name: manifest.name))
+        let manifest = try self.loadManifest()
+        return self.package.with(alternateIdentity: PackageIdentity(name: manifest.name))
     }
 
     public init(
-        _ identifier: PackageReference,
+        package: PackageReference,
         mirrors: DependencyMirrors,
         manifestLoader: ManifestLoaderProtocol,
         toolsVersionLoader: ToolsVersionLoaderProtocol,
         currentToolsVersion: ToolsVersion,
-        fs: FileSystem = localFileSystem
+        fileSystem: FileSystem = localFileSystem
     ) {
-        assert(URL.scheme(identifier.path) == nil, "unexpected scheme \(URL.scheme(identifier.path)!) in \(identifier.path)")
-        self.identifier = identifier
+        assert(URL.scheme(package.location) == nil, "unexpected scheme \(URL.scheme(package.location)!) in \(package.location)")
+        self.package = package
         self.mirrors = mirrors
         self.manifestLoader = manifestLoader
         self.toolsVersionLoader = toolsVersionLoader
         self.currentToolsVersion = currentToolsVersion
-        self.fs = fs
+        self.fileSystem = fileSystem
     }
     
     public func isToolsVersionCompatible(at version: Version) -> Bool {
@@ -113,6 +113,6 @@ public final class LocalPackageContainer: PackageContainer {
 
 extension LocalPackageContainer: CustomStringConvertible  {
     public var description: String {
-        return "LocalPackageContainer(\(identifier.path))"
+        return "LocalPackageContainer(\(self.package.location))"
     }
 }

--- a/Sources/PackageGraph/PackageContainer.swift
+++ b/Sources/PackageGraph/PackageContainer.swift
@@ -36,7 +36,7 @@ import struct TSCUtility.Version
 public protocol PackageContainer {
 
     /// The identifier for the package.
-    var identifier: PackageReference { get }
+    var package: PackageReference { get }
 
     /// Returns true if the tools version is compatible at the given version.
     func isToolsVersionCompatible(at version: Version) -> Bool
@@ -116,7 +116,7 @@ extension PackageContainer {
 public struct PackageContainerConstraint: Equatable, Hashable {
 
     /// The identifier for the container the constraint is on.
-    public let identifier: PackageReference
+    public let package: PackageReference
 
     /// The constraint requirement.
     public let requirement: PackageRequirement
@@ -126,22 +126,22 @@ public struct PackageContainerConstraint: Equatable, Hashable {
 
     /// Create a constraint requiring the given `container` satisfying the
     /// `requirement`.
-    public init(container identifier: PackageReference, requirement: PackageRequirement, products: ProductFilter) {
-        self.identifier = identifier
+    public init(package: PackageReference, requirement: PackageRequirement, products: ProductFilter) {
+        self.package = package
         self.requirement = requirement
         self.products = products
     }
 
     /// Create a constraint requiring the given `container` satisfying the
     /// `versionRequirement`.
-    public init(container identifier: PackageReference, versionRequirement: VersionSetSpecifier, products: ProductFilter) {
-        self.init(container: identifier, requirement: .versionSet(versionRequirement), products: products)
+    public init(package: PackageReference, versionRequirement: VersionSetSpecifier, products: ProductFilter) {
+        self.init(package: package, requirement: .versionSet(versionRequirement), products: products)
     }
 }
 
 extension PackageContainerConstraint: CustomStringConvertible {
     public var description: String {
-        return "Constraint(\(identifier), \(requirement), \(products)"
+        return "Constraint(\(self.package), \(self.requirement), \(self.products)"
     }
 }
 
@@ -151,7 +151,7 @@ extension PackageContainerConstraint: CustomStringConvertible {
 public protocol PackageContainerProvider {
     /// Get the container for a particular identifier asynchronously.
     func getContainer(
-        for identifier: PackageReference,
+        for package: PackageReference,
         skipUpdate: Bool,
         on queue: DispatchQueue,
         completion: @escaping (Result<PackageContainer, Swift.Error>) -> Void

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -201,7 +201,7 @@ private func createResolvedPackages(
         guard let package = manifestToPackage[node.manifest] else {
             return nil
         }
-        let isAllowedToVendUnsafeProducts = unsafeAllowedPackages.contains{ $0.path == package.manifest.url }
+        let isAllowedToVendUnsafeProducts = unsafeAllowedPackages.contains{ $0.location == package.manifest.url }
         return ResolvedPackageBuilder(
             package,
             productFilter: node.productFilter,

--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -49,7 +49,7 @@ public struct PackageGraphRoot {
     public init(input: PackageGraphRootInput, manifests: [Manifest], explicitProduct: String? = nil) {
         self.packageRefs = zip(input.packages, manifests).map { (path, manifest) in
             let identity = PackageIdentity(url: manifest.url)
-            return PackageReference(identity: identity, path: path.pathString, kind: .root)
+            return PackageReference.root(identity: identity, path: path)
         }
         self.manifests = manifests
 
@@ -73,11 +73,11 @@ public struct PackageGraphRoot {
     /// Returns the constraints imposed by root manifests + dependencies.
     public func constraints(mirrors: DependencyMirrors) -> [PackageContainerConstraint] {
         let constraints = packageRefs.map({
-            PackageContainerConstraint(container: $0, requirement: .unversioned, products: .everything)
+            PackageContainerConstraint(package: $0, requirement: .unversioned, products: .everything)
         })
         return constraints + dependencies.map({
             PackageContainerConstraint(
-                container: $0.createPackageRef(mirrors: mirrors),
+                package: $0.createPackageRef(mirrors: mirrors),
                 requirement: $0.requirement.toConstraintRequirement(),
                 products: $0.productFilter
             )

--- a/Sources/PackageGraph/PackageModel+Extensions.swift
+++ b/Sources/PackageGraph/PackageModel+Extensions.swift
@@ -27,8 +27,8 @@ extension PackageDependencyDescription {
         
         return PackageReference(
             identity: identity,
-            path: effectiveURL,
-            kind: requirement == .localPackage ? .local : .remote
+            kind: requirement == .localPackage ? .local : .remote,
+            location: effectiveURL
         )
     }
 }
@@ -38,7 +38,7 @@ extension Manifest {
     public func dependencyConstraints(productFilter: ProductFilter, mirrors: DependencyMirrors) -> [PackageContainerConstraint] {
         return dependenciesRequired(for: productFilter).map({
             return PackageContainerConstraint(
-                container: $0.createPackageRef(mirrors: mirrors),
+                package: $0.createPackageRef(mirrors: mirrors),
                 requirement: $0.requirement.toConstraintRequirement(),
                 products: $0.productFilter)
         })
@@ -49,7 +49,7 @@ extension PackageContainerConstraint {
     internal func nodes() -> [DependencyResolutionNode] {
         switch products {
         case .everything:
-            return [.root(package: identifier)]
+            return [.root(package: self.package)]
         case .specific:
             switch products {
             case .everything:
@@ -57,9 +57,9 @@ extension PackageContainerConstraint {
                 return []
             case .specific(let set):
                 if set.isEmpty { // Pointing at the package without a particular product.
-                    return [.empty(package: identifier)]
+                    return [.empty(package: self.package)]
                 } else {
-                    return set.sorted().map { .product($0, package: identifier) }
+                    return set.sorted().map { .product($0, package: self.package) }
                 }
             }
         }
@@ -72,6 +72,6 @@ extension PackageReference {
     /// This should only be accessed when the reference is not local.
     public var repository: RepositorySpecifier {
         precondition(kind == .remote)
-        return RepositorySpecifier(url: path)
+        return RepositorySpecifier(url: self.location)
     }
 }

--- a/Sources/PackageGraph/PinsStore.swift
+++ b/Sources/PackageGraph/PinsStore.swift
@@ -159,7 +159,7 @@ extension PinsStore.Pin: JSONMappable, JSONSerializable {
         } else if let value: String = json.get("name") {
             alternateIdentity = PackageIdentity(name: value)
         }
-        let package = PackageReference(identity: identity, path: location)
+        let package = PackageReference.remote(identity: identity, location: location)
         self.packageRef = alternateIdentity.map{ package.with(alternateIdentity: $0) } ?? package
         self.state = try json.get("state")
     }
@@ -167,11 +167,11 @@ extension PinsStore.Pin: JSONMappable, JSONSerializable {
     /// Convert the pin to JSON.
     public func toJSON() -> JSON {
         var map: [String: JSONSerializable] = [
-            "identity": packageRef.identity,
-            "location": packageRef.path,
-            "state": state
+            "identity": self.packageRef.identity,
+            "location": self.packageRef.location,
+            "state": self.state
         ]
-        if let alternateIdentity = packageRef.alternateIdentity {
+        if let alternateIdentity = self.packageRef.alternateIdentity {
             map["alternate_identity"] = alternateIdentity
         }
         return .init(map)

--- a/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
@@ -294,12 +294,12 @@ public struct PubgrubDependencyResolver {
             constraints.remove(constraint)
 
             // Mark the package as overridden.
-            if var existing = overriddenPackages[constraint.identifier] {
-                assert(existing.version == .unversioned, "Overridden package is not unversioned: \(constraint.identifier)@\(existing.version)")
+            if var existing = overriddenPackages[constraint.package] {
+                assert(existing.version == .unversioned, "Overridden package is not unversioned: \(constraint.package)@\(existing.version)")
                 existing.products.formUnion(constraint.products)
-                overriddenPackages[constraint.identifier] = existing
+                overriddenPackages[constraint.package] = existing
             } else {
-                overriddenPackages[constraint.identifier] = (version: .unversioned, products: constraint.products)
+                overriddenPackages[constraint.package] = (version: .unversioned, products: constraint.products)
             }
 
             for node in constraint.nodes() {
@@ -315,7 +315,7 @@ public struct PubgrubDependencyResolver {
                         for constraint in versionedBasedConstraints {
                             versionBasedDependencies[node, default: []].append(constraint)
                         }
-                    } else if !overriddenPackages.keys.contains(dependency.identifier) {
+                    } else if !overriddenPackages.keys.contains(dependency.package) {
                         // Add the constraint if its not already present. This will ensure we don't
                         // end up looping infinitely due to a cycle (which are diagnosed seperately).
                         constraints.append(dependency)
@@ -332,7 +332,7 @@ public struct PubgrubDependencyResolver {
                 throw InternalError("Expected revision requirement")
             }
             constraints.remove(constraint)
-            let package = constraint.identifier
+            let package = constraint.package
 
             // Check if there is an existing value for this package in the overridden packages.
             switch overriddenPackages[package]?.version {
@@ -346,7 +346,7 @@ public struct PubgrubDependencyResolver {
                 // If this branch-based package was encountered before, ensure the references match.
                 if (branch ?? existingRevision) != revision {
                     // FIXME: Improve diagnostics here.
-                    let lastPathComponent = String(package.path.split(separator: "/").last!).spm_dropGitSuffix()
+                    let lastPathComponent = String(package.location.split(separator: "/").last!).spm_dropGitSuffix()
                     throw PubgrubError.unresolvable("\(lastPathComponent) is required using two different revision-based requirements (\(existingRevision) and \(revision)), which is not supported")
                 } else {
                     // Otherwise, continue since we've already processed this constraint. Any cycles will be diagnosed separately.
@@ -399,7 +399,7 @@ public struct PubgrubDependencyResolver {
                     case .unversioned:
                         throw DependencyResolverError.revisionDependencyContainsLocalPackage(
                             dependency: package.identity,
-                            localPackage: dependency.identifier.identity
+                            localPackage: dependency.package.identity
                         )
                     }
                 }
@@ -1081,12 +1081,12 @@ private final class PubGrubPackageContainer {
     }
 
     var package: PackageReference {
-        self.underlying.identifier
+        self.underlying.package
     }
 
     /// Returns the pinned version for this package, if any.
     var pinnedVersion: Version? {
-        return self.pinsMap[self.underlying.identifier.identity]?.state.version
+        return self.pinsMap[self.underlying.package.identity]?.state.version
     }
 
     /// Returns the numbers of versions that are satisfied by the given version requirement.
@@ -1207,19 +1207,19 @@ private final class PubGrubPackageContainer {
             guard case .versionSet = dep.requirement else {
                 let cause: Incompatibility.Cause = .versionBasedDependencyContainsUnversionedDependency(
                     versionedDependency: package,
-                    unversionedDependency: dep.identifier
+                    unversionedDependency: dep.package
                 )
                 return [try Incompatibility(Term(node, .exact(version)), root: root, cause: cause)]
             }
 
             // Skip if this package is overriden.
-            if overriddenPackages.keys.contains(dep.identifier) {
+            if overriddenPackages.keys.contains(dep.package) {
                 continue
             }
 
             // Skip if we already emitted incompatibilities for this dependency such that the selected
             // falls within the previously computed bounds.
-            if emittedIncompatibilities[dep.identifier]?.contains(version) != true {
+            if emittedIncompatibilities[dep.package]?.contains(version) != true {
                 constraints.append(dep)
             }
         }
@@ -1259,8 +1259,8 @@ private final class PubGrubPackageContainer {
 
         return try constraints.map { constraint in
             var terms: OrderedSet<Term> = []
-            let lowerBound = lowerBounds[constraint.identifier] ?? "0.0.0"
-            let upperBound = upperBounds[constraint.identifier] ?? Version(version.major + 1, 0, 0)
+            let lowerBound = lowerBounds[constraint.package] ?? "0.0.0"
+            let upperBound = upperBounds[constraint.package] ?? Version(version.major + 1, 0, 0)
             assert(lowerBound < upperBound)
 
             // We only have version-based requirements at this point.
@@ -1274,7 +1274,7 @@ private final class PubGrubPackageContainer {
                 terms.append(Term(not: constraintNode, vs))
 
                 // Make a record for this dependency so we don't have to recompute the bounds when the selected version falls within the bounds.
-                self.emittedIncompatibilities[constraint.identifier] = requirement.union(emittedIncompatibilities[constraint.identifier] ?? .empty)
+                self.emittedIncompatibilities[constraint.package] = requirement.union(emittedIncompatibilities[constraint.package] ?? .empty)
             }
 
             return try Incompatibility(terms, root: root, cause: .dependency(node: node))
@@ -1332,17 +1332,17 @@ private final class PubGrubPackageContainer {
                 let bound = upperBound ? version : previousVersion
                 
                 let isToolsVersionCompatible = self.underlying.isToolsVersionCompatible(at: version)
-                for constraint in constraints where !result.keys.contains(constraint.identifier) {
+                for constraint in constraints where !result.keys.contains(constraint.package) {
                     // If we hit a version which doesn't have a compatible tools version then that's the boundary.
                     // Record the bound if the tools version isn't compatible at the current version.
                     if !isToolsVersionCompatible {
-                        result[constraint.identifier] = bound
+                        result[constraint.package] = bound
                     } else {
                         // Get the dependencies at this version.
                         if let currentDependencies = try? self.underlying.getDependencies(at: version, productFilter: products) {
                             // Record this version as the bound for our list of dependencies, if appropriate.
-                            if currentDependencies.first(where: { $0.identifier == constraint.identifier }) != constraint {
-                                result[constraint.identifier] = bound
+                            if currentDependencies.first(where: { $0.package == constraint.package }) != constraint {
+                                result[constraint.package] = bound
                             }
                         }
                     }

--- a/Sources/PackageGraph/RepositoryPackageContainer.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainer.swift
@@ -55,7 +55,7 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
         }
     }
 
-    public let identifier: PackageReference
+    public let package: PackageReference
     private let repository: Repository
     private let mirrors: DependencyMirrors
     private let manifestLoader: ManifestLoaderProtocol
@@ -75,14 +75,14 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
     internal var validToolsVersionsCache = ThreadSafeKeyValueStore<Version, Bool>()
 
     init(
-        identifier: PackageReference,
+        package: PackageReference,
         mirrors: DependencyMirrors,
         repository: Repository,
         manifestLoader: ManifestLoaderProtocol,
         toolsVersionLoader: ToolsVersionLoaderProtocol,
         currentToolsVersion: ToolsVersion
     ) {
-        self.identifier = identifier
+        self.package = package
         self.mirrors = mirrors
         self.repository = repository
         self.manifestLoader = manifestLoader
@@ -163,7 +163,7 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
             }.1
         } catch {
             throw GetDependenciesError(
-                containerIdentifier: identifier.repository.url, reference: version.description, underlyingError: error, suggestion: nil)
+                containerIdentifier: self.package.repository.url, reference: version.description, underlyingError: error, suggestion: nil)
         }
     }
 
@@ -181,7 +181,7 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
                 if let rev = try? repository.resolveRevision(identifier: revision), repository.exists(revision: rev) {
                     // Revision does exist, so something else must be wrong.
                     throw GetDependenciesError(
-                        containerIdentifier: identifier.repository.url, reference: revision, underlyingError: error, suggestion: nil)
+                        containerIdentifier: self.package.repository.url, reference: revision, underlyingError: error, suggestion: nil)
                 }
                 else {
                     // Revision does not exist, so we customize the error.
@@ -191,12 +191,12 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
                     let mainBranchExists = (try? repository.resolveRevision(identifier: "main")) != nil
                     let suggestion = (revision == "master" && mainBranchExists) ? "did you mean ‘main’?" : nil
                     throw GetDependenciesError(
-                        containerIdentifier: identifier.repository.url, reference: revision,
+                        containerIdentifier: self.package.repository.url, reference: revision,
                         underlyingError: StringError(errorMessage), suggestion: suggestion)
                 }
             }
             // If we get this far without having thrown an error, we wrap and throw the underlying error.
-            throw GetDependenciesError(containerIdentifier: identifier.repository.url, reference: revision, underlyingError: error, suggestion: nil)
+            throw GetDependenciesError(containerIdentifier: self.package.repository.url, reference: revision, underlyingError: error, suggestion: nil)
         }
     }
 
@@ -244,11 +244,11 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
             revision = try repository.resolveRevision(identifier: identifier)
         case .unversioned, .excluded:
             assertionFailure("Unexpected type requirement \(boundVersion)")
-            return self.identifier
+            return self.package
         }
 
         let manifest = try self.loadManifest(at: revision, version: version)
-        return self.identifier.with(alternateIdentity: PackageIdentity(name: manifest.name))
+        return self.package.with(alternateIdentity: PackageIdentity(name: manifest.name))
     }
 
     /// Returns true if the tools version is valid and can be used by this
@@ -268,11 +268,11 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
    
     private func loadManifest(at revision: Revision, version: Version?) throws -> Manifest {
         try self.manifestsCache.memoize(revision) {
-            let fs = try repository.openFileView(revision: revision)
-            let packageURL = identifier.repository.url
+            let fileSystem = try repository.openFileView(revision: revision)
+            let packageURL = self.package.repository.url
 
             // Load the tools version.
-            let toolsVersion = try toolsVersionLoader.load(at: .root, fileSystem: fs)
+            let toolsVersion = try toolsVersionLoader.load(at: .root, fileSystem: fileSystem)
 
             // Validate the tools version.
             try toolsVersion.validateToolsVersion(
@@ -285,8 +285,8 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
                                     baseURL: packageURL,
                                     version: version,
                                     toolsVersion: toolsVersion,
-                                    packageKind: identifier.kind,
-                                    fileSystem: fs,
+                                    packageKind: self.package.kind,
+                                    fileSystem: fileSystem,
                                     on: .global(),
                                     completion: $0)
             }
@@ -298,7 +298,7 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
     }
 
     public var description: String {
-        return "RepositoryPackageContainer(\(identifier.repository.url.debugDescription))"
+        return "RepositoryPackageContainer(\(self.package.repository.url.debugDescription))"
     }
 }
 
@@ -340,26 +340,27 @@ public class RepositoryPackageContainerProvider: PackageContainerProvider {
     }
 
     public func getContainer(
-        for identifier: PackageReference,
+        for package: PackageReference,
         skipUpdate: Bool,
         on queue: DispatchQueue,
         completion: @escaping (Result<PackageContainer, Swift.Error>) -> Void
     ) {
         // If the container is local, just create and return a local package container.
-        if identifier.kind != .remote {
+        if package.kind != .remote {
             return queue.async {
-                let container = LocalPackageContainer(identifier,
+                let container = LocalPackageContainer(
+                    package: package,
                     mirrors: self.mirrors,
                     manifestLoader: self.manifestLoader,
                     toolsVersionLoader: self.toolsVersionLoader,
                     currentToolsVersion: self.currentToolsVersion,
-                    fs: self.repositoryManager.fileSystem)
+                    fileSystem: self.repositoryManager.fileSystem)
                 completion(.success(container))
             }
         }
 
         // Resolve the container using the repository manager.
-        repositoryManager.lookup(repository: identifier.repository, skipUpdate: skipUpdate, on: queue) { result in
+        repositoryManager.lookup(repository: package.repository, skipUpdate: skipUpdate, on: queue) { result in
             queue.async {
                 // Create the container wrapper.
                 let result = result.tryMap { handle -> PackageContainer in
@@ -368,7 +369,7 @@ public class RepositoryPackageContainerProvider: PackageContainerProvider {
                     // FIXME: Do we care about holding this open for the lifetime of the container.
                     let repository = try handle.open()
                     return RepositoryPackageContainer(
-                        identifier: identifier,
+                        package: package,
                         mirrors: self.mirrors,
                         repository: repository,
                         manifestLoader: self.manifestLoader,

--- a/Sources/PackageGraph/RepositoryPackageContainer.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainer.swift
@@ -248,7 +248,7 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
         }
 
         let manifest = try self.loadManifest(at: revision, version: version)
-        return self.identifier.with(newName: manifest.name)
+        return self.identifier.with(alternateIdentity: PackageIdentity(name: manifest.name))
     }
 
     /// Returns true if the tools version is valid and can be used by this

--- a/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
@@ -30,10 +30,12 @@ public struct PackageDependencyDescription: Equatable, Codable {
         }
     }
 
+    // FIXME: remove this and use identity instead
     /// The name of the package dependency explicitly defined in the manifest, if any.
     public let explicitName: String?
 
-    /// The name of the packagedependency,
+    // FIXME: remove this and use identity instead
+    /// The name of the package dependency,
     /// either explicitly defined in the manifest,
     /// or derived from the URL.
     ///
@@ -57,6 +59,7 @@ public struct PackageDependencyDescription: Equatable, Codable {
         requirement: Requirement,
         productFilter: ProductFilter = .everything
     ) {
+        // FIXME: remove this / move elsewhere. need a better model for location instead of string URL for both AbsolutePath and URLs
         // FIXME: SwiftPM can't handle file URLs with file:// scheme so we need to
         // strip that. We need to design a URL data structure for SwiftPM.
         let filePrefix = "file://"
@@ -68,7 +71,7 @@ public struct PackageDependencyDescription: Equatable, Codable {
         }
 
         self.explicitName = name
-        self.name = name ?? PackageReference.computeDefaultName(fromURL: normalizedURL)
+        self.name = name ?? LegacyPackageIdentity.computeDefaultName(fromURL: normalizedURL)
         self.url = normalizedURL
         self.requirement = requirement
         self.productFilter = productFilter

--- a/Sources/PackageModel/PackageIdentity.swift
+++ b/Sources/PackageModel/PackageIdentity.swift
@@ -51,6 +51,27 @@ public struct PackageIdentity: Hashable, CustomStringConvertible {
     public init(path: AbsolutePath) {
         self.init(path.pathString)
     }
+
+    /// Creates a package identity from a string
+    /// - Parameter name: An identity for the package.
+    public init(name: String) {
+        // use as-is!
+        self.init(name)
+    }
+}
+
+extension PackageIdentity {
+    public var mangledToC99ExtendedIdentifier: String {
+        get {
+            self.description.spm_mangledToC99ExtendedIdentifier()
+        }
+    }
+
+    public var mangledToBundleIdentifier: String {
+        get {
+            self.description.spm_mangledToBundleIdentifier()
+        }
+    }
 }
 
 extension PackageIdentity: Comparable {
@@ -94,7 +115,34 @@ struct LegacyPackageIdentity: PackageIdentityProvider, Equatable {
 
     /// Instantiates an instance of the conforming type from a string representation.
     public init(_ string: String) {
-        self.description = PackageReference.computeDefaultName(fromURL: string).lowercased()
+        self.description = Self.computeDefaultName(fromURL: string).lowercased()
+    }
+
+    /// Compute the default name of a package given its URL.
+    public static func computeDefaultName(fromURL url: String) -> String {
+        #if os(Windows)
+        let isSeparator : (Character) -> Bool = { $0 == "/" || $0 == "\\" }
+        #else
+        let isSeparator : (Character) -> Bool = { $0 == "/" }
+        #endif
+
+        // Get the last path component of the URL.
+        // Drop the last character in case it's a trailing slash.
+        var endIndex = url.endIndex
+        if let lastCharacter = url.last, isSeparator(lastCharacter) {
+            endIndex = url.index(before: endIndex)
+        }
+
+        let separatorIndex = url[..<endIndex].lastIndex(where: isSeparator)
+        let startIndex = separatorIndex.map { url.index(after: $0) } ?? url.startIndex
+        var lastComponent = url[startIndex..<endIndex]
+
+        // Strip `.git` suffix if present.
+        if lastComponent.hasSuffix(".git") {
+            lastComponent = lastComponent.dropLast(4)
+        }
+
+        return String(lastComponent)
     }
 }
 

--- a/Sources/SPMTestSupport/MockDependencyGraph.swift
+++ b/Sources/SPMTestSupport/MockDependencyGraph.swift
@@ -49,7 +49,7 @@ public extension MockDependencyGraph {
         self.result = Dictionary(uniqueKeysWithValues: result.map { value in
             let (container, version) = value
             guard case .string(let str) = version else { fatalError() }
-            let package = PackageReference(identity: PackageIdentity(url: container.lowercased()), path: "/\(container)")
+            let package = PackageReference.remote(identity: PackageIdentity(url: container.lowercased()), location: "/\(container)")
             return (package, Version(string: str)!)
         })
         self.name = name
@@ -72,7 +72,7 @@ private extension MockPackageContainer {
                 .map { constraint in
                     switch constraint.requirement {
                     case .versionSet(let versionSet):
-                        return (constraint.identifier.identity.description, versionSet)
+                        return (constraint.package.identity.description, versionSet)
                     case .unversioned:
                         fatalError()
                     case .revision:
@@ -91,8 +91,8 @@ private extension MockPackageContainer.Constraint {
         guard case .string(let identifier)? = dict["identifier"] else { fatalError() }
         guard let requirement = dict["requirement"] else { fatalError() }
         let products: ProductFilter = try! JSON(dict).get("products")
-        let id = PackageReference(identity: PackageIdentity(url: identifier), path: "", kind: .remote)
-        self.init(container: id, versionRequirement: VersionSetSpecifier(requirement), products: products)
+        let package = PackageReference.remote(identity: PackageIdentity(url: identifier), location: "")
+        self.init(package: package, versionRequirement: VersionSetSpecifier(requirement), products: products)
     }
 }
 

--- a/Sources/SPMTestSupport/MockPackageContainer.swift
+++ b/Sources/SPMTestSupport/MockPackageContainer.swift
@@ -18,13 +18,10 @@ import TSCBasic
 import struct TSCUtility.Version
 
 public class MockPackageContainer: PackageContainer {
-    public typealias Identifier = PackageReference
-
     public typealias Constraint = PackageContainerConstraint
+    public typealias Dependency = (package: PackageReference, requirement: PackageRequirement)
 
-    public typealias Dependency = (container: Identifier, requirement: PackageRequirement)
-
-    let name: Identifier
+    public let package: PackageReference
 
     let dependencies: [String: [Dependency]]
 
@@ -33,37 +30,33 @@ public class MockPackageContainer: PackageContainer {
     /// Contains the versions for which the dependencies were requested by resolver using getDependencies().
     public var requestedVersions: Set<Version> = []
 
-    public var identifier: Identifier {
-        return name
-    }
-
     public let _versions: [Version]
     public func toolsVersionsAppropriateVersionsDescending() throws -> [Version] {
         return try self.versionsDescending()
     }
 
     public func versionsAscending() throws -> [Version] {
-        return _versions
+        return self._versions
     }
 
     public func getDependencies(at version: Version, productFilter: ProductFilter) -> [MockPackageContainer.Constraint] {
-        requestedVersions.insert(version)
-        return getDependencies(at: version.description, productFilter: productFilter)
+        self.requestedVersions.insert(version)
+        return self.getDependencies(at: version.description, productFilter: productFilter)
     }
 
     public func getDependencies(at revision: String, productFilter: ProductFilter) -> [MockPackageContainer.Constraint] {
-        return dependencies[revision]!.map { value in
-            let (name, requirement) = value
-            return MockPackageContainer.Constraint(container: name, requirement: requirement, products: productFilter)
+        return self.dependencies[revision]!.map { value in
+            let (package, requirement) = value
+            return MockPackageContainer.Constraint(package: package, requirement: requirement, products: productFilter)
         }
     }
 
     public func getUnversionedDependencies(productFilter: ProductFilter) -> [MockPackageContainer.Constraint] {
-        return unversionedDeps
+        return self.unversionedDeps
     }
 
     public func getUpdatedIdentifier(at boundVersion: BoundVersion) throws -> PackageReference {
-        return name
+        return self.package
     }
 
     public func isToolsVersionCompatible(at version: Version) -> Bool {
@@ -85,19 +78,19 @@ public class MockPackageContainer: PackageContainer {
         var dependencies: [String: [Dependency]] = [:]
         for (version, deps) in dependenciesByVersion {
             dependencies[version.description] = deps.map {
-                let ref = PackageReference(identity: PackageIdentity(url: $0.container), path: "/\($0.container)")
+                let ref = PackageReference.remote(identity: PackageIdentity(url: $0.container), location: "/\($0.container)")
                 return (ref, .versionSet($0.versionRequirement))
             }
         }
-        let ref = PackageReference(identity: PackageIdentity(name: name), path: "/\(name)")
-        self.init(name: ref, dependencies: dependencies)
+        let ref = PackageReference.remote(identity: PackageIdentity(name: name), location: "/\(name)")
+        self.init(package: ref, dependencies: dependencies)
     }
 
     public init(
-        name: Identifier,
+        package: PackageReference,
         dependencies: [String: [Dependency]] = [:]
     ) {
-        self.name = name
+        self.package = package
         self._versions = dependencies.keys.compactMap(Version.init(string:)).sorted()
         self.dependencies = dependencies
     }
@@ -109,31 +102,19 @@ public struct MockPackageContainerProvider: PackageContainerProvider {
 
     public init(containers: [MockPackageContainer]) {
         self.containers = containers
-        self.containersByIdentifier = Dictionary(uniqueKeysWithValues: containers.map { ($0.identifier, $0) })
+        self.containersByIdentifier = Dictionary(uniqueKeysWithValues: containers.map { ($0.package, $0) })
     }
 
     public func getContainer(
-        for identifier: PackageReference,
+        for package: PackageReference,
         skipUpdate: Bool,
         on queue: DispatchQueue,
         completion: @escaping (Result<PackageContainer, Swift.Error>
         ) -> Void
     ) {
         queue.async {
-            completion(self.containersByIdentifier[identifier].map { .success($0) } ??
-                .failure(StringError("unknown module \(identifier)")))
+            completion(self.containersByIdentifier[package].map { .success($0) } ??
+                .failure(StringError("unknown module \(package)")))
         }
-    }
-}
-
-public extension MockPackageContainer.Constraint {
-    init(container identifier: String, requirement: PackageRequirement, products: ProductFilter) {
-        let ref = PackageReference(identity: PackageIdentity(url: identifier), path: "")
-        self.init(container: ref, requirement: requirement, products: products)
-    }
-
-    init(container identifier: String, versionRequirement: VersionSetSpecifier, products: ProductFilter) {
-        let ref = PackageReference(identity: PackageIdentity(url: identifier), path: "")
-        self.init(container: ref, versionRequirement: versionRequirement, products: products)
     }
 }

--- a/Sources/SPMTestSupport/MockPackageContainer.swift
+++ b/Sources/SPMTestSupport/MockPackageContainer.swift
@@ -89,7 +89,7 @@ public class MockPackageContainer: PackageContainer {
                 return (ref, .versionSet($0.versionRequirement))
             }
         }
-        let ref = PackageReference(identity: PackageIdentity(url: name), path: "/\(name)")
+        let ref = PackageReference(identity: PackageIdentity(name: name), path: "/\(name)")
         self.init(name: ref, dependencies: dependencies)
     }
 

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -537,7 +537,7 @@ public final class MockWorkspace {
                 return
             }
 
-            XCTAssertEqual(pin.packageRef.path, url, file: file, line: line)
+            XCTAssertEqual(pin.packageRef.location, url, file: file, line: line)
         }
     }
 

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -391,10 +391,11 @@ public final class MockWorkspace {
             XCTAssertEqual(self.managedDependencies.count, 0, file: file, line: line)
         }
 
-        public func check(dependency name: String, at state: State, file: StaticString = #file, line: UInt = #line) {
+        @discardableResult
+        public func check(dependency name: String, at state: State, file: StaticString = #file, line: UInt = #line) -> ManagedDependency? {
             guard let dependency = managedDependencies[forNameOrIdentity: name] else {
                 XCTFail("\(name) does not exists", file: file, line: line)
-                return
+                return nil
             }
             switch state {
             case .checkout(let checkoutState):
@@ -415,6 +416,7 @@ public final class MockWorkspace {
                     XCTFail("Expected local dependency", file: file, line: line)
                 }
             }
+            return dependency
         }
     }
 
@@ -506,11 +508,11 @@ public final class MockWorkspace {
         }
 
         public func check(notPresent name: String, file: StaticString = #file, line: UInt = #line) {
-            XCTAssertFalse(self.store.pinsMap.keys.contains(where: { $0.description == name }), "Unexpectedly found \(name) in Package.resolved", file: file, line: line)
+            XCTAssertFalse(self.store.pinsMap.keys.contains(where: { $0 == PackageIdentity(name: name) }), "Unexpectedly found \(name) in Package.resolved", file: file, line: line)
         }
 
         public func check(dependency package: String, at state: State, file: StaticString = #file, line: UInt = #line) {
-            guard let pin = store.pinsMap.first(where: { $0.key.description == package })?.value else {
+            guard let pin = store.pinsMap.first(where: { $0.key == PackageIdentity(name: package) })?.value else {
                 XCTFail("Pin for \(package) not found", file: file, line: line)
                 return
             }
@@ -530,7 +532,7 @@ public final class MockWorkspace {
         }
 
         public func check(dependency package: String, url: String, file: StaticString = #file, line: UInt = #line) {
-            guard let pin = store.pinsMap.first(where: { $0.key.description == package })?.value else {
+            guard let pin = store.pinsMap.first(where: { $0.key == PackageIdentity(name: package) })?.value else {
                 XCTFail("Pin for \(package) not found", file: file, line: line)
                 return
             }

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -82,10 +82,10 @@ public enum WorkspaceDiagnostics {
     /// is not in edit mode.
     public struct DependencyNotInEditMode: DiagnosticData, Swift.Error {
         /// The name of the dependency being unedited.
-        public let dependencyName: String
+        public let dependency: PackageIdentity
 
         public var description: String {
-            return "dependency '\(dependencyName)' not in edit mode"
+            return "dependency '\(dependency)' not in edit mode"
         }
     }
 
@@ -125,12 +125,12 @@ extension Diagnostic.Message {
         .warning("dependency '\(packageName)' already exists at the edit destination; not using revision '\(revisionIdentifier)'")
     }
 
-    static func editedDependencyMissing(packageName: String) -> Diagnostic.Message {
-        .warning("dependency '\(packageName)' was being edited but is missing; falling back to original checkout")
+    static func editedDependencyMissing(package: PackageIdentity) -> Diagnostic.Message {
+        .warning("dependency '\(package)' was being edited but is missing; falling back to original checkout")
     }
 
-    static func checkedOutDependencyMissing(packageName: String) -> Diagnostic.Message {
-        .warning("dependency '\(packageName)' is missing; cloning again")
+    static func checkedOutDependencyMissing(package: PackageIdentity) -> Diagnostic.Message {
+        .warning("dependency '\(package)' is missing; cloning again")
     }
 
     static func artifactChecksumChanged(targetName: String) -> Diagnostic.Message {

--- a/Sources/Workspace/ManagedArtifact.swift
+++ b/Sources/Workspace/ManagedArtifact.swift
@@ -89,14 +89,14 @@ extension ManagedArtifact: JSONMappable, JSONSerializable, CustomStringConvertib
 
     public func toJSON() -> JSON {
         return .init([
-            "packageRef": packageRef,
-            "targetName": targetName,
-            "source": source,
+            "packageRef": self.packageRef,
+            "targetName": self.targetName,
+            "source": self.source,
         ])
     }
 
     public var description: String {
-        return "<ManagedArtifact: \(packageRef.name).\(targetName) \(source)>"
+        return "<ManagedArtifact: \(self.packageRef.identity).\(targetName) \(source)>"
     }
 }
 
@@ -148,6 +148,7 @@ extension ManagedArtifact.Source: JSONMappable, JSONSerializable, CustomStringCo
 /// A collection of managed artifacts which have been downloaded.
 public final class ManagedArtifacts {
 
+    // FIXME: map by PackageIdentity?
     /// A mapping from package url, to target name, to ManagedArtifact.
     private var artifactMap: [String: [String: ManagedArtifact]]
 
@@ -164,7 +165,11 @@ public final class ManagedArtifacts {
     }
 
     public subscript(packageName packageName: String, targetName targetName: String) -> ManagedArtifact? {
-        artifacts.first(where: { $0.packageRef.name == packageName && $0.targetName == targetName })
+        let identity = PackageIdentity(name: packageName)
+        return artifacts.first(where: {
+            $0.targetName == targetName &&
+            ($0.packageRef.identity == identity || $0.packageRef.alternateIdentity == identity)
+        })
     }
 
     public func add(_ artifact: ManagedArtifact) {

--- a/Sources/Workspace/ManagedArtifact.swift
+++ b/Sources/Workspace/ManagedArtifact.swift
@@ -173,7 +173,7 @@ public final class ManagedArtifacts {
     }
 
     public func add(_ artifact: ManagedArtifact) {
-        artifactMap[artifact.packageRef.path, default: [:]][artifact.targetName] = artifact
+        artifactMap[artifact.packageRef.location, default: [:]][artifact.targetName] = artifact
     }
 
     public func remove(packageURL: String, targetName: String) {
@@ -206,7 +206,7 @@ extension ManagedArtifacts: Collection {
 extension ManagedArtifacts: JSONMappable, JSONSerializable {
     public convenience init(json: JSON) throws {
         let artifacts = try Array<ManagedArtifact>(json: json)
-        let artifactsByPackagePath = Dictionary(grouping: artifacts, by: { $0.packageRef.path })
+        let artifactsByPackagePath = Dictionary(grouping: artifacts, by: { $0.packageRef.location })
         let artifactMap = artifactsByPackagePath.mapValues({ artifacts in
             Dictionary(uniqueKeysWithValues: artifacts.lazy.map({ ($0.targetName, $0) }))
         })

--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -237,7 +237,7 @@ public final class ManagedDependencies {
     }
 
     public func add(_ dependency: ManagedDependency) {
-        self.dependencyMap[dependency.packageRef.path] = dependency
+        self.dependencyMap[dependency.packageRef.location] = dependency
     }
 
     public func remove(forURL url: String) {
@@ -269,7 +269,7 @@ extension ManagedDependencies: Collection {
 extension ManagedDependencies: JSONMappable, JSONSerializable {
     public convenience init(json: JSON) throws {
         let dependencies = try Array<ManagedDependency>(json: json)
-        let dependencyMap = Dictionary(uniqueKeysWithValues: dependencies.lazy.map({ ($0.packageRef.path, $0) }))
+        let dependencyMap = Dictionary(uniqueKeysWithValues: dependencies.lazy.map({ ($0.packageRef.location, $0) }))
         self.init(dependencyMap: dependencyMap)
     }
 

--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -237,7 +237,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
             let provider = GitHubPackageMetadataProvider()
             let reference = PackageReference(repository: RepositorySpecifier(url: UUID().uuidString))
             XCTAssertThrowsError(try tsc_await { callback in provider.get(reference, callback: callback) }, "should throw error") { error in
-                XCTAssertEqual(error as? GitHubPackageMetadataProvider.Errors, .invalidGitURL(reference.path))
+                XCTAssertEqual(error as? GitHubPackageMetadataProvider.Errors, .invalidGitURL(reference.location))
             }
         }
     }
@@ -245,7 +245,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
     func testInvalidRef() throws {
         fixture(name: "Collections") { _ in
             let provider = GitHubPackageMetadataProvider()
-            let reference = PackageReference(identity: .init(path: AbsolutePath("/")), path: "/", kind: .local)
+            let reference = PackageReference.local(identity: .init(name: "test"), path:AbsolutePath("/"))
             XCTAssertThrowsError(try tsc_await { callback in provider.get(reference, callback: callback) }, "should throw error") { error in
                 XCTAssertEqual(error as? GitHubPackageMetadataProvider.Errors, .invalidReferenceType(reference))
             }

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -1201,6 +1201,6 @@ class PackageGraphTests: XCTestCase {
 
         let fs = InMemoryFileSystem(emptyFiles: [])
         let store = try PinsStore(pinsFile: AbsolutePath("/pins"), fileSystem: fs)
-        XCTAssertThrows(StringError("duplicated entry for package \"Yams\""), { try store.restore(from: json) })
+        XCTAssertThrows(StringError("duplicated entry for package \"yams\""), { try store.restore(from: json) })
     }
 }

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -40,7 +40,7 @@ private class MockRepository: Repository {
     }
 
     var packageRef: PackageReference {
-        return PackageReference(identity: PackageIdentity(url: self.url), path: self.url)
+        return PackageReference.remote(identity: PackageIdentity(url: self.url), location: self.url)
     }
 
     func getTags() throws -> [String] {
@@ -178,7 +178,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             manifestLoader: MockManifestLoader(manifests: [:])
         )
 
-        let ref = PackageReference(identity: PackageIdentity(path: repoPath), path: repoPath.pathString)
+        let ref = PackageReference.remote(identity: PackageIdentity(path: repoPath), location: repoPath.pathString)
         let container = try provider.getContainer(for: ref, skipUpdate: false)
         let v = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
         XCTAssertEqual(v, ["2.0.3", "1.0.3", "1.0.2", "1.0.1", "1.0.0"])
@@ -233,7 +233,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
 
         do {
             let provider = createProvider(ToolsVersion(version: "4.0.0"))
-            let ref = PackageReference(identity: PackageIdentity(url: specifier.url), path: specifier.url)
+            let ref = PackageReference.remote(identity: PackageIdentity(url: specifier.url), location: specifier.url)
             let container = try provider.getContainer(for: ref, skipUpdate: false)
             let v = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
             XCTAssertEqual(v, ["1.0.1"])
@@ -241,7 +241,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
 
         do {
             let provider = createProvider(ToolsVersion(version: "4.2.0"))
-            let ref = PackageReference(identity: PackageIdentity(url: specifier.url), path: specifier.url)
+            let ref = PackageReference.remote(identity: PackageIdentity(url: specifier.url), location: specifier.url)
             let container = try provider.getContainer(for: ref, skipUpdate: false) as! RepositoryPackageContainer
             XCTAssertTrue(container.validToolsVersionsCache.isEmpty)
             let v = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
@@ -254,7 +254,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
 
         do {
             let provider = createProvider(ToolsVersion(version: "3.0.0"))
-            let ref = PackageReference(identity: PackageIdentity(url: specifier.url), path: specifier.url)
+            let ref = PackageReference.remote(identity: PackageIdentity(url: specifier.url), location: specifier.url)
             let container = try provider.getContainer(for: ref, skipUpdate: false)
             let v = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
             XCTAssertEqual(v, [])
@@ -263,7 +263,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         // Test that getting dependencies on a revision that has unsupported tools version is diganosed properly.
         do {
             let provider = createProvider(ToolsVersion(version: "4.0.0"))
-            let ref = PackageReference(identity: PackageIdentity(url: specifier.url), path: specifier.url)
+            let ref = PackageReference.remote(identity: PackageIdentity(url: specifier.url), location: specifier.url)
             let container = try provider.getContainer(for: ref, skipUpdate: false) as! RepositoryPackageContainer
             let revision = try container.getRevision(forTag: "1.0.0")
             do {
@@ -310,7 +310,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             repositoryManager: repositoryManager,
             manifestLoader: MockManifestLoader(manifests: [:])
         )
-        let ref = PackageReference(identity: PackageIdentity(path: repoPath), path: repoPath.pathString)
+        let ref = PackageReference.remote(identity: PackageIdentity(path: repoPath), location: repoPath.pathString)
         let container = try provider.getContainer(for: ref, skipUpdate: false)
         let v = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
         XCTAssertEqual(v, ["1.0.4-alpha", "1.0.2-dev.2", "1.0.2-dev", "1.0.1", "1.0.0", "1.0.0-beta.1", "1.0.0-alpha.1"])
@@ -350,7 +350,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             repositoryManager: repositoryManager,
             manifestLoader: MockManifestLoader(manifests: [:])
         )
-        let ref = PackageReference(identity: PackageIdentity(path: repoPath), path: repoPath.pathString)
+        let ref = PackageReference.remote(identity: PackageIdentity(path: repoPath), location: repoPath.pathString)
         let container = try provider.getContainer(for: ref, skipUpdate: false)
         let v = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
         XCTAssertEqual(v, ["2.0.1", "1.0.4", "1.0.2", "1.0.1", "1.0.0"])
@@ -387,7 +387,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         ]
         let v5Constraints = dependencies.map {
             PackageContainerConstraint(
-                container: $0.createPackageRef(mirrors: mirrors),
+                package: $0.createPackageRef(mirrors: mirrors),
                 requirement: $0.requirement.toConstraintRequirement(),
                 products: v5ProductMapping[$0.name]!
             )
@@ -399,7 +399,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         ]
         let v5_2Constraints = dependencies.map {
             PackageContainerConstraint(
-                container: $0.createPackageRef(mirrors: mirrors),
+                package: $0.createPackageRef(mirrors: mirrors),
                 requirement: $0.requirement.toConstraintRequirement(),
                 products: v5_2ProductMapping[$0.name]!
             )
@@ -420,7 +420,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             XCTAssertEqual(
                 manifest
                     .dependencyConstraints(productFilter: .everything, mirrors: mirrors)
-                    .sorted(by: { $0.identifier.identity < $1.identifier.identity }),
+                    .sorted(by: { $0.package.identity < $1.package.identity }),
                 [
                     v5Constraints[0],
                     v5Constraints[1],
@@ -444,7 +444,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             XCTAssertEqual(
                 manifest
                     .dependencyConstraints(productFilter: .everything, mirrors: mirrors)
-                    .sorted(by: { $0.identifier.identity < $1.identifier.identity }),
+                    .sorted(by: { $0.package.identity < $1.package.identity }),
                 [
                     v5Constraints[0],
                     v5Constraints[1],
@@ -468,7 +468,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             XCTAssertEqual(
                 manifest
                     .dependencyConstraints(productFilter: .everything, mirrors: mirrors)
-                    .sorted(by: { $0.identifier.identity < $1.identifier.identity }),
+                    .sorted(by: { $0.package.identity < $1.package.identity }),
                 [
                     v5_2Constraints[0],
                     v5_2Constraints[1],
@@ -492,7 +492,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             XCTAssertEqual(
                 manifest
                     .dependencyConstraints(productFilter: .specific(Set(products.map { $0.name })), mirrors: mirrors)
-                    .sorted(by: { $0.identifier.identity < $1.identifier.identity }),
+                    .sorted(by: { $0.package.identity < $1.package.identity }),
                 [
                     v5_2Constraints[0],
                     v5_2Constraints[1],
@@ -538,7 +538,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             let containerProvider = RepositoryPackageContainerProvider(repositoryManager: repositoryManager, manifestLoader: MockManifestLoader(manifests: [.init(url: packageDir.pathString, version: nil): manifest]))
 
             // Get a hold of the container for the test package.
-            let packageRef = PackageReference(identity: PackageIdentity(path: packageDir), path: packageDir.pathString)
+            let packageRef = PackageReference.remote(identity: PackageIdentity(path: packageDir), location: packageDir.pathString)
             let container = try containerProvider.getContainer(for: packageRef, skipUpdate: false) as! RepositoryPackageContainer
 
             // Simulate accessing a fictitious dependency on the `master` branch, and check that we get back the expected error.
@@ -615,7 +615,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
                 )
             )
 
-            let packageReference = PackageReference(identity: PackageIdentity(path: packageDirectory), path: packageDirectory.pathString)
+            let packageReference = PackageReference.remote(identity: PackageIdentity(path: packageDirectory), location: packageDirectory.pathString)
             let container = try containerProvider.getContainer(for: packageReference, skipUpdate: false)
 
             let forNothing = try container.getDependencies(at: version, productFilter: .specific([]))

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -116,6 +116,7 @@ final class PinsStoreTests: XCTestCase {
                     "pins": [
                       {
                         "package": "Clang_C",
+                        "name": "Clang_C_2",
                         "repositoryURL": "https://github.com/something/Clang_C.git",
                         "state": {
                           "branch": null,
@@ -143,6 +144,45 @@ final class PinsStoreTests: XCTestCase {
         XCTAssertEqual(store.pinsMap.keys.map { $0.description }.sorted(), ["clang_c", "commandant"])
     }
 
+    func testLoadingSchema2() throws {
+        let fs = InMemoryFileSystem()
+        let pinsFile = AbsolutePath("/pinsfile.txt")
+
+        try fs.writeFileContents(pinsFile) {
+            $0 <<< """
+                {
+                  "object": {
+                    "pins": [
+                      {
+                        "identity": "clang_c",
+                        "alternate_identity": "clang_c_2",
+                        "location": "https://github.com/something/Clang_C.git",
+                        "state": {
+                          "branch": null,
+                          "revision": "90a9574276f0fd17f02f58979423c3fd4d73b59e",
+                          "version": "1.0.2",
+                        }
+                      },
+                      {
+                        "identity": "commandant",
+                        "location": "https://github.com/something/Commandant.git",
+                        "state": {
+                          "branch": null,
+                          "revision": "c281992c31c3f41c48b5036c5a38185eaec32626",
+                          "version": "0.12.0"
+                        }
+                      }
+                    ]
+                  },
+                  "version": 1
+                }
+                """
+        }
+
+        let store = try PinsStore(pinsFile: pinsFile, fileSystem: fs)
+        XCTAssertEqual(store.pinsMap.keys.map { $0.description }.sorted(), ["clang_c", "commandant"])
+    }
+    
     func testEmptyPins() throws {
         let fs = InMemoryFileSystem()
         let pinsFile = AbsolutePath("/pinsfile.txt")

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -30,8 +30,8 @@ final class PinsStoreTests: XCTestCase {
         let fooRepo = RepositorySpecifier(url: fooPath.pathString)
         let barRepo = RepositorySpecifier(url: barPath.pathString)
         let revision = Revision(identifier: "81513c8fd220cf1ed1452b98060cd80d3725c5b7")
-        let fooRef = PackageReference(identity: foo, path: fooRepo.url)
-        let barRef = PackageReference(identity: bar, path: barRepo.url)
+        let fooRef = PackageReference.remote(identity: foo, location: fooRepo.url)
+        let barRef = PackageReference.remote(identity: bar, location: barRepo.url)
 
         let state = CheckoutState(revision: revision, version: v1)
         let pin = PinsStore.Pin(packageRef: fooRef, state: state)
@@ -193,7 +193,7 @@ final class PinsStoreTests: XCTestCase {
 
         let fooPath = AbsolutePath("/foo")
         let foo = PackageIdentity(path: fooPath)
-        let fooRef = PackageReference(identity: foo, path: fooPath.pathString)
+        let fooRef = PackageReference.remote(identity: foo, location: fooPath.pathString)
         let revision = Revision(identifier: "81513c8fd220cf1ed1452b98060cd80d3725c5b7")
         store.pin(packageRef: fooRef, state: CheckoutState(revision: revision, version: v1))
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -852,8 +852,8 @@ final class WorkspaceTests: XCTestCase {
 
         let bRepo = RepositorySpecifier(url: workspace.urlForPackage(withName: "B"))
         let cRepo = RepositorySpecifier(url: workspace.urlForPackage(withName: "C"))
-        let bRef = PackageReference(identity: PackageIdentity(url: bRepo.url), path: bRepo.url)
-        let cRef = PackageReference(identity: PackageIdentity(url: cRepo.url), path: cRepo.url)
+        let bRef = PackageReference.remote(identity: PackageIdentity(url: bRepo.url), location: bRepo.url)
+        let cRef = PackageReference.remote(identity: PackageIdentity(url: cRepo.url), location: cRepo.url)
 
         try workspace.set(
             pins: [bRef: v1_5, cRef: v2],
@@ -908,8 +908,8 @@ final class WorkspaceTests: XCTestCase {
 
         let bRepo = RepositorySpecifier(url: workspace.urlForPackage(withName: "B"))
         let cRepo = RepositorySpecifier(url: workspace.urlForPackage(withName: "C"))
-        let bRef = PackageReference(identity: PackageIdentity(url: bRepo.url), path: bRepo.url)
-        let cRef = PackageReference(identity: PackageIdentity(url: cRepo.url), path: cRepo.url)
+        let bRef = PackageReference.remote(identity: PackageIdentity(url: bRepo.url), location: bRepo.url)
+        let cRef = PackageReference.remote(identity: PackageIdentity(url: cRepo.url), location: cRepo.url)
 
         try workspace.set(
             pins: [bRef: v1],
@@ -965,8 +965,8 @@ final class WorkspaceTests: XCTestCase {
 
         let bRepo = RepositorySpecifier(url: workspace.urlForPackage(withName: "B"))
         let cRepo = RepositorySpecifier(url: workspace.urlForPackage(withName: "C"))
-        let bRef = PackageReference(identity: PackageIdentity(url: bRepo.url), path: bRepo.url)
-        let cRef = PackageReference(identity: PackageIdentity(url: cRepo.url), path: cRepo.url)
+        let bRef = PackageReference.remote(identity: PackageIdentity(url: bRepo.url), location: bRepo.url)
+        let cRef = PackageReference.remote(identity: PackageIdentity(url: cRepo.url), location: cRepo.url)
 
         try workspace.set(
             pins: [bRef: v1_5, cRef: v1_5],
@@ -1016,7 +1016,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let cRepo = RepositorySpecifier(url: testWorkspace.urlForPackage(withName: "C"))
-        let cRef = PackageReference(identity: PackageIdentity(url: cRepo.url), path: cRepo.url)
+        let cRef = PackageReference.remote(identity: PackageIdentity(url: cRepo.url), location: cRepo.url)
 
         try testWorkspace.set(
             pins: [cRef: v1_5],
@@ -1075,8 +1075,8 @@ final class WorkspaceTests: XCTestCase {
 
         let bRepo = RepositorySpecifier(url: workspace.urlForPackage(withName: "B"))
         let cRepo = RepositorySpecifier(url: workspace.urlForPackage(withName: "C"))
-        let bRef = PackageReference(identity: PackageIdentity(url: bRepo.url), path: bRepo.url)
-        let cRef = PackageReference(identity: PackageIdentity(url: cRepo.url), path: cRepo.url)
+        let bRef = PackageReference.remote(identity: PackageIdentity(url: bRepo.url), location: bRepo.url)
+        let cRef = PackageReference.remote(identity: PackageIdentity(url: cRepo.url), location: cRepo.url)
 
         try workspace.set(
             pins: [bRef: v1_5],
@@ -1137,8 +1137,8 @@ final class WorkspaceTests: XCTestCase {
 
         let bRepo = RepositorySpecifier(url: workspace.urlForPackage(withName: "B"))
         let cRepo = RepositorySpecifier(url: workspace.urlForPackage(withName: "C"))
-        let bRef = PackageReference(identity: PackageIdentity(url: bRepo.url), path: bRepo.url)
-        let cRef = PackageReference(identity: PackageIdentity(url: cRepo.url), path: cRepo.url)
+        let bRef = PackageReference.remote(identity: PackageIdentity(url: bRepo.url), location: bRepo.url)
+        let cRef = PackageReference.remote(identity: PackageIdentity(url: cRepo.url), location: cRepo.url)
 
         try workspace.set(
             pins: [bRef: v1_5, cRef: v1_5],
@@ -1200,8 +1200,8 @@ final class WorkspaceTests: XCTestCase {
 
         let bRepo = RepositorySpecifier(url: workspace.urlForPackage(withName: "B"))
         let cRepo = RepositorySpecifier(url: workspace.urlForPackage(withName: "C"))
-        let bRef = PackageReference(identity: PackageIdentity(url: bRepo.url), path: bRepo.url)
-        let cRef = PackageReference(identity: PackageIdentity(url: cRepo.url), path: cRepo.url)
+        let bRef = PackageReference.remote(identity: PackageIdentity(url: bRepo.url), location: bRepo.url)
+        let cRef = PackageReference.remote(identity: PackageIdentity(url: cRepo.url), location: cRepo.url)
 
         try workspace.set(
             pins: [bRef: v1_5, cRef: master],
@@ -1262,8 +1262,8 @@ final class WorkspaceTests: XCTestCase {
 
         let bRepo = RepositorySpecifier(url: workspace.urlForPackage(withName: "B"))
         let cRepo = RepositorySpecifier(url: workspace.urlForPackage(withName: "C"))
-        let bRef = PackageReference(identity: PackageIdentity(url: bRepo.url), path: bRepo.url)
-        let cRef = PackageReference(identity: PackageIdentity(url: cRepo.url), path: cRepo.url)
+        let bRef = PackageReference.remote(identity: PackageIdentity(url: bRepo.url), location: bRepo.url)
+        let cRef = PackageReference.remote(identity: PackageIdentity(url: cRepo.url), location: cRepo.url)
 
         try workspace.set(
             pins: [bRef: v1_5, cRef: v1_5],
@@ -1321,8 +1321,8 @@ final class WorkspaceTests: XCTestCase {
 
         let bRepo = RepositorySpecifier(url: workspace.urlForPackage(withName: "B"))
         let cRepo = RepositorySpecifier(url: workspace.urlForPackage(withName: "C"))
-        let bRef = PackageReference(identity: PackageIdentity(url: bRepo.url), path: bRepo.url)
-        let cRef = PackageReference(identity: PackageIdentity(url: cRepo.url), path: cRepo.url)
+        let bRef = PackageReference.remote(identity: PackageIdentity(url: bRepo.url), location: bRepo.url)
+        let cRef = PackageReference.remote(identity: PackageIdentity(url: cRepo.url), location: cRepo.url)
 
         try workspace.set(
             pins: [bRef: v1_5, cRef: v2],
@@ -1532,7 +1532,7 @@ final class WorkspaceTests: XCTestCase {
 
             let path = AbsolutePath("/tmp/ws/pkgs/Foo")
             let expectedChange = (
-                PackageReference(identity: PackageIdentity(path: path), path: path.pathString),
+                PackageReference.remote(identity: PackageIdentity(path: path), location: path.pathString),
                 stateChange
             )
             guard let change = changes?.first, changes?.count == 1 else {
@@ -1773,7 +1773,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Check that we can compute missing dependencies.
         try workspace.loadDependencyManifests(roots: ["Root1", "Root2"]) { manifests, diagnostics in
-            XCTAssertEqual(manifests.missingPackageURLs().map { $0.path }.sorted(), ["/tmp/ws/pkgs/Bar", "/tmp/ws/pkgs/Foo"])
+            XCTAssertEqual(manifests.missingPackageURLs().map { $0.location }.sorted(), ["/tmp/ws/pkgs/Bar", "/tmp/ws/pkgs/Foo"])
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -1787,7 +1787,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Check that we compute the correct missing dependencies.
         try workspace.loadDependencyManifests(roots: ["Root1", "Root2"]) { manifests, diagnostics in
-            XCTAssertEqual(manifests.missingPackageURLs().map { $0.path }.sorted(), ["/tmp/ws/pkgs/Bar"])
+            XCTAssertEqual(manifests.missingPackageURLs().map { $0.location }.sorted(), ["/tmp/ws/pkgs/Bar"])
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -1801,7 +1801,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Check that we compute the correct missing dependencies.
         try workspace.loadDependencyManifests(roots: ["Root1", "Root2"]) { manifests, diagnostics in
-            XCTAssertEqual(manifests.missingPackageURLs().map { $0.path }.sorted(), [])
+            XCTAssertEqual(manifests.missingPackageURLs().map { $0.location }.sorted(), [])
             XCTAssertNoDiagnostics(diagnostics)
         }
     }
@@ -2223,7 +2223,7 @@ final class WorkspaceTests: XCTestCase {
 
         try workspace.loadDependencyManifests(roots: ["Root"]) { manifests, diagnostics in
             let editedPackages = manifests.editedPackagesConstraints()
-            XCTAssertEqual(editedPackages.map { $0.identifier.path }, [fooPath.pathString])
+            XCTAssertEqual(editedPackages.map { $0.package.location }, [fooPath.pathString])
             XCTAssertNoDiagnostics(diagnostics)
         }
 
@@ -3231,7 +3231,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkManagedDependencies { result in
             let dependency = result.check(dependency: "foo", at: .local)
             // make sure it points to foo
-            XCTAssert(dependency!.packageRef.path.hasSuffix(deps.first!.path))
+            XCTAssert(dependency!.packageRef.location.hasSuffix(deps.first!.path))
         }
 
         deps = [
@@ -3243,7 +3243,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkManagedDependencies { result in
             let dependency = result.check(dependency: "foo2", at: .local)
             // make sure it points to foo2
-            XCTAssert(dependency!.packageRef.path.hasSuffix(deps.first!.path))
+            XCTAssert(dependency!.packageRef.location.hasSuffix(deps.first!.path))
         }
     }
 
@@ -3683,7 +3683,7 @@ final class WorkspaceTests: XCTestCase {
             let pinsStore = try ws.pinsStore.load()
             let fooPin = pinsStore.pins.first(where: { $0.packageRef.identity == PackageIdentity(name: "foo") })!
 
-            let fooRepo = workspace.repoProvider.specifierMap[RepositorySpecifier(url: fooPin.packageRef.path)]!
+            let fooRepo = workspace.repoProvider.specifierMap[RepositorySpecifier(url: fooPin.packageRef.location)]!
             let revision = try fooRepo.resolveRevision(tag: "1.0.0")
             let newState = CheckoutState(revision: revision, version: "1.0.0")
 
@@ -4359,7 +4359,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Pin A to 1.0.0, Checkout B to 1.0.0
         let aURL = workspace.urlForPackage(withName: "A")
-        let aRef = PackageReference(identity: PackageIdentity(url: aURL), path: aURL)
+        let aRef = PackageReference.remote(identity: PackageIdentity(url: aURL), location: aURL)
         let aRepo = workspace.repoProvider.specifierMap[RepositorySpecifier(url: aURL)]!
         let aRevision = try aRepo.resolveRevision(tag: "1.0.0")
         let aState = CheckoutState(revision: aRevision, version: "1.0.0")
@@ -4621,7 +4621,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Pin A to 1.0.0, Checkout A to 1.0.0
         let aURL = workspace.urlForPackage(withName: "A")
-        let aRef = PackageReference(identity: PackageIdentity(url: aURL), path: aURL)
+        let aRef = PackageReference.remote(identity: PackageIdentity(url: aURL), location: aURL)
         let aRepo = workspace.repoProvider.specifierMap[RepositorySpecifier(url: aURL)]!
         let aRevision = try aRepo.resolveRevision(tag: "1.0.0")
         let aState = CheckoutState(revision: aRevision, version: "1.0.0")


### PR DESCRIPTION
motivation: improve correctness by using identity more broadly throughout the code

changes:
* remove name from package-reference, replace with alternate-identity for secondary (manifest driven) identity
* use identity to lookup managed-dependencies and pins instead of urls
* adjust tests

❗ this the the first part in a series of PRs, once this is merged and "baked" will continue with the next steps