### PR TITLE
Remove an unconditional print statements in a test

### DIFF
--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -27,22 +27,22 @@ class ManifestSourceGenerationTests: XCTestCase {
             // Generate source code for the loaded manifest, write it out to replace the manifest file contents, and load it again.
             let newContents = manifest.generatedManifestFileContents
             try fs.writeFileContents(packageDir.appending(component: Manifest.filename), bytes: ByteString(encodingAsUTF8: newContents))
-            print(newContents)
             let newManifest = try tsc_await { manifestLoader.load(package: packageDir, baseURL: packageDir.pathString, toolsVersion: toolsVersion, packageKind: .root, on: .global(), completion: $0) }
             
             // Check that all the relevant properties survived.
-            XCTAssertEqual(newManifest.toolsVersion, manifest.toolsVersion)
-            XCTAssertEqual(newManifest.name, manifest.name)
-            XCTAssertEqual(newManifest.defaultLocalization, manifest.defaultLocalization)
-            XCTAssertEqual(newManifest.platforms, manifest.platforms)
-            XCTAssertEqual(newManifest.pkgConfig, manifest.pkgConfig)
-            XCTAssertEqual(newManifest.providers, manifest.providers)
-            XCTAssertEqual(newManifest.products, manifest.products)
-            XCTAssertEqual(newManifest.dependencies, manifest.dependencies)
-            XCTAssertEqual(newManifest.targets, manifest.targets)
-            XCTAssertEqual(newManifest.swiftLanguageVersions, manifest.swiftLanguageVersions)
-            XCTAssertEqual(newManifest.cLanguageStandard, manifest.cLanguageStandard)
-            XCTAssertEqual(newManifest.cxxLanguageStandard, manifest.cxxLanguageStandard)
+            let failureDetails = "\n--- ORIGINAL MANIFEST CONTENTS ---\n" + manifestContents + "\n--- REWRITTEN MANIFEST CONTENTS ---\n" + newContents
+            XCTAssertEqual(newManifest.toolsVersion, manifest.toolsVersion, failureDetails)
+            XCTAssertEqual(newManifest.name, manifest.name, failureDetails)
+            XCTAssertEqual(newManifest.defaultLocalization, manifest.defaultLocalization, failureDetails)
+            XCTAssertEqual(newManifest.platforms, manifest.platforms, failureDetails)
+            XCTAssertEqual(newManifest.pkgConfig, manifest.pkgConfig, failureDetails)
+            XCTAssertEqual(newManifest.providers, manifest.providers, failureDetails)
+            XCTAssertEqual(newManifest.products, manifest.products, failureDetails)
+            XCTAssertEqual(newManifest.dependencies, manifest.dependencies, failureDetails)
+            XCTAssertEqual(newManifest.targets, manifest.targets, failureDetails)
+            XCTAssertEqual(newManifest.swiftLanguageVersions, manifest.swiftLanguageVersions, failureDetails)
+            XCTAssertEqual(newManifest.cLanguageStandard, manifest.cLanguageStandard, failureDetails)
+            XCTAssertEqual(newManifest.cxxLanguageStandard, manifest.cxxLanguageStandard, failureDetails)
         }
     }
 


### PR DESCRIPTION
This was just causing noise.  Now any failure messages include both the original and rewritten contents of the manifest.