### PR TITLE
Don't trap on empty resource lists

### DIFF
--- a/Sources/PackageLoading/PackageDescription4Loader.swift
+++ b/Sources/PackageLoading/PackageDescription4Loader.swift
@@ -171,10 +171,6 @@ enum ManifestJSONParser {
 
     private static func parseResources(_ json: JSON) throws -> [TargetDescription.Resource] {
         guard let resourcesJSON = try? json.getArray("resources") else { return [] }
-        if resourcesJSON.isEmpty {
-            throw ManifestParseError.runtimeManifestErrors(["resources cannot be an empty array; provide at least one value or remove it"])
-        }
-
         return try resourcesJSON.map { json in
             let rawRule = try json.get(String.self, forKey: "rule")
             let rule = TargetDescription.Resource.Rule(rawValue: rawRule)!


### PR DESCRIPTION
Throwing an error on aesthetic issues like this makes it difficult to conditionally generate these arguments.

(This is a followup to #2880.)
