### PR TITLE
introduce archive index files

### DIFF
--- a/Sources/Basics/ConcurrencyHelpers.swift
+++ b/Sources/Basics/ConcurrencyHelpers.swift
@@ -109,6 +109,14 @@ public final class ThreadSafeArrayStore<Value> {
         }
     }
 
+    @discardableResult
+    public func append(contentsOf items: [Value]) -> Int {
+        self.lock.withLock {
+            self.underlying.append(contentsOf: items)
+            return self.underlying.count
+        }
+    }
+
     public var count: Int {
         self.lock.withLock {
             self.underlying.count

--- a/Sources/SPMTestSupport/MockHTTPClient.swift
+++ b/Sources/SPMTestSupport/MockHTTPClient.swift
@@ -9,14 +9,12 @@
 */
 
 import Basics
-import Foundation
 import TSCBasic
 import TSCUtility
 
 extension HTTPClient {
     public static func mock(fileSystem: FileSystem) -> HTTPClient {
         let handler: HTTPClient.Handler = { request, _, completion in
-
             switch request.kind {
             case.generic:
                 completion(.success(.okay(body: request.url.absoluteString)))
@@ -33,6 +31,6 @@ extension HTTPClient {
                 }
             }
         }
-        return HTTPClient(handler: handler)       
+        return HTTPClient(handler: handler)
     }
 }

--- a/Sources/SPMTestSupport/MockHashAlgorithm.swift
+++ b/Sources/SPMTestSupport/MockHashAlgorithm.swift
@@ -6,24 +6,25 @@
 
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
+import Basics
 import TSCBasic
 
 public class MockHashAlgorithm: HashAlgorithm {
     public typealias Hash = (ByteString) -> ByteString
 
-    public private(set) var hashes: [ByteString] = []
+    public private(set) var hashes = ThreadSafeArrayStore<ByteString>()
     private var hashFunction: Hash!
 
     public init(hash: Hash? = nil) {
-        hashFunction = hash ?? { hash in
+        self.hashFunction = hash ?? { hash in
             self.hashes.append(hash)
             return ByteString(hash.contents.reversed())
         }
     }
 
     public func hash(_ bytes: ByteString) -> ByteString {
-        return hashFunction(bytes)
+        return self.hashFunction(bytes)
     }
 }

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -34,7 +34,6 @@ public final class MockWorkspace {
     let skipUpdate: Bool
     let enablePubGrub: Bool
 
-
     public init(
         sandbox: AbsolutePath,
         fs: FileSystem,

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -141,12 +141,12 @@ extension Diagnostic.Message {
         .error("checksum of downloaded artifact of binary target '\(targetName)' (\(actualChecksum)) does not match checksum specified by the manifest (\(expectedChecksum))")
     }
 
-    static func artifactFailedDownload(targetName: String, reason: String) -> Diagnostic.Message {
-        .error("artifact of binary target '\(targetName)' failed download: \(reason)")
+    static func artifactFailedDownload(artifactURL: Foundation.URL, targetName: String, reason: String) -> Diagnostic.Message {
+        .error("failed downloading '\(artifactURL.absoluteString)' which is required by binary target '\(targetName)': \(reason)")
     }
 
-    static func artifactFailedExtraction(targetName: String, reason: String) -> Diagnostic.Message {
-        .error("artifact of binary target '\(targetName)' failed extraction: \(reason)")
+    static func artifactFailedExtraction(artifactURL: Foundation.URL, targetName: String, reason: String) -> Diagnostic.Message {
+        .error("failed extracting '\(artifactURL.absoluteString)' which is required by binary target '\(targetName)': \(reason)")
     }
 
     static func artifactNotFound(targetName: String, artifactName: String) -> Diagnostic.Message {


### PR DESCRIPTION
motivation: to support the package extensions feature, we need to support binary dependencies with tools that can be distributed across different platforms. in previous PR we intriduces the archive file, this PR adds the archive index files which helps control the size of the archive files by splitting them across key platforms

changes:
* introduce new binary dependency file type named "Archive Index" with the extension "ari"
* the structure of the file is a flat list of archive files, their checksums and the target-triples they support
* add code to Workspace pre-downloading the binaryTarget "zip" files to first fetch "ari" files, parse them and add any relevant "zip" files to the *host* tripple to the list of candidate downloads
* add and adjust tests

----

the new archive file name, extension and structure are all up to debate and would take final shape in an evolution proposal, but we can start discussing them now in preparation to such proposal.

the file structure proposed

```
{
    "schemaVersion": "1.0",
    "archives": [
        {
            "fileName": "<zipped archive file name>",
            "checksum": "<checksum of zipped archive>",
            "supportedTriples": ["<triple identifier>"]        
        }
    ]
}
```

concrete example:

web server directory structure

```
www
|- protocol-bufffer-compiler.ari
|  protoc-apple.zip
|  protoc-linux.zip
```

`protocol-bufffer-compiler.ari` content

```
{
    "schemaVersion": "1.0",
    "archives": [
        {
            "fileName": "protoc-apple.zip",
            "checksum": "<checksum of protoc-apple.zip>",
            "supportedTriples": ["x86_64-apple-macosx", "arm64-apple-macos", "x86_64-apple-macosx", "armv7-apple-ios", "arm64-apple-ios"]        
        },
        {
            "fileName": "protoc-linux.zip",
            "checksum": "<checksum of protoc-linux.zip>",
            "supportedTriples": ["x86_64-unknown-linux-gnu"]     
        }
    ]
}
```



