### PR TITLE
Fix compiler warnings

### DIFF
--- a/Sources/Build/SwiftCompilerOutputParser.swift
+++ b/Sources/Build/SwiftCompilerOutputParser.swift
@@ -84,7 +84,7 @@ public struct SwiftCompilerMessage {
 }
 
 /// Protocol for the parser delegate to get notified of parsing events.
-public protocol SwiftCompilerOutputParserDelegate: class {
+public protocol SwiftCompilerOutputParserDelegate: AnyObject {
 
     /// Called for each message parsed.
     func swiftCompilerOutputParser(_ parser: SwiftCompilerOutputParser, didParse message: SwiftCompilerMessage)

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -16,7 +16,7 @@ import TSCUtility
 import Basics
 
 /// Delegate to notify clients about actions being performed by RepositoryManager.
-public protocol RepositoryManagerDelegate: class {
+public protocol RepositoryManagerDelegate: AnyObject {
     /// Called when a repository is about to be fetched.
     func fetchingWillBegin(handle: RepositoryManager.RepositoryHandle, fetchDetails: RepositoryManager.FetchDetails?)
 

--- a/Sources/XCBuildSupport/PIF.swift
+++ b/Sources/XCBuildSupport/PIF.swift
@@ -1190,7 +1190,7 @@ private struct UntypedTarget: Decodable {
     let contents: TargetContents
 }
 
-protocol PIFSignableObject: class {
+protocol PIFSignableObject: AnyObject {
     var signature: String? { get set }
 }
 extension PIF.Workspace: PIFSignableObject {}

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -894,7 +894,7 @@ final class AggregatePIFProjectBuilder: PIFProjectBuilder {
     }
 }
 
-protocol PIFReferenceBuilder: class {
+protocol PIFReferenceBuilder: AnyObject {
     var guid: String { get set }
 
     func construct() -> PIF.Reference

--- a/Sources/XCBuildSupport/XCBuildOutputParser.swift
+++ b/Sources/XCBuildSupport/XCBuildOutputParser.swift
@@ -124,7 +124,7 @@ public enum XCBuildMessage {
 }
 
 /// Protocol for the parser delegate to get notified of parsing events.
-public protocol XCBuildOutputParserDelegate: class {
+public protocol XCBuildOutputParserDelegate: AnyObject {
 
     /// Called for each message parsed.
     func xcBuildOutputParser(_ parser: XCBuildOutputParser, didParse message: XCBuildMessage)

--- a/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
+++ b/Sources/Xcodeproj/XcodeProjectModelSerialization.swift
@@ -571,7 +571,7 @@ fileprivate class PropertyListSerializer {
     }
 }
 
-fileprivate protocol PropertyListSerializable: class {
+fileprivate protocol PropertyListSerializable: AnyObject {
     /// Called by the Serializer to construct and return a dictionary for a
     /// serializable object.  The entries in the dictionary should represent
     /// the receiver's attributes and relationships, as PropertyList values.


### PR DESCRIPTION
> using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead