### PR TITLE
[Collections] Trigger collection refresh if deserialization of SQLite data fails

### DIFF
--- a/Sources/PackageCollections/Model/Collection.swift
+++ b/Sources/PackageCollections/Model/Collection.swift
@@ -122,6 +122,11 @@ extension PackageCollectionsModel {
         public static func == (lhs: CollectionSource, rhs: CollectionSource) -> Bool {
             lhs.type == rhs.type && lhs.url == rhs.url
         }
+
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(self.type)
+            hasher.combine(self.url)
+        }
     }
 
     /// Represents the source type of a `Collection`

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -98,7 +98,7 @@ final class PackageCollectionsTests: XCTestCase {
         }
         // User preference unknown
         XCTAssertThrowsError(
-            try tsc_await { callback in packageCollections.addCollection(mockCollections[1].source, order: nil, trustConfirmationProvider: nil, callback: callback) }) { error in
+            try tsc_await { callback in packageCollections.addCollection(mockCollections[2].source, order: nil, trustConfirmationProvider: nil, callback: callback) }) { error in
             guard case PackageCollectionError.trustConfirmationRequired = error else {
                 return XCTFail("Expected PackageCollectionError.trustConfirmationRequired")
             }


### PR DESCRIPTION
Motivation:
When package collection model/format changes, deserializing data stored in SQLite might fail. Most of the time `SQLitePackageCollectionsStorage`
just silently ignores deserialization errors, and no one would know that something had gone wrong. This could lead to collection APIs not
returning any data, which would be confusing for users.

What we should do with this kind of deserialization error is to trigger collection refresh so that data in SQLite gets updated. `listCollections`
can do this quite easily by calling refresh whenever the results count does not equal sources count.

Modifications:
In `listCollections` check that sources count equals results count, otherwise trigger refresh on the "missing" collections.
