### PR TITLE
Update CanonicalPackageIdentity Initializer

### DIFF
--- a/Sources/PackageModel/PackageIdentity.swift
+++ b/Sources/PackageModel/PackageIdentity.swift
@@ -145,6 +145,12 @@ struct LegacyPackageIdentity: PackageIdentityProvider, Equatable {
 ///   ```
 ///   ssh://mona@example.com/~/LinkedList.git → example.com/~mona/LinkedList
 ///   ```
+/// * Transcoding internationalized domain names using Punycode
+///   and prepending the ASCII Compatible Encoding (ACE) prefix, "xn--",
+///   if applicable:
+///   ```
+///   schlüssel.tld/mona/LinkedList → xn--schlssel-95a.tld/mona/LinkedList
+///   ```
 /// * Removing percent-encoding from the path component, if applicable:
 ///   ```
 ///   example.com/mona/%F0%9F%94%97List → example.com/mona/🔗List
@@ -235,6 +241,9 @@ struct CanonicalPackageIdentity: PackageIdentityProvider, Equatable {
         if isWindowsPath || detectedScheme == "file" || string.first.flatMap({ $0.isSeparator }) ?? false {
             description.insert("/", at: description.startIndex)
         }
+
+        // TODO: Implement PunyCode transcoding
+        assert(description.prefix(while: { $0 != "/" }).allSatisfy({ $0.isLetter || $0.isDigit || $0 == "-" || $0 == "." }), "canonical package identities must not contain internationalized domain name characters")
 
         self.description = description
     }

--- a/Sources/PackageModel/PackageIdentity.swift
+++ b/Sources/PackageModel/PackageIdentity.swift
@@ -271,7 +271,7 @@ private extension String {
 
     @discardableResult
     mutating func dropUserinfoSubcomponentPrefixIfPresent() -> (user: String, password: String?)? {
-        if let indexOfAtSign = firstIndex(of: "@"),
+        if let indexOfAtSign = lastIndex(of: "@"),
            let indexOfFirstPathComponent = firstIndex(where: { $0.isSeparator }),
            indexOfAtSign < indexOfFirstPathComponent
         {

--- a/Tests/PackageModelTests/CanonicalPackageIdentityTests.swift
+++ b/Tests/PackageModelTests/CanonicalPackageIdentityTests.swift
@@ -103,7 +103,7 @@ final class CanonicalPackageIdentityTests: XCTestCase {
 
     func testHTTPSSchemeWithUserAndPassword() {
         XCTAssertEqual(
-            CanonicalPackageIdentity("https://user:sw0rdf1sh!@example.com/mona/LinkedList").description,
+            CanonicalPackageIdentity("https://user:sw0rdf:sh!@@example.com/mona/LinkedList").description,
             "example.com/mona/linkedlist"
         )
     }

--- a/Tests/PackageModelTests/CanonicalPackageIdentityTests.swift
+++ b/Tests/PackageModelTests/CanonicalPackageIdentityTests.swift
@@ -62,6 +62,34 @@ final class CanonicalPackageIdentityTests: XCTestCase {
         )
     }
 
+    func testImplicitFileSchemeWithWindowsLocalFileSystemPath() {
+        XCTAssertEqual(
+            CanonicalPackageIdentity(#"c:\user\mona\LinkedList"#).description,
+            "/user/mona/linkedlist"
+        )
+    }
+
+    func testImplicitFileSchemeWithWindowsUniversalNamingConventionPath() {
+        XCTAssertEqual(
+            CanonicalPackageIdentity(#"\\user\mona\LinkedList"#).description,
+            "/user/mona/linkedlist"
+        )
+    }
+
+    func testImplicitFileSchemeWithWindowsLongDevicePath() {
+        XCTAssertEqual(
+            CanonicalPackageIdentity(#"\\?\C:\USER\MONA\LINKEDLIST"#).description,
+            "/user/mona/linkedlist"
+        )
+    }
+
+    func testImplicitFileSchemeWithWindowsNTObjectManagerPath() {
+        XCTAssertEqual(
+            CanonicalPackageIdentity(#"\\??\C:\USER\MONA\LINKEDLIST"#).description,
+            "/user/mona/linkedlist"
+        )
+    }
+
     // MARK: - FTP / FTPS
 
     func testFTPScheme() {

--- a/Tests/PackageModelTests/CanonicalPackageIdentityTests.swift
+++ b/Tests/PackageModelTests/CanonicalPackageIdentityTests.swift
@@ -239,8 +239,8 @@ final class CanonicalPackageIdentityTests: XCTestCase {
         try XCTSkipIf(true, "internationalized domain names aren't yet supported")
 
         XCTAssertEqual(
-            CanonicalPackageIdentity("https://xn--schlssel-95a.tld/mona/LinkedList").description,
-            "schlüssel.tld/mona/LinkedList"
+            CanonicalPackageIdentity("https://schlüssel.tld/mona/LinkedList").description,
+            "xn--schlssel-95a.tld/mona/LinkedList"
         )
     }
 


### PR DESCRIPTION

### Motivation:

Incorporating feedback from the [SE-0292 review thread](https://forums.swift.org/t/se-0292-package-registry-service/42623/) by making a few changes to the `CanonicalPackageIdentity` initializer and its associated tests.

### Modifications:

- Changes the `isSeparator` test to be platform independent (thanks to [Karl 👑🦆](https://forums.swift.org/u/Karl/) for pointing this out) (6360cda1ecfa2695d675d1c629a09f68f6475aac)
- Fixes the parsing logic for userinfo, which should look for the _last_ instance of "@", not the first (thanks again to Karl 👑🦆)
- Adds normalization logic for Windows paths, like `c:\user\mona\LinkedList` (b160b5881b71ddc802d2f6980781bc4a3bde214c)
- Updates the intended behavior for internationalized domain names (56f7b88ad956123129d4b7ef1d1e0e570705d938). <ins>Note</ins>: Swift doesn't currently have built-in PunyCode transcoding, so the behavior now is to detect and raise an assertion failure when a package identity is constructed with an internationalized domain name.

### Result:

`CanonicalPackageIdentity` is not currently being used, but these changes will help ensure correct behavior when they're introduced for package registry support.
