### PR TITLE
Update swift-crypto dependency to use version instead of main

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -353,7 +353,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         // dependency version changes here with those projects.
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.3.1")),
         .package(url: "https://github.com/apple/swift-driver.git", .branch(relatedDependenciesBranch)),
-        .package(url: "https://github.com/apple/swift-crypto.git", .branch(relatedDependenciesBranch)),
+        .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "1.1.4")),
     ]
 } else {
     package.dependencies += [


### PR DESCRIPTION
[swift-crypto v1.1.4](https://github.com/apple/swift-crypto/releases/tag/1.1.4) has all the changes we need and we can pin to that version instead of `main`.
