### PR TITLE
improve correctness by using identity more broadly throughout the code

### DIFF
--- a/Examples/package-info/Sources/package-info/main.swift
+++ b/Examples/package-info/Sources/package-info/main.swift
@@ -31,9 +31,10 @@ let packagePath = localFileSystem.currentWorkingDirectory!
 // There are several levels of information available.
 // Each takes longer to load than the level above it, but provides more detail.
 let diagnostics = DiagnosticsEngine()
-let manifest = try tsc_await { ManifestLoader.loadManifest(at: packagePath, kind: .local, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], on: .global(), completion: $0) }
-let loadedPackage = try tsc_await { PackageBuilder.loadPackage(at: packagePath, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], diagnostics: diagnostics, on: .global(), completion: $0) }
-let graph = try Workspace.loadGraph(packagePath: packagePath, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], diagnostics: diagnostics)
+let identityResolver = DefaultIdentityResolver()
+let manifest = try tsc_await { ManifestLoader.loadManifest(at: packagePath, kind: .local, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], identityResolver: identityResolver, on: .global(), completion: $0) }
+let loadedPackage = try tsc_await { PackageBuilder.loadPackage(at: packagePath, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], identityResolver: identityResolver, diagnostics: diagnostics, on: .global(), completion: $0) }
+let graph = try Workspace.loadGraph(packagePath: packagePath, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], identityResolver: identityResolver, diagnostics: diagnostics)
 
 // EXAMPLES
 // ========

--- a/Fixtures/DependencyResolution/External/Mirror/App/Package.swift
+++ b/Fixtures/DependencyResolution/External/Mirror/App/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "App",
+    dependencies: [
+        .package(name: "Foo", url: "../Foo", .branch("main")),
+        .package(name: "Bar", url: "../Bar", .branch("main")),
+    ],
+    targets: [
+        .target(name: "App", dependencies: [
+            .product(name: "Foo", package: "Foo"),
+            .product(name: "Bar", package: "Bar"),
+        ], path: "./")
+    ]
+)

--- a/Fixtures/DependencyResolution/External/Mirror/App/main.swift
+++ b/Fixtures/DependencyResolution/External/Mirror/App/main.swift
@@ -1,0 +1,5 @@
+import Foo
+import Bar
+
+public func main() {
+}

--- a/Fixtures/DependencyResolution/External/Mirror/Bar/Bar.swift
+++ b/Fixtures/DependencyResolution/External/Mirror/Bar/Bar.swift
@@ -1,0 +1,2 @@
+public func hello() {
+}

--- a/Fixtures/DependencyResolution/External/Mirror/Bar/Package.swift
+++ b/Fixtures/DependencyResolution/External/Mirror/Bar/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "Bar",
+    products: [
+        .library(name: "Bar", targets: ["Bar"]),
+    ],
+    targets: [
+        .target(name: "Bar", path: "./"),
+    ]
+)

--- a/Fixtures/DependencyResolution/External/Mirror/BarMirror/Bar.swift
+++ b/Fixtures/DependencyResolution/External/Mirror/BarMirror/Bar.swift
@@ -1,0 +1,2 @@
+public func hello() {
+}

--- a/Fixtures/DependencyResolution/External/Mirror/BarMirror/Package.swift
+++ b/Fixtures/DependencyResolution/External/Mirror/BarMirror/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "Bar",
+    products: [
+        .library(name: "Bar", targets: ["Bar"]),
+    ],
+    targets: [
+        .target(name: "Bar", path: "./"),
+    ]
+)

--- a/Fixtures/DependencyResolution/External/Mirror/Foo/Foo.swift
+++ b/Fixtures/DependencyResolution/External/Mirror/Foo/Foo.swift
@@ -1,0 +1,2 @@
+public func hello() {
+}

--- a/Fixtures/DependencyResolution/External/Mirror/Foo/Package.swift
+++ b/Fixtures/DependencyResolution/External/Mirror/Foo/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "Foo",
+    products: [
+        .library(name: "Foo", targets: ["Foo"]),
+    ],
+    targets: [
+        .target(name: "Foo", path: "./"),
+    ]
+)

