### PR TITLE
Allow unit tests to enable feature flag controlling extension feature

### DIFF
--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -30,6 +30,7 @@ extension PackageGraph {
         diagnostics: DiagnosticsEngine,
         fileSystem: FileSystem = localFileSystem,
         shouldCreateMultipleTestProducts: Bool = false,
+        allowExtensionTargets: Bool = false,
         createREPLProduct: Bool = false
     ) throws -> PackageGraph {
 
@@ -111,6 +112,7 @@ extension PackageGraph {
                         fileSystem: fileSystem,
                         diagnostics: diagnostics,
                         shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts,
+                        allowExtensionTargets: allowExtensionTargets,
                         createREPLProduct: manifest.packageKind == .root ? createREPLProduct : false
                     )
                     let package = try builder.construct()

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -238,7 +238,8 @@ public final class PackageBuilder {
     /// Temporary parameter controlling whether to warn about implicit executable targets when tools version is 5.4.
     private let warnAboutImplicitExecutableTargets: Bool
 
-    /// Temporary parameter controlling whether to allow package extension targets (durning bring-up, before proposal is accepted).
+    /// Temporary parameter controlling whether to allow package extension targets (during bring-up, before proposal is accepted).
+    /// This is set if SWIFTPM_ENABLE_EXTENSION_TARGETS=1 or if the feature is enabled in the initializer (for use by unit tests).
     private let allowExtensionTargets: Bool
     
     /// Create the special REPL product for this package.
@@ -271,7 +272,7 @@ public final class PackageBuilder {
         diagnostics: DiagnosticsEngine,
         shouldCreateMultipleTestProducts: Bool = false,
         warnAboutImplicitExecutableTargets: Bool = true,
-        allowExtensionTargets: Bool = (ProcessEnv.vars["SWIFTPM_ENABLE_EXTENSION_TARGETS"] == "1"),
+        allowExtensionTargets: Bool = false,
         createREPLProduct: Bool = false
     ) {
         self.manifest = manifest
@@ -283,7 +284,7 @@ public final class PackageBuilder {
         self.fileSystem = fileSystem
         self.diagnostics = diagnostics
         self.shouldCreateMultipleTestProducts = shouldCreateMultipleTestProducts
-        self.allowExtensionTargets = allowExtensionTargets
+        self.allowExtensionTargets = allowExtensionTargets || ProcessEnv.vars["SWIFTPM_ENABLE_EXTENSION_TARGETS"] == "1"
         self.createREPLProduct = createREPLProduct
         self.warnAboutImplicitExecutableTargets = warnAboutImplicitExecutableTargets
     }

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -221,6 +221,7 @@ public func loadPackageGraph(
     manifests: [Manifest],
     explicitProduct: String? = nil,
     shouldCreateMultipleTestProducts: Bool = false,
+    allowExtensionTargets: Bool = false,
     createREPLProduct: Bool = false
 ) throws -> PackageGraph {
     let rootManifests = manifests.filter { $0.packageKind == .root }
@@ -236,6 +237,7 @@ public func loadPackageGraph(
         diagnostics: diagnostics,
         fileSystem: fs,
         shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts,
+        allowExtensionTargets: allowExtensionTargets,
         createREPLProduct: createREPLProduct
     )
 }


### PR DESCRIPTION
Allow the feature flag to enable package extensions to be controlled by input parameters to the package graph in addition to the SWIFTPM_ENABLE_EXTENSION_TARGETS environment variable.

### Motivation:

This makes it easier to write unit tests for package extensions, which will continue to be behind a feature flag until the proposal is accepted and any needed changes have been made.

### Modifications:

Thread through a new boolean so that the feature is enabled if either the caller asks for it or if SWIFTPM_ENABLE_EXTENSION_TARGETS is set in the environment.

This builds on https://github.com/apple/swift-package-manager/pull/3277 and it is best to review that PR first and then just the diff b4c8df39b4d66b14649ab6f103d0387f1ce33941 of this PR.