### PR TITLE
[Collections] Add more info to certificate subject and issuer in signature

### DIFF
--- a/Sources/Build/SPMSwiftDriverExecutor.swift
+++ b/Sources/Build/SPMSwiftDriverExecutor.swift
@@ -77,7 +77,7 @@ final class SPMSwiftDriverExecutor: DriverExecutor {
 
     if usedResponseFile {
       // Print the response file arguments as a comment.
-      result += " # \(job.commandLine.joinedArguments)"
+      result += " # \(job.commandLine.joinedUnresolvedArguments)"
     }
 
     if !job.extraEnvironment.isEmpty {

--- a/Sources/PackageCollections/Model/Collection.swift
+++ b/Sources/PackageCollections/Model/Collection.swift
@@ -211,12 +211,27 @@ extension PackageCollectionsModel {
 
             /// Generic certificate name (e.g., subject, issuer)
             public struct Name: Equatable, Codable {
+                /// User ID
+                public let userID: String?
+
                 /// Common name
-                public let commonName: String
+                public let commonName: String?
+
+                /// Organizational unit
+                public let organizationalUnit: String?
+
+                /// Organization
+                public let organization: String?
 
                 /// Creates a `Name`
-                public init(commonName: String) {
+                public init(userID: String?,
+                            commonName: String?,
+                            organizationalUnit: String?,
+                            organization: String?) {
+                    self.userID = userID
                     self.commonName = commonName
+                    self.organizationalUnit = organizationalUnit
+                    self.organization = organization
                 }
             }
         }

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -392,6 +392,9 @@ extension Model.SignatureData.Certificate {
 
 extension Model.SignatureData.Certificate.Name {
     fileprivate init(from: JSONModel.Signature.Certificate.Name) {
+        self.userID = from.userID
         self.commonName = from.commonName
+        self.organizationalUnit = from.organizationalUnit
+        self.organization = from.organization
     }
 }

--- a/Sources/PackageCollectionsModel/PackageCollectionModel+v1.swift
+++ b/Sources/PackageCollectionsModel/PackageCollectionModel+v1.swift
@@ -403,12 +403,27 @@ extension PackageCollectionModel.V1 {
 
             /// Generic certificate name (e.g., subject, issuer)
             public struct Name: Equatable, Codable {
+                /// User ID
+                public let userID: String?
+
                 /// Common name
-                public let commonName: String
+                public let commonName: String?
+
+                /// Organizational unit
+                public let organizationalUnit: String?
+
+                /// Organization
+                public let organization: String?
 
                 /// Creates a `Name`
-                public init(commonName: String) {
+                public init(userID: String?,
+                            commonName: String?,
+                            organizationalUnit: String?,
+                            organization: String?) {
+                    self.userID = userID
                     self.commonName = commonName
+                    self.organizationalUnit = organizationalUnit
+                    self.organization = organization
                 }
             }
         }

--- a/Tests/PackageCollectionsModelTests/PackageCollectionModelTests.swift
+++ b/Tests/PackageCollectionsModelTests/PackageCollectionModelTests.swift
@@ -99,8 +99,8 @@ class PackageCollectionModelTests: XCTestCase {
         let signature = Model.Signature(
             signature: "<SIGNATURE>",
             certificate: Model.Signature.Certificate(
-                subject: .init(commonName: "Test Subject"),
-                issuer: .init(commonName: "Test Issuer")
+                subject: .init(userID: "Test User ID", commonName: "Test Subject", organizationalUnit: "Test Org Unit", organization: "Test Org"),
+                issuer: .init(userID: nil, commonName: "Test Issuer", organizationalUnit: nil, organization: nil)
             )
         )
         let signedCollection = Model.SignedCollection(collection: collection, signature: signature)

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -825,8 +825,8 @@ final class PackageCollectionsTests: XCTestCase {
                 } else {
                     let signature = PackageCollectionsModel.SignatureData(
                         certificate: PackageCollectionsModel.SignatureData.Certificate(
-                            subject: .init(commonName: ""),
-                            issuer: .init(commonName: "")
+                            subject: .init(userID: nil, commonName: nil, organizationalUnit: nil, organization: nil),
+                            issuer: .init(userID: nil, commonName: nil, organizationalUnit: nil, organization: nil)
                         )
                     )
                     callback(.success(PackageCollectionsModel.Collection(source: source, name: "", overview: nil, keywords: nil, packages: [], createdAt: Date(), createdBy: nil, signature: signature)))

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -84,8 +84,8 @@ func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: I
         if signed {
             signature = .init(
                 certificate: PackageCollectionsModel.SignatureData.Certificate(
-                    subject: .init(commonName: "subject-\(collectionIndex)"),
-                    issuer: .init(commonName: "issuer-\(collectionIndex)")
+                    subject: .init(userID: nil, commonName: "subject-\(collectionIndex)", organizationalUnit: nil, organization: nil),
+                    issuer: .init(userID: nil, commonName: "issuer-\(collectionIndex)", organizationalUnit: nil, organization: nil)
                 )
             )
         }


### PR DESCRIPTION
Motivation:
Currently we only include common name, but we have all the other information available and there is no reason not to show them.

Modification:
Add user ID, organizational unit, and organization to `Certificate.Name`.