### PR TITLE
deprecate willClone/didClone in favor of willCreateWorkingCopy/didCreateWorkingCopy

### DIFF
--- a/Sources/Commands/APIDigester.swift
+++ b/Sources/Commands/APIDigester.swift
@@ -78,15 +78,14 @@ struct APIDigesterBaselineDumper {
 
         // Clone the current package in a sandbox and checkout the baseline revision.
         let specifier = RepositorySpecifier(url: baselinePackageRoot.pathString)
-        try repositoryManager.provider.cloneCheckout(
+        let workingCopy = try repositoryManager.provider.createWorkingCopy(
             repository: specifier,
-            at: packageRoot,
-            to: baselinePackageRoot,
+            sourcePath: packageRoot,
+            at: baselinePackageRoot,
             editable: false
         )
 
-        let workingCheckout = try repositoryManager.provider.openCheckout(at: baselinePackageRoot)
-        try workingCheckout.checkout(revision: Revision(identifier: baselineTreeish))
+        try workingCopy.checkout(revision: Revision(identifier: baselineTreeish))
 
         // Create the workspace for this package.
         let workspace = Workspace.create(

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -95,17 +95,17 @@ private class ToolWorkspaceDelegate: WorkspaceDelegate {
         }
     }
 
-    func cloning(repository: String) {
+    func willMoveToWorkingDirectory(repository: String, to path: AbsolutePath) {
         queue.async {
-            self.stdoutStream <<< "Cloning \(repository)"
+            self.stdoutStream <<< "Moving \(repository) to working directory"
             self.stdoutStream <<< "\n"
             self.stdoutStream.flush()
         }
     }
 
-    func checkingOut(repository: String, atReference reference: String, to path: AbsolutePath) {
+    func willCheckOut(repository: String, revision: String, at path: AbsolutePath) {
         queue.async {
-            self.stdoutStream <<< "Resolving \(repository) at \(reference)"
+            self.stdoutStream <<< "Resolving \(repository) at \(revision)"
             self.stdoutStream <<< "\n"
             self.stdoutStream.flush()
         }

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -95,9 +95,9 @@ private class ToolWorkspaceDelegate: WorkspaceDelegate {
         }
     }
 
-    func willMoveToWorkingDirectory(repository: String, to path: AbsolutePath) {
+    func willCreateWorkingCopy(repository: String, at path: AbsolutePath) {
         queue.async {
-            self.stdoutStream <<< "Moving \(repository) to working directory"
+            self.stdoutStream <<< "Creating working copy for \(repository)"
             self.stdoutStream <<< "\n"
             self.stdoutStream.flush()
         }

--- a/Sources/SPMTestSupport/InMemoryGitRepository.swift
+++ b/Sources/SPMTestSupport/InMemoryGitRepository.swift
@@ -412,21 +412,22 @@ public final class InMemoryGitRepositoryProvider: RepositoryProvider {
         return fetchedMap[path]!
     }
 
-    public func cloneCheckout(
+    public func createWorkingCopy(
         repository: RepositorySpecifier,
-        at sourcePath: AbsolutePath,
-        to destinationPath: AbsolutePath,
+        sourcePath: AbsolutePath,
+        at destinationPath: AbsolutePath,
         editable: Bool
-    ) throws {
+    ) throws -> WorkingCheckout {
         let checkout = try fetchedMap[sourcePath]!.copy(at: destinationPath)
         checkoutsMap[destinationPath] = checkout
+        return checkout
     }
 
-    public func checkoutExists(at path: AbsolutePath) throws -> Bool {
+    public func workingCopyExists(at path: AbsolutePath) throws -> Bool {
         return checkoutsMap.contains(path)
     }
 
-    public func openCheckout(at path: AbsolutePath) throws -> WorkingCheckout {
+    public func openWorkingCopy(at path: AbsolutePath) throws -> WorkingCheckout {
         return checkoutsMap[path]!
     }
 }

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -604,8 +604,8 @@ public final class MockWorkspaceDelegate: WorkspaceDelegate {
         self.append("finished fetching repo: \(repository)")
     }
 
-    public func willMoveToWorkingDirectory(repository url: String, to path: AbsolutePath) {
-        self.append("moving repo: \(url) to working directory")
+    public func willCreateWorkingCopy(repository url: String, at path: AbsolutePath) {
+        self.append("creating working copy for: \(url)")
     }
 
     public func willCheckOut(repository url: String, revision: String, at path: AbsolutePath) {

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -604,12 +604,12 @@ public final class MockWorkspaceDelegate: WorkspaceDelegate {
         self.append("finished fetching repo: \(repository)")
     }
 
-    public func cloning(repository: String) {
-        self.append("cloning repo: \(repository)")
+    public func willMoveToWorkingDirectory(repository url: String, to path: AbsolutePath) {
+        self.append("moving repo: \(url) to working directory")
     }
 
-    public func checkingOut(repository: String, atReference reference: String, to path: AbsolutePath) {
-        self.append("checking out repo: \(repository)")
+    public func willCheckOut(repository url: String, revision: String, at path: AbsolutePath) {
+        self.append("checking out repo: \(url)")
     }
 
     public func removing(repository: String) {

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -108,12 +108,12 @@ public struct GitRepositoryProvider: RepositoryProvider {
         return GitRepository(path: path, isWorkingRepo: false)
     }
 
-    public func cloneCheckout(
+    public func createWorkingCopy(
         repository: RepositorySpecifier,
-        at sourcePath: AbsolutePath,
-        to destinationPath: AbsolutePath,
+        sourcePath: AbsolutePath,
+        at destinationPath: AbsolutePath,
         editable: Bool
-    ) throws {
+    ) throws -> WorkingCheckout {
         if editable {
             // For editable clones, i.e. the user is expected to directly work on them, first we create
             // a clone from our cache of repositories and then we replace the remote to the one originally
@@ -142,16 +142,17 @@ public struct GitRepositoryProvider: RepositoryProvider {
                              repository: repository,
                              failureMessage: "Failed to clone repository \(repository.url)")
         }
+        return try self.openWorkingCopy(at: destinationPath)
     }
 
-    public func checkoutExists(at path: AbsolutePath) throws -> Bool {
+    public func workingCopyExists(at path: AbsolutePath) throws -> Bool {
         precondition(localFileSystem.exists(path))
 
         let repo = GitRepository(path: path)
         return try repo.checkoutExists()
     }
 
-    public func openCheckout(at path: AbsolutePath) throws -> WorkingCheckout {
+    public func openWorkingCopy(at path: AbsolutePath) throws -> WorkingCheckout {
         return GitRepository(path: path)
     }
 }

--- a/Sources/SourceControl/Repository.swift
+++ b/Sources/SourceControl/Repository.swift
@@ -70,7 +70,7 @@ public protocol RepositoryProvider {
     ///
     /// - Parameters:
     ///   - repository: The specifier of the repository to fetch.
-    ///   - path: The destiantion path for the fetch.
+    ///   - path: The destination path for the fetch.
     /// - Throws: If there is any error fetching the repository.
     func fetch(repository: RepositorySpecifier, to path: AbsolutePath) throws
 
@@ -85,7 +85,7 @@ public protocol RepositoryProvider {
     /// - Throws: If the repository is unable to be opened.
     func open(repository: RepositorySpecifier, at path: AbsolutePath) throws -> Repository
 
-    /// Clone a managed repository into a working copy at on the local file system.
+    /// Create a working copy from a managed repository.
     ///
     /// Once complete, the repository can be opened using `openCheckout`. Note
     /// that there is no requirement that the files have been materialized into
@@ -102,21 +102,21 @@ public protocol RepositoryProvider {
     ///   - editable: The checkout is expected to be edited by users.
     ///
     /// - Throws: If there is any error cloning the repository.
-    func cloneCheckout(
+    func createWorkingCopy(
         repository: RepositorySpecifier,
-        at sourcePath: AbsolutePath,
-        to destinationPath: AbsolutePath,
-        editable: Bool) throws
+        sourcePath: AbsolutePath,
+        at destinationPath: AbsolutePath,
+        editable: Bool) throws -> WorkingCheckout
 
     /// Returns true if a working repository exists at `path`
-    func checkoutExists(at path: AbsolutePath) throws -> Bool
+    func workingCopyExists(at path: AbsolutePath) throws -> Bool
 
     /// Open a working repository copy.
     ///
     /// - Parameters:
     ///   - path: The location of the repository on disk, at which the repository
-    ///     has previously been created via `cloneCheckout`.
-    func openCheckout(at path: AbsolutePath) throws -> WorkingCheckout
+    ///     has previously been created via `copyToWorkingDirectory`.
+    func openWorkingCopy(at path: AbsolutePath) throws -> WorkingCheckout
 
     /// Copies the repository at path `from` to path `to`.
     /// - Parameters:

--- a/Sources/SourceControl/Repository.swift
+++ b/Sources/SourceControl/Repository.swift
@@ -87,7 +87,7 @@ public protocol RepositoryProvider {
 
     /// Create a working copy from a managed repository.
     ///
-    /// Once complete, the repository can be opened using `openCheckout`. Note
+    /// Once complete, the repository can be opened using `openWorkingCopy`. Note
     /// that there is no requirement that the files have been materialized into
     /// the file system at the completion of this call, since it will always be
     /// followed by checking out the cloned working copy at a particular ref.

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -102,16 +102,16 @@ public class RepositoryManager {
             return try self.manager.open(self)
         }
 
-        /// Clone into a working copy at on the local file system.
+        /// Create a working copy at on the local file system.
         ///
         /// - Parameters:
         ///   - path: The path at which to create the working copy; it is
         ///           expected to be non-existent when called.
         ///
         ///   - editable: The clone is expected to be edited by user.
-        public func cloneCheckout(to path: AbsolutePath, editable: Bool) throws {
-            precondition(status == .available, "cloneCheckout() called in invalid state")
-            try self.manager.cloneCheckout(self, to: path, editable: editable)
+        public func createWorkingCopy(at path: AbsolutePath, editable: Bool) throws -> WorkingCheckout {
+            precondition(status == .available, "createWorkingCopy() called in invalid state")
+            return try self.manager.createWorkingCopy(self, at: path, editable: editable)
         }
 
         fileprivate func toJSON() -> JSON {
@@ -412,16 +412,16 @@ public class RepositoryManager {
             repository: handle.repository, at: self.path.appending(handle.subpath))
     }
 
-    /// Clone a repository from a handle.
-    private func cloneCheckout(
+    /// Create a working copy of the repository from a handle.
+    private func createWorkingCopy(
         _ handle: RepositoryHandle,
-        to destinationPath: AbsolutePath,
+        at destinationPath: AbsolutePath,
         editable: Bool
-    ) throws {
-        try self.provider.cloneCheckout(
+    ) throws -> WorkingCheckout {
+        try self.provider.createWorkingCopy(
             repository: handle.repository,
-            at: self.path.appending(handle.subpath),
-            to: destinationPath,
+            sourcePath: self.path.appending(handle.subpath),
+            at: destinationPath,
             editable: editable)
     }
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -62,19 +62,19 @@ public protocol WorkspaceDelegate: AnyObject {
 
     /// The workspace is about to clone a repository from the local cache to a working directory.
     // deprecated 04/2021, remove once clients moved over
-    @available(*, deprecated, message: "use willMoveToWorkingDirectory")
+    @available(*, deprecated, message: "use willCreateWorkingCopy")
     func willClone(repository url: String, to path: AbsolutePath)
-    func willMoveToWorkingDirectory(repository url: String, to path: AbsolutePath)
+    func willCreateWorkingCopy(repository url: String, at path: AbsolutePath)
 
     /// The workspace has cloned a repository from the local cache to a working directory. The error indicates whether the operation failed or succeeded.
     // deprecated 04/2021, remove once clients moved over
-    @available(*, deprecated, message: "use didMoveToWorkingDirectory")
+    @available(*, deprecated, message: "use didCreateWorkingCopy")
     func didClone(repository url: String, to path: AbsolutePath, error: Diagnostic?)
-    func didMoveToWorkingDirectory(repository url: String, to path: AbsolutePath, error: Diagnostic?)
+    func didCreateWorkingCopy(repository url: String, at path: AbsolutePath, error: Diagnostic?)
 
     /// The workspace has started cloning this repository  from the local cache to a working directory. This callback is marginally deprecated in favor of the willClone/didClone pair.
     // deprecated 04/2021, remove once clients moved over
-    @available(*, deprecated, message: "use didMoveToWorkingDirectory")
+    @available(*, deprecated, message: "use didCreateWorkingCopy")
     func cloning(repository url: String)
 
     /// The workspace is about to check out a particular revision of a working directory.
@@ -120,10 +120,10 @@ public extension WorkspaceDelegate {
     // deprecated 04/2021, remove once clients moved over
     @available(*, deprecated)
     func didClone(repository url: String, to path: AbsolutePath, error: Diagnostic?) {}
-    func willMoveToWorkingDirectory(repository url: String, to path: AbsolutePath) {
+    func willCreateWorkingCopy(repository url: String, at path: AbsolutePath) {
         willClone(repository: url, to: path)
     }
-    func didMoveToWorkingDirectory(repository url: String, to path: AbsolutePath, error: Diagnostic?) {
+    func didCreateWorkingCopy(repository url: String, at path: AbsolutePath, error: Diagnostic?) {
         didClone(repository: url, to: path, error: error)
     }
     func willCheckOut(repository url: String, revision: String, at path: AbsolutePath) {
@@ -904,13 +904,12 @@ extension Workspace {
                 throw WorkspaceDiagnostics.RevisionDoesNotExist(revision: revision.identifier)
             }
 
-            try handle.cloneCheckout(to: destination, editable: true)
-            let workingRepo = try repositoryManager.provider.openCheckout(at: destination)
-            try workingRepo.checkout(revision: revision ?? checkoutState.revision)
+            let workingCopy = try handle.createWorkingCopy(at: destination, editable: true)
+            try workingCopy.checkout(revision: revision ?? checkoutState.revision)
 
             // Checkout to the new branch if provided.
             if let branch = checkoutBranch {
-                try workingRepo.checkout(newBranch: branch)
+                try workingCopy.checkout(newBranch: branch)
             }
         }
 
@@ -974,11 +973,11 @@ extension Workspace {
         let path = editablesPath.appending(dependency.subpath)
         // Check for uncommited and unpushed changes if force removal is off.
         if !forceRemove {
-            let workingRepo = try repositoryManager.provider.openCheckout(at: path)
-            guard !workingRepo.hasUncommittedChanges() else {
+            let workingCopy = try repositoryManager.provider.openWorkingCopy(at: path)
+            guard !workingCopy.hasUncommittedChanges() else {
                 throw WorkspaceDiagnostics.UncommitedChanges(repositoryPath: path)
             }
-            guard try !workingRepo.hasUnpushedCommits() else {
+            guard try !workingCopy.hasUnpushedCommits() else {
                 throw WorkspaceDiagnostics.UnpushedChanges(repositoryPath: path)
             }
         }
@@ -2460,19 +2459,19 @@ extension Workspace {
             // if not).
             fetch: if fileSystem.isDirectory(path) {
                 // Fetch the checkout in case there are updates available.
-                let workingRepo = try repositoryManager.provider.openCheckout(at: path)
+                let workingCopy = try repositoryManager.provider.openWorkingCopy(at: path)
 
                 // Ensure that the alternative object store is still valid.
                 //
                 // This can become invalid if the build directory is moved.
-                guard workingRepo.isAlternateObjectStoreValid() else {
+                guard workingCopy.isAlternateObjectStoreValid() else {
                     break fetch
                 }
 
                 // The fetch operation may update contents of the checkout, so
                 // we need do mutable-immutable dance.
                 try fileSystem.chmod(.userWritable, path: path, options: [.recursive, .onlyFiles])
-                try workingRepo.fetch()
+                try workingCopy.fetch()
                 try? fileSystem.chmod(.userUnWritable, path: path, options: [.recursive, .onlyFiles])
 
                 return path
@@ -2492,9 +2491,9 @@ extension Workspace {
         try fileSystem.removeFileTree(path)
 
         // Inform the delegate that we're starting cloning.
-        delegate?.willMoveToWorkingDirectory(repository: handle.repository.url, to: path)
-        try handle.cloneCheckout(to: path, editable: false)
-        delegate?.didMoveToWorkingDirectory(repository: handle.repository.url, to: path, error: nil)
+        delegate?.willCreateWorkingCopy(repository: handle.repository.url, at: path)
+        _ = try handle.createWorkingCopy(at: path, editable: false)
+        delegate?.didCreateWorkingCopy(repository: handle.repository.url, at: path, error: nil)
 
         return path
     }
@@ -2517,14 +2516,14 @@ extension Workspace {
         let path = try fetch(package: package)
 
         // Check out the given revision.
-        let workingRepo = try repositoryManager.provider.openCheckout(at: path)
+        let workingCopy = try repositoryManager.provider.openWorkingCopy(at: path)
 
         // Inform the delegate.
         delegate?.willCheckOut(repository: package.repository.url, revision: checkoutState.description, at: path)
 
         // Do mutable-immutable dance because checkout operation modifies the disk state.
         try fileSystem.chmod(.userWritable, path: path, options: [.recursive, .onlyFiles])
-        try workingRepo.checkout(revision: checkoutState.revision)
+        try workingCopy.checkout(revision: checkoutState.revision)
         try? fileSystem.chmod(.userUnWritable, path: path, options: [.recursive, .onlyFiles])
 
         // Write the state record.
@@ -2614,8 +2613,8 @@ extension Workspace {
 
         // Remove the checkout.
         let dependencyPath = checkoutsPath.appending(dependencyToRemove.subpath)
-        let checkedOutRepo = try repositoryManager.provider.openCheckout(at: dependencyPath)
-        guard !checkedOutRepo.hasUncommittedChanges() else {
+        let workingCopy = try repositoryManager.provider.openWorkingCopy(at: dependencyPath)
+        guard !workingCopy.hasUncommittedChanges() else {
             throw WorkspaceDiagnostics.UncommitedChanges(repositoryPath: dependencyPath)
         }
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -61,13 +61,21 @@ public protocol WorkspaceDelegate: AnyObject {
     func dependenciesUpToDate()
 
     /// The workspace is about to clone a repository from the local cache to a working directory.
+    // deprecated 04/2021, remove once clients moved over
+    @available(*, deprecated, message: "use willMoveToWorkingDirectory")
     func willClone(repository url: String, to path: AbsolutePath)
+    func willMoveToWorkingDirectory(repository url: String, to path: AbsolutePath)
 
     /// The workspace has cloned a repository from the local cache to a working directory. The error indicates whether the operation failed or succeeded.
+    // deprecated 04/2021, remove once clients moved over
+    @available(*, deprecated, message: "use didMoveToWorkingDirectory")
     func didClone(repository url: String, to path: AbsolutePath, error: Diagnostic?)
+    func didMoveToWorkingDirectory(repository url: String, to path: AbsolutePath, error: Diagnostic?)
 
-    /// The workspace has started cloning this repository. This callback is marginally deprecated in favor of the willClone/didClone pair.
-    func cloning(repository: String)
+    /// The workspace has started cloning this repository  from the local cache to a working directory. This callback is marginally deprecated in favor of the willClone/didClone pair.
+    // deprecated 04/2021, remove once clients moved over
+    @available(*, deprecated, message: "use didMoveToWorkingDirectory")
+    func cloning(repository url: String)
 
     /// The workspace is about to check out a particular revision of a working directory.
     func willCheckOut(repository url: String, revision: String, at path: AbsolutePath)
@@ -75,7 +83,9 @@ public protocol WorkspaceDelegate: AnyObject {
     /// The workspace has checked out a particular revision of a working directory. The error indicates whether the operation failed or succeeded.
     func didCheckOut(repository url: String, revision: String, at path: AbsolutePath, error: Diagnostic?)
 
+    // deprecated 04/2021, remove once clients moved over
     /// The workspace is checking out a repository. This callback is marginally deprecated in favor of the willCheckOut/didCheckOut pair.
+    @available(*, deprecated, message: "use didCheckOut")
     func checkingOut(repository: String, atReference reference: String, to path: AbsolutePath)
 
     /// The workspace is removing this repository because it is no longer needed.
@@ -99,16 +109,30 @@ public protocol WorkspaceDelegate: AnyObject {
 public extension WorkspaceDelegate {
     func willLoadManifest(packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind) {}
     func didLoadManifest(packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Diagnostic]) {}
+    // deprecated 04/2021, remove once clients moved over
+    @available(*, deprecated)
     func willClone(repository url: String, to path: AbsolutePath) {
         cloning(repository: url)
     }
+    // deprecated 04/2021, remove once clients moved over
+    @available(*, deprecated)
+    func cloning(repository url: String) {}
+    // deprecated 04/2021, remove once clients moved over
+    @available(*, deprecated)
     func didClone(repository url: String, to path: AbsolutePath, error: Diagnostic?) {}
-    func cloning(repository: String) {}
+    func willMoveToWorkingDirectory(repository url: String, to path: AbsolutePath) {
+        willClone(repository: url, to: path)
+    }
+    func didMoveToWorkingDirectory(repository url: String, to path: AbsolutePath, error: Diagnostic?) {
+        didClone(repository: url, to: path, error: error)
+    }
     func willCheckOut(repository url: String, revision: String, at path: AbsolutePath) {
         checkingOut(repository: url, atReference: revision, to: path)
     }
-    func didCheckOut(repository url: String, revision: String, at path: AbsolutePath, error: Diagnostic?) {}
+    // deprecated 04/2021, remove once clients moved over
+    @available(*, deprecated)
     func checkingOut(repository: String, atReference: String, to path: AbsolutePath) {}
+    func didCheckOut(repository url: String, revision: String, at path: AbsolutePath, error: Diagnostic?) {}
     func repositoryWillUpdate(_ repository: String) {}
     func repositoryDidUpdate(_ repository: String) {}
     func willResolveDependencies(reason: WorkspaceResolveReason) {}
@@ -2468,9 +2492,9 @@ extension Workspace {
         try fileSystem.removeFileTree(path)
 
         // Inform the delegate that we're starting cloning.
-        delegate?.willClone(repository: handle.repository.url, to: path)
+        delegate?.willMoveToWorkingDirectory(repository: handle.repository.url, to: path)
         try handle.cloneCheckout(to: path, editable: false)
-        delegate?.didClone(repository: handle.repository.url, to: path, error: nil)
+        delegate?.didMoveToWorkingDirectory(repository: handle.repository.url, to: path, error: nil)
 
         return path
     }

--- a/Sources/Xcodeproj/generate.swift
+++ b/Sources/Xcodeproj/generate.swift
@@ -97,8 +97,8 @@ public func generate(
         // references in the project.
         extraDirs = try findDirectoryReferences(path: srcroot)
 
-        if try repositoryProvider.checkoutExists(at: srcroot) {
-            let workingCheckout = try repositoryProvider.openCheckout(at: srcroot)
+        if try repositoryProvider.workingCopyExists(at: srcroot) {
+            let workingCheckout = try repositoryProvider.openWorkingCopy(at: srcroot)
             extraFiles = try getExtraFilesFor(package: graph.rootPackages[0], in: workingCheckout)
         }
     } else {

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -91,8 +91,8 @@ class DependencyResolutionTests: XCTestCase {
             // run with no mirror
             do {
                 let output = try executeSwiftPackage(appPath, extraArgs: ["show-dependencies"])
-                XCTAssertTrue(output.stdout.contains("Cloning \(prefix.pathString)/Foo\n"), output.stdout)
-                XCTAssertTrue(output.stdout.contains("Cloning \(prefix.pathString)/Bar\n"), output.stdout)
+                XCTAssertTrue(output.stdout.contains("Fetching \(prefix.pathString)/Foo\n"), output.stdout)
+                XCTAssertTrue(output.stdout.contains("Fetching \(prefix.pathString)/Bar\n"), output.stdout)
                 XCTAssertTrue(output.stdout.contains("foo<\(prefix.pathString)/Foo@unspecified"), output.stdout)
                 XCTAssertTrue(output.stdout.contains("bar<\(prefix.pathString)/Bar@unspecified"), output.stdout)
 
@@ -115,9 +115,9 @@ class DependencyResolutionTests: XCTestCase {
             // run with mirror
             do {
                 let output = try executeSwiftPackage(appPath, extraArgs: ["show-dependencies"])
-                XCTAssertTrue(output.stdout.contains("Cloning \(prefix.pathString)/Foo\n"), output.stdout)
-                XCTAssertTrue(output.stdout.contains("Cloning \(prefix.pathString)/BarMirror\n"), output.stdout)
-                XCTAssertFalse(output.stdout.contains("Cloning \(prefix.pathString)/Bar\n"), output.stdout)
+                XCTAssertTrue(output.stdout.contains("Fetching \(prefix.pathString)/Foo\n"), output.stdout)
+                XCTAssertTrue(output.stdout.contains("Fetching \(prefix.pathString)/BarMirror\n"), output.stdout)
+                XCTAssertFalse(output.stdout.contains("Fetching \(prefix.pathString)/Bar\n"), output.stdout)
 
                 XCTAssertTrue(output.stdout.contains("foo<\(prefix.pathString)/Foo@unspecified"), output.stdout)
                 XCTAssertTrue(output.stdout.contains("barmirror<\(prefix.pathString)/BarMirror@unspecified"), output.stdout)

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -644,8 +644,9 @@ class MiscellaneousTestCase: XCTestCase {
             do {
                 // make sure it builds
                 let output = try executeSwiftBuild(appPath)
-                XCTAssertTrue(output.stdout.contains("Cloning \(prefix)/Foo"))
-                XCTAssertTrue(output.stdout.contains("Build complete!"))
+                XCTAssertTrue(output.stdout.contains("Fetching \(prefix)/Foo"), output.stdout)
+                XCTAssertTrue(output.stdout.contains("Moving \(prefix)/Foo to working directory"), output.stdout)
+                XCTAssertTrue(output.stdout.contains("Build complete!"), output.stdout)
             }
 
             // put foo into edit mode
@@ -662,14 +663,14 @@ class MiscellaneousTestCase: XCTestCase {
             do {
                 // take foo out of edit mode
                 let output = try executeSwiftPackage(appPath, extraArgs: ["unedit", "Foo"])
-                XCTAssertTrue(output.stdout.contains("Cloning \(prefix)/Foo"))
+                XCTAssertTrue(output.stdout.contains("Moving \(prefix)/Foo to working directory"), output.stdout)
                 XCTAssertFalse(localFileSystem.exists(appPath.appending(components: ["Packages", "Foo"])))
             }
 
             // build again in edit mode
             do {
                 let output = try executeSwiftBuild(appPath)
-                XCTAssertTrue(output.stdout.contains("Build complete!"))
+                XCTAssertTrue(output.stdout.contains("Build complete!"), output.stdout)
             }
         }
 

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -645,7 +645,7 @@ class MiscellaneousTestCase: XCTestCase {
                 // make sure it builds
                 let output = try executeSwiftBuild(appPath)
                 XCTAssertTrue(output.stdout.contains("Fetching \(prefix)/Foo"), output.stdout)
-                XCTAssertTrue(output.stdout.contains("Moving \(prefix)/Foo to working directory"), output.stdout)
+                XCTAssertTrue(output.stdout.contains("Creating working copy for \(prefix)/Foo"), output.stdout)
                 XCTAssertTrue(output.stdout.contains("Build complete!"), output.stdout)
             }
 
@@ -663,7 +663,7 @@ class MiscellaneousTestCase: XCTestCase {
             do {
                 // take foo out of edit mode
                 let output = try executeSwiftPackage(appPath, extraArgs: ["unedit", "Foo"])
-                XCTAssertTrue(output.stdout.contains("Moving \(prefix)/Foo to working directory"), output.stdout)
+                XCTAssertTrue(output.stdout.contains("Creating working copy for \(prefix)/Foo"), output.stdout)
                 XCTAssertFalse(localFileSystem.exists(appPath.appending(components: ["Packages", "Foo"])))
             }
 

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -111,7 +111,7 @@ private class MockRepositories: RepositoryProvider {
         // No-op.
     }
 
-    func checkoutExists(at path: AbsolutePath) throws -> Bool {
+    func workingCopyExists(at path: AbsolutePath) throws -> Bool {
         return false
     }
 
@@ -119,11 +119,11 @@ private class MockRepositories: RepositoryProvider {
         return self.repositories[repository.url]!
     }
 
-    func cloneCheckout(repository: RepositorySpecifier, at sourcePath: AbsolutePath, to destinationPath: AbsolutePath, editable: Bool) throws {
+    func createWorkingCopy(repository: RepositorySpecifier, sourcePath: AbsolutePath, at destinationPath: AbsolutePath, editable: Bool) throws -> WorkingCheckout {
         fatalError("unexpected API call")
     }
 
-    func openCheckout(at path: AbsolutePath) throws -> WorkingCheckout {
+    func openWorkingCopy(at path: AbsolutePath) throws -> WorkingCheckout {
         fatalError("unexpected API call")
     }
 }

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -38,7 +38,7 @@ class GitRepositoryTests: XCTestCase {
             // Test the provider.
             let testCheckoutPath = path.appending(component: "checkout")
             let provider = GitRepositoryProvider()
-            XCTAssertTrue(try provider.checkoutExists(at: testRepoPath))
+            XCTAssertTrue(try provider.workingCopyExists(at: testRepoPath))
             let repoSpec = RepositorySpecifier(url: testRepoPath.pathString)
             try! provider.fetch(repository: repoSpec, to: testCheckoutPath)
 
@@ -277,18 +277,18 @@ class GitRepositoryTests: XCTestCase {
 
             // Clone off a checkout.
             let checkoutPath = path.appending(component: "checkout")
-            try provider.cloneCheckout(repository: repoSpec, at: testClonePath, to: checkoutPath, editable: false)
+            _ = try provider.createWorkingCopy(repository: repoSpec, sourcePath: testClonePath, at: checkoutPath, editable: false)
             // The remote of this checkout should point to the clone.
             XCTAssertEqual(try GitRepository(path: checkoutPath).remotes()[0].url, testClonePath.pathString)
 
             let editsPath = path.appending(component: "edit")
-            try provider.cloneCheckout(repository: repoSpec, at: testClonePath, to: editsPath, editable: true)
+            _ = try provider.createWorkingCopy(repository: repoSpec, sourcePath: testClonePath, at: editsPath, editable: true)
             // The remote of this checkout should point to the original repo.
             XCTAssertEqual(try GitRepository(path: editsPath).remotes()[0].url, testRepoPath.pathString)
 
             // Check the working copies.
             for path in [checkoutPath, editsPath] {
-                let workingCopy = try provider.openCheckout(at: path)
+                let workingCopy = try provider.openWorkingCopy(at: path)
                 try workingCopy.checkout(tag: "test-tag")
                 XCTAssertEqual(try workingCopy.getCurrentRevision(), currentRevision)
                 XCTAssert(localFileSystem.exists(path.appending(component: "test.txt")))
@@ -318,8 +318,7 @@ class GitRepositoryTests: XCTestCase {
 
             // Clone off a checkout.
             let checkoutPath = path.appending(component: "checkout")
-            try provider.cloneCheckout(repository: repoSpec, at: testClonePath, to: checkoutPath, editable: false)
-            let checkoutRepo = try provider.openCheckout(at: checkoutPath)
+            let checkoutRepo = try provider.createWorkingCopy(repository: repoSpec, sourcePath: testClonePath, at: checkoutPath, editable: false)
             XCTAssertEqual(try checkoutRepo.getTags(), ["1.2.3"])
 
             // Add a new file to original repo.
@@ -358,8 +357,7 @@ class GitRepositoryTests: XCTestCase {
 
             // Clone off a checkout.
             let checkoutPath = path.appending(component: "checkout")
-            try provider.cloneCheckout(repository: repoSpec, at: testClonePath, to: checkoutPath, editable: true)
-            let checkoutRepo = try provider.openCheckout(at: checkoutPath)
+            let checkoutRepo = try provider.createWorkingCopy(repository: repoSpec, sourcePath: testClonePath, at: checkoutPath, editable: true)
 
             XCTAssertFalse(try checkoutRepo.hasUnpushedCommits())
             // Add a new file to checkout.
@@ -534,7 +532,7 @@ class GitRepositoryTests: XCTestCase {
 
             // Fetch and clone repo foo.
             try provider.fetch(repository: fooSpecifier, to: fooRepoPath)
-            try provider.cloneCheckout(repository: fooSpecifier, at: fooRepoPath, to: fooWorkingPath, editable: false)
+            _ = try provider.createWorkingCopy(repository: fooSpecifier, sourcePath: fooRepoPath, at: fooWorkingPath, editable: false)
 
             let fooRepo = GitRepository(path: fooRepoPath, isWorkingRepo: false)
             let fooWorkingRepo = GitRepository(path: fooWorkingPath)
@@ -606,8 +604,7 @@ class GitRepositoryTests: XCTestCase {
 
             // Clone off a checkout.
             let checkoutPath = path.appending(component: "checkout")
-            try provider.cloneCheckout(repository: repoSpec, at: testClonePath, to: checkoutPath, editable: false)
-            let checkoutRepo = try provider.openCheckout(at: checkoutPath)
+            let checkoutRepo = try provider.createWorkingCopy(repository: repoSpec, sourcePath: testClonePath, at: checkoutPath, editable: false)
 
             // The object store should be valid.
             XCTAssertTrue(checkoutRepo.isAlternateObjectStoreValid())
@@ -680,9 +677,8 @@ class GitRepositoryTests: XCTestCase {
 
             // Clone off a checkout.
             let checkoutPath = path.appending(component: "checkout")
-            try provider.cloneCheckout(repository: repoSpec, at: testClonePath, to: checkoutPath, editable: false)
+            let checkoutRepo = try provider.createWorkingCopy(repository: repoSpec, sourcePath: testClonePath, at: checkoutPath, editable: false)
             XCTAssertFalse(localFileSystem.exists(checkoutPath.appending(component: "file.swift")))
-            let checkoutRepo = try provider.openCheckout(at: checkoutPath)
 
             // Try to check out the `main` branch.
             try checkoutRepo.checkout(revision: Revision(identifier: "newMain"))

--- a/Tests/SourceControlTests/InMemoryGitRepositoryTests.swift
+++ b/Tests/SourceControlTests/InMemoryGitRepositoryTests.swift
@@ -100,10 +100,10 @@ class InMemoryGitRepositoryTests: XCTestCase {
         XCTAssert(fooRepo.exists(revision: try fooRepo.resolveRevision(tag: v1)))
 
         let fooCheckoutPath = AbsolutePath("/fooCheckout")
-        XCTAssertFalse(try provider.checkoutExists(at: fooCheckoutPath))
-        try provider.cloneCheckout(repository: specifier, at: fooRepoPath, to: fooCheckoutPath, editable: false)
-        XCTAssertTrue(try provider.checkoutExists(at: fooCheckoutPath))
-        let fooCheckout = try provider.openCheckout(at: fooCheckoutPath)
+        XCTAssertFalse(try provider.workingCopyExists(at: fooCheckoutPath))
+        _ = try provider.createWorkingCopy(repository: specifier, sourcePath: fooRepoPath, at: fooCheckoutPath, editable: false)
+        XCTAssertTrue(try provider.workingCopyExists(at: fooCheckoutPath))
+        let fooCheckout = try provider.openWorkingCopy(at: fooCheckoutPath)
 
         XCTAssertEqual(try fooCheckout.getTags().sorted(), [v1, v2])
         XCTAssert(fooCheckout.exists(revision: try fooCheckout.getCurrentRevision()))

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -94,17 +94,18 @@ private class DummyRepositoryProvider: RepositoryProvider {
         return DummyRepository(provider: self)
     }
 
-    func cloneCheckout(repository: RepositorySpecifier, at sourcePath: AbsolutePath, to destinationPath: AbsolutePath, editable: Bool) throws {
+    func createWorkingCopy(repository: RepositorySpecifier, sourcePath: AbsolutePath, at destinationPath: AbsolutePath, editable: Bool) throws -> WorkingCheckout  {
         try localFileSystem.createDirectory(destinationPath)
         try localFileSystem.writeFileContents(destinationPath.appending(component: "README.txt"), bytes: "Hi")
+        return try self.openWorkingCopy(at: destinationPath)
     }
 
-    func checkoutExists(at path: AbsolutePath) throws -> Bool {
+    func workingCopyExists(at path: AbsolutePath) throws -> Bool {
         return false
     }
 
-    func openCheckout(at path: AbsolutePath) throws -> WorkingCheckout {
-        fatalError("unsupported")
+    func openWorkingCopy(at path: AbsolutePath) throws -> WorkingCheckout {
+        return DummyWorkingCheckout(at: path)
     }
 
     func increaseFetchCount() {
@@ -122,6 +123,58 @@ private class DummyRepositoryProvider: RepositoryProvider {
     var numFetches: Int {
         self.lock.withLock {
             self._numFetches
+        }
+    }
+
+    struct DummyWorkingCheckout: WorkingCheckout {
+        let path : AbsolutePath
+
+        init(at path: AbsolutePath) {
+            self.path = path
+        }
+
+        func getTags() throws -> [String] {
+            fatalError("not implemented")
+        }
+
+        func getCurrentRevision() throws -> Revision {
+            fatalError("not implemented")
+        }
+
+        func fetch() throws {
+            fatalError("not implemented")
+        }
+
+        func hasUnpushedCommits() throws -> Bool {
+            fatalError("not implemented")
+        }
+
+        func hasUncommittedChanges() -> Bool {
+            fatalError("not implemented")
+        }
+
+        func checkout(tag: String) throws {
+            fatalError("not implemented")
+        }
+
+        func checkout(revision: Revision) throws {
+            fatalError("not implemented")
+        }
+
+        func exists(revision: Revision) -> Bool {
+            fatalError("not implemented")
+        }
+
+        func checkout(newBranch: String) throws {
+            fatalError("not implemented")
+        }
+
+        func isAlternateObjectStoreValid() -> Bool {
+            fatalError("not implemented")
+        }
+
+        func areIgnored(_ paths: [AbsolutePath]) throws -> [Bool] {
+            fatalError("not implemented")
         }
     }
 }
@@ -223,7 +276,7 @@ class RepositoryManagerTests: XCTestCase {
 
                 // Create a checkout of the repository.
                 let checkoutPath = path.appending(component: "checkout")
-                try! handle.cloneCheckout(to: checkoutPath, editable: false)
+                _ = try! handle.createWorkingCopy(at: checkoutPath, editable: false)
 
                 XCTAssert(localFileSystem.exists(checkoutPath.appending(component: "README.txt")))
                 XCTAssert(localFileSystem.exists(checkoutPath))

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -2251,7 +2251,7 @@ final class WorkspaceTests: XCTestCase {
         workspace.checkManagedDependencies { result in
             result.check(dependency: "bar", at: .edited(barPath))
         }
-        let barRepo = try workspace.repoProvider.openCheckout(at: barPath) as! InMemoryGitRepository
+        let barRepo = try workspace.repoProvider.openWorkingCopy(at: barPath) as! InMemoryGitRepository
         XCTAssert(barRepo.revisions.contains("dev"))
 
         // Test unediting.


### PR DESCRIPTION
motivation: cloning has very specific meaning in git repository which is not quite what the delegate method represents, causing confusion

changes:
* deprecate willClone/didClone
* introduce willCreateWorkingCopy/didCreateWorkingCopy
* update call-sites and internal delegates
* adjust tests
