### PR TITLE
[Collections] Missing Content-Length header

### DIFF
--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -225,7 +225,7 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
     private func makeRequestHeaders() -> HTTPClientHeaders {
         var headers = HTTPClientHeaders()
         // Include "Accept-Encoding" header so we receive "Content-Length" header in the response
-        headers.add(name: "Accept-Encoding", value: "*")
+        headers.add(name: "Accept-Encoding", value: "deflate, identity, gzip;q=0")
         return headers
     }
 


### PR DESCRIPTION
Motivation:
It seems like sending request header `Accept-Encoding: *` would cause some servers to do gzip compression (`Content-Encoding: gzip`) and chunked transfer (`Transfer-Encoding: chunked`), and would lead to missing `Content-Length` header in the response.

Modification:
Explicitly disallow gzip encoding.
