### PR TITLE
[Collections] Check for collections that are required to be signed

### DIFF
--- a/Sources/Commands/SwiftPackageCollectionsTool.swift
+++ b/Sources/Commands/SwiftPackageCollectionsTool.swift
@@ -22,6 +22,7 @@ private enum CollectionsError: Swift.Error {
     case unsigned
     case cannotVerifySignature
     case invalidSignature
+    case missingSignature
 }
 
 // FIXME: add links to docs in error messages
@@ -38,6 +39,8 @@ extension CollectionsError: CustomStringConvertible {
             return "The collection's signature cannot be verified due to missing configuration. Please refer to documentations on how to set up trusted root certificates or rerun 'add' with '--skip-signature-check'."
         case .invalidSignature:
             return "The collection's signature is invalid. If you would still like to add it please rerun 'add' with '--skip-signature-check'."
+        case .missingSignature:
+            return "The collection is missing required signature, which means it might have been compromised. Please contact the collection's authors and alert them of the issue."
         }
     }
 }
@@ -139,6 +142,8 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
                     throw CollectionsError.cannotVerifySignature
                 } catch PackageCollectionError.invalidSignature {
                     throw CollectionsError.invalidSignature
+                } catch PackageCollectionError.missingSignature {
+                    throw CollectionsError.missingSignature
                 }
             }
 

--- a/Sources/PackageCollections/API.swift
+++ b/Sources/PackageCollections/API.swift
@@ -180,4 +180,6 @@ public enum PackageCollectionError: Equatable, Error {
     case cannotVerifySignature
 
     case invalidSignature
+
+    case missingSignature
 }

--- a/Sources/PackageCollections/PackageCollections+CertificatePolicy.swift
+++ b/Sources/PackageCollections/PackageCollections+CertificatePolicy.swift
@@ -17,18 +17,28 @@ import TSCBasic
 /// that are more restrictive. For example, a source may want to require that all their package
 /// collections be signed using certificate that belongs to certain subject user ID.
 internal struct PackageCollectionSourceCertificatePolicy {
-    static let sourceCertPolicies: [String: CertificatePolicyConfig] = [:]
+    private static let defaultSourceCertPolicies: [String: CertificatePolicyConfig] = [:]
 
-    static func certificatePolicyKey(for source: Model.CollectionSource) -> CertificatePolicyKey? {
-        // Certificate policy is associated to a collection host
-        source.url.host.flatMap { self.sourceCertPolicies[$0]?.certPolicyKey }
-    }
+    private let sourceCertPolicies: [String: CertificatePolicyConfig]
 
-    static var allRootCerts: [String]? {
-        let allRootCerts = Self.sourceCertPolicies.values
+    var allRootCerts: [String]? {
+        let allRootCerts = self.sourceCertPolicies.values
             .compactMap { $0.base64EncodedRootCerts }
             .flatMap { $0 }
         return allRootCerts.isEmpty ? nil : allRootCerts
+    }
+
+    init(sourceCertPolicies: [String: CertificatePolicyConfig]? = nil) {
+        self.sourceCertPolicies = sourceCertPolicies ?? Self.defaultSourceCertPolicies
+    }
+
+    func mustBeSigned(source: Model.CollectionSource) -> Bool {
+        source.certPolicyConfigKey.map { self.sourceCertPolicies[$0] != nil } ?? false
+    }
+
+    func certificatePolicyKey(for source: Model.CollectionSource) -> CertificatePolicyKey? {
+        // Certificate policy is associated to a collection host
+        source.certPolicyConfigKey.flatMap { self.sourceCertPolicies[$0]?.certPolicyKey }
     }
 
     struct CertificatePolicyConfig {
@@ -37,5 +47,11 @@ internal struct PackageCollectionSourceCertificatePolicy {
         /// Root CAs of the signing certificates. Each item is the base64-encoded string
         /// of the DER representation of a root CA.
         let base64EncodedRootCerts: [String]?
+    }
+}
+
+private extension Model.CollectionSource {
+    var certPolicyConfigKey: String? {
+        self.url.host
     }
 }

--- a/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
+++ b/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
@@ -319,16 +319,46 @@ class CertificatePolicyTests: XCTestCase {
 
             #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
-            let policy = DefaultCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: expectedSubjectUserID,
-                                                  callbackQueue: DispatchQueue.global(), diagnosticsEngine: DiagnosticsEngine())
-            XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
+
+            // Subject user ID matches
+            do {
+                let policy = DefaultCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: expectedSubjectUserID,
+                                                      callbackQueue: DispatchQueue.global(), diagnosticsEngine: DiagnosticsEngine())
+                XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
+            }
+            // Subject user ID does not match
+            do {
+                let mismatchSubjectUserID = "\(expectedSubjectUserID)-2"
+                let policy = DefaultCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: mismatchSubjectUserID,
+                                                      callbackQueue: DispatchQueue.global(), diagnosticsEngine: DiagnosticsEngine())
+                XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
+                    guard CertificatePolicyError.subjectUserIDMismatch == error as? CertificatePolicyError else {
+                        return XCTFail("Expected CertificatePolicyError.subjectUserIDMismatch")
+                    }
+                }
+            }
             #else
             // On other platforms we have to specify `trustedRootCertsDir` so the Apple root cert is trusted
             try withTemporaryDirectory { tmp in
                 try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))
