### PR TITLE
[Collections] Add summary and creation timestamp to package version

### DIFF
--- a/Fixtures/Collections/JSON/good.json
+++ b/Fixtures/Collections/JSON/good.json
@@ -21,6 +21,7 @@
       "versions": [
         {
           "version": "0.1.0",
+          "summary": "Fixed a few bugs",
           "manifests": {
             "5.1": {
               "toolsVersion": "5.1",
@@ -63,7 +64,8 @@
           "license": {
             "name": "Apache-2.0",
             "url": "https://www.example.com/repos/RepoOne/LICENSE"
-          }
+          },
+          "createdAt": "2020-10-21T09:25:36Z"
         }
       ]
     },

--- a/Fixtures/Collections/JSON/good_signed.json
+++ b/Fixtures/Collections/JSON/good_signed.json
@@ -21,6 +21,7 @@
       "versions": [
         {
           "version": "0.1.0",
+          "summary": "Fixed a few bugs",
           "manifests": {
             "5.1": {
               "toolsVersion": "5.1",
@@ -63,7 +64,8 @@
           "license": {
             "name": "Apache-2.0",
             "url": "https://www.example.com/repos/RepoOne/LICENSE"
-          }
+          },
+          "createdAt": "2020-10-21T09:25:36Z"
         }
       ]
     },

--- a/Sources/PackageCollections/Model/Package.swift
+++ b/Sources/PackageCollections/Model/Package.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+import struct Foundation.Date
 import struct Foundation.URL
 
 import PackageModel
