### PR TITLE
[5.4] Change 999.0 to 5.4 in package description and related tests

### DIFF
--- a/Fixtures/Miscellaneous/AtMainSupport/Package.swift
+++ b/Fixtures/Miscellaneous/AtMainSupport/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:999.0
+// swift-tools-version:5.4
 import PackageDescription
 
 let package = Package(

--- a/Sources/PackageDescription/LanguageStandardSettings.swift
+++ b/Sources/PackageDescription/LanguageStandardSettings.swift
@@ -30,15 +30,15 @@ public enum CLanguageStandard: String, Encodable {
     case c11
 
     /// ISO C 2017.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.4)
     case c17
 
     /// ISO C 2017.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.4)
     case c18
 
     /// Working Draft for ISO C2x.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.4)
     case c2x
 
     /// ISO C 1990 with GNU extensions.
@@ -54,15 +54,15 @@ public enum CLanguageStandard: String, Encodable {
     case gnu11
 
     /// ISO C 2017 with GNU extensions.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.4)
     case gnu17
 
     /// ISO C 2017 with GNU extensions.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.4)
     case gnu18
 
     /// Working Draft for ISO C2x with GNU extensions.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.4)
     case gnu2x
 
     /// ISO C 1990.
@@ -78,11 +78,11 @@ public enum CLanguageStandard: String, Encodable {
     case iso9899_2011 = "iso9899:2011"
 
     /// ISO C 2017.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.4)
     case iso9899_2017 = "iso9899:2017"
 
     /// ISO C 2017.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.4)
     case iso9899_2018 = "iso9899:2018"
 }
 
@@ -108,15 +108,15 @@ public enum CXXLanguageStandard: String, Encodable {
     case cxx14 = "c++14"
 
     /// ISO C++ 2017 with amendments.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.4)
     case cxx17 = "c++17"
 
     /// ISO C++ 2017 with amendments.
-    @available(_PackageDescription, introduced: 4, deprecated: 999.0, renamed: "cxx17")
+    @available(_PackageDescription, introduced: 4, deprecated: 5.4, renamed: "cxx17")
     case cxx1z = "c++1z"
 
     /// ISO C++ 2020 DIS.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.4)
     case cxx20 = "c++20"
 
     /// ISO C++ 1998 with amendments and GNU extensions.
@@ -132,15 +132,15 @@ public enum CXXLanguageStandard: String, Encodable {
     case gnucxx14 = "gnu++14"
 
     /// ISO C++ 2017 with amendments and GNU extensions.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.4)
     case gnucxx17 = "gnu++17"
 
     /// ISO C++ 2017 with amendments and GNU extensions.
-    @available(_PackageDescription, introduced: 4, deprecated: 999.0, renamed: "gnucxx17")
+    @available(_PackageDescription, introduced: 4, deprecated: 5.4, renamed: "gnucxx17")
     case gnucxx1z = "gnu++1z"
 
     /// ISO C++ 2020 DIS with GNU extensions.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.4)
     case gnucxx20 = "gnu++20"
 }
 

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -401,7 +401,7 @@ public final class Target {
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.4)
     public static func executableTarget(
        name: String,
        dependencies: [Dependency] = [],

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -225,7 +225,7 @@ public final class PackageBuilder {
     /// If set to true, one test product will be created for each test target.
     private let shouldCreateMultipleTestProducts: Bool
 
-    /// Temporary parameter controlling whether to warn about implicit executable targets when tools version is vNext
+    /// Temporary parameter controlling whether to warn about implicit executable targets when tools version is 5.4.
     private let warnAboutImplicitExecutableTargets: Bool
 
     /// Create the special REPL product for this package.
@@ -773,8 +773,8 @@ public final class PackageBuilder {
             targetType = .executable
         default:
             targetType = sources.computeTargetType()
-            if targetType == .executable && manifest.toolsVersion >= .vNext && warnAboutImplicitExecutableTargets {
-                diagnostics.emit(warning: "in tools version \(ToolsVersion.vNext) and later, use 'executableTarget()' to declare executable targets")
+            if targetType == .executable && manifest.toolsVersion >= .v5_4 && warnAboutImplicitExecutableTargets {
+                diagnostics.emit(warning: "in tools version \(ToolsVersion.v5_4) and later, use 'executableTarget()' to declare executable targets")
             }
         }
         

--- a/Sources/PackageModel/ToolsVersion.swift
+++ b/Sources/PackageModel/ToolsVersion.swift
@@ -22,6 +22,7 @@ public struct ToolsVersion: Equatable, Hashable, Codable {
     public static let v5 = ToolsVersion(version: "5.0.0")
     public static let v5_2 = ToolsVersion(version: "5.2.0")
     public static let v5_3 = ToolsVersion(version: "5.3.0")
+    public static let v5_4 = ToolsVersion(version: "5.4.0")
     public static let vNext = ToolsVersion(version: "999.0.0")
 
     /// The current tools version in use.

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -357,7 +357,7 @@ final class PackageToolTests: XCTestCase {
             name: "PackageA",
             path: "/PackageA",
             url: "/PackageA",
-            v: .currentToolsVersion,
+            v: .v5_3,
             packageKind: .root,
             dependencies: [
                 .init(name: "PackageB", url: "/PackageB", requirement: .localPackage),

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -482,7 +482,7 @@ class PackageBuilderTests: XCTestCase {
             ]
         )
         PackageBuilderTester(manifest, in: fs) { package, diagnostics in
-            diagnostics.check(diagnostic: "in tools version 999.0.0 and later, use 'executableTarget()' to declare executable targets", behavior: .warning)
+            diagnostics.check(diagnostic: "in tools version 5.4.0 and later, use 'executableTarget()' to declare executable targets", behavior: .warning)
             package.checkModule("lib") { _ in }
             package.checkModule("exec2") { _ in }
             package.checkProduct("exec2") { product in


### PR DESCRIPTION
This is the 5.4 cherry-pick of https://github.com/apple/swift-package-manager/pull/3193, which is a mechanical change of the placeholder "999.0" for features in future releases to be "5.4" in the release branch.

This is in addition to the similar PR https://github.com/apple/swift-package-manager/pull/3170 for tools-version-loader specific changes.

This depends on https://github.com/apple/swift-tools-support-core/pull/183 in order for SwiftPM to accept packages that have tools version 5.4.

rdar://73203278