### PR TITLE
[Collections] describe subcommand should include signature info

### DIFF
--- a/Sources/Commands/SwiftPackageCollectionsTool.swift
+++ b/Sources/Commands/SwiftPackageCollectionsTool.swift
@@ -323,11 +323,13 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
                         if jsonOptions.json {
                             try JSONEncoder.makeWithDefaults().print(collection)
                         } else {
+                            let signature = optionalRow("Signed By", collection.signature.map { "\($0.certificate.subject.commonName ?? "Unspecified") (\($0.isVerified ? "" : "not ")verified)" })
+                            
                             print("""
                                 Name: \(collection.name)
                                 Source: \(collection.source.url)\(description)\(keywords)\(createdAt)
                                 Packages:
-                                    \(packages)
+                                    \(packages)\(signature)
                             """)
                         }
                     } catch {


### PR DESCRIPTION
Motivation:
`package-collection`'s `describe` subcommand should display signature info if collection is signed.

Modifications:
Update output for signed collection to print additional:

```
Signed By: Jane Doe (verified)
```
