### PR TITLE
[performance] reduce amount of dispatch queues

### DIFF
--- a/Sources/Basics/ConcurrencyHelpers.swift
+++ b/Sources/Basics/ConcurrencyHelpers.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+import Dispatch
 import class Foundation.ProcessInfo
 import TSCBasic
 
@@ -210,4 +211,9 @@ public func temp_await<T, ErrorType>(_ body: (@escaping (Result<T, ErrorType>) -
 @inlinable
 public func temp_await<T>(_ body: (@escaping (T) -> Void) -> Void) -> T {
     return tsc_await(body)
+}
+
+public extension DispatchQueue {
+    // a shared concurrent queue for running concurrent asynchronous operations
+    static var sharedConcurrent = DispatchQueue(label: "swift.org.swiftpm.shared.concurrent", attributes: .concurrent)
 }

--- a/Sources/Basics/HTTPClient.swift
+++ b/Sources/Basics/HTTPClient.swift
@@ -259,7 +259,7 @@ public struct HTTPClientConfiguration {
         self.authorizationProvider = .none
         self.retryStrategy = .none
         self.circuitBreakerStrategy = .none
-        self.callbackQueue = .global()
+        self.callbackQueue = .sharedConcurrent
     }
 }
 

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -55,7 +55,7 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
         self.signatureValidator = signatureValidator ?? PackageCollectionSigning(
             trustedRootCertsDir: configuration.trustedRootCertsDir ?? fileSystem.dotSwiftPM.appending(components: "config", "trust-root-certs").asURL,
             additionalTrustedRootCerts: sourceCertPolicy.allRootCerts,
-            callbackQueue: DispatchQueue.global(),
+            callbackQueue: .sharedConcurrent,
             diagnosticsEngine: diagnosticsEngine
         )
         self.sourceCertPolicy = sourceCertPolicy

--- a/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
+++ b/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
@@ -24,8 +24,6 @@ struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
 
-    private let queue = DispatchQueue(label: "org.swift.swiftpm.FilePackageCollectionsSourcesStorage")
-
     init(fileSystem: FileSystem = localFileSystem, path: AbsolutePath? = nil, diagnosticsEngine: DiagnosticsEngine? = nil) {
         self.fileSystem = fileSystem
 
@@ -37,7 +35,7 @@ struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
     }
 
     func list(callback: @escaping (Result<[Model.CollectionSource], Error>) -> Void) {
-        self.queue.async {
+        DispatchQueue.sharedConcurrent.async {
             do {
                 let sources = try self.withLock {
                     try self.loadFromDisk()
@@ -52,7 +50,7 @@ struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
     func add(source: Model.CollectionSource,
              order: Int?,
              callback: @escaping (Result<Void, Error>) -> Void) {
-        self.queue.async {
+        DispatchQueue.sharedConcurrent.async {
             do {
                 try self.withLock {
                     var sources = try self.loadFromDisk()
@@ -70,7 +68,7 @@ struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
 
     func remove(source: Model.CollectionSource,
                 callback: @escaping (Result<Void, Error>) -> Void) {
-        self.queue.async {
+        DispatchQueue.sharedConcurrent.async {
             do {
                 try self.withLock {
                     var sources = try self.loadFromDisk()
@@ -87,7 +85,7 @@ struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
     func move(source: Model.CollectionSource,
               to order: Int,
               callback: @escaping (Result<Void, Error>) -> Void) {
-        self.queue.async {
+        DispatchQueue.sharedConcurrent.async {
             do {
                 try self.withLock {
                     var sources = try self.loadFromDisk()
@@ -105,7 +103,7 @@ struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
 
     func exists(source: Model.CollectionSource,
                 callback: @escaping (Result<Bool, Error>) -> Void) {
-        self.queue.async {
+        DispatchQueue.sharedConcurrent.async {
             do {
                 let sources = try self.withLock {
                     try self.loadFromDisk()
@@ -119,7 +117,7 @@ struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
 
     func update(source: PackageCollectionsModel.CollectionSource,
                 callback: @escaping (Result<Void, Error>) -> Void) {
-        self.queue.async {
+        DispatchQueue.sharedConcurrent.async {
             do {
                 try self.withLock {
                     var sources = try self.loadFromDisk()

--- a/Sources/PackageGraph/LocalPackageContainer.swift
+++ b/Sources/PackageGraph/LocalPackageContainer.swift
@@ -56,7 +56,7 @@ public final class LocalPackageContainer: PackageContainer {
                                     identityResolver: identityResolver,
                                     fileSystem: fileSystem,
                                     diagnostics: nil,
-                                    on: .global(),
+                                    on: .sharedConcurrent,
                                     completion: $0)
             }
         }

--- a/Sources/PackageGraph/RepositoryPackageContainer.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainer.swift
@@ -310,7 +310,7 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
                                 identityResolver: identityResolver,
                                 fileSystem: fileSystem,
                                 diagnostics: nil,
-                                on: .global(),
+                                on: .sharedConcurrent,
                                 completion: $0)
         }
     }

--- a/Sources/SPMTestSupport/MockManifestLoader.swift
+++ b/Sources/SPMTestSupport/MockManifestLoader.swift
@@ -95,7 +95,7 @@ extension ManifestLoader {
                       identityResolver: identityResolver,
                       fileSystem: fileSystem,
                       diagnostics: diagnostics,
-                      on: .global(),
+                      on: .sharedConcurrent,
                       completion: $0)
         }
     }

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -77,13 +77,9 @@ public class RepositoryManager {
         /// The status of the repository.
         fileprivate var status: Status = .uninitialized
 
-        /// The serial queue to perform the operations like updating the state
+        /// Lock  to protect  the operations like updating the state
         /// of the handle and fetching the repositories from its remote.
-        ///
-        /// The advantage of having a serial queue in handle is that we don't
-        /// have to worry about multiple lookups on the same handle as they will
-        /// be queued automatically.
-        fileprivate let serialQueue = DispatchQueue(label: "org.swift.swiftpm.repohandle-serial")
+        private let statusLock = Lock()
 
         /// Create a handle.
         fileprivate init(manager: RepositoryManager, repository: RepositorySpecifier, subpath: RelativePath) {
@@ -125,6 +121,10 @@ public class RepositoryManager {
                 "subpath": subpath,
             ])
         }
+
+        func withStatusLock(_ body: () throws -> Void) rethrows {
+            try self.statusLock.withLock(body)
+        }
     }
 
     /// Additional information about a fetch
@@ -155,15 +155,15 @@ public class RepositoryManager {
     // repositories map to the same location.
     //
     /// The map of registered repositories.
-    fileprivate var repositories: [String: RepositoryHandle] = [:]
+    private var repositories: [String: RepositoryHandle] = [:]
 
     /// The map of serialized repositories.
     ///
     /// NOTE: This is to be used only for persistence support.
-    fileprivate var serializedRepositories: [String: JSON] = [:]
+    private var serializedRepositories: [String: JSON] = [:]
 
-    /// Queue to protect concurrent reads and mutations to repositories registery.
-    private let serialQueue = DispatchQueue(label: "org.swift.swiftpm.repomanagerqueue-serial")
+    /// Lock  to protect concurrent reads and mutations to repositories registry.
+    private let lock = Lock()
 
     /// Operation queue to do concurrent operations on manager.
     ///
@@ -243,7 +243,7 @@ public class RepositoryManager {
             // First look for the handle.
             let handle = self.getHandle(repository: repository)
             // Dispatch the action we want to take on the serial queue of the handle.
-            handle.serialQueue.sync {
+            handle.withStatusLock {
                 let result: LookupResult
 
                 switch handle.status {
@@ -305,7 +305,7 @@ public class RepositoryManager {
                     }
 
                     // Save the manager state.
-                    self.serialQueue.sync {
+                    self.lock.withLock {
                         do {
                             // Update the serialized repositories map.
                             //
@@ -382,8 +382,7 @@ public class RepositoryManager {
     ///
     /// Note: This method is thread safe.
     private func getHandle(repository: RepositorySpecifier) -> RepositoryHandle {
-        return serialQueue.sync {
-
+        self.lock.withLock {
             // Reset if the state file was deleted during the lifetime of RepositoryManager.
             if !self.serializedRepositories.isEmpty && !self.persistence.stateFileExists() {
                 self.unsafeReset()
@@ -394,7 +393,7 @@ public class RepositoryManager {
 
             if let oldHandle = self.repositories[repository.url] {
                 handle = oldHandle
-            } else if let cachePath = cachePath, fileSystem.exists(cachePath.appending(subpath)) {
+            } else if let cachePath = self.cachePath, self.fileSystem.exists(cachePath.appending(subpath)) {
                 handle = RepositoryHandle(manager: self, repository: repository, subpath: subpath)
                 handle.status = .cached
                 self.repositories[repository.url] = handle
@@ -409,8 +408,8 @@ public class RepositoryManager {
 
     /// Open a repository from a handle.
     private func open(_ handle: RepositoryHandle) throws -> Repository {
-        return try provider.open(
-            repository: handle.repository, at: path.appending(handle.subpath))
+        try self.provider.open(
+            repository: handle.repository, at: self.path.appending(handle.subpath))
     }
 
     /// Clone a repository from a handle.
@@ -419,24 +418,24 @@ public class RepositoryManager {
         to destinationPath: AbsolutePath,
         editable: Bool
     ) throws {
-        try provider.cloneCheckout(
+        try self.provider.cloneCheckout(
             repository: handle.repository,
-            at: path.appending(handle.subpath),
+            at: self.path.appending(handle.subpath),
             to: destinationPath,
             editable: editable)
     }
 
     /// Removes the repository.
     public func remove(repository: RepositorySpecifier) throws {
-        try serialQueue.sync {
+        try self.lock.withLock {
             // If repository isn't present, we're done.
-            guard let handle = repositories[repository.url] else {
+            guard let handle = self.repositories[repository.url] else {
                 return
             }
-            repositories[repository.url] = nil
-            serializedRepositories[repository.url] = nil
-            let repositoryPath = path.appending(handle.subpath)
-            try fileSystem.removeFileTree(repositoryPath)
+            self.repositories[repository.url] = nil
+            self.serializedRepositories[repository.url] = nil
+            let repositoryPath = self.path.appending(handle.subpath)
+            try self.fileSystem.removeFileTree(repositoryPath)
             try self.persistence.saveState(self)
         }
     }
@@ -445,7 +444,7 @@ public class RepositoryManager {
     ///
     /// Note: This also removes the cloned repositories from the disk.
     public func reset() {
-        serialQueue.sync {
+        self.lock.withLock {
             self.unsafeReset()
         }
     }

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -77,7 +77,7 @@ public class RepositoryManager {
         /// The status of the repository.
         fileprivate var status: Status = .uninitialized
 
-        /// Lock  to protect  the operations like updating the state
+        /// Lock to protect  the operations like updating the state
         /// of the handle and fetching the repositories from its remote.
         private let statusLock = Lock()
 
@@ -162,7 +162,7 @@ public class RepositoryManager {
     /// NOTE: This is to be used only for persistence support.
     private var serializedRepositories: [String: JSON] = [:]
 
-    /// Lock  to protect concurrent reads and mutations to repositories registry.
+    /// Lock to protect concurrent reads and mutations to repositories registry.
     private let lock = Lock()
 
     /// Operation queue to do concurrent operations on manager.


### PR DESCRIPTION
motivation: improve performance, reduce complexity

changes:
* define single shared concurrent queue and update code that runs async operation to use it.
* replace cases where dispatch queue is used "as a lock" with a lock
