### PR TITLE
Refactor global verbosity value to parameters

### DIFF
--- a/Examples/package-info/Sources/package-info/main.swift
+++ b/Examples/package-info/Sources/package-info/main.swift
@@ -33,7 +33,7 @@ let package = localFileSystem.currentWorkingDirectory!
 let diagnostics = DiagnosticsEngine()
 let manifest = try ManifestLoader.loadManifest(packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], packageKind: .local)
 let loadedPackage = try PackageBuilder.loadPackage(packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], diagnostics: diagnostics)
-let graph = try Workspace.loadGraph(packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], diagnostics: diagnostics)
+let graph = try Workspace.loadGraph(packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], diagnostics: diagnostics, verbosity: TSCUtility.verbosity)
 
 // EXAMPLES
 // ========

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -49,7 +49,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
     let stdoutStream: OutputByteStream
 
     /// Wether the build is in a verbose mode.
-    private let isVerbose: Bool
+    private let verbosity: Verbosity
 
     public var builtTestProducts: [BuiltTestProduct] {
         (try? getBuildDescription())?.builtTestProducts ?? []
@@ -59,7 +59,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         buildParameters: BuildParameters,
         cacheBuildManifest: Bool,
         packageGraphLoader: @escaping () throws -> PackageGraph,
-        isVerbose: Bool = false,
+        verbosity: Verbosity,
         diagnostics: DiagnosticsEngine,
         stdoutStream: OutputByteStream
     ) {
@@ -68,7 +68,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         self.packageGraphLoader = packageGraphLoader
         self.diagnostics = diagnostics
         self.stdoutStream = stdoutStream
-        self.isVerbose = isVerbose
+        self.verbosity = verbosity
     }
 
     public func getPackageGraph() throws -> PackageGraph {
@@ -186,7 +186,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         with buildDescription: BuildDescription?
     ) throws -> SPMLLBuild.BuildSystem {
         // Figure out which progress bar we have to use during the build.
-        let progressAnimation: ProgressAnimationProtocol = self.isVerbose
+        let progressAnimation: ProgressAnimationProtocol = self.verbosity != .concise
             ? MultiLineNinjaProgressAnimation(stream: self.stdoutStream)
             : NinjaProgressAnimation(stream: self.stdoutStream)
 
@@ -205,7 +205,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
             progressAnimation: progressAnimation
         )
         self.buildDelegate = buildDelegate
