### PR TITLE
[Collections] Improve error messages

### DIFF
--- a/Sources/PackageCollections/PackageCollections+Validation.swift
+++ b/Sources/PackageCollections/PackageCollections+Validation.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -38,7 +38,7 @@ extension Model.CollectionSource {
                 if absolutePath == nil {
                     appendMessage(.error("Invalid file path: \(self.url.path). It must be an absolute file system path."))
                 } else if let absolutePath = absolutePath, !localFileSystem.exists(absolutePath) {
-                    appendMessage(.error("Non-local files not allowed: \(self.url.path)"))
+                    appendMessage(.error("\(self.url.path) is either a non-local path or the file does not exist."))
                 }
             }
         }

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -107,16 +107,14 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
                 getOptions.maximumResponseSizeInBytes = self.configuration.maximumSizeInBytes
                 self.httpClient.get(source.url, headers: headers, options: getOptions) { result in
                     switch result {
-                    case .failure(let error):
-                        if case HTTPClientError.badResponseStatusCode(let statusCode) = error {
-                            if statusCode == 404 {
-                                return callback(.failure(Errors.collectionNotFound(source.url)))
-                            } else {
-                                return callback(.failure(Errors.collectionUnavailable(source.url, statusCode)))
-                            }
+                    case .failure(HTTPClientError.badResponseStatusCode(let statusCode)):
+                        if statusCode == 404 {
+                            return callback(.failure(Errors.collectionNotFound(source.url)))
                         } else {
-                            return callback(.failure(error))
+                            return callback(.failure(Errors.collectionUnavailable(source.url, statusCode)))
                         }
+                    case .failure(let error):
+                        return callback(.failure(error))
                     case .success(let response):
                         // check content length again so we can record this as a bad actor
                         // if not returning head and exceeding size

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -153,7 +153,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         let provider = JSONPackageCollectionProvider(configuration: configuration, httpClient: httpClient, diagnosticsEngine: DiagnosticsEngine())
         XCTAssertThrowsError(try tsc_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
             switch error {
-            case HTTPClientError.responseTooLarge(let size):
+            case JSONPackageCollectionProvider.Errors.responseTooLarge(_, let size):
                 XCTAssertEqual(size, maxSize * 2)
             default:
                 XCTFail("unexpected error \(error)")
@@ -187,7 +187,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         let provider = JSONPackageCollectionProvider(configuration: configuration, httpClient: httpClient, diagnosticsEngine: DiagnosticsEngine())
         XCTAssertThrowsError(try tsc_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
             switch error {
-            case HTTPClientError.responseTooLarge(let size):
+            case JSONPackageCollectionProvider.Errors.responseTooLarge(_, let size):
                 XCTAssertEqual(size, maxSize * 2)
             default:
                 XCTFail("unexpected error \(error)")
@@ -212,7 +212,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         let provider = JSONPackageCollectionProvider(configuration: configuration, httpClient: httpClient, diagnosticsEngine: DiagnosticsEngine())
         XCTAssertThrowsError(try tsc_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
             switch error {
-            case JSONPackageCollectionProvider.Errors.invalidResponse(let error):
+            case JSONPackageCollectionProvider.Errors.invalidResponse(_, let error):
                 XCTAssertEqual(error, "Missing Content-Length header")
             default:
                 XCTFail("unexpected error \(error)")
@@ -269,7 +269,12 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         httpClient.configuration.retryStrategy = .none
         let provider = JSONPackageCollectionProvider(httpClient: httpClient, diagnosticsEngine: DiagnosticsEngine())
         XCTAssertThrowsError(try tsc_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
-            XCTAssertEqual(error as? HTTPClientError, .badResponseStatusCode(statusCode))
+            switch error {
+            case JSONPackageCollectionProvider.Errors.collectionUnavailable(_, let status):
+                XCTAssertEqual(status, statusCode)
+            default:
+                XCTFail("unexpected error \(error)")
+            }
         })
     }
 
@@ -295,7 +300,12 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         httpClient.configuration.retryStrategy = .none
         let provider = JSONPackageCollectionProvider(httpClient: httpClient, diagnosticsEngine: DiagnosticsEngine())
         XCTAssertThrowsError(try tsc_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
-            XCTAssertEqual(error as? HTTPClientError, .badResponseStatusCode(statusCode))
+            switch error {
+            case JSONPackageCollectionProvider.Errors.collectionUnavailable(_, let status):
+                XCTAssertEqual(status, statusCode)
+            default:
+                XCTFail("unexpected error \(error)")
+            }
         })
     }
 

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -152,12 +152,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         let configuration = JSONPackageCollectionProvider.Configuration(maximumSizeInBytes: 10)
         let provider = JSONPackageCollectionProvider(configuration: configuration, httpClient: httpClient, diagnosticsEngine: DiagnosticsEngine())
         XCTAssertThrowsError(try tsc_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
-            switch error {
-            case JSONPackageCollectionProvider.Errors.responseTooLarge(_, let size):
-                XCTAssertEqual(size, maxSize * 2)
-            default:
-                XCTFail("unexpected error \(error)")
-            }
+            XCTAssertEqual(error as? JSONPackageCollectionProvider.Errors, .responseTooLarge(url, maxSize * 2))
         })
     }
 
@@ -186,12 +181,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         let configuration = JSONPackageCollectionProvider.Configuration(maximumSizeInBytes: 10)
         let provider = JSONPackageCollectionProvider(configuration: configuration, httpClient: httpClient, diagnosticsEngine: DiagnosticsEngine())
         XCTAssertThrowsError(try tsc_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
-            switch error {
-            case JSONPackageCollectionProvider.Errors.responseTooLarge(_, let size):
-                XCTAssertEqual(size, maxSize * 2)
-            default:
-                XCTFail("unexpected error \(error)")
-            }
+            XCTAssertEqual(error as? JSONPackageCollectionProvider.Errors, .responseTooLarge(url, maxSize * 2))
         })
     }
 
@@ -211,12 +201,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         let configuration = JSONPackageCollectionProvider.Configuration(maximumSizeInBytes: 10)
         let provider = JSONPackageCollectionProvider(configuration: configuration, httpClient: httpClient, diagnosticsEngine: DiagnosticsEngine())
         XCTAssertThrowsError(try tsc_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
-            switch error {
-            case JSONPackageCollectionProvider.Errors.invalidResponse(_, let error):
-                XCTAssertEqual(error, "Missing Content-Length header")
-            default:
-                XCTFail("unexpected error \(error)")
-            }
+            XCTAssertEqual(error as? JSONPackageCollectionProvider.Errors, .invalidResponse(url, "Missing Content-Length header"))
         })
     }
 
