### PR TITLE
[Gardening] replace horizontal tabs with correct number of spaces for indentation

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1029,7 +1029,7 @@ extension Workspace {
         diagnostics: DiagnosticsEngine
     ) {
         // Reset the pinsStore and start pinning the required dependencies.
-		pinsStore.unpinAll()
+        pinsStore.unpinAll()
 
         let requiredURLs = dependencyManifests.computePackageURLs().required
 
@@ -1271,7 +1271,7 @@ extension Workspace {
             return checkoutsPath.appending(dependency.subpath)
         case .edited(let path):
             return path ?? editablesPath.appending(dependency.subpath)
-		case .local:
+        case .local:
             return AbsolutePath(dependency.packageRef.path)
         }
     }
@@ -2030,7 +2030,7 @@ extension Workspace {
             return
         }
 
-		let pins = pinsStore.pinsMap.keys
+        let pins = pinsStore.pinsMap.keys
         let requiredURLs = dependencyManifests.computePackageURLs().required
 
         for dependency in state.dependencies {

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -581,7 +581,7 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-	func testCustomTargetPaths() {
+    func testCustomTargetPaths() {
         let fs = InMemoryFileSystem(emptyFiles:
             "/mah/target/exe/swift/exe/main.swift",
             "/mah/target/exe/swift/exe/foo.swift",

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -256,23 +256,23 @@ class PackageGraphTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(diagnostics)
 
-		let project = try xcodeProject(xcodeprojPath: AbsolutePath("/Bar/build").appending(component: "xcodeproj"), graph: g, extraDirs: [], extraFiles: [], options: XcodeprojOptions(), fileSystem: fs, diagnostics: diagnostics)
-		XcodeProjectTester(project) { result in
-      	    result.check(target: "swift") { targetResult in
-      	        XCTAssertEqual(targetResult.target.buildSettings.common.OTHER_SWIFT_FLAGS ?? [], [
-      	            "$(inherited)", "-Xcc",
-      	            "-fmodule-map-file=$(SRCROOT)/Sources/Sea2/include/module.modulemap",
-      	        ])
-      	        XCTAssertEqual(targetResult.target.buildSettings.common.HEADER_SEARCH_PATHS ?? [], [
-      	            "$(inherited)",
-      	            "$(SRCROOT)/Sources/Sea2/include",
-      	            "$(SRCROOT)/Sources/Sea/include",
-      	        ])
-      	    }
-      	    result.check(target: "Sea") { targetResult in
-      	        XCTAssertEqual(targetResult.target.buildSettings.common.MODULEMAP_FILE, nil)
-      	    }
-      	}
+        let project = try xcodeProject(xcodeprojPath: AbsolutePath("/Bar/build").appending(component: "xcodeproj"), graph: g, extraDirs: [], extraFiles: [], options: XcodeprojOptions(), fileSystem: fs, diagnostics: diagnostics)
+        XcodeProjectTester(project) { result in
+            result.check(target: "swift") { targetResult in
+                XCTAssertEqual(targetResult.target.buildSettings.common.OTHER_SWIFT_FLAGS ?? [], [
+                    "$(inherited)", "-Xcc",
+                    "-fmodule-map-file=$(SRCROOT)/Sources/Sea2/include/module.modulemap",
+                ])
+                XCTAssertEqual(targetResult.target.buildSettings.common.HEADER_SEARCH_PATHS ?? [], [
+                    "$(inherited)",
+                    "$(SRCROOT)/Sources/Sea2/include",
+                    "$(SRCROOT)/Sources/Sea/include",
+                ])
+            }
+            result.check(target: "Sea") { targetResult in
+                XCTAssertEqual(targetResult.target.buildSettings.common.MODULEMAP_FILE, nil)
+            }
+        }
     }
 
     func testModuleLinkage() throws {
@@ -332,18 +332,18 @@ class PackageGraphTests: XCTestCase {
 
     func testSchemes() throws {
         let fs = InMemoryFileSystem(emptyFiles:
-      	    "/Foo/Sources/a/main.swift",
-      	    "/Foo/Sources/b/main.swift",
-      	    "/Foo/Sources/c/main.swift",
-      	    "/Foo/Sources/d/main.swift",
-      	    "/Foo/Sources/libd/libd.swift",
+            "/Foo/Sources/a/main.swift",
+            "/Foo/Sources/b/main.swift",
+            "/Foo/Sources/c/main.swift",
+            "/Foo/Sources/d/main.swift",
+            "/Foo/Sources/libd/libd.swift",
 
-      	    "/Foo/Tests/aTests/fooTests.swift",
-      	    "/Foo/Tests/bcTests/fooTests.swift",
-      	    "/Foo/Tests/dTests/fooTests.swift",
-      	    "/Foo/Tests/libdTests/fooTests.swift",
-      	    "/end"
-      	)
+            "/Foo/Tests/aTests/fooTests.swift",
+            "/Foo/Tests/bcTests/fooTests.swift",
+            "/Foo/Tests/dTests/fooTests.swift",
+            "/Foo/Tests/libdTests/fooTests.swift",
+            "/end"
+        )
 
         let diagnostics = DiagnosticsEngine()
         let graph = try loadPackageGraph(fs: fs, diagnostics: diagnostics,


### PR DESCRIPTION
Some are replaced with 2 spaces, some 4. Now all lines in `Sources/` and `Tests/` are indented by multiples of 4 spaces.