### PR TITLE
Fix `BuildOperationBuildSystemDelegateHandler`

### DIFF
--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -18,6 +18,12 @@ import Foundation
 import LLBuildManifest
 import SPMBuildCore
 
+#if canImport(llbuildSwift)
+typealias LLBuildBuildSystemDelegate = llbuildSwift.BuildSystemDelegate
+#else
+typealias LLBuildBuildSystemDelegate = llbuild.BuildSystemDelegate
+#endif
+
 typealias Diagnostic = TSCBasic.Diagnostic
 
 class CustomLLBuildCommand: SPMLLBuild.ExternalCommand {
@@ -356,7 +362,7 @@ final class CopyCommand: CustomLLBuildCommand {
 }
 
 /// Convenient llbuild build system delegate implementation
-final class BuildOperationBuildSystemDelegateHandler: llbuildSwift.BuildSystemDelegate, SwiftCompilerOutputParserDelegate {
+final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate, SwiftCompilerOutputParserDelegate {
     private let diagnostics: DiagnosticsEngine
     var outputStream: ThreadSafeOutputByteStream
     var progressAnimation: ProgressAnimationProtocol


### PR DESCRIPTION
This got broken in #3209 which was using `llbuildSwift` unconditionally. This is easy to miss, but in some environments we set `SWIFTPM_LLBUILD_FWK` and link against a pre-built framework which will only have the module `llbuild`.

We should improve the testing here and build in both modes to avoid this kind of breakage in the future.