### PR TITLE
Fix an assertion failure with XCFramework inside a subdirectory

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1539,7 +1539,7 @@ extension Workspace {
                 if let path = target.path {
                     // TODO: find a better way to get the base path (not via the manifest)
                     // the target path is validated earlier to be within the package directory
-                    let absolutePath = manifest.path.parentDirectory.appending(component: path)
+                    let absolutePath = manifest.path.parentDirectory.appending(RelativePath(path))
                     localArtifacts.append(
                         .local(
                             packageRef: packageRef,

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -4542,7 +4542,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(
                             name: "A4",
                             type: .binary,
-                            path: "A4.xcframework"
+                            path: "XCFrameworks/A4.xcframework"
                         ),
                     ],
                     products: [
@@ -4571,7 +4571,7 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        let a4FrameworkPath = workspace.packagesDir.appending(components: "A", "A4.xcframework")
+        let a4FrameworkPath = workspace.packagesDir.appending(components: "A", "XCFrameworks", "A4.xcframework")
         try fs.createDirectory(a4FrameworkPath, recursive: true)
 
         // Pin A to 1.0.0, Checkout B to 1.0.0


### PR DESCRIPTION
Fix an assertion failure that occurred when a local XCFramework was at a subdirectory (the path in the manifest can be a relative path and not just a path component).