### PR TITLE
run build complete handler sync

### DIFF
--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -609,7 +609,7 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
     }
 
     func buildComplete(success: Bool) {
-        queue.async {
+        queue.sync {
             if success {
                 self.progressAnimation.update(
                     step: self.taskTracker.finishedCount,


### PR DESCRIPTION
motivation: when build-complete handler is run async it may never get actually done since the process may exit

changes: run the complete handler sync

