### PR TITLE
Suggest fix-it to add dependency for missing module

### DIFF
--- a/Fixtures/Miscellaneous/MissingModule/WithDependency/Bar/Package.swift
+++ b/Fixtures/Miscellaneous/MissingModule/WithDependency/Bar/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:999.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Bar",
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "Bar",
+            targets: ["Bar"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+	.package(url: "../Foo", branch: "main"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "Bar",
+            dependencies: []),
+    ]
+)

--- a/Fixtures/Miscellaneous/MissingModule/WithDependency/Bar/Sources/Bar/Bar.swift
+++ b/Fixtures/Miscellaneous/MissingModule/WithDependency/Bar/Sources/Bar/Bar.swift
@@ -1,0 +1,5 @@
+import Foo
+
+struct Bar {
+    var text = "Hello, World!"
+}

--- a/Fixtures/Miscellaneous/MissingModule/WithDependency/Foo/Package.swift
+++ b/Fixtures/Miscellaneous/MissingModule/WithDependency/Foo/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Foo",
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "Foo",
+            targets: ["Foo"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "Foo",
+            dependencies: []),
+    ]
+)

--- a/Fixtures/Miscellaneous/MissingModule/WithDependency/Foo/Sources/Foo/Foo.swift
+++ b/Fixtures/Miscellaneous/MissingModule/WithDependency/Foo/Sources/Foo/Foo.swift
@@ -1,0 +1,3 @@
+struct Foo {
+    var text = "Hello, World!"
+}

--- a/Fixtures/Miscellaneous/MissingModule/WithoutDependency/Bar/Package.swift
+++ b/Fixtures/Miscellaneous/MissingModule/WithoutDependency/Bar/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Bar",
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "Bar",
+            targets: ["Bar"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "Bar",
+            dependencies: []),
+    ]
+)

--- a/Fixtures/Miscellaneous/MissingModule/WithoutDependency/Bar/Sources/Bar/Bar.swift
+++ b/Fixtures/Miscellaneous/MissingModule/WithoutDependency/Bar/Sources/Bar/Bar.swift
@@ -1,0 +1,5 @@
+import Foo
+
+struct Bar {
+    var text = "Hello, World!"
+}

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -133,9 +133,9 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         guard success else {
             if let errorMessages = self.buildSystemDelegate?.targetErrorMessages {
                 errorMessages.forEach { key, value in
-                    value.forEach { entry in
-                        if entry.contains("could not build Objective-C module") || entry.contains("no such module") {
-                            if let missingImport = entry.split(separator: "'").last {
+                    value.forEach {
+                        if $0.contains("could not build Objective-C module") || $0.contains("no such module") {
+                            if let missingImport = $0.split(separator: "'").last {
                                 suggestMissingDependency(missingImport: String(missingImport), sourceTarget: key)
                             }
                         }

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -373,6 +373,7 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
     private let queue = DispatchQueue(label: "org.swift.swiftpm.build-delegate")
     private var taskTracker = CommandTaskTracker()
     private var errorMessagesByTarget: [String: [String]] = [:]
+    public var targetErrorMessages: [String: [String]] { get { return errorMessagesByTarget } }
     
     /// Swift parsers keyed by llbuild command name.
     private var swiftParsers: [String: SwiftCompilerOutputParser] = [:]

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -438,6 +438,28 @@ class MiscellaneousTestCase: XCTestCase {
         }
     }
     
+    func testFixItForMissingModuleWithDependency() throws {
+        fixture(name: "Miscellaneous/MissingModule/WithDependency") { prefix in
+            let app = prefix.appending(component: "Bar")
+            
+            let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: app)
+            
+            let output = try result.utf8stderrOutput()
+            XCTAssert(output.contains("depends on one of the following dependencies"), "Didn't find expected output: \(output)")
+        }
+    }
+    
+        func testFixItForMissingModuleWithoutDependency() throws {
+        fixture(name: "Miscellaneous/MissingModule/WithoutDependency") { prefix in
+            let app = prefix.appending(component: "Bar")
+            
+            let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: app)
+            
+            let output = try result.utf8stderrOutput()
+            XCTAssert(output.contains("has a missing dependency."), "Didn't find expected output: \(output)")
+        }
+    }
+    
     func testUnicode() {
         #if !os(Linux) && !os(Android) // TODO: - Linux has trouble with this and needs investigation.
         fixture(name: "Miscellaneous/Unicode") { prefix in


### PR DESCRIPTION
Provide a fix-it when trying to import a module whose dependency is not included in the appropriate target.

Iterating over the `packageGraph` enables the creation of a list of possible dependencies; one of which needs to be added in order to satisfy a module import. This is accomplished by checking all of the targets from each of the products produced by a package. This can only happen if there's a package dependency to check, otherwise the message just explains that the offending module has a missing dependency. 

rdar://59612175