### PR TITLE
Android: enable BoringSSL and other Package Collections support

### DIFF
--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -15,7 +15,7 @@ import TSCBasic
 // TODO: is there a better name? this conflicts with the module name which is okay in this case but not ideal in Swift
 public struct PackageCollections: PackageCollectionsProtocol {
     // Check JSONPackageCollectionProvider.isSignatureCheckSupported before updating or removing this
-    #if os(macOS) || os(Linux) || os(Windows)
+    #if os(macOS) || os(Linux) || os(Windows) || os(Android)
     static let isSupportedPlatform = true
     #else
     static let isSupportedPlatform = false

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -27,7 +27,7 @@ private typealias JSONModel = PackageCollectionModel.V1
 struct JSONPackageCollectionProvider: PackageCollectionProvider {
     // TODO: This can be removed when the `Security` framework APIs that the `PackageCollectionsSigning`
     // module depends on are available on all Apple platforms.
-    #if os(macOS) || os(Linux) || os(Windows)
+    #if os(macOS) || os(Linux) || os(Windows) || os(Android)
     static let isSignatureCheckSupported = true
     #else
     static let isSignatureCheckSupported = false

--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -798,6 +798,11 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
         """
         try db.exec(query: table)
 
+        #if os(Android)
+        // FTS queries for strings containing hyphens isn't working in SQLite on
+        // Android, so disable for now.
+        useSearchIndices.put(false)
+        #else
         do {
             let ftsPackages = """
                 CREATE VIRTUAL TABLE IF NOT EXISTS \(Self.packagesFTSName) USING fts4(
@@ -824,6 +829,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
             // consistent results we will not fallback to FTS3 and just give up if FTS4 is not available.
             useSearchIndices.put(false)
         }
+        #endif
 
         try db.exec(query: "PRAGMA journal_mode=WAL;")
     }

--- a/Sources/PackageCollectionsSigning/Certificate/Certificate.swift
+++ b/Sources/PackageCollectionsSigning/Certificate/Certificate.swift
@@ -12,13 +12,13 @@ import struct Foundation.Data
 
 #if os(macOS)
 import Security
-#elseif os(Linux) || os(Windows)
+#elseif os(Linux) || os(Windows) || os(Android)
 @_implementationOnly import CCryptoBoringSSL
 #endif
 
 #if os(macOS)
 typealias Certificate = CoreCertificate
-#elseif os(Linux) || os(Windows)
+#elseif os(Linux) || os(Windows) || os(Android)
 typealias Certificate = BoringSSLCertificate
 #else
 typealias Certificate = UnsupportedCertificate
@@ -109,7 +109,7 @@ struct CoreCertificate {
 
 // MARK: - Certificate implementation using BoringSSL
 
-#elseif os(Linux) || os(Windows)
+#elseif os(Linux) || os(Windows) || os(Android)
 final class BoringSSLCertificate {
     private let underlying: UnsafeMutablePointer<X509>
 

--- a/Sources/PackageCollectionsSigning/Key/BoringSSLKey.swift
+++ b/Sources/PackageCollectionsSigning/Key/BoringSSLKey.swift
@@ -21,7 +21,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Linux) || os(Windows)
+#if os(Linux) || os(Windows) || os(Android)
 import Foundation
 
 @_implementationOnly import CCryptoBoringSSL

--- a/Sources/PackageCollectionsSigning/Key/Key+RSA.swift
+++ b/Sources/PackageCollectionsSigning/Key/Key+RSA.swift
@@ -25,14 +25,14 @@ import Foundation
 
 #if os(macOS)
 import Security
-#elseif os(Linux) || os(Windows)
+#elseif os(Linux) || os(Windows) || os(Android)
 @_implementationOnly import CCryptoBoringSSL
 #endif
 
 #if os(macOS)
 typealias RSAPublicKey = CoreRSAPublicKey
 typealias RSAPrivateKey = CoreRSAPrivateKey
-#elseif os(Linux) || os(Windows)
+#elseif os(Linux) || os(Windows) || os(Android)
 typealias RSAPublicKey = BoringSSLRSAPublicKey
 typealias RSAPrivateKey = BoringSSLRSAPrivateKey
 #else
@@ -106,7 +106,7 @@ struct CoreRSAPublicKey: PublicKey {
 
 // Reference: https://github.com/vapor/jwt-kit/blob/master/Sources/JWTKit/RSA/RSAKey.swift
 
-#elseif os(Linux) || os(Windows)
+#elseif os(Linux) || os(Windows) || os(Android)
 final class BoringSSLRSAPrivateKey: PrivateKey, BoringSSLKey {
     let underlying: UnsafeMutablePointer<CCryptoBoringSSL.RSA>
 

--- a/Sources/PackageCollectionsSigning/Signing/BoringSSLSigning.swift
+++ b/Sources/PackageCollectionsSigning/Signing/BoringSSLSigning.swift
@@ -21,7 +21,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Linux) || os(Windows)
+#if os(Linux) || os(Windows) || os(Android)
 import Foundation
 
 @_implementationOnly import CCryptoBoringSSL

--- a/Sources/PackageCollectionsSigning/Signing/Signing+RSAKey.swift
+++ b/Sources/PackageCollectionsSigning/Signing/Signing+RSAKey.swift
@@ -25,7 +25,7 @@ import struct Foundation.Data
 
 #if os(macOS)
 import Security
-#elseif os(Linux) || os(Windows)
+#elseif os(Linux) || os(Windows) || os(Android)
 @_implementationOnly import CCryptoBoringSSL
 #endif
 
@@ -59,7 +59,7 @@ extension CoreRSAPublicKey {
 
 // MARK: - MessageSigner and MessageValidator conformance using BoringSSL
 
-#elseif os(Linux) || os(Windows)
+#elseif os(Linux) || os(Windows) || os(Android)
 // Reference: https://github.com/vapor/jwt-kit/blob/master/Sources/JWTKit/RSA/RSASigner.swift
 extension BoringSSLRSAPrivateKey: BoringSSLSigning {
     private static let algorithm = BoringSSLEVP(type: .sha256)

--- a/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
+++ b/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift
@@ -79,7 +79,7 @@ class CertificatePolicyTests: XCTestCase {
                 guard CertificatePolicyError.invalidCertChain == error as? CertificatePolicyError else {
                     return XCTFail("Expected CertificatePolicyError.invalidCertChain")
                 }
-                #elseif os(Linux) || os(Windows)
+                #elseif os(Linux) || os(Windows) || os(Android)
                 guard CertificatePolicyError.noTrustedRootCertsConfigured == error as? CertificatePolicyError else {
                     return XCTFail("Expected CertificatePolicyError.noTrustedRootCertsConfigured")
                 }
@@ -142,7 +142,7 @@ class CertificatePolicyTests: XCTestCase {
                     return XCTFail("Expected CertificatePolicyError.invalidCertChain")
                 }
             }
-            #elseif os(Linux) || os(Windows)
+            #elseif os(Linux) || os(Windows) || os(Android)
             // On other platforms we have to specify `trustedRootCertsDir` so the Apple root cert is trusted
             try withTemporaryDirectory { tmp in
                 try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))
@@ -192,7 +192,7 @@ class CertificatePolicyTests: XCTestCase {
                                                       callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
-            #elseif os(Linux) || os(Windows)
+            #elseif os(Linux) || os(Windows) || os(Android)
             // On other platforms we have to specify `trustedRootCertsDir` so the Apple root cert is trusted
             try withTemporaryDirectory { tmp in
                 try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))
@@ -257,7 +257,7 @@ class CertificatePolicyTests: XCTestCase {
                                                              callbackQueue: callbackQueue, diagnosticsEngine: diagnosticsEngine)
                 XCTAssertNoThrow(try tsc_await { callback in policy.validate(certChain: certChain, callback: callback) })
             }
-            #elseif os(Linux) || os(Windows)
+            #elseif os(Linux) || os(Windows) || os(Android)
             // On other platforms we have to specify `trustedRootCertsDir` so the Apple root cert is trusted
             try withTemporaryDirectory { tmp in
                 try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))
@@ -327,7 +327,7 @@ class CertificatePolicyTests: XCTestCase {
                     }
                 }
             }
