### PR TITLE
Run package plugin scripts in a sandbox that permits writing only to the designated output directory

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/SandboxTesterPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/SandboxTesterPlugin/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 999.0
+import PackageDescription
+
+let package = Package(
+    name: "SandboxTesterPlugin",
+    targets: [
+        // A local tool that uses a build tool plugin.
+        .executableTarget(
+            name: "MyLocalTool",
+            dependencies: [
+                "MySourceGenBuildToolPlugin",
+            ]
+        ),
+        // The plugin that tries to write outside the sandbox.
+        .plugin(
+            name: "MySourceGenBuildToolPlugin",
+            capability: .buildTool()
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/SandboxTesterPlugin/Sources/MyLocalTool/main.swift
+++ b/Fixtures/Miscellaneous/Plugins/SandboxTesterPlugin/Sources/MyLocalTool/main.swift
@@ -1,0 +1,1 @@
+print("Hello plugin")

--- a/Fixtures/Miscellaneous/Plugins/SandboxTesterPlugin/Sources/MySourceGenBuildToolPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/SandboxTesterPlugin/Sources/MySourceGenBuildToolPlugin/plugin.swift
@@ -1,0 +1,23 @@
+import PackagePlugin
+import Foundation
+ 
+// Check that we can write to the output directory.
+let allowedOutputPath = targetBuildContext.outputDir.appending("Foo")
+if mkdir(allowedOutputPath.string, 0o777) != 0 {
+     throw StringError("unexpectedly could not write to '\(allowedOutputPath)': \(String(utf8String: strerror(errno)))")
+}
+
+// Check that we cannot write to the source directory.
+let disallowedOutputPath = targetBuildContext.targetDir.appending("Bar")
+if mkdir(disallowedOutputPath.string, 0o777) == 0 {
+     throw StringError("unexpectedly could write to '\(disallowedOutputPath)'")
+}
+
+
+struct StringError: Error, CustomStringConvertible {
+    var error: String
+    init(_ error: String) {
+        self.error = error
+    }
+    var description: String { error }
+}

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -91,6 +91,7 @@ extension PackageGraph {
                     sources: pluginTarget.sources,
                     input: pluginInput,
                     toolsVersion: package.manifest.toolsVersion,
+                    writableDirectories: [pluginOutputDir],
                     pluginScriptRunner: pluginScriptRunner,
                     diagnostics: diagnostics,
                     fileSystem: fileSystem
@@ -168,7 +169,7 @@ extension PackageGraph {
     
     /// Private helper function that serializes a PluginEvaluationInput as input JSON, calls the plugin runner to invoke the plugin, and finally deserializes the output JSON it emits to a PluginEvaluationOutput.  Adds any errors or warnings to `diagnostics`, and throws an error if there was a failure.
     /// FIXME: This should be asynchronous, taking a queue and a completion closure.
-    fileprivate func runPluginScript(sources: Sources, input: PluginScriptRunnerInput, toolsVersion: ToolsVersion, pluginScriptRunner: PluginScriptRunner, diagnostics: DiagnosticsEngine, fileSystem: FileSystem) throws -> (output: PluginScriptRunnerOutput, stdoutText: Data) {
+    fileprivate func runPluginScript(sources: Sources, input: PluginScriptRunnerInput, toolsVersion: ToolsVersion, writableDirectories: [AbsolutePath], pluginScriptRunner: PluginScriptRunner, diagnostics: DiagnosticsEngine, fileSystem: FileSystem) throws -> (output: PluginScriptRunnerOutput, stdoutText: Data) {
         // Serialize the PluginEvaluationInput to JSON.
         let encoder = JSONEncoder()
         let inputJSON = try encoder.encode(input)
@@ -178,6 +179,7 @@ extension PackageGraph {
             sources: sources,
             inputJSON: inputJSON,
             toolsVersion: toolsVersion,
+            writableDirectories: writableDirectories,
             diagnostics: diagnostics,
             fileSystem: fileSystem)
 
@@ -292,6 +294,7 @@ public protocol PluginScriptRunner {
         sources: Sources,
         inputJSON: Data,
         toolsVersion: ToolsVersion,
+        writableDirectories: [AbsolutePath],
         diagnostics: DiagnosticsEngine,
         fileSystem: FileSystem
     ) throws -> (outputJSON: Data, stdoutText: Data)

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -90,4 +90,21 @@ class PluginTests: XCTestCase {
         }
     }
 
+    func testPluginScriptSandbox() throws {
+        // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 999.0.
+        try XCTSkipUnless(doesHostSwiftCompilerSupportRenamingMainSymbol(), "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #if os(macOS)
+        fixture(name: "Miscellaneous/Plugins") { path in
+            do {
+                let (stdout, _) = try executeSwiftBuild(path.appending(component: "SandboxTesterPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"], env: ["SWIFTPM_ENABLE_PLUGINS": "1"])
+                XCTAssert(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
+                XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+            }
+            catch {
+                print(error)
+                throw error
+            }
+        }
+        #endif
+    }
 }

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -88,6 +88,7 @@ class PluginInvocationTests: XCTestCase {
                 sources: Sources,
                 inputJSON: Data,
                 toolsVersion: ToolsVersion,
+                writableDirectories: [AbsolutePath],
                 diagnostics: DiagnosticsEngine,
                 fileSystem: FileSystem
             ) throws -> (outputJSON: Data, stdoutText: Data) {


### PR DESCRIPTION
Like package manifests, package extensions are compiled as executables and are run in order to produce output.  These invocations need to be sandboxed in the same way as package manifests are.

As with package manifests, this is currently only supported on macOS, and uses `sandbox-exec`.  Support for other platforms is tracked by rdar://40235432.  When it is implemented for manifests for other platforms, the implementation should be done in a way that supports package plugins as well.

The sandboxes for manifests and package plugins are similar, and the implementations for the two kinds of script runner should be unified. 

rdar://74662476
