### PR TITLE
Clean up warnings, and only emit unique warnings with respect to missing targets, sources, and or resources

### DIFF
--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -87,18 +87,14 @@ public struct TargetSourcesBuilder {
         self.excludedPaths.forEach { exclude in
             if let message = validTargetPath(at: exclude) {
                 let warning = "Invalid Exclude: \(message) '\(exclude)'"
-                if !self.diags.diagnostics.contains(where: { $0.localizedDescription == warning }) {
-                    self.diags.emit(warning: warning)
-                }
+                self.diags.emit(warning: warning)
             }
         }
         
         self.declaredSources?.forEach { source in
             if let message = validTargetPath(at: source) {
                 let warning = "Invalid Source: \(message) '\(source)'"
-                if !self.diags.diagnostics.contains(where: { $0.localizedDescription == warning }) {
-                    self.diags.emit(warning: warning)
-                }
+                self.diags.emit(warning: warning)
             }
         }
 
@@ -175,6 +171,7 @@ public struct TargetSourcesBuilder {
         diagnoseLocalizedAndUnlocalizedVariants(in: resources)
         diagnoseMissingDevelopmentRegionResource(in: resources)
         diagnoseInfoPlistConflicts(in: resources)
+        diagnoseInvalidResource(in: resources)
 
         // It's an error to contain mixed language source files.
         if sources.containsMixedLanguage {
@@ -201,13 +198,6 @@ public struct TargetSourcesBuilder {
                     diags.emit(.error("duplicate resource rule '\(declaredResource.rule)' found for file at '\(path)'"))
                 }
                 matchedRule = Rule(rule: declaredResource.rule.fileRule, localization: declaredResource.localization)
-            }
-            
-            if let message = validTargetPath(at: resourcePath) {
-                let warning = "Invalid Resource: \(message) '\(resourcePath)'"
-                if !self.diags.diagnostics.contains(where: { $0.localizedDescription == warning }) {
-                    self.diags.emit(warning: warning)
-                }
             }
         }
 
@@ -355,6 +345,15 @@ public struct TargetSourcesBuilder {
                 diags.emit(.infoPlistResourceConflict(
                     path: resource.path.relative(to: targetPath),
                     targetName: target.name))
+            }
+        }
+    }
+    
+    private func diagnoseInvalidResource(in resources: [Resource]) {
+        resources.forEach { resource in
+            if let message = validTargetPath(at: resource.path) {
+                let warning = "Invalid Resource: \(message) '\(resource.path)'"
+                self.diags.emit(warning: warning)
             }
         }
     }

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -111,13 +111,13 @@ public struct TargetSourcesBuilder {
         
         // Check if paths that are enumerated in targets: [] exist
         guard self.fs.exists(at) else {
-            return StringError("Could not find")
+            return StringError("File not found")
         }
 
         // Excludes, Sources, and Resources should be found at the root of the package and or
         // its subdirectories
         guard at.pathString.hasPrefix(cwd.pathString) else {
-            return StringError("\(at) should be found within the root of \(cwd)")
+            return StringError("The current working directory '\(cwd)' should contain: ")
         }
         
         return nil

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -86,13 +86,17 @@ public struct TargetSourcesBuilder {
         
         self.excludedPaths.forEach { exclude in
             if let message = validTargetPath(at: exclude) {
-                self.diags.emit(warning: "Invalid Exclude: \(exclude): \(message)")
+                if !self.diags.diagnostics.contains(where: { $0.localizedDescription == "Invalid Exclude: \(message) '\(exclude)'" }) {
+                    self.diags.emit(warning: "Invalid Exclude: \(message) '\(exclude)'")
+                }
             }
         }
         
         self.declaredSources?.forEach { source in
             if let message = validTargetPath(at: source) {
-                self.diags.emit(warning: "Invalid Source: \(source): \(message)")
+                if !self.diags.diagnostics.contains(where: { $0.localizedDescription == "Invalid Source: \(message) '\(source)'" }) {
+                    self.diags.emit(warning: "Invalid Source: \(message) '\(source)'")
+                }
             }
         }
 
@@ -109,7 +113,7 @@ public struct TargetSourcesBuilder {
         
         // Check if paths that are enumerated in targets: [] exist
         guard self.fs.exists(at) else {
-            return StringError("\(at) could not be found")
+            return StringError("Could not find")
         }
 
         // Excludes, Sources, and Resources should be found at the root of the package and or
@@ -198,7 +202,9 @@ public struct TargetSourcesBuilder {
             }
             
             if let message = validTargetPath(at: resourcePath) {
-                self.diags.emit(warning: "Invalid Resource: \(resourcePath): \(message)")
+                if !self.diags.diagnostics.contains(where: { $0.localizedDescription == "Invalid Resource: \(message) '\(resourcePath)'" }) {
+                    self.diags.emit(warning: "Invalid Resource: \(message) '\(resourcePath)'")
+                }
             }
         }
 

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -113,7 +113,7 @@ public struct TargetSourcesBuilder {
         // Excludes, Sources, and Resources should be found at the root of the package and or
         // its subdirectories
         guard at.pathString.hasPrefix(self.packagePath.pathString) else {
-            return StringError("The current working directory '\(self.packagePath.pathString)' should contain: ")
+            return StringError("'\(self.packagePath.pathString)' should contain: ")
         }
         
         return nil

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -97,7 +97,7 @@ public struct TargetSourcesBuilder {
             if let message = validTargetPath(at: source) {
                 let warning = "Invalid Source: \(message) '\(source)'"
                 if !self.diags.diagnostics.contains(where: { $0.localizedDescription == warning }) {
-                    self.diags.emit(warning: "Invalid Source: \(message) '\(source)'")
+                    self.diags.emit(warning: warning)
                 }
             }
         }

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -86,15 +86,17 @@ public struct TargetSourcesBuilder {
         
         self.excludedPaths.forEach { exclude in
             if let message = validTargetPath(at: exclude) {
-                if !self.diags.diagnostics.contains(where: { $0.localizedDescription == "Invalid Exclude: \(message) '\(exclude)'" }) {
-                    self.diags.emit(warning: "Invalid Exclude: \(message) '\(exclude)'")
+                let warning = "Invalid Exclude: \(message) '\(exclude)'"
+                if !self.diags.diagnostics.contains(where: { $0.localizedDescription == warning }) {
+                    self.diags.emit(warning: warning)
                 }
             }
         }
         
         self.declaredSources?.forEach { source in
             if let message = validTargetPath(at: source) {
-                if !self.diags.diagnostics.contains(where: { $0.localizedDescription == "Invalid Source: \(message) '\(source)'" }) {
+                let warning = "Invalid Source: \(message) '\(source)'"
+                if !self.diags.diagnostics.contains(where: { $0.localizedDescription == warning }) {
                     self.diags.emit(warning: "Invalid Source: \(message) '\(source)'")
                 }
             }
@@ -202,8 +204,9 @@ public struct TargetSourcesBuilder {
             }
             
             if let message = validTargetPath(at: resourcePath) {
-                if !self.diags.diagnostics.contains(where: { $0.localizedDescription == "Invalid Resource: \(message) '\(resourcePath)'" }) {
-                    self.diags.emit(warning: "Invalid Resource: \(message) '\(resourcePath)'")
+                let warning = "Invalid Resource: \(message) '\(resourcePath)'"
+                if !self.diags.diagnostics.contains(where: { $0.localizedDescription == warning }) {
+                    self.diags.emit(warning: warning)
                 }
             }
         }

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -86,14 +86,14 @@ public struct TargetSourcesBuilder {
         
         self.excludedPaths.forEach { exclude in
             if let message = validTargetPath(at: exclude) {
-                let warning = "Invalid Exclude: \(message) '\(exclude)'"
+                let warning = "Invalid Exclude '\(exclude)': \(message)."
                 self.diags.emit(warning: warning)
             }
         }
         
         self.declaredSources?.forEach { source in
             if let message = validTargetPath(at: source) {
-                let warning = "Invalid Source: \(message) '\(source)'"
+                let warning = "Invalid Source '\(source)': \(message)."
                 self.diags.emit(warning: warning)
             }
         }
@@ -113,7 +113,7 @@ public struct TargetSourcesBuilder {
         // Excludes, Sources, and Resources should be found at the root of the package and or
         // its subdirectories
         guard at.pathString.hasPrefix(self.packagePath.pathString) else {
-            return StringError("'\(self.packagePath.pathString)' should contain: ")
+            return StringError("File must be within the package directory structure")
         }
         
         return nil
@@ -348,7 +348,7 @@ public struct TargetSourcesBuilder {
     private func diagnoseInvalidResource(in resources: [Resource]) {
         resources.forEach { resource in
             if let message = validTargetPath(at: resource.path) {
-                let warning = "Invalid Resource: \(message) '\(resource.path)'"
+                let warning = "Invalid Resource '\(resource.path)': \(message)."
                 self.diags.emit(warning: warning)
             }
         }

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -105,10 +105,6 @@ public struct TargetSourcesBuilder {
 
     @discardableResult
     private func validTargetPath(at: AbsolutePath) -> Error? {
-        guard let cwd = self.fs.currentWorkingDirectory else {
-            return StringError("Unknown Current Working Directory")
-        }
-        
         // Check if paths that are enumerated in targets: [] exist
         guard self.fs.exists(at) else {
             return StringError("File not found")
@@ -116,8 +112,8 @@ public struct TargetSourcesBuilder {
 
         // Excludes, Sources, and Resources should be found at the root of the package and or
         // its subdirectories
-        guard at.pathString.hasPrefix(cwd.pathString) else {
-            return StringError("The current working directory '\(cwd)' should contain: ")
+        guard at.pathString.hasPrefix(self.packagePath.pathString) else {
+            return StringError("The current working directory '\(self.packagePath.pathString)' should contain: ")
         }
         
         return nil


### PR DESCRIPTION
The current version is repetitive in two ways:

1. Prints the path out twice
2. The same warning can be emitted multiple times

With these changes not only is the warning message more concise, but it only prints unique warnings out 

If an exclude, source, and or resource is missing/found outside the root of the package a warning will be emitted