### PR TITLE
identity collisions diagnostics test and fixes

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1162,6 +1162,7 @@ extension Workspace {
                 return node
             })
 
+            // FIXME: this is dropping legitimate packages with equal identities and should be revised as part of the identity work
             var requiredIdentities: Set<PackageReference> = []
             _ = transitiveClosure(inputNodes) { node in
                 return node.manifest.dependenciesRequired(for: node.productFilter).compactMap({ dependency in


### PR DESCRIPTION
motivation: there are several use cases where identity collisions cause resolution errors with misleading diagnostics. We added several test cases to capture these cases, as a basis for improving identity collisions (some of them are legitimate use cases) or at the minimum by finding ways to emit more helpful / accurate diagnostics.

changes:
* add several test cases to capture use cases of identity collisions
* diagnose potential identity collisions and emit more actioable error messages
* add FIXME highlighting where some of the issues are coming from
