### PR TITLE
enable build manifest caching by default

### DIFF
--- a/Sources/Commands/APIDigester.swift
+++ b/Sources/Commands/APIDigester.swift
@@ -110,7 +110,7 @@ struct APIDigesterBaselineDumper {
         // Build the baseline module.
         let buildOp = BuildOperation(
             buildParameters: buildParameters,
-            useBuildManifestCaching: false,
+            cacheBuildManifest: false,
             packageGraphLoader: { graph },
             diagnostics: diags,
             stdoutStream: stdoutStream

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -267,8 +267,8 @@ public struct SwiftToolOptions: ParsableArguments {
     var enableTestDiscovery: Bool = false
 
     /// Whether to enable llbuild manifest caching.
-    @Flag()
-    var enableBuildManifestCaching: Bool = false
+    @Flag(name: .customLong("build-manifest-caching"), inversion: .prefixedEnableDisable)
+    var cacheBuildManifest: Bool = true
 
     /// Emit the Swift module separately from the object files.
     @Flag()

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -297,7 +297,7 @@ extension SwiftPackageTool {
             // Build the current package.
             //
             // We turn build manifest caching off because we need the build plan.
-            let buildOp = try swiftTool.createBuildOperation(useBuildManifestCaching: false)
+            let buildOp = try swiftTool.createBuildOperation(cacheBuildManifest: false)
             try buildOp.build()
 
             // Dump JSON for the current package.
@@ -343,7 +343,7 @@ extension SwiftPackageTool {
             // Build the current package.
             //
             // We turn build manifest caching off because we need the build plan.
-            let buildOp = try swiftTool.createBuildOperation(useBuildManifestCaching: false)
+            let buildOp = try swiftTool.createBuildOperation(cacheBuildManifest: false)
             try buildOp.build()
 
             try symbolGraphExtract.dumpSymbolGraph(

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -115,7 +115,7 @@ public struct SwiftRunTool: SwiftCommand {
             // Construct the build operation.
             let buildOp = BuildOperation(
                 buildParameters: buildParameters,
-                useBuildManifestCaching: false,
+                cacheBuildManifest: false,
                 packageGraphLoader: graphLoader,
                 diagnostics: swiftTool.diagnostics,
                 stdoutStream: swiftTool.stdoutStream

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -590,30 +590,39 @@ public class SwiftTool {
         return try _manifestLoader.get()
     }
 
-    private func canUseBuildManifestCaching() throws -> Bool {
+    private func canUseCachedBuildManifest() throws -> Bool {
+        if !self.options.cacheBuildManifest {
+            return false
+        }
+
         let buildParameters = try self.buildParameters()
         let haveBuildManifestAndDescription =
-        localFileSystem.exists(buildParameters.llbuildManifest) &&
-        localFileSystem.exists(buildParameters.buildDescriptionPath)
+            localFileSystem.exists(buildParameters.llbuildManifest) &&
+            localFileSystem.exists(buildParameters.buildDescriptionPath)
+
+        if !haveBuildManifestAndDescription {
+            return false
+        }
 
         // Perform steps for build manifest caching if we can enabled it.
         //
         // FIXME: We don't add edited packages in the package structure command yet (SR-11254).
-        let hasEditedPackages = try getActiveWorkspace().state.dependencies.contains(where: { $0.isEdited })
+        let hasEditedPackages = try self.getActiveWorkspace().state.dependencies.contains(where: { $0.isEdited })
+        if hasEditedPackages {
+            return false
+        }
 
-        let enableBuildManifestCaching = ProcessEnv.vars.keys.contains("SWIFTPM_ENABLE_BUILD_MANIFEST_CACHING") || options.enableBuildManifestCaching
-
-        return enableBuildManifestCaching && haveBuildManifestAndDescription && !hasEditedPackages
+        return true
     }
 
-    func createBuildOperation(explicitProduct: String? = nil, useBuildManifestCaching: Bool = true) throws -> BuildOperation {
+    func createBuildOperation(explicitProduct: String? = nil, cacheBuildManifest: Bool = true) throws -> BuildOperation {
         // Load a custom package graph which has a special product for REPL.
         let graphLoader = { try self.loadPackageGraph(explicitProduct: explicitProduct) }
 
         // Construct the build operation.
         let buildOp = try BuildOperation(
             buildParameters: buildParameters(),
-            useBuildManifestCaching: useBuildManifestCaching && canUseBuildManifestCaching(),
+            cacheBuildManifest: cacheBuildManifest && self.canUseCachedBuildManifest(),
             packageGraphLoader: graphLoader,
             diagnostics: diagnostics,
             stdoutStream: self.stdoutStream
@@ -624,14 +633,15 @@ public class SwiftTool {
         return buildOp
     }
 
-    func createBuildSystem(explicitProduct: String? = nil, useBuildManifestCaching: Bool = true, buildParameters: BuildParameters? = nil) throws -> BuildSystem {
+    func createBuildSystem(explicitProduct: String? = nil, buildParameters: BuildParameters? = nil) throws -> BuildSystem {
+        print("createBuildSystem \(try self.canUseCachedBuildManifest())")
         let buildSystem: BuildSystem
         switch options.buildSystem {
         case .native:
             let graphLoader = { try self.loadPackageGraph(explicitProduct: explicitProduct) }
             buildSystem = try BuildOperation(
                 buildParameters: buildParameters ?? self.buildParameters(),
-                useBuildManifestCaching: useBuildManifestCaching && canUseBuildManifestCaching(),
+                cacheBuildManifest: self.canUseCachedBuildManifest(),
                 packageGraphLoader: graphLoader,
                 diagnostics: diagnostics,
                 stdoutStream: stdoutStream


### PR DESCRIPTION
motivation: improve performance

changes:
* set the flag to true by default
* refactor the code to better reflect true meaning of flag
* warn on any error and fallback to non-cached version
* add test for disabling the cache

rdar://63981763