### PR TITLE
Move down the parsing of binary artifacts to SPMBuildCore

### DIFF
--- a/Sources/Build/CMakeLists.txt
+++ b/Sources/Build/CMakeLists.txt
@@ -1,20 +1,18 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(Build
-  ArtifactsArchiveMetadata.swift
   BuildOperationBuildSystemDelegateHandler.swift
   BuildOperation.swift
   BuildPlan.swift
   ManifestBuilder.swift
   SPMSwiftDriverExecutor.swift
-  SwiftCompilerOutputParser.swift
-  XCFrameworkMetadata.swift)
+  SwiftCompilerOutputParser.swift)
 target_link_libraries(Build PUBLIC
   TSCBasic
   Basics

--- a/Sources/SPMBuildCore/ArtifactsArchiveMetadata.swift
+++ b/Sources/SPMBuildCore/ArtifactsArchiveMetadata.swift
@@ -10,7 +10,6 @@
 
 import Foundation
 import PackageModel
-import SPMBuildCore
 import TSCBasic
 import TSCUtility
 

--- a/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
+++ b/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
@@ -1,0 +1,78 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import Basics
+import PackageModel
+import PackageGraph
+import TSCBasic
+import TSCUtility
+
+
+/// Information about a library from a binary dependency.
+public struct LibraryInfo: Equatable {
+    /// The path to the binary.
+    public let libraryPath: AbsolutePath
+
+    /// The path to the headers directory, if one exists.
+    public let headersPath: AbsolutePath?
+}
+
+
+/// Information about an executable from a binary dependency.
+public struct ExecutableInfo: Equatable {
+    /// The tool name
+    public let name: String
+
+    /// The path to the executable.
+    public let executablePath: AbsolutePath
+}
+
+
+extension BinaryTarget {
+    
+    public func parseXCFrameworks(for buildParameters: BuildParameters, fileSystem: FileSystem) throws -> [LibraryInfo] {
+        let metadata = try XCFrameworkMetadata.parse(fileSystem: fileSystem, rootPath: self.artifactPath)
+        guard let library = metadata.libraries.first(where: {
+            $0.platform == buildParameters.triple.os.asXCFrameworkPlatformString &&
+            $0.architectures.contains(buildParameters.triple.arch.rawValue)
+        }) else {
+            return []
+        }
+        let libraryDir = self.artifactPath.appending(component: library.libraryIdentifier)
+        let libraryFile = libraryDir.appending(RelativePath(library.libraryPath))
+        let headersDir = library.headersPath.map({ libraryDir.appending(RelativePath($0)) })
+        return [LibraryInfo(libraryPath: libraryFile, headersPath: headersDir)]
+    }
+
+    public func parseArtifactArchives(for buildParameters: BuildParameters, fileSystem: FileSystem) throws -> [ExecutableInfo] {
+        let metadata = try ArtifactsArchiveMetadata.parse(fileSystem: fileSystem, rootPath: self.artifactPath)
+        // filter the artifacts that are relevant to the triple
+        // FIXME: this filter needs to become more sophisticated
+        let supportedArtifacts = metadata.artifacts.filter { $0.value.variants.contains(where: { $0.supportedTriples.contains(buildParameters.triple) }) }
+        // TODO: add support for libraries
+        let executables = supportedArtifacts.filter { $0.value.type == .executable }
+        return executables.flatMap { entry in
+            entry.value.variants.map{ ExecutableInfo(name: entry.key, executablePath: self.artifactPath.appending(RelativePath($0.path))) }
+        }
+    }
+}
+
+fileprivate extension Triple.OS {
+    /// Returns a representation of the receiver that can be compared with platform strings declared in an XCFramework.
+    var asXCFrameworkPlatformString: String? {
+        switch self {
+        case .darwin, .linux, .wasi, .windows:
+            return nil // XCFrameworks do not support any of these platforms today.
+        case .macOS:
+            return "macos"
+        }
+    }
+}

--- a/Sources/SPMBuildCore/CMakeLists.txt
+++ b/Sources/SPMBuildCore/CMakeLists.txt
@@ -7,6 +7,8 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(SPMBuildCore
+  ArtifactsArchiveMetadata.swift
+  BinaryTarget+Extensions.swift
   BuildParameters.swift
   BuildSystem.swift
   BuildSystemCommand.swift
@@ -15,7 +17,8 @@ add_library(SPMBuildCore
   PluginInvocation.swift
   PrebuildCommandResult.swift
   Sanitizers.swift
-  Toolchain.swift)
+  Toolchain.swift
+  XCFrameworkMetadata.swift)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(SPMBuildCore PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/SPMBuildCore/XCFrameworkMetadata.swift
+++ b/Sources/SPMBuildCore/XCFrameworkMetadata.swift
@@ -10,7 +10,6 @@
 
 import Foundation
 import PackageModel
-import SPMBuildCore
 import TSCBasic
 import TSCUtility
 

--- a/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
+++ b/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
@@ -1,14 +1,14 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
-import Build
+import SPMBuildCore
 import TSCBasic
 import TSCUtility
 import XCTest

--- a/Tests/SPMBuildCoreTests/XCFrameworkMetadataTests.swift
+++ b/Tests/SPMBuildCoreTests/XCFrameworkMetadataTests.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
-import Build
+import SPMBuildCore
 import TSCBasic
 import XCTest
 


### PR DESCRIPTION
Move down the parsing of binary artifacts such as XCFrameworks and ArtifactArchives to SPMBuildCore.

We can also discuss whether it should in fact be moved down to the project model.

### Motivation:

This makes conceptual sense anyway, but in particular so that plugins can have access to it.

### Modifications:

- move down code from Build target to SPMBuildCore target
- adjust CMakeList etc.

This is a fairly literal sinking down of the APIs.  An API cleanup to unify the different kinds of binary artifact can wait for a future PR.