### PR TITLE
Fix experimental-api-diff command and add a test

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1853,11 +1853,22 @@ public class BuildPlan {
         }
     }
 
-    public func createAPIDigesterArgs() -> [String] {
+    public func createAPIToolCommonArgs(includeLibrarySearchPaths: Bool) -> [String] {
         let buildPath = buildParameters.buildPath.pathString
         var arguments = ["-I", buildPath]
 
-        arguments += buildParameters.toolchain.extraSwiftCFlags
+        var extraSwiftCFlags = buildParameters.toolchain.extraSwiftCFlags
+        if !includeLibrarySearchPaths {
+            for index in extraSwiftCFlags.indices.dropLast().reversed() {
+                if extraSwiftCFlags[index] == "-L" {
+                    // Remove the flag
+                    extraSwiftCFlags.remove(at: index)
+                    // Remove the argument
+                    extraSwiftCFlags.remove(at: index)
+                }
+            }
+        }
+        arguments += extraSwiftCFlags
 
         // Add the search path to the directory containing the modulemap file.
         for target in targets {

--- a/Sources/Commands/APIDigester.swift
+++ b/Sources/Commands/APIDigester.swift
@@ -125,7 +125,7 @@ struct APIDigesterBaselineDumper {
         try apiDigesterTool.dumpSDKJSON(
             at: sdkJSON,
             modules: graph.apiDigesterModules,
-            additionalArgs: buildOp.buildPlan!.createAPIDigesterArgs()
+            additionalArgs: buildOp.buildPlan!.createAPIToolCommonArgs(includeLibrarySearchPaths: false)
         )
 
         return sdkJSON

--- a/Sources/Commands/APIDigester.swift
+++ b/Sources/Commands/APIDigester.swift
@@ -160,16 +160,18 @@ public struct SwiftAPIDigester {
     }
 
     public func diagnoseSDK(
-        currentSDKJSON: AbsolutePath,
-        baselineSDKJSON: AbsolutePath
+        baselineSDKJSON: AbsolutePath,
+        apiToolArgs: [String],
+        modules: [String]
     ) throws {
-        let args = [
+        var args = [
             "-diagnose-sdk",
-            "--input-paths",
-            baselineSDKJSON.pathString,
-            "-input-paths",
-            currentSDKJSON.pathString,
+            "-baseline-path", baselineSDKJSON.pathString,
         ]
+        args.append(contentsOf: apiToolArgs)
+        for module in modules {
+            args.append(contentsOf: ["-module", module])
+        }
 
         try runTool(args)
     }

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -287,11 +287,8 @@ extension SwiftPackageTool {
         @OptionGroup()
         var swiftOptions: SwiftToolOptions
 
-        @Argument(help: "The baseline treeish")
+        @Argument(help: "The baseline treeish to compare to (e.g. a commit hash, branch name, tag, etc.)")
         var treeish: String
-        
-        @Flag(help: "Invert the baseline which is helpful for determining API additions")
-        var invertBaseline: Bool = false
 
         func run(_ swiftTool: SwiftTool) throws {
             let apiDigesterPath = try swiftTool.getToolchain().getSwiftAPIDigester()
@@ -303,23 +300,12 @@ extension SwiftPackageTool {
             let buildOp = try swiftTool.createBuildOperation(cacheBuildManifest: false)
             try buildOp.build()
 
-            // Dump JSON for the current package.
-            let buildParameters = buildOp.buildParameters
-            let currentSDKJSON = buildParameters.apiDiff.appending(component: "current.json")
-            let packageGraph = try buildOp.getPackageGraph()
-
-            try apiDigesterTool.dumpSDKJSON(
-                at: currentSDKJSON,
-                modules: packageGraph.apiDigesterModules,
-                additionalArgs: buildOp.buildPlan!.createAPIToolCommonArgs(includeLibrarySearchPaths: false)
-            )
-
             // Dump JSON for the baseline package.
             let workspace = try swiftTool.getActiveWorkspace()
             let baselineDumper = try APIDigesterBaselineDumper(
                 baselineTreeish: treeish,
                 packageRoot: swiftTool.getPackageRoot(),
-                buildParameters: buildParameters,
+                buildParameters: buildOp.buildParameters,
                 manifestLoader: workspace.manifestLoader,
                 repositoryManager: workspace.repositoryManager,
                 apiDigesterTool: apiDigesterTool,
@@ -329,8 +315,9 @@ extension SwiftPackageTool {
 
             // Run the diagnose tool which will print the diff.
             try apiDigesterTool.diagnoseSDK(
-                currentSDKJSON: invertBaseline ? baselineSDKJSON : currentSDKJSON,
-                baselineSDKJSON: invertBaseline ? currentSDKJSON : baselineSDKJSON
+                baselineSDKJSON: baselineSDKJSON,
+                apiToolArgs: buildOp.buildPlan!.createAPIToolCommonArgs(includeLibrarySearchPaths: false),
+                modules: try buildOp.getPackageGraph().apiDigesterModules
             )
         }
     }

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -311,7 +311,7 @@ extension SwiftPackageTool {
             try apiDigesterTool.dumpSDKJSON(
                 at: currentSDKJSON,
                 modules: packageGraph.apiDigesterModules,
-                additionalArgs: buildOp.buildPlan!.createAPIDigesterArgs()
+                additionalArgs: buildOp.buildPlan!.createAPIToolCommonArgs(includeLibrarySearchPaths: false)
             )
 
             // Dump JSON for the baseline package.

--- a/Sources/Commands/SymbolGraphExtract.swift
+++ b/Sources/Commands/SymbolGraphExtract.swift
@@ -42,8 +42,7 @@ public struct SymbolGraphExtract {
             args += ["-module-name", target.c99name]
             args += buildParameters.targetTripleArgs(for: target)
 
-            // FIXME: We should rename this to common Swift tools args or something.
-            args += buildPlan.createAPIDigesterArgs()
+            args += buildPlan.createAPIToolCommonArgs(includeLibrarySearchPaths: true)
             args += ["-module-cache-path", buildParameters.moduleCache.pathString]
 
             args += ["-output-dir", symbolGraphDirectory.pathString]


### PR DESCRIPTION
This fixes swift package experimental-api-diff, which doesn't need or accept library search path arguments. I also added a small test to avoid regressions in the short term. The motivation here is to begin working towards semantic versioning suggestions for packages when tagging a release.