### PR TITLE
[Extensions] Allow commands passed back from extensions to reference a relative or absolute path

### DIFF
--- a/Sources/Build/ManifestBuilder.swift
+++ b/Sources/Build/ManifestBuilder.swift
@@ -577,9 +577,10 @@ extension LLBuildManifestBuilder {
 
         // Add any build tool commands created by extensions for the target (prebuild and postbuild commands are handled outside the build).
         for command in target.extensionEvaluationResults.reduce([], { $0 + $1.commands }) {
-            if case .buildToolCommand(let displayName, let execPath, let arguments, _, _, let inputPaths, let outputPaths, _) = command {
+            if case .buildToolCommand(let displayName, let executable, let arguments, _, _, let inputPaths, let outputPaths, _) = command {
                 // Create a shell command to invoke the executable.  We include the path of the executable as a dependency.
                 // FIXME: We will need to extend the addShellCmd() function to also take working directory and environment.
+                let execPath = AbsolutePath(executable, relativeTo: buildParameters.buildPath)
                 manifest.addShellCmd(
                     name: displayName,
                     description: displayName,

--- a/Sources/SPMBuildCore/ExtensionEvaluator.swift
+++ b/Sources/SPMBuildCore/ExtensionEvaluator.swift
@@ -130,21 +130,21 @@ extension PackageGraph {
                 // Generate commands from the extension output.
                 let commands: [ExtensionEvaluationResult.Command] = extensionOutput.commands.map { cmd in
                     let displayName = cmd.displayName
-                    let execPath = AbsolutePath(cmd.executable)
+                    let executable = cmd.executable
                     let arguments = cmd.arguments
                     let workingDir = cmd.workingDirectory.map{ AbsolutePath($0) }
                     let environment = cmd.environment
                     switch extTarget.capability {
                     case .prebuild:
                         let derivedSourceDirPaths = cmd.derivedSourcePaths.map{ AbsolutePath($0) }
-                        return .prebuildCommand(displayName: displayName, execPath: execPath, arguments: arguments, workingDir: workingDir, environment: environment, derivedSourceDirPaths: derivedSourceDirPaths)
+                        return .prebuildCommand(displayName: displayName, executable: executable, arguments: arguments, workingDir: workingDir, environment: environment, derivedSourceDirPaths: derivedSourceDirPaths)
                     case .buildTool:
                         let inputPaths = cmd.inputPaths.map{ AbsolutePath($0) }
                         let outputPaths = cmd.outputPaths.map{ AbsolutePath($0) }
                         let derivedSourcePaths = cmd.derivedSourcePaths.map{ AbsolutePath($0) }
-                        return .buildToolCommand(displayName: displayName, execPath: execPath, arguments: arguments, workingDir: workingDir, environment: environment, inputPaths: inputPaths, outputPaths: outputPaths, derivedSourcePaths: derivedSourcePaths)
+                        return .buildToolCommand(displayName: displayName, executable: executable, arguments: arguments, workingDir: workingDir, environment: environment, inputPaths: inputPaths, outputPaths: outputPaths, derivedSourcePaths: derivedSourcePaths)
                     case .postbuild:
-                        return .postbuildCommand(displayName: displayName, execPath: execPath, arguments: arguments, workingDir: workingDir, environment: environment)
+                        return .postbuildCommand(displayName: displayName, executable: executable, arguments: arguments, workingDir: workingDir, environment: environment)
                     }
                 }
                 
@@ -203,7 +203,7 @@ public struct ExtensionEvaluationResult {
         /// should be applied.
         case prebuildCommand(
                 displayName: String,
-                execPath: AbsolutePath,
+                executable: String,
                 arguments: [String],
                 workingDir: AbsolutePath?,
                 environment: [String: String]?,
@@ -217,7 +217,7 @@ public struct ExtensionEvaluationResult {
         /// be applied.
         case buildToolCommand(
                 displayName: String,
-                execPath: AbsolutePath,
+                executable: String,
                 arguments: [String],
                 workingDir: AbsolutePath?,
                 environment: [String: String]?,
@@ -229,7 +229,7 @@ public struct ExtensionEvaluationResult {
         /// A command to run after the end of every build.
         case postbuildCommand(
                 displayName: String,
-                execPath: AbsolutePath,
+                executable: String,
                 arguments: [String],
                 workingDir: AbsolutePath?,
                 environment: [String: String]?

--- a/Tests/SPMBuildCoreTests/ExtensionEvaluationTests.swift
+++ b/Tests/SPMBuildCoreTests/ExtensionEvaluationTests.swift
@@ -150,7 +150,7 @@ class ExtensionEvaluationTests: XCTestCase {
         let evalFirstCommand = try XCTUnwrap(evalFirstResult.commands.first)
         if case .buildToolCommand(let name, let exec, let args, let wdir, let env, let inputs, let outputs, let derived) = evalFirstCommand {
             XCTAssertEqual(name, "Do something")
-            XCTAssertEqual(exec, AbsolutePath("/bin/FooTool"))
+            XCTAssertEqual(exec, "/bin/FooTool")
             XCTAssertEqual(args, ["-c", "/Foo/Sources/Foo/SomeFile.abc"])
             XCTAssertEqual(wdir, AbsolutePath("/Foo/Sources/Foo"))
             XCTAssertEqual(env, ["X": "Y"])


### PR DESCRIPTION
Allow the executable in commands passed back from extensions to be a string either a relative or absolute path.  If a string, it will be resolved against the build directory.

Note that the whole feature of build tool extensions is guarded by a feature flag until the proposal has been reviewed and any feedback has been implemented.

### Motivation:

The interface by which extensions specify the executable to invoke is still being worked out for this experimental feature, and allowing them to pass back a string will make it easier to iterate on the possible approaches.  When binary targets support executables, this may change again.

### Modifications:

Changed the executable from AbsolutePath to String
Form an AbsolutePath on use (using build products directory as base path)