### PR TITLE
Do not pass `-framework` to compiler tasks

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -380,10 +380,6 @@ public final class ClangTargetBuildDescription {
             "-I\(target.sources.root.appending(RelativePath($0)).pathString)"
         })
 
-        // Frameworks.
-        let frameworks = scope.evaluate(.LINK_FRAMEWORKS)
-        flags += frameworks.flatMap({ ["-framework", $0] })
-
         // Other C flags.
         flags += scope.evaluate(.OTHER_CFLAGS)
 
@@ -912,10 +908,6 @@ public final class SwiftTargetBuildDescription {
         // Swift defines.
         let swiftDefines = scope.evaluate(.SWIFT_ACTIVE_COMPILATION_CONDITIONS)
         flags += swiftDefines.map({ "-D" + $0 })
-
-        // Frameworks.
-        let frameworks = scope.evaluate(.LINK_FRAMEWORKS)
-        flags += frameworks.flatMap({ ["-framework", $0] })
 
         // Other Swift flags.
         flags += scope.evaluate(.OTHER_SWIFT_FLAGS)

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1917,6 +1917,8 @@ final class BuildPlanTests: XCTestCase {
                     .init(tool: .c, name: .define, value: ["CCC=2"]),
                     .init(tool: .cxx, name: .define, value: ["RCXX"], condition: .init(config: "release")),
 
+                    .init(tool: .linker, name: .linkedFramework, value: ["best"]),
+
                     .init(tool: .c, name: .unsafeFlags, value: ["-Icfoo", "-L", "cbar"]),
                     .init(tool: .cxx, name: .unsafeFlags, value: ["-Icxxfoo", "-L", "cxxbar"]),
                     ]
@@ -1998,7 +2000,7 @@ final class BuildPlanTests: XCTestCase {
             XCTAssertMatch(exe, [.anySequence, "-DFOO", .end])
 
             let linkExe = try result.buildProduct(for: "exe").linkArguments()
-            XCTAssertMatch(linkExe, [.anySequence, "-lsqlite3", "-llibz", "-Ilfoo", "-L", "lbar", .end])
+            XCTAssertMatch(linkExe, [.anySequence, "-lsqlite3", "-llibz", "-framework", "best", "-Ilfoo", "-L", "lbar", .end])
         }
 
         do {
@@ -2011,10 +2013,10 @@ final class BuildPlanTests: XCTestCase {
             XCTAssertMatch(bar, [.anySequence, "-DDMACOS", "-Isfoo", "-L", "sbar", .end])
 
             let exe = try result.target(for: "exe").swiftTarget().compileArguments()
-            XCTAssertMatch(exe, [.anySequence, "-DFOO", "-framework", "CoreData", .end])
+            XCTAssertMatch(exe, [.anySequence, "-DFOO", .end])
 
             let linkExe = try result.buildProduct(for: "exe").linkArguments()
-            XCTAssertMatch(linkExe, [.anySequence, "-lsqlite3", "-llibz", "-framework", "CoreData", "-Ilfoo", "-L", "lbar", .anySequence])
+            XCTAssertMatch(linkExe, [.anySequence, "-lsqlite3", "-llibz", "-framework", "CoreData", "-framework", "best", "-Ilfoo", "-L", "lbar", .anySequence])
         }
     }
 


### PR DESCRIPTION
This fixes warnings of the form

> clang: warning: -framework XCTest: 'linker' input unused [-Wunused-command-line-argument]

when using `linkedFramework` for C-family and Swift targets.

rdar://74548652
