### PR TITLE
Move usage of plugins from `dependencies` to `plugins` parameter to align with SE-0303

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/MySourceGenClient/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/MySourceGenClient/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
         // A unit that uses the plugin.
         .testTarget(
             name: "MyTests",
-            dependencies: [
-                .product(name: "MySourceGenPlugin", package: "MySourceGenPlugin")
+            plugins: [
+                .plugin(name: "MySourceGenPlugin", package: "MySourceGenPlugin")
             ]
         )
     ]

--- a/Fixtures/Miscellaneous/Plugins/MySourceGenPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/MySourceGenPlugin/Package.swift
@@ -49,8 +49,10 @@ let package = Package(
         .testTarget(
             name: "MySourceGenPluginTests",
             dependencies: [
-                "MySourceGenPlugin",
                 "MySourceGenRuntimeLib"
+            ],
+            plugins: [
+                "MySourceGenPlugin"
             ]
         )
     ]

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -178,6 +178,18 @@ public final class Target {
     }
     public var _checksum: String?
 
+    /// The usages of package plugins by the target.
+    @available(_PackageDescription, introduced: 999.0)
+    public var plugins: [PluginUsage]? {
+        get { return _pluginUsages }
+        set { _pluginUsages = newValue }
+    }
+    private var _pluginUsages: [PluginUsage]?
+
+    public enum PluginUsage {
+        case _pluginItem(name: String, package: String?)
+    }
+
     /// Construct a target.
     private init(
         name: String,
@@ -196,7 +208,8 @@ public final class Target {
         cxxSettings: [CXXSetting]? = nil,
         swiftSettings: [SwiftSetting]? = nil,
         linkerSettings: [LinkerSetting]? = nil,
-        checksum: String? = nil
+        checksum: String? = nil,
+        pluginUsages: [PluginUsage]? = nil
     ) {
         self.name = name
         self.dependencies = dependencies
@@ -215,6 +228,7 @@ public final class Target {
         self._swiftSettings = swiftSettings
         self._linkerSettings = linkerSettings
         self._checksum = checksum
+        self._pluginUsages = pluginUsages
 
         switch type {
         case .regular, .executable, .test:
@@ -238,7 +252,8 @@ public final class Target {
                 cxxSettings == nil &&
                 swiftSettings == nil &&
                 linkerSettings == nil &&
-                checksum == nil
+                checksum == nil &&
+                pluginUsages == nil
             )
         case .binary:
             precondition(
@@ -253,7 +268,8 @@ public final class Target {
                 cSettings == nil &&
                 cxxSettings == nil &&
                 swiftSettings == nil &&
-                linkerSettings == nil
+                linkerSettings == nil &&
+                pluginUsages == nil
             )
         case .plugin:
             precondition(
@@ -268,7 +284,8 @@ public final class Target {
                 cSettings == nil &&
                 cxxSettings == nil &&
                 swiftSettings == nil &&
-                linkerSettings == nil
+                linkerSettings == nil &&
+                pluginUsages == nil
             )
         }
     }
@@ -384,7 +401,7 @@ public final class Target {
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    @available(_PackageDescription, introduced: 5.3)
+    @available(_PackageDescription, introduced: 5.3, obsoleted: 999.0)
     public static func target(
         name: String,
         dependencies: [Dependency] = [],
@@ -414,6 +431,62 @@ public final class Target {
         )
     }
 
+    /// Creates a regular target.
+    ///
+    /// A target can contain either Swift or C-family source files, but not both. It contains code that is built as
+    /// a regular module that can be included in a library or executable product, but that cannot itself be used as
+    /// the main target of an executable product.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the target.
+    ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
+    ///   - path: The custom path for the target. By default, the Swift Package Manager requires a target's sources to reside at predefined search paths;
+    ///       for example, `[PackageRoot]/Sources/[TargetName]`.
+    ///       Don't escape the package root; for example, values like `../Foo` or `/Foo` are invalid.
+    ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
+    ///       A path is relative to the target's directory.
+    ///       This parameter has precedence over the `sources` parameter.
+    ///   - sources: An explicit list of source files. If you provide a path to a directory,
+    ///       the Swift Package Manager searches for valid source files recursively.
+    ///   - resources: An explicit list of resources files.
+    ///   - publicHeadersPath: The directory containing public headers of a C-family library target.
+    ///   - cSettings: The C settings for this target.
+    ///   - cxxSettings: The C++ settings for this target.
+    ///   - swiftSettings: The Swift settings for this target.
+    ///   - linkerSettings: The linker settings for this target.
+    ///   - plugins: The plugins used by this target.
+    @available(_PackageDescription, introduced: 999.0)
+    public static func target(
+        name: String,
+        dependencies: [Dependency] = [],
+        path: String? = nil,
+        exclude: [String] = [],
+        sources: [String]? = nil,
+        resources: [Resource]? = nil,
+        publicHeadersPath: String? = nil,
+        cSettings: [CSetting]? = nil,
+        cxxSettings: [CXXSetting]? = nil,
+        swiftSettings: [SwiftSetting]? = nil,
+        linkerSettings: [LinkerSetting]? = nil,
+        plugins: [PluginUsage]? = nil
+    ) -> Target {
+        return Target(
+            name: name,
+            dependencies: dependencies,
+            path: path,
+            exclude: exclude,
+            sources: sources,
+            resources: resources,
+            publicHeadersPath: publicHeadersPath,
+            type: .regular,
+            cSettings: cSettings,
+            cxxSettings: cxxSettings,
+            swiftSettings: swiftSettings,
+            linkerSettings: linkerSettings,
+            pluginUsages: plugins
+        )
+    }
+
     /// Creates an executable target.
     ///
     /// An executable target can contain either Swift or C-family source files, but not both. It contains code that
@@ -438,7 +511,7 @@ public final class Target {
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    @available(_PackageDescription, introduced: 5.4)
+    @available(_PackageDescription, introduced: 5.4, obsoleted: 999.0)
     public static func executableTarget(
        name: String,
        dependencies: [Dependency] = [],
@@ -468,6 +541,63 @@ public final class Target {
        )
     }
     
+    /// Creates an executable target.
+    ///
+    /// An executable target can contain either Swift or C-family source files, but not both. It contains code that
+    /// is built as an executable module that can be used as the main target of an executable product. The target
+    /// is expected to either have a source file named `main.swift`, `main.m`, `main.c`, or `main.cpp`, or a source
+    /// file that contains the `@main` keyword.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the target.
+    ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
+    ///   - path: The custom path for the target. By default, the Swift Package Manager requires a target's sources to reside at predefined search paths;
+    ///       for example, `[PackageRoot]/Sources/[TargetName]`.
+    ///       Don't escape the package root; for example, values like `../Foo` or `/Foo` are invalid.
+    ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
+    ///       A path is relative to the target's directory.
+    ///       This parameter has precedence over the `sources` parameter.
+    ///   - sources: An explicit list of source files. If you provide a path to a directory,
+    ///       the Swift Package Manager searches for valid source files recursively.
+    ///   - resources: An explicit list of resources files.
+    ///   - publicHeadersPath: The directory containing public headers of a C-family library target.
+    ///   - cSettings: The C settings for this target.
+    ///   - cxxSettings: The C++ settings for this target.
+    ///   - swiftSettings: The Swift settings for this target.
+    ///   - linkerSettings: The linker settings for this target.
+    ///   - plugins: The plugins used by this target.
+    @available(_PackageDescription, introduced: 999.0)
+    public static func executableTarget(
+       name: String,
+       dependencies: [Dependency] = [],
+       path: String? = nil,
+       exclude: [String] = [],
+       sources: [String]? = nil,
+       resources: [Resource]? = nil,
+       publicHeadersPath: String? = nil,
+       cSettings: [CSetting]? = nil,
+       cxxSettings: [CXXSetting]? = nil,
+       swiftSettings: [SwiftSetting]? = nil,
+       linkerSettings: [LinkerSetting]? = nil,
+       plugins: [PluginUsage]? = nil
+    ) -> Target {
+       return Target(
+           name: name,
+           dependencies: dependencies,
+           path: path,
+           exclude: exclude,
+           sources: sources,
+           resources: resources,
+           publicHeadersPath: publicHeadersPath,
+           type: .executable,
+           cSettings: cSettings,
+           cxxSettings: cxxSettings,
+           swiftSettings: swiftSettings,
+           linkerSettings: linkerSettings,
+           pluginUsages: plugins
+       )
+    }
+
     /// Creates a test target.
     ///
     /// Write test targets using the XCTest testing framework.
@@ -571,7 +701,7 @@ public final class Target {
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    @available(_PackageDescription, introduced: 5.3)
+    @available(_PackageDescription, introduced: 5.3, obsoleted: 999.0)
     public static func testTarget(
         name: String,
         dependencies: [Dependency] = [],
@@ -597,6 +727,59 @@ public final class Target {
             cxxSettings: cxxSettings,
             swiftSettings: swiftSettings,
             linkerSettings: linkerSettings
+        )
+    }
+
+    /// Creates a test target.
+    ///
+    /// Write test targets using the XCTest testing framework.
+    /// Test targets generally declare a dependency on the targets they test.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the target.
+    ///   - dependencies: The dependencies of the target. A dependency can be another target in the package or a product from a package dependency.
+    ///   - path: The custom path for the target. By default, the Swift Package Manager requires a target's sources to reside at predefined search paths;
+    ///       for example, `[PackageRoot]/Sources/[TargetName]`.
+    ///       Don't escape the package root; for example, values like `../Foo` or `/Foo` are invalid.
+    ///   - exclude: A list of paths to files or directories that the Swift Package Manager shouldn't consider to be source or resource files.
+    ///       A path is relative to the target's directory.
+    ///       This parameter has precedence over the `sources` parameter.
+    ///   - sources: An explicit list of source files. If you provide a path to a directory,
+    ///       the Swift Package Manager searches for valid source files recursively.
+    ///   - resources: An explicit list of resources files.
+    ///   - cSettings: The C settings for this target.
+    ///   - cxxSettings: The C++ settings for this target.
+    ///   - swiftSettings: The Swift settings for this target.
+    ///   - linkerSettings: The linker settings for this target.
+    ///   - plugins: The plugins used by this target.
+    @available(_PackageDescription, introduced: 999.0)
+    public static func testTarget(
+        name: String,
+        dependencies: [Dependency] = [],
+        path: String? = nil,
+        exclude: [String] = [],
+        sources: [String]? = nil,
+        resources: [Resource]? = nil,
+        cSettings: [CSetting]? = nil,
+        cxxSettings: [CXXSetting]? = nil,
+        swiftSettings: [SwiftSetting]? = nil,
+        linkerSettings: [LinkerSetting]? = nil,
+        plugins: [PluginUsage]? = nil
+    ) -> Target {
+        return Target(
+            name: name,
+            dependencies: dependencies,
+            path: path,
+            exclude: exclude,
+            sources: sources,
+            resources: resources,
+            publicHeadersPath: nil,
+            type: .test,
+            cSettings: cSettings,
+            cxxSettings: cxxSettings,
+            swiftSettings: swiftSettings,
+            linkerSettings: linkerSettings,
+            pluginUsages: plugins
         )
     }
 
@@ -688,6 +871,39 @@ public final class Target {
             type: .binary)
     }
 
+    /// Defines a new package plugin target with a given name, declaring it as
+    /// providing a capability of adding custom build commands to SwiftPM (and to
+    /// any IDEs based on libSwiftPM).
+    ///
+    /// The capability determines what kind of build commands it can add. Besides
+    /// determining at what point in the build those commands run, the capability
+    /// determines the context that is available to the plugin and the kinds of
+    /// commands it can create.
+    ///
+    /// In the initial version of this proposal, three capabilities are provided:
+    /// prebuild, build tool, and postbuild. See the declaration of each capability
+    /// under `PluginCapability` for more information.
+    ///
+    /// The package plugin itself is implemented using a Swift script that is
+    /// invoked for each target that uses it. The script is invoked after the
+    /// package graph has been resolved, but before the build system creates its
+    /// dependency graph. It is also invoked after changes to the target or the
+    /// build parameters.
+    ///
+    /// Note that the role of the package plugin is only to define the commands
+    /// that will run before, during, or after the build. It does not itself run
+    /// those commands. The commands are defined in an IDE-neutral way, and are
+    /// run as appropriate by the build system that builds the package. The exten-
+    /// sion itself is only a procedural way of generating commands and their input
+    /// and output dependencies.
+    ///
+    /// The package plugin may specify the executable targets or binary targets
+    /// that provide the build tools that will be used by the generated commands
+    /// during the build. In the initial implementation, prebuild actions can only
+    /// depend on binary targets. Build tool and postbuild plugins can depend
+    /// on executables as well as binary targets. This is because of limitations
+    /// in how SwiftPM constructs its build plan, and the goal is to remove this
+    /// restriction in a future release.
     @available(_PackageDescription, introduced: 999.0)
     public static func plugin(
         name: String,
@@ -726,6 +942,7 @@ extension Target: Encodable {
         case swiftSettings
         case linkerSettings
         case checksum
+        case pluginUsages
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -759,6 +976,10 @@ extension Target: Encodable {
 
         if let linkerSettings = self._linkerSettings {
             try container.encode(linkerSettings, forKey: .linkerSettings)
+        }
+        
+        if let pluginUsages = self._pluginUsages {
+            try container.encode(pluginUsages, forKey: .pluginUsages)
         }
     }
 }
@@ -896,6 +1117,28 @@ extension Target.PluginCapability {
     }
 }
 
+extension Target.PluginUsage {
+    /// Specifies use of a plugin target in the same package.
+    ///
+    /// - parameters:
+    ///   - name: The name of the plugin target.
+    @available(_PackageDescription, introduced: 999.0)
+    public static func plugin(name: String) -> Target.PluginUsage {
+        return ._pluginItem(name: name, package: nil)
+    }
+
+    /// Specifies use of a plugin product in a package dependency.
+    ///
+    /// - parameters:
+    ///   - name: The name of the plugin product.
+    ///   - package: The name of the package in which it is defined.
+    @available(_PackageDescription, introduced: 999.0)
+    public static func plugin(name: String, package: String) -> Target.PluginUsage {
+        return ._pluginItem(name: name, package: package)
+    }
+}
+
+
 // MARK: ExpressibleByStringLiteral
 
 extension Target.Dependency: ExpressibleByStringLiteral {
@@ -912,6 +1155,20 @@ extension Target.Dependency: ExpressibleByStringLiteral {
       #endif
     }
 }
+
+extension Target.PluginUsage: ExpressibleByStringLiteral {
+
+    /// Specifies use of a plugin target in the same package.
+    ///
+    /// - parameters:
+    ///   - value: A string literal.
+    public init(stringLiteral value: String) {
+        self = ._pluginItem(name: value, package: nil)
+    }
+}
+
+
+// MARK: Encodable
 
 /// A condition that limits the application of a target's dependency.
 public struct TargetDependencyCondition: Encodable {
@@ -932,5 +1189,25 @@ public struct TargetDependencyCondition: Encodable {
         // FIXME: This should be an error, not a precondition.
         precondition(!(platforms == nil))
         return TargetDependencyCondition(platforms: platforms)
+    }
+}
+
+extension Target.PluginUsage: Encodable {
+    private enum CodingKeys: CodingKey {
+        case type, name, package
+    }
+
+    private enum Kind: String, Codable {
+        case plugin
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case ._pluginItem(let name, let package):
+            try container.encode(Kind.plugin, forKey: .type)
+            try container.encode(name, forKey: .name)
+            try container.encode(package, forKey: .package)
+        }
     }
 }


### PR DESCRIPTION
Move the usage of plugins from the `dependencies` parameter of targets in the package manifest to instead be in a separate `plugins` parameter.

Despite their similarity to dependencies we want users to consider them differently.  This also leaves room to grow in the future, when plugin usage might support parameters, etc.  We encode them separately in the manifest JSON, but merge them into regular dependencies to avoid duplicated implementation on the SwiftPM side.  This can be changed later without affecting clients.  For now it would just mean duplicate code.

Modifications:
- change PackageDescription API in accordance with proposal (involving the usual unfortunate duplicate of declarations with deprecation of older ones)
- add PluginUsage type, and plumb it through
- in PackageBuilder, infer dependencies from plugin usage, and pass through for the remainder of the existing logic
- for the moment we have a type alias from Target.PackageUsage to Target.Dependency on the internal side (not in the PackageDescription API)

rdar://74663667