### PR TITLE
[Collections] Add and wire up models for signed package collections

### DIFF
--- a/Fixtures/Collections/JSON/good_signed.json
+++ b/Fixtures/Collections/JSON/good_signed.json
@@ -1,0 +1,124 @@
+{
+  "name": "Sample Package Collection",
+  "overview": "This is a sample package collection listing made-up packages.",
+  "keywords": ["sample package collection"],
+  "formatVersion": "1.0",
+  "revision": 3,
+  "generatedAt": "2020-10-22T06:03:52Z",
+  "generatedBy": {
+    "name": "Jane Doe"
+  },
+  "packages": [
+    {
+      "url": "https://www.example.com/repos/RepoOne.git",
+      "summary": "Package One",
+      "keywords": ["sample package"],
+      "readmeURL": "https://www.example.com/repos/RepoOne/README",
+      "license": {
+        "name": "Apache-2.0",
+        "url": "https://www.example.com/repos/RepoOne/LICENSE"
+      },
+      "versions": [
+        {
+          "version": "0.1.0",
+          "packageName": "PackageOne",
+          "targets": [
+            {
+              "name": "Foo",
+              "moduleName": "Foo"
+            }
+          ],
+          "products": [
+            {
+              "name": "Foo",
+              "type": {
+                "library": ["automatic"]
+              },
+              "targets": ["Foo"]
+            }
+          ],
+          "toolsVersion": "5.1",
+          "minimumPlatformVersions": [
+            { "name": "macOS", "version": "10.15" }
+          ],
+          "verifiedCompatibility": [
+            {
+              "platform": { "name": "macOS" },
+              "swiftVersion": "5.1"
+            },
+            {
+              "platform": { "name": "iOS" },
+              "swiftVersion": "5.1"
+            },
+            {
+              "platform": { "name": "Linux" },
+              "swiftVersion": "5.1"
+            }
+          ],
+          "license": {
+            "name": "Apache-2.0",
+            "url": "https://www.example.com/repos/RepoOne/LICENSE"
+          }
+        }
+      ]
+    },
+    {
+      "url": "https://www.example.com/repos/RepoTwo.git",
+      "summary": "Package Two",
+      "readmeURL": "https://www.example.com/repos/RepoTwo/README",
+      "versions": [
+        {
+          "version": "2.1.0",
+          "packageName": "PackageTwo",
+          "targets": [
+            {
+              "name": "Bar",
+              "moduleName": "Bar"
+            }
+          ],
+          "products": [
+            {
+              "name": "Bar",
+              "type": {
+                "library": ["automatic"]
+              },
+              "targets": ["Bar"]
+            }
+          ],
+          "toolsVersion": "5.2"
+        },
+        {
+          "version": "1.8.3",
+          "packageName": "PackageTwo",
+          "targets": [
+            {
+              "name": "Bar",
+              "moduleName": "Bar"
+            }
+          ],
+          "products": [
+            {
+              "name": "Bar",
+              "type": {
+                "library": ["automatic"]
+              },
+              "targets": ["Bar"]
+            }
+          ],
+          "toolsVersion": "5.0"
+        }
+      ]
+    }
+  ],
+  "signature": {
+    "signature": "<SIGNATURE>",
+    "certificate": {
+      "subject": {
+        "commonName": "Sample Subject"
+      },
+      "issuer": {
+        "commonName": "Sample Issuer"
+      }
+    }
+  }
+}

