### PR TITLE
[5.4] Prevent manifest load errors from causing SwiftPM to display "fatalError" in CLI

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1486,7 +1486,13 @@ extension Workspace {
 
                     switch result {
                     case .failure(let error):
-                        diagnostics.emit(error)
+                        // Diagnostics.fatalError indicates that a more specific diagnostic has already been added.
+                        switch error {
+                        case Diagnostics.fatalError:
+                            break
+                        default:
+                            diagnostics.emit(error)
+                        }
                     case .success(let manifest):
                         self.delegate?.didLoadManifest(packagePath: packagePath, url: url, version: version, packageKind: packageKind, manifest: manifest, diagnostics: manifestDiagnostics.diagnostics)
                     }


### PR DESCRIPTION
Looks like `Diagnostics.fatalError` is used to throw errors when appropriate diagnostics have already been emitted and the only goal is to quickly return to the caller.  This is documented in TSCUtility.

Future cleanup should avoid this special behavior.

### Motivation:
This prevents an ugly extra line of output

### Changes:
It prevents `Diagnostics.fatalError` from being added to the diagnostics engine, in a way that's similar to how it is done in some other places.

rdar://74263826