### PR TITLE
Handle both SwiftArgParser 0.3.x and 0.4.x output.

### DIFF
--- a/Tests/CommandsTests/RunToolTests.swift
+++ b/Tests/CommandsTests/RunToolTests.swift
@@ -23,7 +23,8 @@ final class RunToolTests: XCTestCase {
     }
 
     func testUsage() throws {
-        XCTAssert(try execute(["--help"]).stdout.contains("USAGE: swift run <options>"))
+        let stdout = try execute(["-help"]).stdout
+        XCTAssert(stdout.contains("USAGE: swift run <options>") || stdout.contains("USAGE: swift run [<options>]"), "got stdout:\n" + stdout)
     }
 
     func testSeeAlso() throws {


### PR DESCRIPTION
Cherry-picking this change in release/5.4 to unblock Apple Silicon bot.