### PR TITLE
make download test utilities thread-safe

### DIFF
--- a/Sources/Basics/ConcurrencyHelpers.swift
+++ b/Sources/Basics/ConcurrencyHelpers.swift
@@ -67,6 +67,12 @@ public final class ThreadSafeKeyValueStore<Key, Value> where Key: Hashable {
         }
     }
 
+    public func map<T>(_ transform: ((key: Key, value: Value)) throws -> T) rethrows -> [T] {
+        try self.lock.withLock {
+            try self.underlying.map(transform)
+        }
+    }
+
     public func mapValues<T>(_ transform: (Value) throws -> T) rethrows -> [Key: T] {
         try self.lock.withLock {
             try self.underlying.mapValues(transform)

--- a/Sources/SPMTestSupport/MockArchiver.swift
+++ b/Sources/SPMTestSupport/MockArchiver.swift
@@ -8,17 +8,12 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Basics
 import TSCBasic
 import TSCUtility
-import Foundation
 
 public class MockArchiver: Archiver {
-    public typealias Extract = (
-        MockArchiver,
-        AbsolutePath,
-        AbsolutePath,
-        (Result<Void, Error>) -> Void
-    ) -> Void
+    public typealias Handler = (MockArchiver, AbsolutePath, AbsolutePath, (Result<Void, Error>) -> Void) -> Void
 
     public struct Extraction: Equatable {
         public let archivePath: AbsolutePath
@@ -31,14 +26,11 @@ public class MockArchiver: Archiver {
     }
 
     public let supportedExtensions: Set<String> = ["zip"]
-    public var extractions: [Extraction] = []
-    public var extract: Extract!
+    public let extractions = ThreadSafeArrayStore<Extraction>()
+    public let handler: Handler?
 
-    public init(extract: Extract? = nil) {
-        self.extract = extract ?? { archiver, archivePath, destinationPath, completion in
-            self.extractions.append(Extraction(archivePath: archivePath, destinationPath: destinationPath))
-            completion(.success(()))
-        }
+    public init(handler: Handler? = nil) {
+        self.handler = handler
     }
 
     public func extract(
@@ -46,6 +38,11 @@ public class MockArchiver: Archiver {
         to destinationPath: AbsolutePath,
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
-        self.extract(self, archivePath, destinationPath, completion)
+        if let handler = self.handler {
+            handler(self, archivePath, destinationPath, completion)
+        } else {
+            self.extractions.append(Extraction(archivePath: archivePath, destinationPath: destinationPath))
+            completion(.success(()))
+        }
     }
 }

--- a/Sources/SPMTestSupport/MockHashAlgorithm.swift
+++ b/Sources/SPMTestSupport/MockHashAlgorithm.swift
@@ -12,19 +12,21 @@ import Basics
 import TSCBasic
 
 public class MockHashAlgorithm: HashAlgorithm {
-    public typealias Hash = (ByteString) -> ByteString
+    public typealias Handler = (ByteString) -> ByteString
 
     public private(set) var hashes = ThreadSafeArrayStore<ByteString>()
-    private var hashFunction: Hash!
+    private let handler: Handler?
 
-    public init(hash: Hash? = nil) {
-        self.hashFunction = hash ?? { hash in
+    public init(handler: Handler? = nil) {
+        self.handler = handler
+    }
+
+    public func hash(_ hash: ByteString) -> ByteString {
+        if let handler = self.handler {
+            return handler(hash)
+        } else {
             self.hashes.append(hash)
             return ByteString(hash.contents.reversed())
         }
-    }
-
-    public func hash(_ bytes: ByteString) -> ByteString {
-        return self.hashFunction(bytes)
     }
 }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -4266,7 +4266,7 @@ final class WorkspaceTests: XCTestCase {
     func testArtifactDownloadHappyPath() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
-        var downloads = [Foundation.URL: AbsolutePath]()
+        let downloads = ThreadSafeKeyValueStore<Foundation.URL, AbsolutePath>()
 
         // returns a dummy zipfile for the requested artifact
         let httpClient = HTTPClient(handler: { request, _, completion in
@@ -4301,7 +4301,7 @@ final class WorkspaceTests: XCTestCase {
         })
 
         // create a dummy xcframework directory from the request archive
-        let archiver = MockArchiver(extract: { archiver, archivePath, destinationPath, completion in
+        let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
             do {
                 let name: String
                 switch archivePath.basename {
@@ -4441,7 +4441,7 @@ final class WorkspaceTests: XCTestCase {
     func testArtifactDownloadWithPreviousState() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
-        var downloads = [Foundation.URL: AbsolutePath]()
+        let downloads = ThreadSafeKeyValueStore<Foundation.URL, AbsolutePath>()
 
         // returns a dummy zipfile for the requested artifact
         let httpClient = HTTPClient(handler: { request, _, completion in
@@ -4478,7 +4478,7 @@ final class WorkspaceTests: XCTestCase {
         })
 
         // create a dummy xcframework directory from the request archive
-        let archiver = MockArchiver(extract: { archiver, archivePath, destinationPath, completion in
+        let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
             do {
                 let name: String
                 switch archivePath.basename {
@@ -4731,7 +4731,7 @@ final class WorkspaceTests: XCTestCase {
             }
         })
 
-        let archiver = MockArchiver(extract: { _, _, destinationPath, completion in
+        let archiver = MockArchiver(handler: { _, _, destinationPath, completion in
             XCTAssertEqual(destinationPath, AbsolutePath("/tmp/ws/.build/artifacts/A"))
             completion(.failure(DummyError()))
         })
@@ -4871,7 +4871,7 @@ final class WorkspaceTests: XCTestCase {
     func testDownloadArchiveIndexFilesHappyPath() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
-        var downloads = [Foundation.URL: AbsolutePath]()
+        let downloads = ThreadSafeKeyValueStore<Foundation.URL, AbsolutePath>()
         let hostToolchain = try UserToolchain(destination: .hostDestination())
 
         let ariFiles = [
@@ -4951,7 +4951,7 @@ final class WorkspaceTests: XCTestCase {
         })
 
         // create a dummy xcframework directory from the request archive
-        let archiver = MockArchiver(extract: { archiver, archivePath, destinationPath, completion in
+        let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
             do {
                 let name: String
                 switch archivePath.basename {
@@ -5338,7 +5338,7 @@ final class WorkspaceTests: XCTestCase {
         })
 
         // create a dummy xcframework directory from the request archive
-        let archiver = MockArchiver(extract: { archiver, archivePath, destinationPath, completion in
+        let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
             do {
                 let name: String
                 switch archivePath.basename {


### PR DESCRIPTION
motivation: fix flaky tests

changes:
* make MockArchiver thread safe + refactor for better readability
* make few WorkspaceTests that monitor downloads thread-safe
* refactor MockHashAlgorithm for for better readability (same change as MockArchiver)

rdar://75060297

