### PR TITLE
Fix package tool unit tests that assumed that .currentVersion meant .v5_3

### DIFF
--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -357,7 +357,7 @@ final class PackageToolTests: XCTestCase {
             name: "PackageA",
             path: "/PackageA",
             url: "/PackageA",
-            v: .currentToolsVersion,
+            v: .v5_3,
             packageKind: .root,
             dependencies: [
                 .init(name: "PackageB", url: "/PackageB", requirement: .localPackage),
@@ -375,7 +375,7 @@ final class PackageToolTests: XCTestCase {
             name: "PackageB",
             path: "/PackageB",
             url: "/PackageB",
-            v: .currentToolsVersion,
+            v: .v5_3,
             packageKind: .local,
             dependencies: [
                 .init(name: "PackageC", url: "/PackageC", requirement: .localPackage),
@@ -393,7 +393,7 @@ final class PackageToolTests: XCTestCase {
             name: "PackageC",
             path: "/PackageC",
             url: "/PackageC",
-            v: .currentToolsVersion,
+            v: .v5_3,
             packageKind: .local,
             dependencies: [
                 .init(name: "PackageD", url: "/PackageD", requirement: .localPackage),
@@ -410,7 +410,7 @@ final class PackageToolTests: XCTestCase {
             name: "PackageD",
             path: "/PackageD",
             url: "/PackageD",
-            v: .currentToolsVersion,
+            v: .v5_3,
             packageKind: .local,
             products: [
                 .init(name: "PackageD", type: .library(.dynamic), targets: ["TargetD"])

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -371,7 +371,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                                   packageName: UUID().uuidString,
                                                                   targets: mockTargets,
                                                                   products: mockProducts,
-                                                                  toolsVersion: .currentToolsVersion,
+                                                                  toolsVersion: .v5_3,
                                                                   minimumPlatformVersions: nil,
                                                                   verifiedCompatibility: nil,
                                                                   license: nil)
@@ -521,7 +521,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                                   packageName: UUID().uuidString,
                                                                   targets: mockTargets,
                                                                   products: mockProducts,
-                                                                  toolsVersion: .currentToolsVersion,
+                                                                  toolsVersion: .v5_3,
                                                                   minimumPlatformVersions: nil,
                                                                   verifiedCompatibility: nil,
                                                                   license: nil)
@@ -823,7 +823,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                     packageName: "package-\(packageId)",
                                                     targets: targets,
                                                     products: products,
-                                                    toolsVersion: .currentToolsVersion,
+                                                    toolsVersion: .v5_3,
                                                     minimumPlatformVersions: [.init(platform: .macOS, version: .init("10.15"))],
                                                     verifiedCompatibility: [
                                                         .init(platform: .iOS, swiftVersion: SwiftLanguageVersion.knownSwiftLanguageVersions.randomElement()!),

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -57,7 +57,7 @@ func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: I
                                                                packageName: "package-\(packageIndex)",
                                                                targets: targets,
                                                                products: products,
-                                                               toolsVersion: .currentToolsVersion,
+                                                               toolsVersion: .v5_3,
                                                                minimumPlatformVersions: minimumPlatformVersions,
                                                                verifiedCompatibility: verifiedCompatibility,
                                                                license: license)


### PR DESCRIPTION
This caused warnings, and then the tests failed because there were diagnostics.

### Motivation:

This was caused by the ToolsSupportCore change to increment the current SwiftPM version to be 5.4.  What is odd is that the PR tests succeed, and they were supposed to have done a full test, including SwiftPM.