### PR TITLE
[Collections] Potential fix for race in list collections

### DIFF
--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -341,7 +341,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
         // go to db if not found
         self.queue.async {
             do {
-                var blobs = [Data]()
+                let blobs = ThreadSafeArrayStore<Data>()
                 if let identifiers = identifiers {
                     var index = 0
                     while index < identifiers.count {
@@ -374,7 +374,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                     })
                 } else {
                     collections = .init()
-                    blobs.forEach { data in
+                    blobs.get().forEach { data in
                         self.queue.async(group: sync) {
                             if let collection = try? self.decoder.decode(Model.Collection.self, from: data) {
                                 collections.append(collection)


### PR DESCRIPTION
Motivation:
`testHappyRefresh` crashed in https://ci.swift.org/job/oss-swift-package-centos-8/975

```
Test Suite 'PackageCollectionsTests' started at 2021-03-02 22:01:52.483
Test Case 'PackageCollectionsTests.testHappyRefresh' started at 2021-03-02 22:01:52.483
Exited with signal code 11
```

This is similar to https://github.com/apple/swift-package-manager/pull/3232

Modifications:
Both `testHappyRefresh` and `testBrokenRefresh` call `listCollections` after `refreshCollections`, and part of the `listCollections` code where we read collection blobs from the database might be racy since we are not using `ThreadSafeArrayStore`.