-                let policy = DefaultCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil, expectedSubjectUserID: expectedSubjectUserID,
-                                                      callbackQueue: DispatchQueue.global(), diagnosticsEngine: DiagnosticsEngine())
-                XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
+
+                // Subject user ID matches
+                do {
+                    let policy = DefaultCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil, expectedSubjectUserID: expectedSubjectUserID,
+                                                          callbackQueue: DispatchQueue.global(), diagnosticsEngine: DiagnosticsEngine())
+                    XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
+                }
+                // Subject user ID does not match
+                do {
+                    let mismatchSubjectUserID = "\(expectedSubjectUserID)-2"
+                    let policy = DefaultCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil, expectedSubjectUserID: mismatchSubjectUserID,
+                                                          callbackQueue: DispatchQueue.global(), diagnosticsEngine: DiagnosticsEngine())
+                    XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
+                        guard CertificatePolicyError.subjectUserIDMismatch == error as? CertificatePolicyError else {
+                            return XCTFail("Expected CertificatePolicyError.subjectUserIDMismatch")
+                        }
+                    }
+                }
             }
             #endif
         }
@@ -359,16 +389,46 @@ class CertificatePolicyTests: XCTestCase {
 
             #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
             // The Apple root certs come preinstalled on Apple platforms and they are automatically trusted
-            let policy = AppleDeveloperCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: expectedSubjectUserID,
-                                                         callbackQueue: DispatchQueue.global(), diagnosticsEngine: DiagnosticsEngine())
-            XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
+
+            // Subject user ID matches
+            do {
+                let policy = AppleDeveloperCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: expectedSubjectUserID,
+                                                             callbackQueue: DispatchQueue.global(), diagnosticsEngine: DiagnosticsEngine())
+                XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
+            }
+            // Subject user ID does not match
+            do {
+                let mismatchSubjectUserID = "\(expectedSubjectUserID)-2"
+                let policy = AppleDeveloperCertificatePolicy(trustedRootCertsDir: nil, additionalTrustedRootCerts: nil, expectedSubjectUserID: mismatchSubjectUserID,
+                                                             callbackQueue: DispatchQueue.global(), diagnosticsEngine: DiagnosticsEngine())
+                XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
+                    guard CertificatePolicyError.subjectUserIDMismatch == error as? CertificatePolicyError else {
+                        return XCTFail("Expected CertificatePolicyError.subjectUserIDMismatch")
+                    }
+                }
+            }
             #else
             // On other platforms we have to specify `trustedRootCertsDir` so the Apple root cert is trusted
             try withTemporaryDirectory { tmp in
                 try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))
