### PR TITLE
[Bootstrap] Do not pass `-Ddispatch_DIR` to the Yams CMake build

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -554,9 +554,6 @@ def build_yams(args):
         cmake_flags.append("-DCMAKE_C_FLAGS=-target %s%s" % (get_build_target(args), g_macos_deployment_target))
         cmake_flags.append("-DCMAKE_OSX_DEPLOYMENT_TARGET=%s" % g_macos_deployment_target)
     else:
-        if args.dispatch_build_dir:
-            cmake_flags.append(get_dispatch_cmake_arg(args))
-
         if args.foundation_build_dir:
             cmake_flags.append(get_foundation_cmake_arg(args))
 


### PR DESCRIPTION
With the version-bump of Yams in https://github.com/apple/swift/pull/36366, Yams `4.0.2` now actually expresses the dependency on Dispatch in its CMake config.

With the current behavior of passing `-Ddispatch_DIR` to its CMake build, we have the following problem on Linux:
- `swift`'s `build-script` installs Dispatch into a just-built toolchain which we use to build SwiftPM, which will contain, among other things, the Dispatch `.swiftmodule`.
- The compiler workspace checkout of `swift-corelibs-libdispatch` also contains a copy of the Dispatch `.swiftmodule`.

Both of these will be found, leading to build failures like:
```
/home/buildnode/jenkins/workspace/swift-PR-Linux/branch-main/swift-nightly-install/usr/lib/swift/dispatch/module.modulemap:1:8: error: redefinition of module 'Dispatch'
19:37:47 module Dispatch {
19:37:47        ^
19:37:47 /home/buildnode/jenkins/workspace/swift-PR-Linux/branch-main/swift-corelibs-libdispatch/dispatch/module.modulemap:1:8: note: previously defined here
19:37:47 module Dispatch {
19:37:47        ^
19:37:47
```
We also cannot put off building `libDispatch` until SwiftPM is built, because the `libDispatch` dylib is required to link SwiftPM.
Not passing `-Ddispatch_DIR` to Yams' CMake build causes it to successfully locate the Dispatch package in the just-built toolchain on its own.
