### PR TITLE
Use implementation-only imports

### DIFF
--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -16,7 +16,7 @@
 @_implementationOnly import ucrt
 @_implementationOnly import struct WinSDK.HANDLE
 #endif
-import Foundation
+@_implementationOnly import Foundation
 
 /// The configuration of a Swift package.
 ///

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
+@_implementationOnly import Foundation
 
 /// A target, the basic building block of a Swift package.
 ///


### PR DESCRIPTION
This makes it so compiling a manifest won't require the presence of the Foundation .swiftmodule