### PR TITLE
Unify dependencies branch name for non-CI builds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -281,11 +281,13 @@ let package = Package(
 // package dependency like this but there is no other good way of expressing
 // this right now.
 
+/// When not using local dependencies, the branch to use for llbuild and TSC repositories.
+let relatedDependenciesBranch = "main"
 
 if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         package.dependencies += [
-            .package(url: "https://github.com/apple/swift-llbuild.git", .branch("main")),
+            .package(url: "https://github.com/apple/swift-llbuild.git", .branch(relatedDependenciesBranch)),
         ]
     } else {
         // In Swift CI, use a local path to llbuild to interoperate with tools
@@ -299,7 +301,8 @@ if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
 
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("main")),
+        .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch(relatedDependenciesBranch)),
+        
         // The 'swift-argument-parser' version declared here must match that
         // used by 'swift-driver' and 'sourcekit-lsp'. Please coordinate
         // dependency version changes here with those projects.


### PR DESCRIPTION
Same as #3145.
`swift-driver` doesn't follow same tagging conventions so not included.
