### PR TITLE
Package collections: improve search performance

### DIFF
--- a/Sources/Basics/ConcurrencyHelpers.swift
+++ b/Sources/Basics/ConcurrencyHelpers.swift
@@ -126,7 +126,7 @@ public final class ThreadSafeArrayStore<Value> {
     }
 }
 
-/// Thread-safe value boxing  structure
+/// Thread-safe value boxing structure
 public final class ThreadSafeBox<Value> {
     private var underlying: Value?
     private let lock = Lock()

--- a/Sources/PackageCollections/CMakeLists.txt
+++ b/Sources/PackageCollections/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(PackageCollections
   Storage/PackageCollectionsSourcesStorage.swift
   Storage/PackageCollectionsStorage.swift
   Storage/SQLitePackageCollectionsStorage.swift
+  Storage/Trie.swift
   API.swift
   PackageCollections.swift
   PackageCollections+Configuration.swift

--- a/Sources/PackageCollections/Model/TargetListResult.swift
+++ b/Sources/PackageCollections/Model/TargetListResult.swift
@@ -54,9 +54,9 @@ extension PackageCollectionsModel.TargetListResult {
 
         /// Package name
         public let packageName: String
-        
+
         public static func < (lhs: PackageVersion, rhs: PackageVersion) -> Bool {
-             lhs.version < rhs.version
-         }
+            lhs.version < rhs.version
+        }
     }
 }

--- a/Sources/PackageCollections/Model/TargetListResult.swift
+++ b/Sources/PackageCollections/Model/TargetListResult.swift
@@ -48,11 +48,15 @@ extension PackageCollectionsModel.TargetListResult {
 
 extension PackageCollectionsModel.TargetListResult {
     /// Represents a package version
-    public struct PackageVersion: Hashable, Encodable {
+    public struct PackageVersion: Hashable, Encodable, Comparable {
         /// The version
         public let version: TSCUtility.Version
 
         /// Package name
         public let packageName: String
+        
+        public static func < (lhs: PackageVersion, rhs: PackageVersion) -> Bool {
+             lhs.version < rhs.version
+         }
     }
 }

--- a/Sources/PackageCollections/Storage/PackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/PackageCollectionsStorage.swift
@@ -53,7 +53,7 @@ public protocol PackageCollectionsStorage {
                         query: String,
                         callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult, Error>) -> Void)
 
-    /// Returns optional `PackageSearchResult.Item` for the given package identity.
+    /// Returns `PackageSearchResult.Item` for the given package identity.
     ///
     /// - Parameters:
     ///   - identifier: The package identifier

--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -684,26 +684,9 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
 
             useSearchIndices.put(true)
         } catch {
-            // These DDL statements work but queries yield different results when run on different
+            // We can use FTS3 tables but queries yield different results when run on different
             // platforms. This could be because of SQLite version perhaps? But since we can't get
             // consistent results we will not fallback to FTS3 and just give up if FTS4 is not available.
-            /*
-             let ftsPackages = """
-                 CREATE VIRTUAL TABLE IF NOT EXISTS \(Self.packagesFTSName) USING fts3(
-                     collection_id_blob_base64, id, version, name, repository_url, summary, keywords, products, targets,
-                     tokenize=simple
-                 );
-             """
-             try db.exec(query: ftsPackages)
-
-             let ftsTargets = """
-                 CREATE VIRTUAL TABLE IF NOT EXISTS \(Self.targetsFTSName) USING fts3(
-                     collection_id_blob_base64, package_repository_url, name,
-                     tokenize=porter
-                 );
-             """
-             try db.exec(query: ftsTargets)
-             */
             useSearchIndices.put(false)
         }
 

--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -45,6 +45,8 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
     // since only one transaction is allowed per SQLite connection. We need transactions to speed up bulk updates.
     // TODO: we could potentially optimize this with db connection pool
     private let ftsLock = Lock()
+    // FTS not supported on some platforms; the code falls back to "slow path" in that case
+    let useSearchIndices = ThreadSafeBox<Bool>()
 
     // Targets have in-memory trie in addition to SQLite FTS as optimization
     private let targetTrie = Trie<CollectionPackage>()
@@ -101,68 +103,8 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                     try statement.step()
                 }
 
-                try self.ftsLock.withLock {
-                    // Update search indices
-                    try self.withDB { db in
-                        try db.exec(query: "BEGIN TRANSACTION;")
-
-                        // First delete existing data
-                        try self.removeFromSearchIndices(identifier: collection.identifier)
-
-                        let packagesStatement = try db.prepare(query: "INSERT INTO \(Self.packagesFTSName) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);")
-                        let targetsStatement = try db.prepare(query: "INSERT INTO \(Self.targetsFTSName) VALUES (?, ?, ?);")
-
-                        // Then insert new data
-                        try collection.packages.forEach { package in
-                            var targets = Set<String>()
-
-                            try package.versions.forEach { version in
-                                // Packages FTS
-                                let packagesBindings: [SQLite.SQLiteValue] = [
-                                    .string(try self.encoder.encode(collection.identifier).base64EncodedString()),
-                                    .string(package.reference.identity.description),
-                                    .string(version.version.description),
-                                    .string(version.packageName),
-                                    .string(package.repository.url),
-                                    package.summary.map { .string($0) } ?? .null,
-                                    package.keywords.map { .string($0.joined(separator: ",")) } ?? .null,
-                                    .string(version.products.map { $0.name }.joined(separator: ",")),
-                                    .string(version.targets.map { $0.name }.joined(separator: ",")),
-                                ]
-                                try packagesStatement.bind(packagesBindings)
-                                try packagesStatement.step()
-
-                                try packagesStatement.clearBindings()
-                                try packagesStatement.reset()
-
-                                version.targets.forEach { targets.insert($0.name) }
-                            }
-
-                            let collectionPackage = CollectionPackage(collection: collection.identifier, package: package.reference.identity)
-                            try targets.forEach { target in
-                                // Targets in-memory trie
-                                self.targetTrie.insert(word: target.lowercased(), foundIn: collectionPackage)
-
-                                // Targets FTS
-                                let targetsBindings: [SQLite.SQLiteValue] = [
-                                    .string(try self.encoder.encode(collection.identifier).base64EncodedString()),
-                                    .string(package.repository.url),
-                                    .string(target),
-                                ]
-                                try targetsStatement.bind(targetsBindings)
-                                try targetsStatement.step()
-
-                                try targetsStatement.clearBindings()
-                                try targetsStatement.reset()
-                            }
-                        }
-
-                        try db.exec(query: "COMMIT;")
-
-                        try packagesStatement.finalize()
-                        try targetsStatement.finalize()
-                    }
-                }
+                // Add to search indices
+                try self.insertToSearchIndices(collection: collection)
 
                 // write to cache
                 self.cache[collection.identifier] = collection
@@ -173,24 +115,71 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
         }
     }
 
