### PR TITLE
Emit warning when a path is marked for exclude:, resources: but does not actually exist.

### DIFF
--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -69,15 +69,7 @@ public struct TargetSourcesBuilder {
         self.rules = FileRuleDescription.builtinRules
         self.toolsVersion = toolsVersion
         self.fs = fs
-        let excludedPaths = target.exclude.map{ (entry) -> AbsolutePath in
-            let absPath = path.appending(RelativePath(entry))
-            
-            if !fs.exists(absPath) {
-                diags.emit(warning: "Cannot exclude path: \(absPath) because it does not exist")
-            }
-            
-            return absPath
-        }
+        let excludedPaths = target.exclude.map{ path.appending(RelativePath($0)) }
         self.excludedPaths = Set(excludedPaths)
 
         let declaredSources = target.sources?.map{ path.appending(RelativePath($0)) }
@@ -91,12 +83,39 @@ public struct TargetSourcesBuilder {
             }
         }
         self.declaredSources = declaredSources?.spm_uniqueElements()
+        
+        for exclude in self.excludedPaths {
+            validTargetPath(exclude, "Cannot exclude path: \(exclude) because it does not exist")
+        }
+        
+        if let decSources = self.declaredSources {
+            for source in decSources {
+                validTargetPath(source, "Source: \(source) does not exist")
+            }
+        }
 
       #if DEBUG
         validateRules(self.rules)
       #endif
     }
 
+    @discardableResult
+    private func validTargetPath(_ absPath: AbsolutePath, _ message: String) -> Bool {
+        // Check if paths that are enumerated in targets: [] exist 
+        if !self.fs.exists(absPath) {
+            self.diags.emit(warning: message)
+            return false
+        } else {
+            // Excludes, Sources, and Resources should be found at the root of the package and or
+            // its subdirectories
+            if let cwd = self.fs.currentWorkingDirectory {
+                if !absPath.pathString.hasPrefix(cwd.pathString) {
+                    self.diags.emit(warning: "\(absPath) should be found within the root of \(cwd)")
+                }
+            }
+            return true
+        }
+    }
     /// Emits an error in debug mode if we have conflicting rules for any file type.
     private func validateRules(_ rules: [FileRuleDescription]) {
         var extensionMap: [String: FileRuleDescription] = [:]
@@ -171,17 +190,7 @@ public struct TargetSourcesBuilder {
                 matchedRule = Rule(rule: declaredResource.rule.fileRule, localization: declaredResource.localization)
             }
             
-            if !self.fs.exists(resourcePath) {
-                self.diags.emit(warning: "Resource: \(resourcePath) does not exist")
-            } else {
-                // Resources should be found with in the root of the package and or its subdirectories,
-                // not outside of it
-                if let cwd = self.fs.currentWorkingDirectory {
-                    if !resourcePath.pathString.hasPrefix(cwd.pathString) {
-                        self.diags.emit(warning: "Resource: \(resourcePath) should be found within the root of \(cwd)")
-                    }
-                }
-            }
+            validTargetPath(resourcePath, "Resource: \(resourcePath) does not exist")
         }
 
         // Match any sources explicitly declared in the manifest file.

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -72,7 +72,7 @@ public struct TargetSourcesBuilder {
         let excludedPaths = target.exclude.map{ (entry) -> AbsolutePath in
             let absPath = path.appending(RelativePath(entry))
             
-            if !self.fs.exists(absPath) {
+            if !fs.exists(absPath) {
                 diags.emit(warning: "Cannot exclude path: \(absPath) because it does not exist")
             }
             

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -83,7 +83,7 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         let fs = InMemoryFileSystem()
         fs.createEmptyFiles(at: .root, files: [
-            "/.some2/hello.swift",
+            "/some2/hello.swift",
             "/Hello.something/hello.txt",
         ])
 

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -487,4 +487,107 @@ class TargetSourcesBuilderTests: XCTestCase {
             XCTFail(error.localizedDescription, file: file, line: line)
         }
     }
+    
+    func testMissingExclude() throws {
+        let target = try TargetDescription(
+            name: "Foo",
+            path: nil,
+            exclude: ["fakeDir", "../../fileOutsideRoot.py"],
+            sources: nil,
+            resources: [],
+            publicHeadersPath: nil,
+            type: .regular
+        )
+
+        let fs = InMemoryFileSystem()
+        fs.createEmptyFiles(at: .root, files: [
+            "/Foo.swift",
+            "/Bar.swift"
+        ])
+
+        let diags = DiagnosticsEngine()
+
+        let _ = TargetSourcesBuilder(
+            packageName: "",
+            packagePath: .root,
+            target: target,
+            path: .root,
+            defaultLocalization: nil,
+            toolsVersion: .v5,
+            fs: fs,
+            diags: diags
+        )
+
+        diags.diagnostics.forEach { XCTAssert($0.description.contains("Invalid Exclude")) }
+    }
+    
+    func testMissingResource() throws {
+        let target = try TargetDescription(
+            name: "Foo",
+            path: nil,
+            exclude: [],
+            sources: nil,
+            resources: [.init(rule: .copy, path: "../../../Fake.txt"),
+                        .init(rule: .process, path: "NotReal")],
+            publicHeadersPath: nil,
+            type: .regular
+        )
+
+        let fs = InMemoryFileSystem()
+        fs.createEmptyFiles(at: .root, files: [
+            "/Foo.swift",
+            "/Bar.swift"
+        ])
+
+        let diags = DiagnosticsEngine()
+
+        let builder = TargetSourcesBuilder(
+            packageName: "",
+            packagePath: .root,
+            target: target,
+            path: .root,
+            defaultLocalization: nil,
+            toolsVersion: .v5,
+            fs: fs,
+            diags: diags
+        )
+
+        let _ = builder.computeContents().map{ $0.pathString }.sorted()
+        diags.diagnostics.forEach { XCTAssert($0.description.contains("Invalid Resource")) }
+    }
+    
+    func testMissingSource() throws {
+        let target = try TargetDescription(
+            name: "Foo",
+            path: nil,
+            exclude: [],
+            sources: ["InvalidPackage.swift",
+                      "DoesNotExist.swift",
+                      "../../Tests/InvalidPackageTests/InvalidPackageTests.swift"],
+            resources: [],
+            publicHeadersPath: nil,
+            type: .regular
+        )
+
+        let fs = InMemoryFileSystem()
+        fs.createEmptyFiles(at: .root, files: [
+            "/Foo.swift",
+            "/Bar.swift"
+        ])
+
+        let diags = DiagnosticsEngine()
+
+        let _ = TargetSourcesBuilder(
+            packageName: "",
+            packagePath: .root,
+            target: target,
+            path: .root,
+            defaultLocalization: nil,
+            toolsVersion: .v5,
+            fs: fs,
+            diags: diags
+        )
+
+        diags.diagnostics.forEach { XCTAssert($0.description.contains("Invalid Source")) }
+    }
 }


### PR DESCRIPTION
### Motivation:
Introduce a warning that is not currently present, informing the user of paths that they have added to their manifest file that do not exist.

This also includes a warning when trying to use a resource that is located outside the root of the package.

rdar://60745311
rdar://60708059
