### PR TITLE
[Collections] Adjust cert verify date in tests

### DIFF
--- a/Tests/PackageCollectionsSigningTests/Utilities.swift
+++ b/Tests/PackageCollectionsSigningTests/Utilities.swift
@@ -28,7 +28,7 @@ struct TestCertificatePolicy: CertificatePolicy {
         var dateComponents = DateComponents()
         dateComponents.year = 2020
         dateComponents.month = 11
-        dateComponents.day = 16
+        dateComponents.day = 18
         return Calendar.current.date(from: dateComponents)!
     }()
 

--- a/Tests/PackageCollectionsSigningTests/Utilities.swift
+++ b/Tests/PackageCollectionsSigningTests/Utilities.swift
@@ -25,6 +25,10 @@ let diagnosticsEngine = DiagnosticsEngine()
 
 struct TestCertificatePolicy: CertificatePolicy {
     static let testCertValidDate: Date = {
+        // This is the datetime that the tests use to validate test certs (Test_rsa.cer, Test_ec.cer).
+        // Make sure it falls within the certs' validity period, across timezones.
+        // For example, suppose the current date is April 12, 2021, the cert validation runs as if
+        // the date were November 18, 2020.
         var dateComponents = DateComponents()
         dateComponents.year = 2020
         dateComponents.month = 11


### PR DESCRIPTION
Motivation:
Tests in `PackageCollectionsSigningTests` that involve `Test_ec.cer` are failing. See https://github.com/apple/swift-package-manager/pull/3393.

I think this is a timezone-related issue. `Test_ec.cer` is valid from November 15, 2020 10:45:20am PST for a year. In the tests we manipulate the timestamp at which the cert validation is done so we don't have to regenerate new test certs and so we can test for different scenarios. That timestamp is set to November 16, 2020 midnight, and depending on where the tests are run, it might potentially mean a time before `Test_ec.cer` is valid and that's why we see "certificate is not yet valid" error. Note that this doesn't happen with tests that use `Test_rsa.cer` since the certificate is valid from November 8, 2020.

Modification:
Change verify date to November 18, 2020, which should give us more than enough buffer for various timezones.
