### PR TITLE
[5.4] change manifest loading deduping logic to be based on identity instead of manifest name

### DIFF
--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -118,6 +118,17 @@ public enum ProductFilter: Equatable, Hashable {
             return set.contains(product)
         }
     }
+
+    public func merge(_ other: ProductFilter) -> ProductFilter {
+        switch (self, other) {
+        case (.everything, _):
+            return .everything
+        case (_, .everything):
+            return .everything
+        case (.specific(let mine), .specific(let other)):
+            return .specific(mine.union(other))
+        }
+    }
 }
 
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3894,7 +3894,7 @@ final class WorkspaceTests: XCTestCase {
 
         workspace.checkPackageGraph(roots: ["Overridden/bazzz-master"], deps: deps) { _, diagnostics in
             DiagnosticsEngineTester(diagnostics, ignoreNotes: true) { result in
-                result.check(diagnostic: .equal("unable to override package 'Baz' because its basename 'bazzz' doesn't match directory name 'bazzz-master'"), behavior: .error)
+                result.check(diagnostic: .equal("unable to override package 'Baz' because its identity 'bazzz' doesn't match override's identity (directory name) 'bazzz-master'"), behavior: .error)
             }
         }
     }


### PR DESCRIPTION
same as #3165, needs #3179 to be merged first