### PR TITLE
Prevent Xcode from crashing because of a bad branch config in manifest file

### DIFF
--- a/Sources/PackageGraph/PackageModel+Extensions.swift
+++ b/Sources/PackageGraph/PackageModel+Extensions.swift
@@ -35,11 +35,11 @@ extension PackageDependencyDescription {
 
 extension Manifest {
     /// Constructs constraints of the dependencies in the raw package.
-    public func dependencyConstraints(productFilter: ProductFilter) -> [PackageContainerConstraint] {
-        return dependenciesRequired(for: productFilter).map({
+    public func dependencyConstraints(productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
+        return try dependenciesRequired(for: productFilter).map({
             return PackageContainerConstraint(
                 package: $0.createPackageRef(),
-                requirement: $0.toConstraintRequirement(),
+                requirement: try $0.toConstraintRequirement(),
                 products: $0.productFilter)
         })
     }

--- a/Sources/PackageGraph/RepositoryPackageContainer.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainer.swift
@@ -222,7 +222,7 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
         productFilter: ProductFilter
     ) throws -> (Manifest, [Constraint]) {
         let manifest = try self.loadManifest(at: revision, version: version)
-        return (manifest, manifest.dependencyConstraints(productFilter: productFilter))
+        return (manifest, try manifest.dependencyConstraints(productFilter: productFilter))
     }
 
     public func getUnversionedDependencies(productFilter: ProductFilter) throws -> [Constraint] {

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -359,7 +359,7 @@ public final class MockWorkspace {
 
         let dependencyManifests = try workspace.loadDependencyManifests(root: root, diagnostics: diagnostics)
 
-        let result = workspace.precomputeResolution(
+        let result = try workspace.precomputeResolution(
             root: root,
             dependencyManifests: dependencyManifests,
             pinsStore: pinsStore,

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -131,7 +131,7 @@ private struct LocalPackageContainer: PackageContainer {
     func getDependencies(at version: Version, productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
         // Because of the implementation of `reversedVersions`, we should only get the exact same version.
         precondition(dependency?.checkoutState?.version == version)
-        return manifest.dependencyConstraints(productFilter: productFilter)
+        return try manifest.dependencyConstraints(productFilter: productFilter)
     }
 
     func getDependencies(at revision: String, productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
@@ -139,7 +139,7 @@ private struct LocalPackageContainer: PackageContainer {
         if let checkoutState = dependency?.checkoutState,
             checkoutState.version == nil,
             checkoutState.revision.identifier == revision {
-            return manifest.dependencyConstraints(productFilter: productFilter)
+            return try manifest.dependencyConstraints(productFilter: productFilter)
         }
 
         throw ResolverPrecomputationError.differentRequirement(
@@ -159,7 +159,7 @@ private struct LocalPackageContainer: PackageContainer {
             )
         }
 
-        return manifest.dependencyConstraints(productFilter: productFilter)
+        return try manifest.dependencyConstraints(productFilter: productFilter)
     }
 
     // Gets the package reference from the managed dependency or computes it for root packages.

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -387,10 +387,10 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             "Bar2": .specific(["B2", "Bar1", "Bar3"]),
             "Bar3": .specific(["Bar1", "Bar3"]),
         ]
-        let v5Constraints = dependencies.map {
+        let v5Constraints = try dependencies.map {
             PackageContainerConstraint(
                 package: $0.createPackageRef(),
-                requirement: $0.toConstraintRequirement(),
+                requirement: try $0.toConstraintRequirement(),
                 products: v5ProductMapping[$0.nameForTargetDependencyResolutionOnly]!
             )
         }
@@ -399,10 +399,10 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             "Bar2": .specific(["B2"]),
             "Bar3": .specific(["Bar3"]),
         ]
-        let v5_2Constraints = dependencies.map {
+        let v5_2Constraints = try dependencies.map {
             PackageContainerConstraint(
                 package: $0.createPackageRef(),
-                requirement: $0.toConstraintRequirement(),
+                requirement: try $0.toConstraintRequirement(),
                 products: v5_2ProductMapping[$0.nameForTargetDependencyResolutionOnly]!
             )
         }
@@ -420,7 +420,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             )
 
             XCTAssertEqual(
-                manifest
+                try manifest
                     .dependencyConstraints(productFilter: .everything)
                     .sorted(by: { $0.package.identity < $1.package.identity }),
                 [
@@ -444,7 +444,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             )
 
             XCTAssertEqual(
-                manifest
+                try manifest
                     .dependencyConstraints(productFilter: .everything)
                     .sorted(by: { $0.package.identity < $1.package.identity }),
                 [
@@ -468,7 +468,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             )
 
             XCTAssertEqual(
-                manifest
+                try manifest
                     .dependencyConstraints(productFilter: .everything)
                     .sorted(by: { $0.package.identity < $1.package.identity }),
                 [
@@ -492,7 +492,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
             )
 
             XCTAssertEqual(
-                manifest
+                try manifest
                     .dependencyConstraints(productFilter: .specific(Set(products.map { $0.name })))
                     .sorted(by: { $0.package.identity < $1.package.identity }),
                 [


### PR DESCRIPTION
An `assert` would cause Xcode to crash if there is bad configuration in the manifest i.e. using the url to a pull request as if it was a branch. 

Now instead we guard and throw a StringError for a more graceful exit.

rdar://60879046