### PR TITLE
Fix warning

### DIFF
--- a/Sources/Build/SPMSwiftDriverExecutor.swift
+++ b/Sources/Build/SPMSwiftDriverExecutor.swift
@@ -77,7 +77,7 @@ final class SPMSwiftDriverExecutor: DriverExecutor {
 
     if usedResponseFile {
       // Print the response file arguments as a comment.
-      result += " # \(job.commandLine.joinedArguments)"
+      result += " # \(job.commandLine.joinedUnresolvedArguments)"
     }
 
     if !job.extraEnvironment.isEmpty {


### PR DESCRIPTION
We have switched to a newer version of swift-driver at this point and can fix this warning.