### PR TITLE
[Collections] Fix racy refresh

### DIFF
--- a/Sources/Basics/ConcurrencyHelpers.swift
+++ b/Sources/Basics/ConcurrencyHelpers.swift
@@ -1,7 +1,9 @@
 /*
  This source file is part of the Swift.org open source project
+
  Copyright (c) 2020 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
+
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */


### PR DESCRIPTION
Motivation:
`testHappyRefresh` still crashes. See:
https://ci.swift.org/job/oss-swift-package-linux-ubuntu-16_04/5991/console

`refreshCollections` leads to target trie getting updated. `Trie` is not thread-safe.

Modifications:
Make `Trie` thread-safe. `TrieNode` should be thread-safe already.
