### PR TITLE
[Collections] Add concurrency test for trie

### DIFF
--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -113,9 +113,9 @@ public struct PackageCollections: PackageCollectionsProtocol {
                             self.refreshCollectionFromSource(source: source, trustConfirmationProvider: nil) { refreshResult in
                                 let count = refreshResults.append(refreshResult)
                                 if count == missingSources.count {
-                                    collections += refreshResults.compactMap { $0.success } // best-effort; not returning errors
-                                    collections.sort(by: sort)
-                                    callback(.success(collections))
+                                    var result = collections + refreshResults.compactMap { $0.success } // best-effort; not returning errors
+                                    result.sort(by: sort)
+                                    callback(.success(result))
                                 }
                             }
                         }
@@ -399,7 +399,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
             switch result {
             case .failure(let error):
                 callback(.failure(error))
-            case .success(var collection):
+            case .success(let collection):
                 // If collection is signed and signature is valid, save to storage. `provider.get`
                 // would have failed if signature were invalid.
                 if collection.isSigned {
@@ -436,6 +436,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
                             callback(.failure(error))
                         case .success:
                             if userTrusted {
+                                var collection = collection
                                 collection.source = source
                                 self.storage.collections.put(collection: collection, callback: callback)
                             } else {

--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -341,7 +341,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
         // go to db if not found
         self.queue.async {
             do {
-                let blobs = ThreadSafeArrayStore<Data>()
+                var blobs = [Data]()
                 if let identifiers = identifiers {
                     var index = 0
                     while index < identifiers.count {
@@ -374,7 +374,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                     })
                 } else {
                     collections = .init()
-                    blobs.get().forEach { data in
+                    blobs.forEach { data in
                         self.queue.async(group: sync) {
                             if let collection = try? self.decoder.decode(Model.Collection.self, from: data) {
                                 collections.append(collection)


### PR DESCRIPTION
Also undo change in `SQLitePackageCollectionsStorage.list` that made `blobs` thread-safe, we don't actually need that.