-                let policy = AppleDeveloperCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil, expectedSubjectUserID: expectedSubjectUserID,
-                                                             callbackQueue: DispatchQueue.global(), diagnosticsEngine: DiagnosticsEngine())
-                XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
+
+                // Subject user ID matches
+                do {
+                    let policy = AppleDeveloperCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil, expectedSubjectUserID: expectedSubjectUserID,
+                                                                 callbackQueue: DispatchQueue.global(), diagnosticsEngine: DiagnosticsEngine())
+                    XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
+                }
+                // Subject user ID does not match
+                do {
+                    let mismatchSubjectUserID = "\(expectedSubjectUserID)-2"
+                    let policy = AppleDeveloperCertificatePolicy(trustedRootCertsDir: tmp.asURL, additionalTrustedRootCerts: nil, expectedSubjectUserID: mismatchSubjectUserID,
+                                                                 callbackQueue: DispatchQueue.global(), diagnosticsEngine: DiagnosticsEngine())
+                    XCTAssertThrowsError(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) }) { error in
+                        guard CertificatePolicyError.subjectUserIDMismatch == error as? CertificatePolicyError else {
+                            return XCTFail("Expected CertificatePolicyError.subjectUserIDMismatch")
+                        }
+                    }
+                }
             }
             #endif
         }

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -13,6 +13,7 @@ import XCTest
 
 import Basics
 @testable import PackageCollections
+import PackageCollectionsSigning
 import PackageModel
 import SourceControl
 import SPMTestSupport
@@ -605,6 +606,129 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             XCTAssertTrue(signature.isVerified)
             XCTAssertEqual("Sample Subject", signature.certificate.subject.commonName)
             XCTAssertEqual("Sample Issuer", signature.certificate.issuer.commonName)
