### PR TITLE
[Draft] Update model to support version-specific manifests

### DIFF
--- a/Sources/PackageCollections/Model/Package.swift
+++ b/Sources/PackageCollections/Model/Package.swift
@@ -112,19 +112,8 @@ extension PackageCollectionsModel.Package {
         /// The version
         public let version: TSCUtility.Version
 
-        /// The package name
-        public let packageName: String
-
-        // Custom instead of `PackageModel.Target` because we don't need the additional details
-        /// The package version's targets
-        public let targets: [Target]
-
-        // Custom instead of `PackageModel.Product` because of the simplified `Target`
-        /// The package version's products
-        public let products: [Product]
-
-        /// The package version's Swift tools version
-        public let toolsVersion: ToolsVersion
+        /// Manifests by tools version
+        public let manifests: [ToolsVersion: Manifest]
 
         /// The package version's supported platforms
         public let minimumPlatformVersions: [SupportedPlatform]?
@@ -142,6 +131,22 @@ extension PackageCollectionsModel.Package {
 
         /// The package version's license
         public let license: PackageCollectionsModel.License?
+        
+        public struct Manifest: Equatable, Codable {
+            /// The Swift tools version specified in `Package.swift` or filename
+            public let toolsVersion: ToolsVersion
+            
+            /// The package name
+            public let packageName: String
+
+            // Custom instead of `PackageModel.Target` because we don't need the additional details
+            /// The package version's targets
+            public let targets: [Target]
+
+            // Custom instead of `PackageModel.Product` because of the simplified `Target`
+            /// The package version's products
+            public let products: [Product]
+        }
     }
 }
 

