### PR TITLE
[5.4] Fix incorrect use of current tools version in unit tests that assume 5.3 semantics

### DIFF
--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -357,7 +357,7 @@ final class PackageToolTests: XCTestCase {
             name: "PackageA",
             path: "/PackageA",
             url: "/PackageA",
-            v: .currentToolsVersion,
+            v: .v5_3,
             packageKind: .root,
             dependencies: [
                 .init(name: "PackageB", url: "/PackageB", requirement: .localPackage),
@@ -375,7 +375,7 @@ final class PackageToolTests: XCTestCase {
             name: "PackageB",
             path: "/PackageB",
             url: "/PackageB",
-            v: .currentToolsVersion,
+            v: .v5_3,
             packageKind: .local,
             dependencies: [
                 .init(name: "PackageC", url: "/PackageC", requirement: .localPackage),
@@ -393,7 +393,7 @@ final class PackageToolTests: XCTestCase {
             name: "PackageC",
             path: "/PackageC",
             url: "/PackageC",
-            v: .currentToolsVersion,
+            v: .v5_3,
             packageKind: .local,
             dependencies: [
                 .init(name: "PackageD", url: "/PackageD", requirement: .localPackage),
@@ -410,7 +410,7 @@ final class PackageToolTests: XCTestCase {
             name: "PackageD",
             path: "/PackageD",
             url: "/PackageD",
-            v: .currentToolsVersion,
+            v: .v5_3,
             packageKind: .local,
             products: [
                 .init(name: "PackageD", type: .library(.dynamic), targets: ["TargetD"])


### PR DESCRIPTION
A few of the unit tests in SwiftPM use `.currentToolsVersion` instead of `.v5_3` and unintentionally relied on SwiftPM 5.3 semantics.  This causes warnings now that SwiftPM is 5.4 (though they don't seem to affect all integration builds — it's not yet clear why not).  The correct thing to do semantically is for them to use `.v5_3` as the tools version if they rely on 5.3 semantics.

This is the 5.4 cherry-pick of https://github.com/apple/swift-package-manager/pull/3196.

rdar://73253889