### PR TITLE
Unit test should handle both SwiftArgParser 0.3.x and 0.4.x output

### DIFF
--- a/Tests/CommandsTests/RunToolTests.swift
+++ b/Tests/CommandsTests/RunToolTests.swift
@@ -24,7 +24,7 @@ final class RunToolTests: XCTestCase {
 
     func testUsage() throws {
         let stdout = try execute(["-help"]).stdout
-        XCTAssert(stdout.contains("USAGE: swift run <options>"), "got stdout:\n" + stdout)
+        XCTAssert(stdout.contains("USAGE: swift run <options>") || stdout.contains("USAGE: swift run [<options>]"), "got stdout:\n" + stdout)
     }
 
     func testSeeAlso() throws {


### PR DESCRIPTION
rdar://75172724
