### PR TITLE
PackageCollectionsModel: correct dependency (NFC)

### DIFF
--- a/Sources/PackageCollectionsModel/CMakeLists.txt
+++ b/Sources/PackageCollectionsModel/CMakeLists.txt
@@ -9,6 +9,8 @@
 add_library(PackageCollectionsModel
   PackageCollectionModel.swift
   PackageCollectionModel+v1.swift)
+target_link_libraries(PackageCollectionsModel PUBLIC
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
 
 set_target_properties(PackageCollectionsModel PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})


### PR DESCRIPTION
PackageCollectionsModel has grown a dependency on Foundation, explicitly
list it in the build.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
