### PR TITLE
Support `additionalFileRules` inside sources.

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1383,13 +1383,25 @@ private extension Manifest {
 
 extension Sources {
     var hasSwiftSources: Bool {
-        paths.first?.extension == "swift"
+        return paths.contains { path in
+            guard let ext = path.extension else { return false }
+
+            return FileRuleDescription.swift.fileTypes.contains(ext)
+        }
+    }
+
+    var hasClangSources: Bool {
+        let supportedClangFileExtensions = FileRuleDescription.clang.fileTypes.union(FileRuleDescription.asm.fileTypes)
+
+        return paths.contains { path in
+            guard let ext = path.extension else { return false }
+
+            return supportedClangFileExtensions.contains(ext)
+        }
     }
 
     var containsMixedLanguage: Bool {
-        let swiftSources = relativePaths.filter{ $0.extension == "swift" }
-        if swiftSources.isEmpty { return false }
-        return swiftSources.count != relativePaths.count
+        return hasSwiftSources && hasClangSources
     }
     
     /// Determine target type based on the sources.

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -148,6 +148,40 @@ class TargetSourcesBuilderTests: XCTestCase {
         }
     }
 
+    func testDoesNotErrorWithAdditionalFileRules() throws {
+        let target = try TargetDescription(
+            name: "Foo",
+            path: nil,
+            exclude: [],
+            sources: nil,
+            resources: [],
+            publicHeadersPath: nil,
+            type: .regular
+        )
+
+        let files = [
+            "/Foo.swift",
+            "/Bar.swift",
+            "/Baz.something"
+        ]
+
+        let fs = InMemoryFileSystem()
+        fs.createEmptyFiles(at: .root, files: files)
+
+        let somethingRule = FileRuleDescription(
+            rule: .compile,
+            toolsVersion: .vNext,
+            fileTypes: ["something"]
+        )
+
+        build(target: target, additionalFileRules: [somethingRule], toolsVersion: .vNext, fs: fs) { sources, _, _, _,_  in
+            XCTAssertEqual(
+                sources.paths.map(\.pathString).sorted(),
+                files.sorted()
+            )
+        }
+    }
+
     func testResourceConflicts() throws {
         // Conflict between processed resources.
 


### PR DESCRIPTION
Previously, sources directories must be all swift or all clang based source files--even if `additionalFileRules` had a file rule description that matches against a file in sources. This commit makes SwiftPM respect the `additionalFileRules` parameter.

### Motivation:

The `additionalFileRules` parameter was never practically usable for sources directories, since having a rule that matched against a certain file extension would cause SwiftPM to emit an error that the sources were considered mixed. This PR is a targeted fix for allowing `additionalFileRules` to match against files in the sources directory.

### Modifications:

Fixes the implementation for a property called `containsMixedLanguage`, which now checks to if there are both Clang and Swift based sources (instead of what the previous implementation did, which only checked how many Swift files there were).

### Result:

Adding a file rule to `additonalFileRules` that matches against a source file should not cause an error when building a package.

rdar://75386274