### PR TITLE
Fix a problem in the logic to generate manifest source from existing parsed manifest structs

### DIFF
--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -25,8 +25,9 @@ extension Manifest {
     public var generatedManifestFileContents: String {
         /// Only write out the major and minor (not patch) versions of the
         /// tools version, since the patch version doesn't change semantics.
+        /// We leave out the spacer if the tools version doesn't support it.
         return """
-            // swift-tools-version: \(toolsVersion.major).\(toolsVersion.minor)
+            // swift-tools-version:\(toolsVersion < .v5_4 ? "" : " ")\(toolsVersion.major).\(toolsVersion.minor)
             import PackageDescription
 
             let package = \(SourceCodeFragment(from: self).generateSourceCode())
@@ -129,9 +130,9 @@ fileprivate extension SourceCodeFragment {
             params.append(SourceCodeFragment(key: "url", string: data.location))
             switch data.requirement {
             case .exact(let version):
-                params.append(SourceCodeFragment(enum: "exact", string: version.description))
+                params.append(SourceCodeFragment(enum: "exact", string: "\(version)"))
             case .range(let range):
-                params.append(SourceCodeFragment(enum: "range", string: range.description))
+                params.append(SourceCodeFragment("\"\(range.lowerBound)\"..<\"\(range.upperBound)\""))
             case .revision(let revision):
                 params.append(SourceCodeFragment(enum: "revision", string: revision))
             case .branch(let branch):


### PR DESCRIPTION
The logic to generate manifest source from existing parsed manifest data structures misquoted some package version requirement ranges.

### Changes

This fixes those cases, producing a semantically equivalent package manifests.  Since the model does not capture how a particular range was specified, it is not possible to recreate the original shorthands.

A future improvement can either extend the model to record the original spelling of the range requirements, or can apply heuristics to shorten the rules in the future (e.g. automatically derive `upToNextMajor()` etc.

This also eliminates an extra whitespace before the minimum tools version declaration when the specified tools version allows it, so older parsers can parse the generated manifests.

rdar://76559428