### PR TITLE
[Collections] getPackageMetadata from specific collections

### DIFF
--- a/Sources/Commands/SwiftPackageCollectionsTool.swift
+++ b/Sources/Commands/SwiftPackageCollectionsTool.swift
@@ -272,7 +272,7 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
                 let reference = PackageReference.remote(identity: identity, location: packageUrl)
 
                 do { // assume URL is for a package in an imported collection
-                    let result = try tsc_await { collections.getPackageMetadata(reference, callback: $0) }
+                    let result = try tsc_await { collections.getPackageMetadata(reference, collections: nil, callback: $0) }
 
                     if let versionString = version {
                         guard let version = TSCUtility.Version(string: versionString), let result = result.package.versions.first(where: { $0.version == version }), let printedResult = printVersion(result) else {

--- a/Sources/Commands/SwiftPackageCollectionsTool.swift
+++ b/Sources/Commands/SwiftPackageCollectionsTool.swift
@@ -272,7 +272,7 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
                 let reference = PackageReference.remote(identity: identity, location: packageUrl)
 
                 do { // assume URL is for a package in an imported collection
-                    let result = try tsc_await { collections.getPackageMetadata(reference, collections: nil, callback: $0) }
+                    let result = try tsc_await { collections.getPackageMetadata(reference, callback: $0) }
 
                     if let versionString = version {
                         guard let version = TSCUtility.Version(string: versionString), let result = result.package.versions.first(where: { $0.version == version }), let printedResult = printVersion(result) else {
@@ -324,7 +324,7 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
                             try JSONEncoder.makeWithDefaults().print(collection)
                         } else {
                             let signature = optionalRow("Signed By", collection.signature.map { "\($0.certificate.subject.commonName ?? "Unspecified") (\($0.isVerified ? "" : "not ")verified)" })
-                            
+
                             print("""
                                 Name: \(collection.name)
                                 Source: \(collection.source.url)\(description)\(keywords)\(createdAt)

--- a/Sources/PackageCollections/API.swift
+++ b/Sources/PackageCollections/API.swift
@@ -110,6 +110,19 @@ public protocol PackageCollectionsProtocol {
     ///
     /// - Parameters:
     ///   - reference: The package reference
+    ///   - callback: The closure to invoke when result becomes available
+    func getPackageMetadata(
+        _ reference: PackageReference,
+        callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void
+    )
+
+    /// Returns metadata for the package identified by the given `PackageReference`, along with the
+    /// identifiers of `PackageCollection`s where the package is found.
+    ///
+    /// A failure is returned if the package is not found.
+    ///
+    /// - Parameters:
+    ///   - reference: The package reference
     ///   - collections: Optional. If specified, only look for package in these collections. Data from the most recently
     ///                  processed collection will be used.
     ///   - callback: The closure to invoke when result becomes available

--- a/Sources/PackageCollections/API.swift
+++ b/Sources/PackageCollections/API.swift
@@ -110,9 +110,12 @@ public protocol PackageCollectionsProtocol {
     ///
     /// - Parameters:
     ///   - reference: The package reference
+    ///   - collections: Optional. If specified, only look for package in these collections. Data from the most recently
+    ///                  processed collection will be used.
     ///   - callback: The closure to invoke when result becomes available
     func getPackageMetadata(
         _ reference: PackageReference,
+        collections: Set<PackageCollectionsModel.CollectionIdentifier>?,
         callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void
     )
 

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -305,7 +305,12 @@ public struct PackageCollections: PackageCollectionsProtocol {
     // MARK: - Package Metadata
 
     public func getPackageMetadata(_ reference: PackageReference,
-                                   collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil,
+                                   callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void) {
+        self.getPackageMetadata(reference, collections: nil, callback: callback)
+    }
+
+    public func getPackageMetadata(_ reference: PackageReference,
+                                   collections: Set<PackageCollectionsModel.CollectionIdentifier>?,
                                    callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void) {
         guard Self.isSupportedPlatform else {
             return callback(.failure(PackageCollectionError.unsupportedPlatform))

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -305,13 +305,14 @@ public struct PackageCollections: PackageCollectionsProtocol {
     // MARK: - Package Metadata
 
     public func getPackageMetadata(_ reference: PackageReference,
+                                   collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil,
                                    callback: @escaping (Result<PackageCollectionsModel.PackageMetadata, Error>) -> Void) {
         guard Self.isSupportedPlatform else {
             return callback(.failure(PackageCollectionError.unsupportedPlatform))
         }
 
         // first find in storage
-        self.findPackage(identifier: reference.identity) { result in
+        self.findPackage(identifier: reference.identity, collections: collections) { result in
             switch result {
             case .failure(let error):
                 callback(.failure(error))
@@ -453,17 +454,21 @@ public struct PackageCollections: PackageCollectionsProtocol {
     }
 
     func findPackage(identifier: PackageIdentity,
+                     collections: Set<PackageCollectionsModel.CollectionIdentifier>?,
                      callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult.Item, Error>) -> Void) {
         self.storage.sources.list { result in
             switch result {
             case .failure(let error):
                 callback(.failure(error))
             case .success(let sources):
-                let identifiers = sources.map { Model.CollectionIdentifier(from: $0) }
-                if identifiers.isEmpty {
+                var collectionIdentifiers = sources.map { Model.CollectionIdentifier(from: $0) }
+                if let collections = collections {
+                    collectionIdentifiers = collectionIdentifiers.filter { collections.contains($0) }
+                }
+                if collectionIdentifiers.isEmpty {
                     return callback(.failure(NotFoundError("\(identifier)")))
                 }
-                self.storage.collections.findPackage(identifier: identifier, collectionIdentifiers: identifiers, callback: callback)
+                self.storage.collections.findPackage(identifier: identifier, collectionIdentifiers: collectionIdentifiers, callback: callback)
             }
         }
     }

--- a/Sources/PackageCollectionsModel/PackageCollectionModel+v1.swift
+++ b/Sources/PackageCollectionsModel/PackageCollectionModel+v1.swift
@@ -324,7 +324,7 @@ extension PackageCollectionModel.V1 {
 
         /// An executable product.
         case executable
-        
+
         /// An plugin product.
         case plugin
 


### PR DESCRIPTION
Motivation:
Currently `getPackageMetadata` searches across all imported collections for a given package and if found, returns metadata from the most recently processed
collection. This isn't always the desired behavior though, for we might be interested in metadata from specific collection(s) only.

Modifications:
Add optional `collections` parameter to the API. It keeps the current behavior if `nil`, otherwise it only searches inside the specific collections.
