### PR TITLE
[performance] reduce dependency resolution git calls

### DIFF
--- a/Sources/PackageGraph/RepositoryPackageContainer.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainer.swift
@@ -67,7 +67,7 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
     private var dependenciesCacheLock = Lock()
 
     private var knownVersionsCache = ThreadSafeBox<[Version: String]>()
-    private var manifestsCache = ThreadSafeKeyValueStore<Revision, Manifest>()
+    private var manifestsCache = ThreadSafeKeyValueStore<String, Manifest>()
     private var toolsVersionsCache = ThreadSafeKeyValueStore<Version, ToolsVersion>()
 
     /// This is used to remember if tools version of a particular version is
@@ -146,9 +146,8 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
             guard let tag = try self.knownVersions()[version] else {
                 throw StringError("unknown tag \(version)")
             }
-            let revision = try repository.resolveRevision(tag: tag)
-            let fs = try repository.openFileView(revision: revision)
-            return try toolsVersionLoader.load(at: .root, fileSystem: fs)
+            let fileSystem = try repository.openFileView(tag: tag)
+            return try toolsVersionLoader.load(at: .root, fileSystem: fileSystem)
         }
     }
 
@@ -158,8 +157,7 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
                 guard let tag = try self.knownVersions()[version] else {
                     throw StringError("unknown tag \(version)")
                 }
