### PR TITLE
[PkgConfig] Update PkgConfig documentation

### DIFF
--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -113,9 +113,9 @@ public final class Target {
 
     /// The `pkgconfig` name to use for a system library target.
     ///
-    /// If present, the Swift Package Manager tries to
-    /// search for the `<name>.pc` file to get the additional flags needed for the
-    /// system target.
+    /// If present, the Swift Package Manager tries for every pkg-config 
+    /// name separated by a space to search for the `<name>.pc` file 
+    /// to get the additional flags needed for the system target.
     public let pkgConfig: String?
 
     /// The providers array for a system library target.


### PR DESCRIPTION
Edit documentation to fit to the way swift parses pkgConfig files.

### Motivation:

In #3080 I did make changes on how SPM parses pkgConfig to make it consistent. This PR is made to reflect these changes in the documentation

### Modifications:

I added "for each pkg-config file separated by space"

### Result:

The documentation will be closer to the reality

PS: Do not hesitate to edit this PR to make the text better.
