### PR TITLE
[5.4] resolve timeout for repositories with large number of tags (#3218)

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -27,8 +27,7 @@ private struct GitShellHelper {
     /// Private function to invoke the Git tool with its default environment and given set of arguments.  The specified
     /// failure message is used only in case of error.  This function waits for the invocation to finish and returns the
     /// output as a string.
-    func run(_ args: [String], environment: [String: String] = Git.environment) throws -> String
-    {
+    func run(_ args: [String], environment: [String: String] = Git.environment) throws -> String {
         let process = Process(arguments: [Git.tool] + args, environment: environment, outputRedirection: .collect)
         let result: ProcessResult
         do {


### PR DESCRIPTION
motivation: in 5.4 we introduced a timeout on computing packages bounds to help mitigate scenarios where the resolution would hang. using a fixed timeout prooves to be incorrect since the time it takes to compute the bounds is a direct function of the number of version the repository has. as such, repositories with very large nuymber of tags (2000+) would hit the timeout

changes: make the timeout a function of the # of versions

rdar://73470011