-            #elseif os(Linux) || os(Windows)
+            #elseif os(Linux) || os(Windows) || os(Android)
             // On other platforms we have to specify `trustedRootCertsDir` so the Apple root cert is trusted
             try withTemporaryDirectory { tmp in
                 try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))
@@ -395,7 +395,7 @@ class CertificatePolicyTests: XCTestCase {
                     }
                 }
             }
-            #elseif os(Linux) || os(Windows)
+            #elseif os(Linux) || os(Windows) || os(Android)
             // On other platforms we have to specify `trustedRootCertsDir` so the Apple root cert is trusted
             try withTemporaryDirectory { tmp in
                 try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))

--- a/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
+++ b/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift
@@ -247,7 +247,7 @@ class PackageCollectionSigningTests: XCTestCase {
                     signing.validate(signedCollection: signedCollection, certPolicyKey: certPolicyKey, callback: callback)
                 })
             }
-            #elseif os(Linux) || os(Windows)
+            #elseif os(Linux) || os(Windows) || os(Android)
             // On other platforms we have to specify `trustedRootCertsDir` so the Apple root cert is trusted
             try withTemporaryDirectory { tmp in
                 try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))
@@ -339,7 +339,7 @@ class PackageCollectionSigningTests: XCTestCase {
                     signing.validate(signedCollection: signedCollection, certPolicyKey: certPolicyKey, callback: callback)
                 })
             }
