### PR TITLE
Enable symlink support explicitly

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -83,6 +83,8 @@ public struct GitRepositoryProvider: RepositoryProvider {
         precondition(!localFileSystem.exists(path))
 
         // FIXME: Ideally we should pass `--progress` here and report status regularly.  We currently don't have callbacks for that.
+        //
+        // NOTE: Explicitly set `core.symlinks=true` on `git clone` to ensure that symbolic links are correctly resolved.
         try self.callGit("clone", "-c", "core.symlinks=true", "--mirror", repository.url, path.pathString,
                          repository: repository,
                          failureMessage: "Failed to clone repository \(repository.url)")
@@ -118,6 +120,8 @@ public struct GitRepositoryProvider: RepositoryProvider {
             // For editable clones, i.e. the user is expected to directly work on them, first we create
             // a clone from our cache of repositories and then we replace the remote to the one originally
             // present in the bare repository.
+            //
+            // NOTE: Explicitly set `core.symlinks=true` on `git clone` to ensure that symbolic links are correctly resolved.
             try self.callGit("clone", "-c", "core.symlinks=true", "--no-checkout", sourcePath.pathString, destinationPath.pathString,
                              repository: repository,
                              failureMessage: "Failed to clone repository \(repository.url)")
@@ -138,6 +142,8 @@ public struct GitRepositoryProvider: RepositoryProvider {
             // re-resolve such that the objects in this repository changed, we would
             // only ever expect to get back a revision that remains present in the
             // object storage.
+            //
+            // NOTE: Explicitly set `core.symlinks=true` on `git clone` to ensure that symbolic links are correctly resolved.
             try self.callGit("clone", "-c", "core.symlinks=true", "--shared", "--no-checkout", sourcePath.pathString, destinationPath.pathString,
                              repository: repository,
                              failureMessage: "Failed to clone repository \(repository.url)")

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -83,7 +83,7 @@ public struct GitRepositoryProvider: RepositoryProvider {
         precondition(!localFileSystem.exists(path))
 
         // FIXME: Ideally we should pass `--progress` here and report status regularly.  We currently don't have callbacks for that.
-        try self.callGit("clone", "--mirror", repository.url, path.pathString,
+        try self.callGit("clone", "-c", "core.symlinks=true", "--mirror", repository.url, path.pathString,
                          repository: repository,
                          failureMessage: "Failed to clone repository \(repository.url)")
     }
@@ -118,7 +118,7 @@ public struct GitRepositoryProvider: RepositoryProvider {
             // For editable clones, i.e. the user is expected to directly work on them, first we create
             // a clone from our cache of repositories and then we replace the remote to the one originally
             // present in the bare repository.
-            try self.callGit("clone", "--no-checkout", sourcePath.pathString, destinationPath.pathString,
+            try self.callGit("clone", "-c", "core.symlinks=true", "--no-checkout", sourcePath.pathString, destinationPath.pathString,
                              repository: repository,
                              failureMessage: "Failed to clone repository \(repository.url)")
             // The default name of the remote.
@@ -138,7 +138,7 @@ public struct GitRepositoryProvider: RepositoryProvider {
             // re-resolve such that the objects in this repository changed, we would
             // only ever expect to get back a revision that remains present in the
             // object storage.
-            try self.callGit("clone", "--shared", "--no-checkout", sourcePath.pathString, destinationPath.pathString,
+            try self.callGit("clone", "-c", "core.symlinks=true", "--shared", "--no-checkout", sourcePath.pathString, destinationPath.pathString,
                              repository: repository,
                              failureMessage: "Failed to clone repository \(repository.url)")
         }


### PR DESCRIPTION
Explicitly set `core.symlinks` to `true` to enable symlink support.

### Motivation:

On Windows, symbolic link support in `git` is defaulted to `false`. Since SwiftPM itself also heavily depends on symlinking, there’s no reason that we should not enable it.

### Modifications:

Explicitly set `core.symlinks=true` on `git clone`.

### Result:

Repositories cloned by SwiftPM will have `core.symlinks` set to `true`, which means symbolic links can be resolved correctly.

### Note:

If a system doesn’t support symlink, then SwiftPM itself will also break; if it does, then we should enable it regardless of global configs. We need to ensure that Swift package repos are checked out correctly.

