### PR TITLE
[5.4] Remove the in-memory manifest cache to fix an internal error caused by stale cache data

### DIFF
--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -596,7 +596,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             }
 
             let noCacheLoader = ManifestLoader(
-                manifestResources: Resources.default, useInMemoryCache: false, delegate: delegate)
+                manifestResources: Resources.default, delegate: delegate)
             for _ in 0..<2 {
                 check(loader: noCacheLoader, expectCached: false)
             }
@@ -731,7 +731,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             let diagnostics = DiagnosticsEngine()
             let delegate = ManifestTestDelegate()
-            let manifestLoader = ManifestLoader(manifestResources: Resources.default, cacheDir: path, useInMemoryCache: true, delegate: delegate)
+            let manifestLoader = ManifestLoader(manifestResources: Resources.default, cacheDir: path, delegate: delegate)
 
             // warm up caches
             let manifest = try tsc_await { manifestLoader.load(package: manifestPath.parentDirectory,
@@ -782,7 +782,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             let diagnostics = DiagnosticsEngine()
             let delegate = ManifestTestDelegate()
-            let manifestLoader = ManifestLoader(manifestResources: Resources.default, cacheDir: path, useInMemoryCache: true, delegate: delegate)
+            let manifestLoader = ManifestLoader(manifestResources: Resources.default, cacheDir: path, delegate: delegate)
 
             let sync = DispatchGroup()
             for _ in 0 ..< total {


### PR DESCRIPTION
Fix an internal error that would occur when switching a dependency between two repositories that had the same last path component and identical package manifest contents (happens frequently with forks).  The specific problem was that the old URL was part of the cached in-memory manifest, but was not serialized to the database and therefore not part of the manifest key.  There are other properties of Manifest that are also in addition to those stored in the database cache.  Since measurements don't indicate a noticeable performance impact and we don't know all the properties that could cause this, the cache is removed, at least for now.  If restored, it should store only the properties that actually come from the manifest (not the URL).

This was due to the in-memory manifest cache, and thus only seen in libSwiftPM clients and not in the CLI.

(cherry picked from commit a1d8a9d74d2ec2ac1f84ca8d41ae971c16270a1d)

This is the 5.4 nomination of https://github.com/apple/swift-package-manager/pull/3217

rdar://73462555
