### PR TITLE
[RFC] improve clone performance by cloning without blobs

### DIFF
--- a/Sources/SourceControl/Repository.swift
+++ b/Sources/SourceControl/Repository.swift
@@ -70,7 +70,7 @@ public protocol RepositoryProvider {
     ///
     /// - Parameters:
     ///   - repository: The specifier of the repository to fetch.
-    ///   - path: The destiantion path for the fetch.
+    ///   - path: The destination path for the fetch.
     /// - Throws: If there is any error fetching the repository.
     func fetch(repository: RepositorySpecifier, to path: AbsolutePath) throws
 


### PR DESCRIPTION
motivation: faster cloning of large repositories

changes:
* introduce configurtation options to GitRepositoryProvider
* add configuration for cloning w/o blobs
* clone with "--filter=blob:none" when appropriate
