### PR TITLE
[RFC] allow users to define a callback queue when interacting with package collections

### DIFF
--- a/Sources/PackageCollections/PackageCollections+Configuration.swift
+++ b/Sources/PackageCollections/PackageCollections+Configuration.swift
@@ -8,6 +8,8 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+import Dispatch
+
 // TODO: how do we read default config values? ENV variables? user settings?
 extension PackageCollections {
     public struct Configuration {
@@ -15,10 +17,13 @@ extension PackageCollections {
         // JSONPackageCollectionProvider: maximumSizeInBytes
         // JSONPackageCollectionValidator: maximumPackageCount, maximumMajorVersionCount, maximumMinorVersionCount
 
+        public var callbackQueue: DispatchQueue?
+
         /// Auth tokens for the collections or metadata provider
         public var authTokens: [AuthTokenType: String]?
 
         public init(authTokens: [AuthTokenType: String]? = nil) {
+            self.callbackQueue = .none
             self.authTokens = authTokens
         }
     }


### PR DESCRIPTION
motivations: give users control on which dispatch queue callbacks are called on

changes:
* add confguration option for PackageCollections to define the callback queue
* wrap all callbacks in public APIs with the configured queue where available
