### PR TITLE
refactor PackageDependencyDescription towards identity changes

### DIFF
--- a/Sources/Commands/Describe.swift
+++ b/Sources/Commands/Describe.swift
@@ -105,8 +105,8 @@ fileprivate struct DescribedPackage: Encodable {
         let requirement: PackageDependencyDescription.Requirement?
 
         init(from dependency: PackageDependencyDescription) {
-            self.name = dependency.explicitName
-            self.url = dependency.url
+            self.name = dependency.explicitNameForTargetDependencyResolutionOnly
+            self.url = dependency.location
             self.requirement = dependency.requirement
         }
     }

--- a/Sources/PackageGraph/PackageGraph.swift
+++ b/Sources/PackageGraph/PackageGraph.swift
@@ -210,7 +210,7 @@ extension PackageGraphError: CustomStringConvertible {
 
             // If the package dependency name is the same as the package name, or if the product name and package name
             // don't correspond, we need to rewrite the target dependency to explicit specify the package name.
-            if packageDependency.name == packageName || productName != packageName {
+            if packageDependency.nameForTargetDependencyResolutionOnly == packageName || productName != packageName {
                 solutionSteps.append("""
                     reference the package in the target dependency with '.product(name: "\(productName)", package: \
                     "\(packageName)")'
@@ -220,7 +220,7 @@ extension PackageGraphError: CustomStringConvertible {
             // If the name of the product and the package are the same, or if the package dependency implicit name
             // deduced from the URL is not correct, we need to rewrite the package dependency declaration to specify the
             // package name.
-            if productName == packageName || packageDependency.name != packageName {
+            if productName == packageName || packageDependency.nameForTargetDependencyResolutionOnly != packageName {
                 let dependencySwiftRepresentation = packageDependency.swiftRepresentation(overridingName: packageName)
                 solutionSteps.append("""
                     provide the name of the package dependency with '\(dependencySwiftRepresentation)'
@@ -240,14 +240,14 @@ fileprivate extension PackageDependencyDescription {
     func swiftRepresentation(overridingName: String? = nil) -> String {
         var parameters: [String] = []
 
-        if let name = overridingName ?? explicitName {
+        if let name = overridingName ?? self.explicitNameForTargetDependencyResolutionOnly {
             parameters.append("name: \"\(name)\"")
         }
 
         if requirement == .localPackage {
-            parameters.append("path: \"\(url)\"")
+            parameters.append("path: \"\(self.location)\"")
         } else {
-            parameters.append("url: \"\(url)\"")
+            parameters.append("url: \"\(self.location)\"")
 
             switch requirement {
             case .branch(let branch):

--- a/Sources/PackageGraph/PackageModel+Extensions.swift
+++ b/Sources/PackageGraph/PackageModel+Extensions.swift
@@ -14,7 +14,7 @@ import SourceControl
 extension PackageDependencyDescription {
     /// Create the package reference object for the dependency.
     public func createPackageRef(mirrors: DependencyMirrors) -> PackageReference {
-        let effectiveURL = mirrors.effectiveURL(forURL: url)
+        let effectiveURL = mirrors.effectiveURL(forURL: self.location)
 
         // FIXME: The identity of a package dependency is currently based on
         //        on a name computed from the package's effective URL.  This

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -451,7 +451,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         diagnostics: DiagnosticsEngine?
     ) throws {
         let dependenciesByIdentity = Dictionary(grouping: manifest.dependencies, by: { dependency in
-            PackageIdentity(url: dependency.url)
+            PackageIdentity(url: dependency.location)
         })
 
         let duplicateDependencyIdentities = dependenciesByIdentity
@@ -473,7 +473,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             let duplicateDependencyNames = manifest.dependencies
                 .lazy
                 .filter({ !duplicateDependencies.contains($0) })
-                .map({ $0.name })
+                .map({ $0.nameForTargetDependencyResolutionOnly })
                 .spm_findDuplicates()
 
             for name in duplicateDependencyNames {
@@ -522,7 +522,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                         try diagnostics.emit(.unknownTargetPackageDependency(
                             packageName: packageName ?? "unknown package name",
                             targetName: target.name,
-                            validPackages: manifest.dependencies.map { $0.name }
+                            validPackages: manifest.dependencies.map { $0.nameForTargetDependencyResolutionOnly }
                         ))
                     }
                 case .byName(let name, _):
@@ -534,7 +534,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                         try diagnostics.emit(.unknownTargetDependency(
                             dependency: name,
                             targetName: target.name,
-                            validDependencies: manifest.dependencies.map { $0.name }
+                            validDependencies: manifest.dependencies.map { $0.nameForTargetDependencyResolutionOnly }
                         ))
                     }
                 }

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -184,12 +184,12 @@ public final class Manifest: ObjectIdentifierProtocol {
         for target in targetsRequired(for: products) {
             for targetDependency in target.dependencies {
                 if let dependency = packageDependency(referencedBy: targetDependency) {
-                    requiredDependencyURLs.insert(dependency.url)
+                    requiredDependencyURLs.insert(dependency.location)
                 }
             }
         }
         
-        return dependencies.filter { requiredDependencyURLs.contains($0.url) }
+        return dependencies.filter { requiredDependencyURLs.contains($0.location) }
         #endif
     }
 
@@ -211,7 +211,7 @@ public final class Manifest: ObjectIdentifierProtocol {
         })
 
         let requiredTargetNames = Set(productTargetNames).union(dependentTargetNames)
-        let requiredTargets = requiredTargetNames.compactMap({ targetsByName[$0] })
+        let requiredTargets = requiredTargetNames.compactMap{ targetsByName[$0] }
         return requiredTargets
     }
 
@@ -224,7 +224,7 @@ public final class Manifest: ObjectIdentifierProtocol {
     ) -> [PackageDependencyDescription] {
 
         var registry: (known: [String: ProductFilter], unknown: Set<String>) = ([:], [])
-        let availablePackages = Set(dependencies.lazy.map({ $0.name }))
+        let availablePackages = Set(dependencies.lazy.map{ $0.nameForTargetDependencyResolutionOnly })
 
         for target in targets {
             for targetDependency in target.dependencies {
@@ -243,7 +243,7 @@ public final class Manifest: ObjectIdentifierProtocol {
         }
 
         return dependencies.compactMap { dependency in
-            if let filter = associations[dependency.name] {
+            if let filter = associations[dependency.nameForTargetDependencyResolutionOnly] {
                 return dependency.filtered(by: filter)
             } else if keepUnused {
                 // Register that while the dependency was kept, no products are needed.
@@ -271,7 +271,7 @@ public final class Manifest: ObjectIdentifierProtocol {
             return nil
         }
 
-        return dependencies.first(where: { $0.name == packageName })
+        return dependencies.first(where: { $0.nameForTargetDependencyResolutionOnly == packageName })
     }
 
     /// Registers a required product with a particular dependency if possible, or registers it as unknown.

--- a/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
@@ -30,19 +30,14 @@ public struct PackageDependencyDescription: Equatable, Codable, Hashable {
         }
     }
 
-    /// The name of the package dependency explicitly defined in the manifest, if any.
-    public let explicitName: String?
+    /// An explicit name set by the user, to be used  *only*  for target dependencies resolution
+    public let explicitNameForTargetDependencyResolutionOnly: String?
 
-    /// The name of the packagedependency,
-    /// either explicitly defined in the manifest,
-    /// or derived from the URL.
-    ///
-    /// - SeeAlso: `explicitName`
-    /// - SeeAlso: `url`
-    public let name: String
+    /// A computed name to be used *only* for target dependencies resolution
+    public let nameForTargetDependencyResolutionOnly: String
 
-    /// The url of the package dependency.
-    public let url: String
+    /// The location of the package dependency.
+    public let location: String
 
     /// The dependency requirement.
     public let requirement: Requirement
@@ -53,30 +48,23 @@ public struct PackageDependencyDescription: Equatable, Codable, Hashable {
     /// Create a package dependency.
     public init(
         name: String? = nil,
-        url: String,
+        location: String,
         requirement: Requirement,
         productFilter: ProductFilter = .everything
     ) {
-        // FIXME: SwiftPM can't handle file URLs with file:// scheme so we need to
-        // strip that. We need to design a URL data structure for SwiftPM.
-        let filePrefix = "file://"
-        let normalizedURL: String
-        if url.hasPrefix(filePrefix) {
-            normalizedURL = AbsolutePath(String(url.dropFirst(filePrefix.count))).pathString
-        } else {
-            normalizedURL = url
-        }
-
-        self.explicitName = name
-        self.name = name ?? LegacyPackageIdentity.computeDefaultName(fromURL: normalizedURL)
-        self.url = normalizedURL
+        self.explicitNameForTargetDependencyResolutionOnly = name
+        self.nameForTargetDependencyResolutionOnly = name ?? LegacyPackageIdentity.computeDefaultName(fromURL: location)
+        self.location = location
         self.requirement = requirement
         self.productFilter = productFilter
     }
 
     /// Returns a new package dependency with the specified products.
     public func filtered(by productFilter: ProductFilter) -> PackageDependencyDescription {
-        PackageDependencyDescription(name: explicitName, url: url, requirement: requirement, productFilter: productFilter)
+        PackageDependencyDescription(name: self.explicitNameForTargetDependencyResolutionOnly,
+                                     location: self.location,
+                                     requirement: self.requirement,
+                                     productFilter: productFilter)
     }
 }
 

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -117,11 +117,11 @@ fileprivate extension SourceCodeFragment {
     /// Instantiates a SourceCodeFragment to represent a single package dependency.
     init(from dependency: PackageDependencyDescription) {
         var params: [SourceCodeFragment] = []
-        if let explicitName = dependency.explicitName {
+        if let explicitName = dependency.explicitNameForTargetDependencyResolutionOnly {
             params.append(SourceCodeFragment(key: "name", string: explicitName))
         }
         if dependency.requirement != .localPackage {
-            params.append(SourceCodeFragment(key: "url", string: dependency.url))
+            params.append(SourceCodeFragment(key: "url", string: dependency.location))
         }
         switch dependency.requirement {
         case .exact(let version):
@@ -133,7 +133,7 @@ fileprivate extension SourceCodeFragment {
         case .branch(let branch):
             params.append(SourceCodeFragment(enum: "branch", string: branch))
         case .localPackage:
-            params.append(SourceCodeFragment(key: "path", string: dependency.url))
+            params.append(SourceCodeFragment(key: "path", string: dependency.location))
         }
         self.init(enum: "package", subnodes: params)
     }

--- a/Sources/SPMTestSupport/MockDependency.swift
+++ b/Sources/SPMTestSupport/MockDependency.swift
@@ -36,7 +36,7 @@ public struct MockDependency {
     public func convert(baseURL: AbsolutePath) -> PackageDependencyDescription {
         return PackageDependencyDescription(
             name: self.name,
-            url: baseURL.appending(RelativePath(self.path)).pathString,
+            location: baseURL.appending(RelativePath(self.path)).pathString,
             requirement: self.requirement,
             productFilter: self.products
         )

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -275,7 +275,7 @@ final class BuildPlanTests: XCTestCase {
                     path: "/Pkg",
                     packageLocation: "/Pkg",
                     dependencies: [
-                        PackageDependencyDescription(url: "/ExtPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/ExtPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe", dependencies: [
@@ -379,7 +379,7 @@ final class BuildPlanTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/A",
                     dependencies: [
-                        PackageDependencyDescription(url: "/B", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/B", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "ATarget", dependencies: ["BLibrary"]),
@@ -486,7 +486,7 @@ final class BuildPlanTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Pkg",
                     dependencies: [
-                        PackageDependencyDescription(url: "/ExtPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/ExtPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
@@ -598,7 +598,7 @@ final class BuildPlanTests: XCTestCase {
                     path: "/Pkg",
                     packageLocation: "/Pkg",
                     dependencies: [
-                        PackageDependencyDescription(url: "/ExtPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/ExtPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe", dependencies: [
@@ -855,7 +855,7 @@ final class BuildPlanTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Pkg",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Dep", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/Dep", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["swiftlib"]),
@@ -966,7 +966,7 @@ final class BuildPlanTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Pkg",
                     dependencies: [
-                        PackageDependencyDescription(url: "Clibgit", requirement: .upToNextMajor(from: "1.0.0"))
+                        PackageDependencyDescription(location: "Clibgit", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "exe", dependencies: []),
@@ -1068,7 +1068,7 @@ final class BuildPlanTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Foo",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar-Baz"]),
@@ -1278,8 +1278,8 @@ final class BuildPlanTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/A",
                     dependencies: [
-                        PackageDependencyDescription(url: "/B", requirement: .upToNextMajor(from: "1.0.0")),
-                        PackageDependencyDescription(url: "/C", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/B", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/C", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "aexec", type: .executable, targets: ["ATarget"])
@@ -1369,8 +1369,8 @@ final class BuildPlanTests: XCTestCase {
                     path: "/A",
                     packageLocation: "/A",
                     dependencies: [
-                        PackageDependencyDescription(url: "/B", requirement: .upToNextMajor(from: "1.0.0")),
-                        PackageDependencyDescription(url: "/C", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/B", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/C", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "aexec", type: .executable, targets: ["ATarget"]),
@@ -1780,7 +1780,7 @@ final class BuildPlanTests: XCTestCase {
                     ],
                     v: .v5,
                     dependencies: [
-                        PackageDependencyDescription(url: "/B", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/B", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "ATarget", dependencies: ["BLibrary"]),
@@ -1843,7 +1843,7 @@ final class BuildPlanTests: XCTestCase {
                     ],
                     v: .v5,
                     dependencies: [
-                        PackageDependencyDescription(url: "/B", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/B", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "ATarget", dependencies: ["BLibrary"]),
@@ -1905,7 +1905,7 @@ final class BuildPlanTests: XCTestCase {
             packageLocation: "/A",
             v: .v5,
             dependencies: [
-                PackageDependencyDescription(url: "/B", requirement: .upToNextMajor(from: "1.0.0")),
+                PackageDependencyDescription(location: "/B", requirement: .upToNextMajor(from: "1.0.0")),
             ],
             targets: [
                 try TargetDescription(
@@ -2083,7 +2083,7 @@ final class BuildPlanTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/PkgB",
                     dependencies: [
-                        PackageDependencyDescription(url: "/PkgA", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/PkgA", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "PkgB", dependencies: ["swiftlib"]),
@@ -2178,7 +2178,7 @@ final class BuildPlanTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/PkgA",
                     dependencies: [
-                        PackageDependencyDescription(url: "/PkgB", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/PkgB", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Bar", dependencies: ["Foo"]),
@@ -2246,7 +2246,7 @@ final class BuildPlanTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/PkgA",
                     dependencies: [
-                        PackageDependencyDescription(url: "/PkgB", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/PkgB", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Bar", dependencies: ["Foo"]),

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -360,8 +360,8 @@ final class PackageToolTests: XCTestCase {
             packageLocation: "/PackageA",
             v: .v5_3,
             dependencies: [
-                .init(name: "PackageB", url: "/PackageB", requirement: .localPackage),
-                .init(name: "PackageC", url: "/PackageC", requirement: .localPackage),
+                .init(name: "PackageB", location: "/PackageB", requirement: .localPackage),
+                .init(name: "PackageC", location: "/PackageC", requirement: .localPackage),
             ],
             products: [
                 .init(name: "exe", type: .executable, targets: ["TargetA"])
@@ -378,8 +378,8 @@ final class PackageToolTests: XCTestCase {
             packageLocation: "/PackageB",
             v: .v5_3,
             dependencies: [
-                .init(name: "PackageC", url: "/PackageC", requirement: .localPackage),
-                .init(name: "PackageD", url: "/PackageD", requirement: .localPackage),
+                .init(name: "PackageC", location: "/PackageC", requirement: .localPackage),
+                .init(name: "PackageD", location: "/PackageD", requirement: .localPackage),
             ],
             products: [
                 .init(name: "PackageB", type: .library(.dynamic), targets: ["TargetB"])
@@ -396,7 +396,7 @@ final class PackageToolTests: XCTestCase {
             packageLocation: "/PackageC",
             v: .v5_3,
             dependencies: [
-                .init(name: "PackageD", url: "/PackageD", requirement: .localPackage),
+                .init(name: "PackageD", location: "/PackageD", requirement: .localPackage),
             ],
             products: [
                 .init(name: "PackageC", type: .library(.dynamic), targets: ["TargetC"])

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -38,7 +38,7 @@ class PackageGraphPerfTests: XCTestCasePerf {
             } else {
                 let depName = "Foo\(pkg + 1)"
                 let depUrl = "/\(depName)"
-                dependencies = [PackageDependencyDescription(name: depName, url: depUrl, requirement: .upToNextMajor(from: "1.0.0"))]
+                dependencies = [PackageDependencyDescription(name: depName, location: depUrl, requirement: .upToNextMajor(from: "1.0.0"))]
                 targets = [try TargetDescription(name: name, dependencies: [.byName(name: depName, condition: nil)], path: ".")]
             }
             // Create manifest.

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -48,7 +48,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Bar",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
+                        PackageDependencyDescription(location: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -61,7 +61,7 @@ class PackageGraphTests: XCTestCase {
                     path: "/Baz",
                     packageLocation: "/Baz",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
+                        PackageDependencyDescription(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Baz", dependencies: ["Bar"]),
@@ -97,7 +97,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Foo",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
+                        PackageDependencyDescription(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar", "CBar"]),
@@ -143,7 +143,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Foo",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
+                        PackageDependencyDescription(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
@@ -154,7 +154,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .local,
                     packageLocation: "/Bar",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Baz", requirement: .upToNextMajor(from: "1.0.0"))
+                        PackageDependencyDescription(location: "/Baz", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -168,7 +168,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .local,
                     packageLocation: "/Baz",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
+                        PackageDependencyDescription(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     products: [
                         ProductDescription(name: "Baz", type: .library(.automatic), targets: ["Baz"])
@@ -198,7 +198,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Foo",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
+                        PackageDependencyDescription(location: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Foo"),
@@ -228,7 +228,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Bar",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
+                        PackageDependencyDescription(location: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Bar", dependencies: ["Foo"]),
@@ -272,7 +272,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Foo",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
+                        PackageDependencyDescription(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Bar"),
@@ -341,9 +341,9 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/First",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Second", requirement: .upToNextMajor(from: "1.0.0")),
-                        PackageDependencyDescription(url: "/Third", requirement: .upToNextMajor(from: "1.0.0")),
-                        PackageDependencyDescription(url: "/Fourth", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/Second", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/Third", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/Fourth", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "First", dependencies: ["Second", "Third", "Fourth"]),
@@ -406,9 +406,9 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/First",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Second", requirement: .upToNextMajor(from: "1.0.0")),
-                        PackageDependencyDescription(url: "/Third", requirement: .upToNextMajor(from: "1.0.0")),
-                        PackageDependencyDescription(url: "/Fourth", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/Second", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/Third", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/Fourth", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Second", "Third", "Fourth"]),
@@ -450,7 +450,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .local,
                     packageLocation: "/Third",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Fourth", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/Fourth", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Third", type: .library(.automatic), targets: ["Third"])
@@ -464,7 +464,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .local,
                     packageLocation: "/Second",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Third", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/Third", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Second", type: .library(.automatic), targets: ["Second"])
@@ -478,7 +478,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/First",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Second", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/Second", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "First", type: .library(.automatic), targets: ["First"])
@@ -509,7 +509,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Foo",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
@@ -628,9 +628,9 @@ class PackageGraphTests: XCTestCase {
                     packageLocation: "/Foo",
                     v: .v5_2,
                     dependencies: [
-                        PackageDependencyDescription(name: "Bar", url: "/Bar", requirement: .branch("master")),
-                        PackageDependencyDescription(url: "/BizPath", requirement: .exact("1.2.3")),
-                        PackageDependencyDescription(url: "/FizPath", requirement: .upToNextMajor(from: "1.1.2")),
+                        PackageDependencyDescription(name: "Bar", location: "/Bar", requirement: .branch("master")),
+                        PackageDependencyDescription(location: "/BizPath", requirement: .exact("1.2.3")),
+                        PackageDependencyDescription(location: "/FizPath", requirement: .upToNextMajor(from: "1.1.2")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["BarLib", "Biz", "FizLib"]),
@@ -706,7 +706,7 @@ class PackageGraphTests: XCTestCase {
                     packageLocation: "/Foo",
                     v: .v5_2,
                     dependencies: [
-                        PackageDependencyDescription(name: "UnBar", url: "/Bar", requirement: .branch("master")),
+                        PackageDependencyDescription(name: "UnBar", location: "/Bar", requirement: .branch("master")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: [.product(name: "BarProduct", package: "UnBar")]),
@@ -746,9 +746,9 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Foo",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
-                        PackageDependencyDescription(url: "/Baz", requirement: .upToNextMajor(from: "1.0.0")),
-                        PackageDependencyDescription(url: "/Biz", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/Biz", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["BarLibrary"]),
@@ -812,7 +812,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Bar",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Bar"),
@@ -847,7 +847,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Start",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Dep1", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/Dep1", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["BazLibrary"]),
@@ -859,7 +859,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .local,
                     packageLocation: "/Dep1",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Dep2", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/Dep2", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "BazLibrary", type: .library(.automatic), targets: ["Baz"])
@@ -904,8 +904,8 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Foo",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
-                        PackageDependencyDescription(url: "/Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/Baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
@@ -958,7 +958,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Foo",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
@@ -1022,7 +1022,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Foo",
                     dependencies: [
-                        PackageDependencyDescription(name: "Baar", url: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(name: "Baar", location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Baar"]),
@@ -1070,7 +1070,7 @@ class PackageGraphTests: XCTestCase {
                     path: "/Foo",
                     packageLocation: "/Foo",
                     dependencies: [
-                        PackageDependencyDescription(url: "/Biz", requirement: .localPackage),
+                        PackageDependencyDescription(location: "/Biz", requirement: .localPackage),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: [
@@ -1157,7 +1157,7 @@ class PackageGraphTests: XCTestCase {
                     packageLocation: "/Root",
                     v: .v5_2,
                     dependencies: [
-                        PackageDependencyDescription(name: "Immediate", url: "/Immediate", requirement: .upToNextMajor(from: "1.0.0")),
+                        PackageDependencyDescription(name: "Immediate", location: "/Immediate", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Root", dependencies: [
@@ -1174,12 +1174,12 @@ class PackageGraphTests: XCTestCase {
                     dependencies: [
                         PackageDependencyDescription(
                             name: "Transitive",
-                            url: "/Transitive",
+                            location: "/Transitive",
                             requirement: .upToNextMajor(from: "1.0.0")
                         ),
                         PackageDependencyDescription(
                             name: "Nonexistent",
-                            url: "/Nonexistent",
+                            location: "/Nonexistent",
                             requirement: .upToNextMajor(from: "1.0.0")
                         )
                     ],
@@ -1206,7 +1206,7 @@ class PackageGraphTests: XCTestCase {
                     dependencies: [
                         PackageDependencyDescription(
                             name: "Nonexistent",
-                            url: "/Nonexistent",
+                            location: "/Nonexistent",
                             requirement: .upToNextMajor(from: "1.0.0")
                         )
                     ],

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -363,9 +363,9 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         #endif
 
         let dependencies = [
-            PackageDependencyDescription(name: "Bar1", url: "/Bar1", requirement: .upToNextMajor(from: "1.0.0")),
-            PackageDependencyDescription(name: "Bar2", url: "/Bar2", requirement: .upToNextMajor(from: "1.0.0")),
-            PackageDependencyDescription(name: "Bar3", url: "/Bar3", requirement: .upToNextMajor(from: "1.0.0")),
+            PackageDependencyDescription(name: "Bar1", location: "/Bar1", requirement: .upToNextMajor(from: "1.0.0")),
+            PackageDependencyDescription(name: "Bar2", location: "/Bar2", requirement: .upToNextMajor(from: "1.0.0")),
+            PackageDependencyDescription(name: "Bar3", location: "/Bar3", requirement: .upToNextMajor(from: "1.0.0")),
         ]
 
         let products = [
@@ -389,7 +389,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             PackageContainerConstraint(
                 package: $0.createPackageRef(mirrors: mirrors),
                 requirement: $0.requirement.toConstraintRequirement(),
-                products: v5ProductMapping[$0.name]!
+                products: v5ProductMapping[$0.nameForTargetDependencyResolutionOnly]!
             )
         }
         let v5_2ProductMapping: [String: ProductFilter] = [
@@ -401,7 +401,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             PackageContainerConstraint(
                 package: $0.createPackageRef(mirrors: mirrors),
                 requirement: $0.requirement.toConstraintRequirement(),
-                products: v5_2ProductMapping[$0.name]!
+                products: v5_2ProductMapping[$0.nameForTargetDependencyResolutionOnly]!
             )
         }
 
@@ -595,7 +595,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
                 v: .v5_2,
                 dependencies: [
                     PackageDependencyDescription(
-                        url: "Somewhere/Dependency",
+                        location: "Somewhere/Dependency",
                         requirement: .exact(version),
                         productFilter: .specific([])
                     )

--- a/Tests/PackageLoadingTests/PD4LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4LoadingTests.swift
@@ -141,13 +141,13 @@ class PackageDescription4LoadingTests: PackageDescriptionLoadingTests {
             )
             """
        loadManifest(stream.bytes) { manifest in
-            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.url, $0) })
-            XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(url: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
-            XCTAssertEqual(deps["/foo2"], PackageDependencyDescription(url: "/foo2", requirement: .upToNextMajor(from: "1.0.0")))
-            XCTAssertEqual(deps["/foo3"], PackageDependencyDescription(url: "/foo3", requirement: .upToNextMinor(from: "1.0.0")))
-            XCTAssertEqual(deps["/foo4"], PackageDependencyDescription(url: "/foo4", requirement: .exact("1.0.0")))
-            XCTAssertEqual(deps["/foo5"], PackageDependencyDescription(url: "/foo5", requirement: .branch("master")))
-            XCTAssertEqual(deps["/foo6"], PackageDependencyDescription(url: "/foo6", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
+            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.location, $0) })
+            XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(location: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
+            XCTAssertEqual(deps["/foo2"], PackageDependencyDescription(location: "/foo2", requirement: .upToNextMajor(from: "1.0.0")))
+            XCTAssertEqual(deps["/foo3"], PackageDependencyDescription(location: "/foo3", requirement: .upToNextMinor(from: "1.0.0")))
+            XCTAssertEqual(deps["/foo4"], PackageDependencyDescription(location: "/foo4", requirement: .exact("1.0.0")))
+            XCTAssertEqual(deps["/foo5"], PackageDependencyDescription(location: "/foo5", requirement: .branch("master")))
+            XCTAssertEqual(deps["/foo6"], PackageDependencyDescription(location: "/foo6", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
         }
     }
 

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -62,8 +62,8 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             XCTAssertEqual(bar.dependencies, ["foo"])
 
             // Check dependencies.
-            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.url, $0) })
-            XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(url: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
+            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.location, $0) })
+            XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(location: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
 
             // Check products.
             let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })
@@ -248,38 +248,43 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                    .package(path: "~foo11"),
                    .package(path: "~/path/to/~/foo12"),
                    .package(path: "~"),
+                   .package(path: "file:///path/to/foo13"),
+
                ]
             )
             """
        loadManifest(stream.bytes) { manifest in
-            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.url, $0) })
-            XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(url: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
-            XCTAssertEqual(deps["/foo2"], PackageDependencyDescription(url: "/foo2", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
+            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.location, $0) })
+            XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(location: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
+            XCTAssertEqual(deps["/foo2"], PackageDependencyDescription(location: "/foo2", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
 
-            XCTAssertEqual(deps["/foo3"]?.url, "/foo3")
+            XCTAssertEqual(deps["/foo3"]?.location, "/foo3")
             XCTAssertEqual(deps["/foo3"]?.requirement, .localPackage)
 
-            XCTAssertEqual(deps["/path/to/foo4"]?.url, "/path/to/foo4")
+            XCTAssertEqual(deps["/path/to/foo4"]?.location, "/path/to/foo4")
             XCTAssertEqual(deps["/path/to/foo4"]?.requirement, .localPackage)
 
-            XCTAssertEqual(deps["/foo5"], PackageDependencyDescription(url: "/foo5", requirement: .exact("1.2.3")))
-            XCTAssertEqual(deps["/foo6"], PackageDependencyDescription(url: "/foo6", requirement: .range("1.2.3"..<"2.0.0")))
-            XCTAssertEqual(deps["/foo7"], PackageDependencyDescription(url: "/foo7", requirement: .branch("master")))
-            XCTAssertEqual(deps["/foo8"], PackageDependencyDescription(url: "/foo8", requirement: .upToNextMinor(from: "1.3.4")))
-            XCTAssertEqual(deps["/foo9"], PackageDependencyDescription(url: "/foo9", requirement: .upToNextMajor(from: "1.3.4")))
+            XCTAssertEqual(deps["/foo5"], PackageDependencyDescription(location: "/foo5", requirement: .exact("1.2.3")))
+            XCTAssertEqual(deps["/foo6"], PackageDependencyDescription(location: "/foo6", requirement: .range("1.2.3"..<"2.0.0")))
+            XCTAssertEqual(deps["/foo7"], PackageDependencyDescription(location: "/foo7", requirement: .branch("master")))
+            XCTAssertEqual(deps["/foo8"], PackageDependencyDescription(location: "/foo8", requirement: .upToNextMinor(from: "1.3.4")))
+            XCTAssertEqual(deps["/foo9"], PackageDependencyDescription(location: "/foo9", requirement: .upToNextMajor(from: "1.3.4")))
 
             let homeDir = "/home/user"
-            XCTAssertEqual(deps["\(homeDir)/path/to/foo10"]?.url, "\(homeDir)/path/to/foo10")
+            XCTAssertEqual(deps["\(homeDir)/path/to/foo10"]?.location, "\(homeDir)/path/to/foo10")
             XCTAssertEqual(deps["\(homeDir)/path/to/foo10"]?.requirement, .localPackage)
 
-            XCTAssertEqual(deps["/foo/~foo11"]?.url, "/foo/~foo11")
+            XCTAssertEqual(deps["/foo/~foo11"]?.location, "/foo/~foo11")
             XCTAssertEqual(deps["/foo/~foo11"]?.requirement, .localPackage)
 
-            XCTAssertEqual(deps["\(homeDir)/path/to/~/foo12"]?.url, "\(homeDir)/path/to/~/foo12")
+            XCTAssertEqual(deps["\(homeDir)/path/to/~/foo12"]?.location, "\(homeDir)/path/to/~/foo12")
             XCTAssertEqual(deps["\(homeDir)/path/to/~/foo12"]?.requirement, .localPackage)
 
-            XCTAssertEqual(deps["/foo/~"]?.url, "/foo/~")
+            XCTAssertEqual(deps["/foo/~"]?.location, "/foo/~")
             XCTAssertEqual(deps["/foo/~"]?.requirement, .localPackage)
+
+            XCTAssertEqual(deps["/path/to/foo13"]?.location, "/path/to/foo13")
+            XCTAssertEqual(deps["/path/to/foo13"]?.requirement, .localPackage)
         }
     }
 

--- a/Tests/PackageLoadingTests/PD5LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5LoadingTests.swift
@@ -62,8 +62,8 @@ class PackageDescription5LoadingTests: PackageDescriptionLoadingTests {
             XCTAssertEqual(bar.dependencies, ["foo"])
 
             // Check dependencies.
-            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.url, $0) })
-            XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(url: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
+            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.location, $0) })
+            XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(location: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
 
             // Check products.
             let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })

--- a/Tests/PackageLoadingTests/PD5_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5_2LoadingTests.swift
@@ -48,7 +48,7 @@ class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
         }
     }
 
-    func testPackageName() throws {
+    func testDepenencyNameForTargetDependencyResolution() throws {
         let stream = BufferedOutputByteStream()
         stream <<< """
             import PackageDescription
@@ -76,15 +76,15 @@ class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
 
         loadManifest(stream.bytes) { manifest in
             XCTAssertEqual(manifest.name, "Trivial")
-            XCTAssertEqual(manifest.dependencies[0].name, "Foo")
-            XCTAssertEqual(manifest.dependencies[1].name, "Foo2")
-            XCTAssertEqual(manifest.dependencies[2].name, "Foo3")
-            XCTAssertEqual(manifest.dependencies[3].name, "Foo4")
-            XCTAssertEqual(manifest.dependencies[4].name, "Foo5")
-            XCTAssertEqual(manifest.dependencies[5].name, "bar")
-            XCTAssertEqual(manifest.dependencies[6].name, "Bar2")
-            XCTAssertEqual(manifest.dependencies[7].name, "Baz")
-            XCTAssertEqual(manifest.dependencies[8].name, "swift")
+            XCTAssertEqual(manifest.dependencies[0].nameForTargetDependencyResolutionOnly, "Foo")
+            XCTAssertEqual(manifest.dependencies[1].nameForTargetDependencyResolutionOnly, "Foo2")
+            XCTAssertEqual(manifest.dependencies[2].nameForTargetDependencyResolutionOnly, "Foo3")
+            XCTAssertEqual(manifest.dependencies[3].nameForTargetDependencyResolutionOnly, "Foo4")
+            XCTAssertEqual(manifest.dependencies[4].nameForTargetDependencyResolutionOnly, "Foo5")
+            XCTAssertEqual(manifest.dependencies[5].nameForTargetDependencyResolutionOnly, "bar")
+            XCTAssertEqual(manifest.dependencies[6].nameForTargetDependencyResolutionOnly, "Bar2")
+            XCTAssertEqual(manifest.dependencies[7].nameForTargetDependencyResolutionOnly, "Baz")
+            XCTAssertEqual(manifest.dependencies[8].nameForTargetDependencyResolutionOnly, "swift")
         }
     }
 
@@ -193,7 +193,7 @@ class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
             """
 
         loadManifest(stream.bytes) { manifest in
-            let dependencies = Dictionary(uniqueKeysWithValues: manifest.dependencies.map({ ($0.name, $0) }))
+            let dependencies = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.nameForTargetDependencyResolutionOnly, $0) })
             let dependencyFoobar = dependencies["Foobar"]!
             let dependencyBarfoo = dependencies["Barfoo"]!
             let targetFoo = manifest.targetMap["foo"]!

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -2019,7 +2019,7 @@ class PackageBuilderTests: XCTestCase {
             name: "Foo",
             v: .v5,
             dependencies: [
-                PackageDependencyDescription(url: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                PackageDependencyDescription(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
             ],
             targets: [
                 try TargetDescription(
@@ -2053,7 +2053,7 @@ class PackageBuilderTests: XCTestCase {
             name: "Foo",
             v: .v5,
             dependencies: [
-                PackageDependencyDescription(url: "/Biz", requirement: .localPackage),
+                PackageDependencyDescription(location: "/Biz", requirement: .localPackage),
             ],
             targets: [
                 try TargetDescription(

--- a/Tests/PackageModelTests/ManifestTests.swift
+++ b/Tests/PackageModelTests/ManifestTests.swift
@@ -68,9 +68,9 @@ class ManifestTests: XCTestCase {
 
     func testRequiredDependencies() throws {
         let dependencies = [
-            PackageDependencyDescription(name: "Bar1", url: "/Bar1", requirement: .upToNextMajor(from: "1.0.0")),
-            PackageDependencyDescription(name: "Bar2", url: "/Bar2", requirement: .upToNextMajor(from: "1.0.0")),
-            PackageDependencyDescription(name: "Bar3", url: "/Bar3", requirement: .upToNextMajor(from: "1.0.0")),
+            PackageDependencyDescription(location: "/Bar1", requirement: .upToNextMajor(from: "1.0.0")),
+            PackageDependencyDescription(location: "/Bar2", requirement: .upToNextMajor(from: "1.0.0")),
+            PackageDependencyDescription(location: "/Bar3", requirement: .upToNextMajor(from: "1.0.0")),
         ]
 
         let products = [
@@ -95,10 +95,10 @@ class ManifestTests: XCTestCase {
                 targets: targets
             )
 
-            XCTAssertEqual(manifest.dependenciesRequired(for: .everything).map({ $0.name }).sorted(), [
-                "Bar1",
-                "Bar2",
-                "Bar3",
+            XCTAssertEqual(manifest.dependenciesRequired(for: .everything).map({ $0.location }).sorted(), [
+                "/Bar1",
+                "/Bar2",
+                "/Bar3",
             ])
         }
 
@@ -114,10 +114,10 @@ class ManifestTests: XCTestCase {
                 targets: targets
             )
 
-            XCTAssertEqual(manifest.dependenciesRequired(for: .specific(["Foo"])).map({ $0.name }).sorted(), [
-                "Bar1", // Foo → Foo1 → Bar1
-                "Bar2", // Foo → Foo1 → Foo2 → Bar2
-                "Bar3", // Foo → Foo1 → Bar1 → could be from any package due to pre‐5.2 tools version.
+            XCTAssertEqual(manifest.dependenciesRequired(for: .specific(["Foo"])).map({ $0.location }).sorted(), [
+                "/Bar1", // Foo → Foo1 → Bar1
+                "/Bar2", // Foo → Foo1 → Foo2 → Bar2
+                "/Bar3", // Foo → Foo1 → Bar1 → could be from any package due to pre‐5.2 tools version.
             ])
         }
 
@@ -133,10 +133,10 @@ class ManifestTests: XCTestCase {
                 targets: targets
             )
 
-            XCTAssertEqual(manifest.dependenciesRequired(for: .everything).map({ $0.name }).sorted(), [
-                "Bar1",
-                "Bar2",
-                "Bar3",
+            XCTAssertEqual(manifest.dependenciesRequired(for: .everything).map({ $0.location }).sorted(), [
+                "/Bar1",
+                "/Bar2",
+                "/Bar3",
             ])
         }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -337,14 +337,12 @@ final class WorkspaceTests: XCTestCase {
 
         let dependencies: [PackageDependencyDescription] = [
             .init(
-                name: nil,
-                url: workspace.packagesDir.appending(component: "Foo").pathString,
+                location: workspace.packagesDir.appending(component: "Foo").pathString,
                 requirement: .upToNextMajor(from: "1.0.0"),
                 productFilter: .specific(["Foo"])
             ),
             .init(
-                name: nil,
-                url: workspace.packagesDir.appending(component: "Bar").pathString + ".git",
+                location: workspace.packagesDir.appending(component: "Bar").pathString + ".git",
                 requirement: .upToNextMajor(from: "1.0.0"),
                 productFilter: .specific(["Bar"])
             ),
@@ -461,7 +459,8 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        workspace.checkPackageGraph(roots: ["foo-package", "bar-package"], dependencies: [PackageDependencyDescription(url: "/tmp/ws/pkgs/bar-package", requirement: .upToNextMajor(from: "1.0.0"), productFilter: .everything)]) { graph, diagnostics in
+        workspace.checkPackageGraph(roots: ["foo-package", "bar-package"],
+                                    dependencies: [PackageDependencyDescription(location: "/tmp/ws/pkgs/bar-package", requirement: .upToNextMajor(from: "1.0.0"), productFilter: .everything)]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "FooPackage", "BarPackage")
                 result.check(packages: "FooPackage", "BarPackage")
@@ -648,12 +647,12 @@ final class WorkspaceTests: XCTestCase {
 
         let dependencies: [PackageDependencyDescription] = [
             .init(
-                url: workspace.packagesDir.appending(component: "Bar").pathString,
+                location: workspace.packagesDir.appending(component: "Bar").pathString,
                 requirement: .upToNextMajor(from: "1.0.0"),
                 productFilter: .specific(["Bar"])
             ),
             .init(
-                url: "file://\(workspace.packagesDir.appending(component: "Foo").pathString)/",
+                location: workspace.packagesDir.appending(component: "Foo").pathString,
                 requirement: .upToNextMajor(from: "1.0.0"),
                 productFilter: .specific(["Foo"])
             ),
@@ -2656,7 +2655,7 @@ final class WorkspaceTests: XCTestCase {
             platforms: [],
             version: manifest.version,
             toolsVersion: manifest.toolsVersion,
-            dependencies: [PackageDependencyDescription(url: manifest.dependencies[0].url, requirement: .exact("1.5.0"))],
+            dependencies: [PackageDependencyDescription(location: manifest.dependencies[0].location, requirement: .exact("1.5.0"))],
             targets: manifest.targets
         )
 

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -60,7 +60,7 @@ class PIFBuilderTests: XCTestCase {
                         packageLocation: "/A",
                         v: .v5_2,
                         dependencies: [
-                            .init(name: "B", url: "/B", requirement: .branch("master")),
+                            .init(name: "B", location: "/B", requirement: .branch("master")),
                         ],
                         products: [
                             .init(name: "alib", type: .library(.static), targets: ["A2"]),
@@ -119,7 +119,7 @@ class PIFBuilderTests: XCTestCase {
                     defaultLocalization: "fr",
                     v: .v5_2,
                     dependencies: [
-                        .init(name: "Bar", url: "/Bar", requirement: .branch("master")),
+                        .init(name: "Bar", location: "/Bar", requirement: .branch("master")),
                     ],
                     targets: [
                         .init(name: "foo", dependencies: [.product(name: "BarLib", package: "Bar")]),
@@ -389,7 +389,7 @@ class PIFBuilderTests: XCTestCase {
                     v: .v5_2,
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
-                        .init(name: "Bar", url: "/Bar", requirement: .branch("master")),
+                        .init(name: "Bar", location: "/Bar", requirement: .branch("master")),
                     ],
                     targets: [
                         .init(name: "foo", dependencies: [
@@ -715,7 +715,7 @@ class PIFBuilderTests: XCTestCase {
                     v: .v5_2,
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
-                        .init(name: "Bar", url: "/Bar", requirement: .branch("master")),
+                        .init(name: "Bar", location: "/Bar", requirement: .branch("master")),
                     ],
                     targets: [
                         .init(name: "FooTests", dependencies: [
@@ -943,7 +943,7 @@ class PIFBuilderTests: XCTestCase {
                     v: .v5_2,
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
-                        .init(name: "Bar", url: "/Bar", requirement: .branch("master")),
+                        .init(name: "Bar", location: "/Bar", requirement: .branch("master")),
                     ],
                     products: [
                         .init(name: "FooLib1", type: .library(.static), targets: ["FooLib1"]),
@@ -1140,7 +1140,7 @@ class PIFBuilderTests: XCTestCase {
                     cxxLanguageStandard: "c++14",
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
-                        .init(name: "Bar", url: "/Bar", requirement: .branch("master")),
+                        .init(name: "Bar", location: "/Bar", requirement: .branch("master")),
                     ],
                     targets: [
                         .init(name: "FooLib1", dependencies: ["SystemLib", "FooLib2"]),

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -357,7 +357,7 @@ class GenerateXcodeprojTests: XCTestCase {
                         path: fooPackagePath.pathString,
                         packageLocation: fooPackagePath.pathString,
                         dependencies: [
-                            PackageDependencyDescription(name: "Bar", url: barPackagePath.pathString, requirement: .localPackage)
+                            PackageDependencyDescription(name: "Bar", location: barPackagePath.pathString, requirement: .localPackage)
                         ],
                         targets: [
                             TargetDescription(name: "Foo", dependencies: [

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -61,7 +61,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Bar",
                     dependencies: [
-                        PackageDependencyDescription(name: "Foo", url: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
+                        PackageDependencyDescription(name: "Foo", location: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Bar", dependencies: ["Foo"]),


### PR DESCRIPTION
motivation: improve code infrastrucuture towards fixing correctness issues with identity

changes:
* rename PackageDependencyDescription::url to PackageDependencyDescription::location to reflect its true meaning
* rename PackageDependencyDescription::name to PackageDependencyDescription::nameForTargetDependencyResolutionOnly to make sure its not used for wrong reasons
* move "file://" prefix handing from PackageDependencyDescription::init to PackageDependencyDescription::init(json) which where all the other location validation is done
* addjsut call-sites
* adjust and add tests
