### PR TITLE
Fix Xcode project generation build tests to pass the platform to `xcodebuild`

### DIFF
--- a/Tests/XcodeprojTests/FunctionalTests.swift
+++ b/Tests/XcodeprojTests/FunctionalTests.swift
@@ -167,6 +167,7 @@ func XCTAssertXcodeBuild(project: AbsolutePath, file: StaticString = #file, line
               "-scheme", scheme,
               "-xcconfig", xcconfig.pathString,
               "-derivedDataPath", buildDir.pathString,
+              "-destination", "platform=macOS",
               "COMPILER_INDEX_STORE_ENABLE=NO",
             environment: env)
     } catch {


### PR DESCRIPTION
This makes the Xcode project generation tests more robust by passing the `macOS` platform.  These tests are currently specific to macOS anyway, so this is appropriate.

### Modifications:

Pass `-destination` `platform=macOS` to `xcodebuild` to be specific about the destination.  This is more robust.