+        }
+    }
+
+    func testRequiredSigningGood() throws {
+        if !enableSignatureCheck {
+            try XCTSkipIf(true)
+        }
+
+        fixture(name: "Collections") { directoryPath in
+            let path = directoryPath.appending(components: "JSON", "good_signed.json")
+            let url = URL(string: "https://www.test.com/collection.json")!
+            let data = Data(try localFileSystem.readFileContents(path).contents)
+
+            let handler: HTTPClient.Handler = { request, _, completion in
+                XCTAssertEqual(request.url, url, "url should match")
+                switch request.method {
+                case .head:
+                    completion(.success(.init(statusCode: 200,
+                                              headers: .init([.init(name: "Content-Length", value: "\(data.count)")]))))
+                case .get:
+                    completion(.success(.init(statusCode: 200,
+                                              headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
+                                              body: data)))
+                default:
+                    XCTFail("method should match")
+                }
+            }
+
+            var httpClient = HTTPClient(handler: handler)
+            httpClient.configuration.circuitBreakerStrategy = .none
+            httpClient.configuration.retryStrategy = .none
+
+            // Mark collection as having valid signature
+            let signatureValidator = MockCollectionSignatureValidator(["Sample Package Collection"])
+            // Collections from www.test.com must be signed
+            let sourceCertPolicy = PackageCollectionSourceCertificatePolicy(
+                sourceCertPolicies: ["www.test.com": .init(certPolicyKey: CertificatePolicyKey.default, base64EncodedRootCerts: nil)]
+            )
+            let provider = JSONPackageCollectionProvider(httpClient: httpClient, signatureValidator: signatureValidator,
+                                                         sourceCertPolicy: sourceCertPolicy, diagnosticsEngine: DiagnosticsEngine())
+            let source = PackageCollectionsModel.CollectionSource(type: .json, url: url)
+            let collection = try tsc_await { callback in provider.get(source, callback: callback) }
+
+            XCTAssertEqual(collection.name, "Sample Package Collection")
+            XCTAssertEqual(collection.overview, "This is a sample package collection listing made-up packages.")
+            XCTAssertEqual(collection.keywords, ["sample package collection"])
+            XCTAssertEqual(collection.createdBy?.name, "Jane Doe")
+            XCTAssertEqual(collection.packages.count, 2)
+            let package = collection.packages.first!
+            XCTAssertEqual(package.repository, .init(url: "https://www.example.com/repos/RepoOne.git"))
+            XCTAssertEqual(package.summary, "Package One")
+            XCTAssertEqual(package.keywords, ["sample package"])
+            XCTAssertEqual(package.readmeURL, URL(string: "https://www.example.com/repos/RepoOne/README")!)
+            XCTAssertEqual(package.license, .init(type: .Apache2_0, url: URL(string: "https://www.example.com/repos/RepoOne/LICENSE")!))
+            XCTAssertEqual(package.versions.count, 1)
+            let version = package.versions.first!
+            XCTAssertEqual(version.summary, "Fixed a few bugs")
+            let manifest = version.manifests.values.first!
+            XCTAssertEqual(manifest.packageName, "PackageOne")
+            XCTAssertEqual(manifest.targets, [.init(name: "Foo", moduleName: "Foo")])
+            XCTAssertEqual(manifest.products, [.init(name: "Foo", type: .library(.automatic), targets: [.init(name: "Foo", moduleName: "Foo")])])
+            XCTAssertEqual(manifest.toolsVersion, ToolsVersion(string: "5.1")!)
+            XCTAssertEqual(manifest.minimumPlatformVersions, [SupportedPlatform(platform: .macOS, version: .init("10.15"))])
+            XCTAssertEqual(version.verifiedCompatibility?.count, 3)
+            XCTAssertEqual(version.verifiedCompatibility!.first!.platform, .macOS)
+            XCTAssertEqual(version.verifiedCompatibility!.first!.swiftVersion, SwiftLanguageVersion(string: "5.1")!)
+            XCTAssertEqual(version.license, .init(type: .Apache2_0, url: URL(string: "https://www.example.com/repos/RepoOne/LICENSE")!))
+            XCTAssertNotNil(version.createdAt)
+            XCTAssertTrue(collection.isSigned)
+            let signature = collection.signature!
+            XCTAssertTrue(signature.isVerified)
+            XCTAssertEqual("Sample Subject", signature.certificate.subject.commonName)
+            XCTAssertEqual("Sample Issuer", signature.certificate.issuer.commonName)
+        }
+    }
+
+    func testMissingRequiredSignature() throws {
+        if !enableSignatureCheck {
+            try XCTSkipIf(true)
+        }
+
+        fixture(name: "Collections") { directoryPath in
+            let path = directoryPath.appending(components: "JSON", "good.json")
+            let url = URL(string: "https://www.test.com/collection.json")!
+            let data = Data(try localFileSystem.readFileContents(path).contents)
+
+            let handler: HTTPClient.Handler = { request, _, completion in
+                XCTAssertEqual(request.url, url, "url should match")
+                switch request.method {
+                case .head:
+                    completion(.success(.init(statusCode: 200,
+                                              headers: .init([.init(name: "Content-Length", value: "\(data.count)")]))))
+                case .get:
+                    completion(.success(.init(statusCode: 200,
+                                              headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
+                                              body: data)))
+                default:
+                    XCTFail("method should match")
+                }
+            }
+
+            var httpClient = HTTPClient(handler: handler)
+            httpClient.configuration.circuitBreakerStrategy = .none
+            httpClient.configuration.retryStrategy = .none
+
+            // The validator doesn't know about the test collection so its signature would be considered invalid
+            let signatureValidator = MockCollectionSignatureValidator()
+            // Collections from www.test.com must be signed
+            let sourceCertPolicy = PackageCollectionSourceCertificatePolicy(
+                sourceCertPolicies: ["www.test.com": .init(certPolicyKey: CertificatePolicyKey.default, base64EncodedRootCerts: nil)]
+            )
+            let provider = JSONPackageCollectionProvider(httpClient: httpClient, signatureValidator: signatureValidator,
+                                                         sourceCertPolicy: sourceCertPolicy, diagnosticsEngine: DiagnosticsEngine())
+            let source = PackageCollectionsModel.CollectionSource(type: .json, url: url)
+
+            XCTAssertThrowsError(try tsc_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
+                switch error {
+                case PackageCollectionError.missingSignature:
+                    break
+                default:
+                    XCTFail("unexpected error \(error)")
+                }
+            })
         }
     }
 }

