### PR TITLE
Fix potential crash in repository cache fallback

### DIFF
--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -384,6 +384,8 @@ public class RepositoryManager {
             } catch {
                 // Fetch without populating the cache in the case of an error.
                 print("Skipping cache due to an error: \(error)")
+                // It is possible that we already created the directory before failing, so clear leftover data if present.
+                try fileSystem.removeFileTree(repositoryPath)
                 try self.provider.fetch(repository: handle.repository, to: repositoryPath)
                 fromCache = false
             }


### PR DESCRIPTION
### Motivation:

It is possible that copying from the cache fails mid-way which can lead to SwiftPM hitting a precondition in the fallback.

### Modifications:

We should clear any potential leftover data before doing the fallback.

### Result:

Hitting the precondition can be avoided.

rdar://73505115