-                let revision = try repository.resolveRevision(tag: tag)
-                return try self.loadDependencies(at: revision, version: version, productFilter: productFilter)
+                return try self.loadDependencies(tag: tag, version: version, productFilter: productFilter)
             }.1
         } catch {
             throw GetDependenciesError(
@@ -217,6 +215,16 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
 
     /// Returns dependencies of a container at the given revision.
     private func loadDependencies(
+        tag: String,
+        version: Version? = nil,
+        productFilter: ProductFilter
+    ) throws -> (Manifest, [Constraint]) {
+        let manifest = try self.loadManifest(tag: tag, version: version)
+        return (manifest, try manifest.dependencyConstraints(productFilter: productFilter))
+    }
+
+    /// Returns dependencies of a container at the given revision.
+    private func loadDependencies(
         at revision: Revision,
         version: Version? = nil,
         productFilter: ProductFilter
@@ -265,34 +273,45 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
     public func isToolsVersionCompatible(at version: Version) -> Bool {
         return (try? self.toolsVersion(for: version)).flatMap(self.isValidToolsVersion(_:)) ?? false
     }
-   
+
+    private func loadManifest(tag: String, version: Version?) throws -> Manifest {
+        try self.manifestsCache.memoize(tag) {
+            let fileSystem = try repository.openFileView(tag: tag)
+            return try self.loadManifest(fileSystem: fileSystem, version: version, packageVersion: tag)
+        }
+    }
+
     private func loadManifest(at revision: Revision, version: Version?) throws -> Manifest {
-        try self.manifestsCache.memoize(revision) {
-            let fs = try repository.openFileView(revision: revision)
-            let packageLocation = package.repository.url
+        try self.manifestsCache.memoize(revision.identifier) {
+            let fileSystem = try self.repository.openFileView(revision: revision)
+            return try self.loadManifest(fileSystem: fileSystem, version: version, packageVersion: revision.identifier)
+        }
+    }
 
-            // Load the tools version.
-            let toolsVersion = try toolsVersionLoader.load(at: .root, fileSystem: fs)
+    private func loadManifest(fileSystem: FileSystem, version: Version?, packageVersion: String) throws -> Manifest {
+        let packageLocation = self.package.repository.url
 
-            // Validate the tools version.
-            try toolsVersion.validateToolsVersion(
-                self.currentToolsVersion, version: revision.identifier, packagePath: packageLocation)
+        // Load the tools version.
+        let toolsVersion = try self.toolsVersionLoader.load(at: .root, fileSystem: fileSystem)
 
-            // Load the manifest.
-            // FIXME: this should not block
-            return try temp_await {
-                manifestLoader.load(at: AbsolutePath.root,
-                                    packageKind: package.kind,
-                                    packageLocation: packageLocation,
-                                    version: version,
-                                    revision: nil,
-                                    toolsVersion: toolsVersion,
-                                    identityResolver: identityResolver,
-                                    fileSystem: fs,
-                                    diagnostics: nil,
-                                    on: .global(),
-                                    completion: $0)
-            }
+        // Validate the tools version.
+        try toolsVersion.validateToolsVersion(
+            self.currentToolsVersion, packagePath: packageLocation, packageVersion: packageVersion)
+
+        // Load the manifest.
+        // FIXME: this should not block
+        return try temp_await {
+            self.manifestLoader.load(at: AbsolutePath.root,
+                                packageKind: package.kind,
+                                packageLocation: packageLocation,
+                                version: version,
+                                revision: nil,
+                                toolsVersion: toolsVersion,
+                                identityResolver: identityResolver,
+                                fileSystem: fileSystem,
+                                diagnostics: nil,
+                                on: .global(),
+                                completion: $0)
         }
     }
 

--- a/Sources/PackageModel/Diagnostics.swift
+++ b/Sources/PackageModel/Diagnostics.swift
@@ -19,7 +19,7 @@ public struct RequireNewerTools: DiagnosticData, Swift.Error {
     public let packagePath: String
 
     /// The version of the package.
-    public let version: String?
+    public let packageVersion: String?
 
     /// The installed tools version.
     public let installedToolsVersion: ToolsVersion
@@ -29,19 +29,19 @@ public struct RequireNewerTools: DiagnosticData, Swift.Error {
 
     public init(
         packagePath: String,
-        version: String? = nil,
+        packageVersion: String? = nil,
         installedToolsVersion: ToolsVersion,
         packageToolsVersion: ToolsVersion
     ) {
         self.packagePath = packagePath
-        self.version = version
+        self.packageVersion = packageVersion
         self.installedToolsVersion = installedToolsVersion
         self.packageToolsVersion = packageToolsVersion
     }
 
     public var description: String {
         var text = "package at '\(packagePath)'"
-        if let version = self.version {
+        if let version = self.packageVersion {
             text += " @ \(version)"
         }
         text += " is using Swift tools version \(packageToolsVersion.description) but the installed version is \(installedToolsVersion.description)"
@@ -55,7 +55,7 @@ public struct UnsupportedToolsVersion: DiagnosticData, Swift.Error {
     public let packagePath: String
 
     /// The version of the package.
-    public let version: String?
+    public let packageVersion: String?
 
     /// The current tools version support by the tools.
     public let currentToolsVersion: ToolsVersion
@@ -69,19 +69,19 @@ public struct UnsupportedToolsVersion: DiagnosticData, Swift.Error {
 
     public init(
         packagePath: String,
-        version: String? = nil,
+        packageVersion: String? = nil,
         currentToolsVersion: ToolsVersion,
         packageToolsVersion: ToolsVersion
     ) {
         self.packagePath = packagePath
-        self.version = version
+        self.packageVersion = packageVersion
         self.currentToolsVersion = currentToolsVersion
         self.packageToolsVersion = packageToolsVersion
     }
 
     public var description: String {
         var text = "package at '\(self.packagePath)'"
-        if let version = self.version {
+        if let version = self.packageVersion {
             text += " @ \(version)"
         }
         text += " is using Swift tools version \(packageToolsVersion.description) which is no longer supported; \(hintString)"

--- a/Sources/PackageModel/ToolsVersion.swift
+++ b/Sources/PackageModel/ToolsVersion.swift
@@ -102,8 +102,8 @@ public struct ToolsVersion: Equatable, Hashable, Codable {
     /// version of the package manager.
     public func validateToolsVersion(
         _ currentToolsVersion: ToolsVersion,
-        version: String? = nil,
-        packagePath: String
+        packagePath: String,
+        packageVersion: String? = nil
     ) throws {
         // We don't want to throw any error when using the special vNext version.
         if SwiftVersion.currentVersion.isDevelopment && self == .vNext {
@@ -114,7 +114,7 @@ public struct ToolsVersion: Equatable, Hashable, Codable {
         guard self >= .minimumRequired else {
             throw UnsupportedToolsVersion(
                 packagePath: packagePath,
-                version: version,
+                packageVersion: packageVersion,
                 currentToolsVersion: currentToolsVersion,
                 packageToolsVersion: self
             )
@@ -124,7 +124,7 @@ public struct ToolsVersion: Equatable, Hashable, Codable {
         guard currentToolsVersion >= self else {
             throw RequireNewerTools(
                 packagePath: packagePath,
-                version: version,
+                packageVersion: packageVersion,
                 installedToolsVersion: currentToolsVersion,
                 packageToolsVersion: self
             )

--- a/Sources/SPMTestSupport/InMemoryGitRepository.swift
+++ b/Sources/SPMTestSupport/InMemoryGitRepository.swift
@@ -329,6 +329,11 @@ extension InMemoryGitRepository: Repository {
             return self.history[revision.identifier]!.fileSystem
         }
     }
+
+    public func openFileView(tag: String) throws -> FileSystem {
+        let revision = try self.resolveRevision(tag: tag)
+        return try self.openFileView(revision: revision)
+    }
 }
 
 extension InMemoryGitRepository: WorkingCheckout {

--- a/Sources/SourceControl/Repository.swift
+++ b/Sources/SourceControl/Repository.swift
@@ -181,8 +181,24 @@ public protocol Repository {
     /// It is expected behavior that attempts to mutate the given FileSystem
     /// will fail or crash.
     ///
-    /// - Throws: If a error occurs accessing the revision.
+    /// - Throws: If an error occurs accessing the revision.
     func openFileView(revision: Revision) throws -> FileSystem
+
+    /// Open an immutable file system view for a particular tag.
+    ///
+    /// This view exposes the contents of the repository at the given revision
+    /// as a file system rooted inside the repository. The repository must
+    /// support opening multiple views concurrently, but the expectation is that
+    /// clients should be prepared for this to be inefficient when performing
+    /// interleaved accesses across separate views (i.e., the repository may
+    /// back the view by an actual file system representation of the
+    /// repository).
+    ///
+    /// It is expected behavior that attempts to mutate the given FileSystem
+    /// will fail or crash.
+    ///
+    /// - Throws: If an error occurs accessing the revision.
+    func openFileView(tag: String) throws -> FileSystem
 }
 
 /// An editable checkout of a repository (i.e. a working copy) on the local file

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -73,6 +73,11 @@ private class MockRepository: Repository {
         // This is used for reading the tools version.
         return self.fs
     }
+
+    public func openFileView(tag: String) throws -> FileSystem {
+        let revision = try self.resolveRevision(tag: tag)
+        return try self.openFileView(revision: revision)
+    }
 }
 
 private class MockRepositories: RepositoryProvider {

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -49,6 +49,10 @@ private class DummyRepository: Repository {
     func openFileView(revision: Revision) throws -> FileSystem {
         fatalError("unexpected API call")
     }
+
+    public func openFileView(tag: String) throws -> FileSystem {
+        fatalError("unexpected API call")
+    }
 }
 
 private class DummyRepositoryProvider: RepositoryProvider {


### PR DESCRIPTION
motivation: better performance, happier users

changes:
* the bottle neck in dependency resolution is the iteration of available versions and reducing the list to thos with matching tools-versions,
  each version iteration shells out to git several times now, which is fairly expensive given the shelling out aspect.
* change RepositoryPackageContainer::toolsVersion to find & load the manifest based on tag
* change RepositoryPackageContainer::loadManifest to load the manifest based on tag
* this reduces the amount of git shelling (in this use case by 60%), reducing total resolutoin duration  for large packages by 25%
