### PR TITLE
WIP: In package manifest, list use of extensions separately from other dependencies

### DIFF
--- a/Fixtures/Miscellaneous/Extensions/MySourceGenExtension/Package.swift
+++ b/Fixtures/Miscellaneous/Extensions/MySourceGenExtension/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         // A local tool that uses an extension.
         .executableTarget(
             name: "MyLocalTool",
-            dependencies: [
+            usingExtensions: [
                 "MySourceGenExt",
             ]
         ),
@@ -49,8 +49,10 @@ let package = Package(
         .testTarget(
             name: "MySourceGenExtTests",
             dependencies: [
-                "MySourceGenExt",
                 "MySourceGenRuntimeLib"
+            ],
+            usingExtensions: [
+                "MySourceGenExt",
             ]
         )
     ]

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1345,7 +1345,8 @@ public class BuildPlan {
                 )
                 let testManifestTarget = ResolvedTarget(
                     target: swiftTarget,
-                    dependencies: testProduct.targets.map { .target($0, conditions: []) }
+                    dependencies: testProduct.targets.map { .target($0, conditions: []) },
+                    extensionUsages: []
                 )
 
                 let target = try SwiftTargetBuildDescription(

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -178,6 +178,18 @@ public final class Target {
     }
     public var _checksum: String?
 
+    /// The usages of package extensions by the target.
+    @available(_PackageDescription, introduced: 999.0)
+    public var extensionUsages: [ExtensionUsage]? {
+        get { return _extensionUsages }
+        set { _extensionUsages = newValue }
+    }
+    private var _extensionUsages: [ExtensionUsage]?
+
+    public enum ExtensionUsage {
+        case _extensionItem(name: String, package: String?, options: [String: String])
+    }
+
     /// Construct a target.
     private init(
         name: String,
@@ -196,7 +208,8 @@ public final class Target {
         cxxSettings: [CXXSetting]? = nil,
         swiftSettings: [SwiftSetting]? = nil,
         linkerSettings: [LinkerSetting]? = nil,
-        checksum: String? = nil
+        checksum: String? = nil,
+        extensionUsages: [ExtensionUsage]? = nil
     ) {
         self.name = name
         self.dependencies = dependencies
@@ -215,6 +228,7 @@ public final class Target {
         self._swiftSettings = swiftSettings
         self._linkerSettings = linkerSettings
         self._checksum = checksum
+        self._extensionUsages = extensionUsages
 
         switch type {
         case .regular, .executable, .test:
@@ -238,7 +252,8 @@ public final class Target {
                 cxxSettings == nil &&
                 swiftSettings == nil &&
                 linkerSettings == nil &&
-                checksum == nil
+                checksum == nil &&
+                extensionUsages == nil
             )
         case .binary:
             precondition(
@@ -253,7 +268,8 @@ public final class Target {
                 cSettings == nil &&
                 cxxSettings == nil &&
                 swiftSettings == nil &&
-                linkerSettings == nil
+                linkerSettings == nil &&
+                extensionUsages == nil
             )
         case .extension:
             precondition(
@@ -268,7 +284,8 @@ public final class Target {
                 cSettings == nil &&
                 cxxSettings == nil &&
                 swiftSettings == nil &&
-                linkerSettings == nil
+                linkerSettings == nil &&
+                extensionUsages == nil
             )
         }
     }
@@ -384,7 +401,7 @@ public final class Target {
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    @available(_PackageDescription, introduced: 5.3)
+    @available(_PackageDescription, introduced: 5.3, obsoleted: 999.0)
     public static func target(
         name: String,
         dependencies: [Dependency] = [],
@@ -414,6 +431,62 @@ public final class Target {
         )
     }
 
+    /// Creates a regular target.
+    ///
+    /// A target can contain either Swift or C-family source files, but not both. It contains code that is built as
+    /// a regular module that can be included in a library or executable product, but that cannot itself be used as
+    /// the main target of an executable product.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the target.
+    ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
+    ///   - path: The custom path for the target. By default, the Swift Package Manager requires a target's sources to reside at predefined search paths;
+    ///       for example, `[PackageRoot]/Sources/[TargetName]`.
+    ///       Don't escape the package root; for example, values like `../Foo` or `/Foo` are invalid.
+    ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
+    ///       A path is relative to the target's directory.
+    ///       This parameter has precedence over the `sources` parameter.
+    ///   - sources: An explicit list of source files. If you provide a path to a directory,
+    ///       the Swift Package Manager searches for valid source files recursively.
+    ///   - resources: An explicit list of resources files.
+    ///   - publicHeadersPath: The directory containing public headers of a C-family library target.
+    ///   - cSettings: The C settings for this target.
+    ///   - cxxSettings: The C++ settings for this target.
+    ///   - swiftSettings: The Swift settings for this target.
+    ///   - linkerSettings: The linker settings for this target.
+    ///   - usingExtensions: The extensions used by this target.
+    @available(_PackageDescription, introduced: 999.0)
+    public static func target(
+        name: String,
+        dependencies: [Dependency] = [],
+        path: String? = nil,
+        exclude: [String] = [],
+        sources: [String]? = nil,
+        resources: [Resource]? = nil,
+        publicHeadersPath: String? = nil,
+        cSettings: [CSetting]? = nil,
+        cxxSettings: [CXXSetting]? = nil,
+        swiftSettings: [SwiftSetting]? = nil,
+        linkerSettings: [LinkerSetting]? = nil,
+        usingExtensions: [ExtensionUsage]? = nil
+    ) -> Target {
+        return Target(
+            name: name,
+            dependencies: dependencies,
+            path: path,
+            exclude: exclude,
+            sources: sources,
+            resources: resources,
+            publicHeadersPath: publicHeadersPath,
+            type: .regular,
+            cSettings: cSettings,
+            cxxSettings: cxxSettings,
+            swiftSettings: swiftSettings,
+            linkerSettings: linkerSettings,
+            extensionUsages: usingExtensions
+        )
+    }
+
     /// Creates an executable target.
     ///
     /// An executable target can contain either Swift or C-family source files, but not both. It contains code that
@@ -438,7 +511,7 @@ public final class Target {
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    @available(_PackageDescription, introduced: 5.4)
+    @available(_PackageDescription, introduced: 5.4, obsoleted: 999.0)
     public static func executableTarget(
        name: String,
        dependencies: [Dependency] = [],
@@ -468,6 +541,63 @@ public final class Target {
        )
     }
     
+    /// Creates an executable target.
+    ///
+    /// An executable target can contain either Swift or C-family source files, but not both. It contains code that
+    /// is built as an executable module that can be used as the main target of an executable product. The target
+    /// is expected to either have a source file named `main.swift`, `main.m`, `main.c`, or `main.cpp`, or a source
+    /// file that contains the `@main` keyword.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the target.
+    ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
+    ///   - path: The custom path for the target. By default, the Swift Package Manager requires a target's sources to reside at predefined search paths;
+    ///       for example, `[PackageRoot]/Sources/[TargetName]`.
+    ///       Don't escape the package root; for example, values like `../Foo` or `/Foo` are invalid.
+    ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
+    ///       A path is relative to the target's directory.
+    ///       This parameter has precedence over the `sources` parameter.
+    ///   - sources: An explicit list of source files. If you provide a path to a directory,
+    ///       the Swift Package Manager searches for valid source files recursively.
+    ///   - resources: An explicit list of resources files.
+    ///   - publicHeadersPath: The directory containing public headers of a C-family library target.
+    ///   - cSettings: The C settings for this target.
+    ///   - cxxSettings: The C++ settings for this target.
+    ///   - swiftSettings: The Swift settings for this target.
+    ///   - linkerSettings: The linker settings for this target.
+    ///   - usingExtensions: The extensions used by this target.
+    @available(_PackageDescription, introduced: 999.0)
+    public static func executableTarget(
+       name: String,
+       dependencies: [Dependency] = [],
+       path: String? = nil,
+       exclude: [String] = [],
+       sources: [String]? = nil,
+       resources: [Resource]? = nil,
+       publicHeadersPath: String? = nil,
+       cSettings: [CSetting]? = nil,
+       cxxSettings: [CXXSetting]? = nil,
+       swiftSettings: [SwiftSetting]? = nil,
+       linkerSettings: [LinkerSetting]? = nil,
+       usingExtensions: [ExtensionUsage]? = nil
+    ) -> Target {
+       return Target(
+           name: name,
+           dependencies: dependencies,
+           path: path,
+           exclude: exclude,
+           sources: sources,
+           resources: resources,
+           publicHeadersPath: publicHeadersPath,
+           type: .executable,
+           cSettings: cSettings,
+           cxxSettings: cxxSettings,
+           swiftSettings: swiftSettings,
+           linkerSettings: linkerSettings,
+           extensionUsages: usingExtensions
+       )
+    }
+
     /// Creates a test target.
     ///
     /// Write test targets using the XCTest testing framework.
@@ -571,7 +701,7 @@ public final class Target {
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    @available(_PackageDescription, introduced: 5.3)
+    @available(_PackageDescription, introduced: 5.3, obsoleted: 999.0)
     public static func testTarget(
         name: String,
         dependencies: [Dependency] = [],
@@ -597,6 +727,59 @@ public final class Target {
             cxxSettings: cxxSettings,
             swiftSettings: swiftSettings,
             linkerSettings: linkerSettings
+        )
+    }
+
+    /// Creates a test target.
+    ///
+    /// Write test targets using the XCTest testing framework.
+    /// Test targets generally declare a dependency on the targets they test.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the target.
+    ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
+    ///   - path: The custom path for the target. By default, the Swift Package Manager requires a target's sources to reside at predefined search paths;
+    ///       for example, `[PackageRoot]/Sources/[TargetName]`.
+    ///       Don't escape the package root; for example, values like `../Foo` or `/Foo` are invalid.
+    ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
+    ///       A path is relative to the target's directory.
+    ///       This parameter has precedence over the `sources` parameter.
+    ///   - sources: An explicit list of source files. If you provide a path to a directory,
+    ///       the Swift Package Manager searches for valid source files recursively.
+    ///   - resources: An explicit list of resources files.
+    ///   - cSettings: The C settings for this target.
+    ///   - cxxSettings: The C++ settings for this target.
+    ///   - swiftSettings: The Swift settings for this target.
+    ///   - linkerSettings: The linker settings for this target.
+    ///   - usingExtensions: The extensions used by this target.
+    @available(_PackageDescription, introduced: 999.0)
+    public static func testTarget(
+        name: String,
+        dependencies: [Dependency] = [],
+        path: String? = nil,
+        exclude: [String] = [],
+        sources: [String]? = nil,
+        resources: [Resource]? = nil,
+        cSettings: [CSetting]? = nil,
+        cxxSettings: [CXXSetting]? = nil,
+        swiftSettings: [SwiftSetting]? = nil,
+        linkerSettings: [LinkerSetting]? = nil,
+        usingExtensions: [ExtensionUsage]? = nil
+    ) -> Target {
+        return Target(
+            name: name,
+            dependencies: dependencies,
+            path: path,
+            exclude: exclude,
+            sources: sources,
+            resources: resources,
+            publicHeadersPath: nil,
+            type: .test,
+            cSettings: cSettings,
+            cxxSettings: cxxSettings,
+            swiftSettings: swiftSettings,
+            linkerSettings: linkerSettings,
+            extensionUsages: usingExtensions
         )
     }
 
@@ -688,6 +871,39 @@ public final class Target {
             type: .binary)
     }
 
+    /// Defines a new package extension target with a given name, declaring it as
+    /// providing a capability of adding custom build commands to SwiftPM (and to
+    /// any IDEs based on libSwiftPM).
+    ///
+    /// The capability determines what kind of build commands it can add. Besides
+    /// determining at what point in the build those commands run, the capability
+    /// determines the context that is available to the extension and the kinds of
+    /// commands it can create.
+    ///
+    /// In the initial version of this proposal, three capabilities are provided:
+    /// prebuild, build tool, and postbuild. See the declaration of each capability
+    /// under `ExtensionCapability` for more information.
+    ///
+    /// The package extension itself is implemented using a Swift script that is
+    /// invoked for each target that uses it. The script is invoked after the
+    /// package graph has been resolved, but before the build system creates its
+    /// dependency graph. It is also invoked after changes to the target or the
+    /// build parameters.
+    ///
+    /// Note that the role of the package extension is only to define the commands
+    /// that will run before, during, or after the build. It does not itself run
+    /// those commands. The commands are defined in an IDE-neutral way, and are
+    /// run as appropriate by the build system that builds the package. The exten-
+    /// sion itself is only a procedural way of generating commands and their input
+    /// and output dependencies.
+    ///
+    /// The package extension may specify the executable targets or binary targets
+    /// that provide the build tools that will be used by the generated commands
+    /// during the build. In the initial implementation, prebuild actions can only
+    /// depend on binary targets. Build tool and postbuild extensions can depend
+    /// on executables as well as binary targets. This is because of limitations
+    /// in how SwiftPM constructs its build plan, and the goal is to remove this
+    /// restriction in a future release.
     @available(_PackageDescription, introduced: 999.0)
     public static func `extension`(
         name: String,
@@ -726,6 +942,7 @@ extension Target: Encodable {
         case swiftSettings
         case linkerSettings
         case checksum
+        case extensionUsages
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -759,6 +976,10 @@ extension Target: Encodable {
 
         if let linkerSettings = self._linkerSettings {
             try container.encode(linkerSettings, forKey: .linkerSettings)
+        }
+        
+        if let extensionUsages = self._extensionUsages {
+            try container.encode(extensionUsages, forKey: .extensionUsages)
         }
     }
 }
@@ -896,6 +1117,30 @@ extension Target.ExtensionCapability {
     }
 }
 
+extension Target.ExtensionUsage {
+    /// Creates a usage of an extension target in the same package.
+    ///
+    /// - parameters:
+    ///   - name: The name of the extension target.
+    ///   - options: Options to pass to the extension (which determines acceptable key names and value types).
+    @available(_PackageDescription, introduced: 999.0)
+    public static func `extension`(name: String, options: [String: String] = [:]) -> Target.ExtensionUsage {
+        return ._extensionItem(name: name, package: nil, options: options)
+    }
+
+    /// Creates a usage of an extension product in a package dependency.
+    ///
+    /// - parameters:
+    ///   - name: The name of the extension product.
+    ///   - package: The name of the package in which it is defined.
+    ///   - options: Options to pass to the extension (which determines acceptable key names and value types).
+    @available(_PackageDescription, introduced: 999.0)
+    public static func `extension`(name: String, package: String, options: [String: String] = [:]) -> Target.ExtensionUsage {
+        return ._extensionItem(name: name, package: package, options: options)
+    }
+}
+
+
 // MARK: ExpressibleByStringLiteral
 
 extension Target.Dependency: ExpressibleByStringLiteral {
@@ -912,6 +1157,20 @@ extension Target.Dependency: ExpressibleByStringLiteral {
       #endif
     }
 }
+
+extension Target.ExtensionUsage: ExpressibleByStringLiteral {
+
+    /// Creates an extension usage of an extension target with the given name.
+    ///
+    /// - parameters:
+    ///   - value: A string literal.
+    public init(stringLiteral value: String) {
+        self = ._extensionItem(name: value, package: nil, options: [:])
+    }
+}
+
+
+// MARK: Encodable
 
 /// A condition that limits the application of a target's dependency.
 public struct TargetDependencyCondition: Encodable {
@@ -932,5 +1191,29 @@ public struct TargetDependencyCondition: Encodable {
         // FIXME: This should be an error, not a precondition.
         precondition(!(platforms == nil))
         return TargetDependencyCondition(platforms: platforms)
+    }
+}
+
+extension Target.ExtensionUsage: Encodable {
+    private enum CodingKeys: CodingKey {
+        case type
+        case name
+        case package
+        case options
+    }
+
+    private enum Kind: String, Codable {
+        case `extension`
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case ._extensionItem(let name, let package, let options):
+            try container.encode(Kind.extension, forKey: .type)
+            try container.encode(name, forKey: .name)
+            try container.encode(package, forKey: .package)
+            try container.encode(options, forKey: .options)
+        }
     }
 }

--- a/Sources/PackageGraph/ResolvedProduct.swift
+++ b/Sources/PackageGraph/ResolvedProduct.swift
@@ -49,7 +49,8 @@ public final class ResolvedProduct: ObjectIdentifierProtocol {
             // Create an executable resolved target with the linux main, adding product's targets as dependencies.
             let dependencies: [Target.Dependency] = product.targets.map { .target($0, conditions: []) }
             let swiftTarget = SwiftTarget(testManifest: testManifest, name: product.name, dependencies: dependencies)
-            return ResolvedTarget(target: swiftTarget, dependencies: targets.map { .target($0, conditions: []) })
+            // FIXME: resolve extension usages here too
+            return ResolvedTarget(target: swiftTarget, dependencies: targets.map { .target($0, conditions: []) }, extensionUsages: [])
         }
     }
 

--- a/Sources/PackageGraph/ResolvedTarget.swift
+++ b/Sources/PackageGraph/ResolvedTarget.swift
@@ -120,11 +120,20 @@ public final class ResolvedTarget: ObjectIdentifierProtocol {
     public var sources: Sources {
         return underlyingTarget.sources
     }
+    
+    /// The build extensions applied to this target, along with any options provided.
+    public var extensionUsages: [ExtensionUsage]
+    
+    public struct ExtensionUsage {
+        var dependency: Dependency
+        var options: [String: String]
+    }
 
     /// Create a target instance.
-    public init(target: Target, dependencies: [Dependency]) {
+    public init(target: Target, dependencies: [Dependency], extensionUsages: [ExtensionUsage]) {
         self.underlyingTarget = target
-        self.dependencies = dependencies
+        self.dependencies = dependencies + extensionUsages.map { $0.dependency }
+        self.extensionUsages = extensionUsages
     }
 }
 

--- a/Tests/PackageGraphTests/TargetTests.swift
+++ b/Tests/PackageGraphTests/TargetTests.swift
@@ -20,7 +20,8 @@ private extension ResolvedTarget {
             target: SwiftTarget(
                 name: name, type: .library, 
                 sources: Sources(paths: [], root: AbsolutePath("/")), dependencies: [], swiftVersion: .v4),
-            dependencies: deps.map { .target($0, conditions: []) })
+            dependencies: deps.map { .target($0, conditions: []) },
+            extensionUsages: [])
     }
 }
 


### PR DESCRIPTION
In the draft proposal for Extensible Build Tools, the extension dependencies are listed separately from other dependencies.  While it's not clear whether the accepted proposal will list them separately or together with other dependencies, this is a WIP implementation at doing them separately.

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

- add PackageDescription API parallel to the dependencies
- add ProjectModel and ProjectLoading structures parallel to the dependencies
- change the ResolvedTargetBuilder and ResolvedTarget to track extension use

Still need ResolvedProductBuilder support and look at all places where dependencies are used to also take into account extension usage.