### PR TITLE
rename flags for repositories cache

### DIFF
--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -136,11 +136,12 @@ public struct SwiftToolOptions: ParsableArguments {
     @Option(help: "Specify build/cache directory")
     var buildPath: AbsolutePath?
 
-    @Option(help: "Specify the global repository cache directory")
+    @Option(help: "Specify the shared cache directory")
     var cachePath: AbsolutePath?
 
-    @Flag(help: "Skip the cache when fetching")
-    var skipCache: Bool = false
+    /// Disables repository caching.
+    @Flag(name: .customLong("repository-cache"), inversion: .prefixedEnableDisable, help: "Use a shared cache when fetching repositories")
+    var useRepositoriesCache: Bool = true
 
     /// The custom working directory that the tool should operate in (deprecated).
     @Option(name: [.long, .customShort("C")])
@@ -174,7 +175,7 @@ public struct SwiftToolOptions: ParsableArguments {
     var shouldDisableManifestCaching: Bool = false
 
     /// Disables manifest caching.
-    @Option(name: .customLong("manifest-caching"), help: "Caching of Package.swift manifests")
+    @Option(name: .customLong("manifest-cache"), help: "Caching mode of Package.swift manifests (shared: shared cache, local: package's build directory, none: disabled")
     var manifestCachingMode: ManifestCachingMode = .shared
 
     enum ManifestCachingMode: String, ExpressibleByArgument {


### PR DESCRIPTION
motivation: clearer flags, happier users

changes:
* deprecate global "skip-cache" flag
* introduce "--disable-repositories-cache" flag for disabling repositories cache
* update flag help
* adjust call-site
