### PR TITLE
Rename straggling "extension" cases to "plugin"

### DIFF
--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -354,7 +354,7 @@ extension PackageModel.ProductType {
             self = .library(.init(from: libraryType))
         case .executable:
             self = .executable
-        case .extension:
+        case .plugin:
             self = .plugin
         case .test:
             self = .test

--- a/Sources/PackageCollectionsModel/PackageCollectionModel+v1.swift
+++ b/Sources/PackageCollectionsModel/PackageCollectionModel+v1.swift
@@ -325,8 +325,8 @@ extension PackageCollectionModel.V1 {
         /// An executable product.
         case executable
         
-        /// An extension product.
-        case `extension`
+        /// An plugin product.
+        case plugin
 
         /// A test product.
         case test
@@ -335,7 +335,7 @@ extension PackageCollectionModel.V1 {
 
 extension PackageCollectionModel.V1.ProductType: Codable {
     private enum CodingKeys: String, CodingKey {
-        case library, executable, `extension`, test
+        case library, executable, plugin, test
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -346,8 +346,8 @@ extension PackageCollectionModel.V1.ProductType: Codable {
             try unkeyedContainer.encode(a1)
         case .executable:
             try container.encodeNil(forKey: .executable)
-        case .extension:
-            try container.encodeNil(forKey: .extension)
+        case .plugin:
+            try container.encodeNil(forKey: .plugin)
         case .test:
             try container.encodeNil(forKey: .test)
         }
@@ -367,8 +367,8 @@ extension PackageCollectionModel.V1.ProductType: Codable {
             self = .test
         case .executable:
             self = .executable
-        case .extension:
-            self = .extension
+        case .plugin:
+            self = .plugin
         }
     }
 }

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -316,7 +316,7 @@ public protocol PluginScriptRunner {
         fileSystem: FileSystem
     ) throws -> (outputJSON: Data, stdoutText: Data)
 
-    @available(*, deprecated, message: "used runPlugin() instead")
+    @available(*, deprecated, message: "use runPluginScript() instead")
     func runExtension(
         sources: Sources,
         inputJSON: Data,


### PR DESCRIPTION
Follow-up to #3311 where "extension" was renamed to "plugin" — this commit makes that same change in `PackageCollectionModel.V1.ProductType` and other related sites.

### Motivation:

Update `PackageCollectionModel.V1.ProductType` to be consistent with `PackageModel.V1.ProductType`.

### Modifications:

- Renamed `PackageCollectionModel.V1.ProductType` case `.extension` to `.plugin`.
- Fixed deprecation message in `PluginInvocation.swift` to point to correct replacement.

/cc @abertelrud @yim-lee 