### PR TITLE
When compiling manifests, filter out remarks emitted by new Swift compiler driver

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -513,7 +513,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         // We might have some non-fatal output (warnings/notes) from the compiler even when
         // we were able to parse the manifest successfully.
         if let compilerOutput = result.compilerOutput {
-            // Temporary workaround to filter out debug output from integrated Swift driver.
+            // FIXME: Temporary workaround to filter out debug output from integrated Swift driver. [rdar://73710910]
             if !(compilerOutput.hasPrefix("<unknown>:0: remark: new Swift driver at") && compilerOutput.hasSuffix("will be used")) {
                 diagnostics?.emit(.warning(ManifestLoadingDiagnostic(output: compilerOutput, diagnosticFile: result.diagnosticFile)))
             }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -513,7 +513,10 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         // We might have some non-fatal output (warnings/notes) from the compiler even when
         // we were able to parse the manifest successfully.
         if let compilerOutput = result.compilerOutput {
-            diagnostics?.emit(.warning(ManifestLoadingDiagnostic(output: compilerOutput, diagnosticFile: result.diagnosticFile)))
+            // Temporary workaround to filter out debug output from integrated Swift driver.
+            if !(compilerOutput.hasPrefix("<unknown>:0: remark: new Swift driver at") && compilerOutput.hasSuffix("will be used")) {
+                diagnostics?.emit(.warning(ManifestLoadingDiagnostic(output: compilerOutput, diagnosticFile: result.diagnosticFile)))
+            }
         }
 
         return parsedManifest


### PR DESCRIPTION
Filter out remarks from the swift driver when parsing manifests.

### Motivation:

This remark is temporary, but is causing spurious test failures for tests that make sure there are no diagnostics.

### Modifications:

Avoid emitting a diagnostic when the only output from manifest compilation is the remark.

### Result:

Remarks from manifest compilation will no longer show up as diagnostics from SwiftPM.  Note that remarks from building are unaffected.