### PR TITLE
[5.4] Adjust dependencies on 5.4 branch to `release/5.4`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -282,7 +282,7 @@ let package = Package(
 // this right now.
 
 /// When not using local dependencies, the branch to use for llbuild and TSC repositories.
-let relatedDependenciesBranch = "main"
+let relatedDependenciesBranch = "release/5.4"
 
 if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
@@ -306,10 +306,8 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         // The 'swift-argument-parser' version declared here must match that
         // used by 'swift-driver' and 'sourcekit-lsp'. Please coordinate
         // dependency version changes here with those projects.
-        .package(
-            url: "https://github.com/apple/swift-argument-parser.git",
-            .upToNextMinor(from: "0.3.1")),
-        .package(url: "https://github.com/apple/swift-driver.git", .branch("main")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.3.1")),
+        .package(url: "https://github.com/apple/swift-driver.git", .branch(relatedDependenciesBranch)),
     ]
 } else {
     package.dependencies += [


### PR DESCRIPTION
The Package.swift on the `release/5.4` branch should use that branch for the dependencies also.  We might need to first open related PRs for adjustment of the `release/5.4` branches of those dependencies, as it seems that some haven’t yet been updated.

rdar://73202559