### PR TITLE
Add compiler diagnostics to a test that sometimes fails in CI

### DIFF
--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -518,29 +518,30 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testEnableTestDiscoveryDeprecation() throws {
+        let compilerDiagnosticFlags = ["-Xswiftc", "-Xfrontend", "-Xswiftc", "-Rmodule-interface-rebuild"]
         #if canImport(Darwin)
         // should emit when LinuxMain is present
         fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
-            let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"], packagePath: path)
+            let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: path)
             XCTAssertMatch(stderr, .contains("warning: '--enable-test-discovery' option is deprecated"))
         }
 
         // should emit when LinuxMain is not present
         fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
             try localFileSystem.writeFileContents(path.appending(components: "Tests", SwiftTarget.testManifestNames.first!), bytes: "fatalError(\"boom\")")
-            let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"], packagePath: path)
+            let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: path)
             XCTAssertMatch(stderr, .contains("warning: '--enable-test-discovery' option is deprecated"))
         }
         #else
         // should emit when LinuxMain is present
         fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
-            let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"], packagePath: path)
+            let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: path)
             XCTAssertMatch(stderr, .contains("warning: '--enable-test-discovery' option is deprecated"))
         }
         // should not emit when LinuxMain is present
         fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
             try localFileSystem.writeFileContents(path.appending(components: "Tests", SwiftTarget.testManifestNames.first!), bytes: "fatalError(\"boom\")")
-            let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"], packagePath: path)
+            let (_, stderr) = try SwiftPMProduct.SwiftTest.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: path)
             XCTAssertNoMatch(stderr, .contains("warning: '--enable-test-discovery' option is deprecated"))
         }
         #endif


### PR DESCRIPTION
This test sometimes fails due to what seem to be module rebuilding issues.  The diagnostics are only shown if the test fails; they don't pollute the regular output.
