### PR TITLE
Remove duplicated “.com” in product example code documentation

### DIFF
--- a/Documentation/PackageDescription.md
+++ b/Documentation/PackageDescription.md
@@ -200,7 +200,7 @@ let package = Package(
         .library(name: "PaperDynamic", type: .dynamic, targets: ["Paper"]),
     ],
     dependencies: [
-        .package(url: "http://example.com.com/ExamplePackage/ExamplePackage", from: "1.2.3"),
+        .package(url: "http://example.com/ExamplePackage/ExamplePackage", from: "1.2.3"),
         .package(url: "http://some/other/lib", .exact("1.2.3")),
     ],
     targets: [


### PR DESCRIPTION
A one-line description for a one-line documentation change: just reducing “.com.com” to “.com”.

### Motivation:

Doubled-up “.com” is unnecessary in example code or anywhere, really.

### Modifications:

Reduced the example package URL from “http://example.com.com/ExamplePackage/ExamplePackage” to “http://example.com/ExamplePackage/ExamplePackage”.

### Result:

Example code is now easier to grok. Hooray!