### PR TITLE
Preparatory work for extensions to generate build commands (under feature flag pending proposal review)

### DIFF
--- a/Fixtures/Miscellaneous/Extensions/MySourceGenExtension/Package.swift
+++ b/Fixtures/Miscellaneous/Extensions/MySourceGenExtension/Package.swift
@@ -1,0 +1,53 @@
+// swift-tools-version: 999.0
+import PackageDescription
+
+let package = Package(
+    name: "MySourceGenExtension",
+    products: [
+        // The product that vends MySourceGenExt to client packages.
+        // .extension(
+        //     name: "MySourceGenExt",
+        //     target: "MySourceGenExt"
+        // )
+    ],
+    targets: [
+        // The target that implements the extension and generates commands to invoke MySourceGenTool.
+        .extension(
+            name: "MySourceGenExt",
+            capability: .prebuild(),
+            dependencies: [
+                "MySourceGenTool"
+            ]
+        ),
+        // The command line tool that generates source files.
+        .executableTarget(
+            name: "MySourceGenTool",
+            dependencies: [
+                "MySourceGenToolLib"
+            ]
+        ),
+        // A library used by MySourceGenTool (not the client).
+        .executableTarget(
+            name: "MySourceGenToolLib"
+        ),
+        // A runtime library that the client needs to link against.
+        .target(
+            name: "MySourceGenRuntimeLib"
+        ),
+        // A local tool that uses the extension.
+        .executableTarget(
+            name: "MyLocalTool",
+            dependencies: [
+                "MySourceGenExt"
+            ]
+        ),
+        // Unit tests for the extension.
+        .testTarget(
+            name: "MySourceGenExtTests",
+            dependencies: [
+                "MySourceGenExt",
+                "MySourceGenRuntimeLib"
+            ]
+        )
+    ]
+)

--- a/Fixtures/Miscellaneous/Extensions/MySourceGenExtension/Sources/MyLocalTool/main.swift
+++ b/Fixtures/Miscellaneous/Extensions/MySourceGenExtension/Sources/MyLocalTool/main.swift
@@ -1,0 +1,1 @@
+print("Exec: \\(name)")

--- a/Fixtures/Miscellaneous/Extensions/MySourceGenExtension/Sources/MySourceGenExt/extension.swift
+++ b/Fixtures/Miscellaneous/Extensions/MySourceGenExtension/Sources/MySourceGenExt/extension.swift
@@ -1,0 +1,4 @@
+import PackageExtension
+
+print("Hello MySourceGenExt")
+print(targetBuildContext)

--- a/Fixtures/Miscellaneous/Extensions/MySourceGenExtension/Sources/MySourceGenRuntimeLib/library.swift
+++ b/Fixtures/Miscellaneous/Extensions/MySourceGenExtension/Sources/MySourceGenRuntimeLib/library.swift
@@ -1,0 +1,3 @@
+public func GetLibraryName() -> String {
+    return "MySourceGenRuntimeLib"
+}

--- a/Fixtures/Miscellaneous/Extensions/MySourceGenExtension/Sources/MySourceGenTool/main.swift
+++ b/Fixtures/Miscellaneous/Extensions/MySourceGenExtension/Sources/MySourceGenTool/main.swift
@@ -1,0 +1,1 @@
+print("Hello MySourceGenTool")

--- a/Fixtures/Miscellaneous/Extensions/MySourceGenExtension/Sources/MySourceGenToolLib/library.swift
+++ b/Fixtures/Miscellaneous/Extensions/MySourceGenExtension/Sources/MySourceGenToolLib/library.swift
@@ -1,0 +1,3 @@
+public func GetLibraryName() -> String {
+    return "MySourceGenToolLib"
+}