--- a/Sources/Commands/Describe.swift
+++ b/Sources/Commands/Describe.swift
@@ -100,14 +100,22 @@ fileprivate struct DescribedPackage: Encodable {
     
     /// Represents a package dependency for the sole purpose of generating a description.
     struct DescribedPackageDependency: Encodable {
+        let identity: PackageIdentity
         let name: String?
         let url: String?
         let requirement: PackageDependencyDescription.Requirement?
 
         init(from dependency: PackageDependencyDescription) {
+            self.identity = dependency.identity
             self.name = dependency.explicitNameForTargetDependencyResolutionOnly
-            self.url = dependency.location
-            self.requirement = dependency.requirement
+            switch dependency {
+            case .local(let data):
+                self.url = data.path.pathString
+                self.requirement = nil
+            case .scm(let data):
+                self.url = data.location
+                self.requirement = data.requirement
+            }
         }
     }
 

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -784,6 +784,7 @@ public class SwiftTool {
             case (false, .shared):
                 cachePath = try self.getCachePath().map{ $0.appending(component: "manifests") }
             }
+
             return try ManifestLoader(
                 // Always use the host toolchain's resources for parsing manifest.
                 manifestResources: self._hostToolchain.get().manifestResources,

--- a/Sources/PackageGraph/LocalPackageContainer.swift
+++ b/Sources/PackageGraph/LocalPackageContainer.swift
@@ -25,7 +25,7 @@ import TSCUtility
 /// Examples: Root packages, local dependencies, edited packages.
 public final class LocalPackageContainer: PackageContainer {
     public let package: PackageReference
-    private let mirrors: DependencyMirrors
+    private let identityResolver: IdentityResolver
     private let manifestLoader: ManifestLoaderProtocol
     private let toolsVersionLoader: ToolsVersionLoaderProtocol
     private let currentToolsVersion: ToolsVersion
@@ -53,6 +53,7 @@ public final class LocalPackageContainer: PackageContainer {
                                     version: nil,
                                     revision: nil,
                                     toolsVersion: toolsVersion,
+                                    identityResolver: identityResolver,
                                     fileSystem: fileSystem,
                                     diagnostics: nil,
                                     on: .global(),
@@ -62,7 +63,7 @@ public final class LocalPackageContainer: PackageContainer {
     }
 
     public func getUnversionedDependencies(productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
-        return try loadManifest().dependencyConstraints(productFilter: productFilter, mirrors: mirrors)
+        return try loadManifest().dependencyConstraints(productFilter: productFilter)
     }
 
     public func getUpdatedIdentifier(at boundVersion: BoundVersion) throws -> PackageReference {
@@ -73,7 +74,7 @@ public final class LocalPackageContainer: PackageContainer {
 
     public init(
         package: PackageReference,
-        mirrors: DependencyMirrors,
+        identityResolver: IdentityResolver,
         manifestLoader: ManifestLoaderProtocol,
         toolsVersionLoader: ToolsVersionLoaderProtocol,
         currentToolsVersion: ToolsVersion,
@@ -81,7 +82,7 @@ public final class LocalPackageContainer: PackageContainer {
     ) {
         assert(URL.scheme(package.location) == nil, "unexpected scheme \(URL.scheme(package.location)!) in \(package.location)")
         self.package = package
-        self.mirrors = mirrors
+        self.identityResolver = identityResolver
         self.manifestLoader = manifestLoader
         self.toolsVersionLoader = toolsVersionLoader
         self.currentToolsVersion = currentToolsVersion

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -20,7 +20,7 @@ extension PackageGraph {
     /// Load the package graph for the given package path.
     public static func load(
         root: PackageGraphRoot,
-        mirrors: DependencyMirrors = [:],
+        identityResolver: IdentityResolver,
         additionalFileRules: [FileRuleDescription] = [],
         externalManifests: [Manifest],
         requiredDependencies: Set<PackageReference> = [],
@@ -39,25 +39,24 @@ extension PackageGraph {
         // the URL but that shouldn't be needed after <rdar://problem/33693433>
         // Ensure that identity and package name are the same once we have an
         // API to specify identity in the manifest file
-        let manifestMapSequence = (root.manifests + externalManifests).map({ (PackageIdentity(url: $0.packageLocation), $0) })
+        let manifestMapSequence = (root.manifests + externalManifests).map({ (identityResolver.resolveIdentity(for: $0.packageLocation), $0) })
         let manifestMap = Dictionary(uniqueKeysWithValues: manifestMapSequence)
         let successors: (GraphLoadingNode) -> [GraphLoadingNode] = { node in
-            node.requiredDependencies().compactMap({ dependency in
-                let url = mirrors.effectiveURL(forURL: dependency.location)
-                return manifestMap[PackageIdentity(url: url)].map { manifest in
+            node.requiredDependencies().compactMap{ dependency in
+                return manifestMap[dependency.identity].map { manifest in
                     GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
                 }
-            })
+            }
         }
 
         // Construct the root manifest and root dependencies set.
         let rootManifestSet = Set(root.manifests)
-        let rootDependencies = Set(root.dependencies.compactMap({
-            manifestMap[PackageIdentity(url: $0.location)]
-        }))
+        let rootDependencies = Set(root.dependencies.compactMap{
+            manifestMap[$0.identity]
+        })
         let rootManifestNodes = root.manifests.map { GraphLoadingNode(manifest: $0, productFilter: .everything) }
         let rootDependencyNodes = root.dependencies.lazy.compactMap { (dependency: PackageDependencyDescription) -> GraphLoadingNode? in
-            guard let manifest = manifestMap[PackageIdentity(url: dependency.location)] else { return nil }
+            guard let manifest = manifestMap[dependency.identity] else { return nil }
             return GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
         }
         let inputManifests = rootManifestNodes + rootDependencyNodes
@@ -130,7 +129,7 @@ extension PackageGraph {
         // Resolve dependencies and create resolved packages.
         let resolvedPackages = try createResolvedPackages(
             allManifests: allManifests,
-            mirrors: mirrors,
+            identityResolver: identityResolver,
             manifestToPackage: manifestToPackage,
             rootManifestSet: rootManifestSet,
             unsafeAllowedPackages: unsafeAllowedPackages,
@@ -188,7 +187,7 @@ private func checkAllDependenciesAreUsed(_ rootPackages: [ResolvedPackage], _ di
 /// Create resolved packages from the loaded packages.
 private func createResolvedPackages(
     allManifests: [GraphLoadingNode],
-    mirrors: DependencyMirrors,
+    identityResolver: IdentityResolver,
     manifestToPackage: [Manifest: Package],
     // FIXME: This shouldn't be needed once <rdar://problem/33693433> is fixed.
     rootManifestSet: Set<Manifest>,
@@ -211,7 +210,7 @@ private func createResolvedPackages(
 
     // Create a map of package builders keyed by the package identity.
     let packageMapByIdentity: [PackageIdentity: ResolvedPackageBuilder] = packageBuilders.spm_createDictionary{
-        let identity = PackageIdentity(url: $0.package.manifest.packageLocation)
+        let identity = identityResolver.resolveIdentity(for: $0.package.manifest.packageLocation)
         return (identity, $0)
     }
     let packageMapByName: [String: ResolvedPackageBuilder] = packageBuilders.spm_createDictionary{ ($0.package.name, $0) }
@@ -223,8 +222,15 @@ private func createResolvedPackages(
         var dependencies = [ResolvedPackageBuilder]()
         // Establish the manifest-declared package dependencies.
         package.manifest.dependenciesRequired(for: packageBuilder.productFilter).forEach { dependency in
-            let dependencyURL = mirrors.effectiveURL(forURL: dependency.location)
-            let dependencyIdentity = PackageIdentity(url: dependencyURL)
+            let dependencyIdentity = dependency.identity
+            // FIXME: change this validation logic to use identity instead of location
+            let dependencyLocation: String
+            switch dependency {
+            case .local(let data):
+                dependencyLocation = data.path.pathString
+            case .scm(let data):
+                dependencyLocation = data.location
+            }
 
             // Use the package name to lookup the dependency. The package name will be present in packages with tools version >= 5.2.
             if let explicitDependencyName = dependency.explicitNameForTargetDependencyResolutionOnly, let resolvedPackage = packageMapByName[explicitDependencyName] {
@@ -234,7 +240,7 @@ private func createResolvedPackages(
                     // FIXME: this works but the way we find out about this is based on a side effect, need to improve it when working on identity
                     let error = PackageGraphError.dependencyAlreadySatisfiedByName(
                         dependencyPackageName: package.name,
-                        dependencyURL: dependencyURL,
+                        dependencyLocation: dependencyLocation,
                         otherDependencyURL: resolvedPackage.package.manifest.packageLocation,
                         name: explicitDependencyName)
                     let diagnosticLocation = PackageLocation.Local(name: package.name, packagePath: package.path)
@@ -251,7 +257,7 @@ private func createResolvedPackages(
                 guard !dependencies.contains(resolvedPackage) else {
                     let error = PackageGraphError.dependencyAlreadySatisfiedByIdentifier(
                         dependencyPackageName: package.name,
-                        dependencyURL: dependencyURL,
+                        dependencyLocation: dependencyLocation,
                         otherDependencyURL: resolvedPackage.package.manifest.packageLocation,
                         identity: dependencyIdentity)
                     let diagnosticLocation = PackageLocation.Local(name: package.name, packagePath: package.path)
@@ -262,10 +268,10 @@ private func createResolvedPackages(
                     // check if this resolvedPackage url is the same as the dependency one
                     // if not, this means that the dependencies share the same identity
                     // FIXME: this works but the way we find out about this is based on a side effect, need to improve it when working on identity
-                    if resolvedPackage.package.manifest.packageLocation != dependencyURL {
+                    if resolvedPackage.package.manifest.packageLocation != dependencyLocation {
                         let error = PackageGraphError.dependencyAlreadySatisfiedByIdentifier(
                             dependencyPackageName: package.name,
-                            dependencyURL: dependencyURL,
+                            dependencyLocation: dependencyLocation,
                             otherDependencyURL: resolvedPackage.package.manifest.packageLocation,
                             identity: dependencyIdentity)
                         let diagnosticLocation = PackageLocation.Local(name: package.name, packagePath: package.path)
@@ -274,7 +280,7 @@ private func createResolvedPackages(
                         let error = PackageGraphError.incorrectPackageDependencyName(
                             dependencyPackageName: package.name,
                             dependencyName: explicitDependencyName,
-                            dependencyURL: dependencyURL,
+                            dependencyLocation: dependencyLocation,
                             resolvedPackageName: resolvedPackage.package.name,
                             resolvedPackageURL: resolvedPackage.package.manifest.packageLocation)
                         let diagnosticLocation = PackageLocation.Local(name: package.name, packagePath: package.path)
@@ -414,14 +420,11 @@ private func createResolvedPackages(
                     // explicitly reference the package containing the product, or for the product, package and
                     // dependency to share the same name. We don't check this in manifest loading for root-packages so
                     // we can provide a more detailed diagnostic here.
-                    let referencedPackageURL = mirrors.effectiveURL(forURL: product.packageBuilder.package.manifest.packageLocation)
-                    let referencedPackageIdentity = PackageIdentity(url: referencedPackageURL)
+                    let referencedPackageIdentity = identityResolver.resolveIdentity(for: product.packageBuilder.package.manifest.packageLocation)
                     guard let packageDependency = (packageBuilder.package.manifest.dependencies.first { package in
-                        let packageURL = mirrors.effectiveURL(forURL: package.location)
-                        let packageIdentity = PackageIdentity(url: packageURL)
-                        return packageIdentity == referencedPackageIdentity
+                        return package.identity == referencedPackageIdentity
                     }) else {
-                        throw InternalError("dependency reference for \(referencedPackageURL) not found")
+                        throw InternalError("dependency reference for \(product.packageBuilder.package.manifest.packageLocation) not found")
                     }
 
                     let packageName = product.packageBuilder.package.name

--- a/Sources/PackageGraph/PackageGraph.swift
+++ b/Sources/PackageGraph/PackageGraph.swift
@@ -25,13 +25,13 @@ enum PackageGraphError: Swift.Error {
     case productDependencyIncorrectPackage(name: String, package: String)
 
     /// The package dependency name does not match the package name.
-    case incorrectPackageDependencyName(dependencyPackageName: String, dependencyName: String, dependencyURL: String, resolvedPackageName: String, resolvedPackageURL: String)
+    case incorrectPackageDependencyName(dependencyPackageName: String, dependencyName: String, dependencyLocation: String, resolvedPackageName: String, resolvedPackageURL: String)
 
     /// The package dependency already satisfied by a different dependency package
-    case dependencyAlreadySatisfiedByIdentifier(dependencyPackageName: String, dependencyURL: String, otherDependencyURL: String, identity: PackageIdentity)
+    case dependencyAlreadySatisfiedByIdentifier(dependencyPackageName: String, dependencyLocation: String, otherDependencyURL: String, identity: PackageIdentity)
 
     /// The package dependency already satisfied by a different dependency package
-    case dependencyAlreadySatisfiedByName(dependencyPackageName: String, dependencyURL: String, otherDependencyURL: String, name: String)
+    case dependencyAlreadySatisfiedByName(dependencyPackageName: String, dependencyLocation: String, otherDependencyURL: String, name: String)
 
     /// The product dependency was found but the package name was not referenced correctly (tools version > 5.2).
     case productDependencyMissingPackage(
@@ -233,12 +233,12 @@ fileprivate extension PackageDependencyDescription {
             parameters.append("name: \"\(name)\"")
         }
 
-        if requirement == .localPackage {
-            parameters.append("path: \"\(self.location)\"")
-        } else {
-            parameters.append("url: \"\(self.location)\"")
-
-            switch requirement {
+        switch self {
+        case .local(let data):
+            parameters.append("path: \"\(data.path)\"")
+        case .scm(let data):
+            parameters.append("url: \"\(data.location)\"")
+            switch data.requirement {
             case .branch(let branch):
                 parameters.append(".branch(\"\(branch)\")")
             case .exact(let version):
@@ -253,8 +253,6 @@ fileprivate extension PackageDependencyDescription {
                 } else {
                     parameters.append(".upToNextMinor(\"\(range.lowerBound)\"..<\"\(range.upperBound)\")")
                 }
-            case .localPackage:
-                fatalError("handled above")
             }
         }
 

--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -22,14 +22,11 @@ public struct PackageGraphRootInput {
     /// Top level dependencies to the graph.
     public let dependencies: [PackageDependencyDescription]
 
-    /// Dependency mirrors for the graph.
-    public let mirrors: DependencyMirrors
 
     /// Create a package graph root.
-    public init(packages: [AbsolutePath], dependencies: [PackageDependencyDescription] = [], mirrors: DependencyMirrors = [:]) {
+    public init(packages: [AbsolutePath], dependencies: [PackageDependencyDescription] = []) {
         self.packages = packages
         self.dependencies = dependencies
-        self.mirrors = mirrors
     }
 }
 
@@ -47,6 +44,7 @@ public struct PackageGraphRoot {
 
     /// Create a package graph root.
     public init(input: PackageGraphRootInput, manifests: [Manifest], explicitProduct: String? = nil) {
+        // TODO: this does not use the identity resolver which is probably fine since its the root packages
         self.packageRefs = zip(input.packages, manifests).map { (path, manifest) in
             let identity = PackageIdentity(url: manifest.packageLocation)
             return .root(identity: identity, path: path)
@@ -71,43 +69,46 @@ public struct PackageGraphRoot {
     }
 
     /// Returns the constraints imposed by root manifests + dependencies.
-    public func constraints(mirrors: DependencyMirrors) -> [PackageContainerConstraint] {
-        let constraints = packageRefs.map({
+    public func constraints() -> [PackageContainerConstraint] {
+        let constraints = packageRefs.map{
             PackageContainerConstraint(package: $0, requirement: .unversioned, products: .everything)
-        })
-        return constraints + dependencies.map({
+        }
+        return constraints + dependencies.map{
             PackageContainerConstraint(
-                package: $0.createPackageRef(mirrors: mirrors),
-                requirement: $0.requirement.toConstraintRequirement(),
+                package: $0.createPackageRef(),
+                requirement: $0.toConstraintRequirement(),
                 products: $0.productFilter
             )
-        })
+        }
+    }
+}
+
+extension PackageDependencyDescription {
+    /// Returns the constraint requirement representation.
+    public func toConstraintRequirement() -> PackageRequirement {
+        switch self {
+        case .local:
+            return .unversioned
+        case .scm(let data):
+            return data.requirement.toConstraintRequirement()
+        }
     }
 }
 
 extension PackageDependencyDescription.Requirement {
-
     /// Returns the constraint requirement representation.
     public func toConstraintRequirement() -> PackageRequirement {
         switch self {
         case .range(let range):
             return .versionSet(.range(range))
-
         case .revision(let identifier):
             assert(Git.checkRefFormat(ref: identifier))
-
             return .revision(identifier)
-
         case .branch(let identifier):
             assert(Git.checkRefFormat(ref: identifier))
-
             return .revision(identifier)
-
         case .exact(let version):
             return .versionSet(.exact(version))
-
-        case .localPackage:
-            return .unversioned
         }
     }
 }

--- a/Sources/PackageLoading/CMakeLists.txt
+++ b/Sources/PackageLoading/CMakeLists.txt
@@ -8,6 +8,7 @@
 
 add_library(PackageLoading
   Diagnostics.swift
+  IdentityResolver.swift
   ManifestLoader.swift
   MinimumDeploymentTarget.swift
   ModuleMapGenerator.swift

--- a/Sources/PackageLoading/IdentityResolver.swift
+++ b/Sources/PackageLoading/IdentityResolver.swift
@@ -1,0 +1,40 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import TSCBasic
+import PackageModel
+
+// TODO: refactor this when adding registry support
+public protocol IdentityResolver {
+    func resolveIdentity(for location: String) -> PackageIdentity
+    func resolveIdentity(for path: AbsolutePath) -> PackageIdentity
+    func resolveLocation(from location: String) -> String
+}
+
+public struct DefaultIdentityResolver: IdentityResolver {
+    let locationMapper: (String) -> String
+
+    public init(locationMapper: @escaping (String) -> String = { $0 }) {
+        self.locationMapper = locationMapper
+    }
+    
+    public func resolveIdentity(for location: String) -> PackageIdentity {
+        let location = self.resolveLocation(from: location)
+        return PackageIdentity(url: location)
+    }
+
+    public func resolveIdentity(for path: AbsolutePath) -> PackageIdentity {
+        return PackageIdentity(url: path.pathString)
+    }
+
+    public func resolveLocation(from location: String) -> String {
+        return self.locationMapper(location)
+    }
+}

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -287,6 +287,7 @@ public final class PackageBuilder {
         swiftCompilerFlags: [String],
         xcTestMinimumDeploymentTargets: [PackageModel.Platform:PlatformVersion]
             = MinimumDeploymentTarget.default.xcTestMinimumDeploymentTargets,
+        identityResolver: IdentityResolver,
         diagnostics: DiagnosticsEngine,
         on queue: DispatchQueue,
         completion: @escaping (Result<Package, Error>) -> Void
@@ -295,6 +296,7 @@ public final class PackageBuilder {
                                     kind: kind,
                                     swiftCompiler: swiftCompiler,
                                     swiftCompilerFlags: swiftCompilerFlags,
+                                    identityResolver: identityResolver,
                                     on: queue) { result in
             let result = result.tryMap { manifest -> Package in
                 let builder = PackageBuilder(

--- a/Sources/PackageLoading/UserManifestResources.swift
+++ b/Sources/PackageLoading/UserManifestResources.swift
@@ -48,6 +48,7 @@ public struct UserManifestResources: ManifestResourceProvider {
         self.init(
             swiftCompiler: swiftCompiler,
             swiftCompilerFlags: swiftCompilerFlags,
-            libDir: UserManifestResources.libDir(forBinDir: binDir))
+            libDir: UserManifestResources.libDir(forBinDir: binDir)
+        )
     }
 }

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -167,30 +167,30 @@ public final class Manifest: ObjectIdentifierProtocol {
     public func dependenciesRequired(for productFilter: ProductFilter) -> [PackageDependencyDescription] {
         #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
         // If we have already calcualted it, returned the cached value.
-        if let dependencies = _requiredDependencies[productFilter] {
-            return dependencies
+        if let dependencies = self._requiredDependencies[productFilter] {
+            return self.dependencies
         } else {
-            let targets = targetsRequired(for: productFilter)
-            let dependencies = dependenciesRequired(for: targets, keepUnused: productFilter == .everything)
-            _requiredDependencies[productFilter] = dependencies
-            return dependencies
+            let targets = self.targetsRequired(for: productFilter)
+            let dependencies = self.dependenciesRequired(for: targets, keepUnused: productFilter == .everything)
+            self._requiredDependencies[productFilter] = dependencies
+            return self.dependencies
         }
         #else
         guard toolsVersion >= .v5_2 && packageKind != .root else {
-            return dependencies
+            return self.dependencies
         }
         
-        var requiredDependencyURLs: Set<String> = []
+        var requiredDependencyURLs: Set<PackageIdentity> = []
         
-        for target in targetsRequired(for: products) {
+        for target in self.targetsRequired(for: products) {
             for targetDependency in target.dependencies {
-                if let dependency = packageDependency(referencedBy: targetDependency) {
-                    requiredDependencyURLs.insert(dependency.location)
+                if let dependency = self.packageDependency(referencedBy: targetDependency) {
+                    requiredDependencyURLs.insert(dependency.identity)
                 }
             }
         }
         
-        return dependencies.filter { requiredDependencyURLs.contains($0.location) }
+        return self.dependencies.filter { requiredDependencyURLs.contains($0.identity) }
         #endif
     }
 

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -120,20 +120,21 @@ fileprivate extension SourceCodeFragment {
         if let explicitName = dependency.explicitNameForTargetDependencyResolutionOnly {
             params.append(SourceCodeFragment(key: "name", string: explicitName))
         }
-        if dependency.requirement != .localPackage {
-            params.append(SourceCodeFragment(key: "url", string: dependency.location))
-        }
-        switch dependency.requirement {
-        case .exact(let version):
-            params.append(SourceCodeFragment(enum: "exact", string: version.description))
-        case .range(let range):
-            params.append(SourceCodeFragment(enum: "range", string: range.description))
-        case .revision(let revision):
-            params.append(SourceCodeFragment(enum: "revision", string: revision))
-        case .branch(let branch):
-            params.append(SourceCodeFragment(enum: "branch", string: branch))
-        case .localPackage:
-            params.append(SourceCodeFragment(key: "path", string: dependency.location))
+        switch dependency {
+        case .local(let data):
+            params.append(SourceCodeFragment(key: "path", string: data.path.pathString))
+        case .scm(let data):
+            params.append(SourceCodeFragment(key: "url", string: data.location))
+            switch data.requirement {
+            case .exact(let version):
+                params.append(SourceCodeFragment(enum: "exact", string: version.description))
+            case .range(let range):
+                params.append(SourceCodeFragment(enum: "range", string: range.description))
+            case .revision(let revision):
+                params.append(SourceCodeFragment(enum: "revision", string: revision))
+            case .branch(let branch):
+                params.append(SourceCodeFragment(enum: "branch", string: branch))
+            }
         }
         self.init(enum: "package", subnodes: params)
     }

--- a/Sources/SPMTestSupport/MockManifestLoader.swift
+++ b/Sources/SPMTestSupport/MockManifestLoader.swift
@@ -55,6 +55,7 @@ public final class MockManifestLoader: ManifestLoaderProtocol {
         version: Version?,
         revision: String?,
         toolsVersion: ToolsVersion,
+        identityResolver: IdentityResolver,
         fileSystem: FileSystem,
         diagnostics: DiagnosticsEngine?,
         on queue: DispatchQueue,
@@ -80,6 +81,7 @@ extension ManifestLoader {
         packageKind: PackageModel.PackageReference.Kind,
         packageLocation: String,
         toolsVersion: PackageModel.ToolsVersion,
+        identityResolver: IdentityResolver = DefaultIdentityResolver(),
         fileSystem: PackageLoading.FileSystem,
         diagnostics: TSCBasic.DiagnosticsEngine? = nil
     ) throws -> Manifest{
@@ -90,6 +92,7 @@ extension ManifestLoader {
                       version: nil,
                       revision: nil,
                       toolsVersion: toolsVersion,
+                      identityResolver: identityResolver,
                       fileSystem: fileSystem,
                       diagnostics: diagnostics,
                       on: .global(),

--- a/Sources/SPMTestSupport/PackageDependencyDescriptionExtensions.swift
+++ b/Sources/SPMTestSupport/PackageDependencyDescriptionExtensions.swift
@@ -1,0 +1,51 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import PackageModel
+import TSCBasic
+
+public extension PackageDependencyDescription {
+    static func local(identity: PackageIdentity? = nil,
+                      name: String? = nil,
+                      path: String,
+                      productFilter: ProductFilter = .everything
+    ) -> PackageDependencyDescription {
+        return .local(identity: identity,
+                      name: name,
+                      path: AbsolutePath(path),
+                      productFilter: productFilter)
+    }
+
+    static func local(identity: PackageIdentity? = nil,
+                      name: String? = nil,
+                      path: AbsolutePath,
+                      productFilter: ProductFilter = .everything
+    ) -> PackageDependencyDescription {
+        let identity = identity ?? PackageIdentity(url: path.pathString)
+        return .local(identity: identity,
+                      name: name,
+                      path: path,
+                      productFilter: productFilter)
+    }
+
+    static func scm(identity: PackageIdentity? = nil,
+                    name: String? = nil,
+                    location: String,
+                    requirement: Requirement,
+                    productFilter: ProductFilter = .everything
+    ) -> PackageDependencyDescription {
+        let identity = identity ?? PackageIdentity(url: location)
+        return .scm(identity: identity,
+                    name: name,
+                    location: location,
+                    requirement: requirement,
+                    productFilter: productFilter)
+    }
+}

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -215,6 +215,7 @@ private func swiftArgs(
 }
 
 public func loadPackageGraph(
+    identityResolver: IdentityResolver = DefaultIdentityResolver(),
     fs: FileSystem,
     diagnostics: DiagnosticsEngine = DiagnosticsEngine(),
     manifests: [Manifest],
@@ -230,6 +231,7 @@ public func loadPackageGraph(
 
     return try PackageGraph.load(
         root: graphRoot,
+        identityResolver: identityResolver,
         externalManifests: externalManifests,
         diagnostics: diagnostics,
         fileSystem: fs,

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -274,7 +274,7 @@ public class RepositoryManager {
                     let repositoryPath = self.path.appending(handle.subpath)
                     // Change the state to pending.
                     handle.status = .pending
-                    // Make sure desination is free.
+                    // Make sure destination is free.
                     try? self.fileSystem.removeFileTree(repositoryPath)
 
                     // Inform delegate.
@@ -334,7 +334,7 @@ public class RepositoryManager {
     ///   - update: Update a repository that is already cached or alternatively fetch the repository into the cache.
     /// - Throws:
     /// - Returns: Details about the performed fetch.
-   @discardableResult
+    @discardableResult
     func fetchAndPopulateCache(handle: RepositoryHandle, repositoryPath: AbsolutePath) throws -> FetchDetails {
         var updatedCache = false
         var fromCache = false

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -205,6 +205,9 @@ public class Workspace {
     /// The repository manager.
     public let repositoryManager: RepositoryManager
 
+    /// Utility to resolve package identifiers
+    public let identityResolver: IdentityResolver
+
     /// The package container provider.
     fileprivate let containerProvider: RepositoryPackageContainerProvider
 
@@ -263,6 +266,7 @@ public class Workspace {
         config: Workspace.Configuration = Workspace.Configuration(),
         fileSystem: FileSystem = localFileSystem,
         repositoryProvider: RepositoryProvider = GitRepositoryProvider(),
+        identityResolver: IdentityResolver? = nil,
         downloader: Downloader = FoundationDownloader(),
         netrcFilePath: AbsolutePath? = nil,
         archiver: Archiver = ZipArchiver(),
@@ -311,9 +315,11 @@ public class Workspace {
         self.checkoutsPath = self.dataPath.appending(component: "checkouts")
         self.artifactsPath = self.dataPath.appending(component: "artifacts")
 
+        self.identityResolver = identityResolver ?? DefaultIdentityResolver(locationMapper: config.mirrors.effectiveURL(forURL:))
+
         self.containerProvider = RepositoryPackageContainerProvider(
             repositoryManager: repositoryManager,
-            mirrors: self.config.mirrors,
+            identityResolver: self.identityResolver,
             manifestLoader: manifestLoader,
             currentToolsVersion: currentToolsVersion,
             toolsVersionLoader: toolsVersionLoader
@@ -561,7 +567,7 @@ extension Workspace {
         var updateConstraints = currentManifests.editedPackagesConstraints()
 
         // Create constraints based on root manifest and pins for the update resolution.
-        updateConstraints += graphRoot.constraints(mirrors: config.mirrors)
+        updateConstraints += graphRoot.constraints()
 
         let pinsMap: PinsStore.PinsMap
         if packages.isEmpty {
@@ -624,6 +630,7 @@ extension Workspace {
         packagePath: AbsolutePath,
         swiftCompiler: AbsolutePath,
         swiftCompilerFlags: [String],
+        identityResolver: IdentityResolver,
         diagnostics: DiagnosticsEngine
     ) throws -> PackageGraph {
         let resources = try UserManifestResources(swiftCompiler: swiftCompiler, swiftCompilerFlags: swiftCompilerFlags)
@@ -674,7 +681,7 @@ extension Workspace {
         // Load the graph.
         return try PackageGraph.load(
             root: manifests.root,
-            mirrors: config.mirrors,
+            identityResolver: self.identityResolver,
             additionalFileRules: additionalFileRules,
             externalManifests: manifests.allDependencyManifests(),
             requiredDependencies: manifests.computePackageURLs().required,
@@ -695,7 +702,7 @@ extension Workspace {
         diagnostics: DiagnosticsEngine
     ) throws -> PackageGraph {
         try self.loadPackageGraph(
-            rootInput: PackageGraphRootInput(packages: [rootPath], mirrors: config.mirrors),
+            rootInput: PackageGraphRootInput(packages: [rootPath]),
             explicitProduct: explicitProduct,
             diagnostics: diagnostics
         )
@@ -1075,22 +1082,20 @@ extension Workspace {
 
         func computePackageURLs() -> (required: Set<PackageReference>, missing: Set<PackageReference>) {
             let manifestsMap: [PackageIdentity: Manifest] = Dictionary(uniqueKeysWithValues:
-                self.root.manifests.map { (PackageIdentity(url: $0.packageLocation), $0) } +
-                self.dependencies.map { (PackageIdentity(url: $0.manifest.packageLocation), $0.manifest) })
+                self.root.manifests.map { (workspace.identityResolver.resolveIdentity(for: $0.packageLocation), $0) } +
+                self.dependencies.map { (workspace.identityResolver.resolveIdentity(for: $0.manifest.packageLocation), $0.manifest) })
 
             var inputIdentities: Set<PackageReference> = []
             let inputNodes: [GraphLoadingNode] = self.root.manifests.map{ manifest in
-                let identity = PackageIdentity(url: manifest.packageLocation)
+                let identity = workspace.identityResolver.resolveIdentity(for: manifest.packageLocation)
                 let package = PackageReference(identity: identity, kind: manifest.packageKind, location: manifest.packageLocation)
                 inputIdentities.insert(package)
                 let node = GraphLoadingNode(manifest: manifest, productFilter: .everything)
                 return node
             } + self.root.dependencies.compactMap{ dependency in
-                let url = workspace.config.mirrors.effectiveURL(forURL: dependency.location)
-                let identity = PackageIdentity(url: url)
-                let package = PackageReference.remote(identity: identity, location: url)
+                let package = dependency.createPackageRef()
                 inputIdentities.insert(package)
-                return manifestsMap[identity].map { manifest in
+                return manifestsMap[dependency.identity].map { manifest in
                     GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
                 }
             }
@@ -1099,11 +1104,9 @@ extension Workspace {
             var requiredIdentities: Set<PackageReference> = []
             _ = transitiveClosure(inputNodes) { node in
                 return node.manifest.dependenciesRequired(for: node.productFilter).compactMap{ dependency in
-                    let url = workspace.config.mirrors.effectiveURL(forURL: dependency.location)
-                    let identity = PackageIdentity(url: url)
-                    let package = PackageReference.remote(identity: identity, location: url)
+                    let package = dependency.createPackageRef()
                     requiredIdentities.insert(package)
-                    return manifestsMap[identity].map { manifest in
+                    return manifestsMap[dependency.identity].map { manifest in
                         GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
                     }
                 }
@@ -1146,10 +1149,7 @@ extension Workspace {
                 case .checkout, .local:
                     break
                 }
-                allConstraints += externalManifest.dependencyConstraints(
-                    productFilter: productFilter,
-                    mirrors: workspace.config.mirrors
-                )
+                allConstraints += externalManifest.dependencyConstraints(productFilter: productFilter)
             }
             return allConstraints
         }
@@ -1247,6 +1247,7 @@ extension Workspace {
     /// This will load the manifests for the root package as well as all the
     /// current dependencies from the working checkouts.
     // @testable internal
+    // FIXME: this logic should be changed to use identity instead of location once identity is unique
     public func loadDependencyManifests(
         root: PackageGraphRoot,
         diagnostics: DiagnosticsEngine
@@ -1270,7 +1271,7 @@ extension Workspace {
         }
 
         // optimization: preload in parallel
-        let rootDependencyManifestsURLs = root.dependencies.map{ config.mirrors.effectiveURL(forURL: $0.location) }
+        let rootDependencyManifestsURLs = root.dependencies.map{ $0.location }
         let rootDependencyManifests = try temp_await { self.loadManifests(forURLs: rootDependencyManifestsURLs, diagnostics: diagnostics, completion: $0) }
 
         let inputManifests = root.manifests + rootDependencyManifests
@@ -1284,18 +1285,18 @@ extension Workspace {
         }
 
         // optimization: preload manifest we know about in parallel
-        let inputDependenciesURLs = inputManifests.map { $0.dependencies.map{ config.mirrors.effectiveURL(forURL: $0.location) } }.flatMap { $0 }
+        let inputDependenciesURLs = inputManifests.map { $0.dependencies.map{ $0.location } }.flatMap { $0 }
         // FIXME: this should not block
         var loadedManifests = try temp_await { self.loadManifests(forURLs: inputDependenciesURLs, diagnostics: diagnostics, completion: $0) }.spm_createDictionary{ ($0.packageLocation, $0) }
 
         // continue to load the rest of the manifest for this graph
         let allManifestsWithPossibleDuplicates = try topologicalSort(inputManifests.map{ KeyedPair($0, key: URLAndFilter(url: $0.packageLocation, productFilter: .everything)) }) { node in
             return node.item.dependenciesRequired(for: node.key.productFilter).compactMap{ dependency in
-                let url = config.mirrors.effectiveURL(forURL: dependency.location)
+                let location = dependency.location
                 // FIXME: this should not block
                 // note: loadManifest emits diagnostics in case it fails
-                let manifest = loadedManifests[url] ?? temp_await { self.loadManifest(forURL: url, diagnostics: diagnostics, completion: $0) }
-                loadedManifests[url] = manifest
+                let manifest = loadedManifests[location] ?? temp_await { self.loadManifest(forURL: location, diagnostics: diagnostics, completion: $0) }
+                loadedManifests[location] = manifest
                 return manifest.flatMap { KeyedPair($0, key: URLAndFilter(url: $0.packageLocation, productFilter: dependency.productFilter)) }
             }
         }
@@ -1304,7 +1305,7 @@ extension Workspace {
         var deduplication = [PackageIdentity: Int]()
         var allManifests = [(manifest: Manifest, productFilter: ProductFilter)]()
         for node in allManifestsWithPossibleDuplicates {
-            let identity = PackageIdentity(url: node.item.packageLocation)
+            let identity = self.identityResolver.resolveIdentity(for: node.item.packageLocation)
             if let index = deduplication[identity]  {
                 let productFilter = allManifests[index].productFilter.merge(node.key.productFilter)
                 allManifests[index] = (node.item, productFilter)
@@ -1418,6 +1419,7 @@ extension Workspace {
                                     version: version,
                                     revision: nil,
                                     toolsVersion: toolsVersion,
+                                    identityResolver: self.identityResolver,
                                     fileSystem: localFileSystem,
                                     diagnostics: diagnostics,
                                     on: self.queue) { result in
@@ -1733,9 +1735,9 @@ extension Workspace {
         //
         // FIXME: This will only work for top-level local packages right now.
         for rootManifest in rootManifests {
-            let dependencies = rootManifest.dependencies.filter{ $0.requirement == .localPackage }
+            let dependencies = rootManifest.dependencies.filter{ $0.isLocal }
             for localPackage in dependencies {
-                let package = localPackage.createPackageRef(mirrors: self.config.mirrors)
+                let package = localPackage.createPackageRef()
                 state.dependencies.add(ManagedDependency.local(packageRef: package))
             }
         }
@@ -1829,7 +1831,7 @@ extension Workspace {
         // Create the constraints.
         var constraints = [PackageContainerConstraint]()
         constraints += currentManifests.editedPackagesConstraints()
-        constraints += graphRoot.constraints(mirrors: config.mirrors) + extraConstraints
+        constraints += graphRoot.constraints() + extraConstraints
 
         // Perform dependency resolution.
         let resolver = createResolver(pinsMap: pinsStore.pinsMap)
@@ -1936,16 +1938,16 @@ extension Workspace {
         extraConstraints: [PackageContainerConstraint] = []
     ) -> ResolutionPrecomputationResult {
         let constraints =
-            root.constraints(mirrors: config.mirrors) +
+            root.constraints() +
             // Include constraints from the manifests in the graph root.
-            root.manifests.flatMap({ $0.dependencyConstraints(productFilter: .everything, mirrors: config.mirrors) }) +
+            root.manifests.flatMap({ $0.dependencyConstraints(productFilter: .everything) }) +
             dependencyManifests.dependencyConstraints() +
             extraConstraints
 
         let precomputationProvider = ResolverPrecomputationProvider(
             root: root,
             dependencyManifests: dependencyManifests,
-            mirrors: config.mirrors
+            identityResolver: self.identityResolver
         )
 
         let resolver = PubgrubDependencyResolver(provider: precomputationProvider, pinsMap: pinsStore.pinsMap)
@@ -2543,5 +2545,18 @@ public final class LoadableResult<Value> {
     /// Load and return the value.
     public func load() throws -> Value {
         return try loadResult().get()
+    }
+}
+
+// FIXME: the manifest loading logic should be changed to use identity instead of location once identity is unique
+// at that time we should remove this
+extension PackageDependencyDescription {
+    var location: String {
+        switch self {
+        case .local(let data):
+            return data.path.pathString
+        case .scm(let data):
+            return data.location
+        }
     }
 }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -275,7 +275,7 @@ final class BuildPlanTests: XCTestCase {
                     path: "/Pkg",
                     packageLocation: "/Pkg",
                     dependencies: [
-                        PackageDependencyDescription(location: "/ExtPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/ExtPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe", dependencies: [
@@ -379,7 +379,7 @@ final class BuildPlanTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/A",
                     dependencies: [
-                        PackageDependencyDescription(location: "/B", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/B", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "ATarget", dependencies: ["BLibrary"]),
@@ -486,7 +486,7 @@ final class BuildPlanTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Pkg",
                     dependencies: [
-                        PackageDependencyDescription(location: "/ExtPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/ExtPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["lib"]),
@@ -598,7 +598,7 @@ final class BuildPlanTests: XCTestCase {
                     path: "/Pkg",
                     packageLocation: "/Pkg",
                     dependencies: [
-                        PackageDependencyDescription(location: "/ExtPkg", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/ExtPkg", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe", dependencies: [
@@ -855,7 +855,7 @@ final class BuildPlanTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Pkg",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Dep", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/Dep", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "exe", dependencies: ["swiftlib"]),
@@ -966,7 +966,7 @@ final class BuildPlanTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Pkg",
                     dependencies: [
-                        PackageDependencyDescription(location: "Clibgit", requirement: .upToNextMajor(from: "1.0.0"))
+                        .scm(location: "Clibgit", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "exe", dependencies: []),
@@ -1068,7 +1068,7 @@ final class BuildPlanTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Foo",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar-Baz"]),
@@ -1278,8 +1278,8 @@ final class BuildPlanTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/A",
                     dependencies: [
-                        PackageDependencyDescription(location: "/B", requirement: .upToNextMajor(from: "1.0.0")),
-                        PackageDependencyDescription(location: "/C", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/B", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/C", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "aexec", type: .executable, targets: ["ATarget"])
@@ -1369,8 +1369,8 @@ final class BuildPlanTests: XCTestCase {
                     path: "/A",
                     packageLocation: "/A",
                     dependencies: [
-                        PackageDependencyDescription(location: "/B", requirement: .upToNextMajor(from: "1.0.0")),
-                        PackageDependencyDescription(location: "/C", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/B", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/C", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "aexec", type: .executable, targets: ["ATarget"]),
@@ -1780,7 +1780,7 @@ final class BuildPlanTests: XCTestCase {
                     ],
                     v: .v5,
                     dependencies: [
-                        PackageDependencyDescription(location: "/B", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/B", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "ATarget", dependencies: ["BLibrary"]),
@@ -1843,7 +1843,7 @@ final class BuildPlanTests: XCTestCase {
                     ],
                     v: .v5,
                     dependencies: [
-                        PackageDependencyDescription(location: "/B", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/B", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "ATarget", dependencies: ["BLibrary"]),
@@ -1905,7 +1905,7 @@ final class BuildPlanTests: XCTestCase {
             packageLocation: "/A",
             v: .v5,
             dependencies: [
-                PackageDependencyDescription(location: "/B", requirement: .upToNextMajor(from: "1.0.0")),
+                .scm(location: "/B", requirement: .upToNextMajor(from: "1.0.0")),
             ],
             targets: [
                 try TargetDescription(
@@ -2083,7 +2083,7 @@ final class BuildPlanTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/PkgB",
                     dependencies: [
-                        PackageDependencyDescription(location: "/PkgA", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/PkgA", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "PkgB", dependencies: ["swiftlib"]),
@@ -2178,7 +2178,7 @@ final class BuildPlanTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/PkgA",
                     dependencies: [
-                        PackageDependencyDescription(location: "/PkgB", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/PkgB", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Bar", dependencies: ["Foo"]),
@@ -2246,7 +2246,7 @@ final class BuildPlanTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/PkgA",
                     dependencies: [
-                        PackageDependencyDescription(location: "/PkgB", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/PkgB", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Bar", dependencies: ["Foo"]),

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -360,8 +360,8 @@ final class PackageToolTests: XCTestCase {
             packageLocation: "/PackageA",
             v: .v5_3,
             dependencies: [
-                .init(name: "PackageB", location: "/PackageB", requirement: .localPackage),
-                .init(name: "PackageC", location: "/PackageC", requirement: .localPackage),
+                .local(name: "PackageB", path: "/PackageB"),
+                .local(name: "PackageC", path: "/PackageC"),
             ],
             products: [
                 .init(name: "exe", type: .executable, targets: ["TargetA"])
@@ -378,8 +378,8 @@ final class PackageToolTests: XCTestCase {
             packageLocation: "/PackageB",
             v: .v5_3,
             dependencies: [
-                .init(name: "PackageC", location: "/PackageC", requirement: .localPackage),
-                .init(name: "PackageD", location: "/PackageD", requirement: .localPackage),
+                .local(name: "PackageC", path: "/PackageC"),
+                .local(name: "PackageD", path: "/PackageD"),
             ],
             products: [
                 .init(name: "PackageB", type: .library(.dynamic), targets: ["TargetB"])
@@ -396,7 +396,7 @@ final class PackageToolTests: XCTestCase {
             packageLocation: "/PackageC",
             v: .v5_3,
             dependencies: [
-                .init(name: "PackageD", location: "/PackageD", requirement: .localPackage),
+                .local(name: "PackageD", path: "/PackageD"),
             ],
             products: [
                 .init(name: "PackageC", type: .library(.dynamic), targets: ["TargetC"])

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -13,6 +13,7 @@ import XCTest
 import TSCBasic
 import PackageGraph
 import PackageModel
+import PackageLoading
 import SPMTestSupport
 
 class PackageGraphPerfTests: XCTestCasePerf {
@@ -38,7 +39,7 @@ class PackageGraphPerfTests: XCTestCasePerf {
             } else {
                 let depName = "Foo\(pkg + 1)"
                 let depUrl = "/\(depName)"
-                dependencies = [PackageDependencyDescription(name: depName, location: depUrl, requirement: .upToNextMajor(from: "1.0.0"))]
+                dependencies = [.scm(name: depName, location: depUrl, requirement: .upToNextMajor(from: "1.0.0"))]
                 targets = [try TargetDescription(name: name, dependencies: [.byName(name: depName, condition: nil)], path: ".")]
             }
             // Create manifest.
@@ -63,11 +64,14 @@ class PackageGraphPerfTests: XCTestCasePerf {
                 externalManifests.append(manifest)
             }
         }
-        
+
+        let identityResolver = DefaultIdentityResolver()
+
         measure {
             let diagnostics = DiagnosticsEngine()
             let g = try! PackageGraph.load(
                 root: PackageGraphRoot(input: PackageGraphRootInput(packages: rootManifests.map({$0.path})), manifests: rootManifests),
+                identityResolver: identityResolver,
                 externalManifests: externalManifests,
                 diagnostics: diagnostics,
                 fileSystem: fs)

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -48,7 +48,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Bar",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
+                        .scm(location: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -61,7 +61,7 @@ class PackageGraphTests: XCTestCase {
                     path: "/Baz",
                     packageLocation: "/Baz",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
+                        .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Baz", dependencies: ["Bar"]),
@@ -97,7 +97,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Foo",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
+                        .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar", "CBar"]),
@@ -143,7 +143,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Foo",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
+                        .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
@@ -154,7 +154,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .local,
                     packageLocation: "/Bar",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Baz", requirement: .upToNextMajor(from: "1.0.0"))
+                        .scm(location: "/Baz", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     products: [
                         ProductDescription(name: "Bar", type: .library(.automatic), targets: ["Bar"])
@@ -168,7 +168,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .local,
                     packageLocation: "/Baz",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
+                        .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     products: [
                         ProductDescription(name: "Baz", type: .library(.automatic), targets: ["Baz"])
@@ -198,7 +198,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Foo",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
+                        .scm(location: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Foo"),
@@ -228,7 +228,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Bar",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
+                        .scm(location: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Bar", dependencies: ["Foo"]),
@@ -272,7 +272,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Foo",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
+                        .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Bar"),
@@ -341,9 +341,9 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/First",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Second", requirement: .upToNextMajor(from: "1.0.0")),
-                        PackageDependencyDescription(location: "/Third", requirement: .upToNextMajor(from: "1.0.0")),
-                        PackageDependencyDescription(location: "/Fourth", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/Second", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/Third", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/Fourth", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "First", dependencies: ["Second", "Third", "Fourth"]),
@@ -406,9 +406,9 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/First",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Second", requirement: .upToNextMajor(from: "1.0.0")),
-                        PackageDependencyDescription(location: "/Third", requirement: .upToNextMajor(from: "1.0.0")),
-                        PackageDependencyDescription(location: "/Fourth", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/Second", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/Third", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/Fourth", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Second", "Third", "Fourth"]),
@@ -450,7 +450,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .local,
                     packageLocation: "/Third",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Fourth", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/Fourth", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Third", type: .library(.automatic), targets: ["Third"])
@@ -464,7 +464,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .local,
                     packageLocation: "/Second",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Third", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/Third", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "Second", type: .library(.automatic), targets: ["Second"])
@@ -478,7 +478,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/First",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Second", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/Second", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "First", type: .library(.automatic), targets: ["First"])
@@ -509,7 +509,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Foo",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
@@ -628,9 +628,9 @@ class PackageGraphTests: XCTestCase {
                     packageLocation: "/Foo",
                     v: .v5_2,
                     dependencies: [
-                        PackageDependencyDescription(name: "Bar", location: "/Bar", requirement: .branch("master")),
-                        PackageDependencyDescription(location: "/BizPath", requirement: .exact("1.2.3")),
-                        PackageDependencyDescription(location: "/FizPath", requirement: .upToNextMajor(from: "1.1.2")),
+                        .scm(name: "Bar", location: "/Bar", requirement: .branch("master")),
+                        .scm(location: "/BizPath", requirement: .exact("1.2.3")),
+                        .scm(location: "/FizPath", requirement: .upToNextMajor(from: "1.1.2")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["BarLib", "Biz", "FizLib"]),
@@ -706,7 +706,7 @@ class PackageGraphTests: XCTestCase {
                     packageLocation: "/Foo",
                     v: .v5_2,
                     dependencies: [
-                        PackageDependencyDescription(name: "UnBar", location: "/Bar", requirement: .branch("master")),
+                        .scm(name: "UnBar", location: "/Bar", requirement: .branch("master")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: [.product(name: "BarProduct", package: "UnBar")]),
@@ -746,9 +746,9 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Foo",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
-                        PackageDependencyDescription(location: "/Baz", requirement: .upToNextMajor(from: "1.0.0")),
-                        PackageDependencyDescription(location: "/Biz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/Biz", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["BarLibrary"]),
@@ -812,7 +812,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Bar",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Bar"),
@@ -847,7 +847,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Start",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Dep1", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/Dep1", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["BazLibrary"]),
@@ -859,7 +859,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .local,
                     packageLocation: "/Dep1",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Dep2", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/Dep2", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     products: [
                         ProductDescription(name: "BazLibrary", type: .library(.automatic), targets: ["Baz"])
@@ -904,8 +904,8 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Foo",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
-                        PackageDependencyDescription(location: "/Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/Baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
@@ -958,7 +958,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Foo",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Bar"]),
@@ -1022,7 +1022,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Foo",
                     dependencies: [
-                        PackageDependencyDescription(name: "Baar", location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(name: "Baar", location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Baar"]),
@@ -1070,7 +1070,7 @@ class PackageGraphTests: XCTestCase {
                     path: "/Foo",
                     packageLocation: "/Foo",
                     dependencies: [
-                        PackageDependencyDescription(location: "/Biz", requirement: .localPackage),
+                        .local(path: "/Biz"),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: [
@@ -1157,7 +1157,7 @@ class PackageGraphTests: XCTestCase {
                     packageLocation: "/Root",
                     v: .v5_2,
                     dependencies: [
-                        PackageDependencyDescription(name: "Immediate", location: "/Immediate", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(name: "Immediate", location: "/Immediate", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Root", dependencies: [
@@ -1172,12 +1172,12 @@ class PackageGraphTests: XCTestCase {
                     packageLocation: "/Immediate",
                     v: .v5_2,
                     dependencies: [
-                        PackageDependencyDescription(
+                        .scm(
                             name: "Transitive",
                             location: "/Transitive",
                             requirement: .upToNextMajor(from: "1.0.0")
                         ),
-                        PackageDependencyDescription(
+                        .scm(
                             name: "Nonexistent",
                             location: "/Nonexistent",
                             requirement: .upToNextMajor(from: "1.0.0")
@@ -1204,7 +1204,7 @@ class PackageGraphTests: XCTestCase {
                     packageLocation: "/Transitive",
                     v: .v5_2,
                     dependencies: [
-                        PackageDependencyDescription(
+                        .scm(
                             name: "Nonexistent",
                             location: "/Nonexistent",
                             requirement: .upToNextMajor(from: "1.0.0")

--- a/Tests/PackageLoadingTests/PD4LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4LoadingTests.swift
@@ -141,13 +141,13 @@ class PackageDescription4LoadingTests: PackageDescriptionLoadingTests {
             )
             """
        loadManifest(stream.bytes) { manifest in
-            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.location, $0) })
-            XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(location: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
-            XCTAssertEqual(deps["/foo2"], PackageDependencyDescription(location: "/foo2", requirement: .upToNextMajor(from: "1.0.0")))
-            XCTAssertEqual(deps["/foo3"], PackageDependencyDescription(location: "/foo3", requirement: .upToNextMinor(from: "1.0.0")))
-            XCTAssertEqual(deps["/foo4"], PackageDependencyDescription(location: "/foo4", requirement: .exact("1.0.0")))
-            XCTAssertEqual(deps["/foo5"], PackageDependencyDescription(location: "/foo5", requirement: .branch("master")))
-            XCTAssertEqual(deps["/foo6"], PackageDependencyDescription(location: "/foo6", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
+        let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
+            XCTAssertEqual(deps["foo1"], .scm(location: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
+            XCTAssertEqual(deps["foo2"], .scm(location: "/foo2", requirement: .upToNextMajor(from: "1.0.0")))
+            XCTAssertEqual(deps["foo3"], .scm(location: "/foo3", requirement: .upToNextMinor(from: "1.0.0")))
+            XCTAssertEqual(deps["foo4"], .scm(location: "/foo4", requirement: .exact("1.0.0")))
+            XCTAssertEqual(deps["foo5"], .scm(location: "/foo5", requirement: .branch("master")))
+            XCTAssertEqual(deps["foo6"], .scm(location: "/foo6", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
         }
     }
 

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -62,8 +62,8 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             XCTAssertEqual(bar.dependencies, ["foo"])
 
             // Check dependencies.
-            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.location, $0) })
-            XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(location: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
+            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
+            XCTAssertEqual(deps["foo1"], .scm(location: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
 
             // Check products.
             let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })
@@ -254,37 +254,58 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             )
             """
        loadManifest(stream.bytes) { manifest in
-            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.location, $0) })
-            XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(location: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
-            XCTAssertEqual(deps["/foo2"], PackageDependencyDescription(location: "/foo2", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
+            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
+            XCTAssertEqual(deps["foo1"], .scm(location: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
+            XCTAssertEqual(deps["foo2"], .scm(location: "/foo2", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
 
-            XCTAssertEqual(deps["/foo3"]?.location, "/foo3")
-            XCTAssertEqual(deps["/foo3"]?.requirement, .localPackage)
+            if case .local(let dep) = deps["foo3"] {
+                XCTAssertEqual(dep.path.pathString, "/foo3")
+            } else {
+                XCTFail("expected to be local dependency")
+            }
 
-            XCTAssertEqual(deps["/path/to/foo4"]?.location, "/path/to/foo4")
-            XCTAssertEqual(deps["/path/to/foo4"]?.requirement, .localPackage)
+            if case .local(let dep) = deps["foo4"] {
+                XCTAssertEqual(dep.path.pathString, "/path/to/foo4")
+            } else {
+                XCTFail("expected to be local dependency")
+            }
 
-            XCTAssertEqual(deps["/foo5"], PackageDependencyDescription(location: "/foo5", requirement: .exact("1.2.3")))
-            XCTAssertEqual(deps["/foo6"], PackageDependencyDescription(location: "/foo6", requirement: .range("1.2.3"..<"2.0.0")))
-            XCTAssertEqual(deps["/foo7"], PackageDependencyDescription(location: "/foo7", requirement: .branch("master")))
-            XCTAssertEqual(deps["/foo8"], PackageDependencyDescription(location: "/foo8", requirement: .upToNextMinor(from: "1.3.4")))
-            XCTAssertEqual(deps["/foo9"], PackageDependencyDescription(location: "/foo9", requirement: .upToNextMajor(from: "1.3.4")))
+            XCTAssertEqual(deps["foo5"], .scm(location: "/foo5", requirement: .exact("1.2.3")))
+            XCTAssertEqual(deps["foo6"], .scm(location: "/foo6", requirement: .range("1.2.3"..<"2.0.0")))
+            XCTAssertEqual(deps["foo7"], .scm(location: "/foo7", requirement: .branch("master")))
+            XCTAssertEqual(deps["foo8"], .scm(location: "/foo8", requirement: .upToNextMinor(from: "1.3.4")))
+            XCTAssertEqual(deps["foo9"], .scm(location: "/foo9", requirement: .upToNextMajor(from: "1.3.4")))
 
             let homeDir = "/home/user"
-            XCTAssertEqual(deps["\(homeDir)/path/to/foo10"]?.location, "\(homeDir)/path/to/foo10")
-            XCTAssertEqual(deps["\(homeDir)/path/to/foo10"]?.requirement, .localPackage)
+            if case .local(let dep) = deps["foo10"] {
+                XCTAssertEqual(dep.path.pathString, "\(homeDir)/path/to/foo10")
+            } else {
+                XCTFail("expected to be local dependency")
+            }
 
-            XCTAssertEqual(deps["/foo/~foo11"]?.location, "/foo/~foo11")
-            XCTAssertEqual(deps["/foo/~foo11"]?.requirement, .localPackage)
+            if case .local(let dep) = deps["~foo11"] {
+                XCTAssertEqual(dep.path.pathString, "/foo/~foo11")
+            } else {
+                XCTFail("expected to be local dependency")
+            }
 
-            XCTAssertEqual(deps["\(homeDir)/path/to/~/foo12"]?.location, "\(homeDir)/path/to/~/foo12")
-            XCTAssertEqual(deps["\(homeDir)/path/to/~/foo12"]?.requirement, .localPackage)
+            if case .local(let dep) = deps["foo12"] {
+                XCTAssertEqual(dep.path.pathString, "\(homeDir)/path/to/~/foo12")
+            } else {
+                XCTFail("expected to be local dependency")
+            }
 
-            XCTAssertEqual(deps["/foo/~"]?.location, "/foo/~")
-            XCTAssertEqual(deps["/foo/~"]?.requirement, .localPackage)
+            if case .local(let dep) = deps["~"] {
+                XCTAssertEqual(dep.path.pathString, "/foo/~")
+            } else {
+                XCTFail("expected to be local dependency")
+            }
 
-            XCTAssertEqual(deps["/path/to/foo13"]?.location, "/path/to/foo13")
-            XCTAssertEqual(deps["/path/to/foo13"]?.requirement, .localPackage)
+            if case .local(let dep) = deps["foo13"] {
+                XCTAssertEqual(dep.path.pathString, "/path/to/foo13")
+            } else {
+                XCTFail("expected to be local dependency")
+            }
         }
     }
 
@@ -499,8 +520,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             let delegate = ManifestTestDelegate()
 
-            let manifestLoader = ManifestLoader(
-                manifestResources: Resources.default, cacheDir: path, delegate: delegate)
+            let manifestLoader = ManifestLoader(manifestResources: Resources.default, cacheDir: path, delegate: delegate)
 
             func check(loader: ManifestLoader, expectCached: Bool) {
                 delegate.clear()
@@ -556,8 +576,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             let delegate = ManifestTestDelegate()
 
-            let manifestLoader = ManifestLoader(
-                manifestResources: Resources.default, cacheDir: path, delegate: delegate)
+            let manifestLoader = ManifestLoader(manifestResources: Resources.default, cacheDir: path, delegate: delegate)
 
             func check(loader: ManifestLoader, expectCached: Bool) {
                 delegate.clear()
@@ -602,8 +621,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 check(loader: manifestLoader, expectCached: true)
             }
 
-            let noCacheLoader = ManifestLoader(
-                manifestResources: Resources.default, delegate: delegate)
+            let noCacheLoader = ManifestLoader(manifestResources: Resources.default, delegate: delegate)
             for _ in 0..<2 {
                 check(loader: noCacheLoader, expectCached: false)
             }
@@ -630,8 +648,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             let delegate = ManifestTestDelegate()
 
-            let manifestLoader = ManifestLoader(
-                manifestResources: Resources.default, cacheDir: path, delegate: delegate)
+            let manifestLoader = ManifestLoader(manifestResources: Resources.default, cacheDir: path, delegate: delegate)
 
             func check(loader: ManifestLoader) throws {
                 let fs = InMemoryFileSystem()
@@ -739,6 +756,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             let diagnostics = DiagnosticsEngine()
             let delegate = ManifestTestDelegate()
             let manifestLoader = ManifestLoader(manifestResources: Resources.default, cacheDir: path, delegate: delegate)
+            let identityResolver = DefaultIdentityResolver()
 
             // warm up caches
             let manifest = try tsc_await { manifestLoader.load(at: manifestPath.parentDirectory,
@@ -747,6 +765,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                                                                version: nil,
                                                                revision: nil,
                                                                toolsVersion: .v4_2,
+                                                               identityResolver: identityResolver,
                                                                fileSystem: localFileSystem,
                                                                on: .global(),
                                                                completion: $0) }
@@ -763,6 +782,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                                     version: nil,
                                     revision: nil,
                                     toolsVersion: .v4_2,
+                                    identityResolver: identityResolver,
                                     fileSystem: localFileSystem,
                                     diagnostics: diagnostics,
                                     on: .global()) { result in
@@ -796,6 +816,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             let diagnostics = DiagnosticsEngine()
             let delegate = ManifestTestDelegate()
             let manifestLoader = ManifestLoader(manifestResources: Resources.default, cacheDir: path, delegate: delegate)
+            let identityResolver = DefaultIdentityResolver()
 
             let sync = DispatchGroup()
             for _ in 0 ..< total {
@@ -824,6 +845,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                                     version: nil,
                                     revision: nil,
                                     toolsVersion: .v4_2,
+                                    identityResolver: identityResolver,
                                     fileSystem: localFileSystem,
                                     diagnostics: diagnostics,
                                     on: .global()) { result in

--- a/Tests/PackageLoadingTests/PD5LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5LoadingTests.swift
@@ -62,8 +62,8 @@ class PackageDescription5LoadingTests: PackageDescriptionLoadingTests {
             XCTAssertEqual(bar.dependencies, ["foo"])
 
             // Check dependencies.
-            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.location, $0) })
-            XCTAssertEqual(deps["/foo1"], PackageDependencyDescription(location: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
+            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
+            XCTAssertEqual(deps["foo1"], .scm(location: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
 
             // Check products.
             let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })
@@ -343,7 +343,8 @@ class PackageDescription5LoadingTests: PackageDescriptionLoadingTests {
 
             let loader = ManifestLoader(
                 manifestResources: Resources.default,
-                serializedDiagnostics: true, cacheDir: path)
+                serializedDiagnostics: true,
+                cacheDir: path)
 
             do {
                 _ = try loader.load(

--- a/Tests/PackageLoadingTests/PD5_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5_2LoadingTests.swift
@@ -48,7 +48,7 @@ class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
         }
     }
 
-    func testDepenencyNameForTargetDependencyResolution() throws {
+    func testDependencyNameForTargetDependencyResolution() throws {
         let stream = BufferedOutputByteStream()
         stream <<< """
             import PackageDescription

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -2019,7 +2019,7 @@ class PackageBuilderTests: XCTestCase {
             name: "Foo",
             v: .v5,
             dependencies: [
-                PackageDependencyDescription(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                .scm(location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
             ],
             targets: [
                 try TargetDescription(
@@ -2053,7 +2053,7 @@ class PackageBuilderTests: XCTestCase {
             name: "Foo",
             v: .v5,
             dependencies: [
-                PackageDependencyDescription(location: "/Biz", requirement: .localPackage),
+                .local(path: "/Biz"),
             ],
             targets: [
                 try TargetDescription(

--- a/Tests/PackageModelTests/ManifestTests.swift
+++ b/Tests/PackageModelTests/ManifestTests.swift
@@ -67,10 +67,10 @@ class ManifestTests: XCTestCase {
     }
 
     func testRequiredDependencies() throws {
-        let dependencies = [
-            PackageDependencyDescription(location: "/Bar1", requirement: .upToNextMajor(from: "1.0.0")),
-            PackageDependencyDescription(location: "/Bar2", requirement: .upToNextMajor(from: "1.0.0")),
-            PackageDependencyDescription(location: "/Bar3", requirement: .upToNextMajor(from: "1.0.0")),
+        let dependencies: [PackageDependencyDescription] = [
+            .scm(location: "/Bar1", requirement: .upToNextMajor(from: "1.0.0")),
+            .scm(location: "/Bar2", requirement: .upToNextMajor(from: "1.0.0")),
+            .scm(location: "/Bar3", requirement: .upToNextMajor(from: "1.0.0")),
         ]
 
         let products = [
@@ -95,10 +95,10 @@ class ManifestTests: XCTestCase {
                 targets: targets
             )
 
-            XCTAssertEqual(manifest.dependenciesRequired(for: .everything).map({ $0.location }).sorted(), [
-                "/Bar1",
-                "/Bar2",
-                "/Bar3",
+            XCTAssertEqual(manifest.dependenciesRequired(for: .everything).map({ $0.identity.description }).sorted(), [
+                "bar1",
+                "bar2",
+                "bar3",
             ])
         }
 
@@ -114,10 +114,10 @@ class ManifestTests: XCTestCase {
                 targets: targets
             )
 
-            XCTAssertEqual(manifest.dependenciesRequired(for: .specific(["Foo"])).map({ $0.location }).sorted(), [
-                "/Bar1", // Foo → Foo1 → Bar1
-                "/Bar2", // Foo → Foo1 → Foo2 → Bar2
-                "/Bar3", // Foo → Foo1 → Bar1 → could be from any package due to pre‐5.2 tools version.
+            XCTAssertEqual(manifest.dependenciesRequired(for: .specific(["Foo"])).map({ $0.identity.description }).sorted(), [
+                "bar1", // Foo → Foo1 → Bar1
+                "bar2", // Foo → Foo1 → Foo2 → Bar2
+                "bar3", // Foo → Foo1 → Bar1 → could be from any package due to pre‐5.2 tools version.
             ])
         }
 
@@ -133,10 +133,10 @@ class ManifestTests: XCTestCase {
                 targets: targets
             )
 
-            XCTAssertEqual(manifest.dependenciesRequired(for: .everything).map({ $0.location }).sorted(), [
-                "/Bar1",
-                "/Bar2",
-                "/Bar3",
+            XCTAssertEqual(manifest.dependenciesRequired(for: .everything).map({ $0.identity.description }).sorted(), [
+                "bar1",
+                "bar2",
+                "bar3",
             ])
         }
 

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -22,6 +22,7 @@ class ManifestSourceGenerationTests: XCTestCase {
             // Write the original manifest file contents, and load it.
             try fs.writeFileContents(packageDir.appending(component: Manifest.filename), bytes: ByteString(encodingAsUTF8: manifestContents))
             let manifestLoader = ManifestLoader(manifestResources: Resources.default)
+            let identityResolver = DefaultIdentityResolver()
             let manifest = try tsc_await {
                 manifestLoader.load(at: packageDir,
                                     packageKind: .root,
@@ -29,6 +30,7 @@ class ManifestSourceGenerationTests: XCTestCase {
                                     version: nil,
                                     revision: nil,
                                     toolsVersion: toolsVersion,
+                                    identityResolver: identityResolver,
                                     fileSystem: fs,
                                     on: .global(),
                                     completion: $0)
@@ -44,6 +46,7 @@ class ManifestSourceGenerationTests: XCTestCase {
                                     version: nil,
                                     revision: nil,
                                     toolsVersion: toolsVersion,
+                                    identityResolver: identityResolver,
                                     fileSystem: fs,
                                     on: .global(),
                                     completion: $0)

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -42,7 +42,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo", "Bar"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -71,8 +71,8 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let deps: [MockDependency] = [
-            .init(name: "Quix", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Quix"])),
-            .init(name: "Baz", requirement: .exact("1.0.0"), products: .specific(["Baz"])),
+            .git(name: "Quix", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Quix"])),
+            .git(name: "Baz", requirement: .exact("1.0.0"), products: .specific(["Baz"])),
         ]
         workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
@@ -193,7 +193,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
                 MockPackage(
@@ -203,7 +203,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Baz", requirement: .exact("1.0.1")),
+                        .git(name: "Baz", requirement: .exact("1.0.1")),
                     ]
                 ),
             ],
@@ -250,7 +250,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: nil, path: "bazzz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: nil, path: "bazzz", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -318,7 +318,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -336,12 +336,12 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let dependencies: [PackageDependencyDescription] = [
-            .init(
+            .scm(
                 location: workspace.packagesDir.appending(component: "Foo").pathString,
                 requirement: .upToNextMajor(from: "1.0.0"),
                 productFilter: .specific(["Foo"])
             ),
-            .init(
+            .scm(
                 location: workspace.packagesDir.appending(component: "Bar").pathString + ".git",
                 requirement: .upToNextMajor(from: "1.0.0"),
                 productFilter: .specific(["Bar"])
@@ -428,7 +428,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "BarPackage", path: "bar-package", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "BarPackage", path: "bar-package", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -460,7 +460,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraph(roots: ["foo-package", "bar-package"],
-                                    dependencies: [PackageDependencyDescription(location: "/tmp/ws/pkgs/bar-package", requirement: .upToNextMajor(from: "1.0.0"), productFilter: .everything)]) { graph, diagnostics in
+                                    dependencies: [.scm(location: "/tmp/ws/pkgs/bar-package", requirement: .upToNextMajor(from: "1.0.0"))]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(roots: "FooPackage", "BarPackage")
                 result.check(packages: "FooPackage", "BarPackage")
@@ -486,7 +486,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -547,7 +547,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
                 MockPackage(
@@ -628,7 +628,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -646,12 +646,12 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let dependencies: [PackageDependencyDescription] = [
-            .init(
+            .scm(
                 location: workspace.packagesDir.appending(component: "Bar").pathString,
                 requirement: .upToNextMajor(from: "1.0.0"),
                 productFilter: .specific(["Bar"])
             ),
-            .init(
+            .scm(
                 location: workspace.packagesDir.appending(component: "Foo").pathString,
                 requirement: .upToNextMajor(from: "1.0.0"),
                 productFilter: .specific(["Foo"])
@@ -690,7 +690,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "A", targets: ["A"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "AA", requirement: .exact("1.0.0")),
+                        .git(name: "AA", requirement: .exact("1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -703,7 +703,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "A", targets: ["A"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "AA", requirement: .exact("2.0.0")),
+                        .git(name: "AA", requirement: .exact("2.0.0")),
                     ],
                     versions: ["1.0.1"]
                 ),
@@ -723,7 +723,7 @@ final class WorkspaceTests: XCTestCase {
         // Resolve when A = 1.0.0.
         do {
             let deps: [MockDependency] = [
-                .init(name: "A", requirement: .exact("1.0.0"), products: .specific(["A"])),
+                .git(name: "A", requirement: .exact("1.0.0"), products: .specific(["A"])),
             ]
             workspace.checkPackageGraph(deps: deps) { graph, diagnostics in
                 PackageGraphTester(graph) { result in
@@ -746,7 +746,7 @@ final class WorkspaceTests: XCTestCase {
         // Resolve when A = 1.0.1.
         do {
             let deps: [MockDependency] = [
-                .init(name: "A", requirement: .exact("1.0.1"), products: .specific(["A"])),
+                .git(name: "A", requirement: .exact("1.0.1"), products: .specific(["A"])),
             ]
             workspace.checkPackageGraph(deps: deps) { graph, diagnostics in
                 PackageGraphTester(graph) { result in
@@ -786,7 +786,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "A", targets: ["A"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "AA", requirement: .exact("1.0.0")),
+                        .git(name: "AA", requirement: .exact("1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -799,7 +799,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "B", targets: ["B"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "AA", requirement: .exact("2.0.0")),
+                        .git(name: "AA", requirement: .exact("2.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -817,8 +817,8 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let deps: [MockDependency] = [
-            .init(name: "A", requirement: .exact("1.0.0"), products: .specific(["A"])),
-            .init(name: "B", requirement: .exact("1.0.0"), products: .specific(["B"])),
+            .git(name: "A", requirement: .exact("1.0.0"), products: .specific(["A"])),
+            .git(name: "B", requirement: .exact("1.0.0"), products: .specific(["B"])),
         ]
         workspace.checkPackageGraph(deps: deps) { _, diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
@@ -884,8 +884,8 @@ final class WorkspaceTests: XCTestCase {
                     targets: [MockTarget(name: "A")],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "B", requirement: v1Requirement),
-                        MockDependency(name: "C", requirement: v1Requirement),
+                        .git(name: "B", requirement: v1Requirement),
+                        .git(name: "C", requirement: v1Requirement),
                     ]
                 ),
             ],
@@ -941,8 +941,8 @@ final class WorkspaceTests: XCTestCase {
                     targets: [MockTarget(name: "A")],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "B", requirement: v1Requirement),
-                        MockDependency(name: "C", requirement: branchRequirement),
+                        .git(name: "B", requirement: v1Requirement),
+                        .git(name: "C", requirement: branchRequirement),
                     ]
                 ),
             ],
@@ -1000,7 +1000,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [MockTarget(name: "A")],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "C", requirement: .revision("hello")),
+                        .git(name: "C", requirement: .revision("hello")),
                     ]
                 ),
             ],
@@ -1051,8 +1051,8 @@ final class WorkspaceTests: XCTestCase {
                     targets: [MockTarget(name: "A")],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "B", requirement: v1Requirement),
-                        MockDependency(name: "C", requirement: masterRequirement),
+                        .git(name: "B", requirement: v1Requirement),
+                        .git(name: "C", requirement: masterRequirement),
                     ]
                 ),
             ],
@@ -1101,7 +1101,7 @@ final class WorkspaceTests: XCTestCase {
         let bPath = RelativePath("B")
         let cPath = RelativePath("C")
         let v1Requirement: MockDependency.Requirement = .range("1.0.0" ..< "2.0.0")
-        let localRequirement: MockDependency.Requirement = .localPackage
+        //let localRequirement: MockDependency.Requirement = .localPackage
         let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
 
         let workspace = try MockWorkspace(
@@ -1113,8 +1113,8 @@ final class WorkspaceTests: XCTestCase {
                     targets: [MockTarget(name: "A")],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "B", requirement: v1Requirement),
-                        MockDependency(name: "C", requirement: localRequirement),
+                        .git(name: "B", requirement: v1Requirement),
+                        .local(name: "C"),
                     ]
                 ),
             ],
@@ -1163,7 +1163,7 @@ final class WorkspaceTests: XCTestCase {
         let bPath = RelativePath("B")
         let cPath = RelativePath("C")
         let v1Requirement: MockDependency.Requirement = .range("1.0.0" ..< "2.0.0")
-        let localRequirement: MockDependency.Requirement = .localPackage
+        //let localRequirement: MockDependency.Requirement = .localPackage
         let v1_5 = CheckoutState(revision: Revision(identifier: "hello"), version: "1.0.5")
         let master = CheckoutState(revision: Revision(identifier: "master"), branch: "master")
 
@@ -1176,8 +1176,8 @@ final class WorkspaceTests: XCTestCase {
                     targets: [MockTarget(name: "A")],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "B", requirement: v1Requirement),
-                        MockDependency(name: "C", requirement: localRequirement),
+                        .git(name: "B", requirement: v1Requirement),
+                        .local(name: "C"),
                     ]
                 ),
             ],
@@ -1238,8 +1238,8 @@ final class WorkspaceTests: XCTestCase {
                     targets: [MockTarget(name: "A")],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "B", requirement: v1Requirement),
-                        MockDependency(name: "C", requirement: v2Requirement),
+                        .git(name: "B", requirement: v1Requirement),
+                        .git(name: "C", requirement: v2Requirement),
                     ]
                 ),
             ],
@@ -1297,8 +1297,8 @@ final class WorkspaceTests: XCTestCase {
                     targets: [MockTarget(name: "A")],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "B", requirement: v1Requirement),
-                        MockDependency(name: "C", requirement: v2Requirement),
+                        .git(name: "B", requirement: v1Requirement),
+                        .git(name: "C", requirement: v2Requirement),
                     ]
                 ),
             ],
@@ -1378,7 +1378,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Root", targets: ["Root"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -1392,7 +1392,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -1421,7 +1421,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Do an intial run, capping at Foo at 1.0.0.
         let deps: [MockDependency] = [
-            .init(name: "Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
+            .git(name: "Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
@@ -1476,7 +1476,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Root", targets: ["Root"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -1506,7 +1506,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Do an intial run, capping at Foo at 1.0.0.
         let deps: [MockDependency] = [
-            .init(name: "Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
+            .git(name: "Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
         ]
 
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
@@ -1569,7 +1569,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Root", targets: ["Root"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -1583,7 +1583,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.5.0"]
                 ),
@@ -1596,7 +1596,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Bar", requirement: .upToNextMinor(from: "1.0.0")),
+                        .git(name: "Bar", requirement: .upToNextMinor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -1615,7 +1615,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Do an intial run, capping at Foo at 1.0.0.
         let deps: [MockDependency] = [
-            .init(name: "Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
+            .git(name: "Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -1673,7 +1673,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Root", targets: ["Root"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -1750,7 +1750,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
                 MockPackage(
@@ -1760,7 +1760,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -1820,10 +1820,10 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        MockDependency(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
-                        MockDependency(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
-                        MockDependency(name: "Bam", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Bam", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -1837,8 +1837,8 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
-                        MockDependency(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -1852,7 +1852,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Baz", targets: ["Baz"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Bam", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Bam", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -1886,7 +1886,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Foo", requirement: .branch("develop")),
+                        .git(name: "Foo", requirement: .branch("develop")),
                     ]
                 ),
             ],
@@ -1920,7 +1920,7 @@ final class WorkspaceTests: XCTestCase {
 
         // We request Bar via revision.
         let deps: [MockDependency] = [
-            .init(name: "Bar", requirement: .revision(barRevision), products: .specific(["Bar"])),
+            .git(name: "Bar", requirement: .revision(barRevision), products: .specific(["Bar"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
@@ -1950,7 +1950,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2023,7 +2023,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2069,7 +2069,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2172,8 +2172,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        MockDependency(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2280,7 +2280,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2346,7 +2346,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let deps: [MockDependency] = [
-            .init(name: "Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
+            .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
         ]
         let ws = workspace.createWorkspace()
 
@@ -2404,8 +2404,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        MockDependency(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2434,7 +2434,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let deps: [MockDependency] = [
-            .init(name: "Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
+            .git(name: "Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
         ]
         // Load the graph.
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
@@ -2525,7 +2525,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2549,7 +2549,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: [nil]
                 ),
@@ -2579,7 +2579,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         let deps: [MockDependency] = [
-            .init(name: "Foo", requirement: .localPackage, products: .specific(["Foo"])),
+            .local(name: "Foo", products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
@@ -2612,7 +2612,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Bar", requirement: .exact("1.0.0")),
+                        .git(name: "Bar", requirement: .exact("1.0.0"))
                     ]
                 ),
             ],
@@ -2643,21 +2643,34 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Check that changing the requirement to 1.5.0 triggers re-resolution.
-        //
-        // FIXME: Find a cleaner way to change a dependency requirement.
         let fooKey = MockManifestLoader.Key(url: "/tmp/ws/roots/Foo")
         let manifest = workspace.manifestLoader.manifests[fooKey]!
-        workspace.manifestLoader.manifests[fooKey] = Manifest(
-            name: manifest.name,
-            path: manifest.path,
-            packageKind: .root,
-            packageLocation: manifest.packageLocation,
-            platforms: [],
-            version: manifest.version,
-            toolsVersion: manifest.toolsVersion,
-            dependencies: [PackageDependencyDescription(location: manifest.dependencies[0].location, requirement: .exact("1.5.0"))],
-            targets: manifest.targets
-        )
+
+        let dependency = manifest.dependencies[0]
+        switch dependency {
+        case .scm(let data):
+            let updatedDependency: PackageDependencyDescription = .scm(
+                identity: data.identity,
+                name: data.name,
+                location: data.location,
+                requirement: .exact("1.5.0"),
+                productFilter: data.productFilter
+            )
+
+            workspace.manifestLoader.manifests[fooKey] = Manifest(
+                name: manifest.name,
+                path: manifest.path,
+                packageKind: .root,
+                packageLocation: manifest.packageLocation,
+                platforms: [],
+                version: manifest.version,
+                toolsVersion: manifest.toolsVersion,
+                dependencies: [updatedDependency],
+                targets: manifest.targets
+            )
+        default:
+            XCTFail("unexpected dependency type")
+        }
 
         workspace.checkPackageGraph(roots: ["Foo"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -2682,7 +2695,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2738,7 +2751,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Try resolving a bad graph.
         let deps: [MockDependency] = [
-            .init(name: "Bar", requirement: .exact("1.1.0"), products: .specific(["Bar"])),
+            .git(name: "Bar", requirement: .exact("1.1.0"), products: .specific(["Bar"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
@@ -2764,7 +2777,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Root", targets: ["Root"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2812,8 +2825,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Bar", requirement: .localPackage),
-                        MockDependency(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .local(name: "Bar"),
+                        .git(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2837,7 +2850,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Baz", targets: ["Baz"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0", "1.5.0"]
                 ),
@@ -2890,7 +2903,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2904,7 +2917,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Bar", targets: ["Bar"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Baz", requirement: .localPackage),
+                        .local(name: "Baz"),
                     ],
                     versions: ["1.0.0", "1.5.0", nil]
                 ),
@@ -2950,7 +2963,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2981,7 +2994,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Override with local package and run update.
         let deps: [MockDependency] = [
-            .init(name: "Bar", requirement: .localPackage, products: .specific(["Bar"])),
+            .local(name: "Bar", products: .specific(["Bar"])),
         ]
         workspace.checkUpdate(roots: ["Foo"], deps: deps) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3014,7 +3027,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: nil, path: "Bar", requirement: .localPackage),
+                        .local(name: nil, path: "Bar"),
                     ]
                 ),
             ],
@@ -3069,7 +3082,7 @@ final class WorkspaceTests: XCTestCase {
         // without running swift package update.
 
         var deps: [MockDependency] = [
-            .init(name: "Foo", requirement: .branch("develop"), products: .specific(["Foo"])),
+            .git(name: "Foo", requirement: .branch("develop"), products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
@@ -3083,7 +3096,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         deps = [
-            .init(name: "Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
+            .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3093,7 +3106,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         deps = [
-            .init(name: "Foo", requirement: .branch("develop"), products: .specific(["Foo"])),
+            .git(name: "Foo", requirement: .branch("develop"), products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3138,7 +3151,7 @@ final class WorkspaceTests: XCTestCase {
         // without running swift package update.
 
         var deps: [MockDependency] = [
-            .init(name: "Foo", requirement: .localPackage, products: .specific(["Foo"])),
+            .local(name: "Foo", products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
@@ -3152,7 +3165,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         deps = [
-            .init(name: "Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
+            .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3162,7 +3175,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         deps = [
-            .init(name: "Foo", requirement: .localPackage, products: .specific(["Foo"])),
+            .local(name: "Foo", products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3218,7 +3231,7 @@ final class WorkspaceTests: XCTestCase {
         // different locations works correctly.
 
         var deps: [MockDependency] = [
-            .init(name: "Foo", requirement: .localPackage, products: .specific(["Foo"])),
+            .local(name: "Foo", products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
@@ -3232,7 +3245,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         deps = [
-            .init(name: "Foo2", requirement: .localPackage, products: .specific(["Foo"])),
+            .local(name: "Foo2", products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3288,7 +3301,7 @@ final class WorkspaceTests: XCTestCase {
         // different locations works correctly.
 
         var deps: [MockDependency] = [
-            .init(name: "Foo", requirement: .localPackage, products: .specific(["Foo"])),
+            .local(name: "Foo", products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
@@ -3306,7 +3319,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         deps = [
-            .init(name: "Nested/Foo", requirement: .localPackage, products: .specific(["Foo"])),
+            .local(name: "Nested/Foo", products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3352,7 +3365,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let deps: [MockDependency] = [
-            .init(name: "Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
+            .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3379,9 +3392,15 @@ final class WorkspaceTests: XCTestCase {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
+        let config = try Workspace.Configuration(path: sandbox.appending(component: "swiftpm"), fs: fs)
+        config.mirrors.set(mirrorURL: sandbox.appending(components: "pkgs", "Baz").pathString, forURL: sandbox.appending(components: "pkgs", "Bar").pathString)
+        config.mirrors.set(mirrorURL: sandbox.appending(components: "pkgs", "Baz").pathString, forURL: sandbox.appending(components: "pkgs", "Bam").pathString)
+        try config.saveState()
+
         let workspace = try MockWorkspace(
             sandbox: sandbox,
             fs: fs,
+            config: config,
             roots: [
                 MockPackage(
                     name: "Foo",
@@ -3392,7 +3411,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Dep", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Dep", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -3407,7 +3426,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Dep", targets: ["Dep"]),
                     ],
                     dependencies: [
-                        MockDependency(name: nil, path: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(path: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0", "1.5.0"],
                     toolsVersion: .v5
@@ -3445,26 +3464,8 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
-            PackageGraphTester(graph) { result in
-                result.check(roots: "Foo")
-                result.check(packages: "Foo", "Dep", "Bar")
-                result.check(targets: "Foo", "Dep", "Bar")
-            }
-            XCTAssertNoDiagnostics(diagnostics)
-        }
-        workspace.checkManagedDependencies { result in
-            result.check(dependency: "Dep", at: .checkout(.version("1.5.0")))
-            result.check(dependency: "Bar", at: .checkout(.version("1.5.0")))
-            result.check(notPresent: "Baz")
-        }
-
-        workspace.config.mirrors.set(mirrorURL: workspace.packagesDir.appending(component: "Baz").pathString, forURL: workspace.packagesDir.appending(component: "Bar").pathString)
-        workspace.config.mirrors.set(mirrorURL: workspace.packagesDir.appending(component: "Baz").pathString, forURL: workspace.packagesDir.appending(component: "Bam").pathString)
-        try workspace.config.saveState()
-
         let deps: [MockDependency] = [
-            .init(name: "Bam", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Bar"])),
+            .git(name: "Bam", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Bar"])),
         ]
 
         workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
@@ -3498,7 +3499,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -3512,7 +3513,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Bar", targets: ["Bar"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -3525,7 +3526,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Bar", targets: ["Bar"]),
                     ],
                     dependencies: [
-                        MockDependency(name: nil, path: "Nested/Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: nil, path: "Nested/Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.1.0"],
                     toolsVersion: .v5
@@ -3568,7 +3569,7 @@ final class WorkspaceTests: XCTestCase {
         // dependencies.
 
         var deps: [MockDependency] = [
-            .init(name: "Bar", requirement: .exact("1.0.0"), products: .specific(["Bar"])),
+            .git(name: "Bar", requirement: .exact("1.0.0"), products: .specific(["Bar"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
@@ -3592,7 +3593,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         deps = [
-            .init(name: "Bar", requirement: .exact("1.1.0"), products: .specific(["Bar"])),
+            .git(name: "Bar", requirement: .exact("1.1.0"), products: .specific(["Bar"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
@@ -3627,8 +3628,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        MockDependency(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -3658,7 +3659,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Load the initial graph.
         let deps: [MockDependency] = [
-            .init(name: "Bar", requirement: .revision("develop"), products: .specific(["Bar"])),
+            .git(name: "Bar", requirement: .revision("develop"), products: .specific(["Bar"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3743,7 +3744,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Foo", requirement: .localPackage),
+                        .local(name: "Foo"),
                     ]
                 ),
             ],
@@ -3781,18 +3782,38 @@ final class WorkspaceTests: XCTestCase {
         // (This just uses the same one used by all the other tests.)
         let swiftCompiler = Resources.default.swiftCompiler
 
+        // identity resolver helps go from textual description to actual identity
+        let identityResolver = DefaultIdentityResolver()
+
         // From here the API should be simple and straightforward:
         let diagnostics = DiagnosticsEngine()
         let manifest = try tsc_await {
-            ManifestLoader.loadManifest(at: packagePath, kind: .local, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], on: .global(), completion: $0)
+            ManifestLoader.loadManifest(at: packagePath,
+                                        kind: .local,
+                                        swiftCompiler: swiftCompiler,
+                                        swiftCompilerFlags: [],
+                                        identityResolver: identityResolver,
+                                        on: .global(),
+                                        completion: $0)
         }
 
         let loadedPackage = try tsc_await {
-            PackageBuilder.loadPackage(at: packagePath, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], xcTestMinimumDeploymentTargets: [:], diagnostics: diagnostics, on: .global(), completion: $0)
+            PackageBuilder.loadPackage(at: packagePath,
+                                       swiftCompiler: swiftCompiler,
+                                       swiftCompilerFlags: [],
+                                       xcTestMinimumDeploymentTargets: [:],
+                                       identityResolver: identityResolver,
+                                       diagnostics: diagnostics,
+                                       on: .global(),
+                                       completion: $0)
         }
 
         let graph = try Workspace.loadGraph(
-            packagePath: packagePath, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], diagnostics: diagnostics
+            packagePath: packagePath,
+            swiftCompiler: swiftCompiler,
+            swiftCompilerFlags: [],
+            identityResolver: identityResolver,
+            diagnostics: diagnostics
         )
 
         XCTAssertEqual(manifest.name, "SwiftPM")
@@ -3815,7 +3836,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Foo", requirement: .branch("develop")),
+                        .git(name: "Foo", requirement: .branch("develop")),
                     ]
                 ),
             ],
@@ -3829,7 +3850,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Local", requirement: .localPackage),
+                        .local(name: "Local"),
                     ],
                     versions: ["develop"]
                 ),
@@ -3888,7 +3909,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let deps: [MockDependency] = [
-            .init(name: "bazzz", requirement: .exact("1.0.0"), products: .specific(["Baz"])),
+            .git(name: "bazzz", requirement: .exact("1.0.0"), products: .specific(["Baz"])),
         ]
 
         workspace.checkPackageGraph(roots: ["Overridden/bazzz-master"], deps: deps) { _, diagnostics in
@@ -3923,8 +3944,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Bar", requirement: .localPackage),
-                        MockDependency(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .local(name: "Bar"),
+                        .git(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -3948,7 +3969,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Baz", targets: ["Baz"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0", "1.5.0"]
                 ),
@@ -3979,8 +4000,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Foo", requirement: .branch("master")),
-                        MockDependency(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Foo", requirement: .branch("master")),
+                        .git(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -3994,7 +4015,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Bar", requirement: .branch("master")),
+                        .git(name: "Bar", requirement: .branch("master")),
                     ],
                     versions: ["master", nil]
                 ),
@@ -4017,7 +4038,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Baz", targets: ["Baz"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0", nil]
                 ),
@@ -4089,9 +4110,9 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        MockDependency(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
-                        MockDependency(name: "TestHelper1", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "TestHelper1", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5_2
                 ),
@@ -4108,8 +4129,8 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo1"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "TestHelper2", requirement: .upToNextMajor(from: "1.0.0")),
-                        MockDependency(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "TestHelper2", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"],
                     toolsVersion: .v5_2
@@ -4123,8 +4144,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: barProducts,
                     dependencies: [
-                        MockDependency(name: "TestHelper2", requirement: .upToNextMajor(from: "1.0.0")),
-                        MockDependency(name: "Biz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "TestHelper2", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "Biz", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"],
                     toolsVersion: .v5_2
@@ -4285,8 +4306,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "A", requirement: .exact("1.0.0")),
-                        MockDependency(name: "B", requirement: .exact("1.0.0")),
+                        .git(name: "A", requirement: .exact("1.0.0")),
+                        .git(name: "B", requirement: .exact("1.0.0")),
                     ]
                 ),
             ],
@@ -4534,7 +4555,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "A", requirement: .exact("1.0.0")),
+                        .git(name: "A", requirement: .exact("1.0.0")),
                     ]
                 ),
             ],
@@ -4596,7 +4617,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "A", requirement: .exact("1.0.0")),
+                        .git(name: "A", requirement: .exact("1.0.0")),
                     ]
                 ),
             ],
@@ -4681,8 +4702,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "FooUtilityPackage", path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
-                        MockDependency(name: "BarUtilityPackage", path: "bar/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "FooUtilityPackage", path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "BarUtilityPackage", path: "bar/utility", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -4743,8 +4764,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "FooPackage", path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        MockDependency(name: "FooPackage", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "FooPackage", path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "FooPackage", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -4805,8 +4826,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "FooUtilityPackage", path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
-                        MockDependency(name: "BarPackage", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "FooUtilityPackage", path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "BarPackage", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -4835,7 +4856,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "BarProduct", targets: ["BarTarget"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "OtherUtilityPackage", path: "other/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "OtherUtilityPackage", path: "other/utility", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -4885,8 +4906,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: nil, path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
-                        MockDependency(name: nil, path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: nil, path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: nil, path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -4915,7 +4936,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "BarProduct", targets: ["BarTarget"]),
                     ],
                     dependencies: [
-                        MockDependency(name: nil, path: "other-foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: nil, path: "other-foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -4964,7 +4985,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "FooUtilityPackage", path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "FooUtilityPackage", path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -4982,7 +5003,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "FooUtilityProduct", targets: ["FooUtilityTarget"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "BarPackage", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "BarPackage", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -4998,7 +5019,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "BarProduct", targets: ["BarTarget"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "OtherUtilityPackage", path: "other/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "OtherUtilityPackage", path: "other/utility", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -5047,7 +5068,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: nil, path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -5065,7 +5086,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "FooUtilityProduct", targets: ["FooUtilityTarget"]),
                     ],
                     dependencies: [
-                        MockDependency(name: nil, path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"],
                     toolsVersion: .v5
@@ -5082,7 +5103,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "BarProduct", targets: ["BarTarget"]),
                     ],
                     dependencies: [
-                        MockDependency(name: nil, path: "other/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(path: "other/utility", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"],
                     toolsVersion: .v5
@@ -5133,7 +5154,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        MockDependency(name: "BarPackage", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "BarPackage", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -5151,7 +5172,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "BarProduct", targets: ["BarTarget"]),
                     ],
                     dependencies: [
-                        MockDependency(name: "FooPackage", path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "FooPackage", path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -60,7 +60,7 @@ class PIFBuilderTests: XCTestCase {
                         packageLocation: "/A",
                         v: .v5_2,
                         dependencies: [
-                            .init(name: "B", location: "/B", requirement: .branch("master")),
+                            .scm(name: "B", location: "/B", requirement: .branch("master")),
                         ],
                         products: [
                             .init(name: "alib", type: .library(.static), targets: ["A2"]),
@@ -119,7 +119,7 @@ class PIFBuilderTests: XCTestCase {
                     defaultLocalization: "fr",
                     v: .v5_2,
                     dependencies: [
-                        .init(name: "Bar", location: "/Bar", requirement: .branch("master")),
+                        .scm(name: "Bar", location: "/Bar", requirement: .branch("master")),
                     ],
                     targets: [
                         .init(name: "foo", dependencies: [.product(name: "BarLib", package: "Bar")]),
@@ -389,7 +389,7 @@ class PIFBuilderTests: XCTestCase {
                     v: .v5_2,
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
-                        .init(name: "Bar", location: "/Bar", requirement: .branch("master")),
+                        .scm(name: "Bar", location: "/Bar", requirement: .branch("master")),
                     ],
                     targets: [
                         .init(name: "foo", dependencies: [
@@ -715,7 +715,7 @@ class PIFBuilderTests: XCTestCase {
                     v: .v5_2,
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
-                        .init(name: "Bar", location: "/Bar", requirement: .branch("master")),
+                        .scm(name: "Bar", location: "/Bar", requirement: .branch("master")),
                     ],
                     targets: [
                         .init(name: "FooTests", dependencies: [
@@ -943,7 +943,7 @@ class PIFBuilderTests: XCTestCase {
                     v: .v5_2,
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
-                        .init(name: "Bar", location: "/Bar", requirement: .branch("master")),
+                        .scm(name: "Bar", location: "/Bar", requirement: .branch("master")),
                     ],
                     products: [
                         .init(name: "FooLib1", type: .library(.static), targets: ["FooLib1"]),
@@ -1140,7 +1140,7 @@ class PIFBuilderTests: XCTestCase {
                     cxxLanguageStandard: "c++14",
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
-                        .init(name: "Bar", location: "/Bar", requirement: .branch("master")),
+                        .scm(name: "Bar", location: "/Bar", requirement: .branch("master")),
                     ],
                     targets: [
                         .init(name: "FooLib1", dependencies: ["SystemLib", "FooLib2"]),

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -357,7 +357,7 @@ class GenerateXcodeprojTests: XCTestCase {
                         path: fooPackagePath.pathString,
                         packageLocation: fooPackagePath.pathString,
                         dependencies: [
-                            PackageDependencyDescription(name: "Bar", location: barPackagePath.pathString, requirement: .localPackage)
+                            .local(name: "Bar", path: barPackagePath)
                         ],
                         targets: [
                             TargetDescription(name: "Foo", dependencies: [

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -61,7 +61,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Bar",
                     dependencies: [
-                        PackageDependencyDescription(name: "Foo", location: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
+                        .scm(name: "Foo", location: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Bar", dependencies: ["Foo"]),


### PR DESCRIPTION
motivation: improve correctness by using identity more broadly throughout the code, prepare to package registry

changes:
* refector as PackageDependencyDescription with "scm" and "local" cases, this reflects better the true meaning and associated data with the two options and prepares us to adding a third option for registry
* create new abstraction IdentityResolver, with default implementation that follows existing identity resolution logic
* move mirror logic into IdentityResolver, and simplify code that used mirrors
* move all logic to generate identity, apply mirrors to PackageDependencyDescription so it is handles as soon as possible in the call stack
* adjust call-sites
* adjust and add tests for mirror

builds on https://github.com/apple/swift-package-manager/pull/3239 and https://github.com/apple/swift-package-manager/pull/3240 so lets merge those first 