### PR TITLE
[Collections] API changes to support signed collections

### DIFF
--- a/Sources/PackageCollections/Model/Collection.swift
+++ b/Sources/PackageCollections/Model/Collection.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -54,6 +54,9 @@ extension PackageCollectionsModel {
         /// When this collection was last processed locally
         public let lastProcessedAt: Date
 
+        /// Indicates if the collection is signed
+        public let isSigned: Bool
+
         /// Initializes a `Collection`
         init(
             source: Source,
@@ -63,7 +66,8 @@ extension PackageCollectionsModel {
             packages: [Package],
             createdAt: Date,
             createdBy: Author?,
-            lastProcessedAt: Date = Date()
+            lastProcessedAt: Date = Date(),
+            isSigned: Bool
         ) {
             self.identifier = .init(from: source)
             self.source = source
@@ -74,6 +78,7 @@ extension PackageCollectionsModel {
             self.createdAt = createdAt
             self.createdBy = createdBy
             self.lastProcessedAt = lastProcessedAt
+            self.isSigned = isSigned
         }
     }
 }
@@ -87,18 +92,26 @@ extension PackageCollectionsModel {
         /// URL of the source file
         public let url: URL
 
+        /// Indicates if the source is explicitly trusted or untrusted by the user
+        public var isTrusted: Bool?
+
         /// The source's absolute file system path, if its URL is of 'file' scheme.
         let absolutePath: AbsolutePath?
 
-        public init(type: CollectionSourceType, url: URL) {
+        public init(type: CollectionSourceType, url: URL, isTrusted: Bool? = nil) {
             self.type = type
             self.url = url
+            self.isTrusted = isTrusted
 
             if url.scheme?.lowercased() == "file", let absolutePath = try? AbsolutePath(validating: url.path) {
                 self.absolutePath = absolutePath
             } else {
                 self.absolutePath = nil
             }
+        }
+
+        public static func == (lhs: CollectionSource, rhs: CollectionSource) -> Bool {
+            lhs.type == rhs.type && lhs.url == rhs.url
         }
     }
 

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -103,7 +103,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
                 }
                 let refreshResults = ThreadSafeArrayStore<Result<Model.Collection, Error>>()
                 sources.forEach { source in
-                    self.refreshCollectionFromSource(source: source) { refreshResult in
+                    self.refreshCollectionFromSource(source: source, trustConfirmationProvider: nil) { refreshResult in
                         refreshResults.append(refreshResult)
                         if refreshResults.count == sources.count {
                             let errors = refreshResults.compactMap { $0.failure }
@@ -115,8 +115,16 @@ public struct PackageCollections: PackageCollectionsProtocol {
         }
     }
 
+    public func refreshCollection(
+        _ source: PackageCollectionsModel.CollectionSource,
+        callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void
+    ) {
+        self.refreshCollectionFromSource(source: source, trustConfirmationProvider: nil, callback: callback)
+    }
+
     public func addCollection(_ source: PackageCollectionsModel.CollectionSource,
                               order: Int? = nil,
+                              trustConfirmationProvider: ((PackageCollectionsModel.Collection, @escaping (Bool) -> Void) -> Void)? = nil,
                               callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void) {
         if let errors = source.validate()?.errors() {
             return callback(.failure(MultipleErrors(errors)))
@@ -129,7 +137,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
                 callback(.failure(error))
             case .success:
                 // next try to fetch the collection from the network and store it locally so future operations dont need to access the network
-                self.refreshCollectionFromSource(source: source, order: order, callback: callback)
+                self.refreshCollectionFromSource(source: source, trustConfirmationProvider: trustConfirmationProvider, callback: callback)
             }
         }
     }
@@ -150,6 +158,18 @@ public struct PackageCollections: PackageCollectionsProtocol {
                                to order: Int,
                                callback: @escaping (Result<Void, Error>) -> Void) {
         self.storage.sources.move(source: source, to: order, callback: callback)
+    }
+
+    public func updateCollection(_ source: PackageCollectionsModel.CollectionSource,
+                                 callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void) {
+        self.storage.sources.update(source: source) { result in
+            switch result {
+            case .failure(let error):
+                callback(.failure(error))
+            case .success:
+                self.refreshCollectionFromSource(source: source, trustConfirmationProvider: nil, callback: callback)
+            }
+        }
     }
 
     // Returns information about a package collection.
@@ -275,7 +295,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
     // Fetch the collection from the network and store it in local storage
     // This helps avoid network access in normal operations
     private func refreshCollectionFromSource(source: PackageCollectionsModel.CollectionSource,
-                                             order _: Int? = nil,
+                                             trustConfirmationProvider: ((PackageCollectionsModel.Collection, @escaping (Bool) -> Void) -> Void)?,
                                              callback: @escaping (Result<Model.Collection, Error>) -> Void) {
         if let errors = source.validate()?.errors() {
             return callback(.failure(MultipleErrors(errors)))
@@ -288,7 +308,52 @@ public struct PackageCollections: PackageCollectionsProtocol {
             case .failure(let error):
                 callback(.failure(error))
             case .success(let collection):
-                self.storage.collections.put(collection: collection, callback: callback)
+                // If collection is signed and signature is valid, save to storage. `provider.get`
+                // would have failed if signature were invalid.
+                if collection.isSigned {
+                    return self.storage.collections.put(collection: collection, callback: callback)
+                }
+
+                // If collection is not signed, check if it's trusted by user and prompt user if needed.
+                if let isTrusted = source.isTrusted {
+                    if isTrusted {
+                        return self.storage.collections.put(collection: collection, callback: callback)
+                    } else {
+                        // Try to remove the untrusted collection (if previously saved) from storage before calling back
+                        return self.storage.collections.remove(identifier: collection.identifier) { _ in
+                            callback(.failure(PackageCollectionError.untrusted))
+                        }
+                    }
+                }
+
+                // No user preference recorded, so we need to prompt if we can.
+                guard let trustConfirmationProvider = trustConfirmationProvider else {
+                    // Try to remove the untrusted collection (if previously saved) from storage before calling back
+                    return self.storage.collections.remove(identifier: collection.identifier) { _ in
+                        callback(.failure(PackageCollectionError.trustConfirmationRequired))
+                    }
+                }
+
+                trustConfirmationProvider(collection) { userTrusted in
+                    var source = source
+                    source.isTrusted = userTrusted
+                    // Record user preference then save collection to storage
+                    self.storage.sources.update(source: source) { updateSourceResult in
+                        switch updateSourceResult {
+                        case .failure(let error):
+                            callback(.failure(error))
+                        case .success:
+                            if userTrusted {
+                                self.storage.collections.put(collection: collection, callback: callback)
+                            } else {
+                                // Try to remove the untrusted collection (if previously saved) from storage before calling back
+                                return self.storage.collections.remove(identifier: collection.identifier) { _ in
+                                    callback(.failure(PackageCollectionError.untrusted))
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -108,6 +108,13 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
     }
 
     private func makeCollection(from collection: JSONModel.Collection, source: Model.CollectionSource) -> Result<Model.Collection, Error> {
+        // TODO: Check collection's signature
+        // 1. If signed and signature is
+        //      a. valid: process the collection; set isSigned=true
+        //      b. invalid: includes expired cert, untrusted cert, signature-payload mismatch => return error
+        // 2. If unsigned, process the collection; set isSigned=false.
+        let isSigned = true
+
         var serializationOkay = true
         let packages = collection.packages.map { package -> Model.Package in
             let versions = package.versions.compactMap { version -> Model.Package.Version? in
@@ -170,7 +177,8 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
                               packages: packages,
                               createdAt: collection.generatedAt,
                               createdBy: collection.generatedBy.flatMap { Model.Collection.Author(name: $0.name) },
-                              lastProcessedAt: Date()))
+                              lastProcessedAt: Date(),
+                              isSigned: isSigned))
     }
 
     private func makeRequestOptions(validResponseCodes: [Int]) -> HTTPClientRequest.Options {

--- a/Sources/PackageCollections/Storage/PackageCollectionsSourcesStorage.swift
+++ b/Sources/PackageCollections/Storage/PackageCollectionsSourcesStorage.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -9,24 +9,24 @@
  */
 
 public protocol PackageCollectionsSourcesStorage {
-    /// Lists all `PackageCollectionSource`s in the given profile.
+    /// Lists all `PackageCollectionSource`s.
     ///
     /// - Parameters:
     ///   - callback: The closure to invoke when result becomes available
     func list(callback: @escaping (Result<[PackageCollectionsModel.CollectionSource], Error>) -> Void)
 
-    /// Adds source to the given profile.
+    /// Adds the given source.
     ///
     /// - Parameters:
     ///   - source: The `PackageCollectionSource` to add
-    ///   - order: Optional. The order that the source should take after being added to the profile.
+    ///   - order: Optional. The order that the source should take after being added.
     ///            By default the new source is appended to the end (i.e., the least relevant order).
     ///   - callback: The closure to invoke when result becomes available
     func add(source: PackageCollectionsModel.CollectionSource,
              order: Int?,
              callback: @escaping (Result<Void, Error>) -> Void)
 
-    /// Removes source from the given profile.
+    /// Removes the given source.
     ///
     /// - Parameters:
     ///   - source: The `PackageCollectionSource` to remove
@@ -35,21 +35,29 @@ public protocol PackageCollectionsSourcesStorage {
     func remove(source: PackageCollectionsModel.CollectionSource,
                 callback: @escaping (Result<Void, Error>) -> Void)
 
-    /// Moves source to a different order within the given profile.
+    /// Moves source to a different order.
     ///
     /// - Parameters:
     ///   - source: The `PackageCollectionSource` to move
-    ///   - order: The order that the source should take in the profile.
+    ///   - order: The order that the source should take.
     ///   - callback: The closure to invoke when result becomes available
     func move(source: PackageCollectionsModel.CollectionSource,
               to order: Int,
               callback: @escaping (Result<Void, Error>) -> Void)
 
-    /// Checks if a source is already in a profile.
+    /// Checks if a source has already been added.
     ///
     /// - Parameters:
     ///   - source: The `PackageCollectionSource`
     ///   - callback: The closure to invoke when result becomes available
     func exists(source: PackageCollectionsModel.CollectionSource,
                 callback: @escaping (Result<Bool, Error>) -> Void)
+
+    /// Updates the given source.
+    ///
+    /// - Parameters:
+    ///   - source: The `PackageCollectionSource` to update
+    ///   - callback: The closure to invoke when result becomes available
+    func update(source: PackageCollectionsModel.CollectionSource,
+                callback: @escaping (Result<Void, Error>) -> Void)
 }

--- a/Tests/PackageCollectionsTests/PackageCollectionsSourcesStorageTest.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsSourcesStorageTest.swift
@@ -48,7 +48,7 @@ final class PackageCollectionsSourcesStorageTest: XCTestCase {
 
         do {
             let list = try tsc_await { callback in storage.list(callback: callback) }
-            XCTAssertEqual(list.count, sources.count, "collections should match")
+            XCTAssertEqual(list.count, sources.count, "sources should match")
         }
 
         let remove = sources.enumerated().filter { index, _ in index % 2 == 0 }.map { $1 }
@@ -58,7 +58,7 @@ final class PackageCollectionsSourcesStorageTest: XCTestCase {
 
         do {
             let list = try tsc_await { callback in storage.list(callback: callback) }
-            XCTAssertEqual(list.count, sources.count - remove.count, "collections should match")
+            XCTAssertEqual(list.count, sources.count - remove.count, "sources should match")
         }
 
         let remaining = sources.filter { !remove.contains($0) }
@@ -69,15 +69,24 @@ final class PackageCollectionsSourcesStorageTest: XCTestCase {
         do {
             _ = try tsc_await { callback in storage.move(source: remaining.last!, to: 0, callback: callback) }
             let list = try tsc_await { callback in storage.list(callback: callback) }
-            XCTAssertEqual(list.count, remaining.count, "collections should match")
+            XCTAssertEqual(list.count, remaining.count, "sources should match")
             XCTAssertEqual(list.first, remaining.last, "item should match")
         }
 
         do {
             _ = try tsc_await { callback in storage.move(source: remaining.last!, to: remaining.count - 1, callback: callback) }
             let list = try tsc_await { callback in storage.list(callback: callback) }
-            XCTAssertEqual(list.count, remaining.count, "collections should match")
+            XCTAssertEqual(list.count, remaining.count, "sources should match")
             XCTAssertEqual(list.last, remaining.last, "item should match")
+        }
+
+        do {
+            let list = try tsc_await { callback in storage.list(callback: callback) }
+            var source = list.first!
+            source.isTrusted = !(source.isTrusted ?? false)
+            _ = try tsc_await { callback in storage.update(source: source, callback: callback) }
+            let listAfter = try tsc_await { callback in storage.list(callback: callback) }
+            XCTAssertEqual(source.isTrusted, listAfter.first!.isTrusted, "item should match")
         }
     }
 

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -18,12 +18,13 @@ import TSCBasic
 import TSCUtility
 
 func makeMockSources(count: Int = Int.random(in: 5 ... 10)) -> [PackageCollectionsModel.CollectionSource] {
+    let isTrusted: [Bool?] = [true, false, nil]
     return (0 ..< count).map { index in
-        .init(type: .json, url: URL(string: "https://source-\(index)")!)
+        .init(type: .json, url: URL(string: "https://source-\(index)")!, isTrusted: isTrusted.randomElement()!)
     }
 }
 
-func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: Int = 50) -> [PackageCollectionsModel.Collection] {
+func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: Int = 50, signed: Bool = true) -> [PackageCollectionsModel.Collection] {
     let platforms: [PackageModel.Platform] = [.macOS, .iOS, .tvOS, .watchOS, .linux, .android, .windows, .wasi]
     let supportedPlatforms: [PackageModel.SupportedPlatform] = [
         .init(platform: .macOS, version: .init("10.15")),
@@ -79,7 +80,8 @@ func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: I
                                                   keywords: (0 ..< Int.random(in: 1 ... 3)).map { "keyword \($0)" },
                                                   packages: packages,
                                                   createdAt: Date(),
-                                                  createdBy: PackageCollectionsModel.Collection.Author(name: "Jane Doe"))
+                                                  createdBy: PackageCollectionsModel.Collection.Author(name: "Jane Doe"),
+                                                  isSigned: signed)
     }
 }
 


### PR DESCRIPTION
Motivation:
Package collections may optionally be signed in the future ([forum post](https://forums.swift.org/t/package-collection-signing/43855)). Unsigned collections will require some changes to the UX (e.g., user needs to confirm their trust on unsigned collections), therefore the Package Collection APIs will need to be updated accordingly.

Modifications:
- Each package collection "source" in the config has a new `isTrusted` flag to record user's trust preference.
- `addCollection` has a new `trustConfirmationProvider` closure that gets invoked when the newly added collection is unsigend. API client needs to provide user's trust preference when the closure is invoked.
- New `updateCollection` API to update a collection's trust preference. This is for one-off config changes.
- New `refreshCollection` API - `refreshCollections` already exists. It seems reasonable to allow refreshing individual collections.

Result:
APIs are ready to support signed (unsigned) collections.
