### PR TITLE
[Collections] Add skip signature check option to 'add'

### DIFF
--- a/Sources/PackageCollections/API.swift
+++ b/Sources/PackageCollections/API.swift
@@ -174,4 +174,8 @@ public enum PackageCollectionError: Equatable, Error {
 
     /// Package collection is not signed and user explicitly marks it untrusted
     case untrusted
+
+    /// There are no trusted root certificates. Signature check cannot be done in this case since it involves validating
+    /// the certificate chain that is used for signing and one requirement is that the root certificate must be trusted.
+    case cannotVerifySignature
 }

--- a/Sources/PackageCollections/Model/Collection.swift
+++ b/Sources/PackageCollections/Model/Collection.swift
@@ -100,13 +100,17 @@ extension PackageCollectionsModel {
         /// Indicates if the source is explicitly trusted or untrusted by the user
         public var isTrusted: Bool?
 
+        /// Indicates if the source can skip signature validation
+        public var skipSignatureCheck: Bool
+
         /// The source's absolute file system path, if its URL is of 'file' scheme.
         let absolutePath: AbsolutePath?
 
-        public init(type: CollectionSourceType, url: URL, isTrusted: Bool? = nil) {
+        public init(type: CollectionSourceType, url: URL, isTrusted: Bool? = nil, skipSignatureCheck: Bool = false) {
             self.type = type
             self.url = url
             self.isTrusted = isTrusted
+            self.skipSignatureCheck = skipSignatureCheck
 
             if url.scheme?.lowercased() == "file", let absolutePath = try? AbsolutePath(validating: url.path) {
                 self.absolutePath = absolutePath
@@ -192,8 +196,12 @@ extension PackageCollectionsModel {
         /// Details about the certificate used to generate the signature
         public let certificate: Certificate
 
-        public init(certificate: Certificate) {
+        /// Indicates if the signature has been validated. This is set to false if signature check didn't take place.
+        public let isVerified: Bool
+
+        public init(certificate: Certificate, isVerified: Bool) {
             self.certificate = certificate
+            self.isVerified = isVerified
         }
 
         public struct Certificate: Equatable, Codable {

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -140,8 +140,9 @@ public struct PackageCollections: PackageCollectionsProtocol {
                 self.refreshCollectionFromSource(source: source, trustConfirmationProvider: trustConfirmationProvider) { collectionResult in
                     switch collectionResult {
                     case .failure(let error):
-                        // Don't delete the source if we are either pending user confirmation or have recorded user's preference
-                        if let error = error as? PackageCollectionError, error == .trustConfirmationRequired || error == .untrusted {
+                        // Don't delete the source if we are either pending user confirmation or have recorded user's preference.
+                        // It is also possible that we can't verify signature (yet) due to config issue, which user can fix and we retry later.
+                        if let error = error as? PackageCollectionError, error == .trustConfirmationRequired || error == .untrusted || error == .cannotVerifySignature {
                             return callback(.failure(error))
                         }
                         // Otherwise remove source since it fails to be fetched

--- a/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
+++ b/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
@@ -187,6 +187,7 @@ private enum StorageModel {
         let type: String
         let value: String
         let isTrusted: Bool?
+        let skipSignatureCheck: Bool?
     }
 
     enum SourceType: String {
@@ -204,7 +205,7 @@ private extension Model.CollectionSource {
 
         switch from.type {
         case StorageModel.SourceType.json.rawValue:
-            self.init(type: .json, url: url, isTrusted: from.isTrusted)
+            self.init(type: .json, url: url, isTrusted: from.isTrusted, skipSignatureCheck: from.skipSignatureCheck ?? false)
         default:
             throw SerializationError.unknownType(from.type)
         }
@@ -213,7 +214,8 @@ private extension Model.CollectionSource {
     func source() -> StorageModel.Source {
         switch self.type {
         case .json:
-            return .init(type: StorageModel.SourceType.json.rawValue, value: self.url.absoluteString, isTrusted: self.isTrusted)
+            return .init(type: StorageModel.SourceType.json.rawValue, value: self.url.absoluteString,
+                         isTrusted: self.isTrusted, skipSignatureCheck: self.skipSignatureCheck)
         }
     }
 }

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -132,6 +132,69 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertNotNil(version.createdAt)
             XCTAssertTrue(collection.isSigned)
             let signature = collection.signature!
+            XCTAssertTrue(signature.isVerified)
+            XCTAssertEqual("Sample Subject", signature.certificate.subject.commonName)
+            XCTAssertEqual("Sample Issuer", signature.certificate.issuer.commonName)
+        }
+    }
+
+    func testGoodSigned_skipSignatureCheck() throws {
+        fixture(name: "Collections") { directoryPath in
+            let path = directoryPath.appending(components: "JSON", "good_signed.json")
+            let url = URL(string: "https://www.test.com/collection.json")!
+            let data = Data(try localFileSystem.readFileContents(path).contents)
+
+            let handler: HTTPClient.Handler = { request, _, completion in
+                XCTAssertEqual(request.url, url, "url should match")
+                switch request.method {
+                case .head:
+                    completion(.success(.init(statusCode: 200,
+                                              headers: .init([.init(name: "Content-Length", value: "\(data.count)")]))))
+                case .get:
+                    completion(.success(.init(statusCode: 200,
+                                              headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
+                                              body: data)))
+                default:
+                    XCTFail("method should match")
+                }
+            }
+
+            var httpClient = HTTPClient(handler: handler)
+            httpClient.configuration.circuitBreakerStrategy = .none
+            httpClient.configuration.retryStrategy = .none
+            let provider = JSONPackageCollectionProvider(httpClient: httpClient)
+            // Skip signature check
+            let source = PackageCollectionsModel.CollectionSource(type: .json, url: url, skipSignatureCheck: true)
+            let collection = try tsc_await { callback in provider.get(source, callback: callback) }
+
+            XCTAssertEqual(collection.name, "Sample Package Collection")
+            XCTAssertEqual(collection.overview, "This is a sample package collection listing made-up packages.")
+            XCTAssertEqual(collection.keywords, ["sample package collection"])
+            XCTAssertEqual(collection.createdBy?.name, "Jane Doe")
+            XCTAssertEqual(collection.packages.count, 2)
+            let package = collection.packages.first!
+            XCTAssertEqual(package.repository, .init(url: "https://www.example.com/repos/RepoOne.git"))
+            XCTAssertEqual(package.summary, "Package One")
+            XCTAssertEqual(package.keywords, ["sample package"])
+            XCTAssertEqual(package.readmeURL, URL(string: "https://www.example.com/repos/RepoOne/README")!)
+            XCTAssertEqual(package.license, .init(type: .Apache2_0, url: URL(string: "https://www.example.com/repos/RepoOne/LICENSE")!))
+            XCTAssertEqual(package.versions.count, 1)
+            let version = package.versions.first!
+            XCTAssertEqual(version.summary, "Fixed a few bugs")
+            let manifest = version.manifests.values.first!
+            XCTAssertEqual(manifest.packageName, "PackageOne")
+            XCTAssertEqual(manifest.targets, [.init(name: "Foo", moduleName: "Foo")])
+            XCTAssertEqual(manifest.products, [.init(name: "Foo", type: .library(.automatic), targets: [.init(name: "Foo", moduleName: "Foo")])])
+            XCTAssertEqual(manifest.toolsVersion, ToolsVersion(string: "5.1")!)
+            XCTAssertEqual(manifest.minimumPlatformVersions, [SupportedPlatform(platform: .macOS, version: .init("10.15"))])
+            XCTAssertEqual(version.verifiedCompatibility?.count, 3)
+            XCTAssertEqual(version.verifiedCompatibility!.first!.platform, .macOS)
+            XCTAssertEqual(version.verifiedCompatibility!.first!.swiftVersion, SwiftLanguageVersion(string: "5.1")!)
+            XCTAssertEqual(version.license, .init(type: .Apache2_0, url: URL(string: "https://www.example.com/repos/RepoOne/LICENSE")!))
+            XCTAssertNotNil(version.createdAt)
+            XCTAssertTrue(collection.isSigned)
+            let signature = collection.signature!
+            XCTAssertFalse(signature.isVerified)
             XCTAssertEqual("Sample Subject", signature.certificate.subject.commonName)
             XCTAssertEqual("Sample Issuer", signature.certificate.issuer.commonName)
         }

--- a/Tests/PackageCollectionsTests/PackageCollectionsSourcesStorageTest.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsSourcesStorageTest.swift
@@ -86,7 +86,16 @@ final class PackageCollectionsSourcesStorageTest: XCTestCase {
             source.isTrusted = !(source.isTrusted ?? false)
             _ = try tsc_await { callback in storage.update(source: source, callback: callback) }
             let listAfter = try tsc_await { callback in storage.list(callback: callback) }
-            XCTAssertEqual(source.isTrusted, listAfter.first!.isTrusted, "item should match")
+            XCTAssertEqual(source.isTrusted, listAfter.first!.isTrusted, "isTrusted should match")
+        }
+
+        do {
+            let list = try tsc_await { callback in storage.list(callback: callback) }
+            var source = list.first!
+            source.skipSignatureCheck = !source.skipSignatureCheck
+            _ = try tsc_await { callback in storage.update(source: source, callback: callback) }
+            let listAfter = try tsc_await { callback in storage.list(callback: callback) }
+            XCTAssertEqual(source.skipSignatureCheck, listAfter.first!.skipSignatureCheck, "skipSignatureCheck should match")
         }
     }
 

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -831,7 +831,8 @@ final class PackageCollectionsTests: XCTestCase {
                         certificate: PackageCollectionsModel.SignatureData.Certificate(
                             subject: .init(userID: nil, commonName: nil, organizationalUnit: nil, organization: nil),
                             issuer: .init(userID: nil, commonName: nil, organizationalUnit: nil, organization: nil)
-                        )
+                        ),
+                        isVerified: true
                     )
                     callback(.success(PackageCollectionsModel.Collection(source: source, name: "", overview: nil, keywords: nil, packages: [], createdAt: Date(), createdBy: nil, signature: signature)))
                 }

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -88,7 +88,8 @@ func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: I
                 certificate: PackageCollectionsModel.SignatureData.Certificate(
                     subject: .init(userID: nil, commonName: "subject-\(collectionIndex)", organizationalUnit: nil, organization: nil),
                     issuer: .init(userID: nil, commonName: "issuer-\(collectionIndex)", organizationalUnit: nil, organization: nil)
-                )
+                ),
+                isVerified: true
             )
         }
 


### PR DESCRIPTION
Motivation:
On non-Apple platforms since there are no trusted root certificates by default, signature checks will most certainly fail. To help people get started more quickly, and to offer people a way to opt-out, we will add a `--skip-signature-check` flag to the `add` collection command. User's selection is persisted to collection sources config such that `refresh` would honor it as well.

Modifications:
- Add `skipSignatureCheck` to `CollectionSource`
- Add `--skip-signature-check` to CLI
- Add `isVerified` to `Collection.SignatureData`. It is `false` when `skipSignatureCheck == true`.
- Update logic in `JSONPackageCollectionProvider` to honor `skipSignatureCheck`
- Update CLI to handle `cannotVerifySignature` error
