### PR TITLE
[5.4] Enable symlink support explicitly

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -84,9 +84,16 @@ public struct GitRepositoryProvider: RepositoryProvider {
         // FIXME: Ideally we should pass `--progress` here and report status regularly.  We currently don't have callbacks for that.
         //
         // NOTE: Explicitly set `core.symlinks=true` on `git clone` to ensure that symbolic links are correctly resolved.
+        // FIXME: Remove the judgement before a cross-platform release
+        #if os(Windows)
         try self.callGit("clone", "-c", "core.symlinks=true", "--mirror", repository.url, path.pathString,
                          repository: repository,
                          failureMessage: "Failed to clone repository \(repository.url)")
+        #else
+        try self.callGit("clone", "--mirror", repository.url, path.pathString,
+                         repository: repository,
+                         failureMessage: "Failed to clone repository \(repository.url)")
+        #endif
     }
 
     public func copy(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
@@ -109,9 +116,16 @@ public struct GitRepositoryProvider: RepositoryProvider {
             // present in the bare repository.
             //
             // NOTE: Explicitly set `core.symlinks=true` on `git clone` to ensure that symbolic links are correctly resolved.
+            // FIXME: Remove the judgement before a cross-platform release
+            #if os(Windows)
             try self.callGit("clone", "-c", "core.symlinks=true", "--no-checkout", sourcePath.pathString, destinationPath.pathString,
                              repository: repository,
                              failureMessage: "Failed to clone repository \(repository.url)")
+            #else
+            try self.callGit("clone", "--no-checkout", sourcePath.pathString, destinationPath.pathString,
+                             repository: repository,
+                             failureMessage: "Failed to clone repository \(repository.url)")
+            #endif
             // The default name of the remote.
             let origin = "origin"
             // In destination repo remove the remote which will be pointing to the source repo.
@@ -131,9 +145,16 @@ public struct GitRepositoryProvider: RepositoryProvider {
             // object storage.
             //
             // NOTE: Explicitly set `core.symlinks=true` on `git clone` to ensure that symbolic links are correctly resolved.
+            // FIXME: Remove the judgement before a cross-platform release
+            #if os(Windows)
             try self.callGit("clone", "-c", "core.symlinks=true", "--shared", "--no-checkout", sourcePath.pathString, destinationPath.pathString,
                              repository: repository,
                              failureMessage: "Failed to clone repository \(repository.url)")
+            #else
+            try self.callGit("clone", "--shared", "--no-checkout", sourcePath.pathString, destinationPath.pathString,
+                             repository: repository,
+                             failureMessage: "Failed to clone repository \(repository.url)")
+            #endif
         }
     }
 

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -82,7 +82,9 @@ public struct GitRepositoryProvider: RepositoryProvider {
         // shallow clone.
         precondition(!localFileSystem.exists(path))
         // FIXME: Ideally we should pass `--progress` here and report status regularly.  We currently don't have callbacks for that.
-        try self.callGit("clone", "--mirror", repository.url, path.pathString,
+        //
+        // NOTE: Explicitly set `core.symlinks=true` on `git clone` to ensure that symbolic links are correctly resolved.
+        try self.callGit("clone", "-c", "core.symlinks=true", "--mirror", repository.url, path.pathString,
                          repository: repository,
                          failureMessage: "Failed to clone repository \(repository.url)")
     }
@@ -105,7 +107,9 @@ public struct GitRepositoryProvider: RepositoryProvider {
             // For editable clones, i.e. the user is expected to directly work on them, first we create
             // a clone from our cache of repositories and then we replace the remote to the one originally
             // present in the bare repository.
-            try self.callGit("clone", "--no-checkout", sourcePath.pathString, destinationPath.pathString,
+            //
+            // NOTE: Explicitly set `core.symlinks=true` on `git clone` to ensure that symbolic links are correctly resolved.
+            try self.callGit("clone", "-c", "core.symlinks=true", "--no-checkout", sourcePath.pathString, destinationPath.pathString,
                              repository: repository,
                              failureMessage: "Failed to clone repository \(repository.url)")
             // The default name of the remote.
@@ -125,7 +129,9 @@ public struct GitRepositoryProvider: RepositoryProvider {
             // re-resolve such that the objects in this repository changed, we would
             // only ever expect to get back a revision that remains present in the
             // object storage.
-            try self.callGit("clone", "--shared", "--no-checkout", sourcePath.pathString, destinationPath.pathString,
+            //
+            // NOTE: Explicitly set `core.symlinks=true` on `git clone` to ensure that symbolic links are correctly resolved.
+            try self.callGit("clone", "-c", "core.symlinks=true", "--shared", "--no-checkout", sourcePath.pathString, destinationPath.pathString,
                              repository: repository,
                              failureMessage: "Failed to clone repository \(repository.url)")
         }


### PR DESCRIPTION
Enable symlink support explicitly

This is a cherry-pick of commit 5f80bd7 from `main`.

### Motivation:

enable git symlink support for Windows

### Modifications:

pass core.symlinks=true to git clone operations

### Result:

repositories cloned by SwiftPM will have `core.symlinks` set to `true`
