### PR TITLE
identity improvements

### DIFF
--- a/Examples/package-info/Sources/package-info/main.swift
+++ b/Examples/package-info/Sources/package-info/main.swift
@@ -32,9 +32,9 @@ let packagePath = localFileSystem.currentWorkingDirectory!
 // Each takes longer to load than the level above it, but provides more detail.
 let diagnostics = DiagnosticsEngine()
 let identityResolver = DefaultIdentityResolver()
-let manifest = try tsc_await { ManifestLoader.loadManifest(at: packagePath, kind: .local, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], identityResolver: identityResolver, on: .global(), completion: $0) }
-let loadedPackage = try tsc_await { PackageBuilder.loadPackage(at: packagePath, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], identityResolver: identityResolver, diagnostics: diagnostics, on: .global(), completion: $0) }
-let graph = try Workspace.loadGraph(packagePath: packagePath, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], identityResolver: identityResolver, diagnostics: diagnostics)
+let manifest = try tsc_await { ManifestLoader.loadRootManifest(at: packagePath, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], identityResolver: identityResolver, on: .global(), completion: $0) }
+let loadedPackage = try tsc_await { PackageBuilder.loadRootPackage(at: packagePath, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], identityResolver: identityResolver, diagnostics: diagnostics, on: .global(), completion: $0) }
+let graph = try Workspace.loadRootGraph(at: packagePath, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], identityResolver: identityResolver, diagnostics: diagnostics)
 
 // EXAMPLES
 // ========

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -215,13 +215,8 @@ public struct BuildDescription: Codable {
         self.testDiscoveryCommands = testDiscoveryCommands
         self.copyCommands = copyCommands
 
-        self.builtTestProducts = try plan.buildProducts.filter{ $0.product.type == .test }.map { desc in
-            // FIXME(perf): Provide faster lookups.
-            guard let package = (plan.graph.packages.first{ $0.products.contains(desc.product) }) else {
-                throw InternalError("package with product \(desc.product) not found")
-            }
+        self.builtTestProducts = plan.buildProducts.filter{ $0.product.type == .test }.map { desc in
             return BuiltTestProduct(
-                packageName: package.name,
                 productName: desc.product.name,
                 binaryPath: desc.binary
             )

--- a/Sources/Commands/Describe.swift
+++ b/Sources/Commands/Describe.swift
@@ -55,7 +55,7 @@ fileprivate struct DescribedPackage: Encodable {
     let swiftLanguagesVersions: [String]?
 
     init(from package: Package) {
-        self.name = package.name
+        self.name = package.manifestName // TODO: rename property to manifestName?
         self.path = package.path.pathString
         self.toolsVersion = "\(package.manifest.toolsVersion.major).\(package.manifest.toolsVersion.minor)"
             + (package.manifest.toolsVersion.patch == 0 ? "" : ".\(package.manifest.toolsVersion.patch)")

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -170,16 +170,16 @@ extension SwiftPackageTool {
             let workspace = try swiftTool.getActiveWorkspace()
             let root = try swiftTool.getWorkspaceRoot()
 
-            let manifests = try temp_await {
+            let rootManifests = try temp_await {
                 workspace.loadRootManifests(packages: root.packages, diagnostics: swiftTool.diagnostics, completion: $0)
             }
-            guard let manifest = manifests.first else { return }
-            // FIXME: use PackageIdentity.root?
-            let packageIdentity = workspace.identityResolver.resolveIdentity(for: manifest.packageLocation)
+            guard let rootManifest = rootManifests.first else {
+                throw StringError("invalid manifests at \(root.packages)")
+            }
 
             let builder = PackageBuilder(
-                identity: packageIdentity,
-                manifest: manifest,
+                identity: .root(name: rootManifest.name),
+                manifest: rootManifest,
                 productFilter: .everything,
                 path: try swiftTool.getPackageRoot(),
                 xcTestMinimumDeploymentTargets: MinimumDeploymentTarget.default.xcTestMinimumDeploymentTargets,
@@ -240,15 +240,16 @@ extension SwiftPackageTool {
             // Get the root package.
             let workspace = try swiftTool.getActiveWorkspace()
             let root = try swiftTool.getWorkspaceRoot()
-            let manifest = try temp_await {
+            let rootManifests = try temp_await {
                 workspace.loadRootManifests(packages: root.packages, diagnostics: swiftTool.diagnostics, completion: $0)
-            }[0]
-            // FIXME: use PackageIdentity.root?
-            let packageIdentity = workspace.identityResolver.resolveIdentity(for: manifest.packageLocation)
+            }
+            guard let rootManifest = rootManifests.first else {
+                throw StringError("invalid manifests at \(root.packages)")
+            }
 
             let builder = PackageBuilder(
-                identity: packageIdentity,
-                manifest: manifest,
+                identity: .root(name: rootManifest.name),
+                manifest: rootManifest,
                 productFilter: .everything,
                 path: try swiftTool.getPackageRoot(),
                 xcTestMinimumDeploymentTargets: [:], // Minimum deployment target does not matter for this operation.
@@ -372,15 +373,17 @@ extension SwiftPackageTool {
             let workspace = try swiftTool.getActiveWorkspace()
             let root = try swiftTool.getWorkspaceRoot()
 
-            let manifests = try temp_await {
+            let rootManifests = try temp_await {
                 workspace.loadRootManifests(packages: root.packages, diagnostics: swiftTool.diagnostics, completion: $0)
             }
-            guard let manifest = manifests.first else { return }
+            guard let rootManifest = rootManifests.first else {
+                throw StringError("invalid manifests at \(root.packages)")
+            }
 
             let encoder = JSONEncoder.makeWithDefaults()
             encoder.userInfo[Manifest.dumpPackageKey] = true
 
-            let jsonData = try encoder.encode(manifest)
+            let jsonData = try encoder.encode(rootManifest)
             let jsonString = String(data: jsonData, encoding: .utf8)!
             print(jsonString)
         }

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -174,8 +174,11 @@ extension SwiftPackageTool {
                 workspace.loadRootManifests(packages: root.packages, diagnostics: swiftTool.diagnostics, completion: $0)
             }
             guard let manifest = manifests.first else { return }
+            // FIXME: use PackageIdentity.root?
+            let packageIdentity = workspace.identityResolver.resolveIdentity(for: manifest.packageLocation)
 
             let builder = PackageBuilder(
+                identity: packageIdentity,
                 manifest: manifest,
                 productFilter: .everything,
                 path: try swiftTool.getPackageRoot(),
@@ -240,8 +243,11 @@ extension SwiftPackageTool {
             let manifest = try temp_await {
                 workspace.loadRootManifests(packages: root.packages, diagnostics: swiftTool.diagnostics, completion: $0)
             }[0]
+            // FIXME: use PackageIdentity.root?
+            let packageIdentity = workspace.identityResolver.resolveIdentity(for: manifest.packageLocation)
 
             let builder = PackageBuilder(
+                identity: packageIdentity,
                 manifest: manifest,
                 productFilter: .everything,
                 path: try swiftTool.getPackageRoot(),
@@ -582,7 +588,7 @@ extension SwiftPackageTool {
                 destination = output
             } else {
                 let graph = try swiftTool.loadPackageGraph()
-                let packageName = graph.rootPackages[0].name
+                let packageName = graph.rootPackages[0].manifestName // TODO: use identity instead?
                 destination = packageRoot.appending(component: "\(packageName).zip")
             }
 
@@ -657,10 +663,10 @@ extension SwiftPackageTool {
                 dstdir = outpath.parentDirectory
             case let outpath?:
                 dstdir = outpath
-                projectName = graph.rootPackages[0].name
+                projectName = graph.rootPackages[0].manifestName // TODO: use identity instead?
             case _:
                 dstdir = try swiftTool.getPackageRoot()
-                projectName = graph.rootPackages[0].name
+                projectName = graph.rootPackages[0].manifestName // TODO: use identity instead?
             }
             let xcodeprojPath = Xcodeproj.buildXcodeprojPath(outputDir: dstdir, projectName: projectName)
 

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -224,9 +224,12 @@ public struct SwiftTestTool: SwiftCommand {
         case .codeCovPath:
             let workspace = try swiftTool.getActiveWorkspace()
             let root = try swiftTool.getWorkspaceRoot()
-            let rootManifest = try temp_await {
+            let rootManifests = try temp_await {
                 workspace.loadRootManifests(packages: root.packages, diagnostics: swiftTool.diagnostics, completion: $0)                
-            }[0]
+            }
+            guard let rootManifest = rootManifests.first else {
+                throw StringError("invalid manifests at \(root.packages)")
+            }
             let buildParameters = try swiftTool.buildParametersForTest()
             print(codeCovAsJSONPath(buildParameters: buildParameters, packageName: rootManifest.name))
 
@@ -354,9 +357,12 @@ public struct SwiftTestTool: SwiftCommand {
     private func processCodeCoverage(_ testProducts: [BuiltTestProduct], swiftTool: SwiftTool) throws {
         let workspace = try swiftTool.getActiveWorkspace()
         let root = try swiftTool.getWorkspaceRoot()
-        let rootManifest = try temp_await {
+        let rootManifests = try temp_await {
             workspace.loadRootManifests(packages: root.packages, diagnostics: swiftTool.diagnostics, completion: $0)
-        }[0]
+        }
+        guard let rootManifest = rootManifests.first else {
+            throw StringError("invalid manifests at \(root.packages)")
+        }
 
         // Merge all the profraw files to produce a single profdata file.
         try mergeCodeCovRawDataFiles(swiftTool: swiftTool)

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -352,6 +352,12 @@ public struct SwiftTestTool: SwiftCommand {
 
     /// Processes the code coverage data and emits a json.
     private func processCodeCoverage(_ testProducts: [BuiltTestProduct], swiftTool: SwiftTool) throws {
+        let workspace = try swiftTool.getActiveWorkspace()
+        let root = try swiftTool.getWorkspaceRoot()
+        let rootManifest = try temp_await {
+            workspace.loadRootManifests(packages: root.packages, diagnostics: swiftTool.diagnostics, completion: $0)
+        }[0]
+
         // Merge all the profraw files to produce a single profdata file.
         try mergeCodeCovRawDataFiles(swiftTool: swiftTool)
 
@@ -360,7 +366,7 @@ public struct SwiftTestTool: SwiftCommand {
             // Export the codecov data as JSON.
             let jsonPath = codeCovAsJSONPath(
                 buildParameters: buildParameters,
-                packageName: product.packageName)
+                packageName: rootManifest.name)
             try exportCodeCovAsJSON(to: jsonPath, testBinary: product.binaryPath, swiftTool: swiftTool)
         }
     }

--- a/Sources/Commands/show-dependencies.swift
+++ b/Sources/Commands/show-dependencies.swift
@@ -44,7 +44,7 @@ private final class PlainTextDumper: DependenciesDumper {
 
                 let pkgVersion = package.manifest.version?.description ?? "unspecified"
 
-                stream <<< "\(hanger)\(package.name)<\(package.manifest.packageLocation)@\(pkgVersion)>\n"
+                stream <<< "\(hanger)\(package.identity.description)<\(package.manifest.packageLocation)@\(pkgVersion)>\n"
 
                 if !package.dependencies.isEmpty {
                     let replacement = (index == packages.count - 1) ?  "    " : "│   "
@@ -69,7 +69,7 @@ private final class FlatListDumper: DependenciesDumper {
     func dump(dependenciesOf rootpkg: ResolvedPackage, on stream: OutputByteStream) {
         func recursiveWalk(packages: [ResolvedPackage]) {
             for package in packages {
-                stream <<< package.name <<< "\n"
+                stream <<< package.identity.description <<< "\n"
                 if !package.dependencies.isEmpty {
                     recursiveWalk(packages: package.dependencies)
                 }
@@ -88,7 +88,8 @@ private final class DotDumper: DependenciesDumper {
             let url = package.manifest.packageLocation
             if nodesAlreadyPrinted.contains(url) { return }
             let pkgVersion = package.manifest.version?.description ?? "unspecified"
-            stream <<< #""\#(url)" [label="\#(package.name)\n\#(url)\n\#(pkgVersion)"]"# <<< "\n"
+            // 👀 is this correct? or manifest name is better?
+            stream <<< #""\#(url)" [label="\#(package.identity.description)\n\#(url)\n\#(pkgVersion)"]"# <<< "\n"
             nodesAlreadyPrinted.insert(url)
         }
         
@@ -130,7 +131,7 @@ private final class JSONDumper: DependenciesDumper {
     func dump(dependenciesOf rootpkg: ResolvedPackage, on stream: OutputByteStream) {
         func convert(_ package: ResolvedPackage) -> JSON {
             return .orderedDictionary([
-                "name": .string(package.name),
+                "name": .string(package.manifestName), // TODO: remove? add identity?
                 "url": .string(package.manifest.packageLocation),
                 "version": .string(package.manifest.version?.description ?? "unspecified"),
                 "path": .string(package.path.pathString),

--- a/Sources/Commands/show-dependencies.swift
+++ b/Sources/Commands/show-dependencies.swift
@@ -88,7 +88,6 @@ private final class DotDumper: DependenciesDumper {
             let url = package.manifest.packageLocation
             if nodesAlreadyPrinted.contains(url) { return }
             let pkgVersion = package.manifest.version?.description ?? "unspecified"
-            // 👀 is this correct? or manifest name is better?
             stream <<< #""\#(url)" [label="\#(package.identity.description)\n\#(url)\n\#(pkgVersion)"]"# <<< "\n"
             nodesAlreadyPrinted.insert(url)
         }

--- a/Sources/PackageGraph/GraphLoadingNode.swift
+++ b/Sources/PackageGraph/GraphLoadingNode.swift
@@ -20,13 +20,17 @@ import TSCUtility
 /// - SeeAlso: DependencyResolutionNode
 public struct GraphLoadingNode: Equatable, Hashable {
 
+    /// The package identity.
+    public let identity: PackageIdentity
+
     /// The package manifest.
     public let manifest: Manifest
 
     /// The product filter applied to the package.
     public let productFilter: ProductFilter
 
-    public init(manifest: Manifest, productFilter: ProductFilter) {
+    public init(identity: PackageIdentity, manifest: Manifest, productFilter: ProductFilter) {
+        self.identity = identity
         self.manifest = manifest
         self.productFilter = productFilter
     }
@@ -41,9 +45,9 @@ extension GraphLoadingNode: CustomStringConvertible {
     public var description: String {
         switch productFilter {
         case .everything:
-            return manifest.name
+            return self.manifest.name
         case .specific(let set):
-            return "\(manifest.name)[\(set.sorted().joined(separator: ", "))]"
+            return "\(self.manifest.name)[\(set.sorted().joined(separator: ", "))]"
         }
     }
 }

--- a/Sources/PackageGraph/LocalPackageContainer.swift
+++ b/Sources/PackageGraph/LocalPackageContainer.swift
@@ -39,22 +39,23 @@ public final class LocalPackageContainer: PackageContainer {
     private func loadManifest() throws -> Manifest {
         try manifest.memoize() {
             // Load the tools version.
-            let toolsVersion = try toolsVersionLoader.load(at: AbsolutePath(package.location), fileSystem: fileSystem)
+            let toolsVersion = try self.toolsVersionLoader.load(at: AbsolutePath(self.package.location), fileSystem: self.fileSystem)
 
             // Validate the tools version.
-            try toolsVersion.validateToolsVersion(self.currentToolsVersion, packagePath: package.location)
+            try toolsVersion.validateToolsVersion(self.currentToolsVersion, packagePath: self.package.location)
 
             // Load the manifest.
             // FIXME: this should not block
             return try temp_await {
-                manifestLoader.load(at: AbsolutePath(package.location),
-                                    packageKind: package.kind,
-                                    packageLocation: package.location,
+                manifestLoader.load(at: AbsolutePath(self.package.location),
+                                    packageIdentity: self.package.identity,
+                                    packageKind: self.package.kind,
+                                    packageLocation: self.package.location,
                                     version: nil,
                                     revision: nil,
                                     toolsVersion: toolsVersion,
-                                    identityResolver: identityResolver,
-                                    fileSystem: fileSystem,
+                                    identityResolver: self.identityResolver,
+                                    fileSystem: self.fileSystem,
                                     diagnostics: nil,
                                     on: .global(),
                                     completion: $0)

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -55,7 +55,6 @@ extension PackageGraph {
             manifestMap[$0.identity]
         })
         let rootManifestNodes = root.packages.map { identity, package in
-            // FIXME: use PackageIdentity.root?
             GraphLoadingNode(identity: identity,
                              manifest: package.manifest,
                              productFilter: .everything)
@@ -273,7 +272,6 @@ private func createResolvedPackages(
                         dependencyLocation: dependencyLocation,
                         otherDependencyURL: resolvedPackage.package.manifest.packageLocation,
                         identity: dependencyIdentity)
-                    //let diagnosticLocation = PackageLocation.Local(name: package.name, packagePath: package.path)
                     return diagnostics.emit(error, location: package.diagnosticLocation)
                 }
                 // check that the explicit package dependency name matches the package name.
@@ -366,9 +364,6 @@ private func createResolvedPackages(
     // Do another pass and establish product dependencies of each target.
     for packageBuilder in packageBuilders {
         let package = packageBuilder.package
-
-        // The diagnostics location for this package.
-        //let diagnosticLocation = { PackageLocation.Local(name: package.name, packagePath: package.path) }
 
         // Get all implicit system library dependencies in this package.
         let implicitSystemTargetDeps = packageBuilder.dependencies

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -38,7 +38,7 @@ extension PackageGraph {
         let rootManifestsMap = root.packages.mapValues { $0.manifest }
         let externalManifestsMap = externalManifests.map{ (identityResolver.resolveIdentity(for: $0.packageLocation), $0) }
         let manifestMap = rootManifestsMap.merging(externalManifestsMap, uniquingKeysWith: { lhs, rhs in
-            return rhs // 👀 this was not possible before (the dictionary creation would crash), is preferring external correct?
+            return lhs
         })
 
         let successors: (GraphLoadingNode) -> [GraphLoadingNode] = { node in

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -40,12 +40,13 @@ extension PackageGraph {
         // the URL but that shouldn't be needed after <rdar://problem/33693433>
         // Ensure that identity and package name are the same once we have an
         // API to specify identity in the manifest file
+        // FIXME: use PackageIdentity.root?
         let manifestMapSequence = (root.manifests + externalManifests).map({ (identityResolver.resolveIdentity(for: $0.packageLocation), $0) })
         let manifestMap = Dictionary(uniqueKeysWithValues: manifestMapSequence)
         let successors: (GraphLoadingNode) -> [GraphLoadingNode] = { node in
             node.requiredDependencies().compactMap{ dependency in
                 return manifestMap[dependency.identity].map { manifest in
-                    GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
+                    GraphLoadingNode(identity: dependency.identity, manifest: manifest, productFilter: dependency.productFilter)
                 }
             }
         }
@@ -55,56 +56,62 @@ extension PackageGraph {
         let rootDependencies = Set(root.dependencies.compactMap{
             manifestMap[$0.identity]
         })
-        let rootManifestNodes = root.manifests.map { GraphLoadingNode(manifest: $0, productFilter: .everything) }
+        let rootManifestNodes = root.manifests.map {
+            // FIXME: use PackageIdentity.root?
+            GraphLoadingNode(identity: identityResolver.resolveIdentity(for: $0.packageLocation),
+                             manifest: $0,
+                             productFilter: .everything)
+        }
         let rootDependencyNodes = root.dependencies.lazy.compactMap { (dependency: PackageDependencyDescription) -> GraphLoadingNode? in
             guard let manifest = manifestMap[dependency.identity] else { return nil }
-            return GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
+            return GraphLoadingNode(identity: dependency.identity, manifest: manifest, productFilter: dependency.productFilter)
         }
         let inputManifests = rootManifestNodes + rootDependencyNodes
 
         // Collect the manifests for which we are going to build packages.
-        var allManifests: [GraphLoadingNode]
+        var allNodes: [GraphLoadingNode]
 
         // Detect cycles in manifest dependencies.
         if let cycle = findCycle(inputManifests, successors: successors) {
             diagnostics.emit(PackageGraphError.cycleDetected(cycle))
             // Break the cycle so we can build a partial package graph.
-            allManifests = inputManifests.filter({ $0.manifest != cycle.cycle[0] })
+            allNodes = inputManifests.filter({ $0.manifest != cycle.cycle[0] })
         } else {
             // Sort all manifests toplogically.
-            allManifests = try topologicalSort(inputManifests, successors: successors)
+            allNodes = try topologicalSort(inputManifests, successors: successors)
         }
 
         var flattenedManifests: [PackageIdentity: GraphLoadingNode] = [:]
-        for node in allManifests {
-            let packageIdentity = identityResolver.resolveIdentity(for: node.manifest.packageLocation)
-            if let existing = flattenedManifests[packageIdentity] {
+        for node in allNodes {
+            if let existing = flattenedManifests[node.identity] {
                 let merged = GraphLoadingNode(
+                    identity: node.identity,
                     manifest: node.manifest,
                     productFilter: existing.productFilter.union(node.productFilter)
                 )
-                flattenedManifests[packageIdentity] = merged
+                flattenedManifests[node.identity] = merged
             } else {
-                flattenedManifests[packageIdentity] = node
+                flattenedManifests[node.identity] = node
             }
         }
-        allManifests = flattenedManifests.values.sorted(by: { identityResolver.resolveIdentity(for: $0.manifest.packageLocation) < identityResolver.resolveIdentity(for: $1.manifest.packageLocation) })
+        // sort by identity
+        allNodes = flattenedManifests.keys.sorted().map { flattenedManifests[$0]! } // force unwrap fine since we are iterating on keys
 
         // Create the packages.
         var manifestToPackage: [Manifest: Package] = [:]
-        for node in allManifests {
+        for node in allNodes {
             let manifest = node.manifest
 
             // Derive the path to the package.
             //
             // FIXME: Lift this out of the manifest.
             let packagePath = manifest.path.parentDirectory
-
-            let packageLocation = PackageLocation.Local(name: manifest.name, packagePath: packagePath)
-            diagnostics.with(location: packageLocation) { diagnostics in
+            let diagnosticsLocation = PackageLocation.Local(name: manifest.name, packagePath: packagePath)
+            diagnostics.with(location: diagnosticsLocation) { diagnostics in
                 diagnostics.wrap {
                     // Create a package from the manifest and sources.
                     let builder = PackageBuilder(
+                        identity: node.identity,
                         manifest: manifest,
                         productFilter: node.productFilter,
                         path: packagePath,
@@ -132,7 +139,7 @@ extension PackageGraph {
 
         // Resolve dependencies and create resolved packages.
         let resolvedPackages = try createResolvedPackages(
-            allManifests: allManifests,
+            nodes: allNodes,
             identityResolver: identityResolver,
             manifestToPackage: manifestToPackage,
             rootManifestSet: rootManifestSet,
@@ -153,7 +160,7 @@ extension PackageGraph {
 
 private func checkAllDependenciesAreUsed(_ rootPackages: [ResolvedPackage], _ diagnostics: DiagnosticsEngine) {
     for package in rootPackages {
-        // List all dependency products dependended on by the package targets.
+        // List all dependency products dependent on by the package targets.
         let productDependencies: Set<ResolvedProduct> = Set(package.targets.flatMap({ target in
             return target.dependencies.compactMap({ targetDependency in
                 switch targetDependency {
@@ -181,7 +188,7 @@ private func checkAllDependenciesAreUsed(_ rootPackages: [ResolvedPackage], _ di
 
             let dependencyIsUsed = dependency.products.contains(where: productDependencies.contains)
             if !dependencyIsUsed && !diagnostics.hasErrors {
-                diagnostics.emit(.unusedDependency(dependency.name))
+                diagnostics.emit(.unusedDependency(dependency.identity.description))
             }
         }
     }
@@ -189,7 +196,7 @@ private func checkAllDependenciesAreUsed(_ rootPackages: [ResolvedPackage], _ di
 
 /// Create resolved packages from the loaded packages.
 private func createResolvedPackages(
-    allManifests: [GraphLoadingNode],
+    nodes: [GraphLoadingNode],
     identityResolver: IdentityResolver,
     manifestToPackage: [Manifest: Package],
     // FIXME: This shouldn't be needed once <rdar://problem/33693433> is fixed.
@@ -199,7 +206,7 @@ private func createResolvedPackages(
 ) throws -> [ResolvedPackage] {
 
     // Create package builder objects from the input manifests.
-    let packageBuilders: [ResolvedPackageBuilder] = allManifests.compactMap{ node in
+    let packageBuilders: [ResolvedPackageBuilder] = nodes.compactMap{ node in
         guard let package = manifestToPackage[node.manifest] else {
             return nil
         }
@@ -214,15 +221,14 @@ private func createResolvedPackages(
     // Create a map of package builders keyed by the package identity.
     // This is guaranteed to be unique so we can use spm_createDictionary
     let packageMapByIdentity: [PackageIdentity: ResolvedPackageBuilder] = packageBuilders.spm_createDictionary{
-        let identity = identityResolver.resolveIdentity(for: $0.package.manifest.packageLocation)
-        return (identity, $0)
+        return ($0.package.identity, $0)
     }
 
     // in case packages have same manifest name this map can miss packages which will lead to missing product errors
     // our plan is to deprecate the use of manifest + dependency explicit name in target dependency lookup and instead lean 100% on identity
     // which means this map would go away too
     let packageMapByNameForTargetDependencyResolutionOnly = packageBuilders.reduce(into: [String: ResolvedPackageBuilder](), { partial, item in
-        partial[item.package.name] = item
+        partial[item.package.manifestName] = item
     })
 
     // Scan and validate the dependencies
@@ -249,12 +255,11 @@ private func createResolvedPackages(
                     // this means that the dependencies share the same name
                     // FIXME: this works but the way we find out about this is based on a side effect, need to improve it when working on identity
                     let error = PackageGraphError.dependencyAlreadySatisfiedByName(
-                        dependencyPackageName: package.name,
+                        package: package.identity.description,
                         dependencyLocation: dependencyLocation,
                         otherDependencyURL: resolvedPackage.package.manifest.packageLocation,
                         name: explicitDependencyName)
-                    let diagnosticLocation = PackageLocation.Local(name: package.name, packagePath: package.path)
-                    return diagnostics.emit(error, location: diagnosticLocation)
+                    return diagnostics.emit(error, location: package.diagnosticLocation)
                 }
                 return dependencies.append(resolvedPackage)
             }
@@ -266,35 +271,33 @@ private func createResolvedPackages(
                 // FIXME: this works but the way we find out about this is based on a side effect, need to improve it when working on identity
                 guard !dependencies.contains(resolvedPackage) else {
                     let error = PackageGraphError.dependencyAlreadySatisfiedByIdentifier(
-                        dependencyPackageName: package.name,
+                        package: package.identity.description,
                         dependencyLocation: dependencyLocation,
                         otherDependencyURL: resolvedPackage.package.manifest.packageLocation,
                         identity: dependencyIdentity)
-                    let diagnosticLocation = PackageLocation.Local(name: package.name, packagePath: package.path)
-                    return diagnostics.emit(error, location: diagnosticLocation)
+                    //let diagnosticLocation = PackageLocation.Local(name: package.name, packagePath: package.path)
+                    return diagnostics.emit(error, location: package.diagnosticLocation)
                 }
                 // check that the explicit package dependency name matches the package name.
-                if let explicitDependencyName = dependency.explicitNameForTargetDependencyResolutionOnly, resolvedPackage.package.name != explicitDependencyName {
+                if let explicitDependencyName = dependency.explicitNameForTargetDependencyResolutionOnly, resolvedPackage.package.manifestName != explicitDependencyName {
                     // check if this resolvedPackage url is the same as the dependency one
                     // if not, this means that the dependencies share the same identity
                     // FIXME: this works but the way we find out about this is based on a side effect, need to improve it when working on identity
                     if resolvedPackage.package.manifest.packageLocation != dependencyLocation {
                         let error = PackageGraphError.dependencyAlreadySatisfiedByIdentifier(
-                            dependencyPackageName: package.name,
+                            package: package.identity.description,
                             dependencyLocation: dependencyLocation,
                             otherDependencyURL: resolvedPackage.package.manifest.packageLocation,
                             identity: dependencyIdentity)
-                        let diagnosticLocation = PackageLocation.Local(name: package.name, packagePath: package.path)
-                        return diagnostics.emit(error, location: diagnosticLocation)
+                        return diagnostics.emit(error, location: package.diagnosticLocation)
                     } else  {
                         let error = PackageGraphError.incorrectPackageDependencyName(
-                            dependencyPackageName: package.name,
+                            package: package.identity.description,
                             dependencyName: explicitDependencyName,
                             dependencyLocation: dependencyLocation,
-                            resolvedPackageName: resolvedPackage.package.name,
+                            resolvedPackageManifestName: resolvedPackage.package.manifestName,
                             resolvedPackageURL: resolvedPackage.package.manifest.packageLocation)
-                        let diagnosticLocation = PackageLocation.Local(name: package.name, packagePath: package.path)
-                        return diagnostics.emit(error, location: diagnosticLocation)
+                        return diagnostics.emit(error, location: package.diagnosticLocation)
                     }
                 }
                 dependencies.append(resolvedPackage)
@@ -345,7 +348,7 @@ private func createResolvedPackages(
     for productName in duplicateProducts {
         let packages = packageBuilders
             .filter({ $0.products.contains(where: { $0.product.name == productName }) })
-            .map({ $0.package.name })
+            .map{ $0.package.identity.description }
             .sorted()
 
         diagnostics.emit(PackageGraphError.duplicateProduct(product: productName, packages: packages))
@@ -367,7 +370,7 @@ private func createResolvedPackages(
         let package = packageBuilder.package
 
         // The diagnostics location for this package.
-        let diagnosticLocation = { PackageLocation.Local(name: package.name, packagePath: package.path) }
+        //let diagnosticLocation = { PackageLocation.Local(name: package.name, packagePath: package.path) }
 
         // Get all implicit system library dependencies in this package.
         let implicitSystemTargetDeps = packageBuilder.dependencies
@@ -403,12 +406,12 @@ private func createResolvedPackages(
                     // resolve (like authentication issues).
                     if !diagnostics.hasErrors {
                         let error = PackageGraphError.productDependencyNotFound(
+                            package: package.identity.description,
+                            targetName: targetBuilder.target.name,
                             dependencyProductName: productRef.name,
-                            dependencyPackageName: productRef.package,
-                            packageName: package.name,
-                            targetName: targetBuilder.target.name
+                            dependencyPackageName: productRef.package
                         )
-                        diagnostics.emit(error, location: diagnosticLocation())
+                        diagnostics.emit(error, location: package.diagnosticLocation)
                     }
                     continue
                 }
@@ -418,7 +421,7 @@ private func createResolvedPackages(
                 // dependency to share the same name. We don't check this in manifest loading for root-packages so
                 // we can provide a more detailed diagnostic here.
                 if packageBuilder.package.manifest.toolsVersion >= .v5_2 && productRef.package == nil{
-                    let referencedPackageIdentity = identityResolver.resolveIdentity(for: product.packageBuilder.package.manifest.packageLocation)
+                    let referencedPackageIdentity = product.packageBuilder.package.identity
                     guard let referencedPackageDependency = (packageBuilder.package.manifest.dependencies.first { package in
                         return package.identity == referencedPackageIdentity
                     }) else {
@@ -431,7 +434,7 @@ private func createResolvedPackages(
                             targetName: targetBuilder.target.name,
                             packageDependency: referencedPackageDependency
                         )
-                        diagnostics.emit(error, location: diagnosticLocation())
+                        diagnostics.emit(error, location: package.diagnosticLocation)
                     }
                 }
 
@@ -444,12 +447,12 @@ private func createResolvedPackages(
     if foundDuplicateTarget {
         for targetName in allTargetNames.sorted() {
             // Find the packages this target is present in.
-            let packageNames = packageBuilders
+            let packages = packageBuilders
                 .filter({ $0.targets.contains(where: { $0.target.name == targetName }) })
-                .map({ $0.package.name })
+                .map{ $0.package.identity.description }
                 .sorted()
-            if packageNames.count > 1 {
-                diagnostics.emit(ModuleError.duplicateModule(targetName, packageNames))
+            if packages.count > 1 {
+                diagnostics.emit(ModuleError.duplicateModule(targetName, packages))
             }
         }
     }

--- a/Sources/PackageGraph/PackageGraph.swift
+++ b/Sources/PackageGraph/PackageGraph.swift
@@ -19,16 +19,16 @@ enum PackageGraphError: Swift.Error {
     case cycleDetected((path: [Manifest], cycle: [Manifest]))
 
     /// The product dependency not found.
-    case productDependencyNotFound(dependencyProductName: String, dependencyPackageName: String?, packageName: String, targetName: String)
+    case productDependencyNotFound(package: String, targetName: String, dependencyProductName: String, dependencyPackageName: String?)
 
     /// The package dependency name does not match the package name.
-    case incorrectPackageDependencyName(dependencyPackageName: String, dependencyName: String, dependencyLocation: String, resolvedPackageName: String, resolvedPackageURL: String)
+    case incorrectPackageDependencyName(package: String, dependencyName: String, dependencyLocation: String, resolvedPackageManifestName: String, resolvedPackageURL: String)
 
     /// The package dependency already satisfied by a different dependency package
-    case dependencyAlreadySatisfiedByIdentifier(dependencyPackageName: String, dependencyLocation: String, otherDependencyURL: String, identity: PackageIdentity)
+    case dependencyAlreadySatisfiedByIdentifier(package: String, dependencyLocation: String, otherDependencyURL: String, identity: PackageIdentity)
 
     /// The package dependency already satisfied by a different dependency package
-    case dependencyAlreadySatisfiedByName(dependencyPackageName: String, dependencyLocation: String, otherDependencyURL: String, name: String)
+    case dependencyAlreadySatisfiedByName(package: String, dependencyLocation: String, otherDependencyURL: String, name: String)
 
     /// The product dependency was found but the package name was not referenced correctly (tools version > 5.2).
     case productDependencyMissingPackage(
@@ -192,20 +192,20 @@ extension PackageGraphError: CustomStringConvertible {
                 (cycle.path + cycle.cycle).map({ $0.name }).joined(separator: " -> ") +
                 " -> " + cycle.cycle[0].name
 
-        case .productDependencyNotFound(let dependencyProductName, let dependencyPackageName, let packageName, let targetName):
-            return "product '\(dependencyProductName)' \(dependencyPackageName.map{ "not found in package '\($0)'" } ?? "not found"). it is required by package '\(packageName)' target '\(targetName)'."
+        case .productDependencyNotFound(let package, let targetName, let dependencyProductName, let dependencyPackageName):
+            return "product '\(dependencyProductName)' required by package '\(package)' target '\(targetName)' \(dependencyPackageName.map{ "not found in package '\($0)'" } ?? "not found")."
 
-        case .incorrectPackageDependencyName(let dependencyPackageName, let dependencyName, let dependencyURL, let resolvedPackageName, let resolvedPackageURL):
+        case .incorrectPackageDependencyName(let package, let dependencyName, let dependencyURL, let resolvedPackageManifestName, let resolvedPackageURL):
             return """
-                '\(dependencyPackageName)' dependency on '\(dependencyURL)' has an explicit name '\(dependencyName)' which does not match the \
-                name '\(resolvedPackageName)' set for '\(resolvedPackageURL)'
+                '\(package)' dependency on '\(dependencyURL)' has an explicit name '\(dependencyName)' which does not match the \
+                name '\(resolvedPackageManifestName)' set for '\(resolvedPackageURL)'
                 """
 
-        case .dependencyAlreadySatisfiedByIdentifier(let dependencyPackageName, let dependencyURL, let otherDependencyURL, let identity):
-            return "'\(dependencyPackageName)' dependency on '\(dependencyURL)' conflicts with dependency on '\(otherDependencyURL)' which has the same identity '\(identity)'"
+        case .dependencyAlreadySatisfiedByIdentifier(let package, let dependencyURL, let otherDependencyURL, let identity):
+            return "'\(package)' dependency on '\(dependencyURL)' conflicts with dependency on '\(otherDependencyURL)' which has the same identity '\(identity)'"
 
-        case .dependencyAlreadySatisfiedByName(let dependencyPackageName, let dependencyURL, let otherDependencyURL, let name):
-            return "'\(dependencyPackageName)' dependency on '\(dependencyURL)' conflicts with dependency on '\(otherDependencyURL)' which has the same explicit name '\(name)'"
+        case .dependencyAlreadySatisfiedByName(let package, let dependencyURL, let otherDependencyURL, let name):
+            return "'\(package)' dependency on '\(dependencyURL)' conflicts with dependency on '\(otherDependencyURL)' which has the same explicit name '\(name)'"
 
         case .productDependencyMissingPackage(
                 let productName,
@@ -221,7 +221,7 @@ extension PackageGraphError: CustomStringConvertible {
             return "dependency '\(productName)' in target '\(targetName)' requires explicit declaration; \(solution)"
 
         case .duplicateProduct(let product, let packages):
-            return "multiple products named '\(product)' in: \(packages.joined(separator: ", "))"
+            return "multiple products named '\(product)' in: '\(packages.joined(separator: "', '"))'"
         }
     }
 }

--- a/Sources/PackageGraph/PinsStore.swift
+++ b/Sources/PackageGraph/PinsStore.swift
@@ -135,7 +135,7 @@ extension PinsStore.Pin: JSONMappable, JSONSerializable {
     public init(json: JSON) throws {
         let name: String? = json.get("package")
         let url: String = try json.get("repositoryURL")
-        let identity = PackageIdentity(url: url)
+        let identity = PackageIdentity(url: url) // FIXME: pin store should also encode identity
         let ref = PackageReference.remote(identity: identity, location: url)
         self.packageRef = name.flatMap(ref.with(newName:)) ?? ref
         self.state = try json.get("state")

--- a/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
@@ -153,7 +153,7 @@ public struct PubgrubDependencyResolver {
     /// Execute the resolution algorithm to find a valid assignment of versions.
     public func solve(constraints: [Constraint]) -> Result<[DependencyResolver.Binding], Error> {
         let root = DependencyResolutionNode.root(package: .root(
-            identity: PackageIdentity(url: "<synthesized-root>"),
+            identity: .root(name: "<synthesized-root>"),
             path: .root
         ))
 
@@ -988,7 +988,7 @@ private struct DiagnosticReportBuilder {
 
     // FIXME: This is duplicated and wrong.
     private func isFailure(_ incompatibility: Incompatibility) -> Bool {
-        return incompatibility.terms.count == 1 && incompatibility.terms.first?.node.package.identity == PackageIdentity(url: "<synthesized-root>")
+        return incompatibility.terms.count == 1 && incompatibility.terms.first?.node.package.identity == .root(name: "<synthesized-root>")
     }
 
     private func description(for term: Term, normalizeRange: Bool = false) throws -> String {

--- a/Sources/PackageGraph/RepositoryPackageContainer.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainer.swift
@@ -282,12 +282,13 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
             // FIXME: this should not block
             return try temp_await {
                 manifestLoader.load(at: AbsolutePath.root,
-                                    packageKind: package.kind,
+                                    packageIdentity: self.package.identity,
+                                    packageKind: self.package.kind,
                                     packageLocation: packageLocation,
                                     version: version,
                                     revision: nil,
                                     toolsVersion: toolsVersion,
-                                    identityResolver: identityResolver,
+                                    identityResolver: self.identityResolver,
                                     fileSystem: fs,
                                     diagnostics: nil,
                                     on: .global(),

--- a/Sources/PackageGraph/ResolvedPackage.swift
+++ b/Sources/PackageGraph/ResolvedPackage.swift
@@ -34,7 +34,7 @@ public final class ResolvedPackage: ObjectIdentifierProtocol {
     }
 
     /// The name of the package as entered in the manifest.
-    @available(*, deprecated, message: "use identity instead")
+    /// This should rarely be used beyond presentation purposes
     public var manifestName: String {
         return self.underlyingPackage.manifestName
     }

--- a/Sources/PackageGraph/ResolvedPackage.swift
+++ b/Sources/PackageGraph/ResolvedPackage.swift
@@ -17,19 +17,31 @@ public final class ResolvedPackage: ObjectIdentifierProtocol {
     /// The underlying package reference.
     public let underlyingPackage: Package
 
+    // The identity of the package.
+    public var identity: PackageIdentity {
+        return self.underlyingPackage.identity
+    }
+
     /// The manifest describing the package.
     public var manifest: Manifest {
-        return underlyingPackage.manifest
+        return self.underlyingPackage.manifest
     }
 
     /// The name of the package.
+    @available(*, deprecated, message: "use identity (or manifestName, but only if you must) instead")
     public var name: String {
-        return underlyingPackage.name
+        return self.underlyingPackage.name
+    }
+
+    /// The name of the package as entered in the manifest.
+    @available(*, deprecated, message: "use identity instead")
+    public var manifestName: String {
+        return self.underlyingPackage.manifestName
     }
 
     /// The local path of the package.
     public var path: AbsolutePath {
-        return underlyingPackage.path
+        return self.underlyingPackage.path
     }
 
     /// The targets contained in the package.
@@ -56,6 +68,6 @@ public final class ResolvedPackage: ObjectIdentifierProtocol {
 
 extension ResolvedPackage: CustomStringConvertible {
     public var description: String {
-        return "<ResolvedPackage: \(name)>"
+        return "<ResolvedPackage: \(self.identity)>"
     }
 }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -157,14 +157,8 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         self.operationQueue.maxConcurrentOperationCount = Concurrency.maxOperations
     }
 
-    /// Loads a manifest from a package repository using the resources associated with a particular `swiftc` executable.
-    ///
-    /// - Parameters:
-    ///     - at: The absolute path of the package root.
-    ///     - kind: The kind of package the manifest is from.
-    ///     - swiftCompiler: The absolute path of a `swiftc` executable.
-    ///         Its associated resources will be used by the loader.
-    // FIXME: take identity?
+    // deprecated 3/21, remove once clients migrated over
+    @available(*, deprecated, message: "use loadRootManifest instead")
     public static func loadManifest(
         at path: AbsolutePath,
         kind: PackageReference.Kind,
@@ -200,6 +194,51 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         }
     }
 
+    /// Loads a root manifest from a path using the resources associated with a particular `swiftc` executable.
+    ///
+    /// - Parameters:
+    ///   - at: The absolute path of the package root.
+    ///   - swiftCompiler: The absolute path of a `swiftc` executable. Its associated resources will be used by the loader.
+    ///   - identityResolver: A helper to resolve identities based on configuration
+    ///   - diagnostics: Optional.  The diagnostics engine.
+    ///   - on: The dispatch queue to perform asynchronous operations on.
+    ///   - completion: The completion handler .
+    public static func loadRootManifest(
+        at path: AbsolutePath,
+        swiftCompiler: AbsolutePath,
+        swiftCompilerFlags: [String],
+        identityResolver: IdentityResolver,
+        diagnostics: DiagnosticsEngine? = nil,
+        on queue: DispatchQueue,
+        completion: @escaping (Result<Manifest, Error>) -> Void
+    ) {
+        do {
+            let fileSystem = localFileSystem
+            let resources = try UserManifestResources(swiftCompiler: swiftCompiler, swiftCompilerFlags: swiftCompilerFlags)
+            let loader = ManifestLoader(manifestResources: resources)
+            let toolsVersion = try ToolsVersionLoader().load(at: path, fileSystem: fileSystem)
+            let packageLocation = path.basename == Manifest.filename ? path.parentDirectory : path
+            let packageIdentity = identityResolver.resolveIdentity(for: packageLocation)
+            loader.load(
+                at: path,
+                packageIdentity: packageIdentity,
+                packageKind: .root,
+                packageLocation: packageLocation.pathString,
+                version: nil,
+                revision: nil,
+                toolsVersion: toolsVersion,
+                identityResolver: identityResolver,
+                fileSystem: fileSystem,
+                diagnostics: diagnostics,
+                on: queue,
+                completion: completion
+            )
+        } catch {
+            return completion(.failure(error))
+        }
+    }
+
+    // deprecated 3/21, remove once clients migrated over
     @available(*, deprecated, message: "use load(at: packageIdentity:, ...) variant instead")
     public func load(
         at path: AbsolutePath,
@@ -262,16 +301,6 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         }
     }
 
-    /// Create a manifest by loading a specific manifest file from the given `path`.
-    ///
-    /// - Parameters:
-    ///   - at: The path to the manifest file (or a package root).
-    ///   - packageIdentity: The identity of package the manifest is from.
-    ///   - packageKind: The kind of package the manifest is from.
-    ///   - packageLocation: The location the manifest was loaded from.
-    ///   - version: The version the manifest is from, if known.
-    ///   - revision: The revision the manifest is from, if known.
-    ///   - fileSystem: If given, the file system to load from (otherwise load from the local file system).
     private func loadFile(
         at path: AbsolutePath,
         packageIdentity: PackageIdentity,

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -80,8 +80,8 @@ extension ModuleError: CustomStringConvertible {
     public var description: String {
         switch self {
         case .duplicateModule(let name, let packages):
-            let packages = packages.joined(separator: ", ")
-            return "multiple targets named '\(name)' in: \(packages)"
+            let packages = packages.joined(separator: "', '")
+            return "multiple targets named '\(name)' in: '\(packages)'"
         case .moduleNotFound(let target, let type):
             let folderName = type == .test ? "Tests" : "Sources"
             return "Source files for target \(target) should be located under '\(folderName)/\(target)', or a custom sources path can be set with the 'path' property in Package.swift"
@@ -215,6 +215,9 @@ public struct BinaryArtifact {
 /// The 'builder' here refers to the builder pattern and not any build system
 /// related function.
 public final class PackageBuilder {
+    /// The identity for the package being constructed.
+    private let identity: PackageIdentity
+
     /// The manifest for the package being constructed.
     private let manifest: Manifest
 
@@ -257,6 +260,7 @@ public final class PackageBuilder {
     /// Create a builder for the given manifest and package `path`.
     ///
     /// - Parameters:
+    ///   - identity: The identity of this package.
     ///   - manifest: The manifest of this package.
     ///   - path: The root path of the package.
     ///   - artifactPaths: Paths to the downloaded binary target artifacts.
@@ -265,6 +269,7 @@ public final class PackageBuilder {
     ///   - createMultipleTestProducts: If enabled, create one test product for
     ///     each test target.
     public init(
+        identity: PackageIdentity,
         manifest: Manifest,
         productFilter: ProductFilter,
         path: AbsolutePath,
@@ -278,6 +283,7 @@ public final class PackageBuilder {
         allowPluginTargets: Bool = false,
         createREPLProduct: Bool = false
     ) {
+        self.identity = identity
         self.manifest = manifest
         self.productFilter = productFilter
         self.packagePath = path
@@ -295,10 +301,11 @@ public final class PackageBuilder {
     /// Loads a package from a package repository using the resources associated with a particular `swiftc` executable.
     ///
     /// - Parameters:
-    ///     - packagePath: The absolute path of the package root.
+    ///     - path: The absolute path of the package root.
     ///     - swiftCompiler: The absolute path of a `swiftc` executable.
     ///         Its associated resources will be used by the loader.
     ///     - kind: The kind of package.
+    // FIXME: use PackageIdentity.root? tae identity?
     public static func loadPackage(
         at path: AbsolutePath,
         kind: PackageReference.Kind = .root,
@@ -318,7 +325,9 @@ public final class PackageBuilder {
                                     identityResolver: identityResolver,
                                     on: queue) { result in
             let result = result.tryMap { manifest -> Package in
+                let identity = identityResolver.resolveIdentity(for: manifest.packageLocation)
                 let builder = PackageBuilder(
+                    identity: identity,
                     manifest: manifest,
                     productFilter: .everything,
                     path: path,
@@ -332,23 +341,24 @@ public final class PackageBuilder {
 
     /// Build a new package following the conventions.
     public func construct() throws -> Package {
-        let targets = try constructTargets()
-        let products = try constructProducts(targets)
+        let targets = try self.constructTargets()
+        let products = try self.constructProducts(targets)
         // Find the special directory for targets.
         let targetSpecialDirs = findTargetSpecialDirs(targets)
 
         return Package(
-            manifest: manifest,
-            path: packagePath,
+            identity: self.identity,
+            manifest: self.manifest,
+            path: self.packagePath,
             targets: targets,
             products: products,
-            targetSearchPath: packagePath.appending(component: targetSpecialDirs.targetDir),
-            testTargetSearchPath: packagePath.appending(component: targetSpecialDirs.testTargetDir)
+            targetSearchPath: self.packagePath.appending(component: targetSpecialDirs.targetDir),
+            testTargetSearchPath: self.packagePath.appending(component: targetSpecialDirs.testTargetDir)
         )
     }
 
-    private func diagnosticLocation() -> DiagnosticLocation {
-        return PackageLocation.Local(name: manifest.name, packagePath: packagePath)
+    private var diagnosticLocation: DiagnosticLocation {
+        return PackageLocation.Local(name: self.manifest.name, packagePath: self.packagePath)
     }
 
     /// Computes the special directory where targets are present or should be placed in future.
@@ -395,7 +405,7 @@ public final class PackageBuilder {
 
             // Diagnose broken symlinks.
             if fileSystem.isSymlink(path) {
-                diagnostics.emit(.brokenSymlink(path), location: diagnosticLocation())
+                diagnostics.emit(.brokenSymlink(path), location: self.diagnosticLocation)
             }
 
             return false
@@ -448,24 +458,26 @@ public final class PackageBuilder {
             if !manifest.targets.isEmpty {
                 diagnostics.emit(
                     .systemPackageDeclaresTargets(targets: Array(manifest.targets.map({ $0.name }))),
-                    location: diagnosticLocation()
+                    location: self.diagnosticLocation
                 )
             }
 
             // Emit deprecation notice.
             if manifest.toolsVersion >= .v4_2 {
-                diagnostics.emit(.systemPackageDeprecation, location: diagnosticLocation())
+                diagnostics.emit(.systemPackageDeprecation, location: self.diagnosticLocation)
             }
 
             // Package contains a modulemap at the top level, so we assuming
             // it's a system library target.
             return [
                 SystemLibraryTarget(
-                    name: manifest.name,
+                    name: self.manifest.name,
                     platforms: self.platforms(),
-                    path: packagePath, isImplicit: true,
-                    pkgConfig: manifest.pkgConfig,
-                    providers: manifest.providers)
+                    path: self.packagePath,
+                    isImplicit: true,
+                    pkgConfig: self.manifest.pkgConfig,
+                    providers: self.manifest.providers
+                )
             ]
         }
 
@@ -473,12 +485,12 @@ public final class PackageBuilder {
         // system target specific configuration.
         guard manifest.pkgConfig == nil else {
             throw ModuleError.invalidManifestConfig(
-                manifest.name, "the 'pkgConfig' property can only be used with a System Module Package")
+                self.manifest.name, "the 'pkgConfig' property can only be used with a System Module Package")
         }
 
         guard manifest.providers == nil else {
             throw ModuleError.invalidManifestConfig(
-                manifest.name, "the 'providers' property can only be used with a System Module Package")
+                self.manifest.name, "the 'providers' property can only be used with a System Module Package")
         }
 
         return try constructV4Targets()
@@ -537,7 +549,7 @@ public final class PackageBuilder {
                 let path = packagePath.appending(relativeSubPath)
                 // Make sure the target is inside the package root.
                 guard path.contains(packagePath) else {
-                    throw ModuleError.targetOutsidePackage(package: manifest.name, target: target.name)
+                    throw ModuleError.targetOutsidePackage(package: self.manifest.name, target: target.name)
                 }
                 if fileSystem.isDirectory(path) {
                     return path
@@ -562,7 +574,7 @@ public final class PackageBuilder {
 
             // Otherwise, if the path "exists" then the case in manifest differs from the case on the file system.
             if fileSystem.isDirectory(path) {
-                diagnostics.emit(.targetNameHasIncorrectCase(target: target.name), location: diagnosticLocation())
+                diagnostics.emit(.targetNameHasIncorrectCase(target: target.name), location: self.diagnosticLocation)
                 return path
             }
             throw ModuleError.moduleNotFound(target.name, target.type)
@@ -767,15 +779,15 @@ public final class PackageBuilder {
         }
 
         let sourcesBuilder = TargetSourcesBuilder(
-            packageName: manifest.name,
-            packagePath: packagePath,
+            packageName: self.manifest.name,
+            packagePath: self.packagePath,
             target: manifestTarget,
             path: potentialModule.path,
-            defaultLocalization: manifest.defaultLocalization,
-            additionalFileRules: additionalFileRules,
-            toolsVersion: manifest.toolsVersion,
-            fs: fileSystem,
-            diags: diagnostics
+            defaultLocalization: self.manifest.defaultLocalization,
+            additionalFileRules: self.additionalFileRules,
+            toolsVersion: self.manifest.toolsVersion,
+            fs: self.fileSystem,
+            diags: self.diagnostics
         )
         let (sources, resources, headers, others) = try sourcesBuilder.run()
 
@@ -786,7 +798,7 @@ public final class PackageBuilder {
         }
 
         // The name of the bundle, if one is being generated.
-        let bundleName = resources.isEmpty ? nil : manifest.name + "_" + potentialModule.name
+        let bundleName = resources.isEmpty ? nil : self.manifest.name + "_" + potentialModule.name
 
         if sources.relativePaths.isEmpty && resources.isEmpty {
             return nil
@@ -1120,7 +1132,7 @@ public final class PackageBuilder {
         // It is an error if there are multiple linux main files.
         if testManifestFiles.count > 1 {
             throw ModuleError.multipleTestManifestFilesFound(
-                package: manifest.name, files: testManifestFiles.map({ $0 }))
+                package: self.manifest.name, files: testManifestFiles.map({ $0 }))
         }
         return testManifestFiles.first
     }
@@ -1135,7 +1147,7 @@ public final class PackageBuilder {
             if !inserted {
                 diagnostics.emit(
                     .duplicateProduct(product: product),
-                    location: diagnosticLocation()
+                    location: self.diagnosticLocation
                 )
             }
         }
@@ -1205,7 +1217,7 @@ public final class PackageBuilder {
                 if product.type != .library(.automatic) || targets.count != 1 {
                     self.diagnostics.emit(
                         .systemPackageProductValidation(product: product.name),
-                        location: self.diagnosticLocation()
+                        location: self.diagnosticLocation
                     )
                     continue
                 }
@@ -1273,11 +1285,11 @@ public final class PackageBuilder {
             if libraryTargets.isEmpty {
                 self.diagnostics.emit(
                     .noLibraryTargetsForREPL,
-                    location: self.diagnosticLocation()
+                    location: self.diagnosticLocation
                 )
             } else {
                 let replProduct = Product(
-                    name: manifest.name + Product.replProductSuffix,
+                    name: self.manifest.name + Product.replProductSuffix,
                     type: .library(.dynamic),
                     targets: libraryTargets
                 )
@@ -1295,18 +1307,18 @@ public final class PackageBuilder {
                 if let target = targets.spm_only {
                     diagnostics.emit(
                         .executableProductTargetNotExecutable(product: product.name, target: target.name),
-                        location: diagnosticLocation()
+                        location: self.diagnosticLocation
                     )
                 } else {
                     diagnostics.emit(
                         .executableProductWithoutExecutableTarget(product: product.name),
-                        location: diagnosticLocation()
+                        location: self.diagnosticLocation
                     )
                 }
             } else {
                 diagnostics.emit(
                     .executableProductWithMoreThanOneExecutableTarget(product: product.name),
-                    location: diagnosticLocation()
+                    location: self.diagnosticLocation
                 )
             }
 
@@ -1321,14 +1333,14 @@ public final class PackageBuilder {
         guard nonPluginTargets.isEmpty else {
             diagnostics.emit(
                 .pluginProductWithNonPluginTargets(product: product.name, otherTargets: nonPluginTargets.map{ $0.name }),
-                location: diagnosticLocation()
+                location: self.diagnosticLocation
             )
             return false
         }
         guard !targets.isEmpty else {
             diagnostics.emit(
                 .pluginProductWithNoTargets(product: product.name),
-                location: diagnosticLocation()
+                location: self.diagnosticLocation
             )
             return false
         }

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -25,6 +25,7 @@ public final class Manifest: ObjectIdentifierProtocol {
 
     /// FIXME: deprecate this, there is no value in this once we have real package identifiers
     /// The name of the package.
+    //@available(*, deprecated)
     public let name: String
 
     // FIXME: deprecate this, this is not part of the manifest information, we just use it as a container for this data
@@ -32,6 +33,7 @@ public final class Manifest: ObjectIdentifierProtocol {
     // to the repository state, it shouldn't matter where it is.
     //
     /// The path of the manifest file.
+    //@available(*, deprecated)
     public let path: AbsolutePath
 
     // FIXME: deprecate this, this is not part of the manifest information, we just use it as a container for this data
@@ -42,7 +44,7 @@ public final class Manifest: ObjectIdentifierProtocol {
     public let packageLocation: String
 
     // FIXME: deprecated 2/2021, remove once clients migrate
-    @available(*, deprecated)
+    @available(*, deprecated, message: "use packageLocation instead")
     public var url: String {
         get {
             self.packageLocation
@@ -363,7 +365,7 @@ public final class Manifest: ObjectIdentifierProtocol {
 
 extension Manifest: CustomStringConvertible {
     public var description: String {
-        return "<Manifest: \(name)>"
+        return "<Manifest: \(self.name)>"
     }
 }
 
@@ -381,7 +383,7 @@ extension Manifest: Encodable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(name, forKey: .name)
+        try container.encode(self.name, forKey: .name)
 
         // Hide the keys that users shouldn't see when
         // we're encoding for the dump-package command.

--- a/Sources/PackageModel/Package.swift
+++ b/Sources/PackageModel/Package.swift
@@ -43,6 +43,9 @@ import TSCUtility
 /// loaded. There is not currently a data structure for this, but it is the
 /// result after `PackageLoading.transmute()`.
 public final class Package: ObjectIdentifierProtocol, Encodable {
+    /// The identity of the package.
+    public let identity: PackageIdentity
+
     /// The manifest describing the package.
     public let manifest: Manifest
 
@@ -50,7 +53,14 @@ public final class Package: ObjectIdentifierProtocol, Encodable {
     public let path: AbsolutePath
 
     /// The name of the package.
+    @available(*, deprecated, message: "use identity (or manifestName, but only if you must) instead")
     public var name: String {
+        return self.manifestName
+    }
+
+    /// The name of the package as entered in the manifest.
+    @available(*, deprecated, message: "use identity instead")
+    public var manifestName: String {
         return manifest.name
     }
 
@@ -72,6 +82,7 @@ public final class Package: ObjectIdentifierProtocol, Encodable {
     public let testTargetSearchPath: AbsolutePath
 
     public init(
+        identity: PackageIdentity,
         manifest: Manifest,
         path: AbsolutePath,
         targets: [Target],
@@ -79,6 +90,7 @@ public final class Package: ObjectIdentifierProtocol, Encodable {
         targetSearchPath: AbsolutePath,
         testTargetSearchPath: AbsolutePath
     ) {
+        self.identity = identity
         self.manifest = manifest
         self.path = path
         self._targets = .init(wrappedValue: targets)
@@ -92,9 +104,15 @@ public final class Package: ObjectIdentifierProtocol, Encodable {
     }
 }
 
+extension Package {
+    public var diagnosticLocation: DiagnosticLocation {
+        return PackageLocation.Local(name: self.manifest.name, packagePath: self.path)
+    }
+}
+
 extension Package: CustomStringConvertible {
     public var description: String {
-        return name
+        return self.identity.description
     }
 }
 

--- a/Sources/PackageModel/Package.swift
+++ b/Sources/PackageModel/Package.swift
@@ -59,7 +59,7 @@ public final class Package: ObjectIdentifierProtocol, Encodable {
     }
 
     /// The name of the package as entered in the manifest.
-    @available(*, deprecated, message: "use identity instead")
+    /// This should rarely be used beyond presentation purposes
     public var manifestName: String {
         return manifest.name
     }

--- a/Sources/PackageModel/PackageIdentity.swift
+++ b/Sources/PackageModel/PackageIdentity.swift
@@ -36,20 +36,26 @@ public struct PackageIdentity: Hashable, CustomStringConvertible {
 
     /// Creates a package identity from a string.
     /// - Parameter string: A string used to identify a package.
-    init(_ string: String) {
-        self.description = Self.provider.init(string).description
+    init(_ description: String) {
+        self.description = description
     }
 
     /// Creates a package identity from a URL.
     /// - Parameter url: The package's URL.
     public init(url: String) { // TODO: Migrate to Foundation.URL
-        self.init(url)
+        self.description = Self.provider.init(url).description
     }
 
     /// Creates a package identity from a file path.
     /// - Parameter path: An absolute path to the package.
     public init(path: AbsolutePath) {
-        self.init(path.pathString)
+        self.description = Self.provider.init(path.pathString).description
+    }
+
+    /// Creates a package identity for a root package
+    /// - Parameter name: The name of the package, will be used unmodified
+    public static func root(name: String) -> PackageIdentity {
+        PackageIdentity(name)
     }
 }
 

--- a/Sources/SPMBuildCore/BuiltTestProduct.swift
+++ b/Sources/SPMBuildCore/BuiltTestProduct.swift
@@ -12,10 +12,6 @@ import TSCBasic
 
 /// Represents a test product which is built and is present on disk.
 public struct BuiltTestProduct: Codable {
-
-    /// The name of the package to which the test binary belongs.
-    public let packageName: String
-
     /// The test product name.
     public let productName: String
 
@@ -35,11 +31,9 @@ public struct BuiltTestProduct: Codable {
 
     /// Creates a new instance.
     /// - Parameters:
-    ///   - packageName: The name of the package to which the test binary belongs.
     ///   - productName: The test product name.
     ///   - binaryPath: The path of the test binary.
-    public init(packageName: String, productName: String, binaryPath: AbsolutePath) {
-        self.packageName = packageName
+    public init(productName: String, binaryPath: AbsolutePath) {
         self.productName = productName
         self.binaryPath = binaryPath
     }

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -61,7 +61,7 @@ extension PackageGraph {
             var evalResults: [PluginInvocationResult] = []
             for pluginTarget in pluginTargets {
                 // Give each invocation of a plugin a separate output directory.
-                let pluginOutputDir = outputDir.appending(components: package.name, target.name, pluginTarget.name)
+                let pluginOutputDir = outputDir.appending(components: package.manifestName, target.name, pluginTarget.name)
                 do {
                     try fileSystem.createDirectory(pluginOutputDir, recursive: true)
                 }

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -61,7 +61,7 @@ extension PackageGraph {
             var evalResults: [PluginInvocationResult] = []
             for pluginTarget in pluginTargets {
                 // Give each invocation of a plugin a separate output directory.
-                let pluginOutputDir = outputDir.appending(components: package.manifestName, target.name, pluginTarget.name)
+                let pluginOutputDir = outputDir.appending(components: package.identity.description, target.name, pluginTarget.name)
                 do {
                     try fileSystem.createDirectory(pluginOutputDir, recursive: true)
                 }

--- a/Sources/SPMTestSupport/MockManifestLoader.swift
+++ b/Sources/SPMTestSupport/MockManifestLoader.swift
@@ -50,6 +50,7 @@ public final class MockManifestLoader: ManifestLoaderProtocol {
 
     public func load(
         at path: TSCBasic.AbsolutePath,
+        packageIdentity: PackageIdentity,
         packageKind: PackageReference.Kind,
         packageLocation: String,
         version: Version?,
@@ -86,7 +87,9 @@ extension ManifestLoader {
         diagnostics: TSCBasic.DiagnosticsEngine? = nil
     ) throws -> Manifest{
         try tsc_await {
+            // FIXME: take identity?
             self.load(at: path,
+                      packageIdentity: identityResolver.resolveIdentity(for: packageLocation),
                       packageKind: packageKind,
                       packageLocation: packageLocation,
                       version: nil,

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -355,7 +355,7 @@ public final class MockWorkspace {
 
         let rootInput = PackageGraphRootInput(packages: rootPaths(for: roots.map { $0.name }), dependencies: [])
         let rootManifests = try temp_await { workspace.loadRootManifests(packages: rootInput.packages, diagnostics: diagnostics, completion: $0) }
-        let root = PackageGraphRoot(input: rootInput, manifests: rootManifests)
+        let root = try PackageGraphRoot(input: rootInput, manifests: rootManifests)
 
         let dependencyManifests = try workspace.loadDependencyManifests(root: root, diagnostics: diagnostics)
 
@@ -508,7 +508,7 @@ public final class MockWorkspace {
             packages: rootPaths(for: roots), dependencies: dependencies
         )
         let rootManifests = try tsc_await { workspace.loadRootManifests(packages: rootInput.packages, diagnostics: diagnostics, completion: $0) }
-        let graphRoot = PackageGraphRoot(input: rootInput, manifests: rootManifests)
+        let graphRoot = try PackageGraphRoot(input: rootInput, manifests: rootManifests)
         let manifests = try workspace.loadDependencyManifests(root: graphRoot, diagnostics: diagnostics)
         result(manifests, diagnostics)
     }

--- a/Sources/SPMTestSupport/PackageGraphTester.swift
+++ b/Sources/SPMTestSupport/PackageGraphTester.swift
@@ -25,11 +25,11 @@ public final class PackageGraphResult {
     }
 
     public func check(roots: String..., file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(graph.rootPackages.map{$0.name}.sorted(), roots.sorted(), file: file, line: line)
+        XCTAssertEqual(graph.rootPackages.map{$0.manifestName}.sorted(), roots.sorted(), file: file, line: line)
     }
 
     public func check(packages: String..., file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(graph.packages.map {$0.name}.sorted(), packages.sorted(), file: file, line: line)
+        XCTAssertEqual(graph.packages.map {$0.manifestName}.sorted(), packages.sorted(), file: file, line: line)
     }
 
     public func check(targets: String..., file: StaticString = #file, line: UInt = #line) {

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -233,7 +233,7 @@ public func loadPackageGraph(
     let externalManifests = manifests.filter { $0.packageKind != .root }
     let packages = rootManifests.map { $0.path }
     let input = PackageGraphRootInput(packages: packages)
-    let graphRoot = PackageGraphRoot(input: input, manifests: rootManifests, explicitProduct: explicitProduct)
+    let graphRoot = try PackageGraphRoot(input: input, manifests: rootManifests, explicitProduct: explicitProduct)
 
     return try PackageGraph.load(
         root: graphRoot,

--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -76,6 +76,10 @@ public final class ManagedDependency {
     /// unedit a package.
     public internal(set) var basedOn: ManagedDependency?
 
+    public var packageIdentity: PackageIdentity {
+        self.packageRef.identity
+    }
+
     public init(
         packageRef: PackageReference,
         subpath: RelativePath,

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -38,21 +38,16 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
     /// The managed manifests to make available to the resolver.
     let dependencyManifests: Workspace.DependencyManifests
 
-    /// The identity resolver
-    let identityResolver: IdentityResolver
-
     /// The tools version currently in use.
     let currentToolsVersion: ToolsVersion
 
     init(
         root: PackageGraphRoot,
         dependencyManifests: Workspace.DependencyManifests,
-        identityResolver: IdentityResolver,
         currentToolsVersion: ToolsVersion = ToolsVersion.currentToolsVersion
     ) {
         self.root = root
         self.dependencyManifests = dependencyManifests
-        self.identityResolver = identityResolver
         self.currentToolsVersion = currentToolsVersion
     }
 
@@ -69,20 +64,17 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
                     package: package,
                     manifest: manifest.manifest,
                     dependency: manifest.dependency,
-                    identityResolver: self.identityResolver,
                     currentToolsVersion: self.currentToolsVersion
                 )
                 return completion(.success(container))
             }
 
             // Continue searching from the Workspace's root manifests.
-            // FIXME: We might want to use a dictionary for faster lookups.
-            if let index = self.dependencyManifests.root.packageRefs.firstIndex(of: package) {
+            if let rootPackage = self.dependencyManifests.root.packages[package.identity] {
                 let container = LocalPackageContainer(
                     package: package,
-                    manifest: self.dependencyManifests.root.manifests[index],
+                    manifest: rootPackage.manifest,
                     dependency: nil,
-                    identityResolver: self.identityResolver,
                     currentToolsVersion: self.currentToolsVersion
                 )
 
@@ -100,7 +92,6 @@ private struct LocalPackageContainer: PackageContainer {
     let manifest: Manifest
     /// The managed dependency if the package is not a root package.
     let dependency: ManagedDependency?
-    let identityResolver: IdentityResolver
     let currentToolsVersion: ToolsVersion
 
     func versionsAscending() throws -> [Version] {
@@ -167,9 +158,7 @@ private struct LocalPackageContainer: PackageContainer {
         if let packageRef = dependency?.packageRef {
             return packageRef
         } else {
-            // FIXME: reuse the identity from the package?
-            let identity = self.identityResolver.resolveIdentity(for: manifest.packageLocation)
-            return .root(identity: identity, path: manifest.path)
+            return .root(identity: self.package.identity, path: self.manifest.path)
         }
     }
 }

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -167,6 +167,7 @@ private struct LocalPackageContainer: PackageContainer {
         if let packageRef = dependency?.packageRef {
             return packageRef
         } else {
+            // FIXME: reuse the identity from the package?
             let identity = self.identityResolver.resolveIdentity(for: manifest.packageLocation)
             return .root(identity: identity, path: manifest.path)
         }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1098,7 +1098,8 @@ extension Workspace {
         func computePackageURLs() -> (required: Set<PackageReference>, missing: Set<PackageReference>) {
             let manifestsMap: [PackageIdentity: Manifest] = Dictionary(uniqueKeysWithValues:
                 self.root.packages.map { ($0.key, $0.value.manifest) } +
-                self.dependencies.map { ($0.dependency.packageIdentity, $0.manifest) }) // FIXME: use dependency identity
+                self.dependencies.map { ($0.dependency.packageIdentity, $0.manifest) }
+            )
 
             var inputIdentities: Set<PackageReference> = []
             let inputNodes: [GraphLoadingNode] = self.root.packages.map{ identity, package in

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -106,7 +106,7 @@ public final class PIFBuilder {
         try memoize(to: &pif) {
             let rootPackage = graph.rootPackages[0]
 
-            let sortedPackages = graph.packages.sorted { $0.name < $1.name }
+            let sortedPackages = graph.packages.sorted { $0.manifestName < $1.manifestName } // TODO: use identity instead?
             var projects: [PIFProjectBuilder] = try sortedPackages.map { package in
                 try PackagePIFProjectBuilder(
                     package: package,
@@ -120,7 +120,7 @@ public final class PIFBuilder {
 
             let workspace = PIF.Workspace(
                 guid: "Workspace:\(rootPackage.path.pathString)",
-                name: rootPackage.name,
+                name: rootPackage.manifestName,  // TODO: use identity instead?
                 path: rootPackage.path,
                 projects: try projects.map { try $0.construct() }
             )
@@ -239,7 +239,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         super.init()
 
         guid = package.pifProjectGUID
-        name = package.name
+        name = package.manifestName // TODO: use identity instead?
         path = package.path
         projectDirectory = package.path
         developmentRegion = package.manifest.defaultLocalization ?? "en"
@@ -766,7 +766,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
             return nil
         }
 
-        let bundleName = "\(package.name)_\(target.name)"
+        let bundleName = "\(package.manifestName)_\(target.name)" // TODO: use identity instead?
         let resourcesTarget = addTarget(
             guid: target.pifResourceTargetGUID,
             name: bundleName,
@@ -784,7 +784,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         settings[.TARGET_NAME] = bundleName
         settings[.PRODUCT_NAME] = bundleName
         settings[.PRODUCT_MODULE_NAME] = bundleName
-        let bundleIdentifier = "\(package.name).\(target.name).resources".spm_mangledToBundleIdentifier()
+        let bundleIdentifier = "\(package.manifestName).\(target.name).resources".spm_mangledToBundleIdentifier() // TODO: use identity instead?
         settings[.PRODUCT_BUNDLE_IDENTIFIER] = bundleIdentifier
         settings[.GENERATE_INFOPLIST_FILE] = "YES"
         settings[.PACKAGE_RESOURCE_TARGET_KIND] = "resource"

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -41,11 +41,12 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         for package in graph.rootPackages {
             for product in package.products where product.type == .test {
                 let binaryPath = buildParameters.binaryPath(for: product)
-                builtProducts.append(BuiltTestProduct(
-                    packageName: package.name,
-                    productName: product.name,
-                    binaryPath: binaryPath
-                ))
+                builtProducts.append(
+                    BuiltTestProduct(
+                        productName: product.name,
+                        binaryPath: binaryPath
+                    )
+                )
             }
         }
 

--- a/Sources/Xcodeproj/SchemesGenerator.swift
+++ b/Sources/Xcodeproj/SchemesGenerator.swift
@@ -86,7 +86,7 @@ public final class SchemesGenerator {
             }
         })
         schemes.append(Scheme(
-            name: rootPackage.name + "-Package",
+            name: rootPackage.manifestName + "-Package", // TODO: use identity instead?
             regularTargets: regularTargets,
             testTargets: rootPackage.targets.filter({ $0.type == .test })
         ))

--- a/Sources/Xcodeproj/generate.swift
+++ b/Sources/Xcodeproj/generate.swift
@@ -226,7 +226,7 @@ func generateSchemes(
         // tests associated so testing works. We suffix the name of this scheme with
         // -Package so its name doesn't collide with any products or target with
         // same name.
-        let schemeName = "\(graph.rootPackages[0].name)-Package.xcscheme"
+        let schemeName = "\(graph.rootPackages[0].manifestName)-Package.xcscheme" // TODO: use identity instead?
         try open(schemesDir.appending(RelativePath(schemeName))) { stream in
             legacySchemeGenerator(
                 container: schemeContainer,

--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -73,8 +73,8 @@ public func xcodeProject(
         guard let manifestLoader = options.manifestLoader else { return }
 
         let pdTarget = project.addTarget(
-            objectID: "\(package.name)::SwiftPMPackageDescription",
-            productType: .framework, name: "\(package.name)PackageDescription")
+            objectID: "\(package.manifestName)::SwiftPMPackageDescription", // TODO: use identity instead?
+            productType: .framework, name: "\(package.manifestName)PackageDescription") // TODO: use identity instead?
         let compilePhase = pdTarget.addSourcesBuildPhase()
         compilePhase.addBuildFile(fileRef: manifestFileRef)
 
@@ -334,8 +334,9 @@ public func xcodeProject(
             if targetSet.intersection(package.targets).isEmpty {
                 continue
             }
+            // TODO: use identity instead
             // Construct a group name from the package name and optional version.
-            var groupName = package.name
+            var groupName = package.manifestName // TODO: use identity instead?
             if let version = package.manifest.version {
                 groupName += " " + version.description
             }
@@ -404,7 +405,7 @@ public func xcodeProject(
         // Create a Xcode target for the target.
         let package = packagesByTarget[target]!
         let xcodeTarget = project.addTarget(
-            objectID: "\(package.name)::\(target.name)",
+            objectID: "\(package.manifestName)::\(target.name)", // TODO: use identity instead?
             productType: productType, name: target.name)
 
         // Set the product name to the C99-mangled form of the target name.
@@ -519,8 +520,9 @@ public func xcodeProject(
         // Add framework search path to build settings.
         targetSettings.common.FRAMEWORK_SEARCH_PATHS = ["$(inherited)", "$(PLATFORM_DIR)/Developer/Library/Frameworks"]
 
+        // TODO: use identity instead
         // Add a file reference for the target's product.
-        let productRef = productsGroup.addFileReference(path: target.productPath.pathString, pathBase: .buildDir, objectID: "\(package.name)::\(target.name)::Product")
+        let productRef = productsGroup.addFileReference(path: target.productPath.pathString, pathBase: .buildDir, objectID: "\(package.manifestName)::\(target.name)::Product")
 
         // Set that file reference as the target's product reference.
         xcodeTarget.productReference = productRef
@@ -686,10 +688,10 @@ public func xcodeProject(
     for product in graph.reachableProducts {
         // Go on to next product if we already have a target with the same name.
         if targetNames.contains(product.name) { continue }
-        // Otherwise, create an aggreate target.
+        // Otherwise, create an aggregate target.
         let package = packagesByProduct[product]!
         let aggregateTarget = project.addTarget(
-            objectID: "\(package.name)::\(product.name)::ProductTarget",
+            objectID: "\(package.manifestName)::\(product.name)::ProductTarget", // TODO: use identity instead?
             productType: nil, name: product.name)
         // Add dependencies on the targets created for each of the dependencies.
         for target in product.targets {

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -461,10 +461,10 @@ final class PackageToolTests: XCTestCase {
         }
         
         let expectedLines: [Substring] = [
-            #""/PackageA" [label="PackageA\n/PackageA\nunspecified"]"#,
-            #""/PackageB" [label="PackageB\n/PackageB\nunspecified"]"#,
-            #""/PackageC" [label="PackageC\n/PackageC\nunspecified"]"#,
-            #""/PackageD" [label="PackageD\n/PackageD\nunspecified"]"#,
+            #""/PackageA" [label="packagea\n/PackageA\nunspecified"]"#,
+            #""/PackageB" [label="packageb\n/PackageB\nunspecified"]"#,
+            #""/PackageC" [label="packagec\n/PackageC\nunspecified"]"#,
+            #""/PackageD" [label="packaged\n/PackageD\nunspecified"]"#,
             #""/PackageA" -> "/PackageB""#,
             #""/PackageA" -> "/PackageC""#,
             #""/PackageB" -> "/PackageC""#,

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -93,8 +93,8 @@ class DependencyResolutionTests: XCTestCase {
                 let output = try executeSwiftPackage(appPath, extraArgs: ["show-dependencies"])
                 XCTAssertTrue(output.stdout.contains("Cloning \(prefix.pathString)/Foo\n"), output.stdout)
                 XCTAssertTrue(output.stdout.contains("Cloning \(prefix.pathString)/Bar\n"), output.stdout)
-                XCTAssertTrue(output.stdout.contains("Foo<\(prefix.pathString)/Foo@unspecified"), output.stdout)
-                XCTAssertTrue(output.stdout.contains("Bar<\(prefix.pathString)/Bar@unspecified"), output.stdout)
+                XCTAssertTrue(output.stdout.contains("foo<\(prefix.pathString)/Foo@unspecified"), output.stdout)
+                XCTAssertTrue(output.stdout.contains("bar<\(prefix.pathString)/Bar@unspecified"), output.stdout)
 
                 let pins = try String(bytes: localFileSystem.readFileContents(appPinsPath).contents, encoding: .utf8)!
                 XCTAssertTrue(pins.contains("\"\(prefix.pathString)/Foo\""), pins)
@@ -119,9 +119,9 @@ class DependencyResolutionTests: XCTestCase {
                 XCTAssertTrue(output.stdout.contains("Cloning \(prefix.pathString)/BarMirror\n"), output.stdout)
                 XCTAssertFalse(output.stdout.contains("Cloning \(prefix.pathString)/Bar\n"), output.stdout)
 
-                XCTAssertTrue(output.stdout.contains("Foo<\(prefix.pathString)/Foo@unspecified"), output.stdout)
-                XCTAssertTrue(output.stdout.contains("Bar<\(prefix.pathString)/BarMirror@unspecified"), output.stdout)
-                XCTAssertFalse(output.stdout.contains("Bar<\(prefix.pathString)/Bar@unspecified"), output.stdout)
+                XCTAssertTrue(output.stdout.contains("foo<\(prefix.pathString)/Foo@unspecified"), output.stdout)
+                XCTAssertTrue(output.stdout.contains("barmirror<\(prefix.pathString)/BarMirror@unspecified"), output.stdout)
+                XCTAssertFalse(output.stdout.contains("bar<\(prefix.pathString)/Bar@unspecified"), output.stdout)
 
                 let pins = try String(bytes: localFileSystem.readFileContents(appPinsPath).contents, encoding: .utf8)!
                 XCTAssertTrue(pins.contains("\"\(prefix.pathString)/Foo\""), pins)

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -188,7 +188,9 @@ class PackageGraphTests: XCTestCase {
             ]
         )
 
-        XCTAssertEqual(diagnostics.diagnostics[0].description, "cyclic dependency declaration found: Foo -> Bar -> Baz -> Bar")
+        DiagnosticsEngineTester(diagnostics) { result in
+            result.check(diagnostic: "cyclic dependency declaration found: Foo -> Bar -> Baz -> Bar", behavior: .error)
+        }
     }
 
     func testCycle2() throws {
@@ -215,7 +217,9 @@ class PackageGraphTests: XCTestCase {
             ]
         )
 
-        XCTAssertEqual(diagnostics.diagnostics[0].description, "cyclic dependency declaration found: Foo -> Foo")
+        DiagnosticsEngineTester(diagnostics) { result in
+            result.check(diagnostic: "cyclic dependency declaration found: Foo -> Foo", behavior: .error)
+        }
     }
 
     // Make sure there is no error when we reference Test targets in a package and then
@@ -297,7 +301,9 @@ class PackageGraphTests: XCTestCase {
             ]
         )
 
-        XCTAssertEqual(diagnostics.diagnostics[0].description, "multiple targets named 'Bar' in: 'bar', 'foo'")
+        DiagnosticsEngineTester(diagnostics) { result in
+            result.check(diagnostic: "multiple targets named 'Bar' in: 'bar', 'foo'", behavior: .error)
+        }
     }
 
     func testMultipleDuplicateModules() throws {

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -297,7 +297,7 @@ class PackageGraphTests: XCTestCase {
             ]
         )
 
-        XCTAssertEqual(diagnostics.diagnostics[0].description, "multiple targets named 'Bar' in: Bar, Foo")
+        XCTAssertEqual(diagnostics.diagnostics[0].description, "multiple targets named 'Bar' in: 'bar', 'foo'")
     }
 
     func testMultipleDuplicateModules() throws {
@@ -361,7 +361,7 @@ class PackageGraphTests: XCTestCase {
         )
 
         DiagnosticsEngineTester(diagnostics) { result in
-            result.check(diagnostic: "multiple targets named 'First' in: First, Fourth, Second, Third", behavior: .error)
+            result.check(diagnostic: "multiple targets named 'First' in: 'first', 'fourth', 'second', 'third'", behavior: .error)
         }
     }
 
@@ -426,8 +426,8 @@ class PackageGraphTests: XCTestCase {
         )
 
         DiagnosticsEngineTester(diagnostics) { result in
-            result.check(diagnostic: "multiple targets named 'Bar' in: Fourth, Third", behavior: .error)
-            result.check(diagnostic: "multiple targets named 'Foo' in: First, Second", behavior: .error)
+            result.check(diagnostic: "multiple targets named 'Bar' in: 'fourth', 'third'", behavior: .error)
+            result.check(diagnostic: "multiple targets named 'Foo' in: 'first', 'second'", behavior: .error)
         }
     }
 
@@ -499,7 +499,7 @@ class PackageGraphTests: XCTestCase {
         )
 
         DiagnosticsEngineTester(diagnostics) { result in
-            result.check(diagnostic: "multiple targets named 'First' in: First, Fourth", behavior: .error)
+            result.check(diagnostic: "multiple targets named 'First' in: 'first', 'fourth'", behavior: .error)
         }
     }
 
@@ -563,7 +563,7 @@ class PackageGraphTests: XCTestCase {
         )
 
         DiagnosticsEngineTester(diagnostics) { result in
-            result.check(diagnostic: "product 'Barx' not found. it is required by package 'Foo' target 'FooTarget'.", behavior: .error, location: "'Foo' /Foo")
+            result.check(diagnostic: "product 'Barx' required by package 'foo' target 'FooTarget' not found.", behavior: .error, location: "'Foo' /Foo")
         }
     }
 
@@ -589,7 +589,7 @@ class PackageGraphTests: XCTestCase {
         )
 
         DiagnosticsEngineTester(diagnostics) { result in
-            result.check(diagnostic: "product 'Barx' not found in package 'Bar'. it is required by package 'Foo' target 'FooTarget'.", behavior: .error, location: "'Foo' /Foo")
+            result.check(diagnostic: "product 'Barx' required by package 'foo' target 'FooTarget' not found in package 'Bar'.", behavior: .error, location: "'Foo' /Foo")
         }
     }
 
@@ -615,7 +615,7 @@ class PackageGraphTests: XCTestCase {
         )
 
         DiagnosticsEngineTester(diagnostics) { result in
-            result.check(diagnostic: "product 'Barx' not found. it is required by package 'Foo' target 'FooTarget'.", behavior: .error, location: "'Foo' /Foo")
+            result.check(diagnostic: "product 'Barx' required by package 'foo' target 'FooTarget' not found.", behavior: .error, location: "'Foo' /Foo")
         }
     }
 
@@ -807,9 +807,9 @@ class PackageGraphTests: XCTestCase {
         )
 
         DiagnosticsEngineTester(diagnostics) { result in
-            result.check(diagnostic: "dependency 'Baz' is not used by any target", behavior: .warning)
+            result.check(diagnostic: "dependency 'baz' is not used by any target", behavior: .warning)
             #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
-            result.check(diagnostic: "dependency 'Biz' is not used by any target", behavior: .warning)
+            result.check(diagnostic: "dependency 'biz' is not used by any target", behavior: .warning)
             #endif
         }
     }
@@ -901,7 +901,7 @@ class PackageGraphTests: XCTestCase {
         )
 
         DiagnosticsEngineTester(diagnostics) { result in
-            result.check(diagnostic: "multiple targets named 'Foo' in: Dep2, Start", behavior: .error)
+            result.check(diagnostic: "multiple targets named 'Foo' in: 'dep2', 'start'", behavior: .error)
         }
     }
 
@@ -952,7 +952,7 @@ class PackageGraphTests: XCTestCase {
             ]
         )
 
-        XCTAssertTrue(diagnostics.diagnostics.contains(where: { $0.description.contains("multiple products named 'Bar' in: Bar, Baz") }), "\(diagnostics.diagnostics)")
+        XCTAssertTrue(diagnostics.diagnostics.contains(where: { $0.description.contains("multiple products named 'Bar' in: 'bar', 'baz'") }), "\(diagnostics.diagnostics)")
     }
 
     func testUnsafeFlags() throws {
@@ -1061,7 +1061,7 @@ class PackageGraphTests: XCTestCase {
         DiagnosticsEngineTester(diagnostics, ignoreNotes: true) { result in
             result.check(
                 diagnostic: """
-                    'Foo' dependency on '/Bar' has an explicit name 'Baar' which does not match the name 'Bar' set for '/Bar'
+                    'foo' dependency on '/Bar' has an explicit name 'Baar' which does not match the name 'Bar' set for '/Bar'
                     """,
                 behavior: .error,
                 location: "'Foo' /Foo"
@@ -1351,7 +1351,7 @@ class PackageGraphTests: XCTestCase {
         DiagnosticsEngineTester(diagnostics, ignoreNotes: true) { result in
             result.check(
                 diagnostic: """
-                    product 'Unknown' not found. it is required by package 'Foo' target 'Foo'.
+                    product 'Unknown' required by package 'foo' target 'Foo' not found.
                     """,
                 behavior: .error,
                 location: "'Foo' /Foo"
@@ -1437,7 +1437,7 @@ class PackageGraphTests: XCTestCase {
         DiagnosticsEngineTester(diagnostics, ignoreNotes: true) { result in
             result.check(
                 diagnostic: """
-                    product 'Unknown' not found. it is required by package 'Foo' target 'Foo'.
+                    product 'Unknown' required by package 'foo' target 'Foo' not found.
                     """,
                 behavior: .error,
                 location: "'Foo' /Foo"
@@ -1844,7 +1844,7 @@ class PackageGraphTests: XCTestCase {
             DiagnosticsEngineTester(diagnostics, ignoreNotes: true) { result in
                 result.check(
                     diagnostic: """
-                        'Foo' dependency on '/Bar' has an explicit name 'Bar' which does not match the name 'Some-Bar' set for '/Bar'
+                        'foo' dependency on '/Bar' has an explicit name 'Bar' which does not match the name 'Some-Bar' set for '/Bar'
                         """,
                     behavior: .error,
                     location: "'Foo' /Foo"

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -760,6 +760,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             // warm up caches
             let manifest = try tsc_await { manifestLoader.load(at: manifestPath.parentDirectory,
+                                                               packageIdentity: .root(name: "Trivial"),
                                                                packageKind: .local,
                                                                packageLocation: manifestPath.pathString,
                                                                version: nil,
@@ -777,6 +778,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             for _ in 0 ..< total {
                 sync.enter()
                 manifestLoader.load(at: manifestPath.parentDirectory,
+                                    packageIdentity: .root(name: "Trivial"),
                                     packageKind: .local,
                                     packageLocation: manifestPath.pathString,
                                     version: nil,
@@ -840,6 +842,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
                 sync.enter()
                 manifestLoader.load(at: manifestPath.parentDirectory,
+                                    packageIdentity: .root(name: "Trivial-\(random)"),
                                     packageKind: .local,
                                     packageLocation: manifestPath.pathString,
                                     version: nil,

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -2243,6 +2243,7 @@ final class PackageBuilderTester {
         do {
             // FIXME: We should allow customizing root package boolean.
             let builder = PackageBuilder(
+                identity: PackageIdentity(url: manifest.packageLocation), // FIXME
                 manifest: manifest,
                 productFilter: .everything,
                 path: path,

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -25,6 +25,7 @@ class ManifestSourceGenerationTests: XCTestCase {
             let identityResolver = DefaultIdentityResolver()
             let manifest = try tsc_await {
                 manifestLoader.load(at: packageDir,
+                                    packageIdentity: .root(name: "Root"),
                                     packageKind: .root,
                                     packageLocation: packageDir.pathString,
                                     version: nil,
@@ -41,6 +42,7 @@ class ManifestSourceGenerationTests: XCTestCase {
             try fs.writeFileContents(packageDir.appending(component: Manifest.filename), bytes: ByteString(encodingAsUTF8: newContents))
             let newManifest = try tsc_await {
                 manifestLoader.load(at: packageDir,
+                                    packageIdentity: .root(name: "Root"),
                                     packageKind: .root,
                                     packageLocation: packageDir.pathString,
                                     version: nil,

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3817,7 +3817,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         XCTAssertEqual(manifest.name, "SwiftPM")
-        XCTAssertEqual(loadedPackage.name, "SwiftPM")
+        XCTAssertEqual(loadedPackage.manifestName, manifest.name)
         XCTAssert(graph.reachableProducts.contains(where: { $0.name == "SwiftPM" }))
     }
 
@@ -5619,7 +5619,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(
-                    diagnostic: "'Root' dependency on '/tmp/ws/pkgs/bar/utility' conflicts with dependency on '/tmp/ws/pkgs/foo/utility' which has the same identity 'utility'",
+                    diagnostic: "'root' dependency on '/tmp/ws/pkgs/bar/utility' conflicts with dependency on '/tmp/ws/pkgs/foo/utility' which has the same identity 'utility'",
                     behavior: .error,
                     location: "'Root' /tmp/ws/roots/Root"
                 )
@@ -5627,7 +5627,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
-    func testDuplicateExplicitDependencyNameAtRoot() throws {
+    func testDuplicateExplicitDependencyName_AtRoot() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
@@ -5681,7 +5681,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(
-                    diagnostic: "'Root' dependency on '/tmp/ws/pkgs/bar' conflicts with dependency on '/tmp/ws/pkgs/foo' which has the same explicit name 'FooPackage'",
+                    diagnostic: "'root' dependency on '/tmp/ws/pkgs/bar' conflicts with dependency on '/tmp/ws/pkgs/foo' which has the same explicit name 'FooPackage'",
                     behavior: .error,
                     location: "'Root' /tmp/ws/roots/Root"
                 )
@@ -5746,7 +5746,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
-    func testDuplicateManifestNameAtRoot_ExplicitTargetDependecy() throws {
+    func testDuplicateManifestName_ExplicitProductPackage_AtRoot() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
@@ -5803,7 +5803,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
-    func testExplicitDependencyNameAndManifestNameMismatchAtRoot() throws {
+    func testExplicitDependencyNam_ManifestNameMismatch_AtRoot() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
@@ -5856,12 +5856,12 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(
-                    diagnostic: "'Root' dependency on '/tmp/ws/pkgs/foo' has an explicit name 'MyPackage1' which does not match the name 'MyPackage' set for '/tmp/ws/pkgs/foo'",
+                    diagnostic: "'root' dependency on '/tmp/ws/pkgs/foo' has an explicit name 'MyPackage1' which does not match the name 'MyPackage' set for '/tmp/ws/pkgs/foo'",
                     behavior: .error,
                     location: "'Root' /tmp/ws/roots/Root"
                 )
                 result.check(
-                    diagnostic: "'Root' dependency on '/tmp/ws/pkgs/bar' has an explicit name 'MyPackage2' which does not match the name 'MyPackage' set for '/tmp/ws/pkgs/bar'",
+                    diagnostic: "'root' dependency on '/tmp/ws/pkgs/bar' has an explicit name 'MyPackage2' which does not match the name 'MyPackage' set for '/tmp/ws/pkgs/bar'",
                     behavior: .error,
                     location: "'Root' /tmp/ws/roots/Root"
                 )
@@ -5869,7 +5869,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
-    func testManifestNameAndIdentityConflictAtRoot_Pre52() throws {
+    func testManifestNameAndIdentityConflict_AtRoot_Pre52() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
@@ -5926,7 +5926,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
-    func testManifestNameAndIdentityConflictAtRoot_Post52_Incorrect() throws {
+    func testManifestNameAndIdentityConflict_AtRoot_Post52_Incorrect() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
@@ -5992,7 +5992,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
-    func testManifestNameAndIdentityConflictAtRoot_Post52_Correct() throws {
+    func testManifestNameAndIdentityConflict_AtRoot_Post52_Correct() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
@@ -6049,7 +6049,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
-    func testManifestNameAndIdentityConflictWithExplicitDependencyNamesAtRoot() throws {
+    func testManifestNameAndIdentityConflict_ExplicitDependencyNames_AtRoot() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
@@ -6061,8 +6061,8 @@ final class WorkspaceTests: XCTestCase {
                     name: "Root",
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
-                            "FooPackage",
-                            "BarPackage"
+                            "FooProduct",
+                            "BarProduct"
                         ]),
                     ],
                     products: [],
@@ -6102,7 +6102,68 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(
-                    diagnostic: "'Root' dependency on '/tmp/ws/pkgs/bar' conflicts with dependency on '/tmp/ws/pkgs/foo' which has the same explicit name 'foo'",
+                    diagnostic: "'root' dependency on '/tmp/ws/pkgs/bar' conflicts with dependency on '/tmp/ws/pkgs/foo' which has the same explicit name 'foo'",
+                    behavior: .error,
+                    location: "'Root' /tmp/ws/roots/Root"
+                )
+            }
+        }
+    }
+
+    func testManifestNameAndIdentityConflict_ExplicitDependencyNames_ExplicitProductPackage_AtRoot() throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try MockWorkspace(
+            sandbox: sandbox,
+            fs: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(name: "RootTarget", dependencies: [
+                            .product(name: "FooProduct", package: "foo"),
+                            .product(name: "BarProduct", package: "bar"),
+                        ]),
+                    ],
+                    products: [],
+                    dependencies: [
+                        .git(path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "foo", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    toolsVersion: .v5
+                ),
+            ],
+            packages: [
+                MockPackage(
+                    name: "foo",
+                    path: "foo",
+                    targets: [
+                        MockTarget(name: "FooTarget"),
+                    ],
+                    products: [
+                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                    ],
+                    versions: ["1.0.0", "2.0.0"]
+                ),
+                MockPackage(
+                    name: "foo",
+                    path: "bar",
+                    targets: [
+                        MockTarget(name: "BarTarget"),
+                    ],
+                    products: [
+                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                    ],
+                    versions: ["1.0.0", "2.0.0"]
+                ),
+            ]
+        )
+
+        workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+            DiagnosticsEngineTester(diagnostics) { result in
+                result.check(
+                    diagnostic: "'root' dependency on '/tmp/ws/pkgs/bar' conflicts with dependency on '/tmp/ws/pkgs/foo' which has the same explicit name 'foo'",
                     behavior: .error,
                     location: "'Root' /tmp/ws/roots/Root"
                 )
@@ -6182,7 +6243,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(
-                    diagnostic: "'BarPackage' dependency on '/tmp/ws/pkgs/other/utility' conflicts with dependency on '/tmp/ws/pkgs/foo/utility' which has the same identity 'utility'",
+                    diagnostic: "'bar' dependency on '/tmp/ws/pkgs/other/utility' conflicts with dependency on '/tmp/ws/pkgs/foo/utility' which has the same identity 'utility'",
                     behavior: .error,
                     location: "'BarPackage' /tmp/ws/pkgs/bar"
                 )
@@ -6262,7 +6323,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(
-                    diagnostic: "product 'OtherUtilityProduct' not found in package 'OtherUtilityPackage'. it is required by package 'BarPackage' target 'BarTarget'.",
+                    diagnostic: "product 'OtherUtilityProduct' required by package 'bar' target 'BarTarget' not found in package 'OtherUtilityPackage'.",
                     behavior: .error,
                     location: "'BarPackage' /tmp/ws/pkgs/bar"
                 )
@@ -6504,13 +6565,6 @@ final class WorkspaceTests: XCTestCase {
                 )
             }
         }
-    }
-}
-
-extension PackageGraph {
-    /// Finds the package matching the given name.
-    func lookup(_ name: String) -> ResolvedPackage {
-        return packages.first { $0.name == name }!
     }
 }
 


### PR DESCRIPTION
motivation: improve correctness by using identity more broadly throughout the codebase

changes:
* expose identity on Package, ResolvedPackage and GraphLoadingNode
* reduce calls to identityResolver.resolveIdentity since we now have identity more broadly available (also improves performance)
* ManifestLoader now take PackageIdentity to reduce calls to identityResolver.resolveIdentity when the identity is already known
* introduce PackageIdentity.root as a utility for root packages, since their identity is straight-forward
* adjust call-sites
* adjust tests