### PR TITLE
Fix `diagnoseInvalidResource`

### DIFF
--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -167,7 +167,7 @@ public struct TargetSourcesBuilder {
         diagnoseLocalizedAndUnlocalizedVariants(in: resources)
         diagnoseMissingDevelopmentRegionResource(in: resources)
         diagnoseInfoPlistConflicts(in: resources)
-        diagnoseInvalidResource(in: resources)
+        diagnoseInvalidResource(in: target.resources)
 
         // It's an error to contain mixed language source files.
         if sources.containsMixedLanguage {
@@ -345,9 +345,10 @@ public struct TargetSourcesBuilder {
         }
     }
     
-    private func diagnoseInvalidResource(in resources: [Resource]) {
+    private func diagnoseInvalidResource(in resources: [TargetDescription.Resource]) {
         resources.forEach { resource in
-            if let message = validTargetPath(at: resource.path) {
+            let resourcePath = self.targetPath.appending(RelativePath(resource.path))
+            if let message = validTargetPath(at: resourcePath) {
                 let warning = "Invalid Resource '\(resource.path)': \(message)."
                 self.diags.emit(warning: warning)
             }

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -518,6 +518,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             diags: diags
         )
 
+        XCTAssertEqual(diags.diagnostics.count, 2)
         diags.diagnostics.forEach { XCTAssert($0.description.contains("Invalid Exclude")) }
     }
     
@@ -551,8 +552,9 @@ class TargetSourcesBuilderTests: XCTestCase {
             fs: fs,
             diags: diags
         )
+        _ = try builder.run()
 
-        let _ = builder.computeContents().map{ $0.pathString }.sorted()
+        XCTAssertEqual(diags.diagnostics.count, 2)
         diags.diagnostics.forEach { XCTAssert($0.description.contains("Invalid Resource")) }
     }
     
@@ -588,6 +590,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             diags: diags
         )
 
+        XCTAssertEqual(diags.diagnostics.count, 3)
         diags.diagnostics.forEach { XCTAssert($0.description.contains("Invalid Source")) }
     }
 }


### PR DESCRIPTION
This changes `diagnoseInvalidResource` to work off the declared resources instead of the ones we found rules for. Also amended some of the tests with a check for a count of diagnostics since they could pass with zero diagnostics being emitted.
