### PR TITLE
reduce use of fatalError

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -732,7 +732,7 @@ private class GitFileSystemView: FileSystem {
     }
 
     func changeCurrentWorkingDirectory(to path: AbsolutePath) throws {
-        fatalError("Unsupported")
+        throw InternalError("changeCurrentWorkingDirectory not supported")
     }
 
     func getDirectoryContents(_ path: AbsolutePath) throws -> [String] {
@@ -754,7 +754,7 @@ private class GitFileSystemView: FileSystem {
             throw FileSystemError(.isDirectory, path)
         }
         guard entry.type != .symlink else {
-            fatalError("FIXME: not implemented")
+            throw InternalError("symlinks not supported")
         }
         return try self.repository.read(blob: entry.hash)
     }

--- a/Sources/SourceControl/Repository.swift
+++ b/Sources/SourceControl/Repository.swift
@@ -125,17 +125,6 @@ public protocol RepositoryProvider {
     func copy(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws
 }
 
-extension RepositoryProvider {
-    public func checkoutExists(at path: AbsolutePath) throws -> Bool {
-        fatalError("Unimplemented")
-    }
-
-    public func copy(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
-        fatalError("Unimplemented")
-    }
-
-}
-
 /// Abstract repository operations.
 ///
 /// This interface provides access to an abstracted representation of a
@@ -236,12 +225,6 @@ public protocol WorkingCheckout {
 
     /// Returns true if the file at `path` is ignored by `git`
     func areIgnored(_ paths: [AbsolutePath]) throws -> [Bool]
-}
-
-extension WorkingCheckout {
-    public func areIgnored(_ paths: [AbsolutePath]) throws -> [Bool] {
-        fatalError("Unimplemented")
-    }
 }
 
 /// A single repository revision.


### PR DESCRIPTION
motivation: fatalError crashes the process, do not uses unless absolutley required

changes:
* replace fatalError with throw InternalError where possible
* remove redundant overrides that are not in use
