### PR TITLE
fix potential race in PackageCollections.refreshCollections

### DIFF
--- a/Sources/Basics/ConcurrencyHelpers.swift
+++ b/Sources/Basics/ConcurrencyHelpers.swift
@@ -95,9 +95,11 @@ public final class ThreadSafeArrayStore<Value> {
         }
     }
 
-    public func append(_ item: Value) {
+    @discardableResult
+    public func append(_ item: Value) -> Int {
         self.lock.withLock {
             self.underlying.append(item)
+            return self.underlying.count
         }
     }
 

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -104,8 +104,8 @@ public struct PackageCollections: PackageCollectionsProtocol {
                 let refreshResults = ThreadSafeArrayStore<Result<Model.Collection, Error>>()
                 sources.forEach { source in
                     self.refreshCollectionFromSource(source: source) { refreshResult in
-                        refreshResults.append(refreshResult)
-                        if refreshResults.count == sources.count {
+                        let count = refreshResults.append(refreshResult)
+                        if count == sources.count {
                             let errors = refreshResults.compactMap { $0.failure }
                             callback(errors.isEmpty ? .success(sources) : .failure(MultipleErrors(errors)))
                         }


### PR DESCRIPTION
motivation: CI crashes in PackageCollectsTest::testBrokenRefresh suggest a race condition in the code

changes:
* change ThreadSafeArrayStore::apend to return the current count in a thread safe manner
* update the callsite to use the count returned from append instead of after the append -- which could be racy

rdar://73884751

