### PR TITLE
SwiftPM still support v3 manifests in dependencies but then it complains that they have no tools version comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,6 @@ Swift Next
   * Source Breakages for Swift Packages
     
     The package manager now throws an error if a manifest file contains invalid UTF-8 byte sequences.
-    
-    The package manager no longer silently falls back to using Swift 3.1 as the lowest supported version. Instead, a descriptive error is thrown for each misspelling or malformation in the manifest file.
 
 Swift 4.2
 ---------


### PR DESCRIPTION
The changes to how tools version comments are parsed introduced a subtle regression, causing packages that have a `Package@swift-3.swift` manifest to fail with an error about the missing tools version, even if the regular manifest is newer.  As described in https://swift.org/blog/swift-package-manager-manifest-api-redesign, packages without a tools version comment should be assumed to have version 3.1.

### Motivation:

This fixes a regression introduced in 5.4, as described above.

### Modifications:

Check for a version-specific tools version less than v4 and consider it to be v3.1.0 (i.e. the documented behavior).

rdar://72939860
