### PR TITLE
add a dependency between PackageLoading and SourceControl in CMake

### DIFF
--- a/Sources/PackageLoading/CMakeLists.txt
+++ b/Sources/PackageLoading/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(PackageLoading PUBLIC
   TSCBasic
   Basics
   PackageModel
+  SourceControl
   TSCUtility)
 if(Foundation_FOUND)
   target_link_libraries(PackageLoading PUBLIC


### PR DESCRIPTION
motivation: PR #3236 added a dependency between PackageLoading and SourceControl but did not update CMake

changes: add a dependency between PackageLoading and SourceControl in CMake

