### PR TITLE
PackageDescription: mark imports as implementation-only

### DIFF
--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -9,12 +9,12 @@
 */
 
 #if canImport(Glibc)
-import Glibc
+@_implementationOnly import Glibc
 #elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-import Darwin.C
+@_implementationOnly import Darwin.C
 #elseif os(Windows)
-import ucrt
-import struct WinSDK.HANDLE
+@_implementationOnly import ucrt
+@_implementationOnly import struct WinSDK.HANDLE
 #endif
 import Foundation
 


### PR DESCRIPTION
### Motivation:

Symbols from `Glibc`/`Darwin`/`ucrt` are not used in the public interface of `PackageDescription`, so there is no need to expose them in the generated module interface.

### Modifications:

This change hides the import statements from the generated `PackageDescription` module interface.
It relies on https://github.com/apple/swift/pull/35575 (already merged).

### Result:

After this change SourceKit returns a `PackageDescription` interface without `import Darwin.C`/`import Glibc`/`import ucrt`.