--- a/Sources/PackageCollections/Model/Collection.swift
+++ b/Sources/PackageCollections/Model/Collection.swift
@@ -54,8 +54,13 @@ extension PackageCollectionsModel {
         /// When this collection was last processed locally
         public let lastProcessedAt: Date
 
+        /// The collection's signature metadata
+        public let signature: SignatureData?
+
         /// Indicates if the collection is signed
-        public let isSigned: Bool
+        public var isSigned: Bool {
+            self.signature != nil
+        }
 
         /// Initializes a `Collection`
         init(
@@ -66,8 +71,8 @@ extension PackageCollectionsModel {
             packages: [Package],
             createdAt: Date,
             createdBy: Author?,
-            lastProcessedAt: Date = Date(),
-            isSigned: Bool
+            signature: SignatureData?,
+            lastProcessedAt: Date = Date()
         ) {
             self.identifier = .init(from: source)
             self.source = source
@@ -77,8 +82,8 @@ extension PackageCollectionsModel {
             self.packages = packages
             self.createdAt = createdAt
             self.createdBy = createdBy
+            self.signature = signature
             self.lastProcessedAt = lastProcessedAt
-            self.isSigned = isSigned
         }
     }
 }
@@ -178,5 +183,42 @@ extension PackageCollectionsModel.Collection {
     public struct Author: Equatable, Codable {
         /// The name of the author
         public let name: String
+    }
+}
+
+extension PackageCollectionsModel {
+    /// Package collection signature metadata
+    public struct SignatureData: Equatable, Codable {
+        /// Details about the certificate used to generate the signature
+        public let certificate: Certificate
+
+        public init(certificate: Certificate) {
+            self.certificate = certificate
+        }
+
+        public struct Certificate: Equatable, Codable {
+            /// Subject of the certificate
+            public let subject: Name
+
+            /// Issuer of the certificate
+            public let issuer: Name
+
+            /// Creates a `Certificate`
+            public init(subject: Name, issuer: Name) {
+                self.subject = subject
+                self.issuer = issuer
+            }
+
+            /// Generic certificate name (e.g., subject, issuer)
+            public struct Name: Equatable, Codable {
+                /// Common name
+                public let commonName: String
+
+                /// Creates a `Name`
+                public init(commonName: String) {
+                    self.commonName = commonName
+                }
+            }
+        }
     }
 }

--- a/Tests/PackageCollectionsModelTests/PackageCollectionModelTests.swift
+++ b/Tests/PackageCollectionsModelTests/PackageCollectionModelTests.swift
@@ -16,7 +16,7 @@ import XCTest
 class PackageCollectionModelTests: XCTestCase {
     typealias Model = PackageCollectionModel.V1
 
-    func testCodable() throws {
+    func testCollectionCodable() throws {
         let packages = [
             Model.Collection.Package(
                 url: URL(string: "https://package-collection-tests.com/repos/foobar.git")!,
@@ -52,5 +52,59 @@ class PackageCollectionModelTests: XCTestCase {
         let data = try JSONEncoder().encode(collection)
         let decoded = try JSONDecoder().decode(Model.Collection.self, from: data)
         XCTAssertEqual(collection, decoded)
+    }
+
+    func testSignedCollectionCodable() throws {
+        let packages = [
+            Model.Collection.Package(
+                url: URL(string: "https://package-collection-tests.com/repos/foobar.git")!,
+                summary: "Package Foobar",
+                keywords: ["test package"],
+                versions: [
+                    Model.Collection.Package.Version(
+                        version: "1.3.2",
+                        packageName: "Foobar",
+                        targets: [.init(name: "Foo", moduleName: "Foo")],
+                        products: [.init(name: "Bar", type: .library(.automatic), targets: ["Foo"])],
+                        toolsVersion: "5.2",
+                        minimumPlatformVersions: [.init(name: "macOS", version: "10.15")],
+                        verifiedCompatibility: [Model.Compatibility(platform: Model.Platform(name: "macOS"), swiftVersion: "5.2")],
+                        license: .init(name: "Apache-2.0", url: URL(string: "https://package-collection-tests.com/repos/foobar/LICENSE")!)
+                    ),
+                ],
+                readmeURL: URL(string: "https://package-collection-tests.com/repos/foobar/README")!,
+                license: .init(name: "Apache-2.0", url: URL(string: "https://package-collection-tests.com/repos/foobar/LICENSE")!)
+            ),
+        ]
+        let collection = Model.Collection(
+            name: "Test Package Collection",
+            overview: "A test package collection",
+            keywords: ["swift packages"],
+            packages: packages,
+            formatVersion: .v1_0,
+            revision: 3,
+            generatedAt: Date(),
+            generatedBy: .init(name: "Jane Doe")
+        )
+        let signature = Model.Signature(
+            signature: "<SIGNATURE>",
+            certificate: Model.Signature.Certificate(
+                subject: .init(commonName: "Test Subject"),
+                issuer: .init(commonName: "Test Issuer")
+            )
+        )
+        let signedCollection = Model.SignedCollection(collection: collection, signature: signature)
+
+        let data = try JSONEncoder().encode(signedCollection)
+
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(Model.SignedCollection.self, from: data)
+        XCTAssertEqual(signedCollection, decoded)
+
+        let decodedCollection = try Model.SignedCollection.collection(from: data, using: decoder)
+        XCTAssertEqual(collection, decodedCollection)
+
+        let decodedSignature = try Model.SignedCollection.signature(from: data, using: decoder)
+        XCTAssertEqual(signature, decodedSignature)
     }
 }

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -70,6 +70,64 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(version.verifiedCompatibility!.first!.platform, .macOS)
             XCTAssertEqual(version.verifiedCompatibility!.first!.swiftVersion, SwiftLanguageVersion(string: "5.1")!)
             XCTAssertEqual(version.license, .init(type: .Apache2_0, url: URL(string: "https://www.example.com/repos/RepoOne/LICENSE")!))
+            XCTAssertFalse(collection.isSigned)
+        }
+    }
+
+    func testGoodSigned() throws {
+        fixture(name: "Collections") { directoryPath in
+            let path = directoryPath.appending(components: "JSON", "good_signed.json")
+            let url = URL(string: "https://www.test.com/collection.json")!
+            let data = Data(try localFileSystem.readFileContents(path).contents)
+
+            let handler = { (request: HTTPClient.Request, callback: @escaping (Result<HTTPClient.Response, Error>) -> Void) in
+                XCTAssertEqual(request.url, url, "url should match")
+                switch request.method {
+                case .head:
+                    callback(.success(.init(statusCode: 200,
+                                            headers: .init([.init(name: "Content-Length", value: "\(data.count)")]))))
+                case .get:
+                    callback(.success(.init(statusCode: 200,
+                                            headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
+                                            body: data)))
+                default:
+                    XCTFail("method should match")
+                }
+            }
+
+            var httpClient = HTTPClient(handler: handler)
+            httpClient.configuration.circuitBreakerStrategy = .none
+            httpClient.configuration.retryStrategy = .none
+            let provider = JSONPackageCollectionProvider(httpClient: httpClient)
+            let source = PackageCollectionsModel.CollectionSource(type: .json, url: url)
+            let collection = try tsc_await { callback in provider.get(source, callback: callback) }
+
+            XCTAssertEqual(collection.name, "Sample Package Collection")
+            XCTAssertEqual(collection.overview, "This is a sample package collection listing made-up packages.")
+            XCTAssertEqual(collection.keywords, ["sample package collection"])
+            XCTAssertEqual(collection.createdBy?.name, "Jane Doe")
+            XCTAssertEqual(collection.packages.count, 2)
+            let package = collection.packages.first!
+            XCTAssertEqual(package.repository, .init(url: "https://www.example.com/repos/RepoOne.git"))
+            XCTAssertEqual(package.summary, "Package One")
+            XCTAssertEqual(package.keywords, ["sample package"])
+            XCTAssertEqual(package.readmeURL, URL(string: "https://www.example.com/repos/RepoOne/README")!)
+            XCTAssertEqual(package.license, .init(type: .Apache2_0, url: URL(string: "https://www.example.com/repos/RepoOne/LICENSE")!))
+            XCTAssertEqual(package.versions.count, 1)
+            let version = package.versions.first!
+            XCTAssertEqual(version.packageName, "PackageOne")
+            XCTAssertEqual(version.targets, [.init(name: "Foo", moduleName: "Foo")])
+            XCTAssertEqual(version.products, [.init(name: "Foo", type: .library(.automatic), targets: [.init(name: "Foo", moduleName: "Foo")])])
+            XCTAssertEqual(version.toolsVersion, ToolsVersion(string: "5.1")!)
+            XCTAssertEqual(version.minimumPlatformVersions, [SupportedPlatform(platform: .macOS, version: .init("10.15"))])
+            XCTAssertEqual(version.verifiedCompatibility?.count, 3)
+            XCTAssertEqual(version.verifiedCompatibility!.first!.platform, .macOS)
+            XCTAssertEqual(version.verifiedCompatibility!.first!.swiftVersion, SwiftLanguageVersion(string: "5.1")!)
+            XCTAssertEqual(version.license, .init(type: .Apache2_0, url: URL(string: "https://www.example.com/repos/RepoOne/LICENSE")!))
+            XCTAssertTrue(collection.isSigned)
+            let signature = collection.signature!
+            XCTAssertEqual("Sample Subject", signature.certificate.subject.commonName)
+            XCTAssertEqual("Sample Issuer", signature.certificate.issuer.commonName)
         }
     }
 
@@ -106,6 +164,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(version.verifiedCompatibility!.first!.platform, .macOS)
             XCTAssertEqual(version.verifiedCompatibility!.first!.swiftVersion, SwiftLanguageVersion(string: "5.1")!)
             XCTAssertEqual(version.license, .init(type: .Apache2_0, url: URL(string: "https://www.example.com/repos/RepoOne/LICENSE")!))
+            XCTAssertFalse(collection.isSigned)
         }
     }
 

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -547,7 +547,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                                 packages: [mockPackage],
                                                                 createdAt: Date(),
                                                                 createdBy: nil,
-                                                                isSigned: true)
+                                                                signature: nil)
 
         let mockCollection2 = PackageCollectionsModel.Collection(source: .init(type: .json, url: URL(string: "https://feed.mock/\(UUID().uuidString)")!),
                                                                  name: UUID().uuidString,
@@ -556,7 +556,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                                  packages: [mockPackage],
                                                                  createdAt: Date(),
                                                                  createdBy: nil,
-                                                                 isSigned: true)
+                                                                 signature: nil)
 
         let expectedCollections = [mockCollection, mockCollection2]
         let expectedCollectionsIdentifiers = expectedCollections.map { $0.identifier }.sorted()
