### PR TITLE
Turn the --name option into the preferred method of package creation

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -40,6 +40,7 @@ A library package contains code which other packages can use and depend on. To
 get started run `swift package init --name MyPackage`:
 
     $ swift package init --name MyPackage # or swift package init --name MyPackage --type library
+    $ cd MyPackage
     $ swift build
     $ swift test
 
@@ -119,7 +120,7 @@ for that library. Such a wrapper package does not contain any code of its own.
 Let's see an example of using [libgit2](https://libgit2.github.com) from an
 executable.
 
-    $ swift package init --name executable --type executable
+    $ swift package init --name example --type executable
 
 Edit the `Sources/example/main.swift` so it consists of this code:
 

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -37,27 +37,24 @@ that contains Swift sources and a `Package.swift` manifest file at its root.
 ### Creating a Library Package
 
 A library package contains code which other packages can use and depend on. To
-get started, create a directory and run `swift package init`:
+get started run `swift package init --name MyPackage`:
 
-    $ mkdir MyPackage
-    $ cd MyPackage
-    $ swift package init # or swift package init --type library
+    $ swift package init --name MyPackage # or swift package init --name MyPackage --type library
     $ swift build
     $ swift test
 
 This will create the directory structure needed for a library package with a
 target and the corresponding test target to write unit tests. A library package
 can contain multiple targets as explained in [Target Format
-Reference](PackageDescription.md#target).
+Reference](PackageDescription.md#target).  Omitting the `--name` option will
+utilize the name of the current working directory for the package's name.
 
 ### Creating an Executable Package
 
 SwiftPM can create native binaries which can be executed from the command line. To
 get started:
 
-    $ mkdir MyExecutable
-    $ cd MyExecutable
-    $ swift package init --type executable
+    $ swift package init --name MyExecutable --type executable
     $ swift build
     $ swift run
     Hello, World!
@@ -122,12 +119,7 @@ for that library. Such a wrapper package does not contain any code of its own.
 Let's see an example of using [libgit2](https://libgit2.github.com) from an
 executable.
 
-First, create a directory called `example`, and initialize it as a package that
-builds an executable:
-
-    $ mkdir example
-    $ cd example
-    example$ swift package init --type executable
+    $ swift package init --name executable --type executable
 
 Edit the `Sources/example/main.swift` so it consists of this code:
 
@@ -151,13 +143,9 @@ differently from regular Swift packages.
 Note that the system library may be located elsewhere on your system, such as
 `/usr/` rather than `/usr/local/`.
 
-Create a directory called `Clibgit` next to the `example` directory and
-initialize it as a package that builds a system module:
-
-    example$ cd ..
-    $ mkdir Clibgit
-    $ cd Clibgit
-    Clibgit$ swift package init --type system-module
+Next to the `example` directory initialize `Clibgit` as a package that builds a system module: 
+    
+    $ swift package init --name Clibgit --type system-module
 
 This creates `Package.swift` and `module.modulemap` files in the directory.
 Edit `Package.swift` and add `pkgConfig` parameter:
@@ -233,12 +221,9 @@ executable:
 Let’s see another example of using [IJG’s JPEG library](http://www.ijg.org)
 from an executable, which has some caveats.
 
-Create a directory called `example`, and initialize it as a package that builds
-an executable:
+Create a package called `example` as a package that builds an executable:
 
-    $ mkdir example
-    $ cd example
-    example$ swift package init --type executable
+    $ swift package init --name example --type executable
 
 Edit the `Sources/main.swift` so it consists of this code:
 
@@ -251,13 +236,9 @@ print(jpegData)
 
 Install JPEG library using a system packager, e.g, `$ brew install jpeg`
 
-Create a directory called `CJPEG` next to the `example` directory and
-initialize it as a package that builds a system module:
-
-    example$ cd ..
-    $ mkdir CJPEG
-    $ cd CJPEG
-    CJPEG$ swift package init --type system-module
+Next to the `example` directory initialize `CJPEG` as a package that builds a system module: 
+    
+    $ swift package init --name CJPEG --type system-module
 
 This creates `Package.swift` and `module.modulemap` files in the directory.
 Edit `module.modulemap` so it consists of the following:

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -201,21 +201,22 @@ extension SwiftPackageTool {
         var packageName: String?
 
         func run(_ swiftTool: SwiftTool) throws {
-            guard var cwd = localFileSystem.currentWorkingDirectory else {
+            guard let cwd = localFileSystem.currentWorkingDirectory else {
                 throw StringError("No Current Working Directory")
             }
             var packageName: String
+            var destinationPath = cwd
             
             if let optionalPackageName = self.packageName {
                 try localFileSystem.createDirectory(cwd.appending(RelativePath(optionalPackageName)))
                 packageName = optionalPackageName
-                cwd = cwd.appending(RelativePath(optionalPackageName))
+                destinationPath = cwd.appending(RelativePath(optionalPackageName))
             } else {
                 packageName = cwd.basename
             }
             
             let initPackage = try InitPackage(
-                name: packageName, destinationPath: cwd, packageType: initMode)
+                name: packageName, destinationPath: destinationPath, packageType: initMode)
             initPackage.progressReporter = { message in
                 print(message)
             }

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -201,10 +201,19 @@ extension SwiftPackageTool {
         var packageName: String?
 
         func run(_ swiftTool: SwiftTool) throws {
-            // FIXME: Error handling.
-            let cwd = localFileSystem.currentWorkingDirectory!
-
-            let packageName = self.packageName ?? cwd.basename
+            guard var cwd = localFileSystem.currentWorkingDirectory else {
+                throw StringError("No Current Working Directory")
+            }
+            var packageName: String
+            
+            if let optionalPackageName = self.packageName {
+                try localFileSystem.createDirectory(cwd.appending(RelativePath(optionalPackageName)))
+                packageName = optionalPackageName
+                cwd = cwd.appending(RelativePath(optionalPackageName))
+            } else {
+                packageName = cwd.basename
+            }
+            
             let initPackage = try InitPackage(
                 name: packageName, destinationPath: cwd, packageType: initMode)
             initPackage.progressReporter = { message in

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -528,10 +528,11 @@ final class PackageToolTests: XCTestCase {
     func testInitCustomNameExecutable() throws {
         try testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
-            let path = tmpPath.appending(component: "Foo")
+            var path = tmpPath.appending(component: "Foo")
             try fs.createDirectory(path)
             _ = try execute(["init", "--name", "CustomName", "--type", "executable"], packagePath: path)
 
+            path = path.appending(RelativePath("CustomName"))
             let manifest = path.appending(component: "Package.swift")
             let contents = try localFileSystem.readFileContents(manifest).description
             let version = "\(InitPackage.newPackageToolsVersion.major).\(InitPackage.newPackageToolsVersion.minor)"


### PR DESCRIPTION
It's more practical for SwiftPM to create the parent directory for a package as opposed to having the user `mkdir`, `cd`, and then finally initialize their package. 

We turn this:
```
$ mkdir MyPackage
$ cd MyPackage
$ swift package init
```

Into this:
```
$ swift package init --name MyPackage
```