### PR TITLE
[Collections] Tighten import conditions

### DIFF
--- a/Sources/PackageCollections/API.swift
+++ b/Sources/PackageCollections/API.swift
@@ -182,4 +182,6 @@ public enum PackageCollectionError: Equatable, Error {
     case invalidSignature
 
     case missingSignature
+
+    case unsupportedPlatform
 }

--- a/Sources/PackageCollectionsSigning/Certificate/Certificate.swift
+++ b/Sources/PackageCollectionsSigning/Certificate/Certificate.swift
@@ -10,11 +10,11 @@
 
 import struct Foundation.Data
 
-#if canImport(Security)
+#if os(macOS)
 import Security
 #endif
 
-#if canImport(Security)
+#if os(macOS)
 typealias Certificate = CoreCertificate
 #else
 typealias Certificate = BoringSSLCertificate
@@ -22,7 +22,7 @@ typealias Certificate = BoringSSLCertificate
 
 // MARK: - Certificate implementation using the Security framework
 
-#if canImport(Security)
+#if os(macOS)
 struct CoreCertificate {
     let underlying: SecCertificate
 

--- a/Sources/PackageCollectionsSigning/Certificate/CertificatePolicy.swift
+++ b/Sources/PackageCollectionsSigning/Certificate/CertificatePolicy.swift
@@ -16,7 +16,7 @@ import struct Foundation.URL
 
 import TSCBasic
 
-#if canImport(Security)
+#if os(macOS)
 import Security
 #endif
 
@@ -53,7 +53,7 @@ extension CertificatePolicy {
             return wrappedCallback(.failure(CertificatePolicyError.emptyCertChain))
         }
 
-        #if canImport(Security)
+        #if os(macOS)
         let policy = SecPolicyCreateBasicX509()
         let revocationPolicy = SecPolicyCreateRevocation(kSecRevocationOCSPMethod)
 
@@ -99,7 +99,7 @@ extension CertificatePolicy {
 
 extension CertificatePolicy {
     func hasExtension(oid: String, in certificate: Certificate) throws -> Bool {
-        #if canImport(Security)
+        #if os(macOS)
         guard let dict = SecCertificateCopyValues(certificate.underlying, [oid as CFString] as CFArray, nil) as? [CFString: Any] else {
             throw CertificatePolicyError.extensionFailure
         }
@@ -110,7 +110,7 @@ extension CertificatePolicy {
     }
 
     func hasExtendedKeyUsage(_ usage: CertificateExtendedKeyUsage, in certificate: Certificate) throws -> Bool {
-        #if canImport(Security)
+        #if os(macOS)
         guard let dict = SecCertificateCopyValues(certificate.underlying, [kSecOIDExtendedKeyUsage] as CFArray, nil) as? [CFString: Any] else {
             throw CertificatePolicyError.extensionFailure
         }
@@ -127,7 +127,7 @@ extension CertificatePolicy {
     /// Checks that the certificate supports OCSP. This **must** be done before calling `verify` to ensure
     /// the necessary properties are in place to trigger revocation check.
     func supportsOCSP(certificate: Certificate) throws -> Bool {
-        #if canImport(Security)
+        #if os(macOS)
         // Check that certificate has "Certificate Authority Information Access" extension and includes OCSP as access method.
         // The actual revocation check will be done by the Security framework in `verify`.
         guard let dict = SecCertificateCopyValues(certificate.underlying, [kSecOIDAuthorityInfoAccess] as CFArray, nil) as? [CFString: Any] else { // ignore error
@@ -147,7 +147,7 @@ extension CertificatePolicy {
 enum CertificateExtendedKeyUsage {
     case codeSigning
 
-    #if canImport(Security)
+    #if os(macOS)
     var data: Data {
         switch self {
         case .codeSigning:

--- a/Sources/PackageCollectionsSigning/Key/Key+EC.swift
+++ b/Sources/PackageCollectionsSigning/Key/Key+EC.swift
@@ -21,7 +21,7 @@ struct ECPrivateKey: PrivateKey {
     init<Data>(pem data: Data) throws where Data: DataProtocol {
         let pem = String(decoding: data, as: UTF8.self)
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-        if #available(macOS 11, *) {
+        if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
             self.underlying = try CryptoECPrivateKey(pemRepresentation: pem)
         } else {
             let pemDocument = try ASN1.PEMDocument(pemString: pem)
@@ -45,7 +45,7 @@ struct ECPublicKey: PublicKey {
     init<Data>(pem data: Data) throws where Data: DataProtocol {
         let pem = String(decoding: data, as: UTF8.self)
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-        if #available(macOS 11, *) {
+        if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
             self.underlying = try CryptoECPublicKey(pemRepresentation: pem)
         } else {
             let pemDocument = try ASN1.PEMDocument(pemString: pem)

--- a/Sources/PackageCollectionsSigning/Key/Key+RSA.swift
+++ b/Sources/PackageCollectionsSigning/Key/Key+RSA.swift
@@ -10,11 +10,11 @@
 
 import Foundation
 
-#if canImport(Security)
+#if os(macOS)
 import Security
 #endif
 
-#if canImport(Security)
+#if os(macOS)
 typealias RSAPublicKey = CoreRSAPublicKey
 typealias RSAPrivateKey = CoreRSAPrivateKey
 #else
@@ -24,7 +24,7 @@ typealias RSAPrivateKey = BoringSSLRSAPrivateKey
 
 // MARK: - RSA key implementations using the Security framework
 
-#if canImport(Security)
+#if os(macOS)
 struct CoreRSAPrivateKey: PrivateKey {
     let underlying: SecKey
 

--- a/Sources/PackageCollectionsSigning/Signing/Signing+RSAKey.swift
+++ b/Sources/PackageCollectionsSigning/Signing/Signing+RSAKey.swift
@@ -10,13 +10,13 @@
 
 import struct Foundation.Data
 
-#if canImport(Security)
+#if os(macOS)
 import Security
 #endif
 
 // MARK: - MessageSigner and MessageValidator conformance using the Security framework
 
-#if canImport(Security)
+#if os(macOS)
 extension CoreRSAPrivateKey {
     func sign(message: Data) throws -> Data {
         var error: Unmanaged<CFError>?

--- a/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
+++ b/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
@@ -18,9 +18,7 @@ import TSCBasic
 
 class CertificatePolicyTests: XCTestCase {
     func test_RSA_validate_happyCase() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let certPath = directoryPath.appending(components: "Signing", "Test_rsa.cer")
@@ -40,9 +38,7 @@ class CertificatePolicyTests: XCTestCase {
     }
 
     func test_EC_validate_happyCase() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let certPath = directoryPath.appending(components: "Signing", "Test_ec.cer")
@@ -62,9 +58,7 @@ class CertificatePolicyTests: XCTestCase {
     }
 
     func test_validate_untrustedRoot() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let certPath = directoryPath.appending(components: "Signing", "Test_rsa.cer")
@@ -89,9 +83,7 @@ class CertificatePolicyTests: XCTestCase {
     }
 
     func test_validate_expiredCert() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let certPath = directoryPath.appending(components: "Signing", "Test_rsa.cer")
@@ -121,9 +113,7 @@ class CertificatePolicyTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let certPath = directoryPath.appending(components: "Signing", "development-revoked.cer")
@@ -168,9 +158,7 @@ class CertificatePolicyTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let certPath = directoryPath.appending(components: "Signing", "development.cer")
@@ -234,9 +222,7 @@ class CertificatePolicyTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             // This must be an Apple Distribution cert
@@ -301,9 +287,7 @@ class CertificatePolicyTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let certPath = directoryPath.appending(components: "Signing", "development.cer")
@@ -370,9 +354,7 @@ class CertificatePolicyTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             // This must be an Apple Distribution cert

--- a/Tests/PackageCollectionsSigningTests/CertificateTests.swift
+++ b/Tests/PackageCollectionsSigningTests/CertificateTests.swift
@@ -17,9 +17,7 @@ import TSCBasic
 
 class CertificateTests: XCTestCase {
     func test_withRSAKey_fromDER() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let path = directoryPath.appending(components: "Signing", "Test_rsa.cer")
@@ -42,9 +40,7 @@ class CertificateTests: XCTestCase {
     }
 
     func test_withECKey_fromDER() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let path = directoryPath.appending(components: "Signing", "Test_ec.cer")

--- a/Tests/PackageCollectionsSigningTests/KeyTests+EC.swift
+++ b/Tests/PackageCollectionsSigningTests/KeyTests+EC.swift
@@ -31,10 +31,18 @@ class ECKeyTests: XCTestCase {
     }
 
     func testPublicKeyFromPEM() throws {
+        if !isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         XCTAssertNoThrow(try ECPublicKey(pem: ecPublicKey.bytes))
     }
 
     func testPrivateKeyFromPEM() throws {
+        if !isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         XCTAssertNoThrow(try ECPrivateKey(pem: ecPrivateKey.bytes))
     }
 }

--- a/Tests/PackageCollectionsSigningTests/KeyTests+EC.swift
+++ b/Tests/PackageCollectionsSigningTests/KeyTests+EC.swift
@@ -17,9 +17,7 @@ import TSCBasic
 
 class ECKeyTests: XCTestCase {
     func testPublicKeyFromCertificate() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let path = directoryPath.appending(components: "Signing", "Test_ec.cer")
@@ -31,17 +29,13 @@ class ECKeyTests: XCTestCase {
     }
 
     func testPublicKeyFromPEM() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         XCTAssertNoThrow(try ECPublicKey(pem: ecPublicKey.bytes))
     }
 
     func testPrivateKeyFromPEM() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         XCTAssertNoThrow(try ECPrivateKey(pem: ecPrivateKey.bytes))
     }

--- a/Tests/PackageCollectionsSigningTests/KeyTests+RSA.swift
+++ b/Tests/PackageCollectionsSigningTests/KeyTests+RSA.swift
@@ -17,9 +17,7 @@ import TSCBasic
 
 class RSAKeyTests: XCTestCase {
     func testPublicKeyFromCertificate() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let path = directoryPath.appending(components: "Signing", "Test_rsa.cer")
@@ -31,17 +29,13 @@ class RSAKeyTests: XCTestCase {
     }
 
     func testPublicKeyFromPEM() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         XCTAssertNoThrow(try RSAPublicKey(pem: rsaPublicKey.bytes))
     }
 
     func testPrivateKeyFromPEM() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         XCTAssertNoThrow(try RSAPrivateKey(pem: rsaPrivateKey.bytes))
     }

--- a/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
+++ b/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
@@ -19,9 +19,7 @@ import TSCBasic
 
 class PackageCollectionSigningTests: XCTestCase {
     func test_RSA_signAndValidate_happyCase() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
@@ -53,9 +51,7 @@ class PackageCollectionSigningTests: XCTestCase {
     }
 
     func test_RSA_signAndValidate_collectionMismatch() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let collection1 = PackageCollectionModel.V1.Collection(
@@ -111,9 +107,7 @@ class PackageCollectionSigningTests: XCTestCase {
     }
 
     func test_EC_signAndValidate_happyCase() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
@@ -145,9 +139,7 @@ class PackageCollectionSigningTests: XCTestCase {
     }
 
     func test_EC_signAndValidate_collectionMismatch() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let collection1 = PackageCollectionModel.V1.Collection(
@@ -208,9 +200,7 @@ class PackageCollectionSigningTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
@@ -302,9 +292,7 @@ class PackageCollectionSigningTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
@@ -397,9 +385,7 @@ class PackageCollectionSigningTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()
@@ -453,9 +439,7 @@ class PackageCollectionSigningTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let jsonDecoder = JSONDecoder.makeWithDefaults()

--- a/Tests/PackageCollectionsSigningTests/SignatureTests.swift
+++ b/Tests/PackageCollectionsSigningTests/SignatureTests.swift
@@ -17,9 +17,7 @@ import TSCBasic
 
 class SignatureTests: XCTestCase {
     func test_RS256_generateAndValidate_happyCase() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let jsonEncoder = JSONEncoder()
@@ -45,9 +43,7 @@ class SignatureTests: XCTestCase {
     }
 
     func test_RS256_generateAndValidate_keyMismatch() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let jsonEncoder = JSONEncoder()
@@ -76,9 +72,7 @@ class SignatureTests: XCTestCase {
     }
 
     func test_ES256_generateAndValidate_happyCase() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let jsonEncoder = JSONEncoder()
@@ -104,9 +98,7 @@ class SignatureTests: XCTestCase {
     }
 
     func test_ES256_generateAndValidate_keyMismatch() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         fixture(name: "Collections") { directoryPath in
             let jsonEncoder = JSONEncoder()

--- a/Tests/PackageCollectionsSigningTests/SigningTests+ECKey.swift
+++ b/Tests/PackageCollectionsSigningTests/SigningTests+ECKey.swift
@@ -15,9 +15,7 @@ import XCTest
 
 class ECKeySigningTests: XCTestCase {
     func test_signAndValidate_happyCase() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let privateKey = try ECPrivateKey(pem: ecPrivateKey.bytes)
         let publicKey = try ECPublicKey(pem: ecPublicKey.bytes)
@@ -28,9 +26,7 @@ class ECKeySigningTests: XCTestCase {
     }
 
     func test_signAndValidate_mismatch() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let privateKey = try ECPrivateKey(pem: ecPrivateKey.bytes)
         let publicKey = try ECPublicKey(pem: ecPublicKey.bytes)

--- a/Tests/PackageCollectionsSigningTests/SigningTests+ECKey.swift
+++ b/Tests/PackageCollectionsSigningTests/SigningTests+ECKey.swift
@@ -15,6 +15,10 @@ import XCTest
 
 class ECKeySigningTests: XCTestCase {
     func test_signAndValidate_happyCase() throws {
+        if !isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let privateKey = try ECPrivateKey(pem: ecPrivateKey.bytes)
         let publicKey = try ECPublicKey(pem: ecPublicKey.bytes)
 
@@ -24,6 +28,10 @@ class ECKeySigningTests: XCTestCase {
     }
 
     func test_signAndValidate_mismatch() throws {
+        if !isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let privateKey = try ECPrivateKey(pem: ecPrivateKey.bytes)
         let publicKey = try ECPublicKey(pem: ecPublicKey.bytes)
 

--- a/Tests/PackageCollectionsSigningTests/SigningTests+RSAKey.swift
+++ b/Tests/PackageCollectionsSigningTests/SigningTests+RSAKey.swift
@@ -15,9 +15,7 @@ import XCTest
 
 class RSAKeySigningTests: XCTestCase {
     func test_signAndValidate_happyCase() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let privateKey = try RSAPrivateKey(pem: rsaPrivateKey.bytes)
         let publicKey = try RSAPublicKey(pem: rsaPublicKey.bytes)
@@ -28,9 +26,7 @@ class RSAKeySigningTests: XCTestCase {
     }
 
     func test_signAndValidate_mismatch() throws {
-        if !isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let privateKey = try RSAPrivateKey(pem: rsaPrivateKey.bytes)
         let publicKey = try RSAPublicKey(pem: rsaPublicKey.bytes)

--- a/Tests/PackageCollectionsSigningTests/Utilities.swift
+++ b/Tests/PackageCollectionsSigningTests/Utilities.swift
@@ -10,15 +10,10 @@
 
 import Dispatch
 import Foundation
+import XCTest
 
 @testable import PackageCollectionsSigning
 import TSCBasic
-
-#if os(macOS)
-let isSupportedPlatform = true
-#else
-let isSupportedPlatform = false
-#endif
 
 // Update this when running ENABLE_REAL_CERT_TEST tests
 let expectedSubjectUserID = "<USER ID>"
@@ -168,5 +163,14 @@ qseI/cG+CoygHw9OqBcffl1d8LVAHmF8mkfzJ2CnQs9CLFxS1+f9
 extension String {
     var bytes: [UInt8] {
         [UInt8](self.utf8)
+    }
+}
+
+extension XCTestCase {
+    func skipIfUnsupportedPlatform() throws {
+        #if os(macOS)
+        #else
+        throw XCTSkip("Skipping test on unsupported platform")
+        #endif
     }
 }

--- a/Tests/PackageCollectionsSigningTests/Utilities.swift
+++ b/Tests/PackageCollectionsSigningTests/Utilities.swift
@@ -14,7 +14,7 @@ import Foundation
 @testable import PackageCollectionsSigning
 import TSCBasic
 
-#if canImport(Security)
+#if os(macOS)
 let isSupportedPlatform = true
 #else
 let isSupportedPlatform = false

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -20,8 +20,6 @@ import SPMTestSupport
 import TSCBasic
 import TSCUtility
 
-private let enableSignatureCheck = JSONPackageCollectionProvider.enableSignatureCheck
-
 class JSONPackageCollectionProviderTests: XCTestCase {
     func testGood() throws {
         fixture(name: "Collections") { directoryPath in
@@ -335,9 +333,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     }
 
     func testSignedGood() throws {
-        if !enableSignatureCheck || !JSONPackageCollectionProvider.isSignatureCheckSupported {
-            try XCTSkipIf(true)
-        }
+        try skipIfSignatureCheckDisabled()
+        try skipIfSignatureCheckNotSupported()
 
         fixture(name: "Collections") { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good_signed.json")
@@ -403,9 +400,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     }
 
     func testSigned_skipSignatureCheck() throws {
-        if !enableSignatureCheck {
-            try XCTSkipIf(true)
-        }
+        try skipIfSignatureCheckDisabled()
 
         fixture(name: "Collections") { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good_signed.json")
@@ -471,9 +466,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     }
 
     func testSigned_noTrustedRootCertsConfigured() throws {
-        if !enableSignatureCheck || !JSONPackageCollectionProvider.isSignatureCheckSupported {
-            try XCTSkipIf(true)
-        }
+        try skipIfSignatureCheckDisabled()
+        try skipIfSignatureCheckNotSupported()
 
         fixture(name: "Collections") { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good_signed.json")
@@ -515,9 +509,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     }
 
     func testSignedBad() throws {
-        if !enableSignatureCheck || !JSONPackageCollectionProvider.isSignatureCheckSupported {
-            try XCTSkipIf(true)
-        }
+        try skipIfSignatureCheckDisabled()
+        try skipIfSignatureCheckNotSupported()
 
         fixture(name: "Collections") { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good_signed.json")
@@ -560,9 +553,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     }
 
     func testSignedLocalFile() throws {
-        if !enableSignatureCheck || !JSONPackageCollectionProvider.isSignatureCheckSupported {
-            try XCTSkipIf(true)
-        }
+        try skipIfSignatureCheckDisabled()
+        try skipIfSignatureCheckNotSupported()
 
         fixture(name: "Collections") { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good_signed.json")
@@ -610,9 +602,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     }
 
     func testRequiredSigningGood() throws {
-        if !enableSignatureCheck {
-            try XCTSkipIf(true)
-        }
+        try skipIfSignatureCheckDisabled()
 
         fixture(name: "Collections") { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good_signed.json")
@@ -683,9 +673,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     }
 
     func testMissingRequiredSignature() throws {
-        if !enableSignatureCheck {
-            try XCTSkipIf(true)
-        }
+        try skipIfSignatureCheckDisabled()
 
         fixture(name: "Collections") { directoryPath in
             let path = directoryPath.appending(components: "JSON", "good.json")
@@ -729,6 +717,20 @@ class JSONPackageCollectionProviderTests: XCTestCase {
                     XCTFail("unexpected error \(error)")
                 }
             })
+        }
+    }
+}
+
+private extension XCTestCase {
+    func skipIfSignatureCheckDisabled() throws {
+        if !JSONPackageCollectionProvider.enableSignatureCheck {
+            throw XCTSkip("Skipping test because signature check is disabled")
+        }
+    }
+
+    func skipIfSignatureCheckNotSupported() throws {
+        if !JSONPackageCollectionProvider.isSignatureCheckSupported {
+            throw XCTSkip("Skipping test because signature check is not supported")
         }
     }
 }

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -335,7 +335,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     }
 
     func testSignedGood() throws {
-        if !enableSignatureCheck {
+        if !enableSignatureCheck || !JSONPackageCollectionProvider.isSignatureCheckSupported {
             try XCTSkipIf(true)
         }
 
@@ -471,7 +471,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     }
 
     func testSigned_noTrustedRootCertsConfigured() throws {
-        if !enableSignatureCheck {
+        if !enableSignatureCheck || !JSONPackageCollectionProvider.isSignatureCheckSupported {
             try XCTSkipIf(true)
         }
 
@@ -515,7 +515,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     }
 
     func testSignedBad() throws {
-        if !enableSignatureCheck {
+        if !enableSignatureCheck || !JSONPackageCollectionProvider.isSignatureCheckSupported {
             try XCTSkipIf(true)
         }
 
@@ -560,7 +560,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
     }
 
     func testSignedLocalFile() throws {
-        if !enableSignatureCheck {
+        if !enableSignatureCheck || !JSONPackageCollectionProvider.isSignatureCheckSupported {
             try XCTSkipIf(true)
         }
 

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -19,6 +19,10 @@ import TSCUtility
 
 final class PackageCollectionsTests: XCTestCase {
     func testBasicRegistration() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -44,6 +48,10 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testAddDuplicates() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -70,6 +78,10 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testAddUnsigned() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -111,6 +123,10 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testInvalidCollectionNotAdded() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -144,6 +160,10 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testCollectionPendingTrustConfirmIsKeptOnAdd() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -176,6 +196,10 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testCollectionWithInvalidSignatureNotAdded() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -210,6 +234,10 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testDelete() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -259,6 +287,10 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testDeleteFromBothStorages() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -292,6 +324,10 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testOrdering() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -361,6 +397,10 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testReorder() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -461,6 +501,10 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testUpdateTrust() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -515,6 +559,10 @@ final class PackageCollectionsTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -543,6 +591,10 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testPackageSearch() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -674,6 +726,10 @@ final class PackageCollectionsTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -702,6 +758,10 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testTargetsSearch() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -800,6 +860,10 @@ final class PackageCollectionsTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -828,6 +892,10 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testHappyRefresh() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -848,6 +916,10 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testBrokenRefresh() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         struct BrokenProvider: PackageCollectionProvider {
             let brokenSources: [PackageCollectionsModel.CollectionSource]
             let error: Error
@@ -920,6 +992,10 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testRefreshOne() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -940,6 +1016,10 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testListTargets() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -976,6 +1056,10 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testFetchMetadataHappy() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -1010,6 +1094,10 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testFetchMetadataInOrder() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -1042,7 +1130,11 @@ final class PackageCollectionsTests: XCTestCase {
         XCTAssertEqual(metadata.package, expectedMetadata, "package should match")
     }
 
-    func testMergedPackageMetadata() {
+    func testMergedPackageMetadata() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let packageId = UUID().uuidString
 
         let targets = (0 ..< Int.random(in: 1 ... 5)).map {
@@ -1125,6 +1217,10 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testFetchMetadataNotFoundInCollections() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -1146,6 +1242,10 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testFetchMetadataNotFoundByProvider() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
@@ -1179,6 +1279,10 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testFetchMetadataProviderError() throws {
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
+
         struct BrokenMetadataProvider: PackageMetadataProvider {
             var name: String = "BrokenMetadataProvider"
 
@@ -1223,6 +1327,10 @@ final class PackageCollectionsTests: XCTestCase {
         #else
         try XCTSkipIf(true)
         #endif
+
+        if !PackageCollections.isSupportedPlatform {
+            try XCTSkipIf(true)
+        }
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -19,9 +19,7 @@ import TSCUtility
 
 final class PackageCollectionsTests: XCTestCase {
     func testBasicRegistration() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -48,9 +46,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testAddDuplicates() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -78,9 +74,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testAddUnsigned() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -123,9 +117,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testInvalidCollectionNotAdded() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -160,9 +152,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testCollectionPendingTrustConfirmIsKeptOnAdd() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -196,9 +186,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testCollectionWithInvalidSignatureNotAdded() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -234,9 +222,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testDelete() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -287,9 +273,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testDeleteFromBothStorages() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -324,9 +308,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testOrdering() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -397,9 +379,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testReorder() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -501,9 +481,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testUpdateTrust() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -559,9 +537,7 @@ final class PackageCollectionsTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -591,9 +567,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testPackageSearch() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -726,9 +700,7 @@ final class PackageCollectionsTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -758,9 +730,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testTargetsSearch() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -860,9 +830,7 @@ final class PackageCollectionsTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -892,9 +860,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testHappyRefresh() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -916,9 +882,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testBrokenRefresh() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         struct BrokenProvider: PackageCollectionProvider {
             let brokenSources: [PackageCollectionsModel.CollectionSource]
@@ -992,9 +956,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testRefreshOne() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -1016,9 +978,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testListTargets() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -1056,9 +1016,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testFetchMetadataHappy() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -1094,9 +1052,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testFetchMetadataInOrder() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -1131,9 +1087,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testMergedPackageMetadata() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let packageId = UUID().uuidString
 
@@ -1217,9 +1171,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testFetchMetadataNotFoundInCollections() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -1242,9 +1194,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testFetchMetadataNotFoundByProvider() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -1279,9 +1229,7 @@ final class PackageCollectionsTests: XCTestCase {
     }
 
     func testFetchMetadataProviderError() throws {
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         struct BrokenMetadataProvider: PackageMetadataProvider {
             var name: String = "BrokenMetadataProvider"
@@ -1328,9 +1276,7 @@ final class PackageCollectionsTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        if !PackageCollections.isSupportedPlatform {
-            try XCTSkipIf(true)
-        }
+        try skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
@@ -1357,5 +1303,13 @@ final class PackageCollectionsTests: XCTestCase {
         XCTAssertNotNil(metadata)
         let delta = Date().timeIntervalSince(start)
         XCTAssert(delta < 1.0, "should fetch quickly, took \(delta)")
+    }
+}
+
+private extension XCTestCase {
+    func skipIfUnsupportedPlatform() throws {
+        if !PackageCollections.isSupportedPlatform {
+            throw XCTSkip("Skipping test on unsupported platform")
+        }
     }
 }


### PR DESCRIPTION
Some `Security` framework APIs are available on macOS only
