### PR TITLE
[5.4] SR-12050: lldb error: could not build C module 'CNIOBoringSSLShims' (Linux 5.1.3) when debugging

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1668,7 +1668,7 @@ public class BuildPlan {
                 guard let moduleMap = target.moduleMap else { break }
                 swiftTarget.additionalFlags += [
                     "-Xcc", "-fmodule-map-file=\(moduleMap.pathString)",
-                    "-I", target.clangTarget.includeDir.pathString,
+                    "-Xcc", "-I", "-Xcc", target.clangTarget.includeDir.pathString,
                 ]
             case let target as SystemLibraryTarget:
                 swiftTarget.additionalFlags += ["-Xcc", "-fmodule-map-file=\(target.moduleMapPath.pathString)"]
@@ -1676,7 +1676,7 @@ public class BuildPlan {
             case let target as BinaryTarget:
                 if let library = xcFrameworkLibrary(for: target) {
                     if let headersPath = library.headersPath {
-                        swiftTarget.additionalFlags += ["-I", headersPath.pathString]
+                        swiftTarget.additionalFlags += ["-Xcc", "-I", "-Xcc", headersPath.pathString]
                     }
                     swiftTarget.libraryBinaryPaths.insert(library.binaryPath)
                 }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -774,7 +774,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(lib.moduleMap, AbsolutePath("/path/to/build/debug/lib.build/module.modulemap"))
 
         let exe = try result.target(for: "exe").swiftTarget().compileArguments()
-        XCTAssertMatch(exe, ["-swift-version", "4", "-enable-batch-mode", "-Onone", "-enable-testing", "-g", .equal(j), "-DSWIFT_PACKAGE", "-DDEBUG","-Xcc", "-fmodule-map-file=/path/to/build/debug/lib.build/module.modulemap", "-I", "/Pkg/Sources/lib/include", "-module-cache-path", "/path/to/build/debug/ModuleCache", .anySequence])
+        XCTAssertMatch(exe, ["-swift-version", "4", "-enable-batch-mode", "-Onone", "-enable-testing", "-g", .equal(j), "-DSWIFT_PACKAGE", "-DDEBUG","-Xcc", "-fmodule-map-file=/path/to/build/debug/lib.build/module.modulemap", "-Xcc", "-I", "-Xcc", "/Pkg/Sources/lib/include", "-module-cache-path", "/path/to/build/debug/ModuleCache", .anySequence])
 
       #if os(macOS)
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
@@ -1610,7 +1610,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(lib.moduleMap, AbsolutePath("/path/to/build/debug/lib.build/module.modulemap"))
 
         let exe = try result.target(for: "exe").swiftTarget().compileArguments()
-        XCTAssertMatch(exe, ["-swift-version", "4", "-enable-batch-mode", "-Onone", "-enable-testing", "-g", .equal(j), "-DSWIFT_PACKAGE", "-DDEBUG","-Xcc", "-fmodule-map-file=/path/to/build/debug/lib.build/module.modulemap", "-I", "/Pkg/Sources/lib/include", "-module-cache-path", "/path/to/build/debug/ModuleCache", .anySequence])
+        XCTAssertMatch(exe, ["-swift-version", "4", "-enable-batch-mode", "-Onone", "-enable-testing", "-g", .equal(j), "-DSWIFT_PACKAGE", "-DDEBUG","-Xcc", "-fmodule-map-file=/path/to/build/debug/lib.build/module.modulemap", "-Xcc", "-I", "-Xcc", "/Pkg/Sources/lib/include", "-module-cache-path", "/path/to/build/debug/ModuleCache", .anySequence])
 
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
             "/fake/path/to/swiftc",
@@ -1681,7 +1681,7 @@ final class BuildPlanTests: XCTestCase {
                 "-swift-version", "4", "-enable-batch-mode", "-Onone", "-enable-testing", "-g",
                 .equal(j), "-DSWIFT_PACKAGE", "-DDEBUG","-Xcc",
                 "-fmodule-map-file=/path/to/build/debug/lib.build/module.modulemap",
-                "-I", "/Pkg/Sources/lib/include",
+                "-Xcc", "-I", "-Xcc", "/Pkg/Sources/lib/include",
                 "-module-cache-path", "/path/to/build/debug/ModuleCache", .anySequence
             ]
         )


### PR DESCRIPTION
This is the 5.4 release nomination of https://github.com/apple/swift-package-manager/pull/3215.

When invoking the Swift compiler, SwiftPM was passing search paths to C headers as "-I" arguments. But it wasn't prefixing them with "-Xcc" so they were being interpreted by the Swift driver and not Clang. This meant that they weren't recorded as serialized import paths in the AST. It isn't fully clear why they are needed when building the module in response to the debugger or REPL but not when building using the compiler, but it is clear that these are C header search paths and not Swift module search paths, so they should indeed be passed using "-Xcc" prefixes.

This PR depends on https://github.com/apple/sourcekit-lsp/pull/363 in SourceKit-LSP, since unit tests in that package make assertions about the command lines SwiftPM generates.

rdar://58709835