### PR TITLE
[5.5] Pass compiler flags to alllow use of @main in single-source-file executable modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Swift v.Next
 
 Swift 5.5
  -----------
+* [3410]
+    In a package that specifies a minimum tools version of 5.5, `@main` can now be used in a single-source file executable as long as the name of the source file isn't `main.swift`.  To work around special compiler semantics with single-file modules, SwiftPM now passes `-parse-as-library` when compiling an executable module that contains a single Swift source file whose name is not `main.swift`.
+
 * [#3310]
     Adding a dependency requirement can now be done with the convenience initializer `.package(url: String, revision: String)`.
 


### PR DESCRIPTION
This is the 5.5 nomination of https://github.com/apple/swift-package-manager/pull/3410 which makes it possible to have single-file source modules with a `@main` by taking the same approach as Xcode does when building such modules (also increasing compatibility of packages between SwiftPM and Xcode).

The original PR is https://github.com/apple/swift-package-manager/pull/3410 and has a lot more details.