### PR TITLE
[Collections] CLI 'remove' results in "database is locked" error

### DIFF
--- a/Sources/Commands/SwiftPackageCollectionsTool.swift
+++ b/Sources/Commands/SwiftPackageCollectionsTool.swift
@@ -134,12 +134,11 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
             }
 
             let source = PackageCollectionsModel.CollectionSource(type: .json, url: collectionUrl)
-            let collection = try with { collections in
-                return try tsc_await { collections.getCollection(source, callback: $0) }
+            try with { collections in
+                let collection = try tsc_await { collections.getCollection(source, callback: $0) }
+                _ = try tsc_await { collections.removeCollection(source, callback: $0) }
+                print("Removed \"\(collection.name)\" from your package collections.")
             }
-
-            _ = try with { collections in try tsc_await { collections.removeCollection(source, callback: $0) } }
-            print("Removed \"\(collection.name)\" from your package collections.")
         }
     }
 
@@ -163,31 +162,29 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
         var searchQuery: String
 
         mutating func run() throws {
-            switch searchMethod {
-            case .keywords:
-                let results = try with { collections in
-                    return try tsc_await { collections.findPackages(searchQuery, collections: nil, callback: $0) }
-                }
-                
-                if jsonOptions.json {
-                    try JSONEncoder.makeWithDefaults().print(results.items)
-                } else {
-                    results.items.forEach {
-                        print("\($0.package.repository.url): \($0.package.summary ?? "")")
+            try with { collections in
+                switch searchMethod {
+                case .keywords:
+                    let results = try tsc_await { collections.findPackages(searchQuery, collections: nil, callback: $0) }
+                    
+                    if jsonOptions.json {
+                        try JSONEncoder.makeWithDefaults().print(results.items)
+                    } else {
+                        results.items.forEach {
+                            print("\($0.package.repository.url): \($0.package.summary ?? "")")
+                        }
                     }
-                }
 
-            case .module:
-                let results = try with { collections in
-                    return try tsc_await { collections.findTargets(searchQuery, searchType: .exactMatch, collections: nil, callback: $0) }
-                }
+                case .module:
+                    let results = try tsc_await { collections.findTargets(searchQuery, searchType: .exactMatch, collections: nil, callback: $0) }
 
-                let packages = Set(results.items.flatMap { $0.packages })
-                if jsonOptions.json {
-                    try JSONEncoder.makeWithDefaults().print(packages)
-                } else {
-                    packages.forEach {
-                        print("\($0.repository.url): \($0.summary ?? "")")
+                    let packages = Set(results.items.flatMap { $0.packages })
+                    if jsonOptions.json {
+                        try JSONEncoder.makeWithDefaults().print(packages)
+                    } else {
+                        packages.forEach {
+                            print("\($0.repository.url): \($0.summary ?? "")")
+                        }
                     }
                 }
             }
@@ -229,70 +226,68 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
         }
 
         mutating func run() throws {
-            let identity = PackageIdentity(url: packageUrl)
-            let reference = PackageReference(identity: identity, path: packageUrl)
-            
-            do { // assume URL is for a package
-                let result = try with { collections in
-                    return try tsc_await { collections.getPackageMetadata(reference, callback: $0) }
-                }
+            try with { collections in
+                let identity = PackageIdentity(url: packageUrl)
+                let reference = PackageReference(identity: identity, path: packageUrl)
                 
-                if let versionString = version {
-                    guard let version = TSCUtility.Version(string: versionString), let result = result.package.versions.first(where: { $0.version == version }), let printedResult = printVersion(result) else {
-                        throw CollectionsError.invalidVersionString(versionString)
+                do { // assume URL is for a package
+                    let result = try tsc_await { collections.getPackageMetadata(reference, callback: $0) }
+                    
+                    if let versionString = version {
+                        guard let version = TSCUtility.Version(string: versionString), let result = result.package.versions.first(where: { $0.version == version }), let printedResult = printVersion(result) else {
+                            throw CollectionsError.invalidVersionString(versionString)
+                        }
+                        
+                        if jsonOptions.json {
+                            try JSONEncoder.makeWithDefaults().print(result)
+                        } else {
+                            print("\(indent())Version: \(printedResult)")
+                        }
+                    } else {
+                        let description = optionalRow("Description", result.package.summary)
+                        let versions = result.package.versions.map { "\($0.version)" }.joined(separator: ", ")
+                        let watchers = optionalRow("Watchers", result.package.watchersCount?.description)
+                        let readme = optionalRow("Readme", result.package.readmeURL?.absoluteString)
+                        let authors = optionalRow("Authors", result.package.authors?.map { $0.username }.joined(separator: ", "))
+                        let latestVersion = optionalRow("\(String(repeating: "-", count: 60))\n\(indent())Latest Version", printVersion(result.package.latestVersion))
+
+                        if jsonOptions.json {
+                            try JSONEncoder.makeWithDefaults().print(result.package)
+                        } else {
+                            print("""
+                                \(description)
+                                Available Versions: \(versions)\(watchers)\(readme)\(authors)\(latestVersion)
+                            """)
+                        }
+                    }
+                } catch { // assume URL is for a collection
+                    // If a version argument was given, we do not perform the fallback.
+                    if version != nil {
+                        throw error
                     }
                     
-                    if jsonOptions.json {
-                        try JSONEncoder.makeWithDefaults().print(result)
-                    } else {
-                        print("\(indent())Version: \(printedResult)")
+                    guard let collectionUrl = URL(string: packageUrl) else {
+                        throw CollectionsError.invalidArgument("collectionUrl")
                     }
-                } else {
-                    let description = optionalRow("Description", result.package.summary)
-                    let versions = result.package.versions.map { "\($0.version)" }.joined(separator: ", ")
-                    let watchers = optionalRow("Watchers", result.package.watchersCount?.description)
-                    let readme = optionalRow("Readme", result.package.readmeURL?.absoluteString)
-                    let authors = optionalRow("Authors", result.package.authors?.map { $0.username }.joined(separator: ", "))
-                    let latestVersion = optionalRow("\(String(repeating: "-", count: 60))\n\(indent())Latest Version", printVersion(result.package.latestVersion))
-
+                    
+                    let source = PackageCollectionsModel.CollectionSource(type: .json, url: collectionUrl)
+                    let collection = try tsc_await { collections.getCollection(source, callback: $0) }
+                    
+                    let description = optionalRow("Description", collection.overview)
+                    let keywords = optionalRow("Keywords", collection.keywords?.joined(separator: ", "))
+                    let createdAt = optionalRow("Created At", DateFormatter().string(from: collection.createdAt))
+                    let packages = collection.packages.map { "\($0.repository.url)" }.joined(separator: "\n\(indent(levels: 2))")
+                    
                     if jsonOptions.json {
-                        try JSONEncoder.makeWithDefaults().print(result.package)
+                        try JSONEncoder.makeWithDefaults().print(collection)
                     } else {
                         print("""
-                            \(description)
-                            Available Versions: \(versions)\(watchers)\(readme)\(authors)\(latestVersion)
-                        """)
+                                        Name: \(collection.name)
+                                        Source: \(collection.source.url)\(description)\(keywords)\(createdAt)
+                                        Packages:
+                                            \(packages)
+                                    """)
                     }
-                }
-            } catch { // assume URL is for a collection
-                // If a version argument was given, we do not perform the fallback.
-                if version != nil {
-                    throw error
-                }
-                
-                guard let collectionUrl = URL(string: packageUrl) else {
-                    throw CollectionsError.invalidArgument("collectionUrl")
-                }
-                
-                let source = PackageCollectionsModel.CollectionSource(type: .json, url: collectionUrl)
-                let collection = try with { collections in
-                    try tsc_await { collections.getCollection(source, callback: $0) }
-                }
-                
-                let description = optionalRow("Description", collection.overview)
-                let keywords = optionalRow("Keywords", collection.keywords?.joined(separator: ", "))
-                let createdAt = optionalRow("Created At", DateFormatter().string(from: collection.createdAt))
-                let packages = collection.packages.map { "\($0.repository.url)" }.joined(separator: "\n\(indent(levels: 2))")
-                
-                if jsonOptions.json {
-                    try JSONEncoder.makeWithDefaults().print(collection)
-                } else {
-                    print("""
-                                    Name: \(collection.name)
-                                    Source: \(collection.source.url)\(description)\(keywords)\(createdAt)
-                                    Packages:
-                                        \(packages)
-                                """)
                 }
             }
         }

--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -131,6 +131,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
         let maximumAttempts: Int
 
         var attempts: Int = 0
+        var multipler: Int = 1
 
         var canRetry: Bool {
             self.attempts < self.maximumAttempts
@@ -144,12 +145,12 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
 
         mutating func nextDelay() throws -> DispatchTimeInterval {
             guard self.canRetry else {
-                print("exhausted: \(attempts)")
                 throw StringError("Maximum attempts reached")
             }
-            let delay = Int(pow(2.0, Double(self.attempts))) * intervalInMilliseconds
+            let delay = self.multipler * intervalInMilliseconds
             let jitter = Int.random(in: 0 ... self.randomizationFactor)
             self.attempts += 1
+            self.multipler *= 2
             return .milliseconds(delay + jitter)
         }
     }


### PR DESCRIPTION
Motivation:
Using the `package-collection` CLI, the `remove` command results in "database is locked" error even though the collection is removed successfully. This is because a `SQLitePackageCollectionsStorage` is created at the beginning of each command run, and in the initializer the time-consuming `populateTargetTrie` is called. When the command finishes running, it triggers `SQLitePackageCollectionsStorage` to be closed, which in turn closes the SQLite connection, but this is done while `populateTargetTrie` is still running and thus causes the "database is locked" error.

Modifications:
- Initializing `PackageCollections` can be expensive and should only be done once in a command
- Add and set `isShuttingDown` flag when `SQLitePackageCollectionsStorage.close` is called so `populateTargetTrie` knows that it should stop.
- Try `db.close` in a second attempt after allowing time for database operations to react to `isShuttingDown` flag
- `populateTargetTrie` should memoize its result

Result:
No "database is locked" error.
