### PR TITLE
Improved the error message when using a local package dependency as 'url:' instead of 'path:'

### DIFF
--- a/Fixtures/Miscellaneous/LocalPackageAsURL/Bar/Package.swift
+++ b/Fixtures/Miscellaneous/LocalPackageAsURL/Bar/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version:5.1
+import PackageDescription
+
+let package = Package(
+    name: "Bar",
+    dependencies: [
+        .package(url: "../Foo", from: "1.0.0"),
+    ],
+    targets: [
+        .target(name: "Bar", dependencies: ["Foo"], path: "./"),
+    ]
+)

--- a/Fixtures/Miscellaneous/LocalPackageAsURL/Bar/main.swift
+++ b/Fixtures/Miscellaneous/LocalPackageAsURL/Bar/main.swift
@@ -1,0 +1,4 @@
+import Foo
+
+foo()
+print("here")

--- a/Fixtures/Miscellaneous/LocalPackageAsURL/Foo/Foo.swift
+++ b/Fixtures/Miscellaneous/LocalPackageAsURL/Foo/Foo.swift
@@ -1,0 +1,3 @@
+public func foo() {
+	{}()
+}

--- a/Fixtures/Miscellaneous/LocalPackageAsURL/Foo/Package.swift
+++ b/Fixtures/Miscellaneous/LocalPackageAsURL/Foo/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "Foo",
+    products: [
+        .library(name: "Foo", targets: ["Foo"]),
+    ],
+    targets: [
+        .target(name: "Foo", path: "./"),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -137,7 +137,7 @@ let package = Package(
         .target(
             /** Package model conventions and loading support */
             name: "PackageLoading",
-            dependencies: ["SwiftToolsSupport-auto", "Basics", "PackageModel"]),
+            dependencies: ["SwiftToolsSupport-auto", "Basics", "PackageModel", "SourceControl"]),
 
         // MARK: Package Dependency Resolution
 

--- a/Sources/PackageLoading/PackageDescription4Loader.swift
+++ b/Sources/PackageLoading/PackageDescription4Loader.swift
@@ -373,7 +373,9 @@ extension PackageDependencyDescription {
             
             if let validPath = try? AbsolutePath(validating: location), fileSystem.exists(validPath) {
                 let gitRepoProvider = GitRepositoryProvider()
-                try gitRepoProvider.isInitializedDirectory(location: location)
+                guard gitRepoProvider.isValidDirectory(location) else {
+                    throw StringError("Cannot clone from local directory \(location)\nPlease git init or use \"path:\" for \(location)")
+                }
             }
             
             // in the future this will check with the registries for the identity of the URL

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -33,6 +33,7 @@ import class Foundation.Bundle
 /// the name were a relative path.
 public func fixture(
     name: String,
+    createGitRepo: Bool = true,
     file: StaticString = #file,
     line: UInt = #line,
     body: (AbsolutePath) throws -> Void
@@ -76,7 +77,9 @@ public func fixture(
                     guard localFileSystem.isDirectory(srcDir) else { continue }
                     let dstDir = tmpDirPath.appending(component: fileName)
                     try systemQuietly("cp", "-R", "-H", srcDir.pathString, dstDir.pathString)
-                    initGitRepo(dstDir, tag: "1.2.3", addFile: false)
+                    if createGitRepo {
+                        initGitRepo(dstDir, tag: "1.2.3", addFile: false)
+                    }
                 }
 
                 // Invoke the block, passing it the path of the copied fixture.

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -88,16 +88,15 @@ public struct GitRepositoryProvider: RepositoryProvider {
                          failureMessage: "Failed to clone repository \(repository.url)")
     }
     
-    public func isInitializedDirectory(location: String) throws {
+    public func isValidDirectory(_ directory: String) -> Bool {
         // Provides better feedback when mistakingly using url: for a dependency that
         // is a local package. Still allows for using url with a local package that has
         // also been initialized by git
         do {
-            try self.callGit("-C", location, "rev-parse", "--git-dir", repository: RepositorySpecifier(url: location))
-        } catch let error as GitCloneError {
-            throw GitCloneError(repository: RepositorySpecifier(url: location),
-                                message: "Cannot clone from local directory \(location)\nPlease git init or use \"path:\" for \(location)",
-                                result: error.result)
+            try self.callGit("-C", directory, "rev-parse", "--git-dir", repository: RepositorySpecifier(url: directory))
+            return true
+        } catch {
+            return false
         }
     }
     

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -421,7 +421,23 @@ class MiscellaneousTestCase: XCTestCase {
             XCTAssert(output.contains("does not exist"), "Error from git was not propogated to process output: \(output)")
         }
     }
+    
+    func testLocalPackageUsedAsURL() throws {
+        fixture(name: "Miscellaneous/LocalPackageAsURL", createGitRepo: false) { prefix in
+            // This fixture has a setup that is trying to use a local package
+            // as a url that hasn't been initialized as a repo
 
+            // Launch swift-build.
+            let app = prefix.appending(component: "Bar")
+
+            let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: app)
+
+            XCTAssert(result.exitStatus != .terminated(code: 0))
+            let output = try result.utf8stderrOutput()
+            XCTAssert(output.contains("Cannot clone from local directory"), "Didn't find expected output: \(output)")
+        }
+    }
+    
     func testUnicode() {
         #if !os(Linux) && !os(Android) // TODO: - Linux has trouble with this and needs investigation.
         fixture(name: "Miscellaneous/Unicode") { prefix in


### PR DESCRIPTION
### Motivation:

Improve error message

rdar://69272273