-            #elseif os(Linux) || os(Windows)
+            #elseif os(Linux) || os(Windows) || os(Android)
             // On other platforms we have to specify `trustedRootCertsDir` so the Apple root cert is trusted
             try withTemporaryDirectory { tmp in
                 try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))
@@ -412,7 +412,7 @@ class PackageCollectionSigningTests: XCTestCase {
             XCTAssertNoThrow(try tsc_await { callback in
                 signing.validate(signedCollection: signedCollection, certPolicyKey: certPolicyKey, callback: callback)
             })
-            #elseif os(Linux) || os(Windows)
+            #elseif os(Linux) || os(Windows) || os(Android)
             // On other platforms we have to specify `trustedRootCertsDir` so the Apple root cert is trusted
             try withTemporaryDirectory { tmp in
                 try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))
@@ -467,7 +467,7 @@ class PackageCollectionSigningTests: XCTestCase {
             XCTAssertNoThrow(try tsc_await { callback in
                 signing.validate(signedCollection: signedCollection, certPolicyKey: certPolicyKey, callback: callback)
             })
-            #elseif os(Linux) || os(Windows)
+            #elseif os(Linux) || os(Windows) || os(Android)
             // On other platforms we have to specify `trustedRootCertsDir` so the Apple root cert is trusted
             try withTemporaryDirectory { tmp in
                 try localFileSystem.copy(from: rootCAPath, to: tmp.appending(components: "AppleIncRoot.cer"))

--- a/Tests/PackageCollectionsSigningTests/Utilities.swift
+++ b/Tests/PackageCollectionsSigningTests/Utilities.swift
@@ -178,7 +178,7 @@ extension String {
 
 extension XCTestCase {
     func skipIfUnsupportedPlatform() throws {
-        #if os(macOS) || os(Linux) || os(Windows)
+        #if os(macOS) || os(Linux) || os(Windows) || os(Android)
         #else
         throw XCTSkip("Skipping test on unsupported platform")
         #endif


### PR DESCRIPTION
Fix building package collections for Android

### Motivation:

Building latest trunk or the last March 25 trunk source snapshot for Android fails because Android is not added to these supported OS lists.

### Modifications:

Add Android to the list of supported OS's.

### Result:

I'm now able to both cross-compile and natively compile SPM for Android. When running the tests, I get the following failures:
```
Test Suite 'Selected tests' started at 2021-04-08 16:09:18.868
Test Suite 'CertificatePolicyTests' started at 2021-04-08 16:09:18.890
Test Case 'CertificatePolicyTests.test_EC_validate_happyCase' started at 2021-04-08 16:09:18.891
/data/data/com.termux/files/home/src/swiftpm/Tests/PackageCollectionsSigningTests/CertificatePolicyTests.swift:56: error: CertificatePolicyTests.test_EC_validate_happyCase : XCTAssertNoThrow failed: threw error "invalidCertChain" - 
Test Case 'CertificatePolicyTests.test_EC_validate_happyCase' failed (0.636 seconds)
Test Suite 'CertificatePolicyTests' failed at 2021-04-08 16:09:19.527
	 Executed 1 test, with 1 failure (0 unexpected) in 0.636 (0.636) seconds
Test Suite 'Selected tests' failed at 2021-04-08 16:09:19.527
	 Executed 1 test, with 1 failure (0 unexpected) in 0.636 (0.636) seconds

Test Suite 'Selected tests' started at 2021-04-08 16:09:21.009
Test Suite 'PackageCollectionSigningTests' started at 2021-04-08 16:09:21.012
Test Case 'PackageCollectionSigningTests.test_EC_signAndValidate_collectionMismatch' started at 2021-04-08 16:09:21.012
/data/data/com.termux/files/home/src/swiftpm/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift:144: error: PackageCollectionSigningTests.test_EC_signAndValidate_collectionMismatch : failed - invalidCertChain
Test Case 'PackageCollectionSigningTests.test_EC_signAndValidate_collectionMismatch' failed (0.764 seconds)
Test Suite 'PackageCollectionSigningTests' failed at 2021-04-08 16:09:21.776
	 Executed 1 test, with 1 failure (0 unexpected) in 0.764 (0.764) seconds
Test Suite 'Selected tests' failed at 2021-04-08 16:09:21.776
	 Executed 1 test, with 1 failure (0 unexpected) in 0.764 (0.764) seconds

Test Suite 'Selected tests' started at 2021-04-08 16:09:21.156
Test Suite 'PackageCollectionSigningTests' started at 2021-04-08 16:09:21.167
Test Case 'PackageCollectionSigningTests.test_EC_signAndValidate_happyCase' started at 2021-04-08 16:09:21.167
/data/data/com.termux/files/home/src/swiftpm/Tests/PackageCollectionsSigningTests/PackageCollectionSigningTest.swift:112: error: PackageCollectionSigningTests.test_EC_signAndValidate_happyCase : failed - invalidCertChain
Test Case 'PackageCollectionSigningTests.test_EC_signAndValidate_happyCase' failed (0.741 seconds)
Test Suite 'PackageCollectionSigningTests' failed at 2021-04-08 16:09:21.908
	 Executed 1 test, with 1 failure (0 unexpected) in 0.741 (0.741) seconds
Test Suite 'Selected tests' failed at 2021-04-08 16:09:21.908
	 Executed 1 test, with 1 failure (0 unexpected) in 0.741 (0.741) seconds

Test Suite 'Selected tests' started at 2021-04-08 16:09:27.357
Test Suite 'PackageCollectionsTests' started at 2021-04-08 16:09:27.368
Test Case 'PackageCollectionsTests.testPackageSearch' started at 2021-04-08 16:09:27.368
/data/data/com.termux/files/home/src/swiftpm/Tests/PackageCollectionsTests/PackageCollectionsTests.swift:644: error: PackageCollectionsTests.testPackageSearch : XCTAssertEqual failed: ("0") is not equal to ("1") - list count should match
/data/data/com.termux/files/home/src/swiftpm/Tests/PackageCollectionsTests/PackageCollectionsTests.swift:645: error: PackageCollectionsTests.testPackageSearch : XCTAssertEqual failed: ("nil") is not equal to ("Optional([PackageCollections.PackageCollectionsModel.CollectionIdentifier.json(https://feed.mock/45754C6E-1B17-4755-82CF-03BD333F42F8), PackageCollections.PackageCollectionsModel.CollectionIdentifier.json(https://feed.mock/C0211A59-EF95-4DE1-B16A-2B92C4610122)])") - list count should match
/data/data/com.termux/files/home/src/swiftpm/Tests/PackageCollectionsTests/PackageCollectionsTests.swift:651: error: PackageCollectionsTests.testPackageSearch : XCTAssertEqual failed: ("0") is not equal to ("1") - list count should match
/data/data/com.termux/files/home/src/swiftpm/Tests/PackageCollectionsTests/PackageCollectionsTests.swift:652: error: PackageCollectionsTests.testPackageSearch : XCTAssertEqual failed: ("nil") is not equal to ("Optional([PackageCollections.PackageCollectionsModel.CollectionIdentifier.json(https://feed.mock/45754C6E-1B17-4755-82CF-03BD333F42F8), PackageCollections.PackageCollectionsModel.CollectionIdentifier.json(https://feed.mock/C0211A59-EF95-4DE1-B16A-2B92C4610122)])") - list count should match
/data/data/com.termux/files/home/src/swiftpm/Tests/PackageCollectionsTests/PackageCollectionsTests.swift:658: error: PackageCollectionsTests.testPackageSearch : XCTAssertEqual failed: ("0") is not equal to ("1") - list count should match
/data/data/com.termux/files/home/src/swiftpm/Tests/PackageCollectionsTests/PackageCollectionsTests.swift:659: error: PackageCollectionsTests.testPackageSearch : XCTAssertEqual failed: ("nil") is not equal to ("Optional([PackageCollections.PackageCollectionsModel.CollectionIdentifier.json(https://feed.mock/45754C6E-1B17-4755-82CF-03BD333F42F8), PackageCollections.PackageCollectionsModel.CollectionIdentifier.json(https://feed.mock/C0211A59-EF95-4DE1-B16A-2B92C4610122)])") - list count should match
/data/data/com.termux/files/home/src/swiftpm/Tests/PackageCollectionsTests/PackageCollectionsTests.swift:665: error: PackageCollectionsTests.testPackageSearch : XCTAssertEqual failed: ("0") is not equal to ("1") - list count should match
/data/data/com.termux/files/home/src/swiftpm/Tests/PackageCollectionsTests/PackageCollectionsTests.swift:666: error: PackageCollectionsTests.testPackageSearch : XCTAssertEqual failed: ("nil") is not equal to ("Optional([PackageCollections.PackageCollectionsModel.CollectionIdentifier.json(https://feed.mock/45754C6E-1B17-4755-82CF-03BD333F42F8), PackageCollections.PackageCollectionsModel.CollectionIdentifier.json(https://feed.mock/C0211A59-EF95-4DE1-B16A-2B92C4610122)])") - collections should match
/data/data/com.termux/files/home/src/swiftpm/Tests/PackageCollectionsTests/PackageCollectionsTests.swift:672: error: PackageCollectionsTests.testPackageSearch : XCTAssertEqual failed: ("0") is not equal to ("1") - list count should match
/data/data/com.termux/files/home/src/swiftpm/Tests/PackageCollectionsTests/PackageCollectionsTests.swift:673: error: PackageCollectionsTests.testPackageSearch : XCTAssertEqual failed: ("nil") is not equal to ("Optional([PackageCollections.PackageCollectionsModel.CollectionIdentifier.json(https://feed.mock/45754C6E-1B17-4755-82CF-03BD333F42F8), PackageCollections.PackageCollectionsModel.CollectionIdentifier.json(https://feed.mock/C0211A59-EF95-4DE1-B16A-2B92C4610122)])") - collections should match
/data/data/com.termux/files/home/src/swiftpm/Tests/PackageCollectionsTests/PackageCollectionsTests.swift:679: error: PackageCollectionsTests.testPackageSearch : XCTAssertEqual failed: ("0") is not equal to ("1") - list count should match
/data/data/com.termux/files/home/src/swiftpm/Tests/PackageCollectionsTests/PackageCollectionsTests.swift:680: error: PackageCollectionsTests.testPackageSearch : XCTAssertEqual failed: ("nil") is not equal to ("Optional([PackageCollections.PackageCollectionsModel.CollectionIdentifier.json(https://feed.mock/45754C6E-1B17-4755-82CF-03BD333F42F8), PackageCollections.PackageCollectionsModel.CollectionIdentifier.json(https://feed.mock/C0211A59-EF95-4DE1-B16A-2B92C4610122)])") - list count should match
/data/data/com.termux/files/home/src/swiftpm/Tests/PackageCollectionsTests/PackageCollectionsTests.swift:686: error: PackageCollectionsTests.testPackageSearch : XCTAssertEqual failed: ("0") is not equal to ("1") - list count should match
/data/data/com.termux/files/home/src/swiftpm/Tests/PackageCollectionsTests/PackageCollectionsTests.swift:687: error: PackageCollectionsTests.testPackageSearch : XCTAssertEqual failed: ("nil") is not equal to ("Optional([PackageCollections.PackageCollectionsModel.CollectionIdentifier.json(https://feed.mock/45754C6E-1B17-4755-82CF-03BD333F42F8), PackageCollections.PackageCollectionsModel.CollectionIdentifier.json(https://feed.mock/C0211A59-EF95-4DE1-B16A-2B92C4610122)])") - collections should match
Test Case 'PackageCollectionsTests.testPackageSearch' failed (4.432 seconds)
Test Suite 'PackageCollectionsTests' failed at 2021-04-08 16:09:31.801
	 Executed 1 test, with 14 failures (0 unexpected) in 4.432 (4.432) seconds
Test Suite 'Selected tests' failed at 2021-04-08 16:09:31.801
	 Executed 1 test, with 14 failures (0 unexpected) in 4.432 (4.432) seconds
```
I'm not sure why these four tests fail, but there's nothing important that can't be fixed later.

@yim-lee, mind reviewing?