### PR TITLE
improve manifest loader concurrency and tests

### DIFF
--- a/Sources/Basics/ConcurrencyHelpers.swift
+++ b/Sources/Basics/ConcurrencyHelpers.swift
@@ -7,6 +7,7 @@
  */
 
 import TSCBasic
+import class Foundation.ProcessInfo
 
 /// Thread-safe dictionary like structure
 public final class ThreadSafeKeyValueStore<Key, Value> where Key: Hashable {
@@ -169,8 +170,7 @@ public final class ThreadSafeBox<Value> {
 
 public enum Concurrency {
     public static var maxOperations: Int {
-        // TODO: compute this by the number of CPUs
-        return (try? ProcessEnv.vars["SWIFTPM_MAX_CONCURRENT_OPERATIONS"].map(Int.init)) ?? 25
+        return (try? ProcessEnv.vars["SWIFTPM_MAX_CONCURRENT_OPERATIONS"].map(Int.init)) ?? ProcessInfo.processInfo.activeProcessorCount
     }
 }
 

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -1214,7 +1214,14 @@ private final class SQLiteManifestCache: Closable {
             return db
         }
 
+        // FIXME: workaround linux sqlite concurrency issues causing CI failures
+        #if os(Linux)
+        return try self.withStateLock {
+            return try body(db)
+        }
+        #else
         return try body(db)
+        #endif
     }
 
     private func createSchemaIfNecessary(db: SQLite) throws {

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -177,7 +177,7 @@ final class PackageToolTests: XCTestCase {
             // Remove .build folder
             _ = try execute(["reset"], packagePath: packageRoot)
 
-            // Perfom another cache this time from the cache
+            // Perform another cache this time from the cache
             _ = try execute(["resolve", "--cache-path", cachePath.pathString], packagePath: packageRoot)
             XCTAssert(try localFileSystem.getDirectoryContents(repositoriesPath).contains { $0.hasPrefix("Foo-") })
 

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -679,7 +679,9 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
         }
     }
 
-    func testConcurrency() throws {
+    // run this with TSAN/ASAN to detect concurrency issues
+    func testConcurrencyWithWarmup() throws {
+        let total = 1000
         try testWithTemporaryDirectory { path in
 
             let manifestPath = path.appending(components: "pkg", "Package.swift")
@@ -700,8 +702,19 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             let delegate = ManifestTestDelegate()
             let manifestLoader = ManifestLoader(manifestResources: Resources.default, cacheDir: path, useInMemoryCache: true, delegate: delegate)
 
+            // warm up caches
+            let manifest = try tsc_await { manifestLoader.load(package: manifestPath.parentDirectory,
+                                                               baseURL: manifestPath.pathString,
+                                                               toolsVersion: .v4_2,
+                                                               packageKind: .local,
+                                                               on: .global(),
+                                                               completion: $0) }
+            XCTAssertEqual(manifest.name, "Trivial")
+            XCTAssertEqual(manifest.targets[0].name, "foo")
+
+
             let sync = DispatchGroup()
-            for _ in 0 ..< 1000 {
+            for _ in 0 ..< total {
                 sync.enter()
                 manifestLoader.load(package: manifestPath.parentDirectory,
                                     baseURL: manifestPath.pathString,
@@ -720,11 +733,64 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 }
             }
 
-            if case .timedOut = sync.wait(timeout: .now() + 120) {
+            if case .timedOut = sync.wait(timeout: .now() + 30) {
                 XCTFail("timeout")
             }
 
-            XCTAssertEqual(delegate.loaded.count, 1000)
+            XCTAssertEqual(delegate.loaded.count, total+1)
+        }
+    }
+
+    // run this with TSAN/ASAN to detect concurrency issues
+    func testConcurrencyNoWarmUp() throws {
+        let total = 1000
+        try testWithTemporaryDirectory { path in
+
+            let delegate = ManifestTestDelegate()
+            let manifestLoader = ManifestLoader(manifestResources: Resources.default, cacheDir: path, useInMemoryCache: true, delegate: delegate)
+
+            let sync = DispatchGroup()
+            for _ in 0 ..< total {
+
+                let random = Int.random(in: 0 ... total / 4)
+                let manifestPath = path.appending(components: "pkg-\(random)", "Package.swift")
+                try localFileSystem.writeFileContents(manifestPath) { stream in
+                    stream <<< """
+                        import PackageDescription
+                        let package = Package(
+                            name: "Trivial-\(random)",
+                            targets: [
+                                .target(
+                                    name: "foo-\(random)",
+                                    dependencies: []),
+                            ]
+                        )
+                        """
+                }
+
+                sync.enter()
+                manifestLoader.load(package: manifestPath.parentDirectory,
+                                    baseURL: manifestPath.pathString,
+                                    toolsVersion: .v4_2,
+                                    packageKind: .local,
+                                    on: .global()) { result in
+                    defer { sync.leave() }
+
+                    switch result {
+                    case .failure(let error):
+                        XCTFail("\(error)")
+                    case .success(let manifest):
+                        XCTAssertEqual(manifest.name, "Trivial-\(random)")
+                        XCTAssertEqual(manifest.targets[0].name, "foo-\(random)")
+                    }
+                }
+            }
+
+            if case .timedOut = sync.wait(timeout: .now() + 600) {
+                XCTFail("timeout")
+            }
+
+            XCTAssertEqual(delegate.loaded.count, total)
         }
     }
 

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -756,7 +756,6 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             let sync = DispatchGroup()
             for _ in 0 ..< total {
-
                 let random = Int.random(in: 0 ... total / 4)
                 let manifestPath = path.appending(components: "pkg-\(random)", "Package.swift")
                 if !localFileSystem.exists(manifestPath) {

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -740,8 +740,8 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             }
 
             XCTAssertEqual(delegate.loaded.count, total+1)
-            XCTAssertFalse(diagnostics.hasWarnings)
-            XCTAssertFalse(diagnostics.hasErrors)
+            XCTAssertFalse(diagnostics.hasWarnings, diagnostics.description)
+            XCTAssertFalse(diagnostics.hasErrors, diagnostics.description)
         }
     }
 
@@ -799,8 +799,8 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             }
 
             XCTAssertEqual(delegate.loaded.count, total)
-            XCTAssertFalse(diagnostics.hasWarnings)
-            XCTAssertFalse(diagnostics.hasErrors)
+            XCTAssertFalse(diagnostics.hasWarnings, diagnostics.description)
+            XCTAssertFalse(diagnostics.hasErrors, diagnostics.description)
         }
     }
 

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -759,18 +759,20 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
                 let random = Int.random(in: 0 ... total / 4)
                 let manifestPath = path.appending(components: "pkg-\(random)", "Package.swift")
