### PR TITLE
Extend LLBuildManifestWriter to let shell commands specify environment and initial working directory

### DIFF
--- a/Sources/LLBuildManifest/BuildManifest.swift
+++ b/Sources/LLBuildManifest/BuildManifest.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -96,6 +96,8 @@ public struct BuildManifest {
         inputs: [Node],
         outputs: [Node],
         args: [String],
+        environ: [String: String] = [:],
+        workingDir: String? = nil,
         allowMissingInputs: Bool = false
     ) {
         let tool = ShellTool(
@@ -103,6 +105,8 @@ public struct BuildManifest {
             inputs: inputs,
             outputs: outputs,
             args: args,
+            environ: environ,
+            workingDir: workingDir,
             allowMissingInputs: allowMissingInputs
         )
         commands[name] = Command(name: name, tool: tool)

--- a/Sources/LLBuildManifest/ManifestWriter.swift
+++ b/Sources/LLBuildManifest/ManifestWriter.swift
@@ -134,6 +134,16 @@ public final class ManifestToolStream {
             stream <<< "    \(key): " <<< Format.asJSON(newValue) <<< "\n"
         }
     }
+
+    public subscript(key: String) -> [String: String] {
+        get { fatalError() }
+        set {
+            stream <<< "    \(key):\n"
+            for (key, value) in newValue.sorted(by: { $0.key < $1.key }) {
+                stream <<< "      " <<< Format.asJSON(key) <<< ": " <<< Format.asJSON(value) <<< "\n"
+            }
+        }
+    }
 }
 
 extension Format {

--- a/Sources/LLBuildManifest/Tools.swift
+++ b/Sources/LLBuildManifest/Tools.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -97,6 +97,8 @@ public struct ShellTool: ToolProtocol {
     public var inputs: [Node]
     public var outputs: [Node]
     public var args: [String]
+    public var environ: [String: String]
+    public var workingDir: String?
     public var allowMissingInputs: Bool
 
     init(
@@ -104,18 +106,28 @@ public struct ShellTool: ToolProtocol {
         inputs: [Node],
         outputs: [Node],
         args: [String],
+        environ: [String: String] = [:],
+        workingDir: String? = nil,
         allowMissingInputs: Bool = false
     ) {
         self.description = description
         self.inputs = inputs
         self.outputs = outputs
         self.args = args
+        self.environ = environ
+        self.workingDir = workingDir
         self.allowMissingInputs = allowMissingInputs
     }
 
     public func write(to stream: ManifestToolStream) {
         stream["description"] = description
         stream["args"] = args
+        if !environ.isEmpty {
+            stream["env"] = environ
+        }
+        if let workingDir = workingDir {
+            stream["working-directory"] = workingDir
+        }
         if allowMissingInputs {
             stream["allow-missing-inputs"] = true
         }

--- a/Tests/BuildTests/LLBuildManifestTests.swift
+++ b/Tests/BuildTests/LLBuildManifestTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -51,6 +51,61 @@ final class LLBuildManifestTests: XCTestCase {
                 tool: phony
                 inputs: ["/some/file.c","/some/dir/","/some/dir/structure/"]
                 outputs: ["<Foo>"]
+
+
+            """)
+    }
+
+    func testShellCommands() throws {
+        var manifest = BuildManifest()
+
+        manifest.defaultTarget = "main"
+        manifest.addShellCmd(
+            name: "shelley",
+            description: "Shelley, Keats, and Byron",
+            inputs: [
+                .file(AbsolutePath("/file.in]"))
+            ],
+            outputs: [
+                .file(AbsolutePath("/file.out"))
+            ],
+            args: [
+                "foo", "bar", "baz"
+            ],
+            environ: [
+                "ABC": "DEF",
+                "G H": "I J K",
+            ],
+            workingDir: "/wdir",
+            allowMissingInputs: true
+        )
+
+        manifest.addNode(.file(AbsolutePath("/file.out")), toTarget: "main")
+
+        let fs = InMemoryFileSystem()
+        try ManifestWriter(fs).write(manifest, at: AbsolutePath("/manifest.yaml"))
+
+        let contents = try fs.readFileContents(AbsolutePath("/manifest.yaml"))
+
+        XCTAssertEqual(contents, """
+            client:
+              name: basic
+            tools: {}
+            targets:
+              "main": ["/file.out"]
+            default: "main"
+            commands:
+              "shelley":
+                tool: shell
+                inputs: ["/file.in]"]
+                outputs: ["/file.out"]
+                description: "Shelley, Keats, and Byron"
+                args: ["foo","bar","baz"]
+                env:
+                  "ABC": "DEF"
+                  "G H": "I J K"
+                working-directory: "/wdir"
+                allow-missing-inputs: true
 
 
             """)


### PR DESCRIPTION
Extend LLBuildManifestWriter to let shell commands specify environment and initial working directory.

### Motivation:

Plugin build tool commands can specify an environment and initial working directory, and we need LLBuildManifestWriter support for this.

### Modifications:

- add parameters to addShellCmd()
- add support for writing out dictionaries to the llbuild manifest
- add unit test for shell command writing
