### PR TITLE
Use implementation only import of Foundation in PackagePlugin

### DIFF
--- a/Sources/PackagePlugin/ImplementationDetails.swift
+++ b/Sources/PackagePlugin/ImplementationDetails.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
-import Foundation
+@_implementationOnly import Foundation
 
 // The way in which SwiftPM communicates with the package plugin is an im-
 // plementation detail, but the way it currently works is that the plugin

--- a/Sources/PackagePlugin/PublicAPI/Path.swift
+++ b/Sources/PackagePlugin/PublicAPI/Path.swift
@@ -8,8 +8,6 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
-import Foundation
-
 /// A simple representation of a path in the file system.
 public struct Path {
     private let _string: String


### PR DESCRIPTION
This is the same as https://github.com/apple/swift-package-manager/pull/3404 but for PackagePlugin.

### Motivation:

As with PackageDescription, PackagePlugin should not have an interface dependency on Foundation.  There is no specific current problem but reducing the dependencies here is cleaner.

### Modifications:

Convert one import of Foundation to implementation-only (we need it for decoding the JSON coming from SwiftPM and for encoding the JSON sent to SwiftPM).

Remove another import of Foundation altogether; it was only left over from code that has since been removed.