-        buildDelegate.isVerbose = isVerbose
+        buildDelegate.isVerbose = verbosity != .concise
 
         let databasePath = buildParameters.dataPath.appending(component: "build.db").pathString
         let buildSystem = BuildSystem(

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -45,9 +45,11 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
 
     /// The loaded package graph.
     private var packageGraph: PackageGraph?
-
     /// The stdout stream for the build delegate.
     let stdoutStream: OutputByteStream
+
+    /// Wether the build is in a verbose mode.
+    private let isVerbose: Bool
 
     public var builtTestProducts: [BuiltTestProduct] {
         (try? getBuildDescription())?.builtTestProducts ?? []
@@ -57,6 +59,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         buildParameters: BuildParameters,
         cacheBuildManifest: Bool,
         packageGraphLoader: @escaping () throws -> PackageGraph,
+        isVerbose: Bool = false,
         diagnostics: DiagnosticsEngine,
         stdoutStream: OutputByteStream
     ) {
@@ -65,6 +68,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         self.packageGraphLoader = packageGraphLoader
         self.diagnostics = diagnostics
         self.stdoutStream = stdoutStream
+        self.isVerbose = isVerbose
     }
 
     public func getPackageGraph() throws -> PackageGraph {
@@ -182,8 +186,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         with buildDescription: BuildDescription?
     ) throws -> SPMLLBuild.BuildSystem {
         // Figure out which progress bar we have to use during the build.
-        let isVerbose = verbosity != .concise
-        let progressAnimation: ProgressAnimationProtocol = isVerbose
+        let progressAnimation: ProgressAnimationProtocol = self.isVerbose
             ? MultiLineNinjaProgressAnimation(stream: self.stdoutStream)
             : NinjaProgressAnimation(stream: self.stdoutStream)
 

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -47,7 +47,7 @@ extension BuildParameters {
     public var swiftCompilerFlags: [String] {
         var flags = self.flags.cCompilerFlags.flatMap({ ["-Xcc", $0] })
         flags += self.flags.swiftCompilerFlags
-        flags += verbosity.ccArgs
+        flags += self.verbosity.ccArgs
         return flags
     }
 

--- a/Sources/Commands/APIDigester.swift
+++ b/Sources/Commands/APIDigester.swift
@@ -92,7 +92,8 @@ struct APIDigesterBaselineDumper {
         let workspace = Workspace.create(
             forRootPackage: baselinePackageRoot,
             manifestLoader: manifestLoader,
-            repositoryManager: repositoryManager
+            repositoryManager: repositoryManager,
+            verbosity: TSCUtility.verbosity
         )
 
         let graph = try workspace.loadPackageGraph(
@@ -112,7 +113,7 @@ struct APIDigesterBaselineDumper {
             buildParameters: buildParameters,
             cacheBuildManifest: false,
             packageGraphLoader: { graph },
-            isVerbose: TSCUtility.verbosity != .concise,
+            verbosity: TSCUtility.verbosity,
             diagnostics: diags,
             stdoutStream: stdoutStream
         )

--- a/Sources/Commands/APIDigester.swift
+++ b/Sources/Commands/APIDigester.swift
@@ -112,6 +112,7 @@ struct APIDigesterBaselineDumper {
             buildParameters: buildParameters,
             cacheBuildManifest: false,
             packageGraphLoader: { graph },
+            isVerbose: TSCUtility.verbosity != .concise,
             diagnostics: diags,
             stdoutStream: stdoutStream
         )
@@ -178,7 +179,7 @@ public struct SwiftAPIDigester {
         let process = Process(
             arguments: arguments,
             outputRedirection: .none,
-            verbose: verbosity != .concise
+            verbose: TSCUtility.verbosity != .concise
         )
         try process.launch()
         try process.waitUntilExit()

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -117,7 +117,7 @@ public struct SwiftRunTool: SwiftCommand {
                 buildParameters: buildParameters,
                 cacheBuildManifest: false,
                 packageGraphLoader: graphLoader,
-                isVerbose: TSCUtility.verbosity != .concise,
+                verbosity: TSCUtility.verbosity,
                 diagnostics: swiftTool.diagnostics,
                 stdoutStream: swiftTool.stdoutStream
             )

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -117,6 +117,7 @@ public struct SwiftRunTool: SwiftCommand {
                 buildParameters: buildParameters,
                 cacheBuildManifest: false,
                 packageGraphLoader: graphLoader,
+                isVerbose: TSCUtility.verbosity != .concise,
                 diagnostics: swiftTool.diagnostics,
                 stdoutStream: swiftTool.stdoutStream
             )

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -530,7 +530,8 @@ public class SwiftTool {
             isResolverPrefetchingEnabled: options.shouldEnableResolverPrefetching,
             skipUpdate: options.skipDependencyUpdate,
             enableResolverTrace: options.enableResolverTrace,
-            cachePath: cachePath
+            cachePath: cachePath,
+            verbosity: isVerbose ? .verbose : .concise
         )
         _workspace = workspace
         _workspaceDelegate = delegate
@@ -638,7 +639,7 @@ public class SwiftTool {
             buildParameters: buildParameters(),
             cacheBuildManifest: cacheBuildManifest && self.canUseCachedBuildManifest(),
             packageGraphLoader: graphLoader,
-            isVerbose: TSCUtility.verbosity != .concise,
+            verbosity: TSCUtility.verbosity,
             diagnostics: diagnostics,
             stdoutStream: self.stdoutStream
         )
@@ -657,7 +658,7 @@ public class SwiftTool {
                 buildParameters: buildParameters ?? self.buildParameters(),
                 cacheBuildManifest: self.canUseCachedBuildManifest(),
                 packageGraphLoader: graphLoader,
-                isVerbose: TSCUtility.verbosity != .concise,
+                verbosity: TSCUtility.verbosity,
                 diagnostics: diagnostics,
                 stdoutStream: stdoutStream
             )
@@ -666,7 +667,7 @@ public class SwiftTool {
             buildSystem = try XcodeBuildSystem(
                 buildParameters: buildParameters ?? self.buildParameters(),
                 packageGraphLoader: graphLoader,
-                isVerbose: TSCUtility.verbosity != .concise,
+                verbosity: TSCUtility.verbosity,
                 diagnostics: diagnostics,
                 stdoutStream: stdoutStream
             )

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -380,8 +380,8 @@ public class SwiftTool {
             (packageRoot ?? cwd).appending(component: ".build")
         
         // Setup the globals.
-        verbosity = Verbosity(rawValue: options.verbosity)
-        Process.verbose = verbosity != .concise
+        TSCUtility.verbosity = Verbosity(rawValue: options.verbosity)
+        Process.verbose = TSCUtility.verbosity != .concise
     }
     
     static func postprocessArgParserResult(options: SwiftToolOptions, diagnostics: DiagnosticsEngine) throws {
@@ -638,6 +638,7 @@ public class SwiftTool {
             buildParameters: buildParameters(),
             cacheBuildManifest: cacheBuildManifest && self.canUseCachedBuildManifest(),
             packageGraphLoader: graphLoader,
+            isVerbose: TSCUtility.verbosity != .concise,
             diagnostics: diagnostics,
             stdoutStream: self.stdoutStream
         )
@@ -656,6 +657,7 @@ public class SwiftTool {
                 buildParameters: buildParameters ?? self.buildParameters(),
                 cacheBuildManifest: self.canUseCachedBuildManifest(),
                 packageGraphLoader: graphLoader,
+                isVerbose: TSCUtility.verbosity != .concise,
                 diagnostics: diagnostics,
                 stdoutStream: stdoutStream
             )
@@ -664,7 +666,7 @@ public class SwiftTool {
             buildSystem = try XcodeBuildSystem(
                 buildParameters: buildParameters ?? self.buildParameters(),
                 packageGraphLoader: graphLoader,
-                isVerbose: verbosity != .concise,
+                isVerbose: TSCUtility.verbosity != .concise,
                 diagnostics: diagnostics,
                 stdoutStream: stdoutStream
             )

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -712,7 +712,8 @@ public class SwiftTool {
                 useExplicitModuleBuild: options.useExplicitModuleBuild,
                 isXcodeBuildSystemEnabled: options.buildSystem == .xcode,
                 printManifestGraphviz: options.printManifestGraphviz,
-                forceTestDiscovery: options.enableTestDiscovery // backwards compatibility, remove with --enable-test-discovery
+                forceTestDiscovery: options.enableTestDiscovery, // backwards compatibility, remove with --enable-test-discovery
+                verbosity: TSCUtility.verbosity
             )
         })
     }()

--- a/Sources/Commands/SymbolGraphExtract.swift
+++ b/Sources/Commands/SymbolGraphExtract.swift
@@ -59,7 +59,7 @@ public struct SymbolGraphExtract {
         let process = Process(
             arguments: arguments,
             outputRedirection: .none,
-            verbose: verbosity != .concise
+            verbose: TSCUtility.verbosity != .concise
         )
         try process.launch()
         try process.waitUntilExit()

--- a/Sources/PackageGraph/LocalPackageContainer.swift
+++ b/Sources/PackageGraph/LocalPackageContainer.swift
@@ -29,6 +29,7 @@ public final class LocalPackageContainer: PackageContainer {
     private let manifestLoader: ManifestLoaderProtocol
     private let toolsVersionLoader: ToolsVersionLoaderProtocol
     private let currentToolsVersion: ToolsVersion
+    private let verbosity: Verbosity
 
     /// The file system that shoud be used to load this package.
     private let fs: FileSystem
@@ -53,6 +54,7 @@ public final class LocalPackageContainer: PackageContainer {
                                     toolsVersion: toolsVersion,
                                     packageKind: identifier.kind,
                                     fileSystem: fs,
+                                    verbosity: self.verbosity,
                                     on: .global(),
                                     completion: $0)
             }
@@ -75,7 +77,8 @@ public final class LocalPackageContainer: PackageContainer {
         manifestLoader: ManifestLoaderProtocol,
         toolsVersionLoader: ToolsVersionLoaderProtocol,
         currentToolsVersion: ToolsVersion,
-        fs: FileSystem = localFileSystem
+        fs: FileSystem = localFileSystem,
+        verbosity: Verbosity
     ) {
         assert(URL.scheme(identifier.path) == nil, "unexpected scheme \(URL.scheme(identifier.path)!) in \(identifier.path)")
         self.identifier = identifier
@@ -84,6 +87,7 @@ public final class LocalPackageContainer: PackageContainer {
         self.toolsVersionLoader = toolsVersionLoader
         self.currentToolsVersion = currentToolsVersion
         self.fs = fs
+        self.verbosity = verbosity
     }
     
     public func isToolsVersionCompatible(at version: Version) -> Bool {

--- a/Sources/PackageGraph/RepositoryPackageContainer.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainer.swift
@@ -61,6 +61,7 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
     private let manifestLoader: ManifestLoaderProtocol
     private let toolsVersionLoader: ToolsVersionLoaderProtocol
     private let currentToolsVersion: ToolsVersion
+    private let verbosity: Verbosity
 
     /// The cached dependency information.
     private var dependenciesCache = [String: [ProductFilter: (Manifest, [Constraint])]] ()
@@ -80,7 +81,8 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
         repository: Repository,
         manifestLoader: ManifestLoaderProtocol,
         toolsVersionLoader: ToolsVersionLoaderProtocol,
-        currentToolsVersion: ToolsVersion
+        currentToolsVersion: ToolsVersion,
+        verbosity: Verbosity
     ) {
         self.identifier = identifier
         self.mirrors = mirrors
@@ -88,6 +90,7 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
         self.manifestLoader = manifestLoader
         self.toolsVersionLoader = toolsVersionLoader
         self.currentToolsVersion = currentToolsVersion
+        self.verbosity = verbosity
     }
     
     // Compute the map of known versions.
@@ -287,6 +290,7 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
                                     toolsVersion: toolsVersion,
                                     packageKind: identifier.kind,
                                     fileSystem: fs,
+                                    verbosity: self.verbosity,
                                     on: .global(),
                                     completion: $0)
             }
@@ -318,6 +322,8 @@ public class RepositoryPackageContainerProvider: PackageContainerProvider {
     /// The tools version loader.
     let toolsVersionLoader: ToolsVersionLoaderProtocol
 
+    private let verbosity: Verbosity
+
     /// Create a repository-based package provider.
     ///
     /// - Parameters:
@@ -330,13 +336,15 @@ public class RepositoryPackageContainerProvider: PackageContainerProvider {
         mirrors: DependencyMirrors = [:],
         manifestLoader: ManifestLoaderProtocol,
         currentToolsVersion: ToolsVersion = ToolsVersion.currentToolsVersion,
-        toolsVersionLoader: ToolsVersionLoaderProtocol = ToolsVersionLoader()
+        toolsVersionLoader: ToolsVersionLoaderProtocol = ToolsVersionLoader(),
+        verbosity: Verbosity
     ) {
         self.repositoryManager = repositoryManager
         self.mirrors = mirrors
         self.manifestLoader = manifestLoader
         self.currentToolsVersion = currentToolsVersion
         self.toolsVersionLoader = toolsVersionLoader
+        self.verbosity = verbosity
     }
 
     public func getContainer(
@@ -353,7 +361,8 @@ public class RepositoryPackageContainerProvider: PackageContainerProvider {
                     manifestLoader: self.manifestLoader,
                     toolsVersionLoader: self.toolsVersionLoader,
                     currentToolsVersion: self.currentToolsVersion,
-                    fs: self.repositoryManager.fileSystem)
+                    fs: self.repositoryManager.fileSystem,
+                    verbosity: self.verbosity)
                 completion(.success(container))
             }
         }
@@ -373,7 +382,8 @@ public class RepositoryPackageContainerProvider: PackageContainerProvider {
                         repository: repository,
                         manifestLoader: self.manifestLoader,
                         toolsVersionLoader: self.toolsVersionLoader,
-                        currentToolsVersion: self.currentToolsVersion
+                        currentToolsVersion: self.currentToolsVersion,
+                        verbosity: self.verbosity
                     )
                 }
                 completion(result)

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -326,8 +326,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                           fileSystem: fileSystem,
                           diagnostics: diagnostics,
                           on: queue,
-                          verbosity: verbosity
-                          ) { result in
+                          verbosity: verbosity) { result in
 
                 // cache positive results
                 if self.useInMemoryCache, case .success(let manifest) = result {

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -91,8 +91,8 @@ public protocol ManifestLoaderProtocol {
         packageKind: PackageReference.Kind,
         fileSystem: FileSystem?,
         diagnostics: DiagnosticsEngine?,
-        on queue: DispatchQueue,
         verbosity: Verbosity,
+        on queue: DispatchQueue,
         completion: @escaping (Result<Manifest, Error>) -> Void
     )
 
@@ -124,8 +124,8 @@ extension ManifestLoaderProtocol {
         packageKind: PackageReference.Kind,
         fileSystem: FileSystem? = nil,
         diagnostics: DiagnosticsEngine? = nil,
+        verbosity: Verbosity,
         on queue: DispatchQueue,
-        verbosity: Verbosity = TSCUtility.verbosity,
         completion: @escaping (Result<Manifest, Error>) -> Void
     ) {
         self.load(
@@ -137,8 +137,8 @@ extension ManifestLoaderProtocol {
             packageKind: packageKind,
             fileSystem: fileSystem,
             diagnostics: diagnostics,
-            on: queue,
             verbosity: verbosity,
+            on: queue,
             completion: completion
         )
     }
@@ -217,6 +217,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                               swiftCompiler: swiftCompiler,
                               swiftCompilerFlags: swiftCompilerFlags,
                               packageKind: packageKind,
+                              verbosity: TSCUtility.verbosity,
                               on: .global(),
                               completion: $0)
         }
@@ -234,6 +235,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         swiftCompiler: AbsolutePath,
         swiftCompilerFlags: [String],
         packageKind: PackageReference.Kind,
+        verbosity: Verbosity,
         on queue: DispatchQueue,
         completion: @escaping (Result<Manifest, Error>) -> Void
     ) {
@@ -248,6 +250,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                 toolsVersion: toolsVersion,
                 packageKind: packageKind,
                 fileSystem: fileSystem,
+                verbosity: verbosity,
                 on: queue,
                 completion: completion
             )
@@ -266,8 +269,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         toolsVersion: ToolsVersion,
         packageKind: PackageReference.Kind,
         fileSystem: FileSystem? = nil,
-        diagnostics: DiagnosticsEngine? = nil,
-        verbosity: Verbosity = TSCUtility.verbosity
+        diagnostics: DiagnosticsEngine? = nil
     ) throws -> Manifest {
         try temp_await{
             self.load(packagePath: path,
@@ -278,8 +280,8 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                       packageKind: packageKind,
                       fileSystem: fileSystem,
                       diagnostics: diagnostics,
+                      verbosity: TSCUtility.verbosity,
                       on: .global(),
-                      verbosity: verbosity,
                       completion: $0)
         }
     }
@@ -293,8 +295,8 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         packageKind: PackageReference.Kind,
         fileSystem: FileSystem? = nil,
         diagnostics: DiagnosticsEngine? = nil,
+        verbosity: Verbosity,
         on queue: DispatchQueue,
-        verbosity: Verbosity = TSCUtility.verbosity,
         completion: @escaping (Result<Manifest, Error>) -> Void
     ) {
         do {

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -291,6 +291,7 @@ public final class PackageBuilder {
                              xcTestMinimumDeploymentTargets: xcTestMinimumDeploymentTargets,
                              diagnostics: diagnostics,
                              kind: kind,
+                             verbosity: TSCUtility.verbosity,
                              on: .global(),
                              completion: $0)
         }
@@ -310,6 +311,7 @@ public final class PackageBuilder {
             = MinimumDeploymentTarget.default.xcTestMinimumDeploymentTargets,
         diagnostics: DiagnosticsEngine,
         kind: PackageReference.Kind = .root,
+        verbosity: Verbosity,
         on queue: DispatchQueue,
         completion: @escaping (Result<Package, Error>) -> Void
     ) {
@@ -317,6 +319,7 @@ public final class PackageBuilder {
                                     swiftCompiler: swiftCompiler,
                                     swiftCompilerFlags: swiftCompilerFlags,
                                     packageKind: kind,
+                                    verbosity: verbosity,
                                     on: queue) { result in
             let result = result.tryMap { manifest -> Package in
                 let builder = PackageBuilder(

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -165,6 +165,9 @@ public struct BuildParameters: Encodable {
     // What strategy to use to discover tests
     public var testDiscoveryStrategy: TestDiscoveryStrategy
 
+    // Setting for verbose level
+    public var verbosity: Verbosity
+
     public init(
         dataPath: AbsolutePath,
         configuration: BuildConfiguration,
@@ -189,7 +192,8 @@ public struct BuildParameters: Encodable {
         isXcodeBuildSystemEnabled: Bool = false,
         printManifestGraphviz: Bool = false,
         enableTestability: Bool? = nil,
-        forceTestDiscovery: Bool = false
+        forceTestDiscovery: Bool = false,
+        verbosity: Verbosity = TSCUtility.verbosity
     ) {
         let triple = destinationTriple ?? .getHostTriple(usingSwiftCompiler: toolchain.swiftCompiler)
 
@@ -219,6 +223,7 @@ public struct BuildParameters: Encodable {
         self.enableTestability = enableTestability ?? (.debug == configuration)
         // decide if to enable the use of test manifests based on platform. this is likely to change in the future
         self.testDiscoveryStrategy = triple.isDarwin() ? .objectiveC : .manifest(generate: forceTestDiscovery)
+        self.verbosity = verbosity
     }
 
     /// The path to the build directory (inside the data directory).
@@ -339,3 +344,5 @@ extension BuildParameters {
         }
     }
 }
+
+extension Verbosity: Encodable { }

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -193,7 +193,7 @@ public struct BuildParameters: Encodable {
         printManifestGraphviz: Bool = false,
         enableTestability: Bool? = nil,
         forceTestDiscovery: Bool = false,
-        verbosity: Verbosity = TSCUtility.verbosity
+        verbosity: Verbosity
     ) {
         let triple = destinationTriple ?? .getHostTriple(usingSwiftCompiler: toolchain.swiftCompiler)
 

--- a/Sources/SPMTestSupport/MockManifestLoader.swift
+++ b/Sources/SPMTestSupport/MockManifestLoader.swift
@@ -58,6 +58,7 @@ public final class MockManifestLoader: ManifestLoaderProtocol {
         fileSystem: FileSystem?,
         diagnostics: DiagnosticsEngine?,
         on queue: DispatchQueue,
+        verbosity: Verbosity = TSCUtility.verbosity,
         completion: @escaping (Result<Manifest, Error>) -> Void
     ) {
         queue.async {

--- a/Sources/SPMTestSupport/MockManifestLoader.swift
+++ b/Sources/SPMTestSupport/MockManifestLoader.swift
@@ -57,8 +57,8 @@ public final class MockManifestLoader: ManifestLoaderProtocol {
         packageKind: PackageReference.Kind,
         fileSystem: FileSystem?,
         diagnostics: DiagnosticsEngine?,
+        verbosity: Verbosity,
         on queue: DispatchQueue,
-        verbosity: Verbosity = TSCUtility.verbosity,
         completion: @escaping (Result<Manifest, Error>) -> Void
     ) {
         queue.async {
@@ -83,6 +83,6 @@ extension ManifestLoader {
               fileSystem: PackageLoading.FileSystem? = nil,
               diagnostics: TSCBasic.DiagnosticsEngine? = nil
     ) throws -> Manifest{
-        try tsc_await { self.load(package: path, baseURL: baseURL, toolsVersion: toolsVersion, packageKind: packageKind, fileSystem: fileSystem, diagnostics: diagnostics, on: .global(), completion: $0) }
+        try tsc_await { self.load(package: path, baseURL: baseURL, toolsVersion: toolsVersion, packageKind: packageKind, fileSystem: fileSystem, diagnostics: diagnostics, verbosity: TSCUtility.verbosity, on: .global(), completion: $0) }
     }
 }

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -173,7 +173,8 @@ public final class MockWorkspace {
             isResolverPrefetchingEnabled: true,
             enablePubgrubResolver: self.enablePubGrub,
             skipUpdate: self.skipUpdate,
-            cachePath: localFileSystem.swiftPMCacheDirectory.appending(component: "repositories")
+            cachePath: localFileSystem.swiftPMCacheDirectory.appending(component: "repositories"),
+            verbosity: TSCUtility.verbosity
         )
         return self._workspace!
     }

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -52,7 +52,7 @@ public final class XcodeBuildSystem: BuildSystem {
     public init(
         buildParameters: BuildParameters,
         packageGraphLoader: @escaping () throws -> PackageGraph,
-        isVerbose: Bool,
+        isVerbose: Bool = false,
         diagnostics: DiagnosticsEngine,
         stdoutStream: OutputByteStream
     ) throws {

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -19,7 +19,7 @@ import SPMBuildCore
 public final class XcodeBuildSystem: BuildSystem {
     private let buildParameters: BuildParameters
     private let packageGraphLoader: () throws -> PackageGraph
-    private let isVerbose: Bool
+    private let verbosity: Verbosity
     private let diagnostics: DiagnosticsEngine
     private let xcbuildPath: AbsolutePath
     private var packageGraph: PackageGraph?
@@ -52,13 +52,13 @@ public final class XcodeBuildSystem: BuildSystem {
     public init(
         buildParameters: BuildParameters,
         packageGraphLoader: @escaping () throws -> PackageGraph,
-        isVerbose: Bool = false,
+        verbosity: Verbosity,
         diagnostics: DiagnosticsEngine,
         stdoutStream: OutputByteStream
     ) throws {
         self.buildParameters = buildParameters
         self.packageGraphLoader = packageGraphLoader
-        self.isVerbose = isVerbose
+        self.verbosity = verbosity
         self.diagnostics = diagnostics
         self.stdoutStream = stdoutStream
 
@@ -151,14 +151,14 @@ public final class XcodeBuildSystem: BuildSystem {
 
     /// Returns a new instance of `XCBuildDelegate` for a build operation.
     private func createBuildDelegate() -> XCBuildDelegate {
-        let progressAnimation: ProgressAnimationProtocol = isVerbose
+        let progressAnimation: ProgressAnimationProtocol = self.verbosity != .concise
             ? VerboseProgressAnimation(stream: stdoutStream)
             : MultiLinePercentProgressAnimation(stream: stdoutStream, header: "")
         let delegate = XCBuildDelegate(
             diagnostics: diagnostics,
             outputStream: stdoutStream,
             progressAnimation: progressAnimation)
-        delegate.isVerbose = isVerbose
+        delegate.isVerbose = self.verbosity != .concise
         return delegate
     }
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -64,7 +64,8 @@ final class BuildPlanTests: XCTestCase {
         shouldLinkStaticSwiftStdlib: Bool = false,
         destinationTriple: TSCUtility.Triple = hostTriple,
         indexStoreMode: BuildParameters.IndexStoreMode = .off,
-        useExplicitModuleBuild: Bool = false
+        useExplicitModuleBuild: Bool = false,
+        verbosity: Verbosity = TSCUtility.verbosity
     ) -> BuildParameters {
         return BuildParameters(
             dataPath: buildPath,
@@ -76,7 +77,8 @@ final class BuildPlanTests: XCTestCase {
             jobs: 3,
             shouldLinkStaticSwiftStdlib: shouldLinkStaticSwiftStdlib,
             indexStoreMode: indexStoreMode,
-            useExplicitModuleBuild: useExplicitModuleBuild
+            useExplicitModuleBuild: useExplicitModuleBuild,
+            verbosity: verbosity
         )
     }
 

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -175,7 +175,8 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
 
         let provider = RepositoryPackageContainerProvider(
             repositoryManager: repositoryManager,
-            manifestLoader: MockManifestLoader(manifests: [:])
+            manifestLoader: MockManifestLoader(manifests: [:]),
+            verbosity: TSCUtility.verbosity
         )
 
         let ref = PackageReference(identity: PackageIdentity(path: repoPath), path: repoPath.pathString)
@@ -227,7 +228,8 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             return RepositoryPackageContainerProvider(
                 repositoryManager: repositoryManager,
                 manifestLoader: MockManifestLoader(manifests: [:]),
-                currentToolsVersion: currentToolsVersion
+                currentToolsVersion: currentToolsVersion,
+                verbosity: TSCUtility.verbosity
             )
         }
 
@@ -308,7 +310,8 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
 
         let provider = RepositoryPackageContainerProvider(
             repositoryManager: repositoryManager,
-            manifestLoader: MockManifestLoader(manifests: [:])
+            manifestLoader: MockManifestLoader(manifests: [:]),
+            verbosity: TSCUtility.verbosity
         )
         let ref = PackageReference(identity: PackageIdentity(path: repoPath), path: repoPath.pathString)
         let container = try provider.getContainer(for: ref, skipUpdate: false)
@@ -348,7 +351,8 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
 
         let provider = RepositoryPackageContainerProvider(
             repositoryManager: repositoryManager,
-            manifestLoader: MockManifestLoader(manifests: [:])
+            manifestLoader: MockManifestLoader(manifests: [:]),
+            verbosity: TSCUtility.verbosity
         )
         let ref = PackageReference(identity: PackageIdentity(path: repoPath), path: repoPath.pathString)
         let container = try provider.getContainer(for: ref, skipUpdate: false)
@@ -535,7 +539,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
                     try TargetDescription(name: packageDir.basename, path: packageDir.pathString),
                 ]
             )
-            let containerProvider = RepositoryPackageContainerProvider(repositoryManager: repositoryManager, manifestLoader: MockManifestLoader(manifests: [.init(url: packageDir.pathString, version: nil): manifest]))
+            let containerProvider = RepositoryPackageContainerProvider(repositoryManager: repositoryManager, manifestLoader: MockManifestLoader(manifests: [.init(url: packageDir.pathString, version: nil): manifest]), verbosity: TSCUtility.verbosity)
 
             // Get a hold of the container for the test package.
             let packageRef = PackageReference(identity: PackageIdentity(path: packageDir), path: packageDir.pathString)
@@ -612,7 +616,8 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
                 repositoryManager: repositoryManager,
                 manifestLoader: MockManifestLoader(
                     manifests: [.init(url: packageDirectory.pathString, version: Version(1, 0, 0)): manifest]
-                )
+                ),
+                verbosity: TSCUtility.verbosity
             )
 
             let packageReference = PackageReference(identity: PackageIdentity(path: packageDirectory), path: packageDirectory.pathString)

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -738,6 +738,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                                                                baseURL: manifestPath.pathString,
                                                                toolsVersion: .v4_2,
                                                                packageKind: .local,
+                                                               verbosity: TSCUtility.verbosity,
                                                                on: .global(),
                                                                completion: $0) }
             XCTAssertEqual(manifest.name, "Trivial")
@@ -752,6 +753,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                                     toolsVersion: .v4_2,
                                     packageKind: .local,
                                     diagnostics: diagnostics,
+                                    verbosity: TSCUtility.verbosity,
                                     on: .global()) { result in
                     defer { sync.leave() }
 
@@ -810,6 +812,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                                     toolsVersion: .v4_2,
                                     packageKind: .local,
                                     diagnostics: diagnostics,
+                                    verbosity: TSCUtility.verbosity,
                                     on: .global()) { result in
                     defer { sync.leave() }
 

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -22,12 +22,12 @@ class ManifestSourceGenerationTests: XCTestCase {
             // Write the original manifest file contents, and load it.
             try fs.writeFileContents(packageDir.appending(component: Manifest.filename), bytes: ByteString(encodingAsUTF8: manifestContents))
             let manifestLoader = ManifestLoader(manifestResources: Resources.default)
-            let manifest = try tsc_await { manifestLoader.load(package: packageDir, baseURL: packageDir.pathString, toolsVersion: toolsVersion, packageKind: .root, on: .global(), completion: $0) }
+            let manifest = try tsc_await { manifestLoader.load(package: packageDir, baseURL: packageDir.pathString, toolsVersion: toolsVersion, packageKind: .root, verbosity: TSCUtility.verbosity, on: .global(), completion: $0) }
 
             // Generate source code for the loaded manifest, write it out to replace the manifest file contents, and load it again.
             let newContents = manifest.generatedManifestFileContents
             try fs.writeFileContents(packageDir.appending(component: Manifest.filename), bytes: ByteString(encodingAsUTF8: newContents))
-            let newManifest = try tsc_await { manifestLoader.load(package: packageDir, baseURL: packageDir.pathString, toolsVersion: toolsVersion, packageKind: .root, on: .global(), completion: $0) }
+            let newManifest = try tsc_await { manifestLoader.load(package: packageDir, baseURL: packageDir.pathString, toolsVersion: toolsVersion, packageKind: .root, verbosity: TSCUtility.verbosity, on: .global(), completion: $0) }
             
             // Check that all the relevant properties survived.
             let failureDetails = "\n--- ORIGINAL MANIFEST CONTENTS ---\n" + manifestContents + "\n--- REWRITTEN MANIFEST CONTENTS ---\n" + newContents

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -142,7 +142,8 @@ final class WorkspaceTests: XCTestCase {
                     pinsFile: sandbox.appending(component: "Package.resolved"),
                     manifestLoader: manifestLoader,
                     delegate: MockWorkspaceDelegate(),
-                    cachePath: fs.swiftPMCacheDirectory.appending(component: "repositories")
+                    cachePath: fs.swiftPMCacheDirectory.appending(component: "repositories"),
+                    verbosity: TSCUtility.verbosity
                 )
             }
 
@@ -3785,15 +3786,15 @@ final class WorkspaceTests: XCTestCase {
         // From here the API should be simple and straightforward:
         let diagnostics = DiagnosticsEngine()
         let manifest = try tsc_await {
-            ManifestLoader.loadManifest(packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], packageKind: .local, on: .global(), completion: $0)
+            ManifestLoader.loadManifest(packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], packageKind: .local, verbosity: TSCUtility.verbosity, on: .global(), completion: $0)
         }
 
         let loadedPackage = try tsc_await {
-            PackageBuilder.loadPackage(packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], xcTestMinimumDeploymentTargets: [:], diagnostics: diagnostics, on: .global(), completion: $0)
+            PackageBuilder.loadPackage(packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], xcTestMinimumDeploymentTargets: [:], diagnostics: diagnostics, verbosity: TSCUtility.verbosity, on: .global(), completion: $0)
         }
 
         let graph = try Workspace.loadGraph(
-            packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], diagnostics: diagnostics
+            packagePath: package, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], diagnostics: diagnostics, verbosity: TSCUtility.verbosity
         )
 
         XCTAssertEqual(manifest.name, "SwiftPM")


### PR DESCRIPTION
Refactor global `TSCUtils.verbosity` value to functions parameter

### Motivation:

While it's okayish to maintain global `TSCUtils.verbosity` for CLI tool, it's not really for library API. I believe it's better to provide a configurable verbosity parameter for library public API.

### Modifications:

replace `TSCUtils.verbosity` with function parameter that default to global `TSCUtils.verbosity`

### Result:

API verbosity setup is more granulated.
