### PR TITLE
[Collections] Should be able to delete a non-existent local collection

### DIFF
--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -262,13 +262,13 @@ public struct PackageCollections: PackageCollectionsProtocol {
             return callback(.failure(PackageCollectionError.unsupportedPlatform))
         }
 
-        if let errors = source.validate()?.errors() {
-            return callback(.failure(MultipleErrors(errors)))
-        }
-
         self.storage.collections.get(identifier: .init(from: source)) { result in
             switch result {
             case .failure:
+                // The collection is not in storage. Validate the source before fetching it.
+                if let errors = source.validate()?.errors() {
+                    return callback(.failure(MultipleErrors(errors)))
+                }
                 guard let provider = self.collectionProviders[source.type] else {
                     return callback(.failure(UnknownProvider(source.type)))
                 }


### PR DESCRIPTION
Steps to reproduce:
1. Add a local collection
2. Delete or rename the local collection file
3. Try deleting the local collection

Result: Error about local file not found
Expected: Non-existent local collection deleted

The `remove` collection subcommand calls `getCollection` API to fetch collection's name for displaying success message later. `getCollection` tries to fetch collection from storage, and if it's not found there, it fetches from the source directly. The error is caused by the source validation logic, which mistakenly is the first thing `getCollection` does but should really only be done when we need to fetch from the source.
