### PR TITLE
fix regression in edit mode

### DIFF
--- a/Fixtures/Miscellaneous/Edit/App/Package.swift
+++ b/Fixtures/Miscellaneous/Edit/App/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "App",
+    dependencies: [
+        .package(name: "Foo", url: "../Foo", .branch("main")),
+        .package(name: "Bar", url: "../Bar", .branch("main")),
+    ],
+    targets: [
+        .target(name: "App", dependencies: [
+            .product(name: "Foo", package: "Foo"),
+            .product(name: "Bar", package: "Bar"),
+        ], path: "./src")
+    ]
+)

--- a/Fixtures/Miscellaneous/Edit/App/src/main.swift
+++ b/Fixtures/Miscellaneous/Edit/App/src/main.swift
@@ -1,0 +1,5 @@
+import Foo
+import Bar
+
+public func main() {
+}

--- a/Fixtures/Miscellaneous/Edit/Bar/Bar.swift
+++ b/Fixtures/Miscellaneous/Edit/Bar/Bar.swift
@@ -1,0 +1,2 @@
+public func hello() {
+}

--- a/Fixtures/Miscellaneous/Edit/Bar/Package.swift
+++ b/Fixtures/Miscellaneous/Edit/Bar/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "Bar",
+    products: [
+        .library(name: "Bar", targets: ["Bar"]),
+    ],
+    targets: [
+        .target(name: "Bar", path: "./"),
+    ]
+)

--- a/Fixtures/Miscellaneous/Edit/Foo/Foo.swift
+++ b/Fixtures/Miscellaneous/Edit/Foo/Foo.swift
@@ -1,0 +1,2 @@
+public func hello() {
+}

--- a/Fixtures/Miscellaneous/Edit/Foo/Package.swift
+++ b/Fixtures/Miscellaneous/Edit/Foo/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "Foo",
+    products: [
+        .library(name: "Foo", targets: ["Foo"]),
+    ],
+    targets: [
+        .target(name: "Foo", path: "./"),
+    ]
+)

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1132,7 +1132,7 @@ extension Workspace {
                     // We should get the correct one from managed dependency object.
                     let ref = PackageReference.local(
                         identity: managedDependency.packageRef.identity,
-                        path: AbsolutePath(managedDependency.packageRef.location)
+                        path: workspace.path(to: managedDependency)
                     )
                     let constraint = PackageContainerConstraint(
                         package: ref,


### PR DESCRIPTION
motivation: changes to identity has broken edit mode

changes:
* compute edited path from the managed depedency instead of relying on location which is now the remote location
* add end to end test for edit mode (local urls)

rdar://75645049

