### PR TITLE
Restore compatibility with 5.3 branch of swift-driver

### DIFF
--- a/Sources/Build/SPMSwiftDriverExecutor.swift
+++ b/Sources/Build/SPMSwiftDriverExecutor.swift
@@ -77,7 +77,7 @@ final class SPMSwiftDriverExecutor: DriverExecutor {
 
     if usedResponseFile {
       // Print the response file arguments as a comment.
-      result += " # \(job.commandLine.joinedUnresolvedArguments)"
+      result += " # \(job.commandLine.joinedArguments)"
     }
 
     if !job.extraEnvironment.isEmpty {


### PR DESCRIPTION
It would be beneficial for us to stay compatible with the 5.3 branch of swift-driver for the time being, so I'm reverting the change to fix a warning here.