-                try localFileSystem.writeFileContents(manifestPath) { stream in
-                    stream <<< """
-                        import PackageDescription
-                        let package = Package(
-                            name: "Trivial-\(random)",
-                            targets: [
-                                .target(
-                                    name: "foo-\(random)",
-                                    dependencies: []),
-                            ]
-                        )
-                        """
+                if !localFileSystem.exists(manifestPath) {
+                    try localFileSystem.writeFileContents(manifestPath) { stream in
+                        stream <<< """
+                            import PackageDescription
+                            let package = Package(
+                                name: "Trivial-\(random)",
+                                targets: [
+                                    .target(
+                                        name: "foo-\(random)",
+                                        dependencies: []),
+                                ]
+                            )
+                            """
+                    }
                 }
 
                 sync.enter()

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -699,6 +699,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                     """
             }
 
+            let diagnostics = DiagnosticsEngine()
             let delegate = ManifestTestDelegate()
             let manifestLoader = ManifestLoader(manifestResources: Resources.default, cacheDir: path, useInMemoryCache: true, delegate: delegate)
 
@@ -720,6 +721,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                                     baseURL: manifestPath.pathString,
                                     toolsVersion: .v4_2,
                                     packageKind: .local,
+                                    diagnostics: diagnostics,
                                     on: .global()) { result in
                     defer { sync.leave() }
 
@@ -738,6 +740,8 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             }
 
             XCTAssertEqual(delegate.loaded.count, total+1)
+            XCTAssertFalse(diagnostics.hasWarnings)
+            XCTAssertFalse(diagnostics.hasErrors)
         }
     }
 
@@ -746,6 +750,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
         let total = 1000
         try testWithTemporaryDirectory { path in
 
+            let diagnostics = DiagnosticsEngine()
             let delegate = ManifestTestDelegate()
             let manifestLoader = ManifestLoader(manifestResources: Resources.default, cacheDir: path, useInMemoryCache: true, delegate: delegate)
 
@@ -773,6 +778,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                                     baseURL: manifestPath.pathString,
                                     toolsVersion: .v4_2,
                                     packageKind: .local,
+                                    diagnostics: diagnostics,
                                     on: .global()) { result in
                     defer { sync.leave() }
 
@@ -791,6 +797,8 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             }
 
             XCTAssertEqual(delegate.loaded.count, total)
+            XCTAssertFalse(diagnostics.hasWarnings)
+            XCTAssertFalse(diagnostics.hasErrors)
         }
     }
 
@@ -829,5 +837,11 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 self._parsed
             }
         }
+    }
+}
+
+extension DiagnosticsEngine {
+    public var hasWarnings: Bool {
+        return diagnostics.contains(where: { $0.message.behavior == .warning })
     }
 }


### PR DESCRIPTION
motivation: more stable tests

changes:
* add a test variant with warmed up caches
* modify test to load 250 different manifests instead of the same one to create concurrent load on the parser
* add file-system lock around sqlite db state (ie when creating/closing it)
* change default concurrency to number of available CPUs
* make manifest cache failures non-fatal, emit warnings and continue  