@@ -568,7 +568,7 @@ final class PackageCollectionsTests: XCTestCase {
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         try mockCollections.forEach { collection in
-            _ = try tsc_await { callback in packageCollections.addCollection(collection.source, callback: callback) }
+            _ = try tsc_await { callback in packageCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) }, callback: callback) }
         }
 
         do {
@@ -699,7 +699,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                                 packages: [mockPackage],
                                                                 createdAt: Date(),
                                                                 createdBy: nil,
-                                                                isSigned: true)
+                                                                signature: nil)
 
         let mockCollection2 = PackageCollectionsModel.Collection(source: .init(type: .json, url: URL(string: "https://feed.mock/\(UUID().uuidString)")!),
                                                                  name: UUID().uuidString,
@@ -708,7 +708,7 @@ final class PackageCollectionsTests: XCTestCase {
                                                                  packages: [mockPackage],
                                                                  createdAt: Date(),
                                                                  createdBy: nil,
-                                                                 isSigned: true)
+                                                                 signature: nil)
 
         let expectedCollections = [mockCollection, mockCollection2]
         let expectedCollectionsIdentifiers = expectedCollections.map { $0.identifier }.sorted()
@@ -720,7 +720,7 @@ final class PackageCollectionsTests: XCTestCase {
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         try mockCollections.forEach { collection in
-            _ = try tsc_await { callback in packageCollections.addCollection(collection.source, callback: callback) }
+            _ = try tsc_await { callback in packageCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) }, callback: callback) }
         }
 
         do {
@@ -813,7 +813,13 @@ final class PackageCollectionsTests: XCTestCase {
                 if self.brokenSources.contains(source) {
                     callback(.failure(self.error))
                 } else {
-                    callback(.success(PackageCollectionsModel.Collection(source: source, name: "", overview: nil, keywords: nil, packages: [], createdAt: Date(), createdBy: nil, isSigned: true)))
+                    let signature = PackageCollectionsModel.SignatureData(
+                        certificate: PackageCollectionsModel.SignatureData.Certificate(
+                            subject: .init(commonName: ""),
+                            issuer: .init(commonName: "")
+                        )
+                    )
+                    callback(.success(PackageCollectionsModel.Collection(source: source, name: "", overview: nil, keywords: nil, packages: [], createdAt: Date(), createdBy: nil, signature: signature)))
                 }
             }
         }

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -74,6 +74,16 @@ func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: I
                                                    authors: nil)
         }
 
+        var signature: PackageCollectionsModel.SignatureData?
+        if signed {
+            signature = .init(
+                certificate: PackageCollectionsModel.SignatureData.Certificate(
+                    subject: .init(commonName: "subject-\(collectionIndex)"),
+                    issuer: .init(commonName: "issuer-\(collectionIndex)")
+                )
+            )
+        }
+
         return PackageCollectionsModel.Collection(source: .init(type: .json, url: URL(string: "https://feed-\(collectionIndex)")!),
                                                   name: "collection \(collectionIndex)",
                                                   overview: "collection \(collectionIndex) description",
@@ -81,7 +91,7 @@ func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: I
                                                   packages: packages,
                                                   createdAt: Date(),
                                                   createdBy: PackageCollectionsModel.Collection.Author(name: "Jane Doe"),
-                                                  isSigned: signed)
+                                                  signature: signature)
     }
 }
 


### PR DESCRIPTION
- Introduce new `SignedCollection` as
  [proposed](https://forums.swift.org/t/package-collection-signing/43855).
- Update logic in `JSONPackageCollectionProvider` to check for signature
- Adjust tests
