### PR TITLE
Revert "Raise the minimum deployment target to 10.11 (#3384)"

### DIFF
--- a/Sources/PackageModel/Platform.swift
+++ b/Sources/PackageModel/Platform.swift
@@ -25,7 +25,7 @@ public struct Platform: Equatable, Hashable, Codable {
         self.oldestSupportedVersion = oldestSupportedVersion
     }
     
-    public static let macOS: Platform = Platform(name: "macos", oldestSupportedVersion: "10.11")
+    public static let macOS: Platform = Platform(name: "macos", oldestSupportedVersion: "10.10")
     public static let iOS: Platform = Platform(name: "ios", oldestSupportedVersion: "9.0")
     public static let tvOS: Platform = Platform(name: "tvos", oldestSupportedVersion: "9.0")
     public static let watchOS: Platform = Platform(name: "watchos", oldestSupportedVersion: "2.0")

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -20,7 +20,7 @@ import XCTest
 
 let hostTriple = Resources.default.toolchain.triple
 #if os(macOS)
-    let defaultTargetTriple: String = hostTriple.tripleString(forPlatformVersion: "10.11")
+    let defaultTargetTriple: String = hostTriple.tripleString(forPlatformVersion: "10.10")
 #else
     let defaultTargetTriple: String = hostTriple.tripleString
 #endif


### PR DESCRIPTION
This reverts commit 5fe380c387b06b4079aa10ccae6be41dc3838707.

With https://github.com/apple/swift-driver/pull/581 being merged, we can undo this temporary workaround.

rdar://76167831
