### PR TITLE
bring back identity improvements

### DIFF
--- a/Examples/package-info/Sources/package-info/main.swift
+++ b/Examples/package-info/Sources/package-info/main.swift
@@ -32,9 +32,9 @@ let packagePath = localFileSystem.currentWorkingDirectory!
 // Each takes longer to load than the level above it, but provides more detail.
 let diagnostics = DiagnosticsEngine()
 let identityResolver = DefaultIdentityResolver()
-let manifest = try tsc_await { ManifestLoader.loadManifest(at: packagePath, kind: .local, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], identityResolver: identityResolver, on: .global(), completion: $0) }
-let loadedPackage = try tsc_await { PackageBuilder.loadPackage(at: packagePath, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], identityResolver: identityResolver, diagnostics: diagnostics, on: .global(), completion: $0) }
-let graph = try Workspace.loadGraph(packagePath: packagePath, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], identityResolver: identityResolver, diagnostics: diagnostics)
+let manifest = try tsc_await { ManifestLoader.loadRootManifest(at: packagePath, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], identityResolver: identityResolver, on: .global(), completion: $0) }
+let loadedPackage = try tsc_await { PackageBuilder.loadRootPackage(at: packagePath, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], identityResolver: identityResolver, diagnostics: diagnostics, on: .global(), completion: $0) }
+let graph = try Workspace.loadRootGraph(at: packagePath, swiftCompiler: swiftCompiler, swiftCompilerFlags: [], identityResolver: identityResolver, diagnostics: diagnostics)
 
 // EXAMPLES
 // ========

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -215,13 +215,8 @@ public struct BuildDescription: Codable {
         self.testDiscoveryCommands = testDiscoveryCommands
         self.copyCommands = copyCommands
 
-        self.builtTestProducts = try plan.buildProducts.filter{ $0.product.type == .test }.map { desc in
-            // FIXME(perf): Provide faster lookups.
-            guard let package = (plan.graph.packages.first{ $0.products.contains(desc.product) }) else {
-                throw InternalError("package with product \(desc.product) not found")
-            }
+        self.builtTestProducts = plan.buildProducts.filter{ $0.product.type == .test }.map { desc in
             return BuiltTestProduct(
-                packageName: package.name,
                 productName: desc.product.name,
                 binaryPath: desc.binary
             )

--- a/Sources/Commands/Describe.swift
+++ b/Sources/Commands/Describe.swift
@@ -55,7 +55,7 @@ fileprivate struct DescribedPackage: Encodable {
     let swiftLanguagesVersions: [String]?
 
     init(from package: Package) {
-        self.name = package.name
+        self.name = package.manifestName // TODO: rename property to manifestName?
         self.path = package.path.pathString
         self.toolsVersion = "\(package.manifest.toolsVersion.major).\(package.manifest.toolsVersion.minor)"
             + (package.manifest.toolsVersion.patch == 0 ? "" : ".\(package.manifest.toolsVersion.patch)")

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -224,9 +224,12 @@ public struct SwiftTestTool: SwiftCommand {
         case .codeCovPath:
             let workspace = try swiftTool.getActiveWorkspace()
             let root = try swiftTool.getWorkspaceRoot()
-            let rootManifest = try temp_await {
+            let rootManifests = try temp_await {
                 workspace.loadRootManifests(packages: root.packages, diagnostics: swiftTool.diagnostics, completion: $0)                
-            }[0]
+            }
+            guard let rootManifest = rootManifests.values.first else {
+                throw StringError("invalid manifests at \(root.packages)")
+            }
             let buildParameters = try swiftTool.buildParametersForTest()
             print(codeCovAsJSONPath(buildParameters: buildParameters, packageName: rootManifest.name))
 
@@ -352,6 +355,15 @@ public struct SwiftTestTool: SwiftCommand {
 
     /// Processes the code coverage data and emits a json.
     private func processCodeCoverage(_ testProducts: [BuiltTestProduct], swiftTool: SwiftTool) throws {
+        let workspace = try swiftTool.getActiveWorkspace()
+        let root = try swiftTool.getWorkspaceRoot()
+        let rootManifests = try temp_await {
+            workspace.loadRootManifests(packages: root.packages, diagnostics: swiftTool.diagnostics, completion: $0)
+        }
+        guard let rootManifest = rootManifests.values.first else {
+            throw StringError("invalid manifests at \(root.packages)")
+        }
+
         // Merge all the profraw files to produce a single profdata file.
         try mergeCodeCovRawDataFiles(swiftTool: swiftTool)
 
@@ -360,7 +372,7 @@ public struct SwiftTestTool: SwiftCommand {
             // Export the codecov data as JSON.
             let jsonPath = codeCovAsJSONPath(
                 buildParameters: buildParameters,
-                packageName: product.packageName)
+                packageName: rootManifest.name)
             try exportCodeCovAsJSON(to: jsonPath, testBinary: product.binaryPath, swiftTool: swiftTool)
         }
     }

--- a/Sources/Commands/show-dependencies.swift
+++ b/Sources/Commands/show-dependencies.swift
@@ -44,7 +44,7 @@ private final class PlainTextDumper: DependenciesDumper {
 
                 let pkgVersion = package.manifest.version?.description ?? "unspecified"
 
-                stream <<< "\(hanger)\(package.name)<\(package.manifest.packageLocation)@\(pkgVersion)>\n"
+                stream <<< "\(hanger)\(package.identity.description)<\(package.manifest.packageLocation)@\(pkgVersion)>\n"
 
                 if !package.dependencies.isEmpty {
                     let replacement = (index == packages.count - 1) ?  "    " : "│   "
@@ -69,7 +69,7 @@ private final class FlatListDumper: DependenciesDumper {
     func dump(dependenciesOf rootpkg: ResolvedPackage, on stream: OutputByteStream) {
         func recursiveWalk(packages: [ResolvedPackage]) {
             for package in packages {
-                stream <<< package.name <<< "\n"
+                stream <<< package.identity.description <<< "\n"
                 if !package.dependencies.isEmpty {
                     recursiveWalk(packages: package.dependencies)
                 }
@@ -88,7 +88,7 @@ private final class DotDumper: DependenciesDumper {
             let url = package.manifest.packageLocation
             if nodesAlreadyPrinted.contains(url) { return }
             let pkgVersion = package.manifest.version?.description ?? "unspecified"
-            stream <<< #""\#(url)" [label="\#(package.name)\n\#(url)\n\#(pkgVersion)"]"# <<< "\n"
+            stream <<< #""\#(url)" [label="\#(package.identity.description)\n\#(url)\n\#(pkgVersion)"]"# <<< "\n"
             nodesAlreadyPrinted.insert(url)
         }
         
@@ -130,7 +130,7 @@ private final class JSONDumper: DependenciesDumper {
     func dump(dependenciesOf rootpkg: ResolvedPackage, on stream: OutputByteStream) {
         func convert(_ package: ResolvedPackage) -> JSON {
             return .orderedDictionary([
-                "name": .string(package.name),
+                "name": .string(package.manifestName), // TODO: remove? add identity?
                 "url": .string(package.manifest.packageLocation),
                 "version": .string(package.manifest.version?.description ?? "unspecified"),
                 "path": .string(package.path.pathString),

--- a/Sources/PackageGraph/GraphLoadingNode.swift
+++ b/Sources/PackageGraph/GraphLoadingNode.swift
@@ -20,13 +20,17 @@ import TSCUtility
 /// - SeeAlso: DependencyResolutionNode
 public struct GraphLoadingNode: Equatable, Hashable {
 
+    /// The package identity.
+    public let identity: PackageIdentity
+
     /// The package manifest.
     public let manifest: Manifest
 
     /// The product filter applied to the package.
     public let productFilter: ProductFilter
 
-    public init(manifest: Manifest, productFilter: ProductFilter) {
+    public init(identity: PackageIdentity, manifest: Manifest, productFilter: ProductFilter) {
+        self.identity = identity
         self.manifest = manifest
         self.productFilter = productFilter
     }
@@ -41,9 +45,9 @@ extension GraphLoadingNode: CustomStringConvertible {
     public var description: String {
         switch productFilter {
         case .everything:
-            return manifest.name
+            return self.manifest.name
         case .specific(let set):
-            return "\(manifest.name)[\(set.sorted().joined(separator: ", "))]"
+            return "\(self.manifest.name)[\(set.sorted().joined(separator: ", "))]"
         }
     }
 }

--- a/Sources/PackageGraph/LocalPackageContainer.swift
+++ b/Sources/PackageGraph/LocalPackageContainer.swift
@@ -39,22 +39,23 @@ public final class LocalPackageContainer: PackageContainer {
     private func loadManifest() throws -> Manifest {
         try manifest.memoize() {
             // Load the tools version.
-            let toolsVersion = try toolsVersionLoader.load(at: AbsolutePath(package.location), fileSystem: fileSystem)
+            let toolsVersion = try self.toolsVersionLoader.load(at: AbsolutePath(self.package.location), fileSystem: self.fileSystem)
 
             // Validate the tools version.
-            try toolsVersion.validateToolsVersion(self.currentToolsVersion, packagePath: package.location)
+            try toolsVersion.validateToolsVersion(self.currentToolsVersion, packagePath: self.package.location)
 
             // Load the manifest.
             // FIXME: this should not block
             return try temp_await {
-                manifestLoader.load(at: AbsolutePath(package.location),
-                                    packageKind: package.kind,
-                                    packageLocation: package.location,
+                manifestLoader.load(at: AbsolutePath(self.package.location),
+                                    packageIdentity: self.package.identity,
+                                    packageKind: self.package.kind,
+                                    packageLocation: self.package.location,
                                     version: nil,
                                     revision: nil,
                                     toolsVersion: toolsVersion,
-                                    identityResolver: identityResolver,
-                                    fileSystem: fileSystem,
+                                    identityResolver: self.identityResolver,
+                                    fileSystem: self.fileSystem,
                                     diagnostics: nil,
                                     on: .sharedConcurrent,
                                     completion: $0)

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -35,76 +35,79 @@ extension PackageGraph {
     ) throws -> PackageGraph {
 
         // Create a map of the manifests, keyed by their identity.
-        //
-        // FIXME: For now, we have to compute the identity of dependencies from
-        // the URL but that shouldn't be needed after <rdar://problem/33693433>
-        // Ensure that identity and package name are the same once we have an
-        // API to specify identity in the manifest file
-        let manifestMapSequence = (root.manifests + externalManifests).map({ (identityResolver.resolveIdentity(for: $0.packageLocation), $0) })
-        let manifestMap = Dictionary(uniqueKeysWithValues: manifestMapSequence)
+        let rootManifestsMap = root.manifests
+        let externalManifestsMap = externalManifests.map{ (identityResolver.resolveIdentity(for: $0.packageLocation), $0) }
+        let manifestMap = rootManifestsMap.merging(externalManifestsMap, uniquingKeysWith: { lhs, rhs in
+            return lhs
+        })
+
         let successors: (GraphLoadingNode) -> [GraphLoadingNode] = { node in
             node.requiredDependencies().compactMap{ dependency in
                 return manifestMap[dependency.identity].map { manifest in
-                    GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
+                    GraphLoadingNode(identity: dependency.identity, manifest: manifest, productFilter: dependency.productFilter)
                 }
             }
         }
 
         // Construct the root manifest and root dependencies set.
-        let rootManifestSet = Set(root.manifests)
+        let rootManifestSet = Set(root.manifests.values)
         let rootDependencies = Set(root.dependencies.compactMap{
             manifestMap[$0.identity]
         })
-        let rootManifestNodes = root.manifests.map { GraphLoadingNode(manifest: $0, productFilter: .everything) }
+        let rootManifestNodes = root.packages.map { identity, package in
+            GraphLoadingNode(identity: identity, manifest: package.manifest, productFilter: .everything)
+        }
         let rootDependencyNodes = root.dependencies.lazy.compactMap { (dependency: PackageDependencyDescription) -> GraphLoadingNode? in
-            guard let manifest = manifestMap[dependency.identity] else { return nil }
-            return GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
+            manifestMap[dependency.identity].map {
+                GraphLoadingNode(identity: dependency.identity, manifest: $0, productFilter: dependency.productFilter)
+            }
         }
         let inputManifests = rootManifestNodes + rootDependencyNodes
 
         // Collect the manifests for which we are going to build packages.
-        var allManifests: [GraphLoadingNode]
+        var allNodes: [GraphLoadingNode]
 
         // Detect cycles in manifest dependencies.
         if let cycle = findCycle(inputManifests, successors: successors) {
             diagnostics.emit(PackageGraphError.cycleDetected(cycle))
             // Break the cycle so we can build a partial package graph.
-            allManifests = inputManifests.filter({ $0.manifest != cycle.cycle[0] })
+            allNodes = inputManifests.filter({ $0.manifest != cycle.cycle[0] })
         } else {
             // Sort all manifests toplogically.
-            allManifests = try topologicalSort(inputManifests, successors: successors)
+            allNodes = try topologicalSort(inputManifests, successors: successors)
         }
 
         var flattenedManifests: [PackageIdentity: GraphLoadingNode] = [:]
-        for node in allManifests {
-            let packageIdentity = identityResolver.resolveIdentity(for: node.manifest.packageLocation)
-            if let existing = flattenedManifests[packageIdentity] {
+        for node in allNodes {
+            if let existing = flattenedManifests[node.identity] {
                 let merged = GraphLoadingNode(
+                    identity: node.identity,
                     manifest: node.manifest,
                     productFilter: existing.productFilter.union(node.productFilter)
                 )
-                flattenedManifests[packageIdentity] = merged
+                flattenedManifests[node.identity] = merged
             } else {
-                flattenedManifests[packageIdentity] = node
+                flattenedManifests[node.identity] = node
             }
         }
-        allManifests = flattenedManifests.values.sorted(by: { identityResolver.resolveIdentity(for: $0.manifest.packageLocation) < identityResolver.resolveIdentity(for: $1.manifest.packageLocation) })
+        // sort by identity
+        allNodes = flattenedManifests.keys.sorted().map { flattenedManifests[$0]! } // force unwrap fine since we are iterating on keys
 
         // Create the packages.
         var manifestToPackage: [Manifest: Package] = [:]
-        for node in allManifests {
+        for node in allNodes {
             let manifest = node.manifest
 
             // Derive the path to the package.
             //
             // FIXME: Lift this out of the manifest.
             let packagePath = manifest.path.parentDirectory
-
-            let packageLocation = PackageLocation.Local(name: manifest.name, packagePath: packagePath)
-            diagnostics.with(location: packageLocation) { diagnostics in
+            let diagnosticsLocation = PackageLocation.Local(name: manifest.name, packagePath: packagePath)
+            diagnostics.with(location: diagnosticsLocation) { diagnostics in
                 diagnostics.wrap {
                     // Create a package from the manifest and sources.
                     let builder = PackageBuilder(
+                        identity: node.identity,
                         manifest: manifest,
                         productFilter: node.productFilter,
                         path: packagePath,
@@ -132,7 +135,7 @@ extension PackageGraph {
 
         // Resolve dependencies and create resolved packages.
         let resolvedPackages = try createResolvedPackages(
-            allManifests: allManifests,
+            nodes: allNodes,
             identityResolver: identityResolver,
             manifestToPackage: manifestToPackage,
             rootManifestSet: rootManifestSet,
@@ -153,7 +156,7 @@ extension PackageGraph {
 
 private func checkAllDependenciesAreUsed(_ rootPackages: [ResolvedPackage], _ diagnostics: DiagnosticsEngine) {
     for package in rootPackages {
-        // List all dependency products dependended on by the package targets.
+        // List all dependency products dependent on by the package targets.
         let productDependencies: Set<ResolvedProduct> = Set(package.targets.flatMap({ target in
             return target.dependencies.compactMap({ targetDependency in
                 switch targetDependency {
@@ -181,7 +184,7 @@ private func checkAllDependenciesAreUsed(_ rootPackages: [ResolvedPackage], _ di
 
             let dependencyIsUsed = dependency.products.contains(where: productDependencies.contains)
             if !dependencyIsUsed && !diagnostics.hasErrors {
-                diagnostics.emit(.unusedDependency(dependency.name))
+                diagnostics.emit(.unusedDependency(dependency.identity.description))
             }
         }
     }
@@ -189,7 +192,7 @@ private func checkAllDependenciesAreUsed(_ rootPackages: [ResolvedPackage], _ di
 
 /// Create resolved packages from the loaded packages.
 private func createResolvedPackages(
-    allManifests: [GraphLoadingNode],
+    nodes: [GraphLoadingNode],
     identityResolver: IdentityResolver,
     manifestToPackage: [Manifest: Package],
     // FIXME: This shouldn't be needed once <rdar://problem/33693433> is fixed.
@@ -199,7 +202,7 @@ private func createResolvedPackages(
 ) throws -> [ResolvedPackage] {
 
     // Create package builder objects from the input manifests.
-    let packageBuilders: [ResolvedPackageBuilder] = allManifests.compactMap{ node in
+    let packageBuilders: [ResolvedPackageBuilder] = nodes.compactMap{ node in
         guard let package = manifestToPackage[node.manifest] else {
             return nil
         }
@@ -214,15 +217,14 @@ private func createResolvedPackages(
     // Create a map of package builders keyed by the package identity.
     // This is guaranteed to be unique so we can use spm_createDictionary
     let packageMapByIdentity: [PackageIdentity: ResolvedPackageBuilder] = packageBuilders.spm_createDictionary{
-        let identity = identityResolver.resolveIdentity(for: $0.package.manifest.packageLocation)
-        return (identity, $0)
+        return ($0.package.identity, $0)
     }
 
     // in case packages have same manifest name this map can miss packages which will lead to missing product errors
     // our plan is to deprecate the use of manifest + dependency explicit name in target dependency lookup and instead lean 100% on identity
     // which means this map would go away too
     let packageMapByNameForTargetDependencyResolutionOnly = packageBuilders.reduce(into: [String: ResolvedPackageBuilder](), { partial, item in
-        partial[item.package.name] = item
+        partial[item.package.manifestName] = item
     })
 
     // Scan and validate the dependencies
@@ -249,12 +251,11 @@ private func createResolvedPackages(
                     // this means that the dependencies share the same name
                     // FIXME: this works but the way we find out about this is based on a side effect, need to improve it when working on identity
                     let error = PackageGraphError.dependencyAlreadySatisfiedByName(
-                        dependencyPackageName: package.name,
+                        package: package.identity.description,
                         dependencyLocation: dependencyLocation,
                         otherDependencyURL: resolvedPackage.package.manifest.packageLocation,
                         name: explicitDependencyName)
-                    let diagnosticLocation = PackageLocation.Local(name: package.name, packagePath: package.path)
-                    return diagnostics.emit(error, location: diagnosticLocation)
+                    return diagnostics.emit(error, location: package.diagnosticLocation)
                 }
                 return dependencies.append(resolvedPackage)
             }
@@ -266,35 +267,32 @@ private func createResolvedPackages(
                 // FIXME: this works but the way we find out about this is based on a side effect, need to improve it when working on identity
                 guard !dependencies.contains(resolvedPackage) else {
                     let error = PackageGraphError.dependencyAlreadySatisfiedByIdentifier(
-                        dependencyPackageName: package.name,
+                        package: package.identity.description,
                         dependencyLocation: dependencyLocation,
                         otherDependencyURL: resolvedPackage.package.manifest.packageLocation,
                         identity: dependencyIdentity)
-                    let diagnosticLocation = PackageLocation.Local(name: package.name, packagePath: package.path)
-                    return diagnostics.emit(error, location: diagnosticLocation)
+                    return diagnostics.emit(error, location: package.diagnosticLocation)
                 }
                 // check that the explicit package dependency name matches the package name.
-                if let explicitDependencyName = dependency.explicitNameForTargetDependencyResolutionOnly, resolvedPackage.package.name != explicitDependencyName {
+                if let explicitDependencyName = dependency.explicitNameForTargetDependencyResolutionOnly, resolvedPackage.package.manifestName != explicitDependencyName {
                     // check if this resolvedPackage url is the same as the dependency one
                     // if not, this means that the dependencies share the same identity
                     // FIXME: this works but the way we find out about this is based on a side effect, need to improve it when working on identity
                     if resolvedPackage.package.manifest.packageLocation != dependencyLocation {
                         let error = PackageGraphError.dependencyAlreadySatisfiedByIdentifier(
-                            dependencyPackageName: package.name,
+                            package: package.identity.description,
                             dependencyLocation: dependencyLocation,
                             otherDependencyURL: resolvedPackage.package.manifest.packageLocation,
                             identity: dependencyIdentity)
-                        let diagnosticLocation = PackageLocation.Local(name: package.name, packagePath: package.path)
-                        return diagnostics.emit(error, location: diagnosticLocation)
+                        return diagnostics.emit(error, location: package.diagnosticLocation)
                     } else  {
                         let error = PackageGraphError.incorrectPackageDependencyName(
-                            dependencyPackageName: package.name,
+                            package: package.identity.description,
                             dependencyName: explicitDependencyName,
                             dependencyLocation: dependencyLocation,
-                            resolvedPackageName: resolvedPackage.package.name,
+                            resolvedPackageManifestName: resolvedPackage.package.manifestName,
                             resolvedPackageURL: resolvedPackage.package.manifest.packageLocation)
-                        let diagnosticLocation = PackageLocation.Local(name: package.name, packagePath: package.path)
-                        return diagnostics.emit(error, location: diagnosticLocation)
+                        return diagnostics.emit(error, location: package.diagnosticLocation)
                     }
                 }
                 dependencies.append(resolvedPackage)
@@ -345,7 +343,7 @@ private func createResolvedPackages(
     for productName in duplicateProducts {
         let packages = packageBuilders
             .filter({ $0.products.contains(where: { $0.product.name == productName }) })
-            .map({ $0.package.name })
+            .map{ $0.package.identity.description }
             .sorted()
 
         diagnostics.emit(PackageGraphError.duplicateProduct(product: productName, packages: packages))
@@ -365,9 +363,6 @@ private func createResolvedPackages(
     // Do another pass and establish product dependencies of each target.
     for packageBuilder in packageBuilders {
         let package = packageBuilder.package
-
-        // The diagnostics location for this package.
-        let diagnosticLocation = { PackageLocation.Local(name: package.name, packagePath: package.path) }
 
         // Get all implicit system library dependencies in this package.
         let implicitSystemTargetDeps = packageBuilder.dependencies
@@ -403,12 +398,12 @@ private func createResolvedPackages(
                     // resolve (like authentication issues).
                     if !diagnostics.hasErrors {
                         let error = PackageGraphError.productDependencyNotFound(
+                            package: package.identity.description,
+                            targetName: targetBuilder.target.name,
                             dependencyProductName: productRef.name,
-                            dependencyPackageName: productRef.package,
-                            packageName: package.name,
-                            targetName: targetBuilder.target.name
+                            dependencyPackageName: productRef.package
                         )
-                        diagnostics.emit(error, location: diagnosticLocation())
+                        diagnostics.emit(error, location: package.diagnosticLocation)
                     }
                     continue
                 }
@@ -418,7 +413,7 @@ private func createResolvedPackages(
                 // dependency to share the same name. We don't check this in manifest loading for root-packages so
                 // we can provide a more detailed diagnostic here.
                 if packageBuilder.package.manifest.toolsVersion >= .v5_2 && productRef.package == nil{
-                    let referencedPackageIdentity = identityResolver.resolveIdentity(for: product.packageBuilder.package.manifest.packageLocation)
+                    let referencedPackageIdentity = product.packageBuilder.package.identity
                     guard let referencedPackageDependency = (packageBuilder.package.manifest.dependencies.first { package in
                         return package.identity == referencedPackageIdentity
                     }) else {
@@ -431,7 +426,7 @@ private func createResolvedPackages(
                             targetName: targetBuilder.target.name,
                             packageDependency: referencedPackageDependency
                         )
-                        diagnostics.emit(error, location: diagnosticLocation())
+                        diagnostics.emit(error, location: package.diagnosticLocation)
                     }
                 }
 
@@ -444,12 +439,12 @@ private func createResolvedPackages(
     if foundDuplicateTarget {
         for targetName in allTargetNames.sorted() {
             // Find the packages this target is present in.
-            let packageNames = packageBuilders
+            let packages = packageBuilders
                 .filter({ $0.targets.contains(where: { $0.target.name == targetName }) })
-                .map({ $0.package.name })
+                .map{ $0.package.identity.description }
                 .sorted()
-            if packageNames.count > 1 {
-                diagnostics.emit(ModuleError.duplicateModule(targetName, packageNames))
+            if packages.count > 1 {
+                diagnostics.emit(ModuleError.duplicateModule(targetName, packages))
             }
         }
     }

--- a/Sources/PackageGraph/PackageGraph.swift
+++ b/Sources/PackageGraph/PackageGraph.swift
@@ -19,16 +19,16 @@ enum PackageGraphError: Swift.Error {
     case cycleDetected((path: [Manifest], cycle: [Manifest]))
 
     /// The product dependency not found.
-    case productDependencyNotFound(dependencyProductName: String, dependencyPackageName: String?, packageName: String, targetName: String)
+    case productDependencyNotFound(package: String, targetName: String, dependencyProductName: String, dependencyPackageName: String?)
 
     /// The package dependency name does not match the package name.
-    case incorrectPackageDependencyName(dependencyPackageName: String, dependencyName: String, dependencyLocation: String, resolvedPackageName: String, resolvedPackageURL: String)
+    case incorrectPackageDependencyName(package: String, dependencyName: String, dependencyLocation: String, resolvedPackageManifestName: String, resolvedPackageURL: String)
 
     /// The package dependency already satisfied by a different dependency package
-    case dependencyAlreadySatisfiedByIdentifier(dependencyPackageName: String, dependencyLocation: String, otherDependencyURL: String, identity: PackageIdentity)
+    case dependencyAlreadySatisfiedByIdentifier(package: String, dependencyLocation: String, otherDependencyURL: String, identity: PackageIdentity)
 
     /// The package dependency already satisfied by a different dependency package
-    case dependencyAlreadySatisfiedByName(dependencyPackageName: String, dependencyLocation: String, otherDependencyURL: String, name: String)
+    case dependencyAlreadySatisfiedByName(package: String, dependencyLocation: String, otherDependencyURL: String, name: String)
 
     /// The product dependency was found but the package name was not referenced correctly (tools version > 5.2).
     case productDependencyMissingPackage(
@@ -192,20 +192,20 @@ extension PackageGraphError: CustomStringConvertible {
                 (cycle.path + cycle.cycle).map({ $0.name }).joined(separator: " -> ") +
                 " -> " + cycle.cycle[0].name
 
-        case .productDependencyNotFound(let dependencyProductName, let dependencyPackageName, let packageName, let targetName):
-            return "product '\(dependencyProductName)' \(dependencyPackageName.map{ "not found in package '\($0)'" } ?? "not found"). it is required by package '\(packageName)' target '\(targetName)'."
+        case .productDependencyNotFound(let package, let targetName, let dependencyProductName, let dependencyPackageName):
+            return "product '\(dependencyProductName)' required by package '\(package)' target '\(targetName)' \(dependencyPackageName.map{ "not found in package '\($0)'" } ?? "not found")."
 
-        case .incorrectPackageDependencyName(let dependencyPackageName, let dependencyName, let dependencyURL, let resolvedPackageName, let resolvedPackageURL):
+        case .incorrectPackageDependencyName(let package, let dependencyName, let dependencyURL, let resolvedPackageManifestName, let resolvedPackageURL):
             return """
-                '\(dependencyPackageName)' dependency on '\(dependencyURL)' has an explicit name '\(dependencyName)' which does not match the \
-                name '\(resolvedPackageName)' set for '\(resolvedPackageURL)'
+                '\(package)' dependency on '\(dependencyURL)' has an explicit name '\(dependencyName)' which does not match the \
+                name '\(resolvedPackageManifestName)' set for '\(resolvedPackageURL)'
                 """
 
-        case .dependencyAlreadySatisfiedByIdentifier(let dependencyPackageName, let dependencyURL, let otherDependencyURL, let identity):
-            return "'\(dependencyPackageName)' dependency on '\(dependencyURL)' conflicts with dependency on '\(otherDependencyURL)' which has the same identity '\(identity)'"
+        case .dependencyAlreadySatisfiedByIdentifier(let package, let dependencyURL, let otherDependencyURL, let identity):
+            return "'\(package)' dependency on '\(dependencyURL)' conflicts with dependency on '\(otherDependencyURL)' which has the same identity '\(identity)'"
 
-        case .dependencyAlreadySatisfiedByName(let dependencyPackageName, let dependencyURL, let otherDependencyURL, let name):
-            return "'\(dependencyPackageName)' dependency on '\(dependencyURL)' conflicts with dependency on '\(otherDependencyURL)' which has the same explicit name '\(name)'"
+        case .dependencyAlreadySatisfiedByName(let package, let dependencyURL, let otherDependencyURL, let name):
+            return "'\(package)' dependency on '\(dependencyURL)' conflicts with dependency on '\(otherDependencyURL)' which has the same explicit name '\(name)'"
 
         case .productDependencyMissingPackage(
                 let productName,
@@ -221,7 +221,7 @@ extension PackageGraphError: CustomStringConvertible {
             return "dependency '\(productName)' in target '\(targetName)' requires explicit declaration; \(solution)"
 
         case .duplicateProduct(let product, let packages):
-            return "multiple products named '\(product)' in: \(packages.joined(separator: ", "))"
+            return "multiple products named '\(product)' in: '\(packages.joined(separator: "', '"))'"
         }
     }
 }

--- a/Sources/PackageGraph/PinsStore.swift
+++ b/Sources/PackageGraph/PinsStore.swift
@@ -135,7 +135,7 @@ extension PinsStore.Pin: JSONMappable, JSONSerializable {
     public init(json: JSON) throws {
         let name: String? = json.get("package")
         let url: String = try json.get("repositoryURL")
-        let identity = PackageIdentity(url: url)
+        let identity = PackageIdentity(url: url) // FIXME: pin store should also encode identity
         let ref = PackageReference.remote(identity: identity, location: url)
         self.packageRef = name.flatMap(ref.with(newName:)) ?? ref
         self.state = try json.get("state")

--- a/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
@@ -150,7 +150,7 @@ public struct PubgrubDependencyResolver {
     /// Execute the resolution algorithm to find a valid assignment of versions.
     public func solve(constraints: [Constraint]) -> Result<[DependencyResolver.Binding], Error> {
         let root = DependencyResolutionNode.root(package: .root(
-            identity: PackageIdentity(url: "<synthesized-root>"),
+            identity: .plain("<synthesized-root>"),
             path: .root
         ))
 
@@ -985,7 +985,7 @@ private struct DiagnosticReportBuilder {
 
     // FIXME: This is duplicated and wrong.
     private func isFailure(_ incompatibility: Incompatibility) -> Bool {
-        return incompatibility.terms.count == 1 && incompatibility.terms.first?.node.package.identity == PackageIdentity(url: "<synthesized-root>")
+        return incompatibility.terms.count == 1 && incompatibility.terms.first?.node.package.identity == .plain("<synthesized-root>")
     }
 
     private func description(for term: Term, normalizeRange: Bool = false) throws -> String {

--- a/Sources/PackageGraph/RepositoryPackageContainer.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainer.swift
@@ -302,16 +302,17 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
         // FIXME: this should not block
         return try temp_await {
             self.manifestLoader.load(at: AbsolutePath.root,
-                                packageKind: package.kind,
-                                packageLocation: packageLocation,
-                                version: version,
-                                revision: nil,
-                                toolsVersion: toolsVersion,
-                                identityResolver: identityResolver,
-                                fileSystem: fileSystem,
-                                diagnostics: nil,
-                                on: .sharedConcurrent,
-                                completion: $0)
+                                     packageIdentity: self.package.identity,
+                                     packageKind: self.package.kind,
+                                     packageLocation: packageLocation,
+                                     version: version,
+                                     revision: nil,
+                                     toolsVersion: toolsVersion,
+                                     identityResolver: self.identityResolver,
+                                     fileSystem: fileSystem,
+                                     diagnostics: nil,
+                                     on: .sharedConcurrent,
+                                     completion: $0)
         }
     }
 

--- a/Sources/PackageGraph/ResolvedPackage.swift
+++ b/Sources/PackageGraph/ResolvedPackage.swift
@@ -17,19 +17,31 @@ public final class ResolvedPackage: ObjectIdentifierProtocol {
     /// The underlying package reference.
     public let underlyingPackage: Package
 
+    // The identity of the package.
+    public var identity: PackageIdentity {
+        return self.underlyingPackage.identity
+    }
+
     /// The manifest describing the package.
     public var manifest: Manifest {
-        return underlyingPackage.manifest
+        return self.underlyingPackage.manifest
     }
 
     /// The name of the package.
+    @available(*, deprecated, message: "use identity (or manifestName, but only if you must) instead")
     public var name: String {
-        return underlyingPackage.name
+        return self.underlyingPackage.name
+    }
+
+    /// The name of the package as entered in the manifest.
+    /// This should rarely be used beyond presentation purposes
+    public var manifestName: String {
+        return self.underlyingPackage.manifestName
     }
 
     /// The local path of the package.
     public var path: AbsolutePath {
-        return underlyingPackage.path
+        return self.underlyingPackage.path
     }
 
     /// The targets contained in the package.
@@ -56,6 +68,6 @@ public final class ResolvedPackage: ObjectIdentifierProtocol {
 
 extension ResolvedPackage: CustomStringConvertible {
     public var description: String {
-        return "<ResolvedPackage: \(name)>"
+        return "<ResolvedPackage: \(self.identity)>"
     }
 }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -75,6 +75,7 @@ public protocol ManifestLoaderProtocol {
     ///
     /// - Parameters:
     ///   - at: The root path of the package.
+    ///   - packageIdentity: the identity of the package
     ///   - packageKind: The kind of package the manifest is from.
     ///   - packageLocation: The location the package the manifest was loaded from.
     ///   - version: Optional. The version the manifest is from, if known.
@@ -87,6 +88,7 @@ public protocol ManifestLoaderProtocol {
     ///   - completion: The completion handler .
     func load(
         at path: AbsolutePath,
+        packageIdentity: PackageIdentity,
         packageKind: PackageReference.Kind,
         packageLocation: String,
         version: Version?,
@@ -155,13 +157,8 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         self.operationQueue.maxConcurrentOperationCount = Concurrency.maxOperations
     }
 
-    /// Loads a manifest from a package repository using the resources associated with a particular `swiftc` executable.
-    ///
-    /// - Parameters:
-    ///     - at: The absolute path of the package root.
-    ///     - kind: The kind of package the manifest is from.
-    ///     - swiftCompiler: The absolute path of a `swiftc` executable.
-    ///         Its associated resources will be used by the loader.
+    // deprecated 3/21, remove once clients migrated over
+    @available(*, deprecated, message: "use loadRootManifest instead")
     public static func loadManifest(
         at path: AbsolutePath,
         kind: PackageReference.Kind,
@@ -176,10 +173,13 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             let resources = try UserManifestResources(swiftCompiler: swiftCompiler, swiftCompilerFlags: swiftCompilerFlags)
             let loader = ManifestLoader(manifestResources: resources)
             let toolsVersion = try ToolsVersionLoader().load(at: path, fileSystem: fileSystem)
+            let packageLocation = path.pathString
+            let packageIdentity = identityResolver.resolveIdentity(for: packageLocation)
             loader.load(
                 at: path,
+                packageIdentity: packageIdentity,
                 packageKind: kind,
-                packageLocation: path.pathString,
+                packageLocation: packageLocation,
                 version: nil,
                 revision: nil,
                 toolsVersion: toolsVersion,
@@ -194,6 +194,52 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         }
     }
 
+    /// Loads a root manifest from a path using the resources associated with a particular `swiftc` executable.
+    ///
+    /// - Parameters:
+    ///   - at: The absolute path of the package root.
+    ///   - swiftCompiler: The absolute path of a `swiftc` executable. Its associated resources will be used by the loader.
+    ///   - identityResolver: A helper to resolve identities based on configuration
+    ///   - diagnostics: Optional.  The diagnostics engine.
+    ///   - on: The dispatch queue to perform asynchronous operations on.
+    ///   - completion: The completion handler .
+    public static func loadRootManifest(
+        at path: AbsolutePath,
+        swiftCompiler: AbsolutePath,
+        swiftCompilerFlags: [String],
+        identityResolver: IdentityResolver,
+        diagnostics: DiagnosticsEngine? = nil,
+        fileSystem: FileSystem = localFileSystem,
+        on queue: DispatchQueue,
+        completion: @escaping (Result<Manifest, Error>) -> Void
+    ) {
+        do {
+            let resources = try UserManifestResources(swiftCompiler: swiftCompiler, swiftCompilerFlags: swiftCompilerFlags)
+            let loader = ManifestLoader(manifestResources: resources)
+            let toolsVersion = try ToolsVersionLoader().load(at: path, fileSystem: fileSystem)
+            let packageLocation = fileSystem.isFile(path) ? path.parentDirectory : path
+            let packageIdentity = identityResolver.resolveIdentity(for: packageLocation)
+            loader.load(
+                at: path,
+                packageIdentity: packageIdentity,
+                packageKind: .root,
+                packageLocation: packageLocation.pathString,
+                version: nil,
+                revision: nil,
+                toolsVersion: toolsVersion,
+                identityResolver: identityResolver,
+                fileSystem: fileSystem,
+                diagnostics: diagnostics,
+                on: queue,
+                completion: completion
+            )
+        } catch {
+            return completion(.failure(error))
+        }
+    }
+
+    // deprecated 3/21, remove once clients migrated over
+    @available(*, deprecated, message: "use load(at: packageIdentity:, ...) variant instead")
     public func load(
         at path: AbsolutePath,
         packageKind: PackageReference.Kind,
@@ -207,9 +253,37 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         on queue: DispatchQueue,
         completion: @escaping (Result<Manifest, Error>) -> Void
     ) {
+        let packageIdentity = identityResolver.resolveIdentity(for: packageLocation)
+        self.load(at: path,
+                  packageIdentity: packageIdentity,
+                  packageKind: packageKind,
+                  packageLocation: packageLocation,
+                  version: version,
+                  revision: revision,
+                  toolsVersion: toolsVersion,
+                  identityResolver: identityResolver,
+                  fileSystem: fileSystem,
+                  diagnostics: diagnostics,
+                  on: queue,
+                  completion: completion)
+    }
+
+    public func load(
+        at path: AbsolutePath,
+        packageIdentity: PackageIdentity,
+        packageKind: PackageReference.Kind,
+        packageLocation: String,
+        version: Version?,
+        revision: String?,
+        toolsVersion: ToolsVersion,
+        identityResolver: IdentityResolver,
+        fileSystem: FileSystem,
+        diagnostics: DiagnosticsEngine? = nil,
+        on queue: DispatchQueue,
+        completion: @escaping (Result<Manifest, Error>) -> Void
+    ) {
         do {
             let manifestPath = try Manifest.path(atPackagePath: path, fileSystem: fileSystem)
-            let packageIdentity = identityResolver.resolveIdentity(for: packageLocation)
             self.loadFile(at: manifestPath,
                           packageIdentity: packageIdentity,
                           packageKind: packageKind,
@@ -220,25 +294,13 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                           identityResolver: identityResolver,
                           fileSystem: fileSystem,
                           diagnostics: diagnostics,
-                          on: queue) { result in
-
-                completion(result)
-            }
+                          on: queue,
+                          completion: completion)
         } catch {
             return completion(.failure(error))
         }
     }
 
-    /// Create a manifest by loading a specific manifest file from the given `path`.
-    ///
-    /// - Parameters:
-    ///   - at: The path to the manifest file (or a package root).
-    ///   - packageIdentity: The identity of package the manifest is from.
-    ///   - packageKind: The kind of package the manifest is from.
-    ///   - packageLocation: The location the manifest was loaded from.
-    ///   - version: The version the manifest is from, if known.
-    ///   - revision: The revision the manifest is from, if known.
-    ///   - fileSystem: If given, the file system to load from (otherwise load from the local file system).
     private func loadFile(
         at path: AbsolutePath,
         packageIdentity: PackageIdentity,

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -80,8 +80,8 @@ extension ModuleError: CustomStringConvertible {
     public var description: String {
         switch self {
         case .duplicateModule(let name, let packages):
-            let packages = packages.joined(separator: ", ")
-            return "multiple targets named '\(name)' in: \(packages)"
+            let packages = packages.joined(separator: "', '")
+            return "multiple targets named '\(name)' in: '\(packages)'"
         case .moduleNotFound(let target, let type):
             let folderName = type == .test ? "Tests" : "Sources"
             return "Source files for target \(target) should be located under '\(folderName)/\(target)', or a custom sources path can be set with the 'path' property in Package.swift"
@@ -215,6 +215,9 @@ public struct BinaryArtifact {
 /// The 'builder' here refers to the builder pattern and not any build system
 /// related function.
 public final class PackageBuilder {
+    /// The identity for the package being constructed.
+    private let identity: PackageIdentity
+
     /// The manifest for the package being constructed.
     private let manifest: Manifest
 
@@ -257,6 +260,7 @@ public final class PackageBuilder {
     /// Create a builder for the given manifest and package `path`.
     ///
     /// - Parameters:
+    ///   - identity: The identity of this package.
     ///   - manifest: The manifest of this package.
     ///   - path: The root path of the package.
     ///   - artifactPaths: Paths to the downloaded binary target artifacts.
@@ -265,6 +269,7 @@ public final class PackageBuilder {
     ///   - createMultipleTestProducts: If enabled, create one test product for
     ///     each test target.
     public init(
+        identity: PackageIdentity,
         manifest: Manifest,
         productFilter: ProductFilter,
         path: AbsolutePath,
@@ -278,6 +283,7 @@ public final class PackageBuilder {
         allowPluginTargets: Bool = false,
         createREPLProduct: Bool = false
     ) {
+        self.identity = identity
         self.manifest = manifest
         self.productFilter = productFilter
         self.packagePath = path
@@ -292,13 +298,8 @@ public final class PackageBuilder {
         self.warnAboutImplicitExecutableTargets = warnAboutImplicitExecutableTargets
     }
 
-    /// Loads a package from a package repository using the resources associated with a particular `swiftc` executable.
-    ///
-    /// - Parameters:
-    ///     - packagePath: The absolute path of the package root.
-    ///     - swiftCompiler: The absolute path of a `swiftc` executable.
-    ///         Its associated resources will be used by the loader.
-    ///     - kind: The kind of package.
+    // deprecated 3/21, remove once clients migrated over
+    @available(*, deprecated, message: "use loadRootPackage instead")
     public static func loadPackage(
         at path: AbsolutePath,
         kind: PackageReference.Kind = .root,
@@ -318,7 +319,49 @@ public final class PackageBuilder {
                                     identityResolver: identityResolver,
                                     on: queue) { result in
             let result = result.tryMap { manifest -> Package in
+                let identity = identityResolver.resolveIdentity(for: manifest.packageLocation)
                 let builder = PackageBuilder(
+                    identity: identity,
+                    manifest: manifest,
+                    productFilter: .everything,
+                    path: path,
+                    xcTestMinimumDeploymentTargets: xcTestMinimumDeploymentTargets,
+                    diagnostics: diagnostics)
+                return try builder.construct()
+            }
+            completion(result)
+        }
+    }
+
+    /// Loads a root package from a path using the resources associated with a particular `swiftc` executable.
+    ///
+    /// - Parameters:
+    ///   - at: The absolute path of the package root.
+    ///   - swiftCompiler: The absolute path of a `swiftc` executable. Its associated resources will be used by the loader.
+    ///   - identityResolver: A helper to resolve identities based on configuration
+    ///   - diagnostics: Optional.  The diagnostics engine.
+    ///   - on: The dispatch queue to perform asynchronous operations on.
+    ///   - completion: The completion handler .
+    public static func loadRootPackage(
+        at path: AbsolutePath,
+        swiftCompiler: AbsolutePath,
+        swiftCompilerFlags: [String],
+        xcTestMinimumDeploymentTargets: [PackageModel.Platform:PlatformVersion] = MinimumDeploymentTarget.default.xcTestMinimumDeploymentTargets,
+        identityResolver: IdentityResolver,
+        diagnostics: DiagnosticsEngine,
+        on queue: DispatchQueue,
+        completion: @escaping (Result<Package, Error>) -> Void
+    ) {
+        ManifestLoader.loadRootManifest(at: path,
+                                        swiftCompiler: swiftCompiler,
+                                        swiftCompilerFlags: swiftCompilerFlags,
+                                        identityResolver: identityResolver,
+                                        diagnostics: diagnostics,
+                                        on: queue) { result in
+            let result = result.tryMap { manifest -> Package in
+                let identity = identityResolver.resolveIdentity(for: manifest.packageLocation)
+                let builder = PackageBuilder(
+                    identity: identity,
                     manifest: manifest,
                     productFilter: .everything,
                     path: path,
@@ -332,23 +375,24 @@ public final class PackageBuilder {
 
     /// Build a new package following the conventions.
     public func construct() throws -> Package {
-        let targets = try constructTargets()
-        let products = try constructProducts(targets)
+        let targets = try self.constructTargets()
+        let products = try self.constructProducts(targets)
         // Find the special directory for targets.
         let targetSpecialDirs = findTargetSpecialDirs(targets)
 
         return Package(
-            manifest: manifest,
-            path: packagePath,
+            identity: self.identity,
+            manifest: self.manifest,
+            path: self.packagePath,
             targets: targets,
             products: products,
-            targetSearchPath: packagePath.appending(component: targetSpecialDirs.targetDir),
-            testTargetSearchPath: packagePath.appending(component: targetSpecialDirs.testTargetDir)
+            targetSearchPath: self.packagePath.appending(component: targetSpecialDirs.targetDir),
+            testTargetSearchPath: self.packagePath.appending(component: targetSpecialDirs.testTargetDir)
         )
     }
 
-    private func diagnosticLocation() -> DiagnosticLocation {
-        return PackageLocation.Local(name: manifest.name, packagePath: packagePath)
+    private var diagnosticLocation: DiagnosticLocation {
+        return PackageLocation.Local(name: self.manifest.name, packagePath: self.packagePath)
     }
 
     /// Computes the special directory where targets are present or should be placed in future.
@@ -395,7 +439,7 @@ public final class PackageBuilder {
 
             // Diagnose broken symlinks.
             if fileSystem.isSymlink(path) {
-                diagnostics.emit(.brokenSymlink(path), location: diagnosticLocation())
+                diagnostics.emit(.brokenSymlink(path), location: self.diagnosticLocation)
             }
 
             return false
@@ -448,24 +492,26 @@ public final class PackageBuilder {
             if !manifest.targets.isEmpty {
                 diagnostics.emit(
                     .systemPackageDeclaresTargets(targets: Array(manifest.targets.map({ $0.name }))),
-                    location: diagnosticLocation()
+                    location: self.diagnosticLocation
                 )
             }
 
             // Emit deprecation notice.
             if manifest.toolsVersion >= .v4_2 {
-                diagnostics.emit(.systemPackageDeprecation, location: diagnosticLocation())
+                diagnostics.emit(.systemPackageDeprecation, location: self.diagnosticLocation)
             }
 
             // Package contains a modulemap at the top level, so we assuming
             // it's a system library target.
             return [
                 SystemLibraryTarget(
-                    name: manifest.name,
+                    name: self.manifest.name,
                     platforms: self.platforms(),
-                    path: packagePath, isImplicit: true,
-                    pkgConfig: manifest.pkgConfig,
-                    providers: manifest.providers)
+                    path: self.packagePath,
+                    isImplicit: true,
+                    pkgConfig: self.manifest.pkgConfig,
+                    providers: self.manifest.providers
+                )
             ]
         }
 
@@ -473,12 +519,12 @@ public final class PackageBuilder {
         // system target specific configuration.
         guard manifest.pkgConfig == nil else {
             throw ModuleError.invalidManifestConfig(
-                manifest.name, "the 'pkgConfig' property can only be used with a System Module Package")
+                self.manifest.name, "the 'pkgConfig' property can only be used with a System Module Package")
         }
 
         guard manifest.providers == nil else {
             throw ModuleError.invalidManifestConfig(
-                manifest.name, "the 'providers' property can only be used with a System Module Package")
+                self.manifest.name, "the 'providers' property can only be used with a System Module Package")
         }
 
         return try constructV4Targets()
@@ -537,7 +583,7 @@ public final class PackageBuilder {
                 let path = packagePath.appending(relativeSubPath)
                 // Make sure the target is inside the package root.
                 guard path.contains(packagePath) else {
-                    throw ModuleError.targetOutsidePackage(package: manifest.name, target: target.name)
+                    throw ModuleError.targetOutsidePackage(package: self.manifest.name, target: target.name)
                 }
                 if fileSystem.isDirectory(path) {
                     return path
@@ -562,7 +608,7 @@ public final class PackageBuilder {
 
             // Otherwise, if the path "exists" then the case in manifest differs from the case on the file system.
             if fileSystem.isDirectory(path) {
-                diagnostics.emit(.targetNameHasIncorrectCase(target: target.name), location: diagnosticLocation())
+                diagnostics.emit(.targetNameHasIncorrectCase(target: target.name), location: self.diagnosticLocation)
                 return path
             }
             throw ModuleError.moduleNotFound(target.name, target.type)
@@ -767,15 +813,15 @@ public final class PackageBuilder {
         }
 
         let sourcesBuilder = TargetSourcesBuilder(
-            packageName: manifest.name,
-            packagePath: packagePath,
+            packageName: self.manifest.name,
+            packagePath: self.packagePath,
             target: manifestTarget,
             path: potentialModule.path,
-            defaultLocalization: manifest.defaultLocalization,
-            additionalFileRules: additionalFileRules,
-            toolsVersion: manifest.toolsVersion,
-            fs: fileSystem,
-            diags: diagnostics
+            defaultLocalization: self.manifest.defaultLocalization,
+            additionalFileRules: self.additionalFileRules,
+            toolsVersion: self.manifest.toolsVersion,
+            fs: self.fileSystem,
+            diags: self.diagnostics
         )
         let (sources, resources, headers, others) = try sourcesBuilder.run()
 
@@ -786,7 +832,7 @@ public final class PackageBuilder {
         }
 
         // The name of the bundle, if one is being generated.
-        let bundleName = resources.isEmpty ? nil : manifest.name + "_" + potentialModule.name
+        let bundleName = resources.isEmpty ? nil : self.manifest.name + "_" + potentialModule.name
 
         if sources.relativePaths.isEmpty && resources.isEmpty {
             return nil
@@ -1116,7 +1162,7 @@ public final class PackageBuilder {
         // It is an error if there are multiple linux main files.
         if testManifestFiles.count > 1 {
             throw ModuleError.multipleTestManifestFilesFound(
-                package: manifest.name, files: testManifestFiles.map({ $0 }))
+                package: self.manifest.name, files: testManifestFiles.map({ $0 }))
         }
         return testManifestFiles.first
     }
@@ -1131,7 +1177,7 @@ public final class PackageBuilder {
             if !inserted {
                 diagnostics.emit(
                     .duplicateProduct(product: product),
-                    location: diagnosticLocation()
+                    location: self.diagnosticLocation
                 )
             }
         }
@@ -1201,7 +1247,7 @@ public final class PackageBuilder {
                 if product.type != .library(.automatic) || targets.count != 1 {
                     self.diagnostics.emit(
                         .systemPackageProductValidation(product: product.name),
-                        location: self.diagnosticLocation()
+                        location: self.diagnosticLocation
                     )
                     continue
                 }
@@ -1269,11 +1315,11 @@ public final class PackageBuilder {
             if libraryTargets.isEmpty {
                 self.diagnostics.emit(
                     .noLibraryTargetsForREPL,
-                    location: self.diagnosticLocation()
+                    location: self.diagnosticLocation
                 )
             } else {
                 let replProduct = Product(
-                    name: manifest.name + Product.replProductSuffix,
+                    name: self.manifest.name + Product.replProductSuffix,
                     type: .library(.dynamic),
                     targets: libraryTargets
                 )
@@ -1291,18 +1337,18 @@ public final class PackageBuilder {
                 if let target = targets.spm_only {
                     diagnostics.emit(
                         .executableProductTargetNotExecutable(product: product.name, target: target.name),
-                        location: diagnosticLocation()
+                        location: self.diagnosticLocation
                     )
                 } else {
                     diagnostics.emit(
                         .executableProductWithoutExecutableTarget(product: product.name),
-                        location: diagnosticLocation()
+                        location: self.diagnosticLocation
                     )
                 }
             } else {
                 diagnostics.emit(
                     .executableProductWithMoreThanOneExecutableTarget(product: product.name),
-                    location: diagnosticLocation()
+                    location: self.diagnosticLocation
                 )
             }
 
@@ -1317,14 +1363,14 @@ public final class PackageBuilder {
         guard nonPluginTargets.isEmpty else {
             diagnostics.emit(
                 .pluginProductWithNonPluginTargets(product: product.name, otherTargets: nonPluginTargets.map{ $0.name }),
-                location: diagnosticLocation()
+                location: self.diagnosticLocation
             )
             return false
         }
         guard !targets.isEmpty else {
             diagnostics.emit(
                 .pluginProductWithNoTargets(product: product.name),
-                location: diagnosticLocation()
+                location: self.diagnosticLocation
             )
             return false
         }

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -25,6 +25,7 @@ public final class Manifest: ObjectIdentifierProtocol {
 
     /// FIXME: deprecate this, there is no value in this once we have real package identifiers
     /// The name of the package.
+    //@available(*, deprecated)
     public let name: String
 
     // FIXME: deprecate this, this is not part of the manifest information, we just use it as a container for this data
@@ -32,6 +33,7 @@ public final class Manifest: ObjectIdentifierProtocol {
     // to the repository state, it shouldn't matter where it is.
     //
     /// The path of the manifest file.
+    //@available(*, deprecated)
     public let path: AbsolutePath
 
     // FIXME: deprecate this, this is not part of the manifest information, we just use it as a container for this data
@@ -42,7 +44,7 @@ public final class Manifest: ObjectIdentifierProtocol {
     public let packageLocation: String
 
     // FIXME: deprecated 2/2021, remove once clients migrate
-    @available(*, deprecated)
+    @available(*, deprecated, message: "use packageLocation instead")
     public var url: String {
         get {
             self.packageLocation
@@ -363,7 +365,7 @@ public final class Manifest: ObjectIdentifierProtocol {
 
 extension Manifest: CustomStringConvertible {
     public var description: String {
-        return "<Manifest: \(name)>"
+        return "<Manifest: \(self.name)>"
     }
 }
 
@@ -381,7 +383,7 @@ extension Manifest: Encodable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(name, forKey: .name)
+        try container.encode(self.name, forKey: .name)
 
         // Hide the keys that users shouldn't see when
         // we're encoding for the dump-package command.

--- a/Sources/PackageModel/Package.swift
+++ b/Sources/PackageModel/Package.swift
@@ -43,6 +43,9 @@ import TSCUtility
 /// loaded. There is not currently a data structure for this, but it is the
 /// result after `PackageLoading.transmute()`.
 public final class Package: ObjectIdentifierProtocol, Encodable {
+    /// The identity of the package.
+    public let identity: PackageIdentity
+
     /// The manifest describing the package.
     public let manifest: Manifest
 
@@ -50,7 +53,14 @@ public final class Package: ObjectIdentifierProtocol, Encodable {
     public let path: AbsolutePath
 
     /// The name of the package.
+    @available(*, deprecated, message: "use identity (or manifestName, but only if you must) instead")
     public var name: String {
+        return self.manifestName
+    }
+
+    /// The name of the package as entered in the manifest.
+    /// This should rarely be used beyond presentation purposes
+    public var manifestName: String {
         return manifest.name
     }
 
@@ -72,6 +82,7 @@ public final class Package: ObjectIdentifierProtocol, Encodable {
     public let testTargetSearchPath: AbsolutePath
 
     public init(
+        identity: PackageIdentity,
         manifest: Manifest,
         path: AbsolutePath,
         targets: [Target],
@@ -79,6 +90,7 @@ public final class Package: ObjectIdentifierProtocol, Encodable {
         targetSearchPath: AbsolutePath,
         testTargetSearchPath: AbsolutePath
     ) {
+        self.identity = identity
         self.manifest = manifest
         self.path = path
         self._targets = .init(wrappedValue: targets)
@@ -92,9 +104,15 @@ public final class Package: ObjectIdentifierProtocol, Encodable {
     }
 }
 
+extension Package {
+    public var diagnosticLocation: DiagnosticLocation {
+        return PackageLocation.Local(name: self.manifest.name, packagePath: self.path)
+    }
+}
+
 extension Package: CustomStringConvertible {
     public var description: String {
-        return name
+        return self.identity.description
     }
 }
 

--- a/Sources/PackageModel/PackageIdentity.swift
+++ b/Sources/PackageModel/PackageIdentity.swift
@@ -35,21 +35,27 @@ public struct PackageIdentity: Hashable, CustomStringConvertible {
     public let description: String
 
     /// Creates a package identity from a string.
-    /// - Parameter string: A string used to identify a package.
-    init(_ string: String) {
-        self.description = Self.provider.init(string).description
+    /// - Parameter value: A string used to identify a package.
+    init(_ value: String) {
+        self.description = value
     }
 
     /// Creates a package identity from a URL.
     /// - Parameter url: The package's URL.
     public init(url: String) { // TODO: Migrate to Foundation.URL
-        self.init(url)
+        self.description = Self.provider.init(url).description
     }
 
     /// Creates a package identity from a file path.
     /// - Parameter path: An absolute path to the package.
     public init(path: AbsolutePath) {
-        self.init(path.pathString)
+        self.description = Self.provider.init(path.pathString).description
+    }
+
+    /// Creates a plain package identity for a root package
+    /// - Parameter value: A string used to identify a package, will be used unmodified
+    public static func plain(_ value: String) -> PackageIdentity {
+        PackageIdentity(value)
     }
 }
 

--- a/Sources/SPMBuildCore/BuiltTestProduct.swift
+++ b/Sources/SPMBuildCore/BuiltTestProduct.swift
@@ -12,10 +12,6 @@ import TSCBasic
 
 /// Represents a test product which is built and is present on disk.
 public struct BuiltTestProduct: Codable {
-
-    /// The name of the package to which the test binary belongs.
-    public let packageName: String
-
     /// The test product name.
     public let productName: String
 
@@ -35,11 +31,9 @@ public struct BuiltTestProduct: Codable {
 
     /// Creates a new instance.
     /// - Parameters:
-    ///   - packageName: The name of the package to which the test binary belongs.
     ///   - productName: The test product name.
     ///   - binaryPath: The path of the test binary.
-    public init(packageName: String, productName: String, binaryPath: AbsolutePath) {
-        self.packageName = packageName
+    public init(productName: String, binaryPath: AbsolutePath) {
         self.productName = productName
         self.binaryPath = binaryPath
     }

--- a/Sources/SPMBuildCore/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/PluginInvocation.swift
@@ -91,7 +91,7 @@ extension PackageGraph {
                 })
                 
                 // Give each invocation of a plugin a separate output directory.
-                let pluginOutputDir = outputDir.appending(components: package.name, target.name, pluginTarget.name)
+                let pluginOutputDir = outputDir.appending(components: package.identity.description, target.name, pluginTarget.name)
                 do {
                     try fileSystem.createDirectory(pluginOutputDir, recursive: true)
                 }

--- a/Sources/SPMTestSupport/MockManifestLoader.swift
+++ b/Sources/SPMTestSupport/MockManifestLoader.swift
@@ -50,6 +50,7 @@ public final class MockManifestLoader: ManifestLoaderProtocol {
 
     public func load(
         at path: TSCBasic.AbsolutePath,
+        packageIdentity: PackageIdentity,
         packageKind: PackageReference.Kind,
         packageLocation: String,
         version: Version?,
@@ -86,7 +87,9 @@ extension ManifestLoader {
         diagnostics: TSCBasic.DiagnosticsEngine? = nil
     ) throws -> Manifest{
         try tsc_await {
+            // FIXME: take identity?
             self.load(at: path,
+                      packageIdentity: identityResolver.resolveIdentity(for: packageLocation),
                       packageKind: packageKind,
                       packageLocation: packageLocation,
                       version: nil,

--- a/Sources/SPMTestSupport/PackageGraphTester.swift
+++ b/Sources/SPMTestSupport/PackageGraphTester.swift
@@ -25,11 +25,11 @@ public final class PackageGraphResult {
     }
 
     public func check(roots: String..., file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(graph.rootPackages.map{$0.name}.sorted(), roots.sorted(), file: file, line: line)
+        XCTAssertEqual(graph.rootPackages.map{$0.manifestName}.sorted(), roots.sorted(), file: file, line: line)
     }
 
     public func check(packages: String..., file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(graph.packages.map {$0.name}.sorted(), packages.sorted(), file: file, line: line)
+        XCTAssertEqual(graph.packages.map {$0.manifestName}.sorted(), packages.sorted(), file: file, line: line)
     }
 
     public func check(targets: String..., file: StaticString = #file, line: UInt = #line) {

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -230,9 +230,9 @@ public func loadPackageGraph(
     createREPLProduct: Bool = false,
     useXCBuildFileRules: Bool = false
 ) throws -> PackageGraph {
-    let rootManifests = manifests.filter { $0.packageKind == .root }
+    let rootManifests = manifests.filter { $0.packageKind == .root }.spm_createDictionary{ ($0.path, $0) }
     let externalManifests = manifests.filter { $0.packageKind != .root }
-    let packages = rootManifests.map { $0.path }
+    let packages = Array(rootManifests.keys)
     let input = PackageGraphRootInput(packages: packages)
     let graphRoot = PackageGraphRoot(input: input, manifests: rootManifests, explicitProduct: explicitProduct)
 

--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -76,6 +76,10 @@ public final class ManagedDependency {
     /// unedit a package.
     public internal(set) var basedOn: ManagedDependency?
 
+    public var packageIdentity: PackageIdentity {
+        self.packageRef.identity
+    }
+
     public init(
         packageRef: PackageReference,
         subpath: RelativePath,

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -38,21 +38,16 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
     /// The managed manifests to make available to the resolver.
     let dependencyManifests: Workspace.DependencyManifests
 
-    /// The identity resolver
-    let identityResolver: IdentityResolver
-
     /// The tools version currently in use.
     let currentToolsVersion: ToolsVersion
 
     init(
         root: PackageGraphRoot,
         dependencyManifests: Workspace.DependencyManifests,
-        identityResolver: IdentityResolver,
         currentToolsVersion: ToolsVersion = ToolsVersion.currentToolsVersion
     ) {
         self.root = root
         self.dependencyManifests = dependencyManifests
-        self.identityResolver = identityResolver
         self.currentToolsVersion = currentToolsVersion
     }
 
@@ -69,20 +64,17 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
                     package: package,
                     manifest: manifest.manifest,
                     dependency: manifest.dependency,
-                    identityResolver: self.identityResolver,
                     currentToolsVersion: self.currentToolsVersion
                 )
                 return completion(.success(container))
             }
 
             // Continue searching from the Workspace's root manifests.
-            // FIXME: We might want to use a dictionary for faster lookups.
-            if let index = self.dependencyManifests.root.packageRefs.firstIndex(of: package) {
+            if let rootPackage = self.dependencyManifests.root.packages[package.identity] {
                 let container = LocalPackageContainer(
                     package: package,
-                    manifest: self.dependencyManifests.root.manifests[index],
+                    manifest: rootPackage.manifest,
                     dependency: nil,
-                    identityResolver: self.identityResolver,
                     currentToolsVersion: self.currentToolsVersion
                 )
 
@@ -100,7 +92,6 @@ private struct LocalPackageContainer: PackageContainer {
     let manifest: Manifest
     /// The managed dependency if the package is not a root package.
     let dependency: ManagedDependency?
-    let identityResolver: IdentityResolver
     let currentToolsVersion: ToolsVersion
 
     func versionsAscending() throws -> [Version] {
@@ -167,8 +158,7 @@ private struct LocalPackageContainer: PackageContainer {
         if let packageRef = dependency?.packageRef {
             return packageRef
         } else {
-            let identity = self.identityResolver.resolveIdentity(for: manifest.packageLocation)
-            return .root(identity: identity, path: manifest.path)
+            return .root(identity: self.package.identity, path: self.manifest.path)
         }
     }
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -339,7 +339,8 @@ public class Workspace {
         forRootPackage packagePath: AbsolutePath,
         manifestLoader: ManifestLoaderProtocol,
         repositoryManager: RepositoryManager? = nil,
-        delegate: WorkspaceDelegate? = nil
+        delegate: WorkspaceDelegate? = nil,
+        identityResolver: IdentityResolver? = nil
     ) -> Workspace {
         return Workspace(
             dataPath: packagePath.appending(component: ".build"),
@@ -347,7 +348,8 @@ public class Workspace {
             pinsFile: packagePath.appending(component: "Package.resolved"),
             manifestLoader: manifestLoader,
             repositoryManager: repositoryManager,
-            delegate: delegate
+            delegate: delegate,
+            identityResolver: identityResolver
         )
     }
 }
@@ -497,7 +499,7 @@ extension Workspace {
         }
     }
 
-    /// Cleans the build artefacts from workspace data.
+    /// Cleans the build artifacts from workspace data.
     ///
     /// - Parameters:
     ///     - diagnostics: The diagnostics engine that reports errors, warnings
@@ -618,12 +620,9 @@ extension Workspace {
         return nil
     }
 
-    /// Loads a package graph from a root package using the resources associated with a particular `swiftc` executable.
-    ///
-    /// - Parameters:
-    ///     - packagePath: The absolute path of the root package.
-    ///     - swiftCompiler: The absolute path of a `swiftc` executable.
-    ///         Its associated resources will be used by the loader.
+
+    // deprecated 3/21, remove once clients migrated over
+    @available(*, deprecated, message: "use loadRootPackage instead")
     public static func loadGraph(
         packagePath: AbsolutePath,
         swiftCompiler: AbsolutePath,
@@ -631,9 +630,28 @@ extension Workspace {
         identityResolver: IdentityResolver,
         diagnostics: DiagnosticsEngine
     ) throws -> PackageGraph {
+        return try Self.loadRootGraph(at: packagePath, swiftCompiler: swiftCompiler, swiftCompilerFlags: swiftCompilerFlags, identityResolver: identityResolver, diagnostics: diagnostics)
+    }
+
+    /// Loads a package graph from a root package using the resources associated with a particular `swiftc` executable.
+    ///
+    /// - Parameters:
+    ///   - at: The absolute path of the root package.
+    ///   - swiftCompiler: The absolute path of a `swiftc` executable. Its associated resources will be used by the loader.
+    ///   - identityResolver: A helper to resolve identities based on configuration
+    ///   - diagnostics: Optional.  The diagnostics engine.
+    ///   - on: The dispatch queue to perform asynchronous operations on.
+    ///   - completion: The completion handler .
+    public static func loadRootGraph(
+        at packagePath: AbsolutePath,
+        swiftCompiler: AbsolutePath,
+        swiftCompilerFlags: [String],
+        identityResolver: IdentityResolver? = nil,
+        diagnostics: DiagnosticsEngine
+    ) throws -> PackageGraph {
         let resources = try UserManifestResources(swiftCompiler: swiftCompiler, swiftCompilerFlags: swiftCompilerFlags)
         let loader = ManifestLoader(manifestResources: resources)
-        let workspace = Workspace.create(forRootPackage: packagePath, manifestLoader: loader)
+        let workspace = Workspace.create(forRootPackage: packagePath, manifestLoader: loader, identityResolver: identityResolver)
         return try workspace.loadPackageGraph(rootPath: packagePath, diagnostics: diagnostics)
     }
 
@@ -719,18 +737,19 @@ extension Workspace {
     public func loadRootManifests(
         packages: [AbsolutePath],
         diagnostics: DiagnosticsEngine,
-        completion: @escaping(Result<[Manifest], Error>) -> Void
+        completion: @escaping(Result<[AbsolutePath: Manifest], Error>) -> Void
     ) {
         let lock = Lock()
         let sync = DispatchGroup()
-        var rootManifests = [Manifest]()
+        var rootManifests = [AbsolutePath: Manifest]()
         Set(packages).forEach { package in
             sync.enter()
-            self.loadManifest(packagePath: package, packageLocation: package.pathString, packageKind: .root, diagnostics: diagnostics) { result in
+            // TODO: this does not use the identity resolver which is probably fine since its the root packages
+            self.loadManifest(packageIdentity: PackageIdentity(path: package), packageKind: .root, packagePath: package, packageLocation: package.pathString, diagnostics: diagnostics) { result in
                 defer { sync.leave() }
                 if case .success(let manifest) = result {
                     lock.withLock {
-                        rootManifests.append(manifest)
+                        rootManifests[package] = manifest
                     }
                 }
             }
@@ -738,11 +757,11 @@ extension Workspace {
 
         sync.notify(queue: .sharedConcurrent) {
             // Check for duplicate root packages.
-            let duplicateRoots = rootManifests.spm_findDuplicateElements(by: \.name)
+            let duplicateRoots = rootManifests.values.spm_findDuplicateElements(by: \.name)
             if !duplicateRoots.isEmpty {
                 let name = duplicateRoots[0][0].name
                 diagnostics.emit(error: "found multiple top-level packages named '\(name)'")
-                return completion(.success([]))
+                return completion(.success([:]))
             }
 
             completion(.success(rootManifests))
@@ -820,9 +839,10 @@ extension Workspace {
         if fileSystem.exists(destination) {
             // FIXME: this should not block
             let manifest = try temp_await {
-                self.loadManifest(packagePath: destination,
-                                  packageLocation: dependency.packageRef.repository.url,
+                self.loadManifest(packageIdentity: dependency.packageRef.identity,
                                   packageKind: .local,
+                                  packagePath: destination,
+                                  packageLocation: dependency.packageRef.repository.url,
                                   diagnostics: diagnostics,
                                   completion: $0)
             }
@@ -1068,28 +1088,27 @@ extension Workspace {
             }
 
             // Root packages are always allowed to use unsafe flags.
-            result.formUnion(root.packageRefs)
+            result.formUnion(root.packageReferences)
 
             return result
         }
 
         func computePackageURLs() -> (required: Set<PackageReference>, missing: Set<PackageReference>) {
             let manifestsMap: [PackageIdentity: Manifest] = Dictionary(uniqueKeysWithValues:
-                self.root.manifests.map { (workspace.identityResolver.resolveIdentity(for: $0.packageLocation), $0) } +
-                self.dependencies.map { (workspace.identityResolver.resolveIdentity(for: $0.manifest.packageLocation), $0.manifest) })
+                self.root.packages.map { ($0.key, $0.value.manifest) } +
+                self.dependencies.map { ($0.dependency.packageIdentity, $0.manifest) }
+            )
 
             var inputIdentities: Set<PackageReference> = []
-            let inputNodes: [GraphLoadingNode] = self.root.manifests.map{ manifest in
-                let identity = workspace.identityResolver.resolveIdentity(for: manifest.packageLocation)
-                let package = PackageReference(identity: identity, kind: manifest.packageKind, location: manifest.packageLocation)
-                inputIdentities.insert(package)
-                let node = GraphLoadingNode(manifest: manifest, productFilter: .everything)
+            let inputNodes: [GraphLoadingNode] = self.root.packages.map{ identity, package in
+                inputIdentities.insert(package.reference)
+                let node = GraphLoadingNode(identity: identity, manifest: package.manifest, productFilter: .everything)
                 return node
             } + self.root.dependencies.compactMap{ dependency in
                 let package = dependency.createPackageRef()
                 inputIdentities.insert(package)
                 return manifestsMap[dependency.identity].map { manifest in
-                    GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
+                    GraphLoadingNode(identity: dependency.identity, manifest: manifest, productFilter: dependency.productFilter)
                 }
             }
 
@@ -1100,7 +1119,7 @@ extension Workspace {
                     let package = dependency.createPackageRef()
                     requiredIdentities.insert(package)
                     return manifestsMap[dependency.identity].map { manifest in
-                        GraphLoadingNode(manifest: manifest, productFilter: dependency.productFilter)
+                        GraphLoadingNode(identity: dependency.identity, manifest: manifest, productFilter: dependency.productFilter)
                     }
                 }
             }
@@ -1235,12 +1254,18 @@ extension Workspace {
         root: PackageGraphRoot,
         diagnostics: DiagnosticsEngine
     ) throws -> DependencyManifests {
+        // Utility Just because a raw tuple cannot be hashable.
+        struct Key: Hashable {
+            let identity: PackageIdentity
+            let url: String
+            let productFilter: ProductFilter
+        }
 
         // Make a copy of dependencies as we might mutate them in the for loop.
         let dependenciesToCheck = Array(state.dependencies)
         // Remove any managed dependency which has become a root.
         for dependency in dependenciesToCheck {
-            if root.packageRefs.contains(dependency.packageRef) {
+            if root.packages.keys.contains(dependency.packageRef.identity) {
                 diagnostics.wrap {
                     try self.remove(package: dependency.packageRef)
                 }
@@ -1256,53 +1281,54 @@ extension Workspace {
         // optimization: preload in parallel
         let rootDependencyManifestsURLs = root.dependencies.map{ $0.location }
         let rootDependencyManifests = try temp_await { self.loadManifests(forURLs: rootDependencyManifestsURLs, diagnostics: diagnostics, completion: $0) }
+            .spm_createDictionary{ (self.identityResolver.resolveIdentity(for: $0.packageLocation), $0) }
 
-        let inputManifests = root.manifests + rootDependencyManifests
+        let inputManifests = root.manifests.merging(rootDependencyManifests, uniquingKeysWith: { lhs, rhs in
+            return lhs // prefer roots!
+        })
 
-        // Map of loaded manifests. We do this to avoid reloading the shared nodes.
-
-        // Compute the transitive closure of available dependencies.
-        struct URLAndFilter: Hashable { // Just because a raw tuple cannot be hashable.
-            let url: String
-            let productFilter: ProductFilter
-        }
-
+        // Create a map of loaded manifests. We do this to avoid reloading the shared nodes.
         // optimization: preload manifest we know about in parallel
         // note: loadManifest emits diagnostics in case it fails
-        let inputDependenciesURLs = inputManifests.map { $0.dependencies.map{ $0.location } }.flatMap { $0 }
-        var loadedManifests = try temp_await { self.loadManifests(forURLs: inputDependenciesURLs, diagnostics: diagnostics, completion: $0) }.spm_createDictionary{ ($0.packageLocation, $0) }
+        let inputManifestsDependenciesURLs = inputManifests.values.map { $0.dependencies.map{ $0.location } }.flatMap { $0 }
+        var loadedManifests = try temp_await { self.loadManifests(forURLs: inputManifestsDependenciesURLs, diagnostics: diagnostics, completion: $0) }.spm_createDictionary{ ($0.packageLocation, $0) } // FIXME: this should not block
 
-        // continue to load the rest of the manifest for this graph
-        let allManifestsWithPossibleDuplicates = try topologicalSort(inputManifests.map{ KeyedPair($0, key: URLAndFilter(url: $0.packageLocation, productFilter: .everything)) }) { node in
+        // Continue to load the rest of the manifest for this graph
+        // Compute the transitive closure of available dependencies.
+        let inputPairs = inputManifests.map { identity, manifest -> KeyedPair<Manifest, Key> in
+            let key = Key(identity: identity, url: manifest.packageLocation, productFilter: .everything)
+            return KeyedPair(manifest, key: key)
+        }
+
+        let allManifestsWithPossibleDuplicates = try topologicalSort(inputPairs) { pair in
             // optimization: preload manifest we know about in parallel
-            let dependenciesRequired = node.item.dependenciesRequired(for: node.key.productFilter)
+            let dependenciesRequired = pair.item.dependenciesRequired(for: pair.key.productFilter)
             let dependenciesRequiredURLs = dependenciesRequired.map{ $0.location }.filter { !loadedManifests.keys.contains($0) }
             // note: loadManifest emits diagnostics in case it fails
             let dependenciesRequiredManifests = try temp_await { self.loadManifests(forURLs: dependenciesRequiredURLs, diagnostics: diagnostics, completion: $0) }
             dependenciesRequiredManifests.forEach { loadedManifests[$0.packageLocation] = $0 }
-            return dependenciesRequired.compactMap{ dependency in
-                loadedManifests[dependency.location].flatMap { KeyedPair($0, key: URLAndFilter(url: $0.packageLocation, productFilter: dependency.productFilter)) }
+            return pair.item.dependenciesRequired(for: pair.key.productFilter).compactMap{ dependency in
+                loadedManifests[dependency.location].flatMap { KeyedPair($0, key: Key(identity: dependency.identity, url: $0.packageLocation, productFilter: dependency.productFilter)) }
             }
         }
 
         // remove duplicates of the same manifest (by identity)
         var deduplication = [PackageIdentity: Int]()
         var allManifests = [(manifest: Manifest, productFilter: ProductFilter)]()
-        for node in allManifestsWithPossibleDuplicates {
-            let identity = self.identityResolver.resolveIdentity(for: node.item.packageLocation)
-            if let index = deduplication[identity]  {
-                let productFilter = allManifests[index].productFilter.merge(node.key.productFilter)
-                allManifests[index] = (node.item, productFilter)
+        for pair in allManifestsWithPossibleDuplicates {
+            if let index = deduplication[pair.key.identity]  {
+                let productFilter = allManifests[index].productFilter.merge(pair.key.productFilter)
+                allManifests[index] = (pair.item, productFilter)
             } else {
-                deduplication[identity] = allManifests.count
-                allManifests.append((node.item, node.key.productFilter))
+                deduplication[pair.key.identity] = allManifests.count
+                allManifests.append((pair.item, pair.key.productFilter))
             }
         }
 
-        let dependencyManifests = allManifests.filter{ !root.manifests.contains($0.manifest) }
+        let dependencyManifests = allManifests.filter{ !root.manifests.values.contains($0.manifest) }
 
         // check for overrides attempts with same name but different path
-        let rootManifestsByName = root.manifests.spm_createDictionary{ ($0.name, $0) }
+        let rootManifestsByName = Array(root.manifests.values).spm_createDictionary{ ($0.name, $0) }
         dependencyManifests.forEach { manifest, _ in
             if let override = rootManifestsByName[manifest.name], override.packageLocation != manifest.packageLocation  {
                 diagnostics.emit(error: "unable to override package '\(manifest.name)' because its identity '\(PackageIdentity(url: manifest.packageLocation))' doesn't match override's identity (directory name) '\(PackageIdentity(url: override.packageLocation))'")
@@ -1342,10 +1368,11 @@ extension Workspace {
         let packagePath = path(to: managedDependency)
 
         // Load and return the manifest.
-        self.loadManifest(packagePath: packagePath,
+        self.loadManifest(packageIdentity: managedDependency.packageRef.identity,
+                          packageKind: packageKind,
+                          packagePath: packagePath,
                           packageLocation: managedDependency.packageRef.location,
                           version: version,
-                          packageKind: packageKind,
                           diagnostics: diagnostics) { result in
             // error is added to diagnostics in the function above
             completion(try? result.get())
@@ -1378,10 +1405,11 @@ extension Workspace {
     ///
     /// This is just a helper wrapper to the manifest loader.
     fileprivate func loadManifest(
+        packageIdentity: PackageIdentity,
+        packageKind: PackageReference.Kind,
         packagePath: AbsolutePath,
         packageLocation: String,
         version: Version? = nil,
-        packageKind: PackageReference.Kind,
         diagnostics: DiagnosticsEngine,
         completion: @escaping (Result<Manifest, Error>) -> Void
     ) {
@@ -1398,6 +1426,7 @@ extension Workspace {
 
                 // Load the manifest.
                 manifestLoader.load(at: packagePath,
+                                    packageIdentity: packageIdentity,
                                     packageKind: packageKind,
                                     packageLocation: packageLocation,
                                     version: version,
@@ -1526,14 +1555,14 @@ extension Workspace {
     }
 
     private func parseArtifacts(from manifests: DependencyManifests) throws -> (local: [ManagedArtifact], remote: [RemoteArtifact]) {
-        let packageAndManifests: [(PackageReference, Manifest)] =
-            zip(manifests.root.packageRefs, manifests.root.manifests) + // Root package and manifests.
+        let packageAndManifests: [(reference: PackageReference, manifest: Manifest)] =
+            manifests.root.packages.values + // Root package and manifests.
             manifests.dependencies.map({ manifest, managed, _ in (managed.packageRef, manifest) }) // Dependency package and manifests.
 
         var localArtifacts: [ManagedArtifact] = []
         var remoteArtifacts: [RemoteArtifact] = []
 
-        for (packageRef, manifest) in packageAndManifests {
+        for (packageReference, manifest) in packageAndManifests {
             for target in manifest.targets where target.type == .binary {
                 if let path = target.path {
                     // TODO: find a better way to get the base path (not via the manifest)
@@ -1541,14 +1570,14 @@ extension Workspace {
                     let absolutePath = manifest.path.parentDirectory.appending(RelativePath(path))
                     localArtifacts.append(
                         .local(
-                            packageRef: packageRef,
+                            packageRef: packageReference,
                             targetName: target.name,
                             path: absolutePath)
                     )
                 } else if let url = target.url.flatMap(URL.init(string:)), let checksum = target.checksum {
                     remoteArtifacts.append(
                         .init(
-                            packageRef: packageRef,
+                            packageRef: packageReference,
                             targetName: target.name,
                             url: url,
                             checksum: checksum)
@@ -1799,7 +1828,7 @@ extension Workspace {
         // Save state for local packages, if any.
         //
         // FIXME: This will only work for top-level local packages right now.
-        for rootManifest in rootManifests {
+        for rootManifest in rootManifests.values {
             let dependencies = rootManifest.dependencies.filter{ $0.isLocal }
             for localPackage in dependencies {
                 let package = localPackage.createPackageRef()
@@ -2005,16 +2034,11 @@ extension Workspace {
         let constraints =
             try root.constraints() +
             // Include constraints from the manifests in the graph root.
-            root.manifests.flatMap({ try $0.dependencyConstraints(productFilter: .everything) }) +
+            root.manifests.values.flatMap{ try $0.dependencyConstraints(productFilter: .everything) } +
             dependencyManifests.dependencyConstraints() +
             extraConstraints
 
-        let precomputationProvider = ResolverPrecomputationProvider(
-            root: root,
-            dependencyManifests: dependencyManifests,
-            identityResolver: self.identityResolver
-        )
-
+        let precomputationProvider = ResolverPrecomputationProvider(root: root, dependencyManifests: dependencyManifests)
         let resolver = PubgrubDependencyResolver(provider: precomputationProvider, pinsMap: pinsStore.pinsMap)
         let result = resolver.solve(constraints: constraints)
 
@@ -2187,7 +2211,7 @@ extension Workspace {
 
             case .unversioned:
                 // Ignore the root packages.
-                if root.packageRefs.contains(packageRef) {
+                if root.packages.keys.contains(packageRef.identity) {
                     continue
                 }
 

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -106,7 +106,7 @@ public final class PIFBuilder {
         try memoize(to: &pif) {
             let rootPackage = graph.rootPackages[0]
 
-            let sortedPackages = graph.packages.sorted { $0.name < $1.name }
+            let sortedPackages = graph.packages.sorted { $0.manifestName < $1.manifestName } // TODO: use identity instead?
             var projects: [PIFProjectBuilder] = try sortedPackages.map { package in
                 try PackagePIFProjectBuilder(
                     package: package,
@@ -120,7 +120,7 @@ public final class PIFBuilder {
 
             let workspace = PIF.Workspace(
                 guid: "Workspace:\(rootPackage.path.pathString)",
-                name: rootPackage.name,
+                name: rootPackage.manifestName,  // TODO: use identity instead?
                 path: rootPackage.path,
                 projects: try projects.map { try $0.construct() }
             )
@@ -239,7 +239,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         super.init()
 
         guid = package.pifProjectGUID
-        name = package.name
+        name = package.manifestName // TODO: use identity instead?
         path = package.path
         projectDirectory = package.path
         developmentRegion = package.manifest.defaultLocalization ?? "en"
@@ -766,7 +766,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
             return nil
         }
 
-        let bundleName = "\(package.name)_\(target.name)"
+        let bundleName = "\(package.manifestName)_\(target.name)" // TODO: use identity instead?
         let resourcesTarget = addTarget(
             guid: target.pifResourceTargetGUID,
             name: bundleName,
@@ -784,7 +784,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         settings[.TARGET_NAME] = bundleName
         settings[.PRODUCT_NAME] = bundleName
         settings[.PRODUCT_MODULE_NAME] = bundleName
-        let bundleIdentifier = "\(package.name).\(target.name).resources".spm_mangledToBundleIdentifier()
+        let bundleIdentifier = "\(package.manifestName).\(target.name).resources".spm_mangledToBundleIdentifier() // TODO: use identity instead?
         settings[.PRODUCT_BUNDLE_IDENTIFIER] = bundleIdentifier
         settings[.GENERATE_INFOPLIST_FILE] = "YES"
         settings[.PACKAGE_RESOURCE_TARGET_KIND] = "resource"

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -41,11 +41,12 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         for package in graph.rootPackages {
             for product in package.products where product.type == .test {
                 let binaryPath = buildParameters.binaryPath(for: product)
-                builtProducts.append(BuiltTestProduct(
-                    packageName: package.name,
-                    productName: product.name,
-                    binaryPath: binaryPath
-                ))
+                builtProducts.append(
+                    BuiltTestProduct(
+                        productName: product.name,
+                        binaryPath: binaryPath
+                    )
+                )
             }
         }
 

--- a/Sources/Xcodeproj/SchemesGenerator.swift
+++ b/Sources/Xcodeproj/SchemesGenerator.swift
@@ -86,7 +86,7 @@ public final class SchemesGenerator {
             }
         })
         schemes.append(Scheme(
-            name: rootPackage.name + "-Package",
+            name: rootPackage.manifestName + "-Package", // TODO: use identity instead?
             regularTargets: regularTargets,
             testTargets: rootPackage.targets.filter({ $0.type == .test })
         ))

--- a/Sources/Xcodeproj/generate.swift
+++ b/Sources/Xcodeproj/generate.swift
@@ -226,7 +226,7 @@ func generateSchemes(
         // tests associated so testing works. We suffix the name of this scheme with
         // -Package so its name doesn't collide with any products or target with
         // same name.
-        let schemeName = "\(graph.rootPackages[0].name)-Package.xcscheme"
+        let schemeName = "\(graph.rootPackages[0].manifestName)-Package.xcscheme" // TODO: use identity instead?
         try open(schemesDir.appending(RelativePath(schemeName))) { stream in
             legacySchemeGenerator(
                 container: schemeContainer,

--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -73,8 +73,8 @@ public func xcodeProject(
         guard let manifestLoader = options.manifestLoader else { return }
 
         let pdTarget = project.addTarget(
-            objectID: "\(package.name)::SwiftPMPackageDescription",
-            productType: .framework, name: "\(package.name)PackageDescription")
+            objectID: "\(package.manifestName)::SwiftPMPackageDescription", // TODO: use identity instead?
+            productType: .framework, name: "\(package.manifestName)PackageDescription") // TODO: use identity instead?
         let compilePhase = pdTarget.addSourcesBuildPhase()
         compilePhase.addBuildFile(fileRef: manifestFileRef)
 
@@ -334,8 +334,9 @@ public func xcodeProject(
             if targetSet.intersection(package.targets).isEmpty {
                 continue
             }
+            // TODO: use identity instead
             // Construct a group name from the package name and optional version.
-            var groupName = package.name
+            var groupName = package.manifestName // TODO: use identity instead?
             if let version = package.manifest.version {
                 groupName += " " + version.description
             }
@@ -404,7 +405,7 @@ public func xcodeProject(
         // Create a Xcode target for the target.
         let package = packagesByTarget[target]!
         let xcodeTarget = project.addTarget(
-            objectID: "\(package.name)::\(target.name)",
+            objectID: "\(package.manifestName)::\(target.name)", // TODO: use identity instead?
             productType: productType, name: target.name)
 
         // Set the product name to the C99-mangled form of the target name.
@@ -519,8 +520,9 @@ public func xcodeProject(
         // Add framework search path to build settings.
         targetSettings.common.FRAMEWORK_SEARCH_PATHS = ["$(inherited)", "$(PLATFORM_DIR)/Developer/Library/Frameworks"]
 
+        // TODO: use identity instead
         // Add a file reference for the target's product.
-        let productRef = productsGroup.addFileReference(path: target.productPath.pathString, pathBase: .buildDir, objectID: "\(package.name)::\(target.name)::Product")
+        let productRef = productsGroup.addFileReference(path: target.productPath.pathString, pathBase: .buildDir, objectID: "\(package.manifestName)::\(target.name)::Product")
 
         // Set that file reference as the target's product reference.
         xcodeTarget.productReference = productRef
@@ -686,10 +688,10 @@ public func xcodeProject(
     for product in graph.reachableProducts {
         // Go on to next product if we already have a target with the same name.
         if targetNames.contains(product.name) { continue }
-        // Otherwise, create an aggreate target.
+        // Otherwise, create an aggregate target.
         let package = packagesByProduct[product]!
         let aggregateTarget = project.addTarget(
-            objectID: "\(package.name)::\(product.name)::ProductTarget",
+            objectID: "\(package.manifestName)::\(product.name)::ProductTarget", // TODO: use identity instead?
             productType: nil, name: product.name)
         // Add dependencies on the targets created for each of the dependencies.
         for target in product.targets {

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -461,10 +461,10 @@ final class PackageToolTests: XCTestCase {
         }
         
         let expectedLines: [Substring] = [
-            #""/PackageA" [label="PackageA\n/PackageA\nunspecified"]"#,
-            #""/PackageB" [label="PackageB\n/PackageB\nunspecified"]"#,
-            #""/PackageC" [label="PackageC\n/PackageC\nunspecified"]"#,
-            #""/PackageD" [label="PackageD\n/PackageD\nunspecified"]"#,
+            #""/PackageA" [label="packagea\n/PackageA\nunspecified"]"#,
+            #""/PackageB" [label="packageb\n/PackageB\nunspecified"]"#,
+            #""/PackageC" [label="packagec\n/PackageC\nunspecified"]"#,
+            #""/PackageD" [label="packaged\n/PackageD\nunspecified"]"#,
             #""/PackageA" -> "/PackageB""#,
             #""/PackageA" -> "/PackageC""#,
             #""/PackageB" -> "/PackageC""#,

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -93,8 +93,8 @@ class DependencyResolutionTests: XCTestCase {
                 let output = try executeSwiftPackage(appPath, extraArgs: ["show-dependencies"])
                 XCTAssertTrue(output.stdout.contains("Cloning \(prefix.pathString)/Foo\n"), output.stdout)
                 XCTAssertTrue(output.stdout.contains("Cloning \(prefix.pathString)/Bar\n"), output.stdout)
-                XCTAssertTrue(output.stdout.contains("Foo<\(prefix.pathString)/Foo@unspecified"), output.stdout)
-                XCTAssertTrue(output.stdout.contains("Bar<\(prefix.pathString)/Bar@unspecified"), output.stdout)
+                XCTAssertTrue(output.stdout.contains("foo<\(prefix.pathString)/Foo@unspecified"), output.stdout)
+                XCTAssertTrue(output.stdout.contains("bar<\(prefix.pathString)/Bar@unspecified"), output.stdout)
 
                 let pins = try String(bytes: localFileSystem.readFileContents(appPinsPath).contents, encoding: .utf8)!
                 XCTAssertTrue(pins.contains("\"\(prefix.pathString)/Foo\""), pins)
@@ -119,9 +119,9 @@ class DependencyResolutionTests: XCTestCase {
                 XCTAssertTrue(output.stdout.contains("Cloning \(prefix.pathString)/BarMirror\n"), output.stdout)
                 XCTAssertFalse(output.stdout.contains("Cloning \(prefix.pathString)/Bar\n"), output.stdout)
 
-                XCTAssertTrue(output.stdout.contains("Foo<\(prefix.pathString)/Foo@unspecified"), output.stdout)
-                XCTAssertTrue(output.stdout.contains("Bar<\(prefix.pathString)/BarMirror@unspecified"), output.stdout)
-                XCTAssertFalse(output.stdout.contains("Bar<\(prefix.pathString)/Bar@unspecified"), output.stdout)
+                XCTAssertTrue(output.stdout.contains("foo<\(prefix.pathString)/Foo@unspecified"), output.stdout)
+                XCTAssertTrue(output.stdout.contains("barmirror<\(prefix.pathString)/BarMirror@unspecified"), output.stdout)
+                XCTAssertFalse(output.stdout.contains("bar<\(prefix.pathString)/Bar@unspecified"), output.stdout)
 
                 let pins = try String(bytes: localFileSystem.readFileContents(appPinsPath).contents, encoding: .utf8)!
                 XCTAssertTrue(pins.contains("\"\(prefix.pathString)/Foo\""), pins)

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -25,7 +25,7 @@ class PackageGraphPerfTests: XCTestCasePerf {
         let fs = InMemoryFileSystem(emptyFiles: files)
         
         var externalManifests = [Manifest]()
-        var rootManifests: [Manifest]!
+        var rootManifest: Manifest!
         for pkg in 1...N {
             let name = "Foo\(pkg)"
             let location = "/" + name
@@ -59,7 +59,7 @@ class PackageGraphPerfTests: XCTestCasePerf {
                 targets: targets
             )
             if isRoot {
-                rootManifests = [manifest]
+                rootManifest = manifest
             } else {
                 externalManifests.append(manifest)
             }
@@ -70,7 +70,7 @@ class PackageGraphPerfTests: XCTestCasePerf {
         measure {
             let diagnostics = DiagnosticsEngine()
             let g = try! PackageGraph.load(
-                root: PackageGraphRoot(input: PackageGraphRootInput(packages: rootManifests.map({$0.path})), manifests: rootManifests),
+                root: PackageGraphRoot(input: PackageGraphRootInput(packages: [rootManifest.path]), manifests: [rootManifest.path: rootManifest]),
                 identityResolver: identityResolver,
                 externalManifests: externalManifests,
                 diagnostics: diagnostics,

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -80,12 +80,12 @@ class PackageGraphTests: XCTestCase {
             result.checkTarget("Baz") { result in result.check(dependencies: "Bar") }
         }
 
-        let fooPackage = try XCTUnwrap(g.packages.first{ $0.name == "Foo" })
+        let fooPackage = try XCTUnwrap(g.packages.first{ $0.manifestName == "Foo" })
         let fooTarget = try XCTUnwrap(g.allTargets.first{ $0.name == "Foo" })
         let fooDepTarget = try XCTUnwrap(g.allTargets.first{ $0.name == "FooDep" })
         XCTAssert(g.package(for: fooTarget) == fooPackage)
         XCTAssert(g.package(for: fooDepTarget) == fooPackage)
-        let barPackage = try XCTUnwrap(g.packages.first{ $0.name == "Bar" })
+        let barPackage = try XCTUnwrap(g.packages.first{ $0.manifestName == "Bar" })
         let barTarget = try XCTUnwrap(g.allTargets.first{ $0.name == "Bar" })
         XCTAssert(g.package(for: barTarget) == barPackage)
     }
@@ -188,7 +188,9 @@ class PackageGraphTests: XCTestCase {
             ]
         )
 
-        XCTAssertEqual(diagnostics.diagnostics[0].description, "cyclic dependency declaration found: Foo -> Bar -> Baz -> Bar")
+        DiagnosticsEngineTester(diagnostics) { result in
+            result.check(diagnostic: "cyclic dependency declaration found: Foo -> Bar -> Baz -> Bar", behavior: .error)
+        }
     }
 
     func testCycle2() throws {
@@ -215,7 +217,9 @@ class PackageGraphTests: XCTestCase {
             ]
         )
 
-        XCTAssertEqual(diagnostics.diagnostics[0].description, "cyclic dependency declaration found: Foo -> Foo")
+        DiagnosticsEngineTester(diagnostics) { result in
+            result.check(diagnostic: "cyclic dependency declaration found: Foo -> Foo", behavior: .error)
+        }
     }
 
     // Make sure there is no error when we reference Test targets in a package and then
@@ -297,7 +301,9 @@ class PackageGraphTests: XCTestCase {
             ]
         )
 
-        XCTAssertEqual(diagnostics.diagnostics[0].description, "multiple targets named 'Bar' in: Bar, Foo")
+        DiagnosticsEngineTester(diagnostics) { result in
+            result.check(diagnostic: "multiple targets named 'Bar' in: 'bar', 'foo'", behavior: .error)
+        }
     }
 
     func testMultipleDuplicateModules() throws {
@@ -361,7 +367,7 @@ class PackageGraphTests: XCTestCase {
         )
 
         DiagnosticsEngineTester(diagnostics) { result in
-            result.check(diagnostic: "multiple targets named 'First' in: First, Fourth, Second, Third", behavior: .error)
+            result.check(diagnostic: "multiple targets named 'First' in: 'first', 'fourth', 'second', 'third'", behavior: .error)
         }
     }
 
@@ -426,8 +432,8 @@ class PackageGraphTests: XCTestCase {
         )
 
         DiagnosticsEngineTester(diagnostics) { result in
-            result.check(diagnostic: "multiple targets named 'Bar' in: Fourth, Third", behavior: .error)
-            result.check(diagnostic: "multiple targets named 'Foo' in: First, Second", behavior: .error)
+            result.check(diagnostic: "multiple targets named 'Bar' in: 'fourth', 'third'", behavior: .error)
+            result.check(diagnostic: "multiple targets named 'Foo' in: 'first', 'second'", behavior: .error)
         }
     }
 
@@ -499,7 +505,7 @@ class PackageGraphTests: XCTestCase {
         )
 
         DiagnosticsEngineTester(diagnostics) { result in
-            result.check(diagnostic: "multiple targets named 'First' in: First, Fourth", behavior: .error)
+            result.check(diagnostic: "multiple targets named 'First' in: 'first', 'fourth'", behavior: .error)
         }
     }
 
@@ -563,7 +569,7 @@ class PackageGraphTests: XCTestCase {
         )
 
         DiagnosticsEngineTester(diagnostics) { result in
-            result.check(diagnostic: "product 'Barx' not found. it is required by package 'Foo' target 'FooTarget'.", behavior: .error, location: "'Foo' /Foo")
+            result.check(diagnostic: "product 'Barx' required by package 'foo' target 'FooTarget' not found.", behavior: .error, location: "'Foo' /Foo")
         }
     }
 
@@ -589,7 +595,7 @@ class PackageGraphTests: XCTestCase {
         )
 
         DiagnosticsEngineTester(diagnostics) { result in
-            result.check(diagnostic: "product 'Barx' not found in package 'Bar'. it is required by package 'Foo' target 'FooTarget'.", behavior: .error, location: "'Foo' /Foo")
+            result.check(diagnostic: "product 'Barx' required by package 'foo' target 'FooTarget' not found in package 'Bar'.", behavior: .error, location: "'Foo' /Foo")
         }
     }
 
@@ -615,7 +621,7 @@ class PackageGraphTests: XCTestCase {
         )
 
         DiagnosticsEngineTester(diagnostics) { result in
-            result.check(diagnostic: "product 'Barx' not found. it is required by package 'Foo' target 'FooTarget'.", behavior: .error, location: "'Foo' /Foo")
+            result.check(diagnostic: "product 'Barx' required by package 'foo' target 'FooTarget' not found.", behavior: .error, location: "'Foo' /Foo")
         }
     }
 
@@ -807,9 +813,9 @@ class PackageGraphTests: XCTestCase {
         )
 
         DiagnosticsEngineTester(diagnostics) { result in
-            result.check(diagnostic: "dependency 'Baz' is not used by any target", behavior: .warning)
+            result.check(diagnostic: "dependency 'baz' is not used by any target", behavior: .warning)
             #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
-            result.check(diagnostic: "dependency 'Biz' is not used by any target", behavior: .warning)
+            result.check(diagnostic: "dependency 'biz' is not used by any target", behavior: .warning)
             #endif
         }
     }
@@ -901,7 +907,7 @@ class PackageGraphTests: XCTestCase {
         )
 
         DiagnosticsEngineTester(diagnostics) { result in
-            result.check(diagnostic: "multiple targets named 'Foo' in: Dep2, Start", behavior: .error)
+            result.check(diagnostic: "multiple targets named 'Foo' in: 'dep2', 'start'", behavior: .error)
         }
     }
 
@@ -952,7 +958,7 @@ class PackageGraphTests: XCTestCase {
             ]
         )
 
-        XCTAssertTrue(diagnostics.diagnostics.contains(where: { $0.description.contains("multiple products named 'Bar' in: Bar, Baz") }), "\(diagnostics.diagnostics)")
+        XCTAssertTrue(diagnostics.diagnostics.contains(where: { $0.description.contains("multiple products named 'Bar' in: 'bar', 'baz'") }), "\(diagnostics.diagnostics)")
     }
 
     func testUnsafeFlags() throws {
@@ -1061,7 +1067,7 @@ class PackageGraphTests: XCTestCase {
         DiagnosticsEngineTester(diagnostics, ignoreNotes: true) { result in
             result.check(
                 diagnostic: """
-                    'Foo' dependency on '/Bar' has an explicit name 'Baar' which does not match the name 'Bar' set for '/Bar'
+                    'foo' dependency on '/Bar' has an explicit name 'Baar' which does not match the name 'Bar' set for '/Bar'
                     """,
                 behavior: .error,
                 location: "'Foo' /Foo"
@@ -1351,7 +1357,7 @@ class PackageGraphTests: XCTestCase {
         DiagnosticsEngineTester(diagnostics, ignoreNotes: true) { result in
             result.check(
                 diagnostic: """
-                    product 'Unknown' not found. it is required by package 'Foo' target 'Foo'.
+                    product 'Unknown' required by package 'foo' target 'Foo' not found.
                     """,
                 behavior: .error,
                 location: "'Foo' /Foo"
@@ -1437,7 +1443,7 @@ class PackageGraphTests: XCTestCase {
         DiagnosticsEngineTester(diagnostics, ignoreNotes: true) { result in
             result.check(
                 diagnostic: """
-                    product 'Unknown' not found. it is required by package 'Foo' target 'Foo'.
+                    product 'Unknown' required by package 'foo' target 'Foo' not found.
                     """,
                 behavior: .error,
                 location: "'Foo' /Foo"
@@ -1844,7 +1850,7 @@ class PackageGraphTests: XCTestCase {
             DiagnosticsEngineTester(diagnostics, ignoreNotes: true) { result in
                 result.check(
                     diagnostic: """
-                        'Foo' dependency on '/Bar' has an explicit name 'Bar' which does not match the name 'Some-Bar' set for '/Bar'
+                        'foo' dependency on '/Bar' has an explicit name 'Bar' which does not match the name 'Some-Bar' set for '/Bar'
                         """,
                     behavior: .error,
                     location: "'Foo' /Foo"

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -760,6 +760,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             // warm up caches
             let manifest = try tsc_await { manifestLoader.load(at: manifestPath.parentDirectory,
+                                                               packageIdentity: .plain("Trivial"),
                                                                packageKind: .local,
                                                                packageLocation: manifestPath.pathString,
                                                                version: nil,
@@ -777,6 +778,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             for _ in 0 ..< total {
                 sync.enter()
                 manifestLoader.load(at: manifestPath.parentDirectory,
+                                    packageIdentity: .plain("Trivial"),
                                     packageKind: .local,
                                     packageLocation: manifestPath.pathString,
                                     version: nil,
@@ -840,6 +842,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
                 sync.enter()
                 manifestLoader.load(at: manifestPath.parentDirectory,
+                                    packageIdentity: .plain("Trivial-\(random)"),
                                     packageKind: .local,
                                     packageLocation: manifestPath.pathString,
                                     version: nil,

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -2243,6 +2243,7 @@ final class PackageBuilderTester {
         do {
             // FIXME: We should allow customizing root package boolean.
             let builder = PackageBuilder(
+                identity: PackageIdentity(url: manifest.packageLocation), // FIXME
                 manifest: manifest,
                 productFilter: .everything,
                 path: path,

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -25,6 +25,7 @@ class ManifestSourceGenerationTests: XCTestCase {
             let identityResolver = DefaultIdentityResolver()
             let manifest = try tsc_await {
                 manifestLoader.load(at: packageDir,
+                                    packageIdentity: .plain("Root"),
                                     packageKind: .root,
                                     packageLocation: packageDir.pathString,
                                     version: nil,
@@ -41,6 +42,7 @@ class ManifestSourceGenerationTests: XCTestCase {
             try fs.writeFileContents(packageDir.appending(component: Manifest.filename), bytes: ByteString(encodingAsUTF8: newContents))
             let newManifest = try tsc_await {
                 manifestLoader.load(at: packageDir,
+                                    packageIdentity: .plain("Root"),
                                     packageKind: .root,
                                     packageLocation: packageDir.pathString,
                                     version: nil,

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -404,7 +404,7 @@ final class WorkspaceTests: XCTestCase {
             packages: []
         )
 
-        workspace.checkPackageGraph(roots: ["Foo", "Nested/Foo"]) { _, diagnostics in
+        workspace.checkPackageGraphFailure(roots: ["Foo", "Nested/Foo"]) { diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(diagnostic: .equal("found multiple top-level packages named 'Foo'"), behavior: .error)
             }
@@ -2140,17 +2140,17 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkPackageGraph(roots: ["Foo"]) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
-        workspace.checkPackageGraph(roots: ["Bar"]) { _, diagnostics in
+        workspace.checkPackageGraphFailure(roots: ["Bar"]) { diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(diagnostic: .equal("package at '/tmp/ws/roots/Bar' is using Swift tools version 4.1.0 but the installed version is 4.0.0"), behavior: .error, location: "/tmp/ws/roots/Bar")
             }
         }
-        workspace.checkPackageGraph(roots: ["Foo", "Bar"]) { _, diagnostics in
+        workspace.checkPackageGraphFailure(roots: ["Foo", "Bar"]) { diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(diagnostic: .equal("package at '/tmp/ws/roots/Bar' is using Swift tools version 4.1.0 but the installed version is 4.0.0"), behavior: .error, location: "/tmp/ws/roots/Bar")
             }
         }
-        workspace.checkPackageGraph(roots: ["Baz"]) { _, diagnostics in
+        workspace.checkPackageGraphFailure(roots: ["Baz"]) { diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(diagnostic: .equal("package at '/tmp/ws/roots/Baz' is using Swift tools version 3.1.0 which is no longer supported; consider using '// swift-tools-version:4.0' to specify the current tools version"), behavior: .error, location: "/tmp/ws/roots/Baz")
             }
@@ -3788,28 +3788,31 @@ final class WorkspaceTests: XCTestCase {
         // From here the API should be simple and straightforward:
         let diagnostics = DiagnosticsEngine()
         let manifest = try tsc_await {
-            ManifestLoader.loadManifest(at: packagePath,
-                                        kind: .local,
-                                        swiftCompiler: swiftCompiler,
-                                        swiftCompilerFlags: [],
-                                        identityResolver: identityResolver,
-                                        on: .global(),
-                                        completion: $0)
+            ManifestLoader.loadRootManifest(
+                at: packagePath,
+                swiftCompiler: swiftCompiler,
+                swiftCompilerFlags: [],
+                identityResolver: identityResolver,
+                on: .global(),
+                completion: $0
+            )
         }
 
         let loadedPackage = try tsc_await {
-            PackageBuilder.loadPackage(at: packagePath,
-                                       swiftCompiler: swiftCompiler,
-                                       swiftCompilerFlags: [],
-                                       xcTestMinimumDeploymentTargets: [:],
-                                       identityResolver: identityResolver,
-                                       diagnostics: diagnostics,
-                                       on: .global(),
-                                       completion: $0)
+            PackageBuilder.loadRootPackage(
+                at: packagePath,
+                swiftCompiler: swiftCompiler,
+                swiftCompilerFlags: [],
+                xcTestMinimumDeploymentTargets: [:],
+                identityResolver: identityResolver,
+                diagnostics: diagnostics,
+                on: .global(),
+                completion: $0
+            )
         }
 
-        let graph = try Workspace.loadGraph(
-            packagePath: packagePath,
+        let graph = try Workspace.loadRootGraph(
+            at: packagePath,
             swiftCompiler: swiftCompiler,
             swiftCompilerFlags: [],
             identityResolver: identityResolver,
@@ -3817,7 +3820,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         XCTAssertEqual(manifest.name, "SwiftPM")
-        XCTAssertEqual(loadedPackage.name, "SwiftPM")
+        XCTAssertEqual(loadedPackage.manifestName, manifest.name)
         XCTAssert(graph.reachableProducts.contains(where: { $0.name == "SwiftPM" }))
     }
 
@@ -5619,7 +5622,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(
-                    diagnostic: "'Root' dependency on '/tmp/ws/pkgs/bar/utility' conflicts with dependency on '/tmp/ws/pkgs/foo/utility' which has the same identity 'utility'",
+                    diagnostic: "'root' dependency on '/tmp/ws/pkgs/bar/utility' conflicts with dependency on '/tmp/ws/pkgs/foo/utility' which has the same identity 'utility'",
                     behavior: .error,
                     location: "'Root' /tmp/ws/roots/Root"
                 )
@@ -5627,7 +5630,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
-    func testDuplicateExplicitDependencyNameAtRoot() throws {
+    func testDuplicateExplicitDependencyName_AtRoot() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
@@ -5681,7 +5684,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(
-                    diagnostic: "'Root' dependency on '/tmp/ws/pkgs/bar' conflicts with dependency on '/tmp/ws/pkgs/foo' which has the same explicit name 'FooPackage'",
+                    diagnostic: "'root' dependency on '/tmp/ws/pkgs/bar' conflicts with dependency on '/tmp/ws/pkgs/foo' which has the same explicit name 'FooPackage'",
                     behavior: .error,
                     location: "'Root' /tmp/ws/roots/Root"
                 )
@@ -5746,7 +5749,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
-    func testDuplicateManifestNameAtRoot_ExplicitTargetDependecy() throws {
+    func testDuplicateManifestName_ExplicitProductPackage_AtRoot() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
@@ -5803,7 +5806,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
-    func testExplicitDependencyNameAndManifestNameMismatchAtRoot() throws {
+    func testExplicitDependencyNam_ManifestNameMismatch_AtRoot() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
@@ -5856,12 +5859,12 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(
-                    diagnostic: "'Root' dependency on '/tmp/ws/pkgs/foo' has an explicit name 'MyPackage1' which does not match the name 'MyPackage' set for '/tmp/ws/pkgs/foo'",
+                    diagnostic: "'root' dependency on '/tmp/ws/pkgs/foo' has an explicit name 'MyPackage1' which does not match the name 'MyPackage' set for '/tmp/ws/pkgs/foo'",
                     behavior: .error,
                     location: "'Root' /tmp/ws/roots/Root"
                 )
                 result.check(
-                    diagnostic: "'Root' dependency on '/tmp/ws/pkgs/bar' has an explicit name 'MyPackage2' which does not match the name 'MyPackage' set for '/tmp/ws/pkgs/bar'",
+                    diagnostic: "'root' dependency on '/tmp/ws/pkgs/bar' has an explicit name 'MyPackage2' which does not match the name 'MyPackage' set for '/tmp/ws/pkgs/bar'",
                     behavior: .error,
                     location: "'Root' /tmp/ws/roots/Root"
                 )
@@ -5869,7 +5872,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
-    func testManifestNameAndIdentityConflictAtRoot_Pre52() throws {
+    func testManifestNameAndIdentityConflict_AtRoot_Pre52() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
@@ -5926,7 +5929,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
-    func testManifestNameAndIdentityConflictAtRoot_Post52_Incorrect() throws {
+    func testManifestNameAndIdentityConflict_AtRoot_Post52_Incorrect() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
@@ -5992,7 +5995,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
-    func testManifestNameAndIdentityConflictAtRoot_Post52_Correct() throws {
+    func testManifestNameAndIdentityConflict_AtRoot_Post52_Correct() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
@@ -6049,7 +6052,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
-    func testManifestNameAndIdentityConflictWithExplicitDependencyNamesAtRoot() throws {
+    func testManifestNameAndIdentityConflict_ExplicitDependencyNames_AtRoot() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
@@ -6061,8 +6064,8 @@ final class WorkspaceTests: XCTestCase {
                     name: "Root",
                     targets: [
                         MockTarget(name: "RootTarget", dependencies: [
-                            "FooPackage",
-                            "BarPackage"
+                            "FooProduct",
+                            "BarProduct"
                         ]),
                     ],
                     products: [],
@@ -6102,7 +6105,68 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(
-                    diagnostic: "'Root' dependency on '/tmp/ws/pkgs/bar' conflicts with dependency on '/tmp/ws/pkgs/foo' which has the same explicit name 'foo'",
+                    diagnostic: "'root' dependency on '/tmp/ws/pkgs/bar' conflicts with dependency on '/tmp/ws/pkgs/foo' which has the same explicit name 'foo'",
+                    behavior: .error,
+                    location: "'Root' /tmp/ws/roots/Root"
+                )
+            }
+        }
+    }
+
+    func testManifestNameAndIdentityConflict_ExplicitDependencyNames_ExplicitProductPackage_AtRoot() throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try MockWorkspace(
+            sandbox: sandbox,
+            fs: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(name: "RootTarget", dependencies: [
+                            .product(name: "FooProduct", package: "foo"),
+                            .product(name: "BarProduct", package: "bar"),
+                        ]),
+                    ],
+                    products: [],
+                    dependencies: [
+                        .git(path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .git(name: "foo", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    toolsVersion: .v5
+                ),
+            ],
+            packages: [
+                MockPackage(
+                    name: "foo",
+                    path: "foo",
+                    targets: [
+                        MockTarget(name: "FooTarget"),
+                    ],
+                    products: [
+                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                    ],
+                    versions: ["1.0.0", "2.0.0"]
+                ),
+                MockPackage(
+                    name: "foo",
+                    path: "bar",
+                    targets: [
+                        MockTarget(name: "BarTarget"),
+                    ],
+                    products: [
+                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                    ],
+                    versions: ["1.0.0", "2.0.0"]
+                ),
+            ]
+        )
+
+        workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
+            DiagnosticsEngineTester(diagnostics) { result in
+                result.check(
+                    diagnostic: "'root' dependency on '/tmp/ws/pkgs/bar' conflicts with dependency on '/tmp/ws/pkgs/foo' which has the same explicit name 'foo'",
                     behavior: .error,
                     location: "'Root' /tmp/ws/roots/Root"
                 )
@@ -6182,7 +6246,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(
-                    diagnostic: "'BarPackage' dependency on '/tmp/ws/pkgs/other/utility' conflicts with dependency on '/tmp/ws/pkgs/foo/utility' which has the same identity 'utility'",
+                    diagnostic: "'bar' dependency on '/tmp/ws/pkgs/other/utility' conflicts with dependency on '/tmp/ws/pkgs/foo/utility' which has the same identity 'utility'",
                     behavior: .error,
                     location: "'BarPackage' /tmp/ws/pkgs/bar"
                 )
@@ -6262,7 +6326,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
                 result.check(
-                    diagnostic: "product 'OtherUtilityProduct' not found in package 'OtherUtilityPackage'. it is required by package 'BarPackage' target 'BarTarget'.",
+                    diagnostic: "product 'OtherUtilityProduct' required by package 'bar' target 'BarTarget' not found in package 'OtherUtilityPackage'.",
                     behavior: .error,
                     location: "'BarPackage' /tmp/ws/pkgs/bar"
                 )
@@ -6504,13 +6568,6 @@ final class WorkspaceTests: XCTestCase {
                 )
             }
         }
-    }
-}
-
-extension PackageGraph {
-    /// Finds the package matching the given name.
-    func lookup(_ name: String) -> ResolvedPackage {
-        return packages.first { $0.name == name }!
     }
 }
 


### PR DESCRIPTION
Bring back #3323

---

motivation: improve correctness by using identity more broadly throughout the codebase

changes:
* expose identity on Package, ResolvedPackage and GraphLoadingNode
* reduce calls to identityResolver.resolveIdentity since we now have identity more broadly available (also improves performance)
* ManifestLoader now take PackageIdentity to reduce calls to identityResolver.resolveIdentity when the identity is already known
* adjust call-sites
* adjust tests