### PR TITLE
[Extensions] Pass through the `allowExtensionTargets` flag from the Workspace to PackageGraph

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -647,6 +647,7 @@ extension Workspace {
         createREPLProduct: Bool = false,
         forceResolvedVersions: Bool = false,
         diagnostics: DiagnosticsEngine,
+        allowExtensionTargets: Bool = false,
         xcTestMinimumDeploymentTargets: [PackageModel.Platform:PlatformVersion]? = nil
     ) throws -> PackageGraph {
 
@@ -684,6 +685,7 @@ extension Workspace {
             diagnostics: diagnostics,
             fileSystem: fileSystem,
             shouldCreateMultipleTestProducts: createMultipleTestProducts,
+            allowExtensionTargets: allowExtensionTargets,
             createREPLProduct: createREPLProduct
         )
     }


### PR DESCRIPTION
### Motivation:

This lets clients of libSwiftPM enable the experimental support for package extensions.
