### PR TITLE
Reinstate 5.3 behavior of target-based dependency resolution

### DIFF
--- a/Sources/PackageGraph/DependencyResolutionNode.swift
+++ b/Sources/PackageGraph/DependencyResolutionNode.swift
@@ -78,7 +78,6 @@ public enum DependencyResolutionNode {
 
     /// Assembles the product filter to use on the manifest for this node to determine its dependencies.
     public var productFilter: ProductFilter {
-        #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
         switch self {
         case .empty:
             return .specific([])
@@ -87,9 +86,6 @@ public enum DependencyResolutionNode {
         case .root:
             return .everything
         }
-        #else
-        return .everything
-        #endif
     }
 
     /// Returns the dependency that a product has on its own package, if relevant.

--- a/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
@@ -11,7 +11,7 @@
 import TSCBasic
 
 /// Represents a package dependency.
-public struct PackageDependencyDescription: Equatable, Codable {
+public struct PackageDependencyDescription: Equatable, Codable, Hashable {
 
     /// The dependency requirement.
     public enum Requirement: Equatable, Hashable {


### PR DESCRIPTION
### Motivation:

Early in the 5.4 development process, we merged #2749 to bring a full implementation of target-based dependency resolution, but we disabled that later because of regressions with some real-world packages. The plan was to bring this back for the final 5.4, but after some discussion in #3121, we have identified a few issues without a clear fix that doesn't carry significant risk this late in the release cycle.

However, the current state is also not acceptable for the 5.4 release, since this regresses dependency resolution back to the state before #2424 which could break real world packages.

This PR brings back the 5.3 behavior of taking only into account targets that are required by any products and omitting any dependencies that aren't required by any products. We can then revisit target-based dependency resolution in a future release.

### Modifications:

This brings back the 5.3 implementation of `dependenciesRequired(for:)` (slightly modified) and also makes it so that `targetsRequired(for:)` for non-root packages only includes targets required by any products. Together this brings the behaviour of dependency resolution to the state of #2424.

### Result:

Dependency resolution will behave the same as it did in SwiftPM 5.3.
