### PR TITLE
The "duplicate target dependency" warning should say what package it's coming from

### DIFF
--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -41,6 +41,10 @@ extension Diagnostic.Message {
 
         return .warning("ignoring duplicate product '\(product.name)'\(typeString)")
     }
+    
+    static func blamePackage(package: String) -> Diagnostic.Message {
+        .warning("The package \(package) is the source of the above warning")
+    }
 
     static func duplicateTargetDependency(dependency: String, target: String) -> Diagnostic.Message {
         .warning("invalid duplicate target dependency declaration '\(dependency)' in target '\(target)'")

--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -41,13 +41,9 @@ extension Diagnostic.Message {
 
         return .warning("ignoring duplicate product '\(product.name)'\(typeString)")
     }
-    
-    static func blamePackage(package: String) -> Diagnostic.Message {
-        .warning("The package \(package) is the source of the above warning")
-    }
 
-    static func duplicateTargetDependency(dependency: String, target: String) -> Diagnostic.Message {
-        .warning("invalid duplicate target dependency declaration '\(dependency)' in target '\(target)'")
+    static func duplicateTargetDependency(dependency: String, target: String, package: String) -> Diagnostic.Message {
+        .warning("invalid duplicate target dependency declaration '\(dependency)' in target '\(target)' from package '\(package)'")
     }
 
     static var systemPackageDeprecation: Diagnostic.Message {

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -705,6 +705,7 @@ public final class PackageBuilder {
         let combinedDependencyNames = dependencies.map { $0.target?.name ?? $0.product!.name }
         combinedDependencyNames.spm_findDuplicates().forEach {
             diagnostics.emit(.duplicateTargetDependency(dependency: $0, target: potentialModule.name))
+            diagnostics.emit(.blamePackage(package: self.manifest.name))
         }
 
         // Create the build setting assignment table for this target.

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -704,8 +704,7 @@ public final class PackageBuilder {
         // Check for duplicate target dependencies by name
         let combinedDependencyNames = dependencies.map { $0.target?.name ?? $0.product!.name }
         combinedDependencyNames.spm_findDuplicates().forEach {
-            diagnostics.emit(.duplicateTargetDependency(dependency: $0, target: potentialModule.name))
-            diagnostics.emit(.blamePackage(package: self.manifest.name))
+            diagnostics.emit(.duplicateTargetDependency(dependency: $0, target: potentialModule.name, package: self.manifest.name))
         }
 
         // Create the build setting assignment table for this target.

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -2037,10 +2037,8 @@ class PackageBuilderTests: XCTestCase {
         PackageBuilderTester(manifest1, path: AbsolutePath("/Foo"), in: fs) { package, diagnostics in
             package.checkModule("Foo")
             package.checkModule("Foo2")
-            diagnostics.checkUnordered(diagnostic: "invalid duplicate target dependency declaration 'Bar' in target 'Foo'", behavior: .warning)
-            diagnostics.checkUnordered(diagnostic: "invalid duplicate target dependency declaration 'Foo2' in target 'Foo'", behavior: .warning)
-            diagnostics.checkUnordered(diagnostic: "The package Foo is the source of the above warning", behavior: .warning)
-            diagnostics.checkUnordered(diagnostic: "The package Foo is the source of the above warning", behavior: .warning)
+            diagnostics.checkUnordered(diagnostic: "invalid duplicate target dependency declaration 'Bar' in target 'Foo' from package 'Foo'", behavior: .warning)
+            diagnostics.checkUnordered(diagnostic: "invalid duplicate target dependency declaration 'Foo2' in target 'Foo' from package 'Foo'", behavior: .warning)
         }
     }
 

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -2039,6 +2039,8 @@ class PackageBuilderTests: XCTestCase {
             package.checkModule("Foo2")
             diagnostics.checkUnordered(diagnostic: "invalid duplicate target dependency declaration 'Bar' in target 'Foo'", behavior: .warning)
             diagnostics.checkUnordered(diagnostic: "invalid duplicate target dependency declaration 'Foo2' in target 'Foo'", behavior: .warning)
+            diagnostics.checkUnordered(diagnostic: "The package Foo is the source of the above warning", behavior: .warning)
+            diagnostics.checkUnordered(diagnostic: "The package Foo is the source of the above warning", behavior: .warning)
         }
     }
 


### PR DESCRIPTION
Inform the user what package contains the duplicate target dependency. Figured it would be better to add a new method for the printout over editing the current message to just include the package name, that way it can be called whenever it's needed. 

rdar://47085587