### PR TITLE
refine when --enable-test-discovery deprecation warning is emmited

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -413,10 +413,13 @@ public class SwiftTool {
             diagnostics.emit(error: "'--netrc-file' option is only supported on macOS >=10.13")
             #endif
         }
-        
+
+        // --enable-test-discovery should never be called on darwin based platforms
+        #if canImport(Darwin)
         if options.enableTestDiscovery {
             diagnostics.emit(warning: "'--enable-test-discovery' option is deprecated; tests are automatically discovered on all platforms")
         }
+        #endif
 
         if options.shouldDisableManifestCaching {
             diagnostics.emit(warning: "'--disable-package-manifest-caching' option is deprecated; use '--manifest-caching' instead")


### PR DESCRIPTION
motivation: nicer user experience in cases LinuxMain is kept for older tools

changes:
* only emit --enable-test-discovery deprecation warning when targeting darwin based platforms or when LinuxMain does not exist
* adjust tests

rdar://76356108
