### PR TITLE
Fix swift package init --help printout

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -358,7 +358,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         // The 'swift-argument-parser' version declared here must match that
         // used by 'swift-driver' and 'sourcekit-lsp'. Please coordinate
         // dependency version changes here with those projects.
-        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.3.1")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.4.3")),
         .package(url: "https://github.com/apple/swift-driver.git", .branch(relatedDependenciesBranch)),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "1.1.4")),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -264,7 +264,7 @@ let package = Package(
             dependencies: ["Build", "SPMTestSupport"]),
         .testTarget(
             name: "CommandsTests",
-            dependencies: ["swift-build", "swift-package", "swift-test", "swift-run", "Commands", "Workspace", "SPMTestSupport"]),
+            dependencies: ["swift-build", "swift-package", "swift-test", "swift-run", "Commands", "Workspace", "SPMTestSupport", "ArgumentParserTestHelpers"]),
         .testTarget(
             name: "WorkspaceTests",
             dependencies: ["Workspace", "SPMTestSupport"]),

--- a/Package.swift
+++ b/Package.swift
@@ -264,7 +264,7 @@ let package = Package(
             dependencies: ["Build", "SPMTestSupport"]),
         .testTarget(
             name: "CommandsTests",
-            dependencies: ["swift-build", "swift-package", "swift-test", "swift-run", "Commands", "Workspace", "SPMTestSupport", "ArgumentParserTestHelpers"]),
+            dependencies: ["swift-build", "swift-package", "swift-test", "swift-run", "Commands", "Workspace", "SPMTestSupport"]),
         .testTarget(
             name: "WorkspaceTests",
             dependencies: ["Workspace", "SPMTestSupport"]),

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -242,13 +242,28 @@ public struct SwiftToolOptions: ParsableArguments {
     @Flag(name: [.long, .customLong("disable-automatic-resolution")], help: "Disable automatic resolution if Package.resolved file is out-of-date")
     var forceResolvedVersions: Bool = false
 
-    @Flag(name: .customLong("index-store"), inversion: .prefixedEnableDisable, help: "Enable or disable  indexing-while-building feature")
-    var indexStoreEnable: Bool?
+    // @Flag works best when there is a default value present
+    // if true, false aren't enough and a third state is needed
+    // nil should not be the goto. Instead create an enum
+    enum StoreMode: String, EnumerableFlag {
+        case autoIndexStore
+        case enableIndexStore
+        case disableIndexStore
+    }
+    
+    @Flag(help: "Enable or disable indexing-while-building feature")
+    var indexStoreMode: StoreMode = .autoIndexStore
     
     /// The mode to use for indexing-while-building feature.
     var indexStore: BuildParameters.IndexStoreMode {
-        guard let enable = indexStoreEnable else { return .auto }
-        return enable ? .on : .off
+        switch indexStoreMode {
+        case .autoIndexStore:
+            return .auto
+        case .enableIndexStore:
+            return .on
+        case .disableIndexStore:
+            return .off
+        }
     }
     
     /// Whether to enable generation of `.swiftinterface`s alongside `.swiftmodule`s.

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -242,30 +242,15 @@ public struct SwiftToolOptions: ParsableArguments {
     @Flag(name: [.long, .customLong("disable-automatic-resolution")], help: "Disable automatic resolution if Package.resolved file is out-of-date")
     var forceResolvedVersions: Bool = false
 
-    // @Flag works best when there is a default value present
-    // if true, false aren't enough and a third state is needed
-    // nil should not be the goto. Instead create an enum
-    enum StoreMode: String, EnumerableFlag {
-        case autoIndexStore
-        case enableIndexStore
-        case disableIndexStore
-    }
-    
-    @Flag(help: "Enable or disable indexing-while-building feature")
-    var indexStoreMode: StoreMode = .autoIndexStore
-    
+    @Flag(name: .customLong("index-store"), inversion: .prefixedEnableDisable, help: "Enable or disable  indexing-while-building feature")
+    var indexStoreEnable: Bool?
+        
     /// The mode to use for indexing-while-building feature.
     var indexStore: BuildParameters.IndexStoreMode {
-        switch indexStoreMode {
-        case .autoIndexStore:
-            return .auto
-        case .enableIndexStore:
-            return .on
-        case .disableIndexStore:
-            return .off
-        }
+        guard let enable = indexStoreEnable else { return .auto }
+        return enable ? .on : .off
     }
-    
+
     /// Whether to enable generation of `.swiftinterface`s alongside `.swiftmodule`s.
     @Flag(name: .customLong("enable-parseable-module-interfaces"))
     var shouldEnableParseableModuleInterfaces: Bool = false

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -83,7 +83,7 @@ public struct SwiftBuildTool: SwiftCommand {
         version: SwiftVersion.currentVersion.completeDisplayString,
         helpNames: [.short, .long, .customLong("help", withSingleDash: true)])
 
-    @OptionGroup()
+    @OptionGroup(_hiddenFromHelp: true)
     var swiftOptions: SwiftToolOptions
 
     @OptionGroup()

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -190,14 +190,20 @@ extension SwiftPackageTool {
         }
     }
 
-    struct Init: SwiftCommand {
+    struct Init: SwiftCommand, CustomReflectable {
+        var customMirror: Mirror {
+            return Mirror(self, children: ["initMode": self._initMode, "packageName": self._packageName as Any])
+        }
+        
         static let configuration = CommandConfiguration(
             abstract: "Initialize a new package")
+        
+        static let includeSuperCommandInHelp = false
 
         @OptionGroup()
         var swiftOptions: SwiftToolOptions
         
-        @Option(name: .customLong("type"))
+        @Option(name: .customLong("type"), help: "Package type: empty | library | executable | system-module | manifest")
         var initMode: InitPackage.PackageType = .library
         
         @Option(name: .customLong("name"), help: "Provide custom package name")

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -78,7 +78,7 @@ extension SwiftPackageTool {
         static let configuration = CommandConfiguration(
             abstract: "Delete build artifacts")
 
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
         
         func run(_ swiftTool: SwiftTool) throws {
@@ -90,7 +90,7 @@ extension SwiftPackageTool {
         static let configuration = CommandConfiguration(
             abstract: "Purge the global repository cache.")
 
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
 
         func run(_ swiftTool: SwiftTool) throws {
@@ -102,7 +102,7 @@ extension SwiftPackageTool {
         static let configuration = CommandConfiguration(
             abstract: "Reset the complete cache/build directory")
 
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
         
         func run(_ swiftTool: SwiftTool) throws {
@@ -114,7 +114,7 @@ extension SwiftPackageTool {
         static let configuration = CommandConfiguration(
             abstract: "Update package dependencies")
 
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
         
         @Flag(name: [.long, .customShort("n")],
@@ -160,7 +160,7 @@ extension SwiftPackageTool {
         static let configuration = CommandConfiguration(
             abstract: "Describe the current package")
 
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
                 
         @Option(help: "json | text")
@@ -222,7 +222,7 @@ extension SwiftPackageTool {
         static let configuration = CommandConfiguration(
             commandName: "_format")
 
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
         
         @Argument(parsing: .unconditionalRemaining,
@@ -292,7 +292,7 @@ extension SwiftPackageTool {
         static let configuration = CommandConfiguration(
             commandName: "experimental-api-diff")
 
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
 
         @Argument(help: "The baseline treeish")
@@ -347,7 +347,7 @@ extension SwiftPackageTool {
         static let configuration = CommandConfiguration(
             abstract: "Dump Symbol Graph")
 
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
         
         func run(_ swiftTool: SwiftTool) throws {
@@ -370,7 +370,7 @@ extension SwiftPackageTool {
         static let configuration = CommandConfiguration(
             abstract: "Print parsed Package.swift as JSON")
 
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
         
         func run(_ swiftTool: SwiftTool) throws {
@@ -394,7 +394,7 @@ extension SwiftPackageTool {
     }
     
     struct DumpPIF: SwiftCommand {
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
         
         @Flag(help: "Preserve the internal structure of PIF")
@@ -413,7 +413,7 @@ extension SwiftPackageTool {
         static let configuration = CommandConfiguration(
             abstract: "Put a package in editable mode")
 
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
 
         @Option(help: "The revision to edit", transform: { Revision(identifier: $0) })
@@ -446,7 +446,7 @@ extension SwiftPackageTool {
         static let configuration = CommandConfiguration(
             abstract: "Remove a package from editable mode")
 
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
         
         @Flag(name: .customLong("force"),
@@ -473,7 +473,7 @@ extension SwiftPackageTool {
         static let configuration = CommandConfiguration(
             abstract: "Print the resolved dependency graph")
 
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
         
         @Option(help: "text | dot | json | flatlist")
@@ -490,7 +490,7 @@ extension SwiftPackageTool {
             commandName: "tools-version",
             abstract: "Manipulate tools version of the current package")
 
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
         
         @Option(help: "text | dot | json | flatlist")
@@ -549,7 +549,7 @@ extension SwiftPackageTool {
         static let configuration = CommandConfiguration(
             abstract: "Compute the checksum for a binary artifact.")
 
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
         
         @Argument(help: "The absolute or relative path to the binary artifact")
@@ -577,7 +577,7 @@ extension SwiftPackageTool {
             abstract: "Create a source archive for the package"
         )
 
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
 
         @Option(
@@ -639,7 +639,7 @@ extension SwiftPackageTool {
             var skipExtraFiles: Bool = false
         }
 
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
 
         @OptionGroup()
@@ -715,7 +715,7 @@ extension SwiftPackageTool.Config {
         static let configuration = CommandConfiguration(
             abstract: "Set a mirror for a dependency")
 
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
         
         @Option(help: "The package dependency url")
@@ -749,7 +749,7 @@ extension SwiftPackageTool.Config {
         static let configuration = CommandConfiguration(
             abstract: "Remove an existing mirror")
 
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
         
         @Option(help: "The package dependency url")
@@ -783,7 +783,7 @@ extension SwiftPackageTool.Config {
         static let configuration = CommandConfiguration(
             abstract: "Print mirror configuration for the given package dependency")
 
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
         
         @Option(help: "The package dependency url")
@@ -835,7 +835,7 @@ extension SwiftPackageTool {
         static let configuration = CommandConfiguration(
             abstract: "Resolve package dependencies")
         
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
 
         @OptionGroup()
@@ -865,7 +865,7 @@ extension SwiftPackageTool {
     struct Fetch: SwiftCommand {
         static let configuration = CommandConfiguration(shouldDisplay: false)
         
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
         
         @OptionGroup()
@@ -909,7 +909,7 @@ extension SwiftPackageTool {
             )
         }
       
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
 
         @Argument(help: "generate-bash-script | generate-zsh-script |\ngenerate-fish-script | list-dependencies | list-executables")

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -163,7 +163,7 @@ extension SwiftPackageTool {
         @OptionGroup()
         var swiftOptions: SwiftToolOptions
                 
-        @Option()
+        @Option(help: "json | text")
         var type: DescribeMode = .text
 
         func run(_ swiftTool: SwiftTool) throws {
@@ -190,17 +190,11 @@ extension SwiftPackageTool {
         }
     }
 
-    struct Init: SwiftCommand, CustomReflectable {
-        var customMirror: Mirror {
-            return Mirror(self, children: ["initMode": self._initMode, "packageName": self._packageName as Any])
-        }
-        
-        static let configuration = CommandConfiguration(
+    public struct Init: SwiftCommand {
+        public static let configuration = CommandConfiguration(
             abstract: "Initialize a new package")
-        
-        static let includeSuperCommandInHelp = false
 
-        @OptionGroup()
+        @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
         
         @Option(name: .customLong("type"), help: "Package type: empty | library | executable | system-module | manifest")
@@ -208,10 +202,13 @@ extension SwiftPackageTool {
         
         @Option(name: .customLong("name"), help: "Provide custom package name")
         var packageName: String?
-
+        
+        public init() {}
+        
         func run(_ swiftTool: SwiftTool) throws {
-            // FIXME: Error handling.
-            let cwd = localFileSystem.currentWorkingDirectory!
+            guard let cwd = localFileSystem.currentWorkingDirectory else {
+                throw StringError("Could not find the current working directory")
+            }
 
             let packageName = self.packageName ?? cwd.basename
             let initPackage = try InitPackage(
@@ -349,6 +346,9 @@ extension SwiftPackageTool {
     }
     
     struct DumpSymbolGraph: SwiftCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Dump Symbol Graph")
+
         @OptionGroup()
         var swiftOptions: SwiftToolOptions
         
@@ -478,7 +478,7 @@ extension SwiftPackageTool {
         @OptionGroup()
         var swiftOptions: SwiftToolOptions
         
-        @Option()
+        @Option(help: "text | dot | json | flatlist")
         var format: ShowDependenciesMode = .text
 
         func run(_ swiftTool: SwiftTool) throws {
@@ -495,7 +495,7 @@ extension SwiftPackageTool {
         @OptionGroup()
         var swiftOptions: SwiftToolOptions
         
-        @Option()
+        @Option(help: "text | dot | json | flatlist")
         var format: ShowDependenciesMode = .text
 
         @Flag(help: "Set tools version of package to the current tools version in use")
@@ -914,7 +914,7 @@ extension SwiftPackageTool {
         @OptionGroup()
         var swiftOptions: SwiftToolOptions
 
-        @Argument()
+        @Argument(help: "generate-bash-script | generate-zsh-script |\ngenerate-fish-script | list-dependencies | list-executables")
         var mode: Mode
 
         func run(_ swiftTool: SwiftTool) throws {

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -190,7 +190,7 @@ extension SwiftPackageTool {
         }
     }
 
-    public struct Init: SwiftCommand {
+    struct Init: SwiftCommand {
         public static let configuration = CommandConfiguration(
             abstract: "Initialize a new package")
 
@@ -203,11 +203,9 @@ extension SwiftPackageTool {
         @Option(name: .customLong("name"), help: "Provide custom package name")
         var packageName: String?
         
-        public init() {}
-        
         func run(_ swiftTool: SwiftTool) throws {
             guard let cwd = localFileSystem.currentWorkingDirectory else {
-                throw StringError("Could not find the current working directory")
+                throw InternalError("Could not find the current working directory")
             }
 
             let packageName = self.packageName ?? cwd.basename

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -90,7 +90,7 @@ public struct SwiftRunTool: SwiftCommand {
         version: SwiftVersion.currentVersion.completeDisplayString,
         helpNames: [.short, .long, .customLong("help", withSingleDash: true)])
 
-    @OptionGroup()
+    @OptionGroup(_hiddenFromHelp: true)
     public var swiftOptions: SwiftToolOptions
 
     @OptionGroup()

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -194,7 +194,7 @@ public struct SwiftTestTool: SwiftCommand {
         version: SwiftVersion.currentVersion.completeDisplayString,
         helpNames: [.short, .long, .customLong("help", withSingleDash: true)])
 
-    @OptionGroup()
+    @OptionGroup(_hiddenFromHelp: true)
     var swiftOptions: SwiftToolOptions
 
     @OptionGroup()

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -12,7 +12,7 @@ import XCTest
 import Foundation
 
 import TSCBasic
-import Commands
+@testable import Commands
 import Xcodeproj
 import PackageModel
 import SourceControl

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -17,6 +17,7 @@ import Xcodeproj
 import PackageModel
 import SourceControl
 import SPMTestSupport
+import ArgumentParserTestHelpers
 import TSCUtility
 import Workspace
 
@@ -46,6 +47,22 @@ final class PackageToolTests: XCTestCase {
     func testVersion() throws {
         let stdout = try execute(["--version"]).stdout
         XCTAssert(stdout.contains("Swift Package Manager"), "got stdout:\n" + stdout)
+    }
+    
+    func testInitHelp() throws {
+        AssertHelp(for: Commands.SwiftPackageTool.Init.self, equals: """
+            OVERVIEW: Initialize a new package
+
+            USAGE: init [<options>] --enable-index-store
+
+            OPTIONS:
+              --type <type>           Package type: empty | library | executable |
+                                      system-module | manifest (default: library)
+              --name <name>           Provide custom package name
+              -h, --help              Show help information.
+            
+            """
+        )
     }
     
     func testNetrcSupportedOS() throws {

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -17,7 +17,6 @@ import Xcodeproj
 import PackageModel
 import SourceControl
 import SPMTestSupport
-import ArgumentParserTestHelpers
 import TSCUtility
 import Workspace
 
@@ -47,22 +46,6 @@ final class PackageToolTests: XCTestCase {
     func testVersion() throws {
         let stdout = try execute(["--version"]).stdout
         XCTAssert(stdout.contains("Swift Package Manager"), "got stdout:\n" + stdout)
-    }
-    
-    func testInitHelp() throws {
-        AssertHelp(for: Commands.SwiftPackageTool.Init.self, equals: """
-            OVERVIEW: Initialize a new package
-
-            USAGE: init [<options>] --enable-index-store
-
-            OPTIONS:
-              --type <type>           Package type: empty | library | executable |
-                                      system-module | manifest (default: library)
-              --name <name>           Provide custom package name
-              -h, --help              Show help information.
-            
-            """
-        )
     }
     
     func testNetrcSupportedOS() throws {

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -12,7 +12,7 @@ import XCTest
 import Foundation
 
 import TSCBasic
-@testable import Commands
+import Commands
 import Xcodeproj
 import PackageModel
 import SourceControl


### PR DESCRIPTION
Depends on this [PR](https://github.com/apple/swift-argument-parser/pull/300)

Fixes `swift package init --help` to only show help for `init`
This is a major UI improvement as it allows the user to focus on the help that is solely relevant to `init`, and not get overwhelmed with other options.

rdar://76116106