### PR TITLE
stop testArchiveSource from writing files to package root

### DIFF
--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1011,10 +1011,9 @@ final class PackageToolTests: XCTestCase {
                 XCTAssert(stdoutOutput.contains("Created Bar-1.2.3.zip"), #"actual: "\#(stdoutOutput)""#)
             }
 
-            // Runnning with output as relative path,
-            // which in execution context is outside package root
-            do {
-                let destination = RelativePath("Bar-1.2.3.zip")
+            // Running with output is outside the package root
+            try withTemporaryDirectory { tempDirectory in
+                let destination = tempDirectory.appending(component: "Bar-1.2.3.zip")
                 let result = try SwiftPMProduct.SwiftPackage.executeProcess(["archive-source", "--output", destination.pathString], packagePath: packageRoot)
                 XCTAssertEqual(result.exitStatus, .terminated(code: 0))
 


### PR DESCRIPTION
motivation the test "testArchiveSource" has been writing a file to the project's root when invoked from the command line

changes: change the test to use a temporary directory instead of current working directory

