### PR TITLE
[5.4] SwiftPM complains about missing tools version comments in SwiftPM v3 version-specific manifest overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,6 @@ Swift Next
   * Source Breakages for Swift Packages
     
     The package manager now throws an error if a manifest file contains invalid UTF-8 byte sequences.
-    
-    The package manager no longer silently falls back to using Swift 3.1 as the lowest supported version. Instead, a descriptive error is thrown for each misspelling or malformation in the manifest file.
 
 Swift 4.2
 ---------


### PR DESCRIPTION
This is the SwiftPM 5.4 nomination of a bug fix in the handling of version-specific manifests that have a manifest version earlier than 4.  Such old versions are no longer supported for any root package, but are still supported as version specific manifest overrides for dependencies.

The original PR is https://github.com/apple/swift-package-manager/pull/3172, which has reviews and more details.