### PR TITLE
Collections hosted as GitHub gist sometimes fail with missing 'Content-Length' header

### DIFF
--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -23,7 +23,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
     func testBaseURL() throws {
         let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")
         let provider = GitHubPackageMetadataProvider()
-        
+
         do {
             let sshURLRetVal = provider.apiURL("git@github.com:octocat/Hello-World.git")
             XCTAssertEqual(apiURL, sshURLRetVal)
@@ -33,7 +33,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
             let httpsURLRetVal = provider.apiURL("https://github.com/octocat/Hello-World.git")
             XCTAssertEqual(apiURL, httpsURLRetVal)
         }
-        
+
         do {
             let httpsURLRetVal = provider.apiURL("https://github.com/octocat/Hello-World")
             XCTAssertEqual(apiURL, httpsURLRetVal)

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionModelTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionModelTests.swift
@@ -54,7 +54,7 @@ class JSONPackageCollectionModelTests: XCTestCase {
         let decoded = try JSONDecoder().decode(Model.Collection.self, from: data)
         XCTAssertEqual(collection, decoded)
     }
-    
+
     func test_validationOK() throws {
         let packages = [
             Model.Collection.Package(
@@ -91,7 +91,7 @@ class JSONPackageCollectionModelTests: XCTestCase {
         let validator = Model.Validator()
         XCTAssertNil(validator.validate(collection: collection))
     }
-    
+
     func test_validationFailed_noPackages() throws {
         let collection = Model.Collection(
             name: "Test Package Collection",
@@ -107,13 +107,13 @@ class JSONPackageCollectionModelTests: XCTestCase {
         let validator = Model.Validator()
         let messages = validator.validate(collection: collection)!
         XCTAssertEqual(1, messages.count)
-        
+
         guard case .error = messages[0].level else {
             return XCTFail("Expected .error")
         }
         XCTAssertTrue(messages[0].message.contains("contain at least one package"))
     }
-    
+
     func test_validationFailed_tooManyPackages() throws {
         let packages = [
             Model.Collection.Package(
@@ -169,13 +169,13 @@ class JSONPackageCollectionModelTests: XCTestCase {
         let validator = Model.Validator(configuration: .init(maximumPackageCount: 1))
         let messages = validator.validate(collection: collection)!
         XCTAssertEqual(1, messages.count)
-        
+
         guard case .warning = messages[0].level else {
             return XCTFail("Expected .warning")
         }
         XCTAssertNotNil(messages[0].message.range(of: "more than the recommended", options: .caseInsensitive))
     }
-    
+
     func test_validationFailed_duplicateVersions_emptyProductsAndTargets() throws {
         let packages = [
             Model.Collection.Package(
@@ -222,23 +222,23 @@ class JSONPackageCollectionModelTests: XCTestCase {
         let validator = Model.Validator()
         let messages = validator.validate(collection: collection)!
         XCTAssertEqual(3, messages.count)
-        
+
         guard case .error = messages[0].level else {
             return XCTFail("Expected .error")
         }
         XCTAssertNotNil(messages[0].message.range(of: "duplicate version(s)", options: .caseInsensitive))
-        
+
         guard case .error = messages[1].level else {
             return XCTFail("Expected .error")
         }
         XCTAssertNotNil(messages[1].message.range(of: "does not contain any products", options: .caseInsensitive))
-        
+
         guard case .error = messages[2].level else {
             return XCTFail("Expected .error")
         }
         XCTAssertNotNil(messages[2].message.range(of: "does not contain any targets", options: .caseInsensitive))
     }
-    
+
     func test_validationFailed_nonSemanticVersion() throws {
         let packages = [
             Model.Collection.Package(
@@ -259,7 +259,7 @@ class JSONPackageCollectionModelTests: XCTestCase {
                 ],
                 readmeURL: nil,
                 license: nil
-            )
+            ),
         ]
         let collection = Model.Collection(
             name: "Test Package Collection",
@@ -275,13 +275,13 @@ class JSONPackageCollectionModelTests: XCTestCase {
         let validator = Model.Validator()
         let messages = validator.validate(collection: collection)!
         XCTAssertEqual(1, messages.count)
-        
+
         guard case .error = messages[0].level else {
             return XCTFail("Expected .error")
         }
         XCTAssertNotNil(messages[0].message.range(of: "non semantic version(s)", options: .caseInsensitive))
     }
-    
+
     func test_validationFailed_tooManyMajorsAndMinors() throws {
         let packages = [
             Model.Collection.Package(
@@ -357,18 +357,18 @@ class JSONPackageCollectionModelTests: XCTestCase {
         let validator = Model.Validator(configuration: .init(maximumMajorVersionCount: 1, maximumMinorVersionCount: 1))
         let messages = validator.validate(collection: collection)!
         XCTAssertEqual(2, messages.count)
-        
+
         guard case .warning = messages[0].level else {
             return XCTFail("Expected .warning")
         }
         XCTAssertNotNil(messages[0].message.range(of: "too many major versions", options: .caseInsensitive))
-        
+
         guard case .warning = messages[1].level else {
             return XCTFail("Expected .warning")
         }
         XCTAssertNotNil(messages[1].message.range(of: "too many minor versions", options: .caseInsensitive))
     }
-    
+
     func test_validationFailed_versionProductNoTargets() throws {
         let packages = [
             Model.Collection.Package(
@@ -389,7 +389,7 @@ class JSONPackageCollectionModelTests: XCTestCase {
                 ],
                 readmeURL: nil,
                 license: nil
-            )
+            ),
         ]
         let collection = Model.Collection(
             name: "Test Package Collection",
@@ -405,7 +405,7 @@ class JSONPackageCollectionModelTests: XCTestCase {
         let validator = Model.Validator()
         let messages = validator.validate(collection: collection)!
         XCTAssertEqual(1, messages.count)
-        
+
         guard case .error = messages[0].level else {
             return XCTFail("Expected .error")
         }

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -255,7 +255,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(request.url, url, "url should match")
             switch request.method {
             case .head:
-                callback(.success(.init(statusCode: 200)))
+                callback(.success(.init(statusCode: 200, headers: .init([.init(name: "Content-Length", value: "1")]))))
             case .get:
                 callback(.success(.init(statusCode: statusCode)))
             default:
@@ -280,7 +280,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(request.url, url, "url should match")
             switch request.method {
             case .head:
-                callback(.success(.init(statusCode: 200)))
+                callback(.success(.init(statusCode: 200, headers: .init([.init(name: "Content-Length", value: "\(data.count)")]))))
             case .get:
                 callback(.success(.init(statusCode: 200,
                                         headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),

--- a/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
@@ -40,11 +40,11 @@ final class PackageCollectionsModelTests: XCTestCase {
                 toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedCompatibility: nil, license: nil
             ),
         ]
-        
+
         XCTAssertEqual("2.1.0", versions.latestRelease?.version.description)
         XCTAssertEqual("3.0.0-beta.1", versions.latestPrerelease?.version.description)
     }
-    
+
     func testNoLatestReleaseVersion() {
         let targets = [PackageCollectionsModel.Target(name: "Foo", moduleName: "Foo")]
         let products = [PackageCollectionsModel.Product(name: "Foo", type: .library(.automatic), targets: targets)]
@@ -59,11 +59,11 @@ final class PackageCollectionsModelTests: XCTestCase {
                 toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedCompatibility: nil, license: nil
             ),
         ]
-        
+
         XCTAssertNil(versions.latestRelease)
         XCTAssertEqual("3.0.0-beta.1", versions.latestPrerelease?.version.description)
     }
-    
+
     func testNoLatestPrereleaseVersion() {
         let targets = [PackageCollectionsModel.Target(name: "Foo", moduleName: "Foo")]
         let products = [PackageCollectionsModel.Product(name: "Foo", type: .library(.automatic), targets: targets)]
@@ -82,7 +82,7 @@ final class PackageCollectionsModelTests: XCTestCase {
                 toolsVersion: toolsVersion, minimumPlatformVersions: nil, verifiedCompatibility: nil, license: nil
             ),
         ]
-        
+
         XCTAssertEqual("2.1.0", versions.latestRelease?.version.description)
         XCTAssertNil(versions.latestPrerelease)
     }

--- a/Tests/PackageCollectionsTests/ValidationMessageTests.swift
+++ b/Tests/PackageCollectionsTests/ValidationMessageTests.swift
@@ -18,13 +18,13 @@ class ValidationMessageTests: XCTestCase {
         let warning = ValidationMessage.warning("warning")
         let errorWithProperty = ValidationMessage.error("error with property", property: "bar")
         let error = ValidationMessage.error("error")
-        
+
         let messages = [warningWithProperty, errorWithProperty, warning, error]
-        
+
         do {
             let errors = messages.errors(include: [.warning])!
             XCTAssertEqual(2, errors.count)
-            
+
             guard case .property(_, let m0) = errors[0], m0 == warningWithProperty.message else {
                 return XCTFail("Expected .property error")
             }
@@ -32,11 +32,11 @@ class ValidationMessageTests: XCTestCase {
                 return XCTFail("Expected .other error")
             }
         }
-        
+
         do {
             let errors = messages.errors(include: [.error])!
             XCTAssertEqual(2, errors.count)
-            
+
             guard case .property(_, let m0) = errors[0], m0 == errorWithProperty.message else {
                 return XCTFail("Expected .property error")
             }
@@ -44,7 +44,7 @@ class ValidationMessageTests: XCTestCase {
                 return XCTFail("Expected .other error")
             }
         }
-        
+
         do {
             let errors = messages.errors(include: [.warning, .error])!
             XCTAssertEqual(4, errors.count)


### PR DESCRIPTION
Motivation:
Some package collections fail to get imported because download response doesn't contain the `Content-Length` header.

Modifications:
The response headers for failed requests contain `Transfer-Encoding` header. If the request includes `Accept-Encoding` header then there will be `Content-Type` header in the response and no `Transfer-Encoding`.

Result:
Can import collections hosted as gists.