@@ -112,6 +113,9 @@ extension PackageCollectionsModel.Package {
         /// The version
         public let version: TSCUtility.Version
 
+        /// Package version description
+        public let summary: String?
+
         // TODO: remove (replaced by manifests)
         public var packageName: String { self.defaultManifest!.packageName }
 
@@ -144,6 +148,9 @@ extension PackageCollectionsModel.Package {
 
         /// The package version's license
         public let license: PackageCollectionsModel.License?
+
+        /// When the package version was created
+        public let createdAt: Date?
 
         public struct Manifest: Equatable, Codable {
             /// The Swift tools version specified in `Package.swift`.

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -439,10 +439,12 @@ public struct PackageCollections: PackageCollectionsProtocol {
                                                basicMetadata: Model.PackageBasicMetadata?) -> Model.Package {
         var versions = package.versions.map { packageVersion -> Model.Package.Version in
             .init(version: packageVersion.version,
+                  summary: packageVersion.summary,
                   manifests: packageVersion.manifests,
                   defaultToolsVersion: packageVersion.defaultToolsVersion,
                   verifiedCompatibility: packageVersion.verifiedCompatibility,
-                  license: packageVersion.license)
+                  license: packageVersion.license,
+                  createdAt: packageVersion.createdAt)
         }
         versions.sort(by: >)
 

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -179,10 +179,12 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
                 let license = version.license.flatMap { Model.License(from: $0) }
 
                 return .init(version: parsedVersion,
+                             summary: version.summary,
                              manifests: manifests,
                              defaultToolsVersion: defaultToolsVersion,
                              verifiedCompatibility: verifiedCompatibility,
-                             license: license)
+                             license: license,
+                             createdAt: version.createdAt)
             }
             if versions.count != package.versions.count {
                 serializationOkay = false

--- a/Sources/PackageCollectionsModel/Formats/v1.md
+++ b/Sources/PackageCollectionsModel/Formats/v1.md
@@ -41,6 +41,7 @@ Each item in the `packages` array is a package object with the following propert
 A version object has metadata extracted from `Package.swift` and optionally additional metadata from other sources:
 
 * `version`: The semantic version string.
+* `summary`: A description of the package version. **Optional.**
 * `manifests`: A non-empty map of manifests by Swift tools version. The keys are (semantic) tools version (more on this below), while the values are:
     * `toolsVersion`: The Swift tools version specified in the manifest.
     * `packageName`: The name of the package.
@@ -98,6 +99,7 @@ A version object has metadata extracted from `Package.swift` and optionally addi
 * `license`: The package version's license. **Optional.**
     * `url`: The URL of the license file.
     * `name`: License name. [SPDX identifier](https://spdx.org/licenses/) (e.g., `Apache-2.0`, `MIT`, etc.) preferred. Omit if unknown. **Optional.**
+* `createdAt`: The ISO 8601-formatted datetime string when the package version was created. **Optional.**
 
 ##### Version-specific manifests
 
@@ -134,6 +136,7 @@ supported by package collections.
       "versions": [
         {
           "version": "0.1.0",
+          "summary": "Fixed a few bugs",
           "manifests": {
             "5.1": {
               "toolsVersion": "5.1",
@@ -173,7 +176,8 @@ supported by package collections.
           "license": {
             "name": "Apache-2.0",
             "url": "https://www.example.com/repos/RepoOne/LICENSE"
-          }
+          },
+          "createdAt": "2020-10-21T09:25:36Z"
         }
       ]
     },

--- a/Sources/PackageCollectionsModel/PackageCollectionModel+v1.swift
+++ b/Sources/PackageCollectionsModel/PackageCollectionModel+v1.swift
@@ -34,7 +34,7 @@ extension PackageCollectionModel.V1 {
         /// The revision number of this package collection.
         public let revision: Int?
 
-        /// The ISO 8601-formatted datetime string when the package collection was generated.
+        /// When the package collection was generated.
         public let generatedAt: Date
 
         /// The author of this package collection.
@@ -119,6 +119,9 @@ extension PackageCollectionModel.V1.Collection.Package {
         /// The semantic version string.
         public let version: String
 
+        /// A description of the package version.
+        public let summary: String?
+
         /// Manifests by tools version.
         public let manifests: [String: Manifest]
 
@@ -131,19 +134,26 @@ extension PackageCollectionModel.V1.Collection.Package {
         /// The package version's license.
         public let license: PackageCollectionModel.V1.License?
 
+        /// When the package version was created.
+        public let createdAt: Date?
+
         /// Creates a `Version`
         public init(
             version: String,
+            summary: String?,
             manifests: [String: Manifest],
             defaultToolsVersion: String,
             verifiedCompatibility: [PackageCollectionModel.V1.Compatibility]?,
-            license: PackageCollectionModel.V1.License?
+            license: PackageCollectionModel.V1.License?,
+            createdAt: Date?
         ) {
             self.version = version
+            self.summary = summary
             self.manifests = manifests
             self.defaultToolsVersion = defaultToolsVersion
             self.verifiedCompatibility = verifiedCompatibility
             self.license = license
+            self.createdAt = createdAt
         }
 
         public struct Manifest: Equatable, Codable {

--- a/Tests/PackageCollectionsModelTests/PackageCollectionModelTests.swift
+++ b/Tests/PackageCollectionsModelTests/PackageCollectionModelTests.swift
@@ -25,6 +25,7 @@ class PackageCollectionModelTests: XCTestCase {
                 versions: [
                     Model.Collection.Package.Version(
                         version: "1.3.2",
+                        summary: "Fix a few bugs",
                         manifests: [
                             "5.2": Model.Collection.Package.Version.Manifest(
                                 toolsVersion: "5.2",
@@ -36,7 +37,8 @@ class PackageCollectionModelTests: XCTestCase {
                         ],
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: [Model.Compatibility(platform: Model.Platform(name: "macOS"), swiftVersion: "5.2")],
-                        license: .init(name: "Apache-2.0", url: URL(string: "https://package-collection-tests.com/repos/foobar/LICENSE")!)
+                        license: .init(name: "Apache-2.0", url: URL(string: "https://package-collection-tests.com/repos/foobar/LICENSE")!),
+                        createdAt: Date()
                     ),
                 ],
                 readmeURL: URL(string: "https://package-collection-tests.com/repos/foobar/README")!,
@@ -68,6 +70,7 @@ class PackageCollectionModelTests: XCTestCase {
                 versions: [
                     Model.Collection.Package.Version(
                         version: "1.3.2",
+                        summary: "Fix a few bugs",
                         manifests: [
                             "5.2": Model.Collection.Package.Version.Manifest(
                                 toolsVersion: "5.2",
@@ -79,7 +82,8 @@ class PackageCollectionModelTests: XCTestCase {
                         ],
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: [Model.Compatibility(platform: Model.Platform(name: "macOS"), swiftVersion: "5.2")],
-                        license: .init(name: "Apache-2.0", url: URL(string: "https://package-collection-tests.com/repos/foobar/LICENSE")!)
+                        license: .init(name: "Apache-2.0", url: URL(string: "https://package-collection-tests.com/repos/foobar/LICENSE")!),
+                        createdAt: Date()
                     ),
                 ],
                 readmeURL: URL(string: "https://package-collection-tests.com/repos/foobar/README")!,

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -61,6 +61,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(package.license, .init(type: .Apache2_0, url: URL(string: "https://www.example.com/repos/RepoOne/LICENSE")!))
             XCTAssertEqual(package.versions.count, 1)
             let version = package.versions.first!
+            XCTAssertEqual(version.summary, "Fixed a few bugs")
             let manifest = version.manifests.values.first!
             XCTAssertEqual(manifest.packageName, "PackageOne")
             XCTAssertEqual(manifest.targets, [.init(name: "Foo", moduleName: "Foo")])
@@ -71,6 +72,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(version.verifiedCompatibility!.first!.platform, .macOS)
             XCTAssertEqual(version.verifiedCompatibility!.first!.swiftVersion, SwiftLanguageVersion(string: "5.1")!)
             XCTAssertEqual(version.license, .init(type: .Apache2_0, url: URL(string: "https://www.example.com/repos/RepoOne/LICENSE")!))
+            XCTAssertNotNil(version.createdAt)
             XCTAssertFalse(collection.isSigned)
         }
     }
@@ -116,6 +118,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(package.license, .init(type: .Apache2_0, url: URL(string: "https://www.example.com/repos/RepoOne/LICENSE")!))
             XCTAssertEqual(package.versions.count, 1)
             let version = package.versions.first!
+            XCTAssertEqual(version.summary, "Fixed a few bugs")
             let manifest = version.manifests.values.first!
             XCTAssertEqual(manifest.packageName, "PackageOne")
             XCTAssertEqual(manifest.targets, [.init(name: "Foo", moduleName: "Foo")])
@@ -126,6 +129,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertEqual(version.verifiedCompatibility!.first!.platform, .macOS)
             XCTAssertEqual(version.verifiedCompatibility!.first!.swiftVersion, SwiftLanguageVersion(string: "5.1")!)
             XCTAssertEqual(version.license, .init(type: .Apache2_0, url: URL(string: "https://www.example.com/repos/RepoOne/LICENSE")!))
+            XCTAssertNotNil(version.createdAt)
             XCTAssertTrue(collection.isSigned)
             let signature = collection.signature!
             XCTAssertEqual("Sample Subject", signature.certificate.subject.commonName)

--- a/Tests/PackageCollectionsTests/PackageCollectionValidationTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionValidationTests.swift
@@ -27,6 +27,7 @@ class PackageCollectionValidationTests: XCTestCase {
                 versions: [
                     Model.Collection.Package.Version(
                         version: "1.3.2",
+                        summary: nil,
                         manifests: [
                             "5.2": Model.Collection.Package.Version.Manifest(
                                 toolsVersion: "5.2",
@@ -38,7 +39,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         ],
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
-                        license: nil
+                        license: nil,
+                        createdAt: nil
                     ),
                 ],
                 readmeURL: nil,
@@ -91,6 +93,7 @@ class PackageCollectionValidationTests: XCTestCase {
                 versions: [
                     Model.Collection.Package.Version(
                         version: "1.3.2",
+                        summary: nil,
                         manifests: [
                             "5.2": Model.Collection.Package.Version.Manifest(
                                 toolsVersion: "5.2",
@@ -102,7 +105,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         ],
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
-                        license: nil
+                        license: nil,
+                        createdAt: nil
                     ),
                 ],
                 readmeURL: nil,
@@ -115,6 +119,7 @@ class PackageCollectionValidationTests: XCTestCase {
                 versions: [
                     Model.Collection.Package.Version(
                         version: "1.3.2",
+                        summary: nil,
                         manifests: [
                             "5.2": Model.Collection.Package.Version.Manifest(
                                 toolsVersion: "5.2",
@@ -126,7 +131,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         ],
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
-                        license: nil
+                        license: nil,
+                        createdAt: nil
                     ),
                 ],
                 readmeURL: nil,
@@ -163,6 +169,7 @@ class PackageCollectionValidationTests: XCTestCase {
                 versions: [
                     Model.Collection.Package.Version(
                         version: "1.3.2",
+                        summary: nil,
                         manifests: [
                             "5.2": Model.Collection.Package.Version.Manifest(
                                 toolsVersion: "5.2",
@@ -174,10 +181,12 @@ class PackageCollectionValidationTests: XCTestCase {
                         ],
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
-                        license: nil
+                        license: nil,
+                        createdAt: nil
                     ),
                     Model.Collection.Package.Version(
                         version: "1.3.2",
+                        summary: nil,
                         manifests: [
                             "5.2": Model.Collection.Package.Version.Manifest(
                                 toolsVersion: "5.2",
@@ -189,7 +198,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         ],
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
-                        license: nil
+                        license: nil,
+                        createdAt: nil
                     ),
                 ],
                 readmeURL: nil,
@@ -236,6 +246,7 @@ class PackageCollectionValidationTests: XCTestCase {
                 versions: [
                     Model.Collection.Package.Version(
                         version: "v1.3.2",
+                        summary: nil,
                         manifests: [
                             "5.2": Model.Collection.Package.Version.Manifest(
                                 toolsVersion: "5.2",
@@ -247,7 +258,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         ],
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
-                        license: nil
+                        license: nil,
+                        createdAt: nil
                     ),
                 ],
                 readmeURL: nil,
@@ -284,6 +296,7 @@ class PackageCollectionValidationTests: XCTestCase {
                 versions: [
                     Model.Collection.Package.Version(
                         version: "2.0.0",
+                        summary: nil,
                         manifests: [
                             "5.2": Model.Collection.Package.Version.Manifest(
                                 toolsVersion: "5.2",
@@ -295,10 +308,12 @@ class PackageCollectionValidationTests: XCTestCase {
                         ],
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
-                        license: nil
+                        license: nil,
+                        createdAt: nil
                     ),
                     Model.Collection.Package.Version(
                         version: "1.3.2",
+                        summary: nil,
                         manifests: [
                             "5.2": Model.Collection.Package.Version.Manifest(
                                 toolsVersion: "5.2",
@@ -310,7 +325,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         ],
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
-                        license: nil
+                        license: nil,
+                        createdAt: nil
                     ),
                 ],
                 readmeURL: nil,
@@ -323,6 +339,7 @@ class PackageCollectionValidationTests: XCTestCase {
                 versions: [
                     Model.Collection.Package.Version(
                         version: "1.4.0",
+                        summary: nil,
                         manifests: [
                             "5.2": Model.Collection.Package.Version.Manifest(
                                 toolsVersion: "5.2",
@@ -334,10 +351,12 @@ class PackageCollectionValidationTests: XCTestCase {
                         ],
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
-                        license: nil
+                        license: nil,
+                        createdAt: nil
                     ),
                     Model.Collection.Package.Version(
                         version: "1.3.2",
+                        summary: nil,
                         manifests: [
                             "5.2": Model.Collection.Package.Version.Manifest(
                                 toolsVersion: "5.2",
@@ -349,7 +368,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         ],
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
-                        license: nil
+                        license: nil,
+                        createdAt: nil
                     ),
                 ],
                 readmeURL: nil,
@@ -391,10 +411,12 @@ class PackageCollectionValidationTests: XCTestCase {
                 versions: [
                     Model.Collection.Package.Version(
                         version: "1.3.2",
+                        summary: nil,
                         manifests: [:],
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
-                        license: nil
+                        license: nil,
+                        createdAt: nil
                     ),
                 ],
                 readmeURL: nil,
@@ -431,6 +453,7 @@ class PackageCollectionValidationTests: XCTestCase {
                 versions: [
                     Model.Collection.Package.Version(
                         version: "1.3.2",
+                        summary: nil,
                         manifests: [
                             "5.2": Model.Collection.Package.Version.Manifest(
                                 toolsVersion: "5.2",
@@ -442,7 +465,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         ],
                         defaultToolsVersion: "5.2",
                         verifiedCompatibility: nil,
-                        license: nil
+                        license: nil,
+                        createdAt: nil
                     ),
                 ],
                 readmeURL: nil,
@@ -479,6 +503,7 @@ class PackageCollectionValidationTests: XCTestCase {
                 versions: [
                     Model.Collection.Package.Version(
                         version: "1.3.2",
+                        summary: nil,
                         manifests: [
                             "5.1": Model.Collection.Package.Version.Manifest(
                                 toolsVersion: "5.2",
@@ -490,7 +515,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         ],
                         defaultToolsVersion: "5.1",
                         verifiedCompatibility: nil,
-                        license: nil
+                        license: nil,
+                        createdAt: nil
                     ),
                 ],
                 readmeURL: nil,
@@ -527,6 +553,7 @@ class PackageCollectionValidationTests: XCTestCase {
                 versions: [
                     Model.Collection.Package.Version(
                         version: "1.3.2",
+                        summary: nil,
                         manifests: [
                             "5.2": Model.Collection.Package.Version.Manifest(
                                 toolsVersion: "5.2",
@@ -538,7 +565,8 @@ class PackageCollectionValidationTests: XCTestCase {
                         ],
                         defaultToolsVersion: "5.1",
                         verifiedCompatibility: nil,
-                        license: nil
+                        license: nil,
+                        createdAt: nil
                     ),
                 ],
                 readmeURL: nil,

--- a/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
@@ -23,11 +23,11 @@ final class PackageCollectionsModelTests: XCTestCase {
             toolsVersion: toolsVersion, packageName: "FooBar", targets: targets, products: products, minimumPlatformVersions: nil
         )]
         let versions: [PackageCollectionsModel.Package.Version] = [
-            .init(version: .init(stringLiteral: "1.2.0"), manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil),
-            .init(version: .init(stringLiteral: "2.0.1"), manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil),
-            .init(version: .init(stringLiteral: "2.1.0-beta.3"), manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil),
-            .init(version: .init(stringLiteral: "2.1.0"), manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil),
-            .init(version: .init(stringLiteral: "3.0.0-beta.1"), manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil),
+            .init(version: .init(stringLiteral: "1.2.0"), summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.0.1"), summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.1.0-beta.3"), summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.1.0"), summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "3.0.0-beta.1"), summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
         ]
 
         XCTAssertEqual("2.1.0", versions.latestRelease?.version.description)
@@ -42,8 +42,8 @@ final class PackageCollectionsModelTests: XCTestCase {
             toolsVersion: toolsVersion, packageName: "FooBar", targets: targets, products: products, minimumPlatformVersions: nil
         )]
         let versions: [PackageCollectionsModel.Package.Version] = [
-            .init(version: .init(stringLiteral: "2.1.0-beta.3"), manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil),
-            .init(version: .init(stringLiteral: "3.0.0-beta.1"), manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil),
+            .init(version: .init(stringLiteral: "2.1.0-beta.3"), summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "3.0.0-beta.1"), summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
         ]
 
         XCTAssertNil(versions.latestRelease)
@@ -58,9 +58,9 @@ final class PackageCollectionsModelTests: XCTestCase {
             toolsVersion: toolsVersion, packageName: "FooBar", targets: targets, products: products, minimumPlatformVersions: nil
         )]
         let versions: [PackageCollectionsModel.Package.Version] = [
-            .init(version: .init(stringLiteral: "1.2.0"), manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil),
-            .init(version: .init(stringLiteral: "2.0.1"), manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil),
-            .init(version: .init(stringLiteral: "2.1.0"), manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil),
+            .init(version: .init(stringLiteral: "1.2.0"), summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.0.1"), summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.1.0"), summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
         ]
 
         XCTAssertEqual("2.1.0", versions.latestRelease?.version.description)

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -531,10 +531,12 @@ final class PackageCollectionsTests: XCTestCase {
         )
 
         let mockVersion = PackageCollectionsModel.Package.Version(version: TSCUtility.Version(1, 0, 0),
+                                                                  summary: nil,
                                                                   manifests: [toolsVersion: mockManifest],
                                                                   defaultToolsVersion: toolsVersion,
                                                                   verifiedCompatibility: nil,
-                                                                  license: nil)
+                                                                  license: nil,
+                                                                  createdAt: nil)
 
         let mockPackage = PackageCollectionsModel.Package(repository: .init(url: "https://packages.mock/\(UUID().uuidString)"),
                                                           summary: UUID().uuidString,
@@ -688,10 +690,12 @@ final class PackageCollectionsTests: XCTestCase {
         )
 
         let mockVersion = PackageCollectionsModel.Package.Version(version: TSCUtility.Version(1, 0, 0),
+                                                                  summary: nil,
                                                                   manifests: [toolsVersion: mockManifest],
                                                                   defaultToolsVersion: toolsVersion,
                                                                   verifiedCompatibility: nil,
-                                                                  license: nil)
+                                                                  license: nil,
+                                                                  createdAt: nil)
 
         let mockPackage = PackageCollectionsModel.Package(repository: RepositorySpecifier(url: "https://packages.mock/\(UUID().uuidString)"),
                                                           summary: UUID().uuidString,
@@ -1023,13 +1027,15 @@ final class PackageCollectionsTests: XCTestCase {
 
         let versions = (0 ... 3).map {
             PackageCollectionsModel.Package.Version(version: TSCUtility.Version($0, 0, 0),
+                                                    summary: "\($0) description",
                                                     manifests: [toolsVersion: manifest],
                                                     defaultToolsVersion: toolsVersion,
                                                     verifiedCompatibility: [
                                                         .init(platform: .iOS, swiftVersion: SwiftLanguageVersion.knownSwiftLanguageVersions.randomElement()!),
                                                         .init(platform: .linux, swiftVersion: SwiftLanguageVersion.knownSwiftLanguageVersions.randomElement()!),
                                                     ],
-                                                    license: PackageCollectionsModel.License(type: .Apache2_0, url: URL(string: "http://apache.license")!))
+                                                    license: PackageCollectionsModel.License(type: .Apache2_0, url: URL(string: "http://apache.license")!),
+                                                    createdAt: Date())
         }
 
         let mockPackage = PackageCollectionsModel.Package(repository: RepositorySpecifier(url: "https://package-\(packageId)"),

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -64,10 +64,12 @@ func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: I
                 let license = PackageCollectionsModel.License(type: licenseType, url: URL(string: "http://\(licenseType).license")!)
 
                 return PackageCollectionsModel.Package.Version(version: TSCUtility.Version(versionIndex, 0, 0),
+                                                               summary: "\(versionIndex) description",
                                                                manifests: manifests,
                                                                defaultToolsVersion: toolsVersion,
                                                                verifiedCompatibility: verifiedCompatibility,
-                                                               license: license)
+                                                               license: license,
+                                                               createdAt: Date())
             }
 
             return PackageCollectionsModel.Package(repository: RepositorySpecifier(url: "https://package-\(packageIndex)"),


### PR DESCRIPTION
Motivation:
It seems useful for package version to have a description and creation timestamp.

Modifications:
- Add `summary` and `createdAt` to the models
- Update collection format doc