--- a/Fixtures/Miscellaneous/Extensions/MySourceGenExtension/Tests/MySourceGenExtTests/MySourceGenExtTests.swift
+++ b/Fixtures/Miscellaneous/Extensions/MySourceGenExtension/Tests/MySourceGenExtTests/MySourceGenExtTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+import class Foundation.Bundle
+
+final class SwiftyProtobufTests: XCTestCase {
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+
+        // Some of the APIs that we use below are available in macOS 10.13 and above.
+        guard #available(macOS 10.13, *) else {
+            return
+        }
+
+        // Mac Catalyst won't have `Process`, but it is supported for executables.
+        #if !targetEnvironment(macCatalyst)
+
+        let fooBinary = productsDirectory.appendingPathComponent("MySourceGenTool")
+
+        let process = Process()
+        process.executableURL = fooBinary
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8)
+
+        XCTAssertEqual(output, "Hello, world!\n")
+        #endif
+    }
+
+    /// Returns path to the built products directory.
+    var productsDirectory: URL {
+      #if os(macOS)
+        for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+            return bundle.bundleURL.deletingLastPathComponent()
+        }
+        fatalError("couldn't find the products directory")
+      #else
+        return Bundle.main.bundleURL
+      #endif
+    }
+}

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright 2015 - 2019 Apple Inc. and the Swift project authors
+ Copyright 2015 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -702,7 +702,7 @@ public final class SwiftTargetBuildDescription {
         case .library, .test:
             result.append("-parse-as-library")
 
-        case .executable, .systemModule, .binary:
+        case .executable, .systemModule, .binary, .extension:
             do { }
         }
 
@@ -1360,7 +1360,7 @@ public class BuildPlan {
                     buildParameters: buildParameters,
                     fileSystem: fileSystem,
                     diagnostics: diagnostics))
-            case is SystemLibraryTarget, is BinaryTarget:
+            case is SystemLibraryTarget, is BinaryTarget, is ExtensionTarget:
                  break
             default:
                  fatalError("unhandled \(target.underlyingTarget)")
@@ -1595,6 +1595,8 @@ public class BuildPlan {
                     if let library = xcFrameworkLibrary(for: binaryTarget) {
                         libraryBinaryPaths.insert(library.binaryPath)
                     }
+                case .extension:
+                    continue
                 }
 
             case .product(let product, _):

--- a/Sources/Commands/Describe.swift
+++ b/Sources/Commands/Describe.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -132,12 +132,29 @@ fileprivate struct DescribedPackage: Encodable {
         }
     }
 
