### PR TITLE
resolve warnings resulting from deprecations in TSC

### DIFF
--- a/Sources/Basics/ConcurrencyHelpers.swift
+++ b/Sources/Basics/ConcurrencyHelpers.swift
@@ -194,7 +194,7 @@ public final class ThreadSafeBox<Value> {
 
 public enum Concurrency {
     public static var maxOperations: Int {
-        return (try? ProcessEnv.vars["SWIFTPM_MAX_CONCURRENT_OPERATIONS"].map(Int.init)) ?? ProcessInfo.processInfo.activeProcessorCount
+        return ProcessEnv.vars["SWIFTPM_MAX_CONCURRENT_OPERATIONS"].flatMap(Int.init) ?? ProcessInfo.processInfo.activeProcessorCount
     }
 }
 

--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -41,11 +41,6 @@ func handle(error: Swift.Error) {
     switch error {
     case Diagnostics.fatalError:
         break
-
-    case ArgumentParserError.expectedArguments(let parser, _):
-        print(error: error)
-        parser.printUsage(on: stderrStream)
-
     default:
         print(error: error)
     }

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -102,7 +102,7 @@ public extension Sanitizer {
             return
         }
 
-        throw ArgumentConversionError.custom("valid sanitizers: \(Sanitizer.formattedValues)")
+        throw StringError("valid sanitizers: \(Sanitizer.formattedValues)")
     }
 
     /// All sanitizer options in a comma separated string

--- a/Sources/SPMBuildCore/Sanitizers.swift
+++ b/Sources/SPMBuildCore/Sanitizers.swift
@@ -69,12 +69,3 @@ public struct EnabledSanitizers: Encodable {
         try container.encode(sanitizers.sorted{ $0.rawValue < $1.rawValue }, forKey: .sanitizers)
     }
 }
-
-extension Sanitizer: StringEnumArgument {
-    public static let completion: ShellCompletion = .values([
-        (address.rawValue, "enable Address sanitizer"),
-        (thread.rawValue, "enable Thread sanitizer"),
-        (undefined.rawValue, "enable Undefined Behavior sanitizer"),
-        (scudo.rawValue, "enable Scudo hardened allocator")
-    ])
-}

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -65,7 +65,7 @@ final class BuildToolTests: XCTestCase {
         do {
             _ = try Sanitizer(argument: "invalid")
             XCTFail("Should have failed to create Sanitizer")
-        } catch let error as ArgumentConversionError {
+        } catch let error as StringError {
             XCTAssertEqual(
                 error.description, "valid sanitizers: address, thread, undefined, scudo")
         }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -5507,7 +5507,7 @@ final class WorkspaceTests: XCTestCase {
                 }
                 completion(.success(.okay(body: contents)))
             } catch {
-                completion(.failure( DownloaderError.clientError(error)))
+                completion(.failure(error))
             }
         })
 


### PR DESCRIPTION
motivation: no warnings, happy delelopers

changes:
* remove left over code referring to TSC argument parser and Downloader which are both deprecated and not in use

