### PR TITLE
[5.5] Fix a problem in the logic to generate manifest source from existing parsed manifest structs

### DIFF
--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -25,8 +25,9 @@ extension Manifest {
     public var generatedManifestFileContents: String {
         /// Only write out the major and minor (not patch) versions of the
         /// tools version, since the patch version doesn't change semantics.
+        /// We leave out the spacer if the tools version doesn't support it.
         return """
-            // swift-tools-version: \(toolsVersion.major).\(toolsVersion.minor)
+            // swift-tools-version:\(toolsVersion < .v5_4 ? "" : " ")\(toolsVersion.major).\(toolsVersion.minor)
             import PackageDescription
 
             let package = \(SourceCodeFragment(from: self).generateSourceCode())
@@ -129,9 +130,9 @@ fileprivate extension SourceCodeFragment {
             params.append(SourceCodeFragment(key: "url", string: data.location))
             switch data.requirement {
             case .exact(let version):
-                params.append(SourceCodeFragment(enum: "exact", string: version.description))
+                params.append(SourceCodeFragment(enum: "exact", string: "\(version)"))
             case .range(let range):
-                params.append(SourceCodeFragment(enum: "range", string: range.description))
+                params.append(SourceCodeFragment("\"\(range.lowerBound)\"..<\"\(range.upperBound)\""))
             case .revision(let revision):
                 params.append(SourceCodeFragment(enum: "revision", string: revision))
             case .branch(let branch):


### PR DESCRIPTION
This is the 5.5 nomination of https://github.com/apple/swift-package-manager/pull/3415 which fixes a problem serializing package manifests with ranged package dependencies.