--- a/Sources/PackageCollectionsModel/Formats/v1.md
+++ b/Sources/PackageCollectionsModel/Formats/v1.md
@@ -1,0 +1,233 @@
+# Package Collection
+
+Package collections are short, curated lists of packages and associated metadata that can be imported
+by SwiftPM to make package discovery easier. Educators and community influencers can publish
+package collections to go along with course materials or blog posts, removing the friction of using
+packages for the first time and the cognitive overload of deciding which packages are useful for
+a particular task. Enterprises may use collections to narrow the decision space for their internal
+engineering teams, focusing them on a trusted set of vetted packages.
+
+## Creating a Package Collection
+
+A package collection is a JSON document that contains a list of packages and metadata per package.
+
+To begin, define the top-level metadata about the collection:
+
+* `name`: The name of the package collection, for display purposes only.
+* `overview`: A description of the package collection. **Optional.**
+* `keywords`: An array of keywords that the collection is associated with. **Optional.**
+* `formatVersion`: The version of the format to which the collection conforms. Currently, `1.0` is the only allowed value.
+* `revision`: The revision number of this package collection. **Optional.**
+* `generatedAt`: The ISO 8601-formatted datetime string when the package collection was generated.
+* `generatedBy`: The author of this package collection. **Optional.**
+    * `name`: The author name.
+* `packages`: An array of package objects.
+
+#### Add packages to the collection
+
+Each item in the `packages` array is a package object with the following properties:
+
+* `url`: The URL of the package. Currently only Git repository URLs are supported.
+* `summary`: A description of the package. **Optional.**
+* `keywords`: An array of keywords that the package is associated with. **Optional.**
+* `readmeURL`: The URL of the package's README. **Optional.**
+* `license`: The package's *current* license information. **Optional.**
+    * `url`: The URL of the license file.
+    * `name`: License name. [SPDX identifier](https://spdx.org/licenses/) (e.g., `Apache-2.0`, `MIT`, etc.) preferred. Omit if unknown. **Optional.**
+* `versions`: An array of version objects representing the most recent and/or relevant releases of the package.
+
+#### Add versions to a package
+
+A version object has metadata extracted from `Package.swift` and optionally additional metadata from other sources:
+
+* `version`: The semantic version string.
+* `manifestsByToolsVersion`: A map of manifests by tools version.
+    * `packageName`: The name of the package.
+    * `targets`: An array of the package version's targets.
+        * `name`: The target name.
+        * `moduleName`: The module name if this target can be imported as a module. **Optional.**
+    * `products`: An array of the package version's products.
+        * `name`: The product name.
+        * `type`: The product type. This must have the same JSON representation as SwiftPM's `PackageModel.ProductType`.
+        * `target`: An array of the product’s targets.
+
+```json
+{
+  "5.2": {
+    "packageName": "MyPackage",
+    "targets": [
+      {
+        "name": "MyTarget",
+        "moduleName": "MyTarget"
+      }
+    ],
+    "products": [
+      {
+        "name": "MyProduct",
+        "type": {
+          "library": ["automatic"]
+        },
+        "targets": ["MyTarget"]
+      }
+    ]
+  }
+}
+```
+
+* `minimumPlatformVersions`: An array of the package version’s supported platforms specified in `Package.swift`. **Optional.**
+
+```json
+{
+  "name": "macOS",
+  "version": "10.15"
+}
+```
+
+* `verifiedCompatibility`: An array of compatible platforms and Swift versions that has been tested and verified for. Valid platform names include `macOS`, `iOS`, `tvOS`, `watchOS`, `Linux`, `Android`, and `Windows`. Swift version should be semantic version string and as specific as possible. **Optional.**
+
+```json
+{
+  "platform": {
+    "name": "macOS"
+  },
+  "swiftVersion": "5.3.2"
+}
+```
+
+* `license`: The package version's license. **Optional.**
+    * `url`: The URL of the license file.
+    * `name`: License name. [SPDX identifier](https://spdx.org/licenses/) (e.g., `Apache-2.0`, `MIT`, etc.) preferred. Omit if unknown. **Optional.**
+
+##### Version-specific manifests
+
+Package collection generators should include data from
+[version-specific manifest(s)](https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#version-specific-manifest-selection).
+
+The keys of the `manifestsByToolsVersion` map are tools (semantic) versions.
+* For `Package.swift`, the tools version specified in `Package.swift` should be used.
+* For version-specific manifests, the tools version specified in the filename should be used. For example, for `Package@swift-4.2.swift` it would be `4.2`.
+
+##### Version-specific tags
+
+[Version-specific tags](https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#version-specific-tag-selection) are not
+supported by package collections.
+
+## Example
+
+```json
+{
+  "name": "Sample Package Collection",
+  "overview": "This is a sample package collection listing made-up packages.",
+  "keywords": ["sample package collection"],
+  "formatVersion": "1.0",
+  "revision": 3,
+  "generatedAt": "2020-10-22T06:03:52Z",
+  "packages": [
+    {
+      "url": "https://www.example.com/repos/RepoOne.git",
+      "summary": "Package One",
+      "readmeURL": "https://www.example.com/repos/RepoOne/README",
+      "license": {
+        "name": "Apache-2.0",
+        "url": "https://www.example.com/repos/RepoOne/LICENSE"
+      },
+      "versions": [
+        {
+          "version": "0.1.0",
+          "manifestsByToolsVersion": {
+            "5.1": {
+              "packageName": "PackageOne",
+              "targets": [
+                {
+                  "name": "Foo",
+                  "moduleName": "Foo"
+                }
+              ],
+              "products": [
+                {
+                  "name": "Foo",
+                  "type": {
+                    "library": ["automatic"]
+                  },
+                  "targets": ["Foo"]
+                }
+              ]
+            }
+          },
+          "verifiedCompatibility": [
+            {
+              "platform": { "name": "macOS" },
+              "swiftVersion": "5.1"
+            },
+            {
+              "platform": { "name": "iOS" },
+              "swiftVersion": "5.1"
+            },
+            {
+              "platform": { "name": "Linux" },
+              "swiftVersion": "5.1"
+            }
+          ],
+          "license": {
+            "name": "Apache-2.0",
+            "url": "https://www.example.com/repos/RepoOne/LICENSE"
+          }
+        }
+      ]
+    },
+    {
+      "url": "https://www.example.com/repos/RepoTwo.git",
+      "summary": "Package Two",
+      "readmeURL": "https://www.example.com/repos/RepoTwo/README",
+      "versions": [
+        {
+          "version": "2.1.0",
+          "manifestsByToolsVersion": {
+            "5.2": {
+              "packageName": "PackageTwo",
+              "targets": [
+                {
+                  "name": "Bar",
+                  "moduleName": "Bar"
+                }
+              ],
+              "products": [
+                {
+                  "name": "Bar",
+                  "type": {
+                    "library": ["automatic"]
+                  },
+                  "targets": ["Bar"]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "version": "1.8.3",
+          "manifestsByToolsVersion": {
+            "5.0": {
+              "packageName": "PackageTwo",
+              "targets": [
+                {
+                  "name": "Bar",
+                  "moduleName": "Bar"
+                }
+              ],
+              "products": [
+                {
+                  "name": "Bar",
+                  "type": {
+                    "library": ["automatic"]
+                  },
+                  "targets": ["Bar"]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+```

--- a/Sources/PackageCollectionsModel/PackageCollectionModel+v1.swift
+++ b/Sources/PackageCollectionsModel/PackageCollectionModel+v1.swift
@@ -120,17 +120,8 @@ extension PackageCollectionModel.V1.Collection.Package {
         /// The semantic version string.
         public let version: String
 
-        /// The name of the package.
-        public let packageName: String
-
-        /// An array of the package version's targets.
-        public let targets: [PackageCollectionModel.V1.Target]
-
-        /// An array of the package version's products.
-        public let products: [PackageCollectionModel.V1.Product]
-
-        /// The tools (semantic) version specified in `Package.swift`.
-        public let toolsVersion: String
+        /// Manifests by tools version.
+        public let manifestsByToolsVersion: [String: Manifest]
 
         /// An array of the package version’s supported platforms specified in `Package.swift`.
         public let minimumPlatformVersions: [PackageCollectionModel.V1.PlatformVersion]?
@@ -144,22 +135,43 @@ extension PackageCollectionModel.V1.Collection.Package {
         /// Creates a `Version`
         public init(
             version: String,
-            packageName: String,
-            targets: [PackageCollectionModel.V1.Target],
-            products: [PackageCollectionModel.V1.Product],
-            toolsVersion: String,
+            manifestsByToolsVersion: [String: Manifest],
             minimumPlatformVersions: [PackageCollectionModel.V1.PlatformVersion]?,
             verifiedCompatibility: [PackageCollectionModel.V1.Compatibility]?,
             license: PackageCollectionModel.V1.License?
         ) {
             self.version = version
-            self.packageName = packageName
-            self.targets = targets
-            self.products = products
-            self.toolsVersion = toolsVersion
+            self.manifestsByToolsVersion = manifestsByToolsVersion
             self.minimumPlatformVersions = minimumPlatformVersions
             self.verifiedCompatibility = verifiedCompatibility
             self.license = license
+        }
+        
+        public struct Manifest: Equatable, Codable {
+            /// The tools (semantic) version specified in `Package.swift`.
+            public let toolsVersion: String
+            
+            /// The name of the package.
+            public let packageName: String
+
+            /// An array of the package version's targets.
+            public let targets: [PackageCollectionModel.V1.Target]
+
+            /// An array of the package version's products.
+            public let products: [PackageCollectionModel.V1.Product]
+
+            /// Creates a `Manifest`
+            public init(
+                toolsVersion: String,
+                packageName: String,
+                targets: [PackageCollectionModel.V1.Target],
+                products: [PackageCollectionModel.V1.Product]
+            ) {
+                self.toolsVersion = toolsVersion
+                self.packageName = packageName
+                self.targets = targets
+                self.products = products
+            }
         }
     }
 }


### PR DESCRIPTION
### Motivation:

Package collections should include data from version-specific manifests.

### Modifications:

Update models to support version-specific manifests.

### Result:

Package collections can hold data from multiple manifests for each package version.
