### PR TITLE
Do not include XCBuild file types by default

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -517,6 +517,7 @@ public class SwiftTool {
         let delegate = ToolWorkspaceDelegate(self.stdoutStream, isVerbose: isVerbose, diagnostics: diagnostics)
         let provider = GitRepositoryProvider(processSet: processSet)
         let cachePath = self.options.useRepositoriesCache ? try self.getCachePath() : .none
+        let isXcodeBuildSystemEnabled = self.options.buildSystem == .xcode
         let workspace = Workspace(
             dataPath: buildPath,
             editablesPath: try editablesPath(),
@@ -527,6 +528,7 @@ public class SwiftTool {
             config: try getSwiftPMConfig(),
             repositoryProvider: provider,
             netrcFilePath: try resolvedNetrcFilePath(),
+            additionalFileRules: isXcodeBuildSystemEnabled ? FileRuleDescription.xcbuildFileTypes : [],
             isResolverPrefetchingEnabled: options.shouldEnableResolverPrefetching,
             skipUpdate: options.skipDependencyUpdate,
             enableResolverTrace: options.enableResolverTrace,

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -66,7 +66,12 @@ public struct TargetSourcesBuilder {
         self.defaultLocalization = defaultLocalization
         self.diags = diags
         self.targetPath = path
-        self.rules = FileRuleDescription.builtinRules
+        if toolsVersion <= ToolsVersion.v5_4 {
+            // In version 5.4 and earlier, we did not support `additionalFileRules` and always implicitly included XCBuild file types.
+            self.rules = FileRuleDescription.builtinRules + FileRuleDescription.xcbuildFileTypes
+        } else {
+            self.rules = FileRuleDescription.builtinRules + additionalFileRules
+        }
         self.toolsVersion = toolsVersion
         self.fs = fs
         let excludedPaths = target.exclude.map{ path.appending(RelativePath($0)) }
@@ -607,7 +612,7 @@ public struct FileRuleDescription {
         asm,
         modulemap,
         header,
-    ] + xcbuildFileTypes
+    ]
 
     /// List of file types that requires the Xcode build system.
     public static let xcbuildFileTypes: [FileRuleDescription] = [

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -227,7 +227,8 @@ public func loadPackageGraph(
     explicitProduct: String? = nil,
     shouldCreateMultipleTestProducts: Bool = false,
     allowPluginTargets: Bool = false,
-    createREPLProduct: Bool = false
+    createREPLProduct: Bool = false,
+    useXCBuildFileRules: Bool = false
 ) throws -> PackageGraph {
     let rootManifests = manifests.filter { $0.packageKind == .root }
     let externalManifests = manifests.filter { $0.packageKind != .root }
@@ -238,6 +239,7 @@ public func loadPackageGraph(
     return try PackageGraph.load(
         root: graphRoot,
         identityResolver: identityResolver,
+        additionalFileRules: useXCBuildFileRules ? FileRuleDescription.xcbuildFileTypes : [],
         externalManifests: externalManifests,
         binaryArtifacts: binaryArtifacts,
         diagnostics: diagnostics,

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -1709,7 +1709,8 @@ class PIFBuilderTests: XCTestCase {
                     ],
                     targets: [
                         .init(name: "foo", resources: [
-                            .init(rule: .process, path: "Resources")
+                            // This is intentionally specific to test that we pick up `.xcdatamodel` implicitly.
+                            .init(rule: .process, path: "Resources/Data.plist")
                         ]),
                         .init(name: "FooLib", resources: [
                             .init(rule: .process, path: "Resources")
@@ -1719,7 +1720,8 @@ class PIFBuilderTests: XCTestCase {
                         ], type: .test),
                     ]),
             ],
-            shouldCreateMultipleTestProducts: true
+            shouldCreateMultipleTestProducts: true,
+            useXCBuildFileRules: true
         )
 
         let builder = PIFBuilder(graph: graph, parameters: .mock(), diagnostics: diagnostics)


### PR DESCRIPTION
When introducing the `--build-system xcode` option, we apparently did not consider that the file types that are specific to that mode should not be enabled when using the built-in build system. We also did not actually support the `additionalFileRules` parameter of `TargetSourcesBuilder`, it was never passed to the actual computation.

This PR changes the behavior for tools version > 5.4 only to be backwards compatible. In newer tools versions, we will only include the XCBuild specific file types in the CLI when XCBuild is being used. When using libSwiftPM, the file types will not be included at all, unless using an older tools version.

rdar://64961989