@@ -244,12 +229,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         let configuration = JSONPackageCollectionProvider.Configuration(maximumSizeInBytes: 10)
         let provider = JSONPackageCollectionProvider(configuration: configuration, httpClient: httpClient, diagnosticsEngine: DiagnosticsEngine())
         XCTAssertThrowsError(try tsc_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
-            switch error {
-            case HTTPClientError.responseTooLarge(let size):
-                XCTAssertEqual(size, maxSize * 2)
-            default:
-                XCTFail("unexpected error \(error)")
-            }
+            XCTAssertEqual(error as? HTTPClientError, .responseTooLarge(maxSize * 2))
         })
     }
 
@@ -269,12 +249,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         httpClient.configuration.retryStrategy = .none
         let provider = JSONPackageCollectionProvider(httpClient: httpClient, diagnosticsEngine: DiagnosticsEngine())
         XCTAssertThrowsError(try tsc_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
-            switch error {
-            case JSONPackageCollectionProvider.Errors.collectionUnavailable(_, let status):
-                XCTAssertEqual(status, statusCode)
-            default:
-                XCTFail("unexpected error \(error)")
-            }
+            XCTAssertEqual(error as? JSONPackageCollectionProvider.Errors, .collectionUnavailable(url, statusCode))
         })
     }
 
@@ -300,12 +275,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         httpClient.configuration.retryStrategy = .none
         let provider = JSONPackageCollectionProvider(httpClient: httpClient, diagnosticsEngine: DiagnosticsEngine())
         XCTAssertThrowsError(try tsc_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
-            switch error {
-            case JSONPackageCollectionProvider.Errors.collectionUnavailable(_, let status):
-                XCTAssertEqual(status, statusCode)
-            default:
-                XCTFail("unexpected error \(error)")
-            }
+            XCTAssertEqual(error as? JSONPackageCollectionProvider.Errors, .collectionUnavailable(url, statusCode))
         })
     }
 
@@ -333,12 +303,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         let provider = JSONPackageCollectionProvider(httpClient: httpClient, diagnosticsEngine: DiagnosticsEngine())
         let source = PackageCollectionsModel.CollectionSource(type: .json, url: url)
         XCTAssertThrowsError(try tsc_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
-            switch error {
-            case JSONPackageCollectionProvider.Errors.invalidJSON:
-                break
-            default:
-                XCTFail("unexpected error \(error)")
-            }
+            XCTAssertEqual(error as? JSONPackageCollectionProvider.Errors, .invalidJSON(url))
         })
     }
 

--- a/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsModelTests.swift
@@ -109,7 +109,7 @@ final class PackageCollectionsModelTests: XCTestCase {
             guard case .error = messages[0].level else {
                 return XCTFail("Expected .error")
             }
-            XCTAssertNotNil(messages[0].message.range(of: "non-local files not allowed", options: .caseInsensitive))
+            XCTAssertNotNil(messages[0].message.range(of: "either a non-local path or the file does not exist", options: .caseInsensitive))
         }
     }
 }


### PR DESCRIPTION
Motivation:
Refresh fails when a collection's URL changes or becomes invalid. The API error returned is `Basics.HTTPClientError.badResponseStatusCode(404)` which 1) doesn't tell user which collection is failing; 2) might be confusing if user is not familiar with HTTP status codes.

Modifications:
Improve error messages. For example, the error above becomes `collectionNotFound` and includes collection URL.
