### PR TITLE
Convert preconditions for `TargetDescription` into errors

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -399,7 +399,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                         type: .library(.automatic),
                         targets: [manifestBuilder.name])
                     )
-                    targets.append(TargetDescription(
+                    targets.append(try TargetDescription(
                         name: manifestBuilder.name,
                         path: "",
                         type: .system,

--- a/Sources/PackageLoading/PackageDescription4Loader.swift
+++ b/Sources/PackageLoading/PackageDescription4Loader.swift
@@ -128,7 +128,7 @@ extension ManifestBuilder {
         let exclude: [String] = try json.get("exclude")
         try exclude.forEach{ _ = try RelativePath(validating: $0) }
 
-        return TargetDescription(
+        return try TargetDescription(
             name: try json.get("name"),
             dependencies: dependencies,
             path: json.get("path"),

--- a/Sources/SPMTestSupport/MockPackage.swift
+++ b/Sources/SPMTestSupport/MockPackage.swift
@@ -41,11 +41,11 @@ public struct MockPackage {
         self.toolsVersion = toolsVersion
     }
 
-    public static func genericPackage1(named name: String) -> MockPackage {
+    public static func genericPackage1(named name: String) throws -> MockPackage {
         return MockPackage(
             name: name,
             targets: [
-                MockTarget(name: name),
+                try MockTarget(name: name),
             ],
             products: [
                 MockProduct(name: name, targets: [name]),

--- a/Sources/SPMTestSupport/MockTarget.swift
+++ b/Sources/SPMTestSupport/MockTarget.swift
@@ -31,7 +31,7 @@ public struct MockTarget {
         url: String? = nil,
         settings: [TargetBuildSettingDescription.Setting] = [],
         checksum: String? = nil
-    ) {
+    ) throws {
         self.name = name
         self.dependencies = dependencies
         self.type = type
@@ -41,10 +41,10 @@ public struct MockTarget {
         self.checksum = checksum
     }
 
-    func convert() -> TargetDescription {
+    func convert() throws -> TargetDescription {
         switch self.type {
         case .regular:
-            return TargetDescription(
+            return try TargetDescription(
                 name: self.name,
                 dependencies: self.dependencies,
                 path: self.path,
@@ -55,7 +55,7 @@ public struct MockTarget {
                 settings: self.settings
             )
         case .test:
-            return TargetDescription(
+            return try TargetDescription(
                 name: self.name,
                 dependencies: self.dependencies,
                 path: self.path,
@@ -66,7 +66,7 @@ public struct MockTarget {
                 settings: self.settings
             )
         case .binary:
-            return TargetDescription(
+            return try TargetDescription(
                 name: self.name,
                 dependencies: self.dependencies,
                 path: self.path,

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -128,7 +128,7 @@ public final class MockWorkspace {
                     packageKind: packageKind,
                     dependencies: package.dependencies.map { $0.convert(baseURL: packagesDir) },
                     products: package.products.map { ProductDescription(name: $0.name, type: .library(.automatic), targets: $0.targets) },
-                    targets: package.targets.map { $0.convert() }
+                    targets: try package.targets.map { try $0.convert() }
                 )
                 if let version = version {
                     try repo.tag(name: version)

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1908,7 +1908,7 @@ final class BuildPlanTests: XCTestCase {
                 PackageDependencyDescription(url: "/B", requirement: .upToNextMajor(from: "1.0.0")),
             ],
             targets: [
-                TargetDescription(
+                try TargetDescription(
                     name: "cbar",
                     settings: [
                     .init(tool: .c, name: .headerSearchPath, value: ["Sources/headers"]),
@@ -1921,7 +1921,7 @@ final class BuildPlanTests: XCTestCase {
                     .init(tool: .cxx, name: .unsafeFlags, value: ["-Icxxfoo", "-L", "cxxbar"]),
                     ]
                 ),
-                TargetDescription(
+                try TargetDescription(
                     name: "bar", dependencies: ["cbar", "Dep"],
                     settings: [
                     .init(tool: .swift, name: .define, value: ["LINUX"], condition: .init(platformNames: ["linux"])),
@@ -1930,7 +1930,7 @@ final class BuildPlanTests: XCTestCase {
                     .init(tool: .swift, name: .unsafeFlags, value: ["-Isfoo", "-L", "sbar"]),
                     ]
                 ),
-                TargetDescription(
+                try TargetDescription(
                     name: "exe", dependencies: ["bar"],
                     settings: [
                     .init(tool: .swift, name: .define, value: ["FOO"]),
@@ -1953,14 +1953,14 @@ final class BuildPlanTests: XCTestCase {
                 ProductDescription(name: "Dep", type: .library(.automatic), targets: ["t1", "t2"]),
             ],
             targets: [
-                TargetDescription(
+                try TargetDescription(
                     name: "t1",
                     settings: [
                         .init(tool: .swift, name: .define, value: ["DEP"]),
                         .init(tool: .linker, name: .linkedLibrary, value: ["libz"]),
                     ]
                 ),
-                TargetDescription(
+                try TargetDescription(
                     name: "t2",
                     settings: [
                         .init(tool: .linker, name: .linkedLibrary, value: ["libz"]),
@@ -2032,7 +2032,7 @@ final class BuildPlanTests: XCTestCase {
             v: .v5,
             packageKind: .root,
             targets: [
-                TargetDescription(name: "exe", dependencies: []),
+                try TargetDescription(name: "exe", dependencies: []),
             ]
         )
 

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -367,7 +367,7 @@ final class PackageToolTests: XCTestCase {
                 .init(name: "exe", type: .executable, targets: ["TargetA"])
             ],
             targets: [
-                .init(name: "TargetA", dependencies: ["PackageB", "PackageC"])
+                try .init(name: "TargetA", dependencies: ["PackageB", "PackageC"])
             ]
         )
         
@@ -385,7 +385,7 @@ final class PackageToolTests: XCTestCase {
                 .init(name: "PackageB", type: .library(.dynamic), targets: ["TargetB"])
             ],
             targets: [
-                .init(name: "TargetB", dependencies: ["PackageC", "PackageD"])
+                try .init(name: "TargetB", dependencies: ["PackageC", "PackageD"])
             ]
         )
         
@@ -402,7 +402,7 @@ final class PackageToolTests: XCTestCase {
                 .init(name: "PackageC", type: .library(.dynamic), targets: ["TargetC"])
             ],
             targets: [
-                .init(name: "TargetC", dependencies: ["PackageD"])
+                try .init(name: "TargetC", dependencies: ["PackageD"])
             ]
         )
         
@@ -416,7 +416,7 @@ final class PackageToolTests: XCTestCase {
                 .init(name: "PackageD", type: .library(.dynamic), targets: ["TargetD"])
             ],
             targets: [
-                .init(name: "TargetD")
+                try .init(name: "TargetD")
             ]
         )
         

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -34,12 +34,12 @@ class PackageGraphPerfTests: XCTestCasePerf {
             // Create package.
             if pkg == N {
                 dependencies = []
-                targets = [TargetDescription(name: name, path: ".")]
+                targets = [try TargetDescription(name: name, path: ".")]
             } else {
                 let depName = "Foo\(pkg + 1)"
                 let depUrl = "/\(depName)"
                 dependencies = [PackageDependencyDescription(name: depName, url: depUrl, requirement: .upToNextMajor(from: "1.0.0"))]
-                targets = [TargetDescription(name: name, dependencies: [.byName(name: depName, condition: nil)], path: ".")]
+                targets = [try TargetDescription(name: name, dependencies: [.byName(name: depName, condition: nil)], path: ".")]
             }
             // Create manifest.
             let isRoot = pkg == 1

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -373,9 +373,9 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         ]
 
         let targets = [
-            TargetDescription(name: "Foo1", dependencies: ["Foo2", "Bar1"]),
-            TargetDescription(name: "Foo2", dependencies: [.product(name: "B2", package: "Bar2")]),
-            TargetDescription(name: "Foo3", dependencies: ["Bar3"]),
+            try TargetDescription(name: "Foo1", dependencies: ["Foo2", "Bar1"]),
+            try TargetDescription(name: "Foo2", dependencies: [.product(name: "B2", package: "Bar2")]),
+            try TargetDescription(name: "Foo3", dependencies: ["Bar3"]),
         ]
 
         let mirrors: DependencyMirrors = [:]
@@ -532,7 +532,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
                 url: packageDir.pathString,
                 packageKind: .root,
                 targets: [
-                    TargetDescription(name: packageDir.basename, path: packageDir.pathString),
+                    try TargetDescription(name: packageDir.basename, path: packageDir.pathString),
                 ]
             )
             let containerProvider = RepositoryPackageContainerProvider(repositoryManager: repositoryManager, manifestLoader: MockManifestLoader(manifests: [.init(url: packageDir.pathString, version: nil): manifest]))
@@ -602,7 +602,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
                 ],
                 products: [ProductDescription(name: "Product", type: .library(.automatic), targets: ["Target"])],
                 targets: [
-                    TargetDescription(
+                    try TargetDescription(
                         name: "Target",
                         dependencies: [.product(name: "DependencyProduct", package: "Dependency")]
                     ),

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -28,7 +28,7 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createV4Manifest(
             name: "pkg",
             targets: [
-                TargetDescription(name: "foo"),
+                try TargetDescription(name: "foo"),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
@@ -47,7 +47,7 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createV4Manifest(
             name: "pkg",
             targets: [
-                TargetDescription(name: "foo"),
+                try TargetDescription(name: "foo"),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { _, diagnostics in
@@ -73,7 +73,7 @@ class PackageBuilderTests: XCTestCase {
             let manifest = Manifest.createV4Manifest(
                 name: "pkg",
                 targets: [
-                    TargetDescription(name: "foo"),
+                    try TargetDescription(name: "foo"),
                 ]
             )
 
@@ -103,7 +103,7 @@ class PackageBuilderTests: XCTestCase {
             let manifest = Manifest.createV4Manifest(
                 name: "pkg",
                 targets: [
-                    TargetDescription(name: "bar"),
+                    try TargetDescription(name: "bar"),
                 ]
             )
 
@@ -121,8 +121,8 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createV4Manifest(
             name: "MyPackage",
             targets: [
-                TargetDescription(name: "MyPackage"),
-                TargetDescription(name: "MyPackageTests", dependencies: ["MyPackage"], type: .test),
+                try TargetDescription(name: "MyPackage"),
+                try TargetDescription(name: "MyPackageTests", dependencies: ["MyPackage"], type: .test),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, diagnostics in
@@ -160,7 +160,7 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createV4Manifest(
             name: "pkg",
             targets: [
-                TargetDescription(name: "pkg"),
+                try TargetDescription(name: "pkg"),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
@@ -183,7 +183,7 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createV4Manifest(
             name: name,
             targets: [
-                TargetDescription(name: name),
+                try TargetDescription(name: name),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
@@ -204,7 +204,7 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createV4Manifest(
             name: "MyPackage",
             targets: [
-                TargetDescription(name: "clib"),
+                try TargetDescription(name: "clib"),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
@@ -230,7 +230,7 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createV4Manifest(
             name: "MyPackage",
             targets: [
-                TargetDescription(
+                try TargetDescription(
                     name: "clib",
                     path: "Sources",
                     sources: ["clib", "clib"],
@@ -261,19 +261,19 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createV4Manifest(
             name: "MyPackage",
             targets: [
-                TargetDescription(
+                try TargetDescription(
                     name: "swift.lib"
                 ),
-                TargetDescription(
+                try TargetDescription(
                     name: "swiftlib1",
                     path: "Sources/swiftlib1",
                     sources: ["swift.lib"]
                 ),
-                TargetDescription(
+                try TargetDescription(
                     name: "swiftlib2",
                     path: "Sources/swiftlib2/swift.lib"
                 ),
-                TargetDescription(
+                try TargetDescription(
                     name: "swiftlib3",
                     path: "Sources/swiftlib3/swift.lib"
                 ),
@@ -307,7 +307,7 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createV4Manifest(
             name: "MyPackage",
             targets: [
-                TargetDescription(
+                try TargetDescription(
                     name: "clib",
                     path: "Sources",
                     sources: ["clib", "clib/subfolder"]
@@ -321,7 +321,7 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testDeclaredExecutableProducts() {
+    func testDeclaredExecutableProducts() throws {
         // Check that declaring executable product doesn't collide with the
         // inferred products.
         let fs = InMemoryFileSystem(emptyFiles:
@@ -335,8 +335,8 @@ class PackageBuilderTests: XCTestCase {
                 ProductDescription(name: "exec", type: .executable, targets: ["exec", "foo"]),
             ],
             targets: [
-                TargetDescription(name: "foo"),
-                TargetDescription(name: "exec"),
+                try TargetDescription(name: "foo"),
+                try TargetDescription(name: "exec"),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
@@ -351,8 +351,8 @@ class PackageBuilderTests: XCTestCase {
             name: "pkg",
             products: [],
             targets: [
-                TargetDescription(name: "foo"),
-                TargetDescription(name: "exec"),
+                try TargetDescription(name: "foo"),
+                try TargetDescription(name: "exec"),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
@@ -371,8 +371,8 @@ class PackageBuilderTests: XCTestCase {
                 ProductDescription(name: "exec1", type: .executable, targets: ["exec"]),
             ],
             targets: [
-                TargetDescription(name: "foo"),
-                TargetDescription(name: "exec"),
+                try TargetDescription(name: "foo"),
+                try TargetDescription(name: "exec"),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
@@ -384,7 +384,7 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testExecutableTargets() {
+    func testExecutableTargets() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/exec1/exec.swift",
             "/Sources/exec2/main.swift",
@@ -399,8 +399,8 @@ class PackageBuilderTests: XCTestCase {
                 ProductDescription(name: "exec1", type: .executable, targets: ["exec1", "lib"]),
             ],
             targets: [
-                TargetDescription(name: "exec1", type: .executable),
-                TargetDescription(name: "lib"),
+                try TargetDescription(name: "exec1", type: .executable),
+                try TargetDescription(name: "lib"),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
@@ -417,8 +417,8 @@ class PackageBuilderTests: XCTestCase {
             toolsVersion: .vNext,
             products: [],
             targets: [
-                TargetDescription(name: "exec1", type: .executable),
-                TargetDescription(name: "lib"),
+                try TargetDescription(name: "exec1", type: .executable),
+                try TargetDescription(name: "lib"),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
@@ -437,8 +437,8 @@ class PackageBuilderTests: XCTestCase {
                 ProductDescription(name: "exec1", type: .executable, targets: ["exec1"]),
             ],
             targets: [
-                TargetDescription(name: "lib"),
-                TargetDescription(name: "exec1", type: .executable),
+                try TargetDescription(name: "lib"),
+                try TargetDescription(name: "exec1", type: .executable),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
@@ -457,8 +457,8 @@ class PackageBuilderTests: XCTestCase {
                 ProductDescription(name: "exec1", type: .executable, targets: ["exec1"]),
             ],
             targets: [
-                TargetDescription(name: "lib"),
-                TargetDescription(name: "exec1", type: .executable),
+                try TargetDescription(name: "lib"),
+                try TargetDescription(name: "exec1", type: .executable),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
@@ -477,8 +477,8 @@ class PackageBuilderTests: XCTestCase {
                 ProductDescription(name: "exec2", type: .executable, targets: ["exec2"]),
             ],
             targets: [
-                TargetDescription(name: "lib"),
-                TargetDescription(name: "exec2"),
+                try TargetDescription(name: "lib"),
+                try TargetDescription(name: "exec2"),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, diagnostics in
@@ -491,8 +491,8 @@ class PackageBuilderTests: XCTestCase {
         }
     }
     
-    func testTestManifestFound() {
-        SwiftTarget.testManifestNames.forEach { name in
+    func testTestManifestFound() throws {
+        try SwiftTarget.testManifestNames.forEach { name in
             let fs = InMemoryFileSystem(emptyFiles:
                 "/swift/exe/foo.swift",
                 "/\(name)",
@@ -502,8 +502,8 @@ class PackageBuilderTests: XCTestCase {
             let manifest = Manifest.createV4Manifest(
                 name: "pkg",
                 targets: [
-                    TargetDescription(name: "exe", path: "swift/exe"),
-                    TargetDescription(name: "tests", path: "swift/tests", type: .test),
+                    try TargetDescription(name: "exe", path: "swift/exe"),
+                    try TargetDescription(name: "tests", path: "swift/tests", type: .test),
                 ]
             )
             PackageBuilderTester(manifest, in: fs) { package, _ in
@@ -525,7 +525,7 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testTestManifestSearch() {
+    func testTestManifestSearch() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/pkg/foo.swift",
             "/pkg/footests.swift"
@@ -534,12 +534,12 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createV4Manifest(
             name: "pkg",
             targets: [
-                TargetDescription(
+                try TargetDescription(
                     name: "exe",
                     path: "./",
                     sources: ["foo.swift"]
                 ),
-                TargetDescription(
+                try TargetDescription(
                     name: "tests",
                     path: "./",
                     sources: ["footests.swift"],
@@ -558,7 +558,7 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testMultipleTestManifestError() {
+    func testMultipleTestManifestError() throws {
         let name = SwiftTarget.testManifestNames.first!
         let fs = InMemoryFileSystem(emptyFiles:
             "/\(name)",
@@ -569,7 +569,7 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createV4Manifest(
             name: "pkg",
             targets: [
-                TargetDescription(
+                try TargetDescription(
                     name: "tests",
                     path: "swift/tests",
                     type: .test
@@ -581,7 +581,7 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testCustomTargetPaths() {
+    func testCustomTargetPaths() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/mah/target/exe/swift/exe/main.swift",
             "/mah/target/exe/swift/exe/foo.swift",
@@ -598,17 +598,17 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createV4Manifest(
             name: "pkg",
             targets: [
-                TargetDescription(
+                try TargetDescription(
                     name: "exe",
                     path: "mah/target/exe",
                     sources: ["swift"]),
-                TargetDescription(
+                try TargetDescription(
                     name: "clib",
                     path: "mah/target/exe",
                     sources: ["foo.c"]),
-                TargetDescription(
+                try TargetDescription(
                     name: "foo"),
-                TargetDescription(
+                try TargetDescription(
                     name: "bar",
                     path: "bar",
                     exclude: ["bar/excluded.swift", "bar/fixture"],
@@ -643,7 +643,7 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testCustomTargetPathsOverlap() {
+    func testCustomTargetPathsOverlap() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/target/bar/bar.swift",
             "/target/bar/Tests/barTests.swift"
@@ -652,10 +652,10 @@ class PackageBuilderTests: XCTestCase {
         var manifest = Manifest.createV4Manifest(
             name: "pkg",
             targets: [
-                TargetDescription(
+                try TargetDescription(
                     name: "bar",
                     path: "target/bar"),
-                TargetDescription(
+                try TargetDescription(
                     name: "barTests",
                     path: "target/bar/Tests",
                     type: .test),
@@ -668,11 +668,11 @@ class PackageBuilderTests: XCTestCase {
         manifest = Manifest.createV4Manifest(
             name: "pkg",
             targets: [
-                TargetDescription(
+                try TargetDescription(
                     name: "bar",
                     path: "target/bar",
                     exclude: ["Tests"]),
-                TargetDescription(
+                try TargetDescription(
                     name: "barTests",
                     path: "target/bar/Tests",
                     type: .test),
@@ -709,10 +709,10 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createV4Manifest(
             name: "Foo",
             targets: [
-                TargetDescription(
+                try TargetDescription(
                     name: "Foo",
                     publicHeadersPath: "inc"),
-                TargetDescription(
+                try TargetDescription(
                     name: "Bar"),
             ]
         )
@@ -751,10 +751,10 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createV4Manifest(
             name: "Foo",
             targets: [
-                TargetDescription(
+                try TargetDescription(
                     name: "Foo",
                     publicHeadersPath: "/inc"),
-                TargetDescription(
+                try TargetDescription(
                     name: "Bar"),
             ]
         )
@@ -774,10 +774,10 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createV4Manifest(
             name: "Foo",
             targets: [
-                TargetDescription(name: "A"),
-                TargetDescription(name: "TheTestOfA", dependencies: ["A"], type: .test),
-                TargetDescription(name: "ATests", type: .test),
-                TargetDescription(name: "B", type: .test),
+                try TargetDescription(name: "A"),
+                try TargetDescription(name: "TheTestOfA", dependencies: ["A"], type: .test),
+                try TargetDescription(name: "ATests", type: .test),
+                try TargetDescription(name: "B", type: .test),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
@@ -811,7 +811,7 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testMultipleTestProducts() {
+    func testMultipleTestProducts() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/foo/foo.swift",
             "/Tests/fooTests/foo.swift",
@@ -821,9 +821,9 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createV4Manifest(
             name: "pkg",
             targets: [
-                TargetDescription(name: "foo"),
-                TargetDescription(name: "fooTests", type: .test),
-                TargetDescription(name: "barTests", type: .test),
+                try TargetDescription(name: "foo"),
+                try TargetDescription(name: "fooTests", type: .test),
+                try TargetDescription(name: "barTests", type: .test),
             ]
         )
 
@@ -859,9 +859,9 @@ class PackageBuilderTests: XCTestCase {
         var manifest = Manifest.createV4Manifest(
             name: "pkg",
             targets: [
-                TargetDescription(name: "Foo", dependencies: ["Bar"]),
-                TargetDescription(name: "Bar"),
-                TargetDescription(name: "Baz"),
+                try TargetDescription(name: "Foo", dependencies: ["Bar"]),
+                try TargetDescription(name: "Bar"),
+                try TargetDescription(name: "Baz"),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
@@ -883,9 +883,9 @@ class PackageBuilderTests: XCTestCase {
         manifest = Manifest.createV4Manifest(
             name: "pkg",
             targets: [
-                TargetDescription(name: "Foo", dependencies: ["Bar"]),
-                TargetDescription(name: "Bar", dependencies: ["Baz"]),
-                TargetDescription(name: "Baz"),
+                try TargetDescription(name: "Foo", dependencies: ["Bar"]),
+                try TargetDescription(name: "Bar", dependencies: ["Baz"]),
+                try TargetDescription(name: "Baz"),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
@@ -917,9 +917,9 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createV4Manifest(
             name: "pkg",
             targets: [
-                TargetDescription(name: "Bar"),
-                TargetDescription(name: "Baz"),
-                TargetDescription(
+                try TargetDescription(name: "Bar"),
+                try TargetDescription(name: "Baz"),
+                try TargetDescription(
                     name: "Foo",
                     dependencies: ["Bar", "Baz", "Bam"]),
             ]
@@ -953,7 +953,7 @@ class PackageBuilderTests: XCTestCase {
             let manifest = Manifest.createV4Manifest(
                 name: "pkg",
                 targets: [
-                    TargetDescription(name: "Random"),
+                    try TargetDescription(name: "Random"),
                 ]
             )
             PackageBuilderTester(manifest, in: fs) { _, diagnostics in
@@ -968,7 +968,7 @@ class PackageBuilderTests: XCTestCase {
             let manifest = Manifest.createV4Manifest(
                 name: "pkg",
                 targets: [
-                    TargetDescription(name: "pkg", dependencies: [.target(name: "Foo")]),
+                    try TargetDescription(name: "pkg", dependencies: [.target(name: "Foo")]),
                 ]
             )
             PackageBuilderTester(manifest, in: fs) { _, diagnostics in
@@ -982,8 +982,8 @@ class PackageBuilderTests: XCTestCase {
             let manifest = Manifest.createV4Manifest(
                 name: "pkg",
                 targets: [
-                    TargetDescription(name: "pkg", dependencies: []),
-                    TargetDescription(name: "pkgTests", dependencies: [], type: .test),
+                    try TargetDescription(name: "pkg", dependencies: []),
+                    try TargetDescription(name: "pkgTests", dependencies: [], type: .test),
                 ]
             )
             PackageBuilderTester(manifest, in: fs) { _, diagnostics in
@@ -998,7 +998,7 @@ class PackageBuilderTests: XCTestCase {
             let manifest = Manifest.createV4Manifest(
                 name: "pkg",
                 targets: [
-                    TargetDescription(name: "pkg", dependencies: [.target(name: "pkg")]),
+                    try TargetDescription(name: "pkg", dependencies: [.target(name: "pkg")]),
                 ]
             )
             PackageBuilderTester(manifest, in: fs) { _, diagnostics in
@@ -1013,7 +1013,7 @@ class PackageBuilderTests: XCTestCase {
             let manifest = Manifest.createV4Manifest(
                 name: "pkg",
                 targets: [
-                    TargetDescription(name: "foo"),
+                    try TargetDescription(name: "foo"),
                 ]
             )
             PackageBuilderTester(manifest, in: fs) { _, diagnotics in
@@ -1027,7 +1027,7 @@ class PackageBuilderTests: XCTestCase {
             let manifest = Manifest.createV4Manifest(
                 name: "pkg",
                 targets: [
-                    TargetDescription(name: "foo", url: "https://foo.com/foo.zip", type: .binary, checksum: "checksum"),
+                    try TargetDescription(name: "foo", url: "https://foo.com/foo.zip", type: .binary, checksum: "checksum"),
                 ]
             )
 
@@ -1047,9 +1047,9 @@ class PackageBuilderTests: XCTestCase {
             var manifest = Manifest.createV4Manifest(
                 name: "pkg",
                 targets: [
-                    TargetDescription(name: "pkg1", dependencies: ["pkg2"]),
-                    TargetDescription(name: "pkg2", dependencies: ["pkg3"]),
-                    TargetDescription(name: "pkg3", dependencies: ["pkg1"]),
+                    try TargetDescription(name: "pkg1", dependencies: ["pkg2"]),
+                    try TargetDescription(name: "pkg2", dependencies: ["pkg3"]),
+                    try TargetDescription(name: "pkg3", dependencies: ["pkg1"]),
                 ]
             )
             PackageBuilderTester(manifest, in: fs) { _, diagnostics in
@@ -1059,9 +1059,9 @@ class PackageBuilderTests: XCTestCase {
             manifest = Manifest.createV4Manifest(
                 name: "pkg",
                 targets: [
-                    TargetDescription(name: "pkg1", dependencies: ["pkg2"]),
-                    TargetDescription(name: "pkg2", dependencies: ["pkg3"]),
-                    TargetDescription(name: "pkg3", dependencies: ["pkg2"]),
+                    try TargetDescription(name: "pkg1", dependencies: ["pkg2"]),
+                    try TargetDescription(name: "pkg2", dependencies: ["pkg3"]),
+                    try TargetDescription(name: "pkg3", dependencies: ["pkg2"]),
                 ]
             )
             PackageBuilderTester(manifest, in: fs) { _, diagnostics in
@@ -1078,8 +1078,8 @@ class PackageBuilderTests: XCTestCase {
             let manifest = Manifest.createV4Manifest(
                 name: "pkg",
                 targets: [
-                    TargetDescription(name: "pkg1", dependencies: ["pkg2"]),
-                    TargetDescription(name: "pkg2"),
+                    try TargetDescription(name: "pkg1", dependencies: ["pkg2"]),
+                    try TargetDescription(name: "pkg2"),
                 ]
             )
             PackageBuilderTester(manifest, in: fs) { package, diagnostics in
@@ -1099,7 +1099,7 @@ class PackageBuilderTests: XCTestCase {
             var manifest = Manifest.createV4Manifest(
                 name: "Foo",
                 targets: [
-                    TargetDescription(name: "Foo", publicHeadersPath: "../inc"),
+                    try TargetDescription(name: "Foo", publicHeadersPath: "../inc"),
                 ]
             )
 
@@ -1110,7 +1110,7 @@ class PackageBuilderTests: XCTestCase {
             manifest = Manifest.createV4Manifest(
                 name: "Foo",
                 targets: [
-                    TargetDescription(name: "Bar", publicHeadersPath: "inc/../../../foo"),
+                    try TargetDescription(name: "Bar", publicHeadersPath: "inc/../../../foo"),
                 ]
             )
             PackageBuilderTester(manifest, in: fs) { _, diagnostics in
@@ -1126,7 +1126,7 @@ class PackageBuilderTests: XCTestCase {
             let manifest = Manifest.createV4Manifest(
                 name: "Foo",
                 targets: [
-                    TargetDescription(name: "Foo", path: "../foo"),
+                    try TargetDescription(name: "Foo", path: "../foo"),
                 ]
             )
             PackageBuilderTester(manifest, path: AbsolutePath("/pkg"), in: fs) { _, diagnostics in
@@ -1141,7 +1141,7 @@ class PackageBuilderTests: XCTestCase {
             let manifest = Manifest.createV4Manifest(
                 name: "Foo",
                 targets: [
-                    TargetDescription(name: "Foo", path: "/foo"),
+                    try TargetDescription(name: "Foo", path: "/foo"),
                 ]
             )
             PackageBuilderTester(manifest, path: AbsolutePath("/pkg"), in: fs) { _, diagnostics in
@@ -1157,7 +1157,7 @@ class PackageBuilderTests: XCTestCase {
             let manifest = Manifest.createV4Manifest(
                 name: "Foo",
                 targets: [
-                    TargetDescription(name: "Foo", path: "~/foo"),
+                    try TargetDescription(name: "Foo", path: "~/foo"),
                 ]
             )
             PackageBuilderTester(manifest, path: AbsolutePath("/pkg"), in: fs) { _, diagnostics in
@@ -1166,7 +1166,7 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testExecutableAsADep() {
+    func testExecutableAsADep() throws {
         // Executable as dependency.
         let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/exec/main.swift",
@@ -1175,8 +1175,8 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createV4Manifest(
             name: "pkg",
             targets: [
-                TargetDescription(name: "lib", dependencies: ["exec"]),
-                TargetDescription(name: "exec"),
+                try TargetDescription(name: "lib", dependencies: ["exec"]),
+                try TargetDescription(name: "exec"),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
@@ -1244,17 +1244,17 @@ class PackageBuilderTests: XCTestCase {
             "/foo/main.swift"
         )
 
-        func createManifest(swiftVersions: [SwiftLanguageVersion]?) -> Manifest {
+        func createManifest(swiftVersions: [SwiftLanguageVersion]?) throws -> Manifest {
             return Manifest.createV4Manifest(
                 name: "pkg",
                 swiftLanguageVersions: swiftVersions,
                 targets: [
-                    TargetDescription(name: "foo", path: "foo"),
+                    try TargetDescription(name: "foo", path: "foo"),
                 ]
             )
         }
 
-        var manifest = createManifest(swiftVersions: [.v3, .v4])
+        var manifest = try createManifest(swiftVersions: [.v3, .v4])
 
         PackageBuilderTester(manifest, in: fs) { package, _ in
             package.checkModule("foo") { module in
@@ -1263,7 +1263,7 @@ class PackageBuilderTests: XCTestCase {
             package.checkProduct("foo") { _ in }
         }
 
-        manifest = createManifest(swiftVersions: [.v3])
+        manifest = try createManifest(swiftVersions: [.v3])
         PackageBuilderTester(manifest, in: fs) { package, _ in
             package.checkModule("foo") { module in
                 module.check(swiftVersion: "3")
@@ -1271,7 +1271,7 @@ class PackageBuilderTests: XCTestCase {
             package.checkProduct("foo") { _ in }
         }
 
-        manifest = createManifest(swiftVersions: [.v4])
+        manifest = try createManifest(swiftVersions: [.v4])
         PackageBuilderTester(manifest, in: fs) { package, _ in
             package.checkModule("foo") { module in
                 module.check(swiftVersion: "4")
@@ -1279,7 +1279,7 @@ class PackageBuilderTests: XCTestCase {
             package.checkProduct("foo") { _ in }
         }
 
-        manifest = createManifest(swiftVersions: nil)
+        manifest = try createManifest(swiftVersions: nil)
         PackageBuilderTester(manifest, in: fs) { package, _ in
             package.checkModule("foo") { module in
                 module.check(swiftVersion: "4")
@@ -1287,19 +1287,19 @@ class PackageBuilderTests: XCTestCase {
             package.checkProduct("foo") { _ in }
         }
 
-        manifest = createManifest(swiftVersions: [])
+        manifest = try createManifest(swiftVersions: [])
         PackageBuilderTester(manifest, in: fs) { _, diagnostics in
             diagnostics.check(diagnostic: "package 'pkg' supported Swift language versions is empty", behavior: .error)
         }
 
-        manifest = createManifest(
+        manifest = try createManifest(
             swiftVersions: [SwiftLanguageVersion(string: "6")!, SwiftLanguageVersion(string: "7")!])
         PackageBuilderTester(manifest, in: fs) { _, diagnostics in
             diagnostics.check(diagnostic: "package 'pkg' requires minimum Swift language version 6 which is not supported by the current tools version (\(ToolsVersion.currentToolsVersion))", behavior: .error)
         }
     }
 
-    func testPredefinedTargetSearchError() {
+    func testPredefinedTargetSearchError() throws {
 
         do {
             // We should look only in one of the predefined search paths.
@@ -1310,8 +1310,8 @@ class PackageBuilderTests: XCTestCase {
             let manifest = Manifest.createV4Manifest(
                 name: "pkg",
                 targets: [
-                    TargetDescription(name: "Foo", dependencies: ["Bar"]),
-                    TargetDescription(name: "Bar"),
+                    try TargetDescription(name: "Foo", dependencies: ["Bar"]),
+                    try TargetDescription(name: "Bar"),
                 ]
             )
 
@@ -1330,8 +1330,8 @@ class PackageBuilderTests: XCTestCase {
             var manifest = Manifest.createV4Manifest(
                 name: "pkg",
                 targets: [
-                    TargetDescription(name: "BarTests", type: .test),
-                    TargetDescription(name: "FooTests", type: .test),
+                    try TargetDescription(name: "BarTests", type: .test),
+                    try TargetDescription(name: "FooTests", type: .test),
                 ]
             )
             PackageBuilderTester(manifest, in: fs) { _, diagnostics in
@@ -1342,8 +1342,8 @@ class PackageBuilderTests: XCTestCase {
             manifest = Manifest.createV4Manifest(
                 name: "pkg",
                 targets: [
-                    TargetDescription(name: "BarTests", path: "Source/BarTests", type: .test),
-                    TargetDescription(name: "FooTests", type: .test),
+                    try TargetDescription(name: "BarTests", path: "Source/BarTests", type: .test),
+                    try TargetDescription(name: "FooTests", type: .test),
                 ]
             )
             PackageBuilderTester(manifest, in: fs) { package, _ in
@@ -1358,13 +1358,13 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testSpecifiedCustomPathDoesNotExist() {
+    func testSpecifiedCustomPathDoesNotExist() throws {
         let fs = InMemoryFileSystem(emptyFiles: "/Foo.swift")
 
         let manifest = Manifest.createV4Manifest(
             name: "Foo",
             targets: [
-                TargetDescription(name: "Foo", path: "./NotExist")
+                try TargetDescription(name: "Foo", path: "./NotExist")
             ]
         )
 
@@ -1373,7 +1373,7 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testSpecialTargetDir() {
+    func testSpecialTargetDir() throws {
         // Special directory should be src because both target and test target are under it.
         let fs = InMemoryFileSystem(emptyFiles:
             "/src/A/Foo.swift",
@@ -1382,8 +1382,8 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createV4Manifest(
             name: "Foo",
             targets: [
-                TargetDescription(name: "A"),
-                TargetDescription(name: "ATests", type: .test),
+                try TargetDescription(name: "A"),
+                try TargetDescription(name: "ATests", type: .test),
             ]
         )
 
@@ -1401,7 +1401,7 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testExcludes() {
+    func testExcludes() throws {
         // The exclude should win if a file is in exclude as well as sources.
         let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/bar/barExcluded.swift",
@@ -1411,7 +1411,7 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createV4Manifest(
             name: "pkg",
             targets: [
-                TargetDescription(
+                try TargetDescription(
                     name: "bar",
                     exclude: ["barExcluded.swift",],
                     sources: ["bar.swift", "barExcluded.swift"]
@@ -1426,7 +1426,7 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testDuplicateProducts() {
+    func testDuplicateProducts() throws {
         // Check that declaring executable product doesn't collide with the
         // inferred products.
         let fs = InMemoryFileSystem(emptyFiles:
@@ -1442,7 +1442,7 @@ class PackageBuilderTests: XCTestCase {
                 ProductDescription(name: "foo-dy", type: .library(.dynamic), targets: ["foo"]),
             ],
             targets: [
-                TargetDescription(name: "foo"),
+                try TargetDescription(name: "foo"),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, diagnostics in
@@ -1464,7 +1464,7 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testSystemPackageDeclaresTargetsDiagnostic() {
+    func testSystemPackageDeclaresTargetsDiagnostic() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/module.modulemap",
             "/Sources/foo/main.swift",
@@ -1474,8 +1474,8 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createV4Manifest(
             name: "SystemModulePackage",
             targets: [
-                TargetDescription(name: "foo"),
-                TargetDescription(name: "bar"),
+                try TargetDescription(name: "foo"),
+                try TargetDescription(name: "bar"),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, diagnostics in
@@ -1490,7 +1490,7 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testSystemLibraryTarget() {
+    func testSystemLibraryTarget() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/foo/module.modulemap",
             "/Sources/bar/bar.swift"
@@ -1502,8 +1502,8 @@ class PackageBuilderTests: XCTestCase {
                 ProductDescription(name: "foo", type: .library(.automatic), targets: ["foo"]),
             ],
             targets: [
-                TargetDescription(name: "foo", type: .system),
-                TargetDescription(name: "bar", dependencies: ["foo"]),
+                try TargetDescription(name: "foo", type: .system),
+                try TargetDescription(name: "bar", dependencies: ["foo"]),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, _ in
@@ -1522,7 +1522,7 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testSystemLibraryTargetDiagnostics() {
+    func testSystemLibraryTargetDiagnostics() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/foo/module.modulemap",
             "/Sources/bar/bar.swift"
@@ -1534,8 +1534,8 @@ class PackageBuilderTests: XCTestCase {
                 ProductDescription(name: "foo", type: .library(.automatic), targets: ["foo", "bar"]),
             ],
             targets: [
-                TargetDescription(name: "foo", type: .system),
-                TargetDescription(name: "bar", dependencies: ["foo"]),
+                try TargetDescription(name: "foo", type: .system),
+                try TargetDescription(name: "bar", dependencies: ["foo"]),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, diagnostics in
@@ -1553,8 +1553,8 @@ class PackageBuilderTests: XCTestCase {
                 ProductDescription(name: "foo", type: .library(.static), targets: ["foo"]),
             ],
             targets: [
-                TargetDescription(name: "foo", type: .system),
-                TargetDescription(name: "bar", dependencies: ["foo"]),
+                try TargetDescription(name: "foo", type: .system),
+                try TargetDescription(name: "bar", dependencies: ["foo"]),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, diagnostics in
@@ -1572,7 +1572,7 @@ class PackageBuilderTests: XCTestCase {
                 ProductDescription(name: "bar", type: .library(.automatic), targets: ["bar"])
             ],
             targets: [
-                TargetDescription(name: "bar", type: .system)
+                try TargetDescription(name: "bar", type: .system)
             ]
         )
         PackageBuilderTester(manifest, in: fs) { _, diagnostics in
@@ -1583,7 +1583,7 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testBadExecutableProductDecl() {
+    func testBadExecutableProductDecl() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/foo1/main.swift",
             "/Sources/foo2/main.swift",
@@ -1599,10 +1599,10 @@ class PackageBuilderTests: XCTestCase {
                 ProductDescription(name: "foo3", type: .executable, targets: ["foo1", "foo2"]),
             ],
             targets: [
-                TargetDescription(name: "foo1"),
-                TargetDescription(name: "foo2"),
-                TargetDescription(name: "FooLib1"),
-                TargetDescription(name: "FooLib2"),
+                try TargetDescription(name: "foo1"),
+                try TargetDescription(name: "foo2"),
+                try TargetDescription(name: "FooLib1"),
+                try TargetDescription(name: "FooLib2"),
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, diagnostics in
@@ -1631,7 +1631,7 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testBadREPLPackage() {
+    func testBadREPLPackage() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/exe/main.swift"
         )
@@ -1639,7 +1639,7 @@ class PackageBuilderTests: XCTestCase {
         let manifest = Manifest.createV4Manifest(
             name: "Pkg",
             targets: [
-                TargetDescription(name: "exe"),
+                try TargetDescription(name: "exe"),
             ]
         )
 
@@ -1653,7 +1653,7 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testPlatforms() {
+    func testPlatforms() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/foo/module.modulemap",
             "/Sources/bar/bar.swift",
@@ -1670,10 +1670,10 @@ class PackageBuilderTests: XCTestCase {
             ],
             v: .v5,
             targets: [
-                TargetDescription(name: "foo", type: .system),
-                TargetDescription(name: "cbar"),
-                TargetDescription(name: "bar", dependencies: ["foo"]),
-                TargetDescription(name: "test", type: .test)
+                try TargetDescription(name: "foo", type: .system),
+                try TargetDescription(name: "cbar"),
+                try TargetDescription(name: "bar", dependencies: ["foo"]),
+                try TargetDescription(name: "test", type: .test)
             ]
         )
 
@@ -1727,9 +1727,9 @@ class PackageBuilderTests: XCTestCase {
             ],
             v: .v5,
             targets: [
-                TargetDescription(name: "foo", type: .system),
-                TargetDescription(name: "cbar"),
-                TargetDescription(name: "bar", dependencies: ["foo"]),
+                try TargetDescription(name: "foo", type: .system),
+                try TargetDescription(name: "cbar"),
+                try TargetDescription(name: "bar", dependencies: ["foo"]),
             ]
         )
 
@@ -1770,7 +1770,7 @@ class PackageBuilderTests: XCTestCase {
             name: "pkg",
             v: .v4_2,
             targets: [
-                TargetDescription(name: "lib", dependencies: []),
+                try TargetDescription(name: "lib", dependencies: []),
             ]
         )
 
@@ -1794,7 +1794,7 @@ class PackageBuilderTests: XCTestCase {
             name: "Pkg",
             v: .v5,
             targets: [
-                TargetDescription(name: "lib", dependencies: []),
+                try TargetDescription(name: "lib", dependencies: []),
             ]
         )
         XCTAssertNoDiagnostics(diagnostics)
@@ -1818,7 +1818,7 @@ class PackageBuilderTests: XCTestCase {
             name: "pkg",
             v: .v5_2,
             targets: [
-                TargetDescription(name: "lib", dependencies: [], path: "./Sources/lib", sources: ["."]),
+                try TargetDescription(name: "lib", dependencies: [], path: "./Sources/lib", sources: ["."]),
             ]
         )
 
@@ -1843,7 +1843,7 @@ class PackageBuilderTests: XCTestCase {
             name: "pkg",
             v: .v5_3,
             targets: [
-                TargetDescription(name: "lib", dependencies: [], path: "./Sources/lib", sources: ["."]),
+                try TargetDescription(name: "lib", dependencies: [], path: "./Sources/lib", sources: ["."]),
             ]
         )
 
@@ -1856,7 +1856,7 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testBuildSettings() {
+    func testBuildSettings() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/exe/main.swift",
             "/Sources/bar/bar.swift",
@@ -1869,7 +1869,7 @@ class PackageBuilderTests: XCTestCase {
             name: "pkg",
             v: .v5,
             targets: [
-                TargetDescription(
+                try TargetDescription(
                     name: "cbar",
                     settings: [
                         .init(tool: .c, name: .headerSearchPath, value: ["Sources/headers"]),
@@ -1883,7 +1883,7 @@ class PackageBuilderTests: XCTestCase {
                         .init(tool: .cxx, name: .unsafeFlags, value: ["-Icxxfoo", "-L", "cxxbar"]),
                     ]
                 ),
-                TargetDescription(
+                try TargetDescription(
                     name: "bar", dependencies: ["foo"],
                     settings: [
                         .init(tool: .swift, name: .define, value: ["SOMETHING"]),
@@ -1893,7 +1893,7 @@ class PackageBuilderTests: XCTestCase {
                         .init(tool: .swift, name: .unsafeFlags, value: ["-Isfoo", "-L", "sbar"]),
                     ]
                 ),
-                TargetDescription(
+                try TargetDescription(
                     name: "exe", dependencies: ["bar"],
                     settings: [
                         .init(tool: .linker, name: .linkedLibrary, value: ["sqlite3"]),
@@ -1968,7 +1968,7 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testInvalidHeaderSearchPath() {
+    func testInvalidHeaderSearchPath() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/pkg/Sources/exe/main.swift"
         )
@@ -1977,7 +1977,7 @@ class PackageBuilderTests: XCTestCase {
             name: "pkg",
             v: .v5,
             targets: [
-                TargetDescription(
+                try TargetDescription(
                     name: "exe",
                     settings: [
                         .init(tool: .c, name: .headerSearchPath, value: ["/Sources/headers"]),
@@ -1994,7 +1994,7 @@ class PackageBuilderTests: XCTestCase {
             name: "pkg",
             v: .v5,
             targets: [
-                TargetDescription(
+                try TargetDescription(
                     name: "exe",
                     settings: [
                         .init(tool: .c, name: .headerSearchPath, value: ["../../.."]),
@@ -2022,7 +2022,7 @@ class PackageBuilderTests: XCTestCase {
                 PackageDependencyDescription(url: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
             ],
             targets: [
-                TargetDescription(
+                try TargetDescription(
                     name: "Foo",
                     dependencies: [
                         "Bar",
@@ -2030,7 +2030,7 @@ class PackageBuilderTests: XCTestCase {
                         "Foo2",
                         "Foo2",
                     ]),
-                TargetDescription(name: "Foo2"),
+                try TargetDescription(name: "Foo2"),
             ]
         )
 
@@ -2042,7 +2042,7 @@ class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testConditionalDependencies() {
+    func testConditionalDependencies() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/Foo/main.swift",
             "/Sources/Bar/bar.swift",
@@ -2056,7 +2056,7 @@ class PackageBuilderTests: XCTestCase {
                 PackageDependencyDescription(url: "/Biz", requirement: .localPackage),
             ],
             targets: [
-                TargetDescription(
+                try TargetDescription(
                     name: "Foo",
                     dependencies: [
                         .target(name: "Bar", condition: PackageConditionDescription(
@@ -2073,8 +2073,8 @@ class PackageBuilderTests: XCTestCase {
                         )),
                     ]
                 ),
-                TargetDescription(name: "Bar"),
-                TargetDescription(name: "Baz"),
+                try TargetDescription(name: "Bar"),
+                try TargetDescription(name: "Baz"),
             ]
         )
 
@@ -2117,7 +2117,7 @@ class PackageBuilderTests: XCTestCase {
             name: "Foo",
             v: .v5_3,
             targets: [
-                TargetDescription(name: "Foo", resources: [
+                try TargetDescription(name: "Foo", resources: [
                     .init(rule: .process, path: "Resources")
                 ]),
             ]
@@ -2141,7 +2141,7 @@ class PackageBuilderTests: XCTestCase {
             name: "Foo",
             v: .v5_3,
             targets: [
-                TargetDescription(name: "Foo"),
+                try TargetDescription(name: "Foo"),
             ]
         )
 

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -17,7 +17,7 @@ import PackageLoading
 
 class TargetSourcesBuilderTests: XCTestCase {
     func testBasicFileContentsComputation() throws {
-        let target = TargetDescription(
+        let target = try TargetDescription(
             name: "Foo",
             path: nil,
             exclude: ["some2"],
@@ -72,7 +72,7 @@ class TargetSourcesBuilderTests: XCTestCase {
     }
 
     func testDirectoryWithExt() throws {
-        let target = TargetDescription(
+        let target = try TargetDescription(
             name: "Foo",
             path: nil,
             exclude: ["some2"],
@@ -110,7 +110,7 @@ class TargetSourcesBuilderTests: XCTestCase {
     }
 
     func testBasicRuleApplication() throws {
-        let target = TargetDescription(
+        let target = try TargetDescription(
             name: "Foo",
             path: nil,
             exclude: ["some2"],
@@ -152,7 +152,7 @@ class TargetSourcesBuilderTests: XCTestCase {
         // Conflict between processed resources.
 
         do {
-            let target = TargetDescription(name: "Foo", resources: [
+            let target = try TargetDescription(name: "Foo", resources: [
                 .init(rule: .process, path: "Resources")
             ])
 
@@ -171,7 +171,7 @@ class TargetSourcesBuilderTests: XCTestCase {
         // Conflict between processed and copied resources.
 
         do {
-            let target = TargetDescription(name: "Foo", resources: [
+            let target = try TargetDescription(name: "Foo", resources: [
                 .init(rule: .process, path: "Processed"),
                 .init(rule: .copy, path: "Copied/foo.txt"),
             ])
@@ -191,7 +191,7 @@ class TargetSourcesBuilderTests: XCTestCase {
         // No conflict between processed and copied in sub-path resources.
 
         do {
-            let target = TargetDescription(name: "Foo", resources: [
+            let target = try TargetDescription(name: "Foo", resources: [
                 .init(rule: .process, path: "Processed"),
                 .init(rule: .copy, path: "Copied"),
             ])
@@ -209,7 +209,7 @@ class TargetSourcesBuilderTests: XCTestCase {
         // Conflict between copied directory resources.
 
         do {
-            let target = TargetDescription(name: "Foo", resources: [
+            let target = try TargetDescription(name: "Foo", resources: [
                 .init(rule: .copy, path: "A/Copy"),
                 .init(rule: .copy, path: "B/Copy"),
             ])
@@ -229,7 +229,7 @@ class TargetSourcesBuilderTests: XCTestCase {
         // Conflict between processed localizations.
 
         do {
-            let target = TargetDescription(name: "Foo", resources: [
+            let target = try TargetDescription(name: "Foo", resources: [
                 .init(rule: .process, path: "A"),
                 .init(rule: .process, path: "B"),
             ])
@@ -249,7 +249,7 @@ class TargetSourcesBuilderTests: XCTestCase {
         // Conflict between processed localizations and copied resources.
 
         do {
-            let target = TargetDescription(name: "Foo", resources: [
+            let target = try TargetDescription(name: "Foo", resources: [
                 .init(rule: .process, path: "A"),
                 .init(rule: .copy, path: "B/en.lproj"),
             ])
@@ -265,8 +265,8 @@ class TargetSourcesBuilderTests: XCTestCase {
         }
     }
 
-    func testLocalizationDirectoryIgnoredOn5_2() {
-        let target = TargetDescription(name: "Foo")
+    func testLocalizationDirectoryIgnoredOn5_2() throws {
+        let target = try TargetDescription(name: "Foo")
 
         let fs = InMemoryFileSystem(emptyFiles:
             "/en.lproj/Localizable.strings"
@@ -278,8 +278,8 @@ class TargetSourcesBuilderTests: XCTestCase {
         }
     }
 
-    func testLocalizationDirectorySubDirectory() {
-        let target = TargetDescription(name: "Foo", resources: [
+    func testLocalizationDirectorySubDirectory() throws {
+        let target = try TargetDescription(name: "Foo", resources: [
             .init(rule: .process, path: "Processed"),
             .init(rule: .copy, path: "Copied")
         ])
@@ -294,8 +294,8 @@ class TargetSourcesBuilderTests: XCTestCase {
         }
     }
 
-    func testExplicitLocalizationInLocalizationDirectory() {
-        let target = TargetDescription(name: "Foo", resources: [
+    func testExplicitLocalizationInLocalizationDirectory() throws {
+        let target = try TargetDescription(name: "Foo", resources: [
             .init(rule: .process, path: "Resources", localization: .base),
         ])
 
@@ -313,8 +313,8 @@ class TargetSourcesBuilderTests: XCTestCase {
         }
     }
 
-    func testMissingDefaultLocalization() {
-        let target = TargetDescription(name: "Foo", resources: [
+    func testMissingDefaultLocalization() throws {
+        let target = try TargetDescription(name: "Foo", resources: [
             .init(rule: .process, path: "Resources"),
             .init(rule: .process, path: "Image.png", localization: .default),
             .init(rule: .process, path: "Icon.png", localization: .base),
@@ -337,8 +337,8 @@ class TargetSourcesBuilderTests: XCTestCase {
         }
     }
 
-    func testLocalizedAndUnlocalizedResources() {
-        let target = TargetDescription(name: "Foo", resources: [
+    func testLocalizedAndUnlocalizedResources() throws {
+        let target = try TargetDescription(name: "Foo", resources: [
             .init(rule: .process, path: "Resources"),
             .init(rule: .process, path: "Image.png", localization: .default),
             .init(rule: .process, path: "Icon.png", localization: .base),
@@ -371,8 +371,8 @@ class TargetSourcesBuilderTests: XCTestCase {
         }
     }
 
-    func testLocalizedResources() {
-        let target = TargetDescription(name: "Foo", resources: [
+    func testLocalizedResources() throws {
+        let target = try TargetDescription(name: "Foo", resources: [
             .init(rule: .process, path: "Processed"),
             .init(rule: .copy, path: "Copied"),
             .init(rule: .process, path: "Other/Launch.storyboard", localization: .base),
@@ -406,13 +406,13 @@ class TargetSourcesBuilderTests: XCTestCase {
         }
     }
 
-    func testLocalizedImage() {
+    func testLocalizedImage() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Foo/fr.lproj/Image.png",
             "/Foo/es.lproj/Image.png"
         )
 
-        build(target: TargetDescription(name: "Foo"), defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, resources, _, diagnostics in
+        build(target: try TargetDescription(name: "Foo"), defaultLocalization: "fr", toolsVersion: .v5_3, fs: fs) { _, resources, _, diagnostics in
             XCTAssertEqual(Set(resources), [
                 Resource(rule: .process, path: AbsolutePath("/Foo/fr.lproj/Image.png"), localization: "fr"),
                 Resource(rule: .process, path: AbsolutePath("/Foo/es.lproj/Image.png"), localization: "es"),
@@ -420,9 +420,9 @@ class TargetSourcesBuilderTests: XCTestCase {
         }
     }
 
-    func testInfoPlistResource() {
+    func testInfoPlistResource() throws {
         do {
-            let target = TargetDescription(name: "Foo", resources: [
+            let target = try TargetDescription(name: "Foo", resources: [
                 .init(rule: .process, path: "Resources"),
             ])
 
@@ -438,7 +438,7 @@ class TargetSourcesBuilderTests: XCTestCase {
         }
 
         do {
-            let target = TargetDescription(name: "Foo", resources: [
+            let target = try TargetDescription(name: "Foo", resources: [
                 .init(rule: .copy, path: "Resources/Copied/Info.plist"),
             ])
 

--- a/Tests/PackageModelTests/ManifestTests.swift
+++ b/Tests/PackageModelTests/ManifestTests.swift
@@ -20,10 +20,10 @@ class ManifestTests: XCTestCase {
         ]
 
         let targets = [
-            TargetDescription(name: "Foo", dependencies: ["Bar"]),
-            TargetDescription(name: "Bar", dependencies: ["Baz"]),
-            TargetDescription(name: "Baz", dependencies: []),
-            TargetDescription(name: "FooBar", dependencies: []),
+            try TargetDescription(name: "Foo", dependencies: ["Bar"]),
+            try TargetDescription(name: "Bar", dependencies: ["Baz"]),
+            try TargetDescription(name: "Baz", dependencies: []),
+            try TargetDescription(name: "FooBar", dependencies: []),
         ]
 
         do {
@@ -78,9 +78,9 @@ class ManifestTests: XCTestCase {
         ]
 
         let targets = [
-            TargetDescription(name: "Foo1", dependencies: ["Foo2", "Bar1"]),
-            TargetDescription(name: "Foo2", dependencies: [.product(name: "B2", package: "Bar2")]),
-            TargetDescription(name: "Foo3", dependencies: ["Bar3"]),
+            try TargetDescription(name: "Foo1", dependencies: ["Foo2", "Bar1"]),
+            try TargetDescription(name: "Foo2", dependencies: [.product(name: "B2", package: "Bar2")]),
+            try TargetDescription(name: "Foo3", dependencies: ["Bar3"]),
         ]
 
         do {


### PR DESCRIPTION
This converts various `preconditions` in `TargetDescription` into errors, since these can actually be hit by users writing manifests in disallowed ways.

I think ideally we would find to change the manifest API so that getting into these kind of illegal states wouldn't even be possible, but at least this turns them into runtime errors instead of crashes.

rdar://70682458
