### PR TITLE
Allow unit test targets to import and link executable targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Swift v.Next
    * Improvements
    
    Adding a dependency requirement can now be done with the convenience initializer `.package(url: String, branch: String)`.
+   
+   Test targets can now link against executable targets as if they were libraries, so that they can test any data strutures or algorithms in them.  All the code in the executable except for the main entry point itself is available to the unit test.  Separate executables are still linked, and can be tested as a subprocess in the same way as before.  This feature is available to tests defined in packages that have a tools version of `vNext` or newer. 
 
 
 

--- a/Fixtures/Miscellaneous/ExeTest/Package.swift
+++ b/Fixtures/Miscellaneous/ExeTest/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.3
+// swift-tools-version: 999.0
 import PackageDescription
 
 let package = Package(
     name: "ExeTest",
     targets: [
-        .target(
+        .executableTarget(
             name: "Exe",
             dependencies: []
         ),

--- a/Fixtures/Miscellaneous/TestableExe/Package.swift
+++ b/Fixtures/Miscellaneous/TestableExe/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 999.0
+import PackageDescription
+
+let package = Package(
+    name: "TestableExe",
+    targets: [
+        .target(
+            name: "TestableExe1"
+        ),
+        .target(
+            name: "TestableExe2"
+        ),
+        .target(
+            name: "TestableExe3"
+        ),
+        .testTarget(
+            name: "TestableExeTests",
+            dependencies: [
+                "TestableExe1",
+                "TestableExe2",
+                "TestableExe3",
+            ]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/TestableExe/Sources/TestableExe1/main.swift
+++ b/Fixtures/Miscellaneous/TestableExe/Sources/TestableExe1/main.swift
@@ -1,0 +1,5 @@
+public func GetGreeting1() -> String {
+    return "Hello, world"
+}
+
+print("\(GetGreeting1())!")

--- a/Fixtures/Miscellaneous/TestableExe/Sources/TestableExe2/main.swift
+++ b/Fixtures/Miscellaneous/TestableExe/Sources/TestableExe2/main.swift
@@ -1,0 +1,5 @@
+public func GetGreeting2() -> String {
+    return "Hello, planet"
+}
+
+print("\(GetGreeting2())!")

--- a/Fixtures/Miscellaneous/TestableExe/Sources/TestableExe3/include/TestableExe3.h
+++ b/Fixtures/Miscellaneous/TestableExe/Sources/TestableExe3/include/TestableExe3.h
@@ -1,0 +1,1 @@
+const char * GetGreeting3();

--- a/Fixtures/Miscellaneous/TestableExe/Sources/TestableExe3/main.c
+++ b/Fixtures/Miscellaneous/TestableExe/Sources/TestableExe3/main.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include "include/TestableExe3.h"
+
+const char * GetGreeting3() {
+    return "Hello, universe";
+}
+
+int main() {
+    printf("%s!\n", GetGreeting3());
+}

--- a/Fixtures/Miscellaneous/TestableExe/Tests/TestableExeTests/TestableExeTests.swift
+++ b/Fixtures/Miscellaneous/TestableExe/Tests/TestableExeTests/TestableExeTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+import TestableExe1
+import TestableExe2
+// import TestableExe3
+import class Foundation.Bundle
+
+final class TestableExeTests: XCTestCase {
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+        
+        print(GetGreeting1())
+        XCTAssertEqual(GetGreeting1(), "Hello, world")
+        print(GetGreeting2())
+        XCTAssertEqual(GetGreeting2(), "Hello, planet")
+        // XCTAssertEqual(String(cString: GetGreeting3()), "Hello, universe")
+
+        // Some of the APIs that we use below are available in macOS 10.13 and above.
+        guard #available(macOS 10.13, *) else {
+            return
+        }
+
+        var execPath = productsDirectory.appendingPathComponent("TestableExe1")
+        var process = Process()
+        process.executableURL = execPath
+        var pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        var data = pipe.fileHandleForReading.readDataToEndOfFile()
+        var output = String(data: data, encoding: .utf8)
+        XCTAssertEqual(output, "Hello, world!\n")
+
+        execPath = productsDirectory.appendingPathComponent("TestableExe2")
+        process = Process()
+        process.executableURL = execPath
+        pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        data = pipe.fileHandleForReading.readDataToEndOfFile()
+        output = String(data: data, encoding: .utf8)
+        XCTAssertEqual(output, "Hello, planet!\n")
+
+        execPath = productsDirectory.appendingPathComponent("TestableExe3")
+        process = Process()
+        process.executableURL = execPath
+        pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        data = pipe.fileHandleForReading.readDataToEndOfFile()
+        output = String(data: data, encoding: .utf8)
+        XCTAssertEqual(output, "Hello, universe!\n")
+    }
+
+    /// Returns path to the built products directory.
+    var productsDirectory: URL {
+      #if os(macOS)
+        for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+            return bundle.bundleURL.deletingLastPathComponent()
+        }
+        fatalError("couldn't find the products directory")
+      #else
+        return Bundle.main.bundleURL
+      #endif
+    }
+
+    static var allTests = [
+        ("testExample", testExample),
+    ]
+}

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -14,7 +14,9 @@ import TSCBasic
 
 class PluginTests: XCTestCase {
     
-    func testUseOfBuildToolPluginTargetByExecutableInSamePackage() {
+    func testUseOfBuildToolPluginTargetByExecutableInSamePackage() throws {
+        // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 999.0.
+        try XCTSkipUnless(doesHostSwiftCompilerSupportRenamingMainSymbol(), "skipping because host compiler doesn't support '-entry-point-function-name'")
         
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
@@ -31,7 +33,10 @@ class PluginTests: XCTestCase {
         }
     }
 
-    func testUseOfBuildToolPluginProductByExecutableAcrossPackages() {
+    func testUseOfBuildToolPluginProductByExecutableAcrossPackages() throws {
+        // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 999.0.
+        try XCTSkipUnless(doesHostSwiftCompilerSupportRenamingMainSymbol(), "skipping because host compiler doesn't support '-entry-point-function-name'")
+
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
                 let (stdout, _) = try executeSwiftBuild(path.appending(component: "MySourceGenClient"), configuration: .Debug, extraArgs: ["--product", "MyTool"], env: ["SWIFTPM_ENABLE_PLUGINS": "1"])
@@ -47,7 +52,10 @@ class PluginTests: XCTestCase {
         }
     }
 
-    func testUseOfPrebuildPluginTargetByExecutableAcrossPackages() {
+    func testUseOfPrebuildPluginTargetByExecutableAcrossPackages() throws {
+        // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 999.0.
+        try XCTSkipUnless(doesHostSwiftCompilerSupportRenamingMainSymbol(), "skipping because host compiler doesn't support '-entry-point-function-name'")
+
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
                 let (stdout, _) = try executeSwiftBuild(path.appending(component: "MySourceGenPlugin"), configuration: .Debug, extraArgs: ["--product", "MyOtherLocalTool"], env: ["SWIFTPM_ENABLE_PLUGINS": "1"])

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -79,6 +79,15 @@ class PackageGraphTests: XCTestCase {
             result.checkTarget("Bar") { result in result.check(dependencies: "Foo") }
             result.checkTarget("Baz") { result in result.check(dependencies: "Bar") }
         }
+
+        let fooPackage = try XCTUnwrap(g.packages.first{ $0.name == "Foo" })
+        let fooTarget = try XCTUnwrap(g.allTargets.first{ $0.name == "Foo" })
+        let fooDepTarget = try XCTUnwrap(g.allTargets.first{ $0.name == "FooDep" })
+        XCTAssert(g.package(for: fooTarget) == fooPackage)
+        XCTAssert(g.package(for: fooDepTarget) == fooPackage)
+        let barPackage = try XCTUnwrap(g.packages.first{ $0.name == "Bar" })
+        let barTarget = try XCTUnwrap(g.allTargets.first{ $0.name == "Bar" })
+        XCTAssert(g.package(for: barTarget) == barPackage)
     }
 
     func testProductDependencies() throws {


### PR DESCRIPTION
Allow unit test targets to import and link executable targets.  This allows them to test everything except the main function in those targets without having to run the executable as a subprocess.  With these changes they can still run the subprocess if they want to.

### Motivation:

Many package authors don’t want to split their code into executable targets vs library targets, but still want to test data structures and algorithms in their executables.

### Modifications:

This uses a new Swift compiler flag introduced in https://github.com/apple/swift/pull/35595 to compile the main symbol to a different name than `_main`, so that it doesn't cause symbol collisions when linked into a test executable.  When linking the actual executable, the entry point symbol is then renamed back to to `_main`.  This is done using linker flags for both Darwin and Linux in this implementation, but for linkers that don't support such options, a fallback would be to generate a stub source file along the lines of the compiler PR.

This feature is guarded with a tools version check, since packages written this way won't be testable on older toolchains.

This PR supersedes the one at https://github.com/apple/swift-package-manager/pull/3103, which modified object files after compilation.  That was a much messier solution but the best possible without support from either the compiler or linker.  Now that there is compiler support, we can do better.

### Modifications:

- when compiling the main module of an executable, use a Swift flag to set the name of the entry point to a name that's based on the module name
- when linking an executable, use a linker flag to rename the renamed entry point back to `_main`
- undo previous changes to prevent the modules of executables from being found by the Swift compiler
- added PackageGraph lookup methods for mapping targets and products back to packages (for the tools version)
- pipe through the tools version in BuildPlan so that logic that generates flags can take it into account

### Result:

Unit test targets can now link executable targets that are implemented in Swift.  Executables implemented using Clang targets would require a corresponding Clang flag, and are therefore currently not supported.

rdar://58122395