### PR TITLE
Fix an internal error resulting from reusing a stale in-memory cached manifest when switching dependencies between forks

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -165,9 +165,6 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
     private let databaseCacheDir: AbsolutePath?
 
-    private let useInMemoryCache: Bool
-    private let memoryCache = ThreadSafeKeyValueStore<ManifestCacheKey, Manifest>()
-
     private let sdkRootCache = ThreadSafeBox<AbsolutePath>()
 
     private let operationQueue: OperationQueue
@@ -177,7 +174,6 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         serializedDiagnostics: Bool = false,
         isManifestSandboxEnabled: Bool = true,
         cacheDir: AbsolutePath? = nil,
-        useInMemoryCache: Bool = true,
         delegate: ManifestLoaderDelegate? = nil,
         extraManifestFlags: [String] = []
     ) {
@@ -187,7 +183,6 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         self.delegate = delegate
         self.extraManifestFlags = extraManifestFlags
 
-        self.useInMemoryCache = useInMemoryCache
         self.databaseCacheDir = cacheDir.map(resolveSymlinks)
 
         self.operationQueue = OperationQueue()
@@ -295,19 +290,6 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             let fileSystem = fileSystem ?? localFileSystem
             let manifestPath = try Manifest.path(atPackagePath: path, fileSystem: fileSystem)
             let packageIdentity = PackageIdentity(url: baseURL)
-            let cacheKey = try ManifestCacheKey(packageIdentity: packageIdentity,
-                                                manifestPath: manifestPath,
-                                                toolsVersion: toolsVersion,
-                                                env: ProcessEnv.vars,
-                                                swiftpmVersion: Versioning.currentVersion.displayString,
-                                                fileSystem: fileSystem)
-
-            if self.useInMemoryCache, let manifest = self.memoryCache[cacheKey], manifest.url == baseURL {
-                // Inform the delegate (backwards compatibility)
-                self.delegate?.willLoad(manifest: manifestPath)
-                return completion(.success(manifest))
-            }
-
             self.loadFile(manifestPath: manifestPath,
                           baseURL: baseURL,
                           version: version,
@@ -318,11 +300,6 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                           fileSystem: fileSystem,
                           diagnostics: diagnostics,
                           on: queue) { result in
-
-                // cache positive results
-                if self.useInMemoryCache, case .success(let manifest) = result {
-                    self.memoryCache[cacheKey] = manifest
-                }
 
                 completion(result)
             }
@@ -992,7 +969,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
     /// reset internal cache
     public func resetCache() throws {
-        self.memoryCache.clear()
+        // nothing needed at this point
     }
 
     /// reset internal state and purge shared cache

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -302,7 +302,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                                                 swiftpmVersion: Versioning.currentVersion.displayString,
                                                 fileSystem: fileSystem)
 
-            if self.useInMemoryCache, let manifest = self.memoryCache[cacheKey] {
+            if self.useInMemoryCache, let manifest = self.memoryCache[cacheKey], manifest.url == baseURL {
                 // Inform the delegate (backwards compatibility)
                 self.delegate?.willLoad(manifest: manifestPath)
                 return completion(.success(manifest))

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -596,7 +596,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             }
 
             let noCacheLoader = ManifestLoader(
-                manifestResources: Resources.default, useInMemoryCache: false, delegate: delegate)
+                manifestResources: Resources.default, delegate: delegate)
             for _ in 0..<2 {
                 check(loader: noCacheLoader, expectCached: false)
             }
@@ -731,7 +731,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             let diagnostics = DiagnosticsEngine()
             let delegate = ManifestTestDelegate()
-            let manifestLoader = ManifestLoader(manifestResources: Resources.default, cacheDir: path, useInMemoryCache: true, delegate: delegate)
+            let manifestLoader = ManifestLoader(manifestResources: Resources.default, cacheDir: path, delegate: delegate)
 
             // warm up caches
             let manifest = try tsc_await { manifestLoader.load(package: manifestPath.parentDirectory,
@@ -782,7 +782,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             let diagnostics = DiagnosticsEngine()
             let delegate = ManifestTestDelegate()
-            let manifestLoader = ManifestLoader(manifestResources: Resources.default, cacheDir: path, useInMemoryCache: true, delegate: delegate)
+            let manifestLoader = ManifestLoader(manifestResources: Resources.default, cacheDir: path, delegate: delegate)
 
             let sync = DispatchGroup()
             for _ in 0 ..< total {


### PR DESCRIPTION
Fix an internal that would occur when switching a dependency between two repositories that had the same last path component and identical package manifest contents (happens frequently with forks).  This was due to the in-memory manifest cache, and thus only seen in libSwiftPM clients and not in the CLI.

rdar://73462555

Need to figure out a good way to unit test this without actually accessing network.