+    /// Represents a extension capability for the sole purpose of generating a description.
+    struct DescribedExtensionCapability: Encodable {
+        let type: String
+
+        init(from capability: ExtensionCapability, in package: Package) {
+            switch capability {
+            case .prebuild:
+                self.type = "prebuild"
+            case .buildTool:
+                self.type = "buildTool"
+            case .postbuild:
+                self.type = "postbuild"
+            }
+        }
+    }
+
     /// Represents a target for the sole purpose of generating a description.
     struct DescribedTarget: Encodable {
         let name: String
         let type: String
         let c99name: String?
         let moduleType: String?
+        let extensionCapability: DescribedExtensionCapability?
         let path: String
         let sources: [String]
         let resources: [PackageModel.Resource]?
@@ -149,6 +166,7 @@ fileprivate struct DescribedPackage: Encodable {
             self.type = target.type.rawValue
             self.c99name = target.c99name
             self.moduleType = String(describing: Swift.type(of: target))
+            self.extensionCapability = (target as? ExtensionTarget).map{ DescribedExtensionCapability(from: $0.capability, in: package) }
             self.path = target.sources.root.relative(to: package.path).pathString
             self.sources = target.sources.relativePaths.map{ $0.pathString }
             self.resources = target.resources.isEmpty ? nil : target.resources

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2018 Apple Inc. and the Swift project authors
+ Copyright (c) 2018 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -592,6 +592,30 @@ extension SystemPackageProvider: Encodable {
     }
 }
 
+extension Target.ExtensionCapability: Encodable {
+    private enum CodingKeys: CodingKey {
+        case type
+    }
+
+    private enum Capability: String, Encodable {
+        case prebuild
+        case buildTool
+        case postbuild
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case ._prebuild:
+            try container.encode(Capability.prebuild, forKey: .type)
+        case ._buildTool:
+            try container.encode(Capability.buildTool, forKey: .type)
+        case ._postbuild:
+            try container.encode(Capability.postbuild, forKey: .type)
+        }
+    }
+}
+
 extension Target.Dependency: Encodable {
     private enum CodingKeys: CodingKey {
         case type
@@ -650,6 +674,7 @@ func manifestToJSON(_ package: Package) -> String {
     }
 
     let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
     let data = try! encoder.encode(Output(package: package, errors: errors))
     return String(data: data, encoding: .utf8)!
 }

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2020 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -165,6 +165,11 @@ fileprivate extension SourceCodeFragment {
 
         params.append(SourceCodeFragment(key: "name", string: target.name))
         
+        if let extensionCapability = target.extensionCapability {
+            let node = SourceCodeFragment(from: extensionCapability)
+            params.append(SourceCodeFragment(key: "capability", subnode: node))
+        }
+
         if !target.dependencies.isEmpty {
             let nodes = target.dependencies.map{ SourceCodeFragment(from: $0) }
             params.append(SourceCodeFragment(key: "dependencies", subnodes: nodes))
@@ -243,6 +248,8 @@ fileprivate extension SourceCodeFragment {
             self.init(enum: "systemLibrary", subnodes: params, multiline: true)
         case .binary:
             self.init(enum: "binaryTarget", subnodes: params, multiline: true)
+        case .extension:
+            self.init(enum: "extension", subnodes: params, multiline: true)
         }
     }
 
@@ -344,6 +351,18 @@ fileprivate extension SourceCodeFragment {
             self.init(enum: "process", subnodes: params)
         case .copy:
             self.init(enum: "copy", subnodes: params)
+        }
+    }
+
+    /// Instantiates a SourceCodeFragment to represent a single extension capability.
+    init(from capability: TargetDescription.ExtensionCapability) {
+        switch capability {
+        case .prebuild:
+            self.init(enum: "prebuild", subnodes: [])
+        case .buildTool:
+            self.init(enum: "buildTool", subnodes: [])
+        case .postbuild:
+            self.init(enum: "postbuild", subnodes: [])
         }
     }
 

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -43,6 +43,7 @@ public final class InitPackage {
         case executable = "executable"
         case systemModule = "system-module"
         case manifest = "manifest"
+        case `extension` = "extension"
 
         public var description: String {
             return rawValue
@@ -284,7 +285,7 @@ public final class InitPackage {
                 print("Hello, world!")
 
                 """
-        case .systemModule, .empty, .manifest:
+        case .systemModule, .empty, .manifest, .`extension`:
             throw InternalError("invalid packageType \(packageType)")
         }
 
@@ -326,7 +327,7 @@ public final class InitPackage {
         try makeDirectories(tests)
 
         switch packageType {
-        case .systemModule, .empty, .manifest: break
+        case .systemModule, .empty, .manifest, .`extension`: break
         case .library, .executable:
             try writeTestFileStubs(testsPath: tests)
         }
@@ -421,7 +422,7 @@ public final class InitPackage {
 
         let testClassFile = testModule.appending(RelativePath("\(moduleName)Tests.swift"))
         switch packageType {
-        case .systemModule, .empty, .manifest: break
+        case .systemModule, .empty, .manifest, .`extension`: break
         case .library:
             try writeLibraryTestsFile(testClassFile)
         case .executable:

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -351,6 +351,9 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
             return
         case .binary:
             // Binary target don't need to be built.
+            return
+        case .extension:
+            // Package extension targets.
             return
         }
     }

--- a/Sources/Xcodeproj/SchemesGenerator.swift
+++ b/Sources/Xcodeproj/SchemesGenerator.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2018 Apple Inc. and the Swift project authors
+ Copyright (c) 2018 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -79,7 +79,7 @@ public final class SchemesGenerator {
         // Finally, create one master scheme for the entire package.
         let regularTargets = rootPackage.targets.filter({ 
             switch $0.type {
-            case .test, .systemModule, .binary:
+            case .test, .systemModule, .binary, .extension:
                 return false
             case .executable, .library:
                 return true

--- a/Sources/Xcodeproj/Target+PBXProj.swift
+++ b/Sources/Xcodeproj/Target+PBXProj.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -43,7 +43,7 @@ extension ResolvedTarget {
             return "com.apple.product-type.framework"
         case .executable:
             return "com.apple.product-type.tool"
-        case .systemModule, .binary:
+        case .systemModule, .binary, .extension:
             fatalError()
         }
     }
@@ -56,7 +56,7 @@ extension ResolvedTarget {
             return "wrapper.framework"
         case .executable:
             return "compiled.mach-o.executable"
-        case .systemModule, .binary:
+        case .systemModule, .binary, .extension:
             fatalError()
         }
     }
@@ -69,7 +69,7 @@ extension ResolvedTarget {
             return RelativePath("\(c99name).framework")
         case .executable:
             return RelativePath(name)
-        case .systemModule, .binary:
+        case .systemModule, .binary, .extension:
             fatalError()
         }
     }
@@ -81,7 +81,7 @@ extension ResolvedTarget {
             return "'lib$(TARGET_NAME)'"
         case .test, .executable:
             return "'$(TARGET_NAME)'"
-        case .systemModule, .binary:
+        case .systemModule, .binary, .extension:
             fatalError()
         }
     }

--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -390,7 +390,7 @@ public func xcodeProject(
             productType = .framework
         case .test:
             productType = .unitTest
-        case .systemModule, .binary:
+        case .systemModule, .binary, .extension:
             throw InternalError("\(target.type) not supported")
         }
 

--- a/Tests/PackageLoadingTests/PD4_0LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_0LoadingTests.swift
@@ -16,7 +16,7 @@ import PackageModel
 import SPMTestSupport
 import PackageLoading
 
-class PackageDescription4LoadingTests: PackageDescriptionLoadingTests {
+class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .v4
     }

--- a/Tests/PackageLoadingTests/PD5_0LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5_0LoadingTests.swift
@@ -16,7 +16,7 @@ import SPMTestSupport
 import PackageModel
 import PackageLoading
 
-class PackageDescription5LoadingTests: PackageDescriptionLoadingTests {
+class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .v5
     }

--- a/Tests/PackageLoadingTests/PD5_4LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5_4LoadingTests.swift
@@ -1,0 +1,42 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+import TSCBasic
+import TSCUtility
+import SPMTestSupport
+import PackageModel
+import PackageLoading
+
+class PackageDescription5_4LoadingTests: PackageDescriptionLoadingTests {
+    override var toolsVersion: ToolsVersion {
+        .v5_4
+    }
+
+    func testExecutableTargets() throws {
+        let stream = BufferedOutputByteStream()
+        stream <<< """
+            import PackageDescription
+            let package = Package(
+               name: "Foo",
+               targets: [
+                   .executableTarget(
+                       name: "Foo"
+                    ),
+               ]
+            )
+            """
+
+        loadManifest(stream.bytes) { manifest in
+            XCTAssertEqual(manifest.targets[0].type, .executable)
+        }
+    }
+}

--- a/Tests/PackageLoadingTests/PD5_4LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5_4LoadingTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2020 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -37,6 +37,34 @@ class PackageDescription5_4LoadingTests: PackageDescriptionLoadingTests {
 
         loadManifest(stream.bytes) { manifest in
             XCTAssertEqual(manifest.targets[0].type, .executable)
+        }
+    }
+    
+    func testExtensionsAreUnavailable() throws {
+        let stream = BufferedOutputByteStream()
+        stream <<< """
+            import PackageDescription
+            let package = Package(
+               name: "Foo",
+               targets: [
+                   .extension(
+                       name: "Foo",
+                       capability: .buildTool()
+                   ),
+               ]
+            )
+            """
+        do {
+            try loadManifestThrowing(stream.bytes) { _ in }
+            XCTFail("expected manifest loading to fail, but it succeeded")
+        }
+        catch {
+            guard case let ManifestParseError.invalidManifestFormat(message, _) = error else {
+                return XCTFail("expected an invalidManifestFormat error, but got: \(error)")
+            }
+
+            XCTAssertMatch(message, .contains("is unavailable"))
+            XCTAssertMatch(message, .contains("was introduced in PackageDescription 999"))
         }
     }
 }

--- a/Tests/PackageLoadingTests/PDNextVersionLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDNextVersionLoadingTests.swift
@@ -21,4 +21,66 @@ class PackageDescriptionNextVersionLoadingTests: PackageDescriptionLoadingTests 
         .vNext
     }
 
+    func testPrebuildExtensionTarget() throws {
+        let stream = BufferedOutputByteStream()
+        stream <<< """
+            import PackageDescription
+            let package = Package(
+               name: "Foo",
+               targets: [
+                   .extension(
+                       name: "Foo",
+                       capability: .prebuild()
+                    ),
+               ]
+            )
+            """
+
+        loadManifest(stream.bytes) { manifest in
+            XCTAssertEqual(manifest.targets[0].type, .extension)
+            XCTAssertEqual(manifest.targets[0].extensionCapability, .prebuild)
+        }
+    }
+
+    func testBuildToolExtensionTarget() throws {
+        let stream = BufferedOutputByteStream()
+        stream <<< """
+            import PackageDescription
+            let package = Package(
+               name: "Foo",
+               targets: [
+                   .extension(
+                       name: "Foo",
+                       capability: .buildTool()
+                    ),
+               ]
+            )
+            """
+
+        loadManifest(stream.bytes) { manifest in
+            XCTAssertEqual(manifest.targets[0].type, .extension)
+            XCTAssertEqual(manifest.targets[0].extensionCapability, .buildTool)
+        }
+    }
+
+    func testPostbuildExtensionTarget() throws {
+        let stream = BufferedOutputByteStream()
+        stream <<< """
+            import PackageDescription
+            let package = Package(
+               name: "Foo",
+               targets: [
+                   .extension(
+                       name: "Foo",
+                       capability: .postbuild()
+                    ),
+               ]
+            )
+            """
+
+        loadManifest(stream.bytes) { manifest in
+            XCTAssertEqual(manifest.targets[0].type, .extension)
+            XCTAssertEqual(manifest.targets[0].extensionCapability, .postbuild)
+        }
+    }
 }

--- a/Tests/PackageLoadingTests/PDNextVersionLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDNextVersionLoadingTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -21,22 +21,4 @@ class PackageDescriptionNextVersionLoadingTests: PackageDescriptionLoadingTests 
         .vNext
     }
 
-    func testExecutableTargets() throws {
-        let stream = BufferedOutputByteStream()
-        stream <<< """
-            import PackageDescription
-            let package = Package(
-               name: "Foo",
-               targets: [
-                   .executableTarget(
-                       name: "Foo"
-                    ),
-               ]
-            )
-            """
-
-        loadManifest(stream.bytes) { manifest in
-            XCTAssertEqual(manifest.targets[0].type, .executable)
-        }
-    }
 }

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
  
- Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2020 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
  
  See http://swift.org/LICENSE.txt for license information
@@ -225,5 +225,27 @@ class ManifestSourceGenerationTests: XCTestCase {
             )
             """
         try testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_3)
+    }
+
+    func testExtensionTargets() throws {
+        let manifestContents = """
+            // swift-tools-version:999.0
+            import PackageDescription
+
+            let package = Package(
+                name: "Extensions",
+                targets: [
+                    .extension(
+                        name: "MyExtension",
+                        capability: .buildTool(),
+                        dependencies: ["MyTool"]
+                    ),
+                    .executableTarget(
+                        name: "MyTool"
+                    ),
+                ]
+            )
+            """
+        try testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .vNext)
     }
 }


### PR DESCRIPTION
A start at a draft implementation of https://github.com/abertelrud/swift-evolution/blob/swiftpm-extensible-build-tools/proposals/NNNN-swiftpm-extensible-build-tools.md

This is guarded by a feature flag until the proposal is accepted and any requested changes have been implemented.  Until then, extensions can be enabled by setting SWIFTPM_ENABLE_EXTENSION_TARGETS=1 in the environment.  If the proposal is rejected, the changes can easily be neutralized by just reverting PackageDescription.
    
Package extension targets don't yet do anything in this PR — that is in the works, and will be in future PRs soon.  But with this PR they can be declared in manifests, and they are present in the project model.  They show up in generated manifest sources and in package descriptions.  This commit includes a test fixture that will also be expanded on and used in future unit tests.

None is this is intended to preempt the evolution proposal review process, but the intent is to have the implementation complete (though guarded by feature flags) by the time the proposal enters formal review.