### PR TITLE
[5.5] MiscellaneousTests.testOverridingSwiftcArguments() fails on Apple Silicon

### DIFF
--- a/Fixtures/Miscellaneous/DistantFutureDeploymentTarget/Package.swift
+++ b/Fixtures/Miscellaneous/DistantFutureDeploymentTarget/Package.swift
@@ -1,0 +1,9 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "DistantFutureDeploymentTarget",
+    targets: [
+        .target(name: "DistantFutureDeploymentTarget", path: "Sources"),
+    ]
+)

--- a/Fixtures/Miscellaneous/DistantFutureDeploymentTarget/Sources/main.swift
+++ b/Fixtures/Miscellaneous/DistantFutureDeploymentTarget/Sources/main.swift
@@ -1,7 +1,7 @@
 /// This file exists to test the ability to override deployment targets via args passed to swiftc
 /// For this test to work, this file must have an API call which was introduced in a version
 /// higher than the default macOS deployment target that is checked in.
-@available(macOS 10.20, *)
+@available(macOS 41.0, *)
 func foo() {}
 
 foo()

--- a/Fixtures/Miscellaneous/OverrideSwiftcArgs/Package.swift
+++ b/Fixtures/Miscellaneous/OverrideSwiftcArgs/Package.swift
@@ -1,9 +1,0 @@
-// swift-tools-version:4.2
-import PackageDescription
-
-let package = Package(
-    name: "OverrideSwiftcArgs",
-    targets: [
-        .target(name: "OverrideSwiftcArgs", path: "Sources"),
-    ]
-)

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -306,10 +306,11 @@ class MiscellaneousTestCase: XCTestCase {
         }
     }
 
-    func testOverridingSwiftcArguments() throws {
+    func testOverridingDeploymentTargetUsingSwiftCompilerArgument() throws {
       #if os(macOS)
-        fixture(name: "Miscellaneous/OverrideSwiftcArgs") { prefix in
-            try executeSwiftBuild(prefix, Xswiftc: ["-target", "x86_64-apple-macosx10.20"])
+        fixture(name: "Miscellaneous/DistantFutureDeploymentTarget") { prefix in
+            let hostTriple = Resources.default.toolchain.triple
+            try executeSwiftBuild(prefix, Xswiftc: ["-target", "\(hostTriple.arch)-apple-macosx41.0"])
         }
       #endif
     }


### PR DESCRIPTION
This is the 5.5 nomination of a fix of a unit test.  Please see https://github.com/apple/swift-package-manager/pull/3414 for details.