### PR TITLE
Cannot import local package collections

### DIFF
--- a/Sources/PackageCollections/Model/Collection.swift
+++ b/Sources/PackageCollections/Model/Collection.swift
@@ -87,25 +87,24 @@ extension PackageCollectionsModel {
         /// URL of the source file
         public let url: URL
 
+        /// The source's absolute file system path, if its URL is of 'file' scheme.
+        let absolutePath: AbsolutePath?
+
         public init(type: CollectionSourceType, url: URL) {
             self.type = type
             self.url = url
+
+            if url.scheme?.lowercased() == "file", let absolutePath = try? AbsolutePath(validating: url.path) {
+                self.absolutePath = absolutePath
+            } else {
+                self.absolutePath = nil
+            }
         }
     }
 
     /// Represents the source type of a `Collection`
     public enum CollectionSourceType: String, Codable, CaseIterable {
         case json
-    }
-}
-
-extension PackageCollectionsModel.CollectionSource {
-    /// Returns the source's absolute file system path, if its URL is of 'file' scheme.
-    var absolutePath: AbsolutePath? {
-        guard self.url.scheme?.lowercased() == "file" else {
-            return nil
-        }
-        return try? AbsolutePath(validating: self.url.path)
     }
 }
 

--- a/Sources/PackageCollections/Model/Collection.swift
+++ b/Sources/PackageCollections/Model/Collection.swift
@@ -13,6 +13,7 @@ import struct Foundation.URL
 
 import PackageModel
 import SourceControl
+import TSCBasic
 import TSCUtility
 
 public enum PackageCollectionsModel {}
@@ -95,6 +96,16 @@ extension PackageCollectionsModel {
     /// Represents the source type of a `Collection`
     public enum CollectionSourceType: String, Codable, CaseIterable {
         case json
+    }
+}
+
+extension PackageCollectionsModel.CollectionSource {
+    /// Returns the source's absolute file system path, if its URL is of 'file' scheme.
+    var absolutePath: AbsolutePath? {
+        guard self.url.scheme?.lowercased() == "file" else {
+            return nil
+        }
+        return try? AbsolutePath(validating: self.url.path)
     }
 }
 

--- a/Sources/PackageCollections/PackageCollections+Validation.swift
+++ b/Sources/PackageCollections/PackageCollections+Validation.swift
@@ -26,9 +26,15 @@ extension Model.CollectionSource {
         case .json:
             let scheme = url.scheme?.lowercased() ?? ""
             if !allowedSchemes.contains(scheme) {
-                appendMessage(.error("Schema not allowed: \(url.absoluteString)"))
-            } else if scheme == "file", !localFileSystem.exists(AbsolutePath(self.url.path)) {
-                appendMessage(.error("Non-local files not allowed: \(url.absoluteString)"))
+                appendMessage(.error("Scheme (\"\(scheme)\") not allowed: \(url.absoluteString). Must be one of \(allowedSchemes)."))
+            } else if scheme == "file" {
+                let absolutePath = self.absolutePath
+
+                if absolutePath == nil {
+                    appendMessage(.error("Invalid file path: \(self.url.path). It must be an absolute file system path."))
+                } else if let absolutePath = absolutePath, !localFileSystem.exists(absolutePath) {
+                    appendMessage(.error("Non-local files not allowed: \(self.url.path)"))
+                }
             }
         }
 

--- a/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
+++ b/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
@@ -182,10 +182,10 @@ private extension Model.CollectionSource {
         guard let url = URL(string: from.value) else {
             throw SerializationError.invalidURL(from.value)
         }
-        self.url = url
+
         switch from.type {
         case StorageModel.SourceType.json.rawValue:
-            self.type = .json
+            self.init(type: .json, url: url)
         default:
             throw SerializationError.unknownType(from.type)
         }


### PR DESCRIPTION
Motivation:
Try passing a local FS path (file:///foo/bar) to the command `swift-package-collection describe`. It fails with `Error: invalidResponse`. This is because we try to fetch local file with HTTP client.

Modications:
If a collection URL points to local FS path, read the file contents instead of downloading it via HTTP GET.

Also improve error messages.

Result:
Local package collections can be imported.
