### PR TITLE
[Collections] refreshCollection should have correct source config

### DIFF
--- a/Sources/PackageCollections/Model/Collection.swift
+++ b/Sources/PackageCollections/Model/Collection.swift
@@ -31,7 +31,7 @@ extension PackageCollectionsModel {
         public let identifier: Identifier
 
         /// Where the collection and its contents are obtained
-        public let source: Source
+        public internal(set) var source: Source
 
         /// The name of the collection
         public let name: String


### PR DESCRIPTION
Motivation:
`refreshCollection` relies on `CollectionSource` argument to provide the correct source config, but it should:
1. Check that the source exists in the config
2. Read latest source config from storage

Modifications:
Update `refreshCollection` to check that the given source exists in config file before actually doing a refresh. Also make sure that `Collection`'s `source` is current before returning it.
