### PR TITLE
Use `executableTarget` in generated new executable packages

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -15,7 +15,7 @@ import PackageModel
 /// Create an initial template package.
 public final class InitPackage {
     /// The tool version to be used for new packages.
-    public static let newPackageToolsVersion = ToolsVersion(version: "5.3.0")
+    public static let newPackageToolsVersion = ToolsVersion.currentToolsVersion
 
     /// Options for the template package.
     public struct InitPackageOptions {
@@ -186,18 +186,34 @@ public final class InitPackage {
                 """)
 
             if packageType == .library || packageType == .executable || packageType == .manifest {
-                pkgParams.append("""
+                var param = ""
+
+                param += """
                     targets: [
                         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
                         // Targets can depend on other targets in this package, and on products in packages this package depends on.
-                        .target(
+
+                """
+                if packageType == .executable {
+                    param += """
+                            .executableTarget(
+                    """
+                } else {
+                    param += """
+                            .target(
+                    """
+                }
+                param += """
+
                             name: "\(pkgname)",
                             dependencies: []),
                         .testTarget(
                             name: "\(pkgname)Tests",
                             dependencies: ["\(pkgname)"]),
                     ]
-                """)
+                """
+
+                pkgParams.append(param)
             }
 
             stream <<< pkgParams.joined(separator: ",\n") <<< "\n)\n"


### PR DESCRIPTION
### Motivation:

Newly generated executable packages currently use `.target(...)` API for declaring the executable target, which seems to be deprecated since 5.4.

### Modifications:

* bumped `swift-tools-version` for new packages to 5.4
* replaced `.target` call with `.executableTarget` for new executable packages

### Result:

After this change `swift package init --type executable` generates a package which declares the executable target via the new `.executableTarget(...)` API.
