### PR TITLE
[5.4] Fix a tools version loading failure that occurred when the regular manifest doesn't contain a tools-version.

### DIFF
--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -99,7 +99,21 @@ extension Manifest {
             else {
                 versionSpecificManifestToolsVersion = try toolsVersionLoader.load(file: versionSpecificManifest, fileSystem: fileSystem)
             }
-            let regularManifestToolsVersion = try toolsVersionLoader.load(file: regularManifest, fileSystem: fileSystem)
+
+            // Try to get the tools version of the regular manifest.  At the comment marker is missing, we default to
+            // tools version 3.1.0 (as documented).
+            let regularManifestToolsVersion: ToolsVersion
+            do {
+                regularManifestToolsVersion = try toolsVersionLoader.load(file: regularManifest, fileSystem: fileSystem)
+            }
+            catch {
+                if case ToolsVersionLoader.Error.malformedToolsVersionSpecification(.commentMarker(.isMissing)) = error {
+                    regularManifestToolsVersion = .v3
+                }
+                else {
+                    throw error
+                }
+            }
 
             // Compare the tools version of this manifest with the regular
             // manifest and use the version-specific manifest if it has


### PR DESCRIPTION
Usually the main manifest is the latest, but there are examples of packages where it's the opposite:  the main version is the old one, and newer ones have version suffixes.  In rare cases the main manifest is so old that it doesn't have a tools version, and the new logic for tools version loading incorrectly reported an error in those cases.

rdar://73267827

(cherry picked from commit a27bbb53f8f32af9e1d8d15b569f63e3dbabffa4)

This was committed to the `main` branch as https://github.com/apple/swift-package-manager/pull/3208.
