### PR TITLE
Update current SwiftPM version to 5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,19 @@ Note: This is in reverse chronological order, so newer entries are added to the 
 
 Swift v.Next
  -----------
- * [#3310]
-    * Improvements
 
+
+
+Swift 5.5
+ -----------
+* [#3310]
     Adding a dependency requirement can now be done with the convenience initializer `.package(url: String, revision: String)`.
 
 * [#3292]
-   * Improvements
+    Adding a dependency requirement can now be done with the convenience initializer `.package(url: String, branch: String)`.
    
-   Adding a dependency requirement can now be done with the convenience initializer `.package(url: String, branch: String)`.
-   
-   Test targets can now link against executable targets as if they were libraries, so that they can test any data strutures or algorithms in them.  All the code in the executable except for the main entry point itself is available to the unit test.  Separate executables are still linked, and can be tested as a subprocess in the same way as before.  This feature is available to tests defined in packages that have a tools version of `vNext` or newer. 
+* [#3316]
+    Test targets can now link against executable targets as if they were libraries, so that they can test any data strutures or algorithms in them.  All the code in the executable except for the main entry point itself is available to the unit test.  Separate executables are still linked, and can be tested as a subprocess in the same way as before.  This feature is available to tests defined in packages that have a tools version of `5.5` or newer. 
 
 
 

--- a/Fixtures/DependencyResolution/External/Branch/Bar/Package.swift
+++ b/Fixtures/DependencyResolution/External/Branch/Bar/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:999.0
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Fixtures/DependencyResolution/External/Branch/Foo/Package.swift
+++ b/Fixtures/DependencyResolution/External/Branch/Foo/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:999.0
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Fixtures/Miscellaneous/ExeTest/Package.swift
+++ b/Fixtures/Miscellaneous/ExeTest/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 999.0
+// swift-tools-version: 5.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/Plugins/ContrivedTestPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/ContrivedTestPlugin/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 999.0
+// swift-tools-version: 5.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 999.0
+// swift-tools-version: 5.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/Plugins/MySourceGenClient/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/MySourceGenClient/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 999.0
+// swift-tools-version: 5.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/Plugins/MySourceGenPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/MySourceGenPlugin/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 999.0
+// swift-tools-version: 5.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/Plugins/SandboxTesterPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/SandboxTesterPlugin/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 999.0
+// swift-tools-version: 5.5
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/TestableExe/Package.swift
+++ b/Fixtures/Miscellaneous/TestableExe/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 999.0
+// swift-tools-version: 5.5
 import PackageDescription
 
 let package = Package(

--- a/IntegrationTests/Tests/IntegrationTests/BasicTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/BasicTests.swift
@@ -96,6 +96,8 @@ final class BasicTests: XCTestCase {
     }
 
     func testSwiftPackageInitExec() throws {
+        try XCTSkipUnless(swiftcSupportsRenamingMainSymbol(), "skipping because host compiler doesn't support `-entry-point-function-name`")
+        
         try withTemporaryDirectory { dir in
             // Create a new package with an executable target.
             let projectDir = dir.appending(component: "Project")
@@ -181,6 +183,8 @@ final class BasicTests: XCTestCase {
     }
 
     func testSwiftRun() throws {
+        try XCTSkipUnless(swiftcSupportsRenamingMainSymbol(), "skipping because host compiler doesn't support `-entry-point-function-name`")
+
         try withTemporaryDirectory { dir in
             let toolDir = dir.appending(component: "secho")
             try localFileSystem.createDirectory(toolDir)

--- a/IntegrationTests/Tests/IntegrationTests/Helpers.swift
+++ b/IntegrationTests/Tests/IntegrationTests/Helpers.swift
@@ -342,3 +342,11 @@ extension ProcessResult {
         """
     }
 }
+
+func swiftcSupportsRenamingMainSymbol() throws -> Bool {
+    try withTemporaryDirectory { tmpDir in
+        FileManager.default.createFile(atPath: "\(tmpDir)/foo.swift", contents: Data())
+        let result = try Process.popen(args: swiftc.pathString, "-c", "-Xfrontend", "-entry-point-function-name", "-Xfrontend", "foo", "\(tmpDir)/foo.swift", "-o", "\(tmpDir)/foo.o")
+        return try !result.utf8stderrOutput().contains("unknown argument: '-entry-point-function-name'")
+    }
+}

--- a/Sources/Basics/SwiftVersion.swift
+++ b/Sources/Basics/SwiftVersion.swift
@@ -63,7 +63,7 @@ public struct SwiftVersion {
 extension SwiftVersion {
     /// The current version of the package manager.
     public static let currentVersion = SwiftVersion(
-        version: (5, 4, 0),
+        version: (5, 5, 0),
         isDevelopment: true,
         buildIdentifier: getBuildIdentifier()
     )

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -528,7 +528,7 @@ public final class SwiftTargetBuildDescription {
     /// The path to the swiftmodule file after compilation.
     var moduleOutputPath: AbsolutePath {
         // If we're an executable and we're not allowing test targets to link against us, we hide the module.
-        let allowLinkingAgainstExecutables = (buildParameters.triple.isDarwin() || buildParameters.triple.isLinux()) && toolsVersion >= .vNext
+        let allowLinkingAgainstExecutables = (buildParameters.triple.isDarwin() || buildParameters.triple.isLinux()) && toolsVersion >= .v5_5
         let dirPath = (target.type == .executable && !allowLinkingAgainstExecutables) ? tempsPath : buildParameters.buildPath
         return dirPath.appending(component: target.c99name + ".swiftmodule")
     }
@@ -712,7 +712,7 @@ public final class SwiftTargetBuildDescription {
         // when we link the executable, we will ask the linker to rename the entry point
         // symbol to just `_main` again (or if the linker doesn't support it, we'll
         // generate a source containing a redirect).
-        if target.type == .executable && !isTestTarget && toolsVersion >= .vNext {
+        if target.type == .executable && !isTestTarget && toolsVersion >= .v5_5 {
             // We only do this if the linker supports it, as indicated by whether we
             // can construct the linker flags. In the future we will use a generated
             // code stub for the cases in which the linker doesn't support it, so that
@@ -1208,7 +1208,7 @@ public final class ProductBuildDescription {
             // we will instead have generated a source file containing the redirect.
             // Support for linking tests againsts executables is conditional on the tools
             // version of the package that defines the executable product.
-            if product.executableModule.underlyingTarget is SwiftTarget, toolsVersion >= .vNext {
+            if product.executableModule.underlyingTarget is SwiftTarget, toolsVersion >= .v5_5 {
                 if let flags = buildParameters.linkerFlagsForRenamingMainFunction(of: product.executableModule) {
                     args += flags
                 }
@@ -1392,7 +1392,7 @@ public class BuildPlan {
             // if test manifest exists, prefer that over test detection,
             // this is designed as an escape hatch when test discovery is not appropriate
             // and for backwards compatibility for projects that have existing test manifests (LinuxMain.swift)
-            let toolsVersion = graph.package(for: testProduct)?.manifest.toolsVersion ?? .vNext
+            let toolsVersion = graph.package(for: testProduct)?.manifest.toolsVersion ?? .v5_5
             if let testManifestTarget = testProduct.testManifestTarget, !generate {
                 let desc = try SwiftTargetBuildDescription(
                     target: testManifestTarget,
@@ -1474,7 +1474,7 @@ public class BuildPlan {
             
             // Determine the appropriate tools version to use for the target.
             // This can affect what flags to pass and other semantics.
-            let toolsVersion = graph.package(for: target)?.manifest.toolsVersion ?? .vNext
+            let toolsVersion = graph.package(for: target)?.manifest.toolsVersion ?? .v5_5
 
             switch target.underlyingTarget {
             case is SwiftTarget:
@@ -1525,7 +1525,7 @@ public class BuildPlan {
 
             // Determine the appropriate tools version to use for the product.
             // This can affect what flags to pass and other semantics.
-            let toolsVersion = graph.package(for: product)?.manifest.toolsVersion ?? .vNext
+            let toolsVersion = graph.package(for: product)?.manifest.toolsVersion ?? .v5_5
             productMap[product] = ProductBuildDescription(
                 product: product,
                 toolsVersion: toolsVersion,
@@ -1717,14 +1717,14 @@ public class BuildPlan {
                 switch target.type {
                 // Executable target have historically only been included if they are directly in the product's
                 // target list.  Otherwise they have always been just build-time dependencies.
-                // In tool version .vNext or greater, we also include executable modules implemented in Swift in
+                // In tool version .v5_5 or greater, we also include executable modules implemented in Swift in
                 // any test products... this is to allow testing of executables.  Note that they are also still
                 // built as separate products that the test can invoke as subprocesses.
                 case .executable:
                     if product.targets.contains(target) {
                         staticTargets.append(target)
                     } else if product.type == .test && target.underlyingTarget is SwiftTarget {
-                        if let toolsVersion = graph.package(for: product)?.manifest.toolsVersion, toolsVersion >= .vNext {
+                        if let toolsVersion = graph.package(for: product)?.manifest.toolsVersion, toolsVersion >= .v5_5 {
                             staticTargets.append(target)
                         }
                     }

--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -73,7 +73,7 @@ extension Package.Dependency {
     ///     - name: The name of the package, or nil to deduce it from the URL.
     ///     - url: The valid Git URL of the package.
     ///     - branch: A dependency requirement. See static methods on `Package.Dependency.Requirement` for available options.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.5)
     public static func package(
         name: String? = nil,
         url: String,
@@ -90,7 +90,7 @@ extension Package.Dependency {
     ///     - name: The name of the package, or nil to deduce it from the URL.
     ///     - url: The valid Git URL of the package.
     ///     - revision: A dependency requirement. See static methods on `Package.Dependency.Requirement` for available options.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.5)
     public static func package(
         name: String? = nil,
         url: String,

--- a/Sources/PackageDescription/Product.swift
+++ b/Sources/PackageDescription/Product.swift
@@ -190,7 +190,7 @@ public class Product: Encodable {
     /// - Parameters:
     ///     - name: The name of the plugin product.
     ///     - targets: The plugin targets to vend as a product.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.5)
     public static func plugin(
         name: String,
         targets: [String]

--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -168,7 +168,7 @@ public struct SupportedPlatform: Encodable, Equatable {
     /// Configures the minimum deployment target version for the DriverKit platform.
     ///
     /// - Parameter version: The minimum deployment target that the package supports.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.5)
     public static func driverKit(_ version: SupportedPlatform.DriverKitVersion) -> SupportedPlatform {
         return SupportedPlatform(platform: .driverKit, version: version.version)
     }
@@ -179,7 +179,7 @@ public struct SupportedPlatform: Encodable, Equatable {
     /// The version string must be a series of two or three dot-separated integers, such as `19.0` or `19.0.1`.
     ///
     /// - Parameter versionString: The minimum deployment target as a string representation of two or three dot-separated integers, such as `19.0.1`.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.5)
     public static func driverKit(_ versionString: String) -> SupportedPlatform {
         return SupportedPlatform(platform: .driverKit, version: SupportedPlatform.DriverKitVersion(string: versionString).version)
     }
@@ -398,11 +398,11 @@ extension SupportedPlatform {
         }
 
         /// The value that represents DriverKit 19.0.
-        @available(_PackageDescription, introduced: 999.0)
+        @available(_PackageDescription, introduced: 5.5)
         public static let v19: DriverKitVersion = .init(string: "19.0")
 
         /// The value that represents DriverKit 20.0.
-        @available(_PackageDescription, introduced: 999.0)
+        @available(_PackageDescription, introduced: 5.5)
         public static let v20: DriverKitVersion = .init(string: "20.0")
     }
 }

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -124,7 +124,7 @@ public final class Target {
     public let providers: [SystemPackageProvider]?
     
     /// The capability provided by a package plugin target.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.5)
     public var pluginCapability: PluginCapability? {
         get { return _pluginCapability }
         set { _pluginCapability = newValue }
@@ -179,7 +179,7 @@ public final class Target {
     public var _checksum: String?
 
     /// The usages of package plugins by the target.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.5)
     public var plugins: [PluginUsage]? {
         get { return _pluginUsages }
         set { _pluginUsages = newValue }
@@ -401,7 +401,7 @@ public final class Target {
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    @available(_PackageDescription, introduced: 5.3, obsoleted: 999.0)
+    @available(_PackageDescription, introduced: 5.3, obsoleted: 5.5)
     public static func target(
         name: String,
         dependencies: [Dependency] = [],
@@ -455,7 +455,7 @@ public final class Target {
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
     ///   - plugins: The plugins used by this target.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.5)
     public static func target(
         name: String,
         dependencies: [Dependency] = [],
@@ -511,7 +511,7 @@ public final class Target {
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    @available(_PackageDescription, introduced: 5.4, obsoleted: 999.0)
+    @available(_PackageDescription, introduced: 5.4, obsoleted: 5.5)
     public static func executableTarget(
        name: String,
        dependencies: [Dependency] = [],
@@ -566,7 +566,7 @@ public final class Target {
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
     ///   - plugins: The plugins used by this target.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.5)
     public static func executableTarget(
        name: String,
        dependencies: [Dependency] = [],
@@ -701,7 +701,7 @@ public final class Target {
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    @available(_PackageDescription, introduced: 5.3, obsoleted: 999.0)
+    @available(_PackageDescription, introduced: 5.3, obsoleted: 5.5)
     public static func testTarget(
         name: String,
         dependencies: [Dependency] = [],
@@ -752,7 +752,7 @@ public final class Target {
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
     ///   - plugins: The plugins used by this target.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.5)
     public static func testTarget(
         name: String,
         dependencies: [Dependency] = [],
@@ -904,7 +904,7 @@ public final class Target {
     /// on executables as well as binary targets. This is because of limitations
     /// in how SwiftPM constructs its build plan, and the goal is to remove this
     /// restriction in a future release.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.5)
     public static func plugin(
         name: String,
         capability: PluginCapability,
@@ -1087,7 +1087,7 @@ extension Target.PluginCapability {
     /// Specifies that the plugin provides a prebuild capability.  The plugin
     /// will be applied to each target that uses it and should create commands
     /// that will run before or during the build of the target.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.5)
     public static func buildTool() -> Target.PluginCapability {
         return ._buildTool
     }
@@ -1098,7 +1098,7 @@ extension Target.PluginUsage {
     ///
     /// - parameters:
     ///   - name: The name of the plugin target.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.5)
     public static func plugin(name: String) -> Target.PluginUsage {
         return ._pluginItem(name: name, package: nil)
     }
@@ -1108,7 +1108,7 @@ extension Target.PluginUsage {
     /// - parameters:
     ///   - name: The name of the plugin product.
     ///   - package: The name of the package in which it is defined.
-    @available(_PackageDescription, introduced: 999.0)
+    @available(_PackageDescription, introduced: 5.5)
     public static func plugin(name: String, package: String) -> Target.PluginUsage {
         return ._pluginItem(name: name, package: package)
     }

--- a/Sources/PackageModel/ToolsVersion.swift
+++ b/Sources/PackageModel/ToolsVersion.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -23,6 +23,7 @@ public struct ToolsVersion: Equatable, Hashable, Codable {
     public static let v5_2 = ToolsVersion(version: "5.2.0")
     public static let v5_3 = ToolsVersion(version: "5.3.0")
     public static let v5_4 = ToolsVersion(version: "5.4.0")
+    public static let v5_5 = ToolsVersion(version: "5.5.0")
     public static let vNext = ToolsVersion(version: "999.0.0")
 
     /// The current tools version in use.

--- a/Sources/SPMTestSupport/Resources.swift
+++ b/Sources/SPMTestSupport/Resources.swift
@@ -65,4 +65,12 @@ public class Resources: ManifestResourceProvider {
     public static var havePD4Runtime: Bool {
         return Resources.default.binDir == nil
     }
+    
+    public var swiftCompilerSupportsRenamingMainSymbol: Bool {
+        return (try? withTemporaryDirectory { tmpDir in
+            FileManager.default.createFile(atPath: "\(tmpDir)/foo.swift", contents: Data())
+            let result = try Process.popen(args: self.swiftCompiler.pathString, "-c", "-Xfrontend", "-entry-point-function-name", "-Xfrontend", "foo", "\(tmpDir)/foo.swift", "-o", "\(tmpDir)/foo.o")
+            return try !result.utf8stderrOutput().contains("unknown argument: '-entry-point-function-name'")
+        }) ?? false
+    }
 }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -580,7 +580,7 @@ class MiscellaneousTestCase: XCTestCase {
     
     func testTestsCanLinkAgainstExecutable() throws {
         // Check if the host compiler supports the '-entry-point-function-name' flag.
-        try XCTSkipUnless(doesHostSwiftCompilerSupportRenamingMainSymbol(), "skipping because host compiler doesn't support '-entry-point-function-name'")
+        try XCTSkipUnless(Resources.default.swiftCompilerSupportsRenamingMainSymbol, "skipping because host compiler doesn't support '-entry-point-function-name'")
         
         fixture(name: "Miscellaneous/TestableExe") { prefix in
             do {
@@ -651,14 +651,5 @@ class MiscellaneousTestCase: XCTestCase {
             }
         }
 
-    }
-}
-
-func doesHostSwiftCompilerSupportRenamingMainSymbol() throws -> Bool {
-    try withTemporaryDirectory { tmpDir in
-        let hostToolchain = try UserToolchain(destination: .hostDestination())
-        FileManager.default.createFile(atPath: "\(tmpDir)/foo.swift", contents: Data())
-        let result = try Process.popen(args: hostToolchain.swiftCompiler.pathString, "-c", "-Xfrontend", "-entry-point-function-name", "-Xfrontend", "foo", "\(tmpDir)/foo.swift", "-o", "\(tmpDir)/foo.o")
-        return try !result.utf8stderrOutput().contains("unknown argument: '-entry-point-function-name'")
     }
 }

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -15,8 +15,8 @@ import TSCBasic
 class PluginTests: XCTestCase {
     
     func testUseOfBuildToolPluginTargetByExecutableInSamePackage() throws {
-        // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 999.0.
-        try XCTSkipUnless(doesHostSwiftCompilerSupportRenamingMainSymbol(), "skipping because host compiler doesn't support '-entry-point-function-name'")
+        // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 5.5.
+        try XCTSkipUnless(Resources.default.swiftCompilerSupportsRenamingMainSymbol, "skipping because host compiler doesn't support '-entry-point-function-name'")
         
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
@@ -34,8 +34,8 @@ class PluginTests: XCTestCase {
     }
 
     func testUseOfBuildToolPluginProductByExecutableAcrossPackages() throws {
-        // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 999.0.
-        try XCTSkipUnless(doesHostSwiftCompilerSupportRenamingMainSymbol(), "skipping because host compiler doesn't support '-entry-point-function-name'")
+        // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 5.5.
+        try XCTSkipUnless(Resources.default.swiftCompilerSupportsRenamingMainSymbol, "skipping because host compiler doesn't support '-entry-point-function-name'")
 
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
@@ -53,8 +53,8 @@ class PluginTests: XCTestCase {
     }
 
     func testUseOfPrebuildPluginTargetByExecutableAcrossPackages() throws {
-        // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 999.0.
-        try XCTSkipUnless(doesHostSwiftCompilerSupportRenamingMainSymbol(), "skipping because host compiler doesn't support '-entry-point-function-name'")
+        // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 5.5.
+        try XCTSkipUnless(Resources.default.swiftCompilerSupportsRenamingMainSymbol, "skipping because host compiler doesn't support '-entry-point-function-name'")
 
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
@@ -72,8 +72,8 @@ class PluginTests: XCTestCase {
     }
 
     func testContrivedTestCases() throws {
-        // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 999.0.
-        try XCTSkipUnless(doesHostSwiftCompilerSupportRenamingMainSymbol(), "skipping because host compiler doesn't support '-entry-point-function-name'")
+        // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 5.5.
+        try XCTSkipUnless(Resources.default.swiftCompilerSupportsRenamingMainSymbol, "skipping because host compiler doesn't support '-entry-point-function-name'")
         
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
@@ -91,8 +91,8 @@ class PluginTests: XCTestCase {
     }
 
     func testPluginScriptSandbox() throws {
-        // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 999.0.
-        try XCTSkipUnless(doesHostSwiftCompilerSupportRenamingMainSymbol(), "skipping because host compiler doesn't support '-entry-point-function-name'")
+        // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 5.5.
+        try XCTSkipUnless(Resources.default.swiftCompilerSupportsRenamingMainSymbol, "skipping because host compiler doesn't support '-entry-point-function-name'")
         #if os(macOS)
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
@@ -109,8 +109,8 @@ class PluginTests: XCTestCase {
     }
 
     func testUseOfVendedBinaryTool() throws {
-        // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 999.0.
-        try XCTSkipUnless(doesHostSwiftCompilerSupportRenamingMainSymbol(), "skipping because host compiler doesn't support '-entry-point-function-name'")
+        // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 5.5.
+        try XCTSkipUnless(Resources.default.swiftCompilerSupportsRenamingMainSymbol, "skipping because host compiler doesn't support '-entry-point-function-name'")
         #if os(macOS)
         fixture(name: "Miscellaneous/Plugins") { path in
             do {

--- a/Tests/PackageLoadingTests/PD4_0LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_0LoadingTests.swift
@@ -140,7 +140,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
                ]
             )
             """
-        loadManifest(stream.bytes, toolsVersion: ToolsVersion(string: "999.0")) { manifest in
+        loadManifest(stream.bytes, toolsVersion: ToolsVersion(string: "5.5")) { manifest in
         let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
             XCTAssertEqual(deps["foo1"], .scm(location: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
             XCTAssertEqual(deps["foo2"], .scm(location: "/foo2", requirement: .upToNextMajor(from: "1.0.0")))

--- a/Tests/PackageLoadingTests/PD5_4LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5_4LoadingTests.swift
@@ -64,7 +64,7 @@ class PackageDescription5_4LoadingTests: PackageDescriptionLoadingTests {
             }
 
             XCTAssertMatch(message, .contains("is unavailable"))
-            XCTAssertMatch(message, .contains("was introduced in PackageDescription 999"))
+            XCTAssertMatch(message, .contains("was introduced in PackageDescription 5.5"))
         }
     }
 }

--- a/Tests/PackageLoadingTests/PD5_5LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD5_5LoadingTests.swift
@@ -1,0 +1,63 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+import TSCBasic
+import TSCUtility
+import SPMTestSupport
+import PackageModel
+import PackageLoading
+
+class PackageDescription5_5LoadingTests: PackageDescriptionLoadingTests {
+    override var toolsVersion: ToolsVersion {
+        .v5_5
+    }
+
+    func testPackageDependencies() throws {
+        let stream = BufferedOutputByteStream()
+        stream <<< """
+            import PackageDescription
+            let package = Package(
+               name: "Foo",
+               dependencies: [
+                   .package(url: "/foo5", branch: "main"),
+                   .package(url: "/foo7", revision: "58e9de4e7b79e67c72a46e164158e3542e570ab6"),
+               ]
+            )
+            """
+        loadManifest(stream.bytes, toolsVersion: .v5_5) { manifest in
+        let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
+            XCTAssertEqual(deps["foo5"], .scm(location: "/foo5", requirement: .branch("main")))
+            XCTAssertEqual(deps["foo7"], .scm(location: "/foo7", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
+        }
+    }
+
+    func testBuildToolPluginTarget() throws {
+        let stream = BufferedOutputByteStream()
+        stream <<< """
+            import PackageDescription
+            let package = Package(
+               name: "Foo",
+               targets: [
+                   .plugin(
+                       name: "Foo",
+                       capability: .buildTool()
+                    )
+               ]
+            )
+            """
+
+        loadManifest(stream.bytes) { manifest in
+            XCTAssertEqual(manifest.targets[0].type, .plugin)
+            XCTAssertEqual(manifest.targets[0].pluginCapability, .buildTool)
+        }
+    }
+}

--- a/Tests/PackageLoadingTests/PDNextVersionLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDNextVersionLoadingTests.swift
@@ -20,44 +20,4 @@ class PackageDescriptionNextVersionLoadingTests: PackageDescriptionLoadingTests 
     override var toolsVersion: ToolsVersion {
         .vNext
     }
-
-    func testBuildToolPluginTarget() throws {
-        let stream = BufferedOutputByteStream()
-        stream <<< """
-            import PackageDescription
-            let package = Package(
-               name: "Foo",
-               targets: [
-                   .plugin(
-                       name: "Foo",
-                       capability: .buildTool()
-                    )
-               ]
-            )
-            """
-
-        loadManifest(stream.bytes) { manifest in
-            XCTAssertEqual(manifest.targets[0].type, .plugin)
-            XCTAssertEqual(manifest.targets[0].pluginCapability, .buildTool)
-        }
-    }
-
-    func testPackageDependencies() throws {
-        let stream = BufferedOutputByteStream()
-        stream <<< """
-            import PackageDescription
-            let package = Package(
-               name: "Foo",
-               dependencies: [
-                   .package(url: "/foo5", branch: "main"),
-                   .package(url: "/foo7", revision: "58e9de4e7b79e67c72a46e164158e3542e570ab6"),
-               ]
-            )
-            """
-        loadManifest(stream.bytes, toolsVersion: ToolsVersion(string: "999.0")) { manifest in
-        let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-            XCTAssertEqual(deps["foo5"], .scm(location: "/foo5", requirement: .branch("main")))
-            XCTAssertEqual(deps["foo7"], .scm(location: "/foo7", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
-        }
-    }
 }

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -394,7 +394,7 @@ class PackageBuilderTests: XCTestCase {
         // Check that an explicitly declared target without a main source file works.
         var manifest = Manifest.createV4Manifest(
             name: "pkg",
-            toolsVersion: .vNext,
+            toolsVersion: .v5_5,
             products: [
                 ProductDescription(name: "exec1", type: .executable, targets: ["exec1", "lib"]),
             ],
@@ -414,7 +414,7 @@ class PackageBuilderTests: XCTestCase {
         // Check that products are inferred for explicitly declared executable targets.
         manifest = Manifest.createV4Manifest(
             name: "pkg",
-            toolsVersion: .vNext,
+            toolsVersion: .v5_5,
             products: [],
             targets: [
                 try TargetDescription(name: "exec1", type: .executable),
@@ -432,7 +432,7 @@ class PackageBuilderTests: XCTestCase {
         // Check that products are not inferred if there is an explicit executable product.
         manifest = Manifest.createV4Manifest(
             name: "pkg",
-            toolsVersion: .vNext,
+            toolsVersion: .v5_5,
             products: [
                 ProductDescription(name: "exec1", type: .executable, targets: ["exec1"]),
             ],
@@ -452,7 +452,7 @@ class PackageBuilderTests: XCTestCase {
         // Check that an explicitly declared target with a main source file still works.
         manifest = Manifest.createV4Manifest(
             name: "pkg",
-            toolsVersion: .vNext,
+            toolsVersion: .v5_5,
             products: [
                 ProductDescription(name: "exec1", type: .executable, targets: ["exec1"]),
             ],
@@ -472,7 +472,7 @@ class PackageBuilderTests: XCTestCase {
         // Check that a inferred target with a main source file still works but yields a warning.
         manifest = Manifest.createV4Manifest(
             name: "pkg",
-            toolsVersion: .vNext,
+            toolsVersion: .v5_5,
             products: [
                 ProductDescription(name: "exec2", type: .executable, targets: ["exec2"]),
             ],
@@ -2168,7 +2168,7 @@ class PackageBuilderTests: XCTestCase {
 
         let manifest = Manifest.createManifest(
             name: "Foo",
-            v: .vNext,
+            v: .v5_5,
             targets: [
                 try TargetDescription(
                     name: "MyPlugin",

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -170,11 +170,11 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         let somethingRule = FileRuleDescription(
             rule: .compile,
-            toolsVersion: .vNext,
+            toolsVersion: .v5_5,
             fileTypes: ["something"]
         )
 
-        build(target: target, additionalFileRules: [somethingRule], toolsVersion: .vNext, fs: fs) { sources, _, _, _,_  in
+        build(target: target, additionalFileRules: [somethingRule], toolsVersion: .v5_5, fs: fs) { sources, _, _, _,_  in
             XCTAssertEqual(
                 sources.paths.map(\.pathString).sorted(),
                 files.sorted()
@@ -653,7 +653,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             target: target,
             path: .root,
             defaultLocalization: nil,
-            toolsVersion: .vNext,
+            toolsVersion: .v5_5,
             fs: fs,
             diags: diags
         )

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -85,12 +85,14 @@ class InitTests: XCTestCase {
                 try fs.getDirectoryContents(path.appending(component: "Tests")).sorted(),
                 ["FooTests"])
             
-            // Try building it
-            XCTAssertBuilds(path)
-            let triple = Resources.default.toolchain.triple
-            let binPath = path.appending(components: ".build", triple.tripleString, "debug")
-            XCTAssertFileExists(binPath.appending(component: "Foo"))
-            XCTAssertFileExists(binPath.appending(components: "Foo.swiftmodule"))
+            // If we have a compiler that supports `-entry-point-function-name`, we try building it (we need that flag now).
+            if (Resources.default.swiftCompilerSupportsRenamingMainSymbol) {
+                XCTAssertBuilds(path)
+                let triple = Resources.default.toolchain.triple
+                let binPath = path.appending(components: ".build", triple.tripleString, "debug")
+                XCTAssertFileExists(binPath.appending(component: "Foo"))
+                XCTAssertFileExists(binPath.appending(components: "Foo.swiftmodule"))
+            }
         }
     }
 

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -90,7 +90,7 @@ class InitTests: XCTestCase {
             let triple = Resources.default.toolchain.triple
             let binPath = path.appending(components: ".build", triple.tripleString, "debug")
             XCTAssertFileExists(binPath.appending(component: "Foo"))
-            XCTAssertFileExists(binPath.appending(components: "Foo.build", "Foo.swiftmodule"))
+            XCTAssertFileExists(binPath.appending(components: "Foo.swiftmodule"))
         }
     }
 

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -231,7 +231,7 @@ class ManifestSourceGenerationTests: XCTestCase {
 
     func testPluginTargets() throws {
         let manifestContents = """
-            // swift-tools-version:999.0
+            // swift-tools-version:5.5
             import PackageDescription
 
             let package = Package(
@@ -248,6 +248,6 @@ class ManifestSourceGenerationTests: XCTestCase {
                 ]
             )
             """
-        try testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .vNext)
+        try testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_5)
     }
 }


### PR DESCRIPTION
This updates the current SwiftPM to 5.5 (see https://forums.swift.org/t/swift-5-5-release-process/45644).

### Motivation:

When a new Swift release is announced, SwiftPM is updated to reflect that version.

### Modifications:

- change default version to 5.5.0
- add `v5_5` tools version
- modify `999.0` availability and `vNext` to `5.5` and `v5_5` respectively
- adjust unit test to reflect that executable modules are now linkable by unit tests

Note that SwiftPM is still marked as a development version so that 999.0 is still accepted in mainline.  This will be changed after branching 5.5.