### PR TITLE
Add swift-crypto dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See http://swift.org/LICENSE.txt for license information
@@ -47,7 +47,7 @@ if(FIND_PM_DEPS)
   endif()
 
   find_package(ArgumentParser CONFIG REQUIRED)
-  find_package(Crypto CONFIG REQUIRED)
+  find_package(SwiftCrypto CONFIG REQUIRED)
   find_package(SwiftDriver CONFIG REQUIRED)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ if(FIND_PM_DEPS)
   endif()
 
   find_package(ArgumentParser CONFIG REQUIRED)
+  find_package(Crypto CONFIG REQUIRED)
   find_package(SwiftDriver CONFIG REQUIRED)
 endif()
 

--- a/Documentation/Contributing.md
+++ b/Documentation/Contributing.md
@@ -152,6 +152,13 @@ For example, if the latest tag is 0.3.1:
 $> git clone https://github.com/apple/swift-argument-parser --branch 0.3.1
 ```
 
+5. Clone [swift-crypto](https://github.com/apple/swift-crypto) beside the SwiftPM directory and check out tag with the [latest version](https://github.com/apple/swift-crypto/tags).
+
+For example, if the latest tag is 1.1.3:
+```bash
+$> git clone https://github.com/apple/swift-crypto --branch 1.1.3
+```
+
 #### Building
 
 ```bash

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -323,7 +323,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         // dependency version changes here with those projects.
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.3.1")),
         .package(url: "https://github.com/apple/swift-driver.git", .branch(relatedDependenciesBranch)),
-        .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMajor(from: "1.1.0")),
+        .package(url: "https://github.com/apple/swift-crypto.git", .branch(relatedDependenciesBranch)),
     ]
 } else {
     package.dependencies += [

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let macOSPlatform: SupportedPlatform
 if let deploymentTarget = ProcessInfo.processInfo.environment["SWIFTPM_MACOS_DEPLOYMENT_TARGET"] {
     macOSPlatform = .macOS(deploymentTarget)
 } else {
-    macOSPlatform = .macOS(.v10_10)
+    macOSPlatform = .macOS(.v10_15)
 }
 
 let package = Package(
@@ -156,7 +156,7 @@ let package = Package(
         .target(
             /** Data structures and support for package collections */
             name: "PackageCollections",
-            dependencies: ["SwiftToolsSupport-auto", "Basics", "PackageModel", "SourceControl", "PackageCollectionsModel"]),
+            dependencies: ["SwiftToolsSupport-auto", "Basics", "PackageModel", "SourceControl", "PackageCollectionsModel", "Crypto"]),
 
         // MARK: Package Manager Functionality
 
@@ -323,6 +323,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         // dependency version changes here with those projects.
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.3.1")),
         .package(url: "https://github.com/apple/swift-driver.git", .branch(relatedDependenciesBranch)),
+        .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMajor(from: "1.1.0")),
     ]
 } else {
     package.dependencies += [

--- a/Package.swift
+++ b/Package.swift
@@ -330,5 +330,6 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(path: "../swift-tools-support-core"),
         .package(path: "../swift-argument-parser"),
         .package(path: "../swift-driver"),
+        .package(path: "../swift-crypto"),
     ]
 }

