### PR TITLE
[Collections] Export PackageCollectionsSigning as library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -101,6 +101,16 @@ let package = Package(
             name: "PackageCollectionsModel",
             targets: ["PackageCollectionsModel"]
         ),
+
+        .library(
+            name: "SwiftPMPackageCollections",
+            targets: [
+                "PackageCollections",
+                "PackageCollectionsModel",
+                "PackageCollectionsSigning",
+                "PackageModel",
+            ]
+        ),
     ],
     targets: [
         // The `PackageDescription` targets define the API which is available to


### PR DESCRIPTION
We will add signing to [the set of collections tools](https://github.com/apple/swift-package-collection-generator), and for that we'd need `PackageCollectionsSigning`.
