### PR TITLE
Allow for .package(url: String, revision: String) syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Note: This is in reverse chronological order, so newer entries are added to the 
 
 Swift v.Next
  -----------
- * [#]
+ * [#3310]
     * Improvements
 
     Adding a dependency requirement can now be done with the convenience initializer `.package(url: String, revision: String)`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 Note: This is in reverse chronological order, so newer entries are added to the top.
 
+Swift v.Next
+ -----------
+ * [#]
+    * Improvements
+
+    Adding a dependency requirement can now be done with the convenience initializer `.package(url: String, revision: String)`.
+
+
 Swift 5.4
 -----------
 * [#2937]

--- a/Documentation/PackageDescription.md
+++ b/Documentation/PackageDescription.md
@@ -306,7 +306,7 @@ static func package(url: String, _ requirement: Package.Dependency.Requirement) 
 ///     - branch: A dependency requirement. See static methods on `Package.Dependency.Requirement` for available options.
 static func package(name: String? = nil, url: String, branch: String) -> Package.Dependency
 
-/// Adds a remote package dependency given a branch requirement.
+/// Adds a remote package dependency given a revision requirement.
 ///
 ///    .package(url: "https://example.com/example-package.git", revision: "aa681bd6c61e22df0fd808044a886fc4a7ed3a65"),
 ///

--- a/Documentation/PackageDescription.md
+++ b/Documentation/PackageDescription.md
@@ -296,6 +296,16 @@ static func package(url: String, from version: Version) -> Package.Dependency
 ///     - requirement: A dependency requirement. See static methods on `Package.Dependency.Requirement` for available options.
 static func package(url: String, _ requirement: Package.Dependency.Requirement) -> Package.Dependency
 
+/// Adds a remote package dependency given a branch requirement.
+///
+///    .package(url: "https://example.com/example-package.git", revision: "aa681bd6c61e22df0fd808044a886fc4a7ed3a65"),
+///
+/// - Parameters:
+///     - name: The name of the package, or nil to deduce it from the URL.
+///     - url: The valid Git URL of the package.
+///     - revision: A dependency requirement. See static methods on `Package.Dependency.Requirement` for available options.
+static func package(name: String? = nil, url: String, revision: String) -> Package.Dependency
+
 /// Add a package dependency starting with a specific minimum version, up to
 /// but not including a specified maximum version.
 ///

--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -64,7 +64,24 @@ extension Package.Dependency {
     ) -> Package.Dependency {
         return .init(name: name, url: url, requirement: .upToNextMajor(from: version))
     }
-
+    
+    /// Adds a remote package dependency given a branch requirement.
+    ///
+    ///    .package(url: "https://example.com/example-package.git", revision: "aa681bd6c61e22df0fd808044a886fc4a7ed3a65"),
+    ///
+    /// - Parameters:
+    ///     - name: The name of the package, or nil to deduce it from the URL.
+    ///     - url: The valid Git URL of the package.
+    ///     - revision: A dependency requirement. See static methods on `Package.Dependency.Requirement` for available options.
+    @available(_PackageDescription, introduced: 999.0)
+    public static func package(
+        name: String? = nil,
+        url: String,
+        revision: String
+    ) -> Package.Dependency {
+        return .init(name: name, url: url, requirement: .revision(revision))
+    }
+    
     /// Adds a remote package dependency given a version requirement.
     ///
     /// - Parameters:
@@ -251,11 +268,6 @@ extension Package.Dependency {
 
     @available(*, unavailable, message: "use package(url:_:) with the .branch(String) initializer instead")
     public static func package(url: String, branch: String) -> Package.Dependency {
-        fatalError()
-    }
-
-    @available(*, unavailable, message: "use package(url:_:) with the .revision(String) initializer instead")
-    public static func package(url: String, revision: String) -> Package.Dependency {
         fatalError()
     }
 

--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -82,7 +82,7 @@ extension Package.Dependency {
         return .init(name: name, url: url, requirement: .branch(branch))
     }
   
-    /// Adds a remote package dependency given a branch requirement.
+    /// Adds a remote package dependency given a revision requirement.
     ///
     ///    .package(url: "https://example.com/example-package.git", revision: "aa681bd6c61e22df0fd808044a886fc4a7ed3a65"),
     ///

--- a/Tests/PackageLoadingTests/PD4_0LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_0LoadingTests.swift
@@ -135,21 +135,19 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
                    .package(url: "/foo2", .upToNextMajor(from: "1.0.0")),
                    .package(url: "/foo3", .upToNextMinor(from: "1.0.0")),
                    .package(url: "/foo4", .exact("1.0.0")),
-                   .package(url: "/foo5", .branch("master")),
+                   .package(url: "/foo5", .branch("main")),
                    .package(url: "/foo6", .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")),
-                   .package(url: "/foo7", revision: "58e9de4e7b79e67c72a46e164158e3542e570ab6"),
                ]
             )
             """
-       loadManifest(stream.bytes, toolsVersion: ToolsVersion(string: "999.0")) { manifest in
+        loadManifest(stream.bytes, toolsVersion: ToolsVersion(string: "999.0")) { manifest in
         let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
             XCTAssertEqual(deps["foo1"], .scm(location: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
             XCTAssertEqual(deps["foo2"], .scm(location: "/foo2", requirement: .upToNextMajor(from: "1.0.0")))
             XCTAssertEqual(deps["foo3"], .scm(location: "/foo3", requirement: .upToNextMinor(from: "1.0.0")))
             XCTAssertEqual(deps["foo4"], .scm(location: "/foo4", requirement: .exact("1.0.0")))
-            XCTAssertEqual(deps["foo5"], .scm(location: "/foo5", requirement: .branch("master")))
+            XCTAssertEqual(deps["foo5"], .scm(location: "/foo5", requirement: .branch("main")))
             XCTAssertEqual(deps["foo6"], .scm(location: "/foo6", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
-            XCTAssertEqual(deps["foo7"], .scm(location: "/foo7", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
         }
     }
 

--- a/Tests/PackageLoadingTests/PD4_0LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_0LoadingTests.swift
@@ -141,7 +141,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
                ]
             )
             """
-       loadManifest(stream.bytes) { manifest in
+       loadManifest(stream.bytes, toolsVersion: ToolsVersion(string: "999.0")) { manifest in
         let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
             XCTAssertEqual(deps["foo1"], .scm(location: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
             XCTAssertEqual(deps["foo2"], .scm(location: "/foo2", requirement: .upToNextMajor(from: "1.0.0")))

--- a/Tests/PackageLoadingTests/PD4_0LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_0LoadingTests.swift
@@ -137,6 +137,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
                    .package(url: "/foo4", .exact("1.0.0")),
                    .package(url: "/foo5", .branch("master")),
                    .package(url: "/foo6", .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")),
+                   .package(url: "/foo7", revision: "58e9de4e7b79e67c72a46e164158e3542e570ab6"),
                ]
             )
             """
@@ -148,6 +149,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             XCTAssertEqual(deps["foo4"], .scm(location: "/foo4", requirement: .exact("1.0.0")))
             XCTAssertEqual(deps["foo5"], .scm(location: "/foo5", requirement: .branch("master")))
             XCTAssertEqual(deps["foo6"], .scm(location: "/foo6", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
+            XCTAssertEqual(deps["foo7"], .scm(location: "/foo7", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
         }
     }
 

--- a/Tests/PackageLoadingTests/PD4_0LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_0LoadingTests.swift
@@ -302,7 +302,6 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
         } catch ManifestParseError.invalidManifestFormat(let error, _) {
             XCTAssert(error.contains("error: 'package(url:version:)' is unavailable: use package(url:_:) with the .exact(Version) initializer instead\n"), "\(error)")
             XCTAssert(error.contains("error: 'package(url:branch:)' is unavailable: use package(url:_:) with the .branch(String) initializer instead\n"), "\(error)")
-            XCTAssert(error.contains("error: 'package(url:revision:)' is unavailable: use package(url:_:) with the .revision(String) initializer instead\n"), "\(error)")
             XCTAssert(error.contains("error: 'package(url:range:)' is unavailable: use package(url:_:) without the range label instead\n"), "\(error)")
         }
     }

--- a/Tests/PackageLoadingTests/PDNextVersionLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDNextVersionLoadingTests.swift
@@ -83,4 +83,23 @@ class PackageDescriptionNextVersionLoadingTests: PackageDescriptionLoadingTests 
             XCTAssertEqual(manifest.targets[0].extensionCapability, .postbuild)
         }
     }
+    
+    func testPackageDependencies() throws {
+        let stream = BufferedOutputByteStream()
+        stream <<< """
+            import PackageDescription
+            let package = Package(
+               name: "Foo",
+               dependencies: [
+                   .package(url: "/foo5", branch: "main"),
+                   .package(url: "/foo7", revision: "58e9de4e7b79e67c72a46e164158e3542e570ab6"),
+               ]
+            )
+            """
+        loadManifest(stream.bytes, toolsVersion: ToolsVersion(string: "999.0")) { manifest in
+        let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
+            XCTAssertEqual(deps["foo5"], .scm(location: "/foo5", requirement: .branch("main")))
+            XCTAssertEqual(deps["foo7"], .scm(location: "/foo7", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
+        }
+    }
 }


### PR DESCRIPTION
Just adding the convenience init .package(url: String, revision: String)