### PR TITLE
Convert some uses of `.v5_3` in unit tests back to `.currentToolsVersion` based on feedback

### DIFF
--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -371,7 +371,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                                   packageName: UUID().uuidString,
                                                                   targets: mockTargets,
                                                                   products: mockProducts,
-                                                                  toolsVersion: .v5_3,
+                                                                  toolsVersion: .currentToolsVersion,
                                                                   minimumPlatformVersions: nil,
                                                                   verifiedCompatibility: nil,
                                                                   license: nil)
@@ -521,7 +521,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                                   packageName: UUID().uuidString,
                                                                   targets: mockTargets,
                                                                   products: mockProducts,
-                                                                  toolsVersion: .v5_3,
+                                                                  toolsVersion: .currentToolsVersion,
                                                                   minimumPlatformVersions: nil,
                                                                   verifiedCompatibility: nil,
                                                                   license: nil)
@@ -823,7 +823,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                     packageName: "package-\(packageId)",
                                                     targets: targets,
                                                     products: products,
-                                                    toolsVersion: .v5_3,
+                                                    toolsVersion: .currentToolsVersion,
                                                     minimumPlatformVersions: [.init(platform: .macOS, version: .init("10.15"))],
                                                     verifiedCompatibility: [
                                                         .init(platform: .iOS, swiftVersion: SwiftLanguageVersion.knownSwiftLanguageVersions.randomElement()!),

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -57,7 +57,7 @@ func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: I
                                                                packageName: "package-\(packageIndex)",
                                                                targets: targets,
                                                                products: products,
-                                                               toolsVersion: .v5_3,
+                                                               toolsVersion: .currentToolsVersion,
                                                                minimumPlatformVersions: minimumPlatformVersions,
                                                                verifiedCompatibility: verifiedCompatibility,
                                                                license: license)


### PR DESCRIPTION
To address unit test failures caused by incorrect assumptions about `.currentToolsVersion` being the same as `.v5_3`, several uses of `.currentToolsVersion` were converted to `.v5_3` in https://github.com/apple/swift-package-manager/pull/3196.  This included some that, based on later conversation in https://github.com/apple/swift-package-manager/pull/3197 should not have been converted.  This restores them so that package-collection-related tests continue using `.currentToolsVersion`.

### Motivation:

This aligns `main` with what's being nominated for `release/5.4` and undoes some overzealous conversion of `.currentToolsVersion` to `.v5_3`.  No other change than unit tests.