--- a/Tests/PackageCollectionsTests/PackageCollectionSourceCertificatePolicyTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionSourceCertificatePolicyTests.swift
@@ -1,0 +1,40 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import SPMTestSupport
+import XCTest
+
+@testable import PackageCollections
+import PackageCollectionsSigning
+
+final class PackageCollectionSourceCertificatePolicyTests: XCTestCase {
+    func testCustomData() {
+        let sourceCertPolicy = PackageCollectionSourceCertificatePolicy(sourceCertPolicies: [
+            "package-collection-1": PackageCollectionSourceCertificatePolicy.CertificatePolicyConfig(
+                certPolicyKey: CertificatePolicyKey.default,
+                base64EncodedRootCerts: ["root-cert-1a", "root-cert-1b"]
+            ),
+            "package-collection-2": PackageCollectionSourceCertificatePolicy.CertificatePolicyConfig(
+                certPolicyKey: CertificatePolicyKey.default,
+                base64EncodedRootCerts: ["root-cert-2"]
+            ),
+        ])
+        let source1 = Model.CollectionSource(type: .json, url: URL(string: "https://package-collection-1")!)
+        let unsignedSource = Model.CollectionSource(type: .json, url: URL(string: "https://package-collection-unsigned")!)
+
+        XCTAssertEqual(["root-cert-1a", "root-cert-1b", "root-cert-2"], sourceCertPolicy.allRootCerts)
+
+        XCTAssertTrue(sourceCertPolicy.mustBeSigned(source: source1))
+        XCTAssertFalse(sourceCertPolicy.mustBeSigned(source: unsignedSource))
+
+        XCTAssertEqual(CertificatePolicyKey.default, sourceCertPolicy.certificatePolicyKey(for: source1))
+        XCTAssertNil(sourceCertPolicy.certificatePolicyKey(for: unsignedSource))
+    }
+}

--- a/Tests/PackageCollectionsTests/PackageCollectionSourceCertificatePolicyTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionSourceCertificatePolicyTests.swift
@@ -29,7 +29,7 @@ final class PackageCollectionSourceCertificatePolicyTests: XCTestCase {
         let source1 = Model.CollectionSource(type: .json, url: URL(string: "https://package-collection-1")!)
         let unsignedSource = Model.CollectionSource(type: .json, url: URL(string: "https://package-collection-unsigned")!)
 
-        XCTAssertEqual(["root-cert-1a", "root-cert-1b", "root-cert-2"], sourceCertPolicy.allRootCerts)
+        XCTAssertEqual(["root-cert-1a", "root-cert-1b", "root-cert-2"], sourceCertPolicy.allRootCerts?.sorted())
 
         XCTAssertTrue(sourceCertPolicy.mustBeSigned(source: source1))
         XCTAssertFalse(sourceCertPolicy.mustBeSigned(source: unsignedSource))


### PR DESCRIPTION
Motivation:
If a collection source has an entry in the certificate pinning configuration that it must be signed. Currently we are not checking for this.

Modifications:
Update `JSONPackageCollectionProvider` to check that if a collection is unsigned, then it shouldn't have an entry in the certificate pinning configuration. Otherwise, throw `missingSignature` error which cannot be bypassed.
