### PR TITLE
Reduce "implicit conversion loses integer precision" warnings

### DIFF
--- a/Sources/PackageCollectionsSigningLibc/asn1/a_d2i_fp.c
+++ b/Sources/PackageCollectionsSigningLibc/asn1/a_d2i_fp.c
@@ -72,7 +72,7 @@ static int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
             if (len + want < len || !BUF_MEM_grow_clean(b, len + want)) {
                 goto err;
             }
-            i = BIO_read(in, &(b->data[len]), want);
+            i = BIO_read(in, &(b->data[len]), (int)want);
             if ((i < 0) && ((len - off) == 0)) {
                 goto err;
             }
@@ -97,7 +97,7 @@ static int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
             else
                 ERR_clear_error(); /* clear error */
         }
-        i = q - p;            /* header length */
+        i = (int)(q - p);            /* header length */
         off += i;               /* end of data */
 
         if (inf & 1) {
@@ -139,7 +139,7 @@ static int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
                     }
                     want -= chunk;
                     while (chunk > 0) {
-                        i = BIO_read(in, &(b->data[len]), chunk);
+                        i = BIO_read(in, &(b->data[len]), (int)chunk);
                         if (i <= 0) {
                             goto err;
                         }
@@ -170,7 +170,7 @@ static int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
     }
 
     *pb = b;
-    return off;
+    return (int)off;
  err:
     BUF_MEM_free(b);
     return -1;

--- a/Sources/PackageCollectionsSigningLibc/ocsp_cl.c
+++ b/Sources/PackageCollectionsSigningLibc/ocsp_cl.c
@@ -55,7 +55,7 @@ OCSP_ONEREQ *OCSP_request_add0_id(OCSP_REQUEST *req, OCSP_CERTID *cid)
 
 int OCSP_response_status(OCSP_RESPONSE *resp)
 {
-    return ASN1_ENUMERATED_get(resp->responseStatus);
+    return (int)ASN1_ENUMERATED_get(resp->responseStatus);
 }
 
 /*

--- a/Sources/PackageCollectionsSigningLibc/ocsp_vfy.c
+++ b/Sources/PackageCollectionsSigningLibc/ocsp_vfy.c
@@ -267,7 +267,7 @@ static int ocsp_check_ids(STACK_OF(OCSP_SINGLERESP) *sresp, OCSP_CERTID **ret)
     OCSP_CERTID *tmpid, *cid;
     int i, idcount;
 
-    idcount = sk_OCSP_SINGLERESP_num(sresp);
+    idcount = (int)sk_OCSP_SINGLERESP_num(sresp);
     if (idcount <= 0) {
         return -1;
     }
@@ -311,7 +311,7 @@ static int ocsp_match_issuerid(X509 *cert, OCSP_CERTID *cid,
             return -1;
         }
 
-        mdlen = EVP_MD_size(dgst);
+        mdlen = (int)EVP_MD_size(dgst);
         if (mdlen < 0) {
             return -1;
         }


### PR DESCRIPTION
Motivation:
Build SwiftPM with `-Xcc -Wshorten-64-to-32` and see a bunch of these warnings.

Modifications:
Fix warnings wherever we can. Many of them come from the dependencies though.