--- a/Sources/PackageCollections/CMakeLists.txt
+++ b/Sources/PackageCollections/CMakeLists.txt
@@ -33,11 +33,14 @@ target_link_libraries(PackageCollections PUBLIC
   TSCUtility
   Basics
   Crypto
+  CCryptoBoringSSL
   PackageModel
   SourceControl)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(PackageCollections PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+target_link_options(PackageCollections PRIVATE
+    "$<$<PLATFORM_ID:Darwin>:SHELL:-Xlinker -framework -Xlinker Security>")
 
 if(USE_CMAKE_INSTALL)
 install(TARGETS PackageCollections

--- a/Sources/PackageCollections/CMakeLists.txt
+++ b/Sources/PackageCollections/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(PackageCollections PUBLIC
   TSCBasic
   TSCUtility
   Basics
+  Crypto
   PackageModel
   SourceControl)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet

--- a/Sources/PackageCollections/Signing/PackageCollectionSignature.swift
+++ b/Sources/PackageCollections/Signing/PackageCollectionSignature.swift
@@ -1,0 +1,16 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Crypto
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import Security
+#else
+import CCryptoBoringSSL
+#endif

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -3,7 +3,7 @@
 """
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -171,6 +171,7 @@ def parse_global_args(args):
     args.yams_source_dir = os.path.join(args.project_root, "..", "yams")
     args.swift_argument_parser_source_dir = os.path.join(args.project_root, "..", "swift-argument-parser")
     args.swift_driver_source_dir = os.path.join(args.project_root, "..", "swift-driver")
+    args.swift_crypto_source_dir = os.path.join(args.project_root, "..", "swift-crypto")
     args.source_root = os.path.join(args.project_root, "Sources")
 
     if platform.system() == 'Darwin':
@@ -307,6 +308,7 @@ def build(args):
         build_yams(args)
         build_swift_argument_parser(args)
         build_swift_driver(args)
+        build_swift_crypto(args)
 
     build_swiftpm_with_cmake(args)
     build_swiftpm_with_swiftpm(args,integrated_swift_driver=False)
@@ -559,6 +561,18 @@ def build_swift_driver(args):
         cmake_flags.append("-DCMAKE_OSX_DEPLOYMENT_TARGET=%s" % g_macos_deployment_target)
 
     build_with_cmake(args, cmake_flags, args.swift_driver_source_dir, args.swift_driver_build_dir)
+    
+def build_swift_crypto(args):
+    note("Building SwiftCrypto")
+    args.swift_crypto_build_dir = os.path.join(args.target_dir, "swift-crypto")
+
+    cmake_flags = []
+    if platform.system() == 'Darwin':
+        cmake_flags.append("-DCMAKE_C_FLAGS=-target %s%s" % (get_build_target(args), g_macos_deployment_target))
+        cmake_flags.append("-DCMAKE_OSX_DEPLOYMENT_TARGET=%s" % g_macos_deployment_target)
+
+    cmake_flags.append("-DBUILD_SHARED_LIBS=YES")
+    build_with_cmake(args, cmake_flags, args.swift_crypto_source_dir, args.swift_crypto_build_dir)
 
 def add_rpath_for_cmake_build(args, rpath):
     "Adds the given rpath to the CMake-built swift-build"
@@ -578,6 +592,7 @@ def build_swiftpm_with_cmake(args):
             "-DYams_DIR=" + os.path.join(args.yams_build_dir, "cmake/modules"),
             "-DArgumentParser_DIR=" + os.path.join(args.swift_argument_parser_build_dir, "cmake/modules"),
             "-DSwiftDriver_DIR=" + os.path.join(args.swift_driver_build_dir, "cmake/modules"),
+            "-DCrypto_DIR=" + os.path.join(args.swift_crypto_build_dir, "cmake/modules"),
             "-DFIND_PM_DEPS:BOOL=YES",
         ]
     else:
@@ -598,6 +613,7 @@ def build_swiftpm_with_cmake(args):
         add_rpath_for_cmake_build(args, os.path.join(args.yams_build_dir, "lib"))
         add_rpath_for_cmake_build(args, os.path.join(args.swift_argument_parser_build_dir, "lib"))
         add_rpath_for_cmake_build(args, os.path.join(args.swift_driver_build_dir, "lib"))
+        add_rpath_for_cmake_build(args, os.path.join(args.swift_crypto_build_dir, "lib"))
 
 def build_swiftpm_with_swiftpm(args, integrated_swift_driver):
     """Builds SwiftPM using the version of SwiftPM built with CMake."""
@@ -694,6 +710,7 @@ def get_swiftpm_env_cmd(args):
             os.path.join(args.yams_build_dir, "lib"),
             os.path.join(args.swift_argument_parser_build_dir, "lib"),
             os.path.join(args.swift_driver_build_dir, "lib"),
+            os.path.join(args.swift_crypto_build_dir, "lib"),
         ] + args.target_info["paths"]["runtimeLibraryPaths"])
 
         if platform.system() == 'Darwin':

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -571,7 +571,6 @@ def build_swift_crypto(args):
         cmake_flags.append("-DCMAKE_C_FLAGS=-target %s%s" % (get_build_target(args), g_macos_deployment_target))
         cmake_flags.append("-DCMAKE_OSX_DEPLOYMENT_TARGET=%s" % g_macos_deployment_target)
 
-    cmake_flags.append("-DBUILD_SHARED_LIBS=YES")
     build_with_cmake(args, cmake_flags, args.swift_crypto_source_dir, args.swift_crypto_build_dir)
 
 def add_rpath_for_cmake_build(args, rpath):
@@ -592,7 +591,7 @@ def build_swiftpm_with_cmake(args):
             "-DYams_DIR=" + os.path.join(args.yams_build_dir, "cmake/modules"),
             "-DArgumentParser_DIR=" + os.path.join(args.swift_argument_parser_build_dir, "cmake/modules"),
             "-DSwiftDriver_DIR=" + os.path.join(args.swift_driver_build_dir, "cmake/modules"),
-            "-DCrypto_DIR=" + os.path.join(args.swift_crypto_build_dir, "cmake/modules"),
+            "-DSwiftCrypto_DIR=" + os.path.join(args.swift_crypto_build_dir, "cmake/modules"),
             "-DFIND_PM_DEPS:BOOL=YES",
         ]
     else:


### PR DESCRIPTION
Motivation:
Upcoming package collections feature will require swift-crypto dependency.

Modifications:
- Add swift-crypto dependency
- Bump minimum macOS version to 10.15, for it's required by swift-crypto