-    private func removeFromSearchIndices(identifier: Model.CollectionIdentifier) throws {
-        let identifierBase64 = try self.encoder.encode(identifier.databaseKey()).base64EncodedString()
+    private func insertToSearchIndices(collection: Model.Collection) throws {
+        guard self.useSearchIndices.get() ?? false else { return }
 
-        let packagesQuery = "DELETE FROM \(Self.packagesFTSName) WHERE collection_id_blob_base64 = ?;"
-        try self.executeStatement(packagesQuery) { statement -> Void in
-            let bindings: [SQLite.SQLiteValue] = [.string(identifierBase64)]
-            try statement.bind(bindings)
-            try statement.step()
+        try self.ftsLock.withLock {
+            // Update search indices
+            try self.withDB { db in
+                try db.exec(query: "BEGIN TRANSACTION;")
+
+                // First delete existing data
+                try self.removeFromSearchIndices(identifier: collection.identifier)
+
+                let packagesStatement = try db.prepare(query: "INSERT INTO \(Self.packagesFTSName) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);")
+                let targetsStatement = try db.prepare(query: "INSERT INTO \(Self.targetsFTSName) VALUES (?, ?, ?);")
+
+                // Then insert new data
+                try collection.packages.forEach { package in
+                    var targets = Set<String>()
+
+                    try package.versions.forEach { version in
+                        // Packages FTS
+                        let packagesBindings: [SQLite.SQLiteValue] = [
+                            .string(try self.encoder.encode(collection.identifier).base64EncodedString()),
+                            .string(package.reference.identity.description),
+                            .string(version.version.description),
+                            .string(version.packageName),
+                            .string(package.repository.url),
+                            package.summary.map { .string($0) } ?? .null,
+                            package.keywords.map { .string($0.joined(separator: ",")) } ?? .null,
+                            .string(version.products.map { $0.name }.joined(separator: ",")),
+                            .string(version.targets.map { $0.name }.joined(separator: ",")),
+                        ]
+                        try packagesStatement.bind(packagesBindings)
+                        try packagesStatement.step()
+
+                        try packagesStatement.clearBindings()
+                        try packagesStatement.reset()
+
+                        version.targets.forEach { targets.insert($0.name) }
+                    }
+
+                    let collectionPackage = CollectionPackage(collection: collection.identifier, package: package.reference.identity)
+                    try targets.forEach { target in
+                        // Targets in-memory trie
+                        self.targetTrie.insert(word: target.lowercased(), foundIn: collectionPackage)
+
+                        // Targets FTS
+                        let targetsBindings: [SQLite.SQLiteValue] = [
+                            .string(try self.encoder.encode(collection.identifier).base64EncodedString()),
+                            .string(package.repository.url),
+                            .string(target),
+                        ]
+                        try targetsStatement.bind(targetsBindings)
+                        try targetsStatement.step()
+
+                        try targetsStatement.clearBindings()
+                        try targetsStatement.reset()
+                    }
+                }
+
+                try db.exec(query: "COMMIT;")
+
+                try packagesStatement.finalize()
+                try targetsStatement.finalize()
+            }
         }
-
-        let targetsQuery = "DELETE FROM \(Self.targetsFTSName) WHERE collection_id_blob_base64 = ?;"
-        try self.executeStatement(targetsQuery) { statement -> Void in
-            let bindings: [SQLite.SQLiteValue] = [.string(identifierBase64)]
-            try statement.bind(bindings)
-            try statement.step()
-        }
-
-        self.targetTrie.remove { $0.collection == identifier }
     }
 
     func remove(identifier: Model.CollectionIdentifier,
@@ -217,6 +206,28 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                 callback(.failure(error))
             }
         }
+    }
+
+    private func removeFromSearchIndices(identifier: Model.CollectionIdentifier) throws {
+        guard self.useSearchIndices.get() ?? false else { return }
+
+        let identifierBase64 = try self.encoder.encode(identifier.databaseKey()).base64EncodedString()
+
+        let packagesQuery = "DELETE FROM \(Self.packagesFTSName) WHERE collection_id_blob_base64 = ?;"
+        try self.executeStatement(packagesQuery) { statement -> Void in
+            let bindings: [SQLite.SQLiteValue] = [.string(identifierBase64)]
+            try statement.bind(bindings)
+            try statement.step()
+        }
+
+        let targetsQuery = "DELETE FROM \(Self.targetsFTSName) WHERE collection_id_blob_base64 = ?;"
+        try self.executeStatement(targetsQuery) { statement -> Void in
+            let bindings: [SQLite.SQLiteValue] = [.string(identifierBase64)]
+            try statement.bind(bindings)
+            try statement.step()
+        }
+
+        self.targetTrie.remove { $0.collection == identifier }
     }
 
     func get(identifier: Model.CollectionIdentifier,
@@ -322,50 +333,83 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
             case .failure(let error):
                 callback(.failure(error))
             case .success(let collections):
-                var matches = [(collection: Model.CollectionIdentifier, package: PackageIdentity)]()
-                do {
-                    let packageQuery = "SELECT collection_id_blob_base64, repository_url FROM \(Self.packagesFTSName) WHERE \(Self.packagesFTSName) MATCH ?;"
-                    try self.executeStatement(packageQuery) { statement in
-                        try statement.bind([.string(query)])
+                if self.useSearchIndices.get() ?? false {
+                    var matches = [(collection: Model.CollectionIdentifier, package: PackageIdentity)]()
+                    do {
+                        let packageQuery = "SELECT collection_id_blob_base64, repository_url FROM \(Self.packagesFTSName) WHERE \(Self.packagesFTSName) MATCH ?;"
+                        try self.executeStatement(packageQuery) { statement in
+                            try statement.bind([.string(query)])
 
-                        while let row = try statement.step() {
-                            if let collectionData = Data(base64Encoded: row.string(at: 0)),
-                                let collection = try? self.decoder.decode(Model.CollectionIdentifier.self, from: collectionData) {
-                                matches.append((collection: collection, package: PackageIdentity(url: row.string(at: 1))))
+                            while let row = try statement.step() {
+                                if let collectionData = Data(base64Encoded: row.string(at: 0)),
+                                    let collection = try? self.decoder.decode(Model.CollectionIdentifier.self, from: collectionData) {
+                                    matches.append((collection: collection, package: PackageIdentity(url: row.string(at: 1))))
+                                }
                             }
                         }
+                    } catch {
+                        return callback(.failure(error))
                     }
-                } catch {
-                    return callback(.failure(error))
-                }
 
-                let collectionDict = collections.reduce(into: [Model.CollectionIdentifier: Model.Collection]()) { result, collection in
-                    result[collection.identifier] = collection
-                }
+                    let collectionDict = collections.reduce(into: [Model.CollectionIdentifier: Model.Collection]()) { result, collection in
+                        result[collection.identifier] = collection
+                    }
 
-                // For each package, find the containing collections
-                let packageCollections = matches.filter { collectionDict.keys.contains($0.collection) }
-                    .reduce(into: [PackageIdentity: (package: Model.Package, collections: Set<Model.CollectionIdentifier>)]()) { result, match in
-                        var entry = result.removeValue(forKey: match.package)
-                        if entry == nil {
-                            guard let package = collectionDict[match.collection].flatMap({ collection in
-                                collection.packages.first { $0.reference.identity == match.package }
-                            }) else {
-                                return
+                    // For each package, find the containing collections
+                    let packageCollections = matches.filter { collectionDict.keys.contains($0.collection) }
+                        .reduce(into: [PackageIdentity: (package: Model.Package, collections: Set<Model.CollectionIdentifier>)]()) { result, match in
+                            var entry = result.removeValue(forKey: match.package)
+                            if entry == nil {
+                                guard let package = collectionDict[match.collection].flatMap({ collection in
+                                    collection.packages.first { $0.reference.identity == match.package }
+                                }) else {
+                                    return
+                                }
+                                entry = (package, .init())
                             }
-                            entry = (package, .init())
+
+                            if var entry = entry {
+                                entry.collections.insert(match.collection)
+                                result[match.package] = entry
+                            }
                         }
 
-                        if var entry = entry {
-                            entry.collections.insert(match.collection)
-                            result[match.package] = entry
+                    let result = Model.PackageSearchResult(items: packageCollections.map { entry in
+                        .init(package: entry.value.package, collections: Array(entry.value.collections))
+                    })
+                    callback(.success(result))
+                } else {
+                    let queryString = query.lowercased()
+                    let collectionsPackages = collections.reduce([Model.CollectionIdentifier: [Model.Package]]()) { partial, collection in
+                        var map = partial
+                        map[collection.identifier] = collection.packages.filter { package in
+                            if package.repository.url.lowercased().contains(queryString) { return true }
+                            if let summary = package.summary, summary.lowercased().contains(queryString) { return true }
+                            if let keywords = package.keywords, (keywords.map { $0.lowercased() }).contains(queryString) { return true }
+                            return package.versions.contains(where: { version in
+                                if version.packageName.lowercased().contains(queryString) { return true }
+                                if version.products.contains(where: { $0.name.lowercased().contains(queryString) }) { return true }
+                                return version.targets.contains(where: { $0.name.lowercased().contains(queryString) })
+                            })
+                        }
+                        return map
+                    }
+
+                    var packageCollections = [PackageReference: (package: Model.Package, collections: Set<Model.CollectionIdentifier>)]()
+                    collectionsPackages.forEach { collectionIdentifier, packages in
+                        packages.forEach { package in
+                            // Avoid copy-on-write: remove entry from dictionary before mutating
+                            var entry = packageCollections.removeValue(forKey: package.reference) ?? (package, .init())
+                            entry.collections.insert(collectionIdentifier)
+                            packageCollections[package.reference] = entry
                         }
                     }
 
-                let result = Model.PackageSearchResult(items: packageCollections.map { entry in
-                    .init(package: entry.value.package, collections: Array(entry.value.collections))
-                })
-                callback(.success(result))
+                    let result = Model.PackageSearchResult(items: packageCollections.map { entry in
+                        .init(package: entry.value.package, collections: Array(entry.value.collections))
+                    })
+                    callback(.success(result))
+                }
             }
         }
     }
@@ -378,37 +422,52 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
             case .failure(let error):
                 return callback(.failure(error))
             case .success(let collections):
-                var matches = [(collection: Model.CollectionIdentifier, package: PackageIdentity)]()
-                do {
-                    let packageQuery = "SELECT collection_id_blob_base64, repository_url FROM \(Self.packagesFTSName) WHERE id = ?;"
-                    try self.executeStatement(packageQuery) { statement in
-                        try statement.bind([.string(identifier.description)])
+                if self.useSearchIndices.get() ?? false {
+                    var matches = [(collection: Model.CollectionIdentifier, package: PackageIdentity)]()
+                    do {
+                        let packageQuery = "SELECT collection_id_blob_base64, repository_url FROM \(Self.packagesFTSName) WHERE id = ?;"
+                        try self.executeStatement(packageQuery) { statement in
+                            try statement.bind([.string(identifier.description)])
 
-                        while let row = try statement.step() {
-                            if let collectionData = Data(base64Encoded: row.string(at: 0)),
-                                let collection = try? self.decoder.decode(Model.CollectionIdentifier.self, from: collectionData) {
-                                matches.append((collection: collection, package: PackageIdentity(url: row.string(at: 1))))
+                            while let row = try statement.step() {
+                                if let collectionData = Data(base64Encoded: row.string(at: 0)),
+                                    let collection = try? self.decoder.decode(Model.CollectionIdentifier.self, from: collectionData) {
+                                    matches.append((collection: collection, package: PackageIdentity(url: row.string(at: 1))))
+                                }
                             }
                         }
+                    } catch {
+                        return callback(.failure(error))
                     }
-                } catch {
-                    return callback(.failure(error))
+
+                    let collectionDict = collections.reduce(into: [Model.CollectionIdentifier: Model.Collection]()) { result, collection in
+                        result[collection.identifier] = collection
+                    }
+
+                    let collections = matches.filter { collectionDict.keys.contains($0.collection) }
+                        .compactMap { collectionDict[$0.collection] }
+                        // Sort collections by processing date so the latest metadata is first
+                        .sorted(by: { lhs, rhs in lhs.lastProcessedAt > rhs.lastProcessedAt })
+
+                    guard let package = collections.compactMap({ $0.packages.first { $0.reference.identity == identifier } }).first else {
+                        return callback(.failure(NotFoundError("\(identifier)")))
+                    }
+
+                    callback(.success(.init(package: package, collections: collections.map { $0.identifier })))
+                } else {
+                    // sorting by collection processing date so the latest metadata is first
+                    let collectionPackages = collections.sorted(by: { lhs, rhs in lhs.lastProcessedAt > rhs.lastProcessedAt }).compactMap { collection in
+                        collection.packages
+                            .first(where: { $0.reference.identity == identifier })
+                            .flatMap { (collection: collection.identifier, package: $0) }
+                    }
+                    // first package should have latest processing date
+                    guard let package = collectionPackages.first?.package else {
+                        return callback(.failure(NotFoundError("\(identifier)")))
+                    }
+                    let collections = collectionPackages.map { $0.collection }
+                    callback(.success(.init(package: package, collections: collections)))
                 }
-
-                let collectionDict = collections.reduce(into: [Model.CollectionIdentifier: Model.Collection]()) { result, collection in
-                    result[collection.identifier] = collection
-                }
-
-                let collections = matches.filter { collectionDict.keys.contains($0.collection) }
-                    .compactMap { collectionDict[$0.collection] }
-                    // Sort collections by processing date so the latest metadata is first
-                    .sorted(by: { lhs, rhs in lhs.lastProcessedAt > rhs.lastProcessedAt })
-
-                guard let package = collections.compactMap({ $0.packages.first { $0.reference.identity == identifier } }).first else {
-                    return callback(.failure(NotFoundError("\(identifier)")))
-                }
-
-                callback(.success(.init(package: package, collections: collections.map { $0.identifier })))
             }
         }
     }
@@ -424,106 +483,166 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
             case .failure(let error):
                 callback(.failure(error))
             case .success(let collections):
-                var matches = [(collection: Model.CollectionIdentifier, package: PackageIdentity, targetName: String)]()
-                // Trie is more performant for target search; use it if available
-                if self.targetTrieReady.get() ?? false {
-                    do {
-                        switch type {
-                        case .exactMatch:
-                            try self.targetTrie.find(word: query).forEach {
-                                matches.append((collection: $0.collection, package: $0.package, targetName: query))
-                            }
-                        case .prefix:
-                            try self.targetTrie.findWithPrefix(query).forEach { targetName, collectionPackages in
-                                collectionPackages.forEach {
-                                    matches.append((collection: $0.collection, package: $0.package, targetName: targetName))
-                                }
-                            }
-                        }
-                    } catch is NotFoundError {
-                        // Do nothing if no matches found
-                    } catch {
-                        return callback(.failure(error))
-                    }
-                } else {
-                    do {
-                        let targetQuery = "SELECT collection_id_blob_base64, package_repository_url, name FROM \(Self.targetsFTSName) WHERE name LIKE ?;"
-                        try self.executeStatement(targetQuery) { statement in
+                if self.useSearchIndices.get() ?? false {
+                    var matches = [(collection: Model.CollectionIdentifier, package: PackageIdentity, targetName: String)]()
+                    // Trie is more performant for target search; use it if available
+                    if self.targetTrieReady.get() ?? false {
+                        do {
                             switch type {
                             case .exactMatch:
-                                try statement.bind([.string("\(query)")])
+                                try self.targetTrie.find(word: query).forEach {
+                                    matches.append((collection: $0.collection, package: $0.package, targetName: query))
+                                }
                             case .prefix:
-                                try statement.bind([.string("\(query)%")])
+                                try self.targetTrie.findWithPrefix(query).forEach { targetName, collectionPackages in
+                                    collectionPackages.forEach {
+                                        matches.append((collection: $0.collection, package: $0.package, targetName: targetName))
+                                    }
+                                }
                             }
+                        } catch is NotFoundError {
+                            // Do nothing if no matches found
+                        } catch {
+                            return callback(.failure(error))
+                        }
+                    } else {
+                        do {
+                            let targetQuery = "SELECT collection_id_blob_base64, package_repository_url, name FROM \(Self.targetsFTSName) WHERE name LIKE ?;"
+                            try self.executeStatement(targetQuery) { statement in
+                                switch type {
+                                case .exactMatch:
+                                    try statement.bind([.string("\(query)")])
+                                case .prefix:
+                                    try statement.bind([.string("\(query)%")])
+                                }
 
-                            while let row = try statement.step() {
-                                if let collectionData = Data(base64Encoded: row.string(at: 0)),
-                                    let collection = try? self.decoder.decode(Model.CollectionIdentifier.self, from: collectionData) {
-                                    matches.append((
-                                        collection: collection,
-                                        package: PackageIdentity(url: row.string(at: 1)),
-                                        targetName: row.string(at: 2)
-                                    ))
+                                while let row = try statement.step() {
+                                    if let collectionData = Data(base64Encoded: row.string(at: 0)),
+                                        let collection = try? self.decoder.decode(Model.CollectionIdentifier.self, from: collectionData) {
+                                        matches.append((
+                                            collection: collection,
+                                            package: PackageIdentity(url: row.string(at: 1)),
+                                            targetName: row.string(at: 2)
+                                        ))
+                                    }
+                                }
+                            }
+                        } catch {
+                            return callback(.failure(error))
+                        }
+                    }
+
+                    let collectionDict = collections.reduce(into: [Model.CollectionIdentifier: Model.Collection]()) { result, collection in
+                        result[collection.identifier] = collection
+                    }
+
+                    // For each package, find the containing collections
+                    var packageCollections = [PackageIdentity: (package: Model.Package, collections: Set<Model.CollectionIdentifier>)]()
+                    // For each matching target, find the containing package version(s)
+                    var targetPackageVersions = [Model.Target: [PackageIdentity: Set<Model.TargetListResult.PackageVersion>]]()
+
+                    matches.filter { collectionDict.keys.contains($0.collection) }.forEach { match in
+                        var packageEntry = packageCollections.removeValue(forKey: match.package)
+                        if packageEntry == nil {
+                            guard let package = collectionDict[match.collection].flatMap({ collection in
+                                collection.packages.first { $0.reference.identity == match.package }
+                            }) else {
+                                return
+                            }
+                            packageEntry = (package, .init())
+                        }
+
+                        if var packageEntry = packageEntry {
+                            packageEntry.collections.insert(match.collection)
+                            packageCollections[match.package] = packageEntry
+
+                            packageEntry.package.versions.forEach { version in
+                                let targets = version.targets.filter { $0.name.lowercased() == match.targetName.lowercased() }
+                                targets.forEach { target in
+                                    var targetEntry = targetPackageVersions.removeValue(forKey: target) ?? [:]
+                                    var targetPackageEntry = targetEntry.removeValue(forKey: packageEntry.package.reference.identity) ?? .init()
+                                    targetPackageEntry.insert(.init(version: version.version, packageName: version.packageName))
+                                    targetEntry[packageEntry.package.reference.identity] = targetPackageEntry
+                                    targetPackageVersions[target] = targetEntry
                                 }
                             }
                         }
-                    } catch {
-                        return callback(.failure(error))
                     }
-                }
 
-                let collectionDict = collections.reduce(into: [Model.CollectionIdentifier: Model.Collection]()) { result, collection in
-                    result[collection.identifier] = collection
-                }
-
-                // For each package, find the containing collections
-                var packageCollections = [PackageIdentity: (package: Model.Package, collections: Set<Model.CollectionIdentifier>)]()
-                // For each matching target, find the containing package version(s)
-                var targetPackageVersions = [Model.Target: [PackageIdentity: Set<Model.TargetListResult.PackageVersion>]]()
-
-                matches.filter { collectionDict.keys.contains($0.collection) }.forEach { match in
-                    var packageEntry = packageCollections.removeValue(forKey: match.package)
-                    if packageEntry == nil {
-                        guard let package = collectionDict[match.collection].flatMap({ collection in
-                            collection.packages.first { $0.reference.identity == match.package }
-                        }) else {
-                            return
+                    let result = Model.TargetSearchResult(items: targetPackageVersions.map { target, packageVersions in
+                        let targetPackages: [Model.TargetListItem.Package] = packageVersions.compactMap { reference, versions in
+                            guard let packageEntry = packageCollections[reference] else {
+                                return nil
+                            }
+                            return Model.TargetListItem.Package(
+                                repository: packageEntry.package.repository,
+                                summary: packageEntry.package.summary,
+                                versions: Array(versions).sorted(by: >),
+                                collections: Array(packageEntry.collections)
+                            )
                         }
-                        packageEntry = (package, .init())
-                    }
-
-                    if var packageEntry = packageEntry {
-                        packageEntry.collections.insert(match.collection)
-                        packageCollections[match.package] = packageEntry
-
-                        packageEntry.package.versions.forEach { version in
-                            let targets = version.targets.filter { $0.name.lowercased() == match.targetName.lowercased() }
-                            targets.forEach { target in
-                                var targetEntry = targetPackageVersions.removeValue(forKey: target) ?? [:]
-                                var targetPackageEntry = targetEntry.removeValue(forKey: packageEntry.package.reference.identity) ?? .init()
-                                targetPackageEntry.insert(.init(version: version.version, packageName: version.packageName))
-                                targetEntry[packageEntry.package.reference.identity] = targetPackageEntry
-                                targetPackageVersions[target] = targetEntry
+                        return Model.TargetListItem(target: target, packages: targetPackages)
+                    })
+                    callback(.success(result))
+                } else {
+                    let collectionsPackages = collections.reduce([Model.CollectionIdentifier: [(target: Model.Target, package: Model.Package)]]()) { partial, collection in
+                        var map = partial
+                        collection.packages.forEach { package in
+                            package.versions.forEach { version in
+                                version.targets.forEach { target in
+                                    let match: Bool
+                                    switch type {
+                                    case .exactMatch:
+                                        match = target.name.lowercased() == query
+                                    case .prefix:
+                                        match = target.name.lowercased().hasPrefix(query)
+                                    }
+                                    if match {
+                                        // Avoid copy-on-write: remove entry from dictionary before mutating
+                                        var entry = map.removeValue(forKey: collection.identifier) ?? .init()
+                                        entry.append((target, package))
+                                        map[collection.identifier] = entry
+                                    }
+                                }
                             }
                         }
+                        return map
                     }
-                }
 
-                let result = Model.TargetSearchResult(items: targetPackageVersions.map { target, packageVersions in
-                    let targetPackages: [Model.TargetListItem.Package] = packageVersions.compactMap { reference, versions in
-                        guard let packageEntry = packageCollections[reference] else {
-                            return nil
+                    // compose result :p
+                    var packageCollections = [PackageReference: (package: Model.Package, collections: Set<Model.CollectionIdentifier>)]()
+                    var targetsPackages = [Model.Target: Set<PackageReference>]()
+
+                    collectionsPackages.forEach { collectionIdentifier, packagesAndTargets in
+                        packagesAndTargets.forEach { item in
+                            // Avoid copy-on-write: remove entry from dictionary before mutating
+                            var packageCollectionsEntry = packageCollections.removeValue(forKey: item.package.reference) ?? (item.package, .init())
+                            packageCollectionsEntry.collections.insert(collectionIdentifier)
+                            packageCollections[item.package.reference] = packageCollectionsEntry
+
+                            // Avoid copy-on-write: remove entry from dictionary before mutating
+                            var targetsPackagesEntry = targetsPackages.removeValue(forKey: item.target) ?? .init()
+                            targetsPackagesEntry.insert(item.package.reference)
+                            targetsPackages[item.target] = targetsPackagesEntry
                         }
-                        return Model.TargetListItem.Package(
-                            repository: packageEntry.package.repository,
-                            summary: packageEntry.package.summary,
-                            versions: Array(versions).sorted(by: >),
-                            collections: Array(packageEntry.collections)
-                        )
                     }
-                    return Model.TargetListItem(target: target, packages: targetPackages)
-                })
-                callback(.success(result))
+
+                    let result = Model.TargetSearchResult(items: targetsPackages.map { target, packages in
+                        let targetsPackages = packages
+                            .compactMap { packageCollections[$0] }
+                            .map { pair -> Model.TargetListItem.Package in
+                                let versions = pair.package.versions.map { Model.TargetListItem.Package.Version(version: $0.version, packageName: $0.packageName) }
+                                return Model.TargetListItem.Package(repository: pair.package.repository,
+                                                                    summary: pair.package.summary,
+                                                                    versions: versions,
+                                                                    collections: Array(pair.collections))
+                            }
+
+                        return Model.TargetListItem(target: target, packages: targetsPackages)
+                    })
+
+                    callback(.success(result))
+                }
             }
         }
     }
@@ -544,23 +663,49 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
         """
         try db.exec(query: table)
 
-        let ftsPackages = """
-            CREATE VIRTUAL TABLE IF NOT EXISTS \(Self.packagesFTSName) USING fts4(
-                collection_id_blob_base64, id, version, name, repository_url, summary, keywords, products, targets,
-                notindexed=collection_id_blob_base64,
-                tokenize=unicode61
-            );
-        """
-        try db.exec(query: ftsPackages)
+        do {
+            let ftsPackages = """
+                CREATE VIRTUAL TABLE IF NOT EXISTS \(Self.packagesFTSName) USING fts4(
+                    collection_id_blob_base64, id, version, name, repository_url, summary, keywords, products, targets,
+                    notindexed=collection_id_blob_base64,
+                    tokenize=unicode61
+                );
+            """
+            try db.exec(query: ftsPackages)
 
-        let ftsTargets = """
-            CREATE VIRTUAL TABLE IF NOT EXISTS \(Self.targetsFTSName) USING fts4(
-                collection_id_blob_base64, package_repository_url, name,
-                notindexed=collection_id_blob_base64,
-                tokenize=unicode61
-            );
-        """
-        try db.exec(query: ftsTargets)
+            let ftsTargets = """
+                CREATE VIRTUAL TABLE IF NOT EXISTS \(Self.targetsFTSName) USING fts4(
+                    collection_id_blob_base64, package_repository_url, name,
+                    notindexed=collection_id_blob_base64,
+                    tokenize=unicode61
+                );
+            """
+            try db.exec(query: ftsTargets)
+
+            useSearchIndices.put(true)
+        } catch {
+            // These DDL statements work but queries yield different results when run on different
+            // platforms. This could be because of SQLite version perhaps? But since we can't get
+            // consistent results we will not fallback to FTS3 and just give up if FTS4 is not available.
+            /*
+             let ftsPackages = """
+                 CREATE VIRTUAL TABLE IF NOT EXISTS \(Self.packagesFTSName) USING fts3(
+                     collection_id_blob_base64, id, version, name, repository_url, summary, keywords, products, targets,
+                     tokenize=simple
+                 );
+             """
+             try db.exec(query: ftsPackages)
+
+             let ftsTargets = """
+                 CREATE VIRTUAL TABLE IF NOT EXISTS \(Self.targetsFTSName) USING fts3(
+                     collection_id_blob_base64, package_repository_url, name,
+                     tokenize=porter
+                 );
+             """
+             try db.exec(query: ftsTargets)
+             */
+            useSearchIndices.put(false)
+        }
 
         try db.exec(query: "PRAGMA journal_mode=WAL;")
     }

--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -20,6 +20,10 @@ import TSCUtility
 
 final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable {
     static let batchSize = 100
+    
+    private static let packageCollectionsTableName = "package_collections"
+    private static let packagesFTSName = "fts_packages"
+    private static let targetsFTSName = "fts_targets"
 
     let fileSystem: FileSystem
     let location: SQLite.Location
@@ -35,6 +39,13 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
     private let stateLock = Lock()
 
     private let cache = ThreadSafeKeyValueStore<Model.CollectionIdentifier, Model.Collection>()
+    private let cacheLock = Lock()
+    
+    private let ftsLock = Lock()
+
+    private let targetTrie = Trie<CollectionPackage>()
+    private var targetTrieReady = false
+    private let targetTrieReadyLock = Lock()
 
     init(location: SQLite.Location? = nil, diagnosticsEngine: DiagnosticsEngine? = nil) {
         self.location = location ?? .path(localFileSystem.swiftPMCacheDirectory.appending(components: "package-collection.db"))
@@ -47,6 +58,8 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
         self.diagnosticsEngine = diagnosticsEngine
         self.encoder = JSONEncoder.makeWithDefaults()
         self.decoder = JSONDecoder.makeWithDefaults()
+        
+        self.populateTargetTrie()
     }
 
     convenience init(path: AbsolutePath, diagnosticsEngine: DiagnosticsEngine? = nil) {
@@ -73,7 +86,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
         self.queue.async {
             do {
                 // write to db
-                let query = "INSERT OR REPLACE INTO PACKAGES_COLLECTIONS VALUES (?, ?);"
+                let query = "INSERT OR REPLACE INTO \(Self.packageCollectionsTableName) VALUES (?, ?);"
                 try self.executeStatement(query) { statement -> Void in
                     let data = try self.encoder.encode(collection)
 
@@ -84,6 +97,69 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                     try statement.bind(bindings)
                     try statement.step()
                 }
+                
+                // Update search indices
+                try self.ftsLock.withLock {
+                    // Lock helps prevent "SQL logic error" thrown by transaction statements during `refreshCollections`,
+                    // since only one transaction is allowed per connection. Bulk updates are faster with transaction.
+                    try self.withDB { db in
+                        try db.exec(query: "BEGIN TRANSACTION;")
+                        
+                        // First delete existing data
+                        try self.removeFromSearchIndices(identifier: collection.identifier)
+                        
+                        // Then insert new data
+                        let packagesStatement = try db.prepare(query: "INSERT INTO \(Self.packagesFTSName) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);")
+                        let targetsStatement = try db.prepare(query: "INSERT INTO \(Self.targetsFTSName) VALUES (?, ?, ?);")
+                        
+                        try collection.packages.forEach { package in
+                            var targets = Set<String>()
+                            
+                            try package.versions.forEach { version in
+                                let packagesBindings: [SQLite.SQLiteValue] = [
+                                    .string(try self.encoder.encode(collection.identifier).base64EncodedString()),
+                                    .string(package.reference.identity.description),
+                                    .string(version.version.description),
+                                    .string(version.packageName),
+                                    .string(package.repository.url),
+                                    package.summary.map { .string($0) } ?? .null,
+                                    package.keywords.map { .string($0.joined(separator: ",")) } ?? .null,
+                                    .string(version.products.map { $0.name }.joined(separator: ",")),
+                                    .string(version.targets.map { $0.name }.joined(separator: ",")),
+                                ]
+                                try packagesStatement.bind(packagesBindings)
+                                try packagesStatement.step()
+
+                                try packagesStatement.clearBindings()
+                                try packagesStatement.reset()
+                                
+                                version.targets.forEach { targets.insert($0.name) }
+                            }
+                            
+                            let collectionPackage = CollectionPackage(collection: collection.identifier, package: package.reference.identity)
+                            try targets.forEach { target in
+                                self.targetTrie.insert(word: target.lowercased(), foundIn: collectionPackage)
+                                
+                                let targetsBindings: [SQLite.SQLiteValue] = [
+                                    .string(try self.encoder.encode(collection.identifier).base64EncodedString()),
+                                    .string(package.repository.url),
+                                    .string(target)
+                                ]
+                                try targetsStatement.bind(targetsBindings)
+                                try targetsStatement.step()
+
+                                try targetsStatement.clearBindings()
+                                try targetsStatement.reset()
+                            }
+                        }
+                        
+                        try db.exec(query: "COMMIT;")
+                        
+                        try packagesStatement.finalize()
+                        try targetsStatement.finalize()
+                    }
+                }
+
                 // write to cache
                 self.cache[collection.identifier] = collection
                 callback(.success(collection))
@@ -92,13 +168,33 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
             }
         }
     }
+    
+    private func removeFromSearchIndices(identifier: Model.CollectionIdentifier) throws {
+        let identifierBase64 = try self.encoder.encode(identifier.databaseKey()).base64EncodedString()
+        
+        let packagesQuery = "DELETE FROM \(Self.packagesFTSName) WHERE collection_id_blob_base64 = ?;"
+        try self.executeStatement(packagesQuery) { statement -> Void in
+            let bindings: [SQLite.SQLiteValue] = [.string(identifierBase64)]
+            try statement.bind(bindings)
+            try statement.step()
+        }
+    
+        let targetsQuery = "DELETE FROM \(Self.targetsFTSName) WHERE collection_id_blob_base64 = ?;"
+        try self.executeStatement(targetsQuery) { statement -> Void in
+            let bindings: [SQLite.SQLiteValue] = [.string(identifierBase64)]
+            try statement.bind(bindings)
+            try statement.step()
+        }
+        
+        self.targetTrie.remove { $0.collection == identifier }
+    }
 
     func remove(identifier: Model.CollectionIdentifier,
                 callback: @escaping (Result<Void, Error>) -> Void) {
         self.queue.async {
             do {
                 // write to db
-                let query = "DELETE FROM PACKAGES_COLLECTIONS WHERE key == ?;"
+                let query = "DELETE FROM \(Self.packageCollectionsTableName) WHERE key = ?;"
                 try self.executeStatement(query) { statement -> Void in
                     let bindings: [SQLite.SQLiteValue] = [
                         .string(identifier.databaseKey()),
@@ -106,6 +202,10 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                     try statement.bind(bindings)
                     try statement.step()
                 }
+                
+                // remove from search indices
+                try self.removeFromSearchIndices(identifier: identifier)
+                
                 // write to cache
                 self.cache[identifier] = nil
                 callback(.success(()))
@@ -125,7 +225,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
         // go to db if not found
         self.queue.async {
             do {
-                let query = "SELECT value FROM PACKAGES_COLLECTIONS WHERE key == ? LIMIT 1;"
+                let query = "SELECT value FROM \(Self.packageCollectionsTableName) WHERE key = ? LIMIT 1;"
                 let collection = try self.executeStatement(query) { statement -> Model.Collection in
                     try statement.bind([.string(identifier.databaseKey())])
 
@@ -160,7 +260,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                     var index = 0
                     while index < identifiers.count {
                         let slice = identifiers[index ..< min(index + Self.batchSize, identifiers.count)]
-                        let query = "SELECT value FROM PACKAGES_COLLECTIONS WHERE key in (\(slice.map { _ in "?" }.joined(separator: ",")));"
+                        let query = "SELECT value FROM \(Self.packageCollectionsTableName) WHERE key in (\(slice.map { _ in "?" }.joined(separator: ",")));"
                         try self.executeStatement(query) { statement in
                             try statement.bind(slice.compactMap { .string($0.databaseKey()) })
                             while let row = try statement.step() {
@@ -170,7 +270,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                         index += Self.batchSize
                     }
                 } else {
-                    let query = "SELECT value FROM PACKAGES_COLLECTIONS;"
+                    let query = "SELECT value FROM \(Self.packageCollectionsTableName);"
                     try self.executeStatement(query) { statement in
                         while let row = try statement.step() {
                             blobs.append(row.blob(at: 0))
@@ -210,54 +310,61 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
         }
     }
 
-    // TODO: this is PoC for search, need a more performant version of this
     func searchPackages(identifiers: [Model.CollectionIdentifier]? = nil,
                         query: String,
                         callback: @escaping (Result<Model.PackageSearchResult, Error>) -> Void) {
-        let queryString = query.lowercased()
-
         self.list(identifiers: identifiers) { result in
             switch result {
             case .failure(let error):
                 callback(.failure(error))
             case .success(let collections):
-                let collectionsPackages = collections.reduce([Model.CollectionIdentifier: [Model.Package]]()) { partial, collection in
-                    var map = partial
-                    map[collection.identifier] = collection.packages.filter { package in
-                        if package.repository.url.lowercased().contains(queryString) { return true }
-                        if let summary = package.summary, summary.lowercased().contains(queryString) { return true }
-                        if let keywords = package.keywords, (keywords.map { $0.lowercased() }).contains(queryString) { return true }
-                        return package.versions.contains(where: { version in
-                            if version.packageName.lowercased().contains(queryString) { return true }
-                            if version.products.contains(where: { $0.name.lowercased().contains(queryString) }) { return true }
-                            return version.targets.contains(where: { $0.name.lowercased().contains(queryString) })
-                        })
+                var matches = [(collection: Model.CollectionIdentifier, package: PackageIdentity)]()
+                do {
+                    let packageQuery = "SELECT collection_id_blob_base64, repository_url FROM \(Self.packagesFTSName) WHERE \(Self.packagesFTSName) MATCH ?;"
+                    try self.executeStatement(packageQuery) { statement in
+                        try statement.bind([.string(query)])
+                        
+                        while let row = try statement.step() {
+                            if let collectionData = Data(base64Encoded: row.string(at: 0)),
+                               let collection = try? self.decoder.decode(Model.CollectionIdentifier.self, from: collectionData) {
+                                matches.append((collection: collection, package: PackageIdentity(url: row.string(at: 1))))
+                            }
+                        }
                     }
-                    return map
+                } catch {
+                    return callback(.failure(error))
                 }
 
-                // compose result :p
-
-                var packageCollections = [PackageReference: (package: Model.Package, collections: Set<Model.CollectionIdentifier>)]()
-                collectionsPackages.forEach { collectionIdentifier, packages in
-                    packages.forEach { package in
-                        // Avoid copy-on-write: remove entry from dictionary before mutating
-                        var entry = packageCollections.removeValue(forKey: package.reference) ?? (package, .init())
-                        entry.collections.insert(collectionIdentifier)
-                        packageCollections[package.reference] = entry
-                    }
+                let collectionDict = collections.reduce(into: [Model.CollectionIdentifier: Model.Collection]()) { result, collection in
+                    result[collection.identifier] = collection
                 }
+                
+                let packageCollections = matches.filter { collectionDict.keys.contains($0.collection) }
+                    .reduce(into: [PackageIdentity: (package: Model.Package, collections: Set<Model.CollectionIdentifier>)]()) { result, match in
+                        var entry = result.removeValue(forKey: match.package)
+                        if entry == nil {
+                            guard let package = collectionDict[match.collection].flatMap({ collection in
+                                collection.packages.first { $0.reference.identity == match.package }
+                            }) else {
+                                return
+                            }
+                            entry = (package, .init())
+                        }
+
+                        if var entry = entry {
+                            entry.collections.insert(match.collection)
+                            result[match.package] = entry
+                        }
+                    }
 
                 let result = Model.PackageSearchResult(items: packageCollections.map { entry in
                     .init(package: entry.value.package, collections: Array(entry.value.collections))
                 })
-
                 callback(.success(result))
             }
         }
     }
 
-    // TODO: this is PoC for search, need a more performant version of this
     func findPackage(identifier: PackageIdentity,
                      collectionIdentifiers: [Model.CollectionIdentifier]?,
                      callback: @escaping (Result<Model.PackageSearchResult.Item, Error>) -> Void) {
@@ -266,23 +373,41 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
             case .failure(let error):
                 return callback(.failure(error))
             case .success(let collections):
-                // sorting by collection processing date so the latest metadata is first
-                let collectionPackages = collections.sorted(by: { lhs, rhs in lhs.lastProcessedAt > rhs.lastProcessedAt }).compactMap { collection in
-                    collection.packages
-                        .first(where: { $0.reference.identity == identifier })
-                        .flatMap { (collection: collection.identifier, package: $0) }
+                var matches = [(collection: Model.CollectionIdentifier, package: PackageIdentity)]()
+                do {
+                    let packageQuery = "SELECT collection_id_blob_base64, repository_url FROM \(Self.packagesFTSName) WHERE id = ?;"
+                    try self.executeStatement(packageQuery) { statement in
+                        try statement.bind([.string(identifier.description)])
+                        
+                        while let row = try statement.step() {
+                            if let collectionData = Data(base64Encoded: row.string(at: 0)),
+                               let collection = try? self.decoder.decode(Model.CollectionIdentifier.self, from: collectionData) {
+                                matches.append((collection: collection, package: PackageIdentity(url: row.string(at: 1))))
+                            }
+                        }
+                    }
+                } catch {
+                    return callback(.failure(error))
                 }
-                // first package should have latest processing date
-                guard let package = collectionPackages.first?.package else {
+
+                let collectionDict = collections.reduce(into: [Model.CollectionIdentifier: Model.Collection]()) { result, collection in
+                    result[collection.identifier] = collection
+                }
+                
+                let collections = matches.filter { collectionDict.keys.contains($0.collection) }
+                    .compactMap { collectionDict[$0.collection] }
+                    // Sort collections by processing date so the latest metadata is first
+                    .sorted(by: { lhs, rhs in lhs.lastProcessedAt > rhs.lastProcessedAt })
+
+                guard let package = collections.compactMap({ $0.packages.first { $0.reference.identity == identifier } }).first else {
                     return callback(.failure(NotFoundError("\(identifier)")))
                 }
-                let collections = collectionPackages.map { $0.collection }
-                callback(.success(.init(package: package, collections: collections)))
+                
+                callback(.success(.init(package: package, collections: collections.map { $0.identifier })))
             }
         }
     }
 
-    // TODO: this is PoC for search, need a more performant version of this
     func searchTargets(identifiers: [Model.CollectionIdentifier]? = nil,
                        query: String,
                        type: Model.TargetSearchType,
@@ -294,63 +419,111 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
             case .failure(let error):
                 callback(.failure(error))
             case .success(let collections):
-                let collectionsPackages = collections.reduce([Model.CollectionIdentifier: [(target: Model.Target, package: Model.Package)]]()) { partial, collection in
-                    var map = partial
-                    collection.packages.forEach { package in
-                        package.versions.forEach { version in
-                            version.targets.forEach { target in
-                                let match: Bool
-                                switch type {
-                                case .exactMatch:
-                                    match = target.name.lowercased() == query
-                                case .prefix:
-                                    match = target.name.lowercased().hasPrefix(query)
-                                }
-                                if match {
-                                    // Avoid copy-on-write: remove entry from dictionary before mutating
-                                    var entry = map.removeValue(forKey: collection.identifier) ?? .init()
-                                    entry.append((target, package))
-                                    map[collection.identifier] = entry
+                var matches = [(collection: Model.CollectionIdentifier, package: PackageIdentity, targetName: String)]()
+                // Trie is more performant for target search; use it if available
+                if self.targetTrieReadyLock.withLock({ self.targetTrieReady }) {
+                    do {
+                        switch type {
+                        case .exactMatch:
+                            try self.targetTrie.find(word: query).forEach {
+                                matches.append((collection: $0.collection, package: $0.package, targetName: query))
+                            }
+                        case .prefix:
+                            try self.targetTrie.findWithPrefix(query).forEach { targetName, collectionPackages in
+                                collectionPackages.forEach {
+                                    matches.append((collection: $0.collection, package: $0.package, targetName: targetName))
                                 }
                             }
                         }
+                    } catch is NotFoundError {
+                        // do nothing if no matches
+                    } catch {
+                        return callback(.failure(error))
                     }
-                    return map
-                }
-
-                // compose result :p
-
-                var packageCollections = [PackageReference: (package: Model.Package, collections: Set<Model.CollectionIdentifier>)]()
-                var targetsPackages = [Model.Target: Set<PackageReference>]()
-
-                collectionsPackages.forEach { collectionIdentifier, packagesAndTargets in
-                    packagesAndTargets.forEach { item in
-                        // Avoid copy-on-write: remove entry from dictionary before mutating
-                        var packageCollectionsEntry = packageCollections.removeValue(forKey: item.package.reference) ?? (item.package, .init())
-                        packageCollectionsEntry.collections.insert(collectionIdentifier)
-                        packageCollections[item.package.reference] = packageCollectionsEntry
-
-                        // Avoid copy-on-write: remove entry from dictionary before mutating
-                        var targetsPackagesEntry = targetsPackages.removeValue(forKey: item.target) ?? .init()
-                        targetsPackagesEntry.insert(item.package.reference)
-                        targetsPackages[item.target] = targetsPackagesEntry
-                    }
-                }
-
-                let result = Model.TargetSearchResult(items: targetsPackages.map { target, packages in
-                    let targetsPackages = packages
-                        .compactMap { packageCollections[$0] }
-                        .map { pair -> Model.TargetListItem.Package in
-                            let versions = pair.package.versions.map { Model.TargetListItem.Package.Version(version: $0.version, packageName: $0.packageName) }
-                            return Model.TargetListItem.Package(repository: pair.package.repository,
-                                                                summary: pair.package.summary,
-                                                                versions: versions,
-                                                                collections: Array(pair.collections))
+                } else {
+                    do {
+                        let targetQuery = "SELECT collection_id_blob_base64, package_repository_url, name FROM \(Self.targetsFTSName) WHERE name LIKE ?;"
+                        try self.executeStatement(targetQuery) { statement in
+                            try statement.bind([.string("\(query)%")])
+                            
+                            while let row = try statement.step() {
+                                let targetName = row.string(at: 2)
+                                let match: Bool
+                                switch type {
+                                case .exactMatch:
+                                    // Cannot do case-insensitive exact-match with FTS
+                                    match = query.lowercased() == targetName.lowercased()
+                                case .prefix:
+                                    // FTS LIKE and MATCH are case-insensitive
+                                    match = true
+                                }
+                                
+                                if match,
+                                   let collectionData = Data(base64Encoded: row.string(at: 0)),
+                                   let collection = try? self.decoder.decode(Model.CollectionIdentifier.self, from: collectionData) {
+                                    matches.append((
+                                        collection: collection,
+                                        package: PackageIdentity(url: row.string(at: 1)),
+                                        targetName: targetName
+                                    ))
+                                }
+                            }
                         }
+                    } catch {
+                        return callback(.failure(error))
+                    }
+                }
+                
+                let collectionDict = collections.reduce(into: [Model.CollectionIdentifier: Model.Collection]()) { result, collection in
+                    result[collection.identifier] = collection
+                }
 
-                    return Model.TargetListItem(target: target, packages: targetsPackages)
+                var packageCollections = [PackageIdentity: (package: Model.Package, collections: Set<Model.CollectionIdentifier>)]()
+                // For each matching target, find the containing package version(s)
+                var targetPackageVersions = [Model.Target: [PackageIdentity: Set<Model.TargetListResult.PackageVersion>]]()
+                
+                matches.filter { collectionDict.keys.contains($0.collection) }.forEach { match in
+                    var packageEntry = packageCollections.removeValue(forKey: match.package)
+                    if packageEntry == nil {
+                        guard let package = collectionDict[match.collection].flatMap({ collection in
+                            collection.packages.first { $0.reference.identity == match.package }
+                        }) else {
+                            return
+                        }
+                        packageEntry = (package, .init())
+                    }
+
+                    if var packageEntry = packageEntry {
+                        packageEntry.collections.insert(match.collection)
+                        packageCollections[match.package] = packageEntry
+                        
+                        packageEntry.package.versions.forEach { version in
+                            let targets = version.targets.filter { $0.name.lowercased() == match.targetName.lowercased() }
+                            targets.forEach { target in
+                                var targetEntry = targetPackageVersions.removeValue(forKey: target) ?? [:]
+                                var targetPackageEntry = targetEntry.removeValue(forKey: packageEntry.package.reference.identity) ?? .init()
+                                targetPackageEntry.insert(.init(version: version.version, packageName: version.packageName))
+                                targetEntry[packageEntry.package.reference.identity] = targetPackageEntry
+                                targetPackageVersions[target] = targetEntry
+                            }
+                         }
+                    }
+                }
+                
+                let result = Model.TargetSearchResult(items: targetPackageVersions.map { target, packageVersions in
+                    let targetPackages: [Model.TargetListItem.Package] = packageVersions.compactMap { reference, versions in
+                        guard let packageEntry = packageCollections[reference] else {
+                            return nil
+                        }
+                        return Model.TargetListItem.Package(
+                            repository: packageEntry.package.repository,
+                            summary: packageEntry.package.summary,
+                            versions: Array(versions).sorted(by: >),
+                            collections: Array(packageEntry.collections)
+                        )
+                    }
+                    return Model.TargetListItem(target: target, packages: targetPackages)
                 })
-
                 callback(.success(result))
             }
         }
@@ -365,13 +538,31 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
 
     private func createSchemaIfNecessary(db: SQLite) throws {
         let table = """
-            CREATE TABLE IF NOT EXISTS PACKAGES_COLLECTIONS (
+            CREATE TABLE IF NOT EXISTS \(Self.packageCollectionsTableName) (
                 key STRING PRIMARY KEY NOT NULL,
                 value BLOB NOT NULL
             );
         """
-
         try db.exec(query: table)
+        
+        let ftsPackages = """
+            CREATE VIRTUAL TABLE IF NOT EXISTS \(Self.packagesFTSName) USING fts4(
+                collection_id_blob_base64, id, version, name, repository_url, summary, keywords, products, targets,
+                notindexed=collection_id_blob_base64,
+                tokenize=unicode61
+            );
+        """
+        try db.exec(query: ftsPackages)
+        
+        let ftsTargets = """
+            CREATE VIRTUAL TABLE IF NOT EXISTS \(Self.targetsFTSName) USING fts4(
+                collection_id_blob_base64, package_repository_url, name,
+                notindexed=collection_id_blob_base64,
+                tokenize=unicode61
+            );
+        """
+        try db.exec(query: ftsTargets)
+        
         try db.exec(query: "PRAGMA journal_mode=WAL;")
     }
 
@@ -434,6 +625,41 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
         }
 
         return try body(db)
+    }
+    
+    func populateTargetTrie(callback: @escaping (Result<Void, Error>) -> Void = { _ in }) {
+        self.queue.async {
+            do {
+                // Use FTS to build the trie
+                let query = "SELECT collection_id_blob_base64, package_repository_url, name FROM \(Self.targetsFTSName);"
+                try self.executeStatement(query) { statement in
+                    while let row = try statement.step() {
+                        let targetName = row.string(at: 2)
+
+                        if let collectionData = Data(base64Encoded: row.string(at: 0)),
+                           let collection = try? self.decoder.decode(Model.CollectionIdentifier.self, from: collectionData) {
+                            let collectionPackage = CollectionPackage(collection: collection, package: PackageIdentity(url: row.string(at: 1)))
+                            self.targetTrie.insert(word: targetName.lowercased(), foundIn: collectionPackage)
+                        }
+                    }
+                }
+                self.targetTrieReadyLock.withLock { self.targetTrieReady = true }
+                callback(.success(()))
+            } catch {
+                self.targetTrieReadyLock.withLock { self.targetTrieReady = false }
+                callback(.failure(error))
+            }
+        }
+    }
+    
+    // For `Trie`
+    private struct CollectionPackage: Hashable, CustomStringConvertible {
+        let collection: Model.CollectionIdentifier
+        let package: PackageIdentity
+
+        var description: String {
+            "\(collection): \(package)"
+        }
     }
 }
 

--- a/Sources/PackageCollections/Storage/Trie.swift
+++ b/Sources/PackageCollections/Storage/Trie.swift
@@ -1,0 +1,253 @@
+/*
+ This source file is part of the Swift.org open source project
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import TSCBasic
+
+import PackageModel
+
+struct Trie<Document: Hashable> {
+    private typealias Node = TrieNode<Character, Document>
+    
+    private let root: Node
+    
+    init() {
+        self.root = Node()
+    }
+    
+    /// Inserts a word and its document to the trie.
+    func insert(word: String, foundIn document: Document) {
+        guard !word.isEmpty else { return }
+        
+        var currentNode = self.root
+        // Check if word already exists otherwise creates the node path
+        for character in word.lowercased() {
+            if let child = currentNode.children[character] {
+                currentNode = child
+            } else {
+                currentNode = currentNode.add(value: character)
+            }
+        }
+        
+        currentNode.add(document: document)
+    }
+    
+    /// Removes word occurrences found in the given document.
+    func remove(document: Document) {
+        func removeInSubTrie(root: Node, document: Document) {
+            if root.isTerminating {
+                root.remove(document: document)
+            }
+            
+            // Clean up sub-tries
+            root.children.values.forEach {
+                removeInSubTrie(root: $0, document: document)
+            }
+            
+            root.children.forEach { value, node in
+                // If a child node doesn't have children (i.e., there are no words under it),
+                // and itself is not a word, delete it since its path has become a deadend.
+                if node.isLeaf, !node.isTerminating {
+                    root.remove(value: value)
+                }
+            }
+        }
+        
+        removeInSubTrie(root: self.root, document: document)
+    }
+    
+    /// Removes word occurrences found in the given document.
+    func remove(where predicate: @escaping (Document) -> Bool) {
+        func removeInSubTrie(root: Node, where predicate: @escaping (Document) -> Bool) {
+            if root.isTerminating {
+                root.remove(where: predicate)
+            }
+            
+            // Clean up sub-tries
+            root.children.values.forEach {
+                removeInSubTrie(root: $0, where: predicate)
+            }
+            
+            root.children.forEach { value, node in
+                // If a child node doesn't have children (i.e., there are no words under it),
+                // and itself is not a word, delete it since its path has become a deadend.
+                if node.isLeaf, !node.isTerminating {
+                    root.remove(value: value)
+                }
+            }
+        }
+        
+        removeInSubTrie(root: self.root, where: predicate)
+    }
+    
+    /// Checks if the trie contains the exact word or words with matching prefix.
+    func contains(word: String, prefixMatch: Bool = false) -> Bool {
+        guard let node = self.findLastNodeOf(word: word) else {
+            return false
+        }
+        return prefixMatch || node.isTerminating
+    }
+    
+    /// Finds the word in this trie and returns its documents.
+    func find(word: String) throws -> Set<Document> {
+        guard let node = self.findLastNodeOf(word: word), node.isTerminating else {
+            throw NotFoundError(word)
+        }
+        return node.documents
+    }
+    
+    /// Finds words with matching prefix in this trie and returns their documents.
+    func findWithPrefix(_ prefix: String) throws -> [String: Set<Document>] {
+        guard let node = self.findLastNodeOf(word: prefix) else {
+            throw NotFoundError(prefix)
+        }
+                
+        func wordsInSubTrie(root: Node, prefix: String) -> [String: Set<Document>] {
+            precondition(root.value != nil, "Sub-trie root's value should not be nil")
+            
+            var subTrieWords = [String: Set<Document>]()
+            
+            // Construct the new prefix by adding the sub-trie root's character
+            var previousCharacters = prefix
+            previousCharacters.append(root.value!.lowercased()) // !-safe; see precondition
+            
+            // The root actually forms a word
+            if root.isTerminating {
+                subTrieWords[previousCharacters] = root.documents
+            }
+            
+            // Collect all words under this sub-trie
+            root.children.values.forEach {
+                let childWords = wordsInSubTrie(root: $0, prefix: previousCharacters)
+                subTrieWords.merge(childWords, uniquingKeysWith: { _, child in child })
+            }
+            
+            return subTrieWords
+        }
+        
+        var words = [String: Set<Document>]()
+        
+        let prefix = prefix.lowercased()
+        // The prefix is actually a word
+        if node.isTerminating {
+            words[prefix] = node.documents
+        }
+        
+        node.children.values.forEach {
+            let childWords = wordsInSubTrie(root: $0, prefix: prefix)
+            words.merge(childWords, uniquingKeysWith: { _, child in child })
+        }
+        
+        return words
+    }
+    
+    /// Finds the last node in the path of the given word if it exists in this trie.
+    private func findLastNodeOf(word: String) -> Node? {
+        guard !word.isEmpty else { return nil }
+        
+        var currentNode = self.root
+        // Traverse down the trie as far as we can
+        for character in word.lowercased() {
+            guard let child = currentNode.children[character] else {
+                return nil
+            }
+            currentNode = child
+        }
+        return currentNode
+    }
+}
+
+private final class TrieNode<T: Hashable, Document: Hashable> {
+    /// The value (i.e., character) that this node stores. `nil` if root.
+    let value: T?
+    
+    /// The parent of this node. `nil` if root.
+    private weak var parent: TrieNode<T, Document>?
+    
+    /// The children of this node identified by their corresponding value.
+    private var _children = [T: TrieNode<T, Document>]()
+    private let childrenLock = Lock()
+    
+    /// If the path to this node forms a valid word, these are the documents where the word can be found.
+    private var _documents = Set<Document>()
+    private let documentsLock = Lock()
+    
+    var isLeaf: Bool {
+        self.childrenLock.withLock {
+            self._children.isEmpty
+        }
+    }
+    
+    /// `true` indicates the path to this node forms a valid word.
+    var isTerminating: Bool {
+        self.documentsLock.withLock {
+            !self._documents.isEmpty
+        }
+    }
+    
+    var children: [T: TrieNode<T, Document>] {
+        self.childrenLock.withLock {
+            self._children
+        }
+    }
+    
+    var documents: Set<Document> {
+        self.documentsLock.withLock {
+            self._documents
+        }
+    }
+    
+    init(value: T? = nil, parent: TrieNode<T, Document>? = nil) {
+        self.value = value
+        self.parent = parent
+    }
+    
+    /// Adds a subpath under this node.
+    func add(value: T) -> TrieNode<T, Document> {
+        self.childrenLock.withLock {
+            if let existing = self._children[value] {
+                return existing
+            }
+            
+            let child = TrieNode<T, Document>(value: value, parent: self)
+            self._children[value] = child
+            return child
+        }
+    }
+    
+    /// Removes a subpath from this node.
+    func remove(value: T) {
+        _ = self.childrenLock.withLock {
+            self._children.removeValue(forKey: value)
+        }
+    }
+    
+    /// Adds a document in which the word formed by path leading to this node can be found.
+    func add(document: Document) {
+        _ = self.documentsLock.withLock {
+            self._documents.insert(document)
+        }
+    }
+    
+    /// Removes a referenced document.
+    func remove(document: Document) {
+        _ = self.documentsLock.withLock {
+            self._documents.remove(document)
+        }
+    }
+    
+    /// Removes documents that satisfy the given predicate.
+    func remove(where predicate: @escaping (Document) -> Bool) {
+        self.documentsLock.withLock {
+            for document in self._documents {
+                if predicate(document) {
+                    self._documents.remove(document)
+                }
+            }
+        }
+    }
+}

--- a/Sources/PackageCollections/Storage/Trie.swift
+++ b/Sources/PackageCollections/Storage/Trie.swift
@@ -60,7 +60,7 @@ struct Trie<Document: Hashable> {
         removeInSubTrie(root: self.root, document: document)
     }
     
-    /// Removes word occurrences found in the given document.
+    /// Removes word occurrences found in matching document(s).
     func remove(where predicate: @escaping (Document) -> Bool) {
         func removeInSubTrie(root: Node, where predicate: @escaping (Document) -> Bool) {
             if root.isTerminating {

--- a/Sources/PackageCollections/Storage/Trie.swift
+++ b/Sources/PackageCollections/Storage/Trie.swift
@@ -12,17 +12,17 @@ import PackageModel
 
 struct Trie<Document: Hashable> {
     private typealias Node = TrieNode<Character, Document>
-    
+
     private let root: Node
-    
+
     init() {
         self.root = Node()
     }
-    
+
     /// Inserts a word and its document to the trie.
     func insert(word: String, foundIn document: Document) {
         guard !word.isEmpty else { return }
-        
+
         var currentNode = self.root
         // Check if word already exists otherwise creates the node path
         for character in word.lowercased() {
@@ -32,22 +32,22 @@ struct Trie<Document: Hashable> {
                 currentNode = currentNode.add(value: character)
             }
         }
-        
+
         currentNode.add(document: document)
     }
-    
+
     /// Removes word occurrences found in the given document.
     func remove(document: Document) {
         func removeInSubTrie(root: Node, document: Document) {
             if root.isTerminating {
                 root.remove(document: document)
             }
-            
+
             // Clean up sub-tries
             root.children.values.forEach {
                 removeInSubTrie(root: $0, document: document)
             }
-            
+
             root.children.forEach { value, node in
                 // If a child node doesn't have children (i.e., there are no words under it),
                 // and itself is not a word, delete it since its path has become a deadend.
@@ -56,22 +56,22 @@ struct Trie<Document: Hashable> {
                 }
             }
         }
-        
+
         removeInSubTrie(root: self.root, document: document)
     }
-    
+
     /// Removes word occurrences found in matching document(s).
     func remove(where predicate: @escaping (Document) -> Bool) {
         func removeInSubTrie(root: Node, where predicate: @escaping (Document) -> Bool) {
             if root.isTerminating {
                 root.remove(where: predicate)
             }
-            
+
             // Clean up sub-tries
             root.children.values.forEach {
                 removeInSubTrie(root: $0, where: predicate)
             }
-            
+
             root.children.forEach { value, node in
                 // If a child node doesn't have children (i.e., there are no words under it),
                 // and itself is not a word, delete it since its path has become a deadend.
@@ -80,10 +80,10 @@ struct Trie<Document: Hashable> {
                 }
             }
         }
-        
+
         removeInSubTrie(root: self.root, where: predicate)
     }
-    
+
     /// Checks if the trie contains the exact word or words with matching prefix.
     func contains(word: String, prefixMatch: Bool = false) -> Bool {
         guard let node = self.findLastNodeOf(word: word) else {
@@ -91,7 +91,7 @@ struct Trie<Document: Hashable> {
         }
         return prefixMatch || node.isTerminating
     }
-    
+
     /// Finds the word in this trie and returns its documents.
     func find(word: String) throws -> Set<Document> {
         guard let node = self.findLastNodeOf(word: word), node.isTerminating else {
@@ -99,56 +99,56 @@ struct Trie<Document: Hashable> {
         }
         return node.documents
     }
-    
+
     /// Finds words with matching prefix in this trie and returns their documents.
     func findWithPrefix(_ prefix: String) throws -> [String: Set<Document>] {
         guard let node = self.findLastNodeOf(word: prefix) else {
             throw NotFoundError(prefix)
         }
-                
+
         func wordsInSubTrie(root: Node, prefix: String) -> [String: Set<Document>] {
             precondition(root.value != nil, "Sub-trie root's value should not be nil")
-            
+
             var subTrieWords = [String: Set<Document>]()
-            
+
             // Construct the new prefix by adding the sub-trie root's character
             var previousCharacters = prefix
             previousCharacters.append(root.value!.lowercased()) // !-safe; see precondition
-            
+
             // The root actually forms a word
             if root.isTerminating {
                 subTrieWords[previousCharacters] = root.documents
             }
-            
+
             // Collect all words under this sub-trie
             root.children.values.forEach {
                 let childWords = wordsInSubTrie(root: $0, prefix: previousCharacters)
                 subTrieWords.merge(childWords, uniquingKeysWith: { _, child in child })
             }
-            
+
             return subTrieWords
         }
-        
+
         var words = [String: Set<Document>]()
-        
+
         let prefix = prefix.lowercased()
         // The prefix is actually a word
         if node.isTerminating {
             words[prefix] = node.documents
         }
-        
+
         node.children.values.forEach {
             let childWords = wordsInSubTrie(root: $0, prefix: prefix)
             words.merge(childWords, uniquingKeysWith: { _, child in child })
         }
-        
+
         return words
     }
-    
+
     /// Finds the last node in the path of the given word if it exists in this trie.
     private func findLastNodeOf(word: String) -> Node? {
         guard !word.isEmpty else { return nil }
-        
+
         var currentNode = self.root
         // Traverse down the trie as far as we can
         for character in word.lowercased() {
@@ -164,82 +164,82 @@ struct Trie<Document: Hashable> {
 private final class TrieNode<T: Hashable, Document: Hashable> {
     /// The value (i.e., character) that this node stores. `nil` if root.
     let value: T?
-    
+
     /// The parent of this node. `nil` if root.
     private weak var parent: TrieNode<T, Document>?
-    
+
     /// The children of this node identified by their corresponding value.
     private var _children = [T: TrieNode<T, Document>]()
     private let childrenLock = Lock()
-    
+
     /// If the path to this node forms a valid word, these are the documents where the word can be found.
     private var _documents = Set<Document>()
     private let documentsLock = Lock()
-    
+
     var isLeaf: Bool {
         self.childrenLock.withLock {
             self._children.isEmpty
         }
     }
-    
+
     /// `true` indicates the path to this node forms a valid word.
     var isTerminating: Bool {
         self.documentsLock.withLock {
             !self._documents.isEmpty
         }
     }
-    
+
     var children: [T: TrieNode<T, Document>] {
         self.childrenLock.withLock {
             self._children
         }
     }
-    
+
     var documents: Set<Document> {
         self.documentsLock.withLock {
             self._documents
         }
     }
-    
+
     init(value: T? = nil, parent: TrieNode<T, Document>? = nil) {
         self.value = value
         self.parent = parent
     }
-    
+
     /// Adds a subpath under this node.
     func add(value: T) -> TrieNode<T, Document> {
         self.childrenLock.withLock {
             if let existing = self._children[value] {
                 return existing
             }
-            
+
             let child = TrieNode<T, Document>(value: value, parent: self)
             self._children[value] = child
             return child
         }
     }
-    
+
     /// Removes a subpath from this node.
     func remove(value: T) {
         _ = self.childrenLock.withLock {
             self._children.removeValue(forKey: value)
         }
     }
-    
+
     /// Adds a document in which the word formed by path leading to this node can be found.
     func add(document: Document) {
         _ = self.documentsLock.withLock {
             self._documents.insert(document)
         }
     }
-    
+
     /// Removes a referenced document.
     func remove(document: Document) {
         _ = self.documentsLock.withLock {
             self._documents.remove(document)
         }
     }
-    
+
     /// Removes documents that satisfy the given predicate.
     func remove(where predicate: @escaping (Document) -> Bool) {
         self.documentsLock.withLock {

--- a/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
@@ -196,4 +196,37 @@ class PackageCollectionsStorageTests: XCTestCase {
         _ = try tsc_await { callback in storage.put(collection: mockCollections.last!, callback: callback) }
         XCTAssertEqual(list.count, mockCollections.count)
     }
+    
+    func testPopulateTargetTrie() throws {
+        try testWithTemporaryDirectory { tmpPath in
+            let path = tmpPath.appending(component: "test.db")
+            let storage = SQLitePackageCollectionsStorage(path: path)
+            defer { XCTAssertNoThrow(try storage.close()) }
+
+            let mockCollections = makeMockCollections(count: 3)
+            try mockCollections.forEach { collection in
+                _ = try tsc_await { callback in storage.put(collection: collection, callback: callback) }
+            }
+
+            let targetName = mockCollections.last!.packages.last!.versions.last!.targets.last!.name
+            
+            do {
+                let searchResult = try tsc_await { callback in storage.searchTargets(query: targetName, type: .exactMatch, callback: callback) }
+                XCTAssert(searchResult.items.count > 0, "should get results")
+            }
+            
+            // Create another instance, which should read existing data and populate target trie with it.
+            // Since we are not calling `storage2.put`, there is no other way for target trie to get populated.
+            let storage2 = SQLitePackageCollectionsStorage(path: path)
+            defer { XCTAssertNoThrow(try storage2.close()) }
+            
+            // populateTargetTrie is called in `.init`; call it again explicitly so we know when it's finished
+            try tsc_await { callback in storage2.populateTargetTrie(callback: callback) }
+            
+            do {
+                let searchResult = try tsc_await { callback in storage2.searchTargets(query: targetName, type: .exactMatch, callback: callback) }
+                XCTAssert(searchResult.items.count > 0, "should get results")
+            }
+        }
+    }
 }

--- a/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
@@ -196,7 +196,7 @@ class PackageCollectionsStorageTests: XCTestCase {
         _ = try tsc_await { callback in storage.put(collection: mockCollections.last!, callback: callback) }
         XCTAssertEqual(list.count, mockCollections.count)
     }
-    
+
     func testPopulateTargetTrie() throws {
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending(component: "test.db")
@@ -209,23 +209,28 @@ class PackageCollectionsStorageTests: XCTestCase {
             }
 
             let targetName = mockCollections.last!.packages.last!.versions.last!.targets.last!.name
-            
+
             do {
                 let searchResult = try tsc_await { callback in storage.searchTargets(query: targetName, type: .exactMatch, callback: callback) }
                 XCTAssert(searchResult.items.count > 0, "should get results")
             }
-            
+
             // Create another instance, which should read existing data and populate target trie with it.
             // Since we are not calling `storage2.put`, there is no other way for target trie to get populated.
             let storage2 = SQLitePackageCollectionsStorage(path: path)
             defer { XCTAssertNoThrow(try storage2.close()) }
-            
+
             // populateTargetTrie is called in `.init`; call it again explicitly so we know when it's finished
-            try tsc_await { callback in storage2.populateTargetTrie(callback: callback) }
-            
             do {
-                let searchResult = try tsc_await { callback in storage2.searchTargets(query: targetName, type: .exactMatch, callback: callback) }
-                XCTAssert(searchResult.items.count > 0, "should get results")
+                try tsc_await { callback in storage2.populateTargetTrie(callback: callback) }
+
+                do {
+                    let searchResult = try tsc_await { callback in storage2.searchTargets(query: targetName, type: .exactMatch, callback: callback) }
+                    XCTAssert(searchResult.items.count > 0, "should get results")
+                }
+            } catch {
+                // It's possible that some platforms don't have support FTS
+                XCTAssertEqual(false, storage2.useSearchIndices.get(), "populateTargetTrie should fail only if FTS is not available")
             }
         }
     }

--- a/Tests/PackageCollectionsTests/TrieTests.swift
+++ b/Tests/PackageCollectionsTests/TrieTests.swift
@@ -1,0 +1,194 @@
+/*
+ This source file is part of the Swift.org open source project
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import XCTest
+
+@testable import PackageCollections
+
+class TrieTests: XCTestCase {
+    func testContains() {
+        let trie = Trie<Int>()
+        
+        let doc1 = "THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG"
+        self.indexDocument(id: 1, contents: doc1, trie: trie)
+        
+        // Whole word match
+        XCTAssertTrue(trie.contains(word: "brown", prefixMatch: false))
+        XCTAssertTrue(trie.contains(word: "Fox", prefixMatch: false))
+        XCTAssertFalse(trie.contains(word: "foobar", prefixMatch: false))
+        
+        // Prefix match
+        XCTAssertTrue(trie.contains(word: "d", prefixMatch: true))
+        XCTAssertTrue(trie.contains(word: "Do", prefixMatch: true))
+        XCTAssertFalse(trie.contains(word: "doo", prefixMatch: true))
+    }
+    
+    func testFind() {
+        let trie = Trie<Int>()
+        
+        let doc1 = "the quick brown fox jumps over the lazy dog and the dog does not notice the fox jumps over it"
+        let doc2 = "the quick brown fox jumps over the lazy dog for the lazy dog has blocked its way for far too long"
+        self.indexDocument(id: 1, contents: doc1, trie: trie)
+        self.indexDocument(id: 2, contents: doc2, trie: trie)
+        
+        XCTAssertEqual(try trie.find(word: "brown"), [1, 2])
+        XCTAssertEqual(try trie.find(word: "blocked"), [2])
+        XCTAssertThrowsError(try trie.find(word: "fo"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+    }
+
+    func testFindWithPrefix() {
+        let trie = Trie<Int>()
+        
+        let doc1 = "the quick brown fox jumps over the lazy dog and the dog does not notice the fox jumps over it"
+        let doc2 = "the quick brown fox jumps over the lazy dog for the lazy dog has blocked its way for far too long"
+        self.indexDocument(id: 1, contents: doc1, trie: trie)
+        self.indexDocument(id: 2, contents: doc2, trie: trie)
+        
+        XCTAssertEqual(try trie.findWithPrefix("f"), ["fox": [1, 2], "for": [2], "far": [2]])
+        XCTAssertEqual(try trie.findWithPrefix("fo"), ["fox": [1, 2], "for": [2]])
+        XCTAssertEqual(try trie.findWithPrefix("far"), ["far": [2]])
+        XCTAssertThrowsError(try trie.findWithPrefix("foo"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+    }
+
+    func testRemoveDocument() {
+        let trie = Trie<Int>()
+        
+        let doc1 = "the quick brown fox jumps over the lazy dog"
+        let doc2 = "the dog does not notice the fox jumps over it"
+        let doc3 = "it has blocked the fox for far too long"
+        self.indexDocument(id: 1, contents: doc1, trie: trie)
+        self.indexDocument(id: 2, contents: doc2, trie: trie)
+        self.indexDocument(id: 3, contents: doc3, trie: trie)
+        
+        XCTAssertEqual(try trie.find(word: "fox"), [1, 2, 3])
+        XCTAssertEqual(try trie.find(word: "dog"), [1, 2])
+        XCTAssertEqual(try trie.find(word: "it"), [2, 3])
+        XCTAssertEqual(try trie.find(word: "lazy"), [1])
+        XCTAssertEqual(try trie.find(word: "notice"), [2])
+        XCTAssertEqual(try trie.find(word: "blocked"), [3])
+
+        trie.remove(document: 3)
+
+        XCTAssertEqual(try trie.find(word: "fox"), [1, 2])
+        XCTAssertEqual(try trie.find(word: "dog"), [1, 2])
+        XCTAssertEqual(try trie.find(word: "it"), [2])
+        XCTAssertEqual(try trie.find(word: "lazy"), [1])
+        XCTAssertEqual(try trie.find(word: "notice"), [2])
+        XCTAssertThrowsError(try trie.find(word: "blocked"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+
+        trie.remove(document: 1)
+
+        XCTAssertEqual(try trie.find(word: "fox"), [2])
+        XCTAssertEqual(try trie.find(word: "dog"), [2])
+        XCTAssertEqual(try trie.find(word: "it"), [2])
+        XCTAssertThrowsError(try trie.find(word: "lazy"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+        XCTAssertEqual(try trie.find(word: "notice"), [2])
+        XCTAssertThrowsError(try trie.find(word: "blocked"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+
+        trie.remove(document: 2)
+        
+        XCTAssertThrowsError(try trie.find(word: "fox"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+        XCTAssertThrowsError(try trie.find(word: "dog"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+        XCTAssertThrowsError(try trie.find(word: "it"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+        XCTAssertThrowsError(try trie.find(word: "lazy"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+        XCTAssertThrowsError(try trie.find(word: "notice"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+        XCTAssertThrowsError(try trie.find(word: "blocked"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+    }
+    
+    func testRemoveDocumentsWithPredicate() {
+        let trie = Trie<Int>()
+        
+        let doc1 = "the quick brown fox jumps over the lazy dog"
+        let doc2 = "the dog does not notice the fox jumps over it"
+        let doc3 = "it has blocked the fox for far too long"
+        self.indexDocument(id: 1, contents: doc1, trie: trie)
+        self.indexDocument(id: 2, contents: doc2, trie: trie)
+        self.indexDocument(id: 3, contents: doc3, trie: trie)
+        
+        XCTAssertEqual(try trie.find(word: "fox"), [1, 2, 3])
+        XCTAssertEqual(try trie.find(word: "dog"), [1, 2])
+        XCTAssertEqual(try trie.find(word: "it"), [2, 3])
+        XCTAssertEqual(try trie.find(word: "lazy"), [1])
+        XCTAssertEqual(try trie.find(word: "notice"), [2])
+        XCTAssertEqual(try trie.find(word: "blocked"), [3])
+
+        trie.remove { $0 == 3 }
+
+        XCTAssertEqual(try trie.find(word: "fox"), [1, 2])
+        XCTAssertEqual(try trie.find(word: "dog"), [1, 2])
+        XCTAssertEqual(try trie.find(word: "it"), [2])
+        XCTAssertEqual(try trie.find(word: "lazy"), [1])
+        XCTAssertEqual(try trie.find(word: "notice"), [2])
+        XCTAssertThrowsError(try trie.find(word: "blocked"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+
+        trie.remove { $0 == 1 }
+
+        XCTAssertEqual(try trie.find(word: "fox"), [2])
+        XCTAssertEqual(try trie.find(word: "dog"), [2])
+        XCTAssertEqual(try trie.find(word: "it"), [2])
+        XCTAssertThrowsError(try trie.find(word: "lazy"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+        XCTAssertEqual(try trie.find(word: "notice"), [2])
+        XCTAssertThrowsError(try trie.find(word: "blocked"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+
+        trie.remove { $0 == 2 }
+        
+        XCTAssertThrowsError(try trie.find(word: "fox"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+        XCTAssertThrowsError(try trie.find(word: "dog"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+        XCTAssertThrowsError(try trie.find(word: "it"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+        XCTAssertThrowsError(try trie.find(word: "lazy"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+        XCTAssertThrowsError(try trie.find(word: "notice"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+        XCTAssertThrowsError(try trie.find(word: "blocked"), "expected error", { error in
+            XCTAssert(error is NotFoundError)
+        })
+    }
+    
+    private func indexDocument(id: Int, contents: String, trie: Trie<Int>) {
+        let words = contents.components(separatedBy: " ")
+        words.forEach { word in
+            trie.insert(word: word, foundIn: id)
+        }
+    }
+}

--- a/Tests/PackageCollectionsTests/TrieTests.swift
+++ b/Tests/PackageCollectionsTests/TrieTests.swift
@@ -13,62 +13,62 @@ import XCTest
 class TrieTests: XCTestCase {
     func testContains() {
         let trie = Trie<Int>()
-        
+
         let doc1 = "THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG"
         self.indexDocument(id: 1, contents: doc1, trie: trie)
-        
+
         // Whole word match
         XCTAssertTrue(trie.contains(word: "brown", prefixMatch: false))
         XCTAssertTrue(trie.contains(word: "Fox", prefixMatch: false))
         XCTAssertFalse(trie.contains(word: "foobar", prefixMatch: false))
-        
+
         // Prefix match
         XCTAssertTrue(trie.contains(word: "d", prefixMatch: true))
         XCTAssertTrue(trie.contains(word: "Do", prefixMatch: true))
         XCTAssertFalse(trie.contains(word: "doo", prefixMatch: true))
     }
-    
+
     func testFind() {
         let trie = Trie<Int>()
-        
+
         let doc1 = "the quick brown fox jumps over the lazy dog and the dog does not notice the fox jumps over it"
         let doc2 = "the quick brown fox jumps over the lazy dog for the lazy dog has blocked its way for far too long"
         self.indexDocument(id: 1, contents: doc1, trie: trie)
         self.indexDocument(id: 2, contents: doc2, trie: trie)
-        
+
         XCTAssertEqual(try trie.find(word: "brown"), [1, 2])
         XCTAssertEqual(try trie.find(word: "blocked"), [2])
-        XCTAssertThrowsError(try trie.find(word: "fo"), "expected error", { error in
+        XCTAssertThrowsError(try trie.find(word: "fo"), "expected error") { error in
             XCTAssert(error is NotFoundError)
-        })
+        }
     }
 
     func testFindWithPrefix() {
         let trie = Trie<Int>()
-        
+
         let doc1 = "the quick brown fox jumps over the lazy dog and the dog does not notice the fox jumps over it"
         let doc2 = "the quick brown fox jumps over the lazy dog for the lazy dog has blocked its way for far too long"
         self.indexDocument(id: 1, contents: doc1, trie: trie)
         self.indexDocument(id: 2, contents: doc2, trie: trie)
-        
+
         XCTAssertEqual(try trie.findWithPrefix("f"), ["fox": [1, 2], "for": [2], "far": [2]])
         XCTAssertEqual(try trie.findWithPrefix("fo"), ["fox": [1, 2], "for": [2]])
         XCTAssertEqual(try trie.findWithPrefix("far"), ["far": [2]])
-        XCTAssertThrowsError(try trie.findWithPrefix("foo"), "expected error", { error in
+        XCTAssertThrowsError(try trie.findWithPrefix("foo"), "expected error") { error in
             XCTAssert(error is NotFoundError)
-        })
+        }
     }
 
     func testRemoveDocument() {
         let trie = Trie<Int>()
-        
+
         let doc1 = "the quick brown fox jumps over the lazy dog"
         let doc2 = "the dog does not notice the fox jumps over it"
         let doc3 = "it has blocked the fox for far too long"
         self.indexDocument(id: 1, contents: doc1, trie: trie)
         self.indexDocument(id: 2, contents: doc2, trie: trie)
         self.indexDocument(id: 3, contents: doc3, trie: trie)
-        
+
         XCTAssertEqual(try trie.find(word: "fox"), [1, 2, 3])
         XCTAssertEqual(try trie.find(word: "dog"), [1, 2])
         XCTAssertEqual(try trie.find(word: "it"), [2, 3])
@@ -83,55 +83,55 @@ class TrieTests: XCTestCase {
         XCTAssertEqual(try trie.find(word: "it"), [2])
         XCTAssertEqual(try trie.find(word: "lazy"), [1])
         XCTAssertEqual(try trie.find(word: "notice"), [2])
-        XCTAssertThrowsError(try trie.find(word: "blocked"), "expected error", { error in
+        XCTAssertThrowsError(try trie.find(word: "blocked"), "expected error") { error in
             XCTAssert(error is NotFoundError)
-        })
+        }
 
         trie.remove(document: 1)
 
         XCTAssertEqual(try trie.find(word: "fox"), [2])
         XCTAssertEqual(try trie.find(word: "dog"), [2])
         XCTAssertEqual(try trie.find(word: "it"), [2])
-        XCTAssertThrowsError(try trie.find(word: "lazy"), "expected error", { error in
+        XCTAssertThrowsError(try trie.find(word: "lazy"), "expected error") { error in
             XCTAssert(error is NotFoundError)
-        })
+        }
         XCTAssertEqual(try trie.find(word: "notice"), [2])
-        XCTAssertThrowsError(try trie.find(word: "blocked"), "expected error", { error in
+        XCTAssertThrowsError(try trie.find(word: "blocked"), "expected error") { error in
             XCTAssert(error is NotFoundError)
-        })
+        }
 
         trie.remove(document: 2)
-        
-        XCTAssertThrowsError(try trie.find(word: "fox"), "expected error", { error in
+
+        XCTAssertThrowsError(try trie.find(word: "fox"), "expected error") { error in
             XCTAssert(error is NotFoundError)
-        })
-        XCTAssertThrowsError(try trie.find(word: "dog"), "expected error", { error in
+        }
+        XCTAssertThrowsError(try trie.find(word: "dog"), "expected error") { error in
             XCTAssert(error is NotFoundError)
-        })
-        XCTAssertThrowsError(try trie.find(word: "it"), "expected error", { error in
+        }
+        XCTAssertThrowsError(try trie.find(word: "it"), "expected error") { error in
             XCTAssert(error is NotFoundError)
-        })
-        XCTAssertThrowsError(try trie.find(word: "lazy"), "expected error", { error in
+        }
+        XCTAssertThrowsError(try trie.find(word: "lazy"), "expected error") { error in
             XCTAssert(error is NotFoundError)
-        })
-        XCTAssertThrowsError(try trie.find(word: "notice"), "expected error", { error in
+        }
+        XCTAssertThrowsError(try trie.find(word: "notice"), "expected error") { error in
             XCTAssert(error is NotFoundError)
-        })
-        XCTAssertThrowsError(try trie.find(word: "blocked"), "expected error", { error in
+        }
+        XCTAssertThrowsError(try trie.find(word: "blocked"), "expected error") { error in
             XCTAssert(error is NotFoundError)
-        })
+        }
     }
-    
+
     func testRemoveDocumentsWithPredicate() {
         let trie = Trie<Int>()
-        
+
         let doc1 = "the quick brown fox jumps over the lazy dog"
         let doc2 = "the dog does not notice the fox jumps over it"
         let doc3 = "it has blocked the fox for far too long"
         self.indexDocument(id: 1, contents: doc1, trie: trie)
         self.indexDocument(id: 2, contents: doc2, trie: trie)
         self.indexDocument(id: 3, contents: doc3, trie: trie)
-        
+
         XCTAssertEqual(try trie.find(word: "fox"), [1, 2, 3])
         XCTAssertEqual(try trie.find(word: "dog"), [1, 2])
         XCTAssertEqual(try trie.find(word: "it"), [2, 3])
@@ -146,45 +146,45 @@ class TrieTests: XCTestCase {
         XCTAssertEqual(try trie.find(word: "it"), [2])
         XCTAssertEqual(try trie.find(word: "lazy"), [1])
         XCTAssertEqual(try trie.find(word: "notice"), [2])
-        XCTAssertThrowsError(try trie.find(word: "blocked"), "expected error", { error in
+        XCTAssertThrowsError(try trie.find(word: "blocked"), "expected error") { error in
             XCTAssert(error is NotFoundError)
-        })
+        }
 
         trie.remove { $0 == 1 }
 
         XCTAssertEqual(try trie.find(word: "fox"), [2])
         XCTAssertEqual(try trie.find(word: "dog"), [2])
         XCTAssertEqual(try trie.find(word: "it"), [2])
-        XCTAssertThrowsError(try trie.find(word: "lazy"), "expected error", { error in
+        XCTAssertThrowsError(try trie.find(word: "lazy"), "expected error") { error in
             XCTAssert(error is NotFoundError)
-        })
+        }
         XCTAssertEqual(try trie.find(word: "notice"), [2])
-        XCTAssertThrowsError(try trie.find(word: "blocked"), "expected error", { error in
+        XCTAssertThrowsError(try trie.find(word: "blocked"), "expected error") { error in
             XCTAssert(error is NotFoundError)
-        })
+        }
 
         trie.remove { $0 == 2 }
-        
-        XCTAssertThrowsError(try trie.find(word: "fox"), "expected error", { error in
+
+        XCTAssertThrowsError(try trie.find(word: "fox"), "expected error") { error in
             XCTAssert(error is NotFoundError)
-        })
-        XCTAssertThrowsError(try trie.find(word: "dog"), "expected error", { error in
+        }
+        XCTAssertThrowsError(try trie.find(word: "dog"), "expected error") { error in
             XCTAssert(error is NotFoundError)
-        })
-        XCTAssertThrowsError(try trie.find(word: "it"), "expected error", { error in
+        }
+        XCTAssertThrowsError(try trie.find(word: "it"), "expected error") { error in
             XCTAssert(error is NotFoundError)
-        })
-        XCTAssertThrowsError(try trie.find(word: "lazy"), "expected error", { error in
+        }
+        XCTAssertThrowsError(try trie.find(word: "lazy"), "expected error") { error in
             XCTAssert(error is NotFoundError)
-        })
-        XCTAssertThrowsError(try trie.find(word: "notice"), "expected error", { error in
+        }
+        XCTAssertThrowsError(try trie.find(word: "notice"), "expected error") { error in
             XCTAssert(error is NotFoundError)
-        })
-        XCTAssertThrowsError(try trie.find(word: "blocked"), "expected error", { error in
+        }
+        XCTAssertThrowsError(try trie.find(word: "blocked"), "expected error") { error in
             XCTAssert(error is NotFoundError)
-        })
+        }
     }
-    
+
     private func indexDocument(id: Int, contents: String, trie: Trie<Int>) {
         let words = contents.components(separatedBy: " ")
         words.forEach { word in


### PR DESCRIPTION
This is an alternative to https://github.com/apple/swift-package-manager/pull/3090 but is a complete solution.

Motivation:
Currently to support search for package collections API we read and deserialize collection blobs from SQLite then perform string matchings on individual properties in memory (e.g., `package.summary.contains("foobar")`). This can be optimized.

Modifications:
Use SQLite FTS--define FTS virtual tables for packages and targets, and update implementation for `findPackage`, `searchPackages`, and `searchTargets` methods of `SQLitePackageCollectionsStorage`.

Without optimization, `PackageCollectionsTests.testPackageSearchPerformance` and `testTargetsSearchPerformance` take about ~400ms to run on my local machine.

With FTS, `testPackageSearchPerformance` takes ~40ms and `testTargetsSearchPerformance` ~50ms.

The `testSearchTargetsPerformance` in `InMemoryPackageCollectionsSearchTests` (https://github.com/apple/swift-package-manager/pull/3090) yields result in ~10ms, though it queries the trie directly without going through the PackageCollections API layer.

Since target search is either exact or prefix match and doesn't tokenize the query, and given the good results I saw in `InMemoryPackageCollectionsSearchTests`, this implementation includes a trie on top of SQLite FTS for target search. The trie is in-memory and loads from SQLite FTS during initialization. `put`/`remove` updates both the SQLite FTS and trie. The improvement with using trie varies--`testTargetsSearchPerformance` takes between ~15-50ms to complete.

`put` now takes longer to complete because of the search index updates.

Result:
Better search performance.
