### PR TITLE
[5.5] Disable the `development` flag on the 5.5 branch, marking 5.5 binaries as release builds

### DIFF
--- a/Sources/Basics/SwiftVersion.swift
+++ b/Sources/Basics/SwiftVersion.swift
@@ -64,7 +64,7 @@ extension SwiftVersion {
     /// The current version of the package manager.
     public static let currentVersion = SwiftVersion(
         version: (5, 5, 0),
-        isDevelopment: true,
+        isDevelopment: false,
         buildIdentifier: getBuildIdentifier()
     )
 }


### PR DESCRIPTION
Mark SwiftPM binaries produced from the 5.5 branch as release instead of development binaries.  Among other things this disables the use of 999.0 as a valid package tools version.

### Motivation:

This is done for every release branch once it has been created.  As this change is only made on the release branch, `main` continues to be marked as a development branch.

### Modifications:

- change a boolean flag in SwiftPM