### PR TITLE
adjust swift-driver branch to use the version-lock variable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -302,14 +302,11 @@ if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch(relatedDependenciesBranch)),
-        
         // The 'swift-argument-parser' version declared here must match that
         // used by 'swift-driver' and 'sourcekit-lsp'. Please coordinate
         // dependency version changes here with those projects.
-        .package(
-            url: "https://github.com/apple/swift-argument-parser.git",
-            .upToNextMinor(from: "0.3.1")),
-        .package(url: "https://github.com/apple/swift-driver.git", .branch("main")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.3.1")),
+        .package(url: "https://github.com/apple/swift-driver.git", .branch(relatedDependenciesBranch)),
     ]
 } else {
     package.dependencies += [


### PR DESCRIPTION
motivation: swift-pm and swift-drivers are version locked

changes: adjust the dependency declaration of swift-driver to use the "relatedDependenciesBranch" variable
