### PR TITLE
[Collections] Add optional title to package version

### DIFF
--- a/Sources/PackageCollections/Model/Package.swift
+++ b/Sources/PackageCollections/Model/Package.swift
@@ -113,6 +113,9 @@ extension PackageCollectionsModel.Package {
         /// The version
         public let version: TSCUtility.Version
 
+        /// The title or name of the version
+        public let title: String?
+
         /// Package version description
         public let summary: String?
 

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -532,6 +532,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
         var versions = package.versions.map { packageVersion -> Model.Package.Version in
             let versionMetadata = basicVersionMetadata[packageVersion.version]
             return .init(version: packageVersion.version,
+                         title: versionMetadata?.title ?? packageVersion.title,
                          summary: versionMetadata?.summary ?? packageVersion.summary,
                          manifests: packageVersion.manifests,
                          defaultToolsVersion: packageVersion.defaultToolsVersion,

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -132,7 +132,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
                             guard let version = $0.tagName.flatMap(TSCUtility.Version.init(string:)) else {
                                 return nil
                             }
-                            return Model.PackageBasicVersionMetadata(version: version, summary: $0.body, createdAt: $0.createdAt, publishedAt: $0.publishedAt)
+                            return Model.PackageBasicVersionMetadata(version: version, title: $0.name, summary: $0.body, createdAt: $0.createdAt, publishedAt: $0.publishedAt)
                         },
                         watchersCount: metadata.watchersCount,
                         readmeURL: readme?.downloadURL,

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -224,6 +224,7 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
                 let license = version.license.flatMap { Model.License(from: $0) }
 
                 return .init(version: parsedVersion,
+                             title: nil,
                              summary: version.summary,
                              manifests: manifests,
                              defaultToolsVersion: defaultToolsVersion,

--- a/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
@@ -40,6 +40,7 @@ extension Model {
 
     struct PackageBasicVersionMetadata: Equatable {
         let version: TSCUtility.Version
+        let title: String?
         let summary: String?
         let createdAt: Date
         let publishedAt: Date?

--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -95,6 +95,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
             XCTAssertEqual(metadata.summary, "This your first repo!")
             XCTAssertEqual(metadata.versions.count, 1)
             XCTAssertEqual(metadata.versions[0].version, TSCUtility.Version("1.0.0"))
+            XCTAssertEqual(metadata.versions[0].title, "1.0.0")
             XCTAssertEqual(metadata.versions[0].summary, "Description of the release")
             XCTAssertEqual(metadata.authors, [PackageCollectionsModel.Package.Author(username: "octocat",
                                                                                      url: URL(string: "https://api.github.com/users/octocat")!,

--- a/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
@@ -23,11 +23,11 @@ final class PackageCollectionsModelTests: XCTestCase {
             toolsVersion: toolsVersion, packageName: "FooBar", targets: targets, products: products, minimumPlatformVersions: nil
         )]
         let versions: [PackageCollectionsModel.Package.Version] = [
-            .init(version: .init(stringLiteral: "1.2.0"), summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
-            .init(version: .init(stringLiteral: "2.0.1"), summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
-            .init(version: .init(stringLiteral: "2.1.0-beta.3"), summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
-            .init(version: .init(stringLiteral: "2.1.0"), summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
-            .init(version: .init(stringLiteral: "3.0.0-beta.1"), summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "1.2.0"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.0.1"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.1.0-beta.3"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.1.0"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "3.0.0-beta.1"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
         ]
 
         XCTAssertEqual("2.1.0", versions.latestRelease?.version.description)
@@ -42,8 +42,8 @@ final class PackageCollectionsModelTests: XCTestCase {
             toolsVersion: toolsVersion, packageName: "FooBar", targets: targets, products: products, minimumPlatformVersions: nil
         )]
         let versions: [PackageCollectionsModel.Package.Version] = [
-            .init(version: .init(stringLiteral: "2.1.0-beta.3"), summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
-            .init(version: .init(stringLiteral: "3.0.0-beta.1"), summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.1.0-beta.3"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "3.0.0-beta.1"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
         ]
 
         XCTAssertNil(versions.latestRelease)
@@ -58,9 +58,9 @@ final class PackageCollectionsModelTests: XCTestCase {
             toolsVersion: toolsVersion, packageName: "FooBar", targets: targets, products: products, minimumPlatformVersions: nil
         )]
         let versions: [PackageCollectionsModel.Package.Version] = [
-            .init(version: .init(stringLiteral: "1.2.0"), summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
-            .init(version: .init(stringLiteral: "2.0.1"), summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
-            .init(version: .init(stringLiteral: "2.1.0"), summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "1.2.0"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.0.1"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
+            .init(version: .init(stringLiteral: "2.1.0"), title: nil, summary: nil, manifests: manifests, defaultToolsVersion: toolsVersion, verifiedCompatibility: nil, license: nil, createdAt: nil),
         ]
 
         XCTAssertEqual("2.1.0", versions.latestRelease?.version.description)

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -591,6 +591,7 @@ final class PackageCollectionsTests: XCTestCase {
         )
 
         let mockVersion = PackageCollectionsModel.Package.Version(version: TSCUtility.Version(1, 0, 0),
+                                                                  title: nil,
                                                                   summary: nil,
                                                                   manifests: [toolsVersion: mockManifest],
                                                                   defaultToolsVersion: toolsVersion,
@@ -754,6 +755,7 @@ final class PackageCollectionsTests: XCTestCase {
         )
 
         let mockVersion = PackageCollectionsModel.Package.Version(version: TSCUtility.Version(1, 0, 0),
+                                                                  title: nil,
                                                                   summary: nil,
                                                                   manifests: [toolsVersion: mockManifest],
                                                                   defaultToolsVersion: toolsVersion,
@@ -1180,6 +1182,7 @@ final class PackageCollectionsTests: XCTestCase {
 
         let versions = (0 ... 3).map {
             PackageCollectionsModel.Package.Version(version: TSCUtility.Version($0, 0, 0),
+                                                    title: "\($0) title",
                                                     summary: "\($0) description",
                                                     manifests: [toolsVersion: manifest],
                                                     defaultToolsVersion: toolsVersion,
@@ -1202,7 +1205,7 @@ final class PackageCollectionsTests: XCTestCase {
 
         let mockMetadata = PackageCollectionsModel.PackageBasicMetadata(summary: "\(mockPackage.summary!) 2",
                                                                         keywords: mockPackage.keywords.flatMap { $0.map { "\($0)-2" } },
-                                                                        versions: mockPackage.versions.map { PackageCollectionsModel.PackageBasicVersionMetadata(version: $0.version, summary: "\($0.summary!) 2", createdAt: Date(), publishedAt: nil) },
+                                                                        versions: mockPackage.versions.map { PackageCollectionsModel.PackageBasicVersionMetadata(version: $0.version, title: "\($0.title!) 2", summary: "\($0.summary!) 2", createdAt: Date(), publishedAt: nil) },
                                                                         watchersCount: mockPackage.watchersCount! + 1,
                                                                         readmeURL: URL(string: "\(mockPackage.readmeURL!.absoluteString)-2")!,
                                                                         license: PackageCollectionsModel.License(type: .Apache2_0, url: URL(string: "\(mockPackage.license!.url.absoluteString)-2")!),

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -67,6 +67,7 @@ func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: I
                 let license = PackageCollectionsModel.License(type: licenseType, url: URL(string: "http://\(licenseType).license")!)
 
                 return PackageCollectionsModel.Package.Version(version: TSCUtility.Version(versionIndex, 0, 0),
+                                                               title: nil,
                                                                summary: "\(versionIndex) description",
                                                                manifests: manifests,
                                                                defaultToolsVersion: toolsVersion,
@@ -110,7 +111,7 @@ func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: I
 func makeMockPackageBasicMetadata() -> PackageCollectionsModel.PackageBasicMetadata {
     return .init(summary: UUID().uuidString,
                  keywords: (0 ..< Int.random(in: 1 ... 3)).map { "keyword \($0)" },
-                 versions: (0 ..< Int.random(in: 1 ... 10)).map { .init(version: TSCUtility.Version($0, 0, 0), summary: "description \($0)", createdAt: Date(), publishedAt: nil) },
+                 versions: (0 ..< Int.random(in: 1 ... 10)).map { .init(version: TSCUtility.Version($0, 0, 0), title: "title \($0)", summary: "description \($0)", createdAt: Date(), publishedAt: nil) },
                  watchersCount: Int.random(in: 0 ... 50),
                  readmeURL: URL(string: "https://package-readme")!,
                  license: PackageCollectionsModel.License(type: .Apache2_0, url: URL(string: "https://package-license")!),


### PR DESCRIPTION
Motivation:
Package release on GitHub has title/name. It would be nice to display it.

Modifications:
 - Add `title` to the `Version` model.
 - Update `GitHubPackageMetadataProvider` to set `version.title` to `release.name`. We were fetching `release.name` already just didn't have a place for it.
 - Update package metadata merge logic.
