### PR TITLE
change manifest loading deduping logic to be based on identity instead of manifest name

### DIFF
--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -118,6 +118,17 @@ public enum ProductFilter: Equatable, Hashable {
             return set.contains(product)
         }
     }
+
+    public func merge(_ other: ProductFilter) -> ProductFilter {
+        switch (self, other) {
+        case (.everything, _):
+            return .everything
+        case (_, .everything):
+            return .everything
+        case (.specific(let mine), .specific(let other)):
+            return .specific(mine.union(other))
+        }
+    }
 }
 
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -594,7 +594,7 @@ extension Workspace {
         
         // Resolve the dependencies.
         let resolver = self.createResolver(pinsMap: pinsMap)
-        activeResolver = resolver
+        self.activeResolver = resolver
 
         let updateResults = resolveDependencies(
             resolver: resolver,
@@ -603,7 +603,7 @@ extension Workspace {
         )
 
         // Reset the active resolver.
-        activeResolver = nil
+        self.activeResolver = nil
 
         guard !diagnostics.hasErrors else { return nil }
 
@@ -786,7 +786,7 @@ extension Workspace {
         let lock = Lock()
         let sync = DispatchGroup()
         var rootManifests = [Manifest]()
-        packages.forEach { package in
+        Set(packages).forEach { package in
             sync.enter()
             self.loadManifest(packagePath: package, url: package.pathString, packageKind: .root, diagnostics: diagnostics) { result in
                 defer { sync.leave() }
@@ -1101,26 +1101,21 @@ extension Workspace {
             self.workspace = workspace
         }
 
-        /// Find a manifest given its name.
-        func lookup(manifest name: String) -> Manifest? {
-            return dependencies.first(where: { $0.manifest.name == name })?.manifest
-        }
-
         /// Returns all manifests contained in DependencyManifests.
         public func allDependencyManifests() -> [Manifest] {
-            return dependencies.map({ $0.manifest })
+            return self.dependencies.map{ $0.manifest }
         }
 
         /// Computes the identities which are declared in the manifests but aren't present in dependencies.
         public func missingPackageURLs() -> Set<PackageReference> {
-            return computePackageURLs().missing
+            return self.computePackageURLs().missing
         }
 
         /// Returns the list of packages which are allowed to vend products with unsafe flags.
         func unsafeAllowedPackages() -> Set<PackageReference> {
             var result = Set<PackageReference>()
 
-            for dependency in dependencies {
+            for dependency in self.dependencies {
                 let dependency = dependency.dependency
                 switch dependency.state {
                 case .checkout(let checkout):
@@ -1142,45 +1137,46 @@ extension Workspace {
 
         func computePackageURLs() -> (required: Set<PackageReference>, missing: Set<PackageReference>) {
             let manifestsMap: [PackageIdentity: Manifest] = Dictionary(uniqueKeysWithValues:
-                root.manifests.map({ (PackageIdentity(url: $0.url), $0) }) +
-                dependencies.map({ (PackageIdentity(url: $0.manifest.url), $0.manifest) }))
+                self.root.manifests.map { (PackageIdentity(url: $0.url), $0) } +
+                self.dependencies.map { (PackageIdentity(url: $0.manifest.url), $0.manifest) })
 
             var inputIdentities: Set<PackageReference> = []
-            let inputNodes: [GraphLoadingNode] = root.manifests.map({ manifest in
+            let inputNodes: [GraphLoadingNode] = self.root.manifests.map{ manifest in
                 let identity = PackageIdentity(url: manifest.url)
                 let package = PackageReference(identity: identity, path: manifest.url, kind: manifest.packageKind)
                 inputIdentities.insert(package)
                 let node = GraphLoadingNode(manifest: manifest, productFilter: .everything)
                 return node
-            }) + root.dependencies.compactMap({ dependency in
+            } + self.root.dependencies.compactMap{ dependency in
                 let url = workspace.config.mirrors.effectiveURL(forURL: dependency.url)
                 let identity = PackageIdentity(url: url)
                 let package = PackageReference(identity: identity, path: url)
                 inputIdentities.insert(package)
-                guard let manifest = manifestsMap[identity] else { return nil }
-                let node = GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
-                return node
-            })
+                return manifestsMap[identity].map { manifest in
+                    GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
+                }
+            }
 
             // FIXME: this is dropping legitimate packages with equal identities and should be revised as part of the identity work
             var requiredIdentities: Set<PackageReference> = []
             _ = transitiveClosure(inputNodes) { node in
-                return node.manifest.dependenciesRequired(for: node.productFilter).compactMap({ dependency in
+                return node.manifest.dependenciesRequired(for: node.productFilter).compactMap{ dependency in
                     let url = workspace.config.mirrors.effectiveURL(forURL: dependency.url)
                     let identity = PackageIdentity(url: url)
                     let package = PackageReference(identity: identity, path: url)
                     requiredIdentities.insert(package)
-                    guard let manifest = manifestsMap[identity] else { return nil }
-                    return GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
-                })
+                    return manifestsMap[identity].map { manifest in
+                        GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
+                    }
+                }
             }
             // FIXME: This should be an ordered set.
             requiredIdentities = inputIdentities.union(requiredIdentities)
 
-            let availableIdentities: Set<PackageReference> = Set(manifestsMap.map({
+            let availableIdentities: Set<PackageReference> = Set(manifestsMap.map {
                 let url = workspace.config.mirrors.effectiveURL(forURL: $0.1.url)
                 return PackageReference(identity: $0.key, path: url, kind: $0.1.packageKind)
-            }))
+            })
             // We should never have loaded a manifest we don't need.
             assert(availableIdentities.isSubset(of: requiredIdentities), "\(availableIdentities) | \(requiredIdentities)")
             // These are the missing package identities.
@@ -1332,7 +1328,7 @@ extension Workspace {
         }
 
         // Try to load current managed dependencies, or emit and return.
-        fixManagedDependencies(with: diagnostics)
+        self.fixManagedDependencies(with: diagnostics)
         guard !diagnostics.hasErrors else {
             return DependencyManifests(root: root, dependencies: [], workspace: self)
         }
@@ -1346,48 +1342,59 @@ extension Workspace {
         // Map of loaded manifests. We do this to avoid reloading the shared nodes.
 
         // Compute the transitive closure of available dependencies.
-        struct NameAndFilter: Hashable { // Just because a raw tuple cannot be hashable.
-            let name: String
+        struct URLAndFilter: Hashable { // Just because a raw tuple cannot be hashable.
+            let url: String
             let filter: ProductFilter
         }
 
-        // optimization: preload in parallel
-        let inputDependenciesURLs = inputManifests.compactMap { $0.dependencies.compactMap{ config.mirrors.effectiveURL(forURL: $0.url) } }.flatMap { $0 }
+        // optimization: preload manifest we know about in parallel
+        let inputDependenciesURLs = inputManifests.map { $0.dependencies.map{ config.mirrors.effectiveURL(forURL: $0.url) } }.flatMap { $0 }
         // FIXME: this should not block
-        var loadedManifests = try temp_await { self.loadManifests(forURLs: inputDependenciesURLs, diagnostics: diagnostics, completion: $0) }.reduce(into: [String: Manifest]()) { (partial, manifest) in
-            partial[manifest.url] = manifest
-        }
+        var loadedManifests = try temp_await { self.loadManifests(forURLs: inputDependenciesURLs, diagnostics: diagnostics, completion: $0) }.spm_createDictionary{ ($0.url, $0) }
 
-        let allManifestsWithPossibleDuplicates = try topologicalSort(inputManifests.map({ KeyedPair(($0, ProductFilter.everything), key: NameAndFilter(name: $0.name, filter: .everything)) })) { node in
-            return node.item.0.dependenciesRequired(for: node.item.1).compactMap({ dependency in
+        // continue to load the rest of the manifest for this graph
+        let allManifestsWithPossibleDuplicates = try topologicalSort(inputManifests.map{ KeyedPair($0, key: URLAndFilter(url: $0.url, filter: .everything)) }) { node in
+            return node.item.dependenciesRequired(for: node.key.filter).compactMap{ dependency in
                 let url = config.mirrors.effectiveURL(forURL: dependency.url)
                 // FIXME: this should not block
+                // note: loadManifest emits diagnostics in case it fails
                 let manifest = loadedManifests[url] ?? temp_await { self.loadManifest(forURL: url, diagnostics: diagnostics, completion: $0) }
                 loadedManifests[url] = manifest
-                return manifest.flatMap({ KeyedPair(($0, dependency.productFilter), key: NameAndFilter(name: $0.name, filter: dependency.productFilter)) })
-            })
-        }
-
-        var deduplication: Set<String> = []
-        var allManifests: [KeyedPair<(Manifest, ProductFilter), NameAndFilter>] = []
-        for node in allManifestsWithPossibleDuplicates {
-            if deduplication.contains(node.item.0.name) {
-                continue // A duplicate.
-            } else {
-                allManifests.append(node)
-                deduplication.insert(node.item.0.name)
+                return manifest.flatMap({ KeyedPair($0, key: URLAndFilter(url: $0.url, filter: dependency.productFilter)) })
             }
         }
 
-        let allDependencyManifests = allManifests.map{ $0.item }.filter{ !root.manifests.contains($0.0) }
-        let deps = try allDependencyManifests.map{ manifest, productFilter -> (Manifest, ManagedDependency, ProductFilter) in
-            guard let dependency = state.dependencies[forURL: manifest.url] else {
+        // remove duplicates of the same manifest
+        // FIXME: this drops duplicates with different filters but filter is not in use in this case. we should clean this API up
+        var deduplication: Set<PackageIdentity> = []
+        var allManifests = [(manifest: Manifest, productFilter: ProductFilter)]()
+        for node in allManifestsWithPossibleDuplicates {
+            let identity = PackageIdentity(url: node.item.url)
+            if deduplication.contains(identity) {
+                continue // A duplicate.
+            } else {
+                allManifests.append((node.item, node.key.filter))
+                deduplication.insert(identity)
+            }
+        }
+
+        let dependencyManifests = allManifests.filter{ !root.manifests.contains($0.manifest) }
+
+        // check for overrides attempts with same name but different path
+        let rootManifestsByName = root.manifests.spm_createDictionary{ ($0.name, $0) }
+        dependencyManifests.forEach { manifest, _ in
+            if let override = rootManifestsByName[manifest.name], override.url != manifest.url  {
+                diagnostics.emit(error: "unable to override package '\(manifest.name)' because its identity '\(PackageIdentity(url: manifest.url))' doesn't match override's identity (directory name) '\(PackageIdentity(url: override.url))'")
+            }
+        }
+
+        let dependencies = try dependencyManifests.map{ manifest, productFilter -> (Manifest, ManagedDependency, ProductFilter) in
+            guard let dependency = self.state.dependencies[forURL: manifest.url] else {
                 throw InternalError("dependency not found for \(manifest.url)")
             }
             return (manifest, dependency, productFilter)
         }
-
-        return DependencyManifests(root: root, dependencies: deps, workspace: self)
+        return DependencyManifests(root: root, dependencies: dependencies, workspace: self)
     }
 
 
@@ -1429,7 +1436,7 @@ extension Workspace {
         let lock = Lock()
         let sync = DispatchGroup()
         var manifests = [Manifest]()
-        urls.forEach { url in
+        Set(urls).forEach { url in
             sync.enter()
             self.loadManifest(forURL: url, diagnostics: diagnostics) { manifest in
                 defer { sync.leave() }
@@ -1888,13 +1895,15 @@ extension Workspace {
 
         // Perform dependency resolution.
         let resolver = createResolver(pinsMap: pinsStore.pinsMap)
-        activeResolver = resolver
+        self.activeResolver = resolver
 
         let result = resolveDependencies(
             resolver: resolver,
             constraints: constraints,
             diagnostics: diagnostics)
-        activeResolver = nil
+
+        // Reset the active resolver.
+        self.activeResolver = nil
 
         guard !diagnostics.hasErrors else {
             return currentManifests
@@ -1918,10 +1927,7 @@ extension Workspace {
         // through a ssh url but its new reference is now changed to http.
         let missing = updatedDependencyManifests.computePackageURLs().missing
         if !missing.isEmpty {
-            // Check if an override package has a mismatching basename.
-            if self.didDiagnosePackageOverrideBasenameMismatch(updatedDependencyManifests, diagnostics) {
-                return updatedDependencyManifests
-            } else if retryOnPackagePathMismatch {
+            if retryOnPackagePathMismatch {
                 // Retry resolution which will most likely resolve correctly now since
                 // we have the manifest files of all the dependencies.
                 return try self._resolve(
@@ -1967,27 +1973,6 @@ extension Workspace {
             diagnostics: diagnostics)
 
         return updatedDependencyManifests
-    }
-
-    private func didDiagnosePackageOverrideBasenameMismatch(
-        _ dependencyManifests: DependencyManifests,
-        _ diagnostics: DiagnosticsEngine
-    ) -> Bool {
-        let rootManifests = dependencyManifests.root.manifests.spm_createDictionary{ ($0.name, $0) }
-
-        for missingURLs in dependencyManifests.computePackageURLs().missing {
-            // FIXME: this should not block
-            guard let manifest = (temp_await { self.loadManifest(forURL: missingURLs.path, diagnostics: diagnostics, completion: $0) }) else { continue }
-            if let override = rootManifests[manifest.name] {
-                let overrideIdentity = PackageIdentity(url: override.url)
-                let manifestIdentity = PackageIdentity(url: manifest.url)
-
-                diagnostics.emit(error: "unable to override package '\(manifest.name)' because its basename '\(manifestIdentity)' doesn't match directory name '\(overrideIdentity)'")
-
-                return true
-            }
-        }
-        return false
     }
 
     public enum ResolutionPrecomputationResult: Equatable {

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3894,7 +3894,7 @@ final class WorkspaceTests: XCTestCase {
 
         workspace.checkPackageGraph(roots: ["Overridden/bazzz-master"], deps: deps) { _, diagnostics in
             DiagnosticsEngineTester(diagnostics, ignoreNotes: true) { result in
-                result.check(diagnostic: .equal("unable to override package 'Baz' because its basename 'bazzz' doesn't match directory name 'bazzz-master'"), behavior: .error)
+                result.check(diagnostic: .equal("unable to override package 'Baz' because its identity 'bazzz' doesn't match override's identity (directory name) 'bazzz-master'"), behavior: .error)
             }
         }
     }


### PR DESCRIPTION
motivation: existing logic deduped manifests avaialbe for graph resolution based on the mainfest name. this is causing issues when a repository is renamed and both the old and new URL are in the graph (as in the case of SR-11338), since the graph can never get resolved with one of the required manifests missing

changes:
* change the logic to dedup based on the identity instead of name. this means we are deduping by URLs instead of manifest names which is more consistent with the way the rest of the code base works and more helpful in most case/
* move the lgoic to identify incorrect overrides to the resolve function instead of being based on the fact a manifest is missing (which is a side effect)
* added some code comments to explain what the code does
* a bit of formatting/gardening in related code

Note that SwiftPM will still have a problems with situations like SR-11338 since the current identity is based on last segment of the URL which is not unique enough. Further, renamed repositories still create issues when some of the graph pulls the old URL and the other parts pull the new URL. This is something we need to discuss in the context of the package registry identity discussion. The good news is that with this change the errors would be more to the point and more actionable.

rdar://54556059
https://bugs.swift.org/browse/SR-11338
