### PR TITLE
Clean up remaining uses of "extension" terminology (it's now "plugin")

### DIFF
--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -30,7 +30,7 @@ extension PackageGraph {
         diagnostics: DiagnosticsEngine,
         fileSystem: FileSystem = localFileSystem,
         shouldCreateMultipleTestProducts: Bool = false,
-        allowExtensionTargets: Bool = false,
+        allowPluginTargets: Bool = false,
         createREPLProduct: Bool = false
     ) throws -> PackageGraph {
 
@@ -114,7 +114,7 @@ extension PackageGraph {
                         fileSystem: fileSystem,
                         diagnostics: diagnostics,
                         shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts,
-                        allowPluginTargets: allowExtensionTargets,
+                        allowPluginTargets: allowPluginTargets,
                         createREPLProduct: manifest.packageKind == .root ? createREPLProduct : false
                     )
                     let package = try builder.construct()

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -226,7 +226,7 @@ public func loadPackageGraph(
     binaryArtifacts: [BinaryArtifact] = [],
     explicitProduct: String? = nil,
     shouldCreateMultipleTestProducts: Bool = false,
-    allowExtensionTargets: Bool = false,
+    allowPluginTargets: Bool = false,
     createREPLProduct: Bool = false
 ) throws -> PackageGraph {
     let rootManifests = manifests.filter { $0.packageKind == .root }
@@ -243,7 +243,7 @@ public func loadPackageGraph(
         diagnostics: diagnostics,
         fileSystem: fs,
         shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts,
-        allowExtensionTargets: allowExtensionTargets,
+        allowPluginTargets: allowPluginTargets,
         createREPLProduct: createREPLProduct
     )
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -647,7 +647,7 @@ extension Workspace {
         createREPLProduct: Bool = false,
         forceResolvedVersions: Bool = false,
         diagnostics: DiagnosticsEngine,
-        allowExtensionTargets: Bool = false,
+        allowPluginTargets: Bool = false,
         xcTestMinimumDeploymentTargets: [PackageModel.Platform:PlatformVersion]? = nil
     ) throws -> PackageGraph {
 
@@ -685,7 +685,7 @@ extension Workspace {
             diagnostics: diagnostics,
             fileSystem: fileSystem,
             shouldCreateMultipleTestProducts: createMultipleTestProducts,
-            allowExtensionTargets: allowExtensionTargets,
+            allowPluginTargets: allowPluginTargets,
             createREPLProduct: createREPLProduct
         )
     }

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -20,7 +20,7 @@ import SPMTestSupport
 class PluginInvocationTests: XCTestCase {
     
     func testBasics() throws {
-        // Construct a canned file system and package graph with a single package and a library that uses an extension that uses a tool.
+        // Construct a canned file system and package graph with a single package and a library that uses a plugin that uses a tool.
         let fileSystem = InMemoryFileSystem(emptyFiles:
             "/Foo/Sources/Foo/source.swift",
             "/Foo/Sources/Foo/SomeFile.abc",
@@ -62,7 +62,7 @@ class PluginInvocationTests: XCTestCase {
                     ]
                 )
             ],
-            allowExtensionTargets: true
+            allowPluginTargets: true
         )
         
         // Check the basic integrity before running plugins.
@@ -82,9 +82,9 @@ class PluginInvocationTests: XCTestCase {
             }
         }
         
-        // A fake ExtensionRunner that just checks the input conditions and returns canned output.
-        struct MockExtensionRunner: ExtensionRunner {
-            func runExtension(
+        // A fake PluginScriptRunner that just checks the input conditions and returns canned output.
+        struct MockPluginScriptRunner: PluginScriptRunner {
+            func runPluginScript(
                 sources: Sources,
                 inputJSON: Data,
                 toolsVersion: ToolsVersion,
@@ -130,12 +130,12 @@ class PluginInvocationTests: XCTestCase {
             }
         }
         
-        // Construct a canned input and run plugins using our MockExtensionRunner().
+        // Construct a canned input and run plugins using our MockPluginScriptRunner().
         let buildEnv = BuildEnvironment(platform: .macOS, configuration: .debug)
         let execsDir = AbsolutePath("/Foo/.build/debug")
         let outputDir = AbsolutePath("/Foo/.build")
-        let extRunner = MockExtensionRunner()
-        let results = try graph.evaluateExtensions(buildEnvironment: buildEnv, execsDir: execsDir, outputDir: outputDir, extensionRunner: extRunner, diagnostics: diagnostics, fileSystem: fileSystem)
+        let pluginRunner = MockPluginScriptRunner()
+        let results = try graph.invokePlugins(buildEnvironment: buildEnv, execsDir: execsDir, outputDir: outputDir, pluginScriptRunner: pluginRunner, diagnostics: diagnostics, fileSystem: fileSystem)
         
         // Check the canned output to make sure nothing was lost in transport.
         XCTAssertNoDiagnostics(diagnostics)


### PR DESCRIPTION
- removed the no-longer-needed deprecated shims
- changed remaining uses of "extension" to "plugin" in comments and unit tests
