### PR TITLE
improve and simplify validation of target based dependencies

### DIFF
--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -272,7 +272,7 @@ public final class Manifest: ObjectIdentifierProtocol {
             return nil
         }
 
-        return dependencies.first(where: { $0.nameForTargetDependencyResolutionOnly == packageName })
+        return self.dependencies.first(where: { $0.nameForTargetDependencyResolutionOnly == packageName })
     }
 
     /// Registers a required product with a particular dependency if possible, or registers it as unknown.


### PR DESCRIPTION
motivation: SwiftPM 5.2 introduced target based dependencies which added complexity at code level and to users, this PR tries to both simplify the "rules" and the code

changes:
* allow target dependency in the form of ".product(name:, package:)" where package parameter is the last segment of the dependency URL, which is the most intuitive choice (IMO)
* change validation code to encourage the above form instead of encouraging adding a "name" attribute to the dependency deceleration. we want to get away from dependency::name in the long run.
* add several tests that capture the numerous permutations we are coding for

rdar://65048461
