### PR TITLE
improve output when resolving packages

### DIFF
--- a/Sources/Basics/DispatchTimeInterval+Extensions.swift
+++ b/Sources/Basics/DispatchTimeInterval+Extensions.swift
@@ -57,3 +57,13 @@ extension DispatchTimeInterval {
         }
     }
 }
+
+// remove when available to all platforms
+#if os(Linux) || os(Windows) || os(Android)
+extension DispatchTime {
+    public func distance(to: DispatchTime) -> DispatchTimeInterval {
+        let duration = to.uptimeNanoseconds - self.uptimeNanoseconds
+        return .nanoseconds(duration >= Int.max ? Int.max : Int(duration))
+    }
+}
+#endif

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -113,12 +113,18 @@ private class ToolWorkspaceDelegate: WorkspaceDelegate {
     }
 
     func willCheckOut(repository: String, revision: String, at path: AbsolutePath) {
-        // 👀 this is a quick operation and does not provide a whole lot of value to report
-        /*queue.async {
-            self.stdoutStream <<< "Checking out \(repository) at \(revision)"
+        // noop
+    }
+
+    func didCheckOut(repository: String, revision: String, at path: AbsolutePath, error: Diagnostic?) {
+        guard case .none = error else {
+            return // error will be printed before hand
+        }
+        queue.async {
+            self.stdoutStream <<< "Working copy of \(repository) resolved at \(revision)"
             self.stdoutStream <<< "\n"
             self.stdoutStream.flush()
-        }*/
+        }
     }
 
     func removing(repository: String) {
@@ -241,7 +247,6 @@ private class ToolWorkspaceDelegate: WorkspaceDelegate {
     func willLoadManifest(packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind) {}
     func didLoadManifest(packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Diagnostic]) {}
     func didCreateWorkingCopy(repository url: String, at path: AbsolutePath, error: Diagnostic?) {}
-    func didCheckOut(repository url: String, revision: String, at path: AbsolutePath, error: Diagnostic?) {}
     func resolvedFileChanged() {}
 }
 

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -937,8 +937,10 @@ extension DispatchTimeInterval {
             return String(format: "%.2f", Double(value)/Double(1_000_000_000)) + "s"
         case .never:
             return "n/a"
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         @unknown default:
             return "n/a"
+        #endif
         }
     }
 }

--- a/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
@@ -238,7 +238,7 @@ public struct PubgrubDependencyResolver {
             finalAssignments.append((identifier, override.version, override.products))
         }
 
-        self.delegate?.computed(bindings: finalAssignments)
+        self.delegate?.solved(result: finalAssignments)
 
         return (finalAssignments, state)
     }
@@ -632,6 +632,7 @@ public struct PubgrubDependencyResolver {
         // get conflicts (if any) sooner.
         self.computeCounts(for: undecided) { result in
             do {
+                let start = DispatchTime.now()
                 let counts = try result.get()
                 // forced unwraps safe since we are testing for count and errors above
                 let pkgTerm = undecided.min { counts[$0]! < counts[$1]! }!
@@ -670,7 +671,7 @@ public struct PubgrubDependencyResolver {
 
                 // Decide this version if there was no conflict with its dependencies.
                 if !haveConflict {
-                    self.delegate?.didResolve(term: pkgTerm, version: version)
+                    self.delegate?.didResolve(term: pkgTerm, version: version, duration: start.distance(to: .now()))
                     state.decide(pkgTerm.node, at: version)
                 }
 

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -592,6 +592,10 @@ public final class MockWorkspaceDelegate: WorkspaceDelegate {
         self.append("updating repo: \(repository)")
     }
 
+    public func repositoryDidUpdate(_ repository: String, duration: DispatchTimeInterval) {
+        self.append("finished updating repo: \(repository)")
+    }
+
     public func dependenciesUpToDate() {
         self.append("Everything is already up-to-date")
     }
@@ -600,7 +604,7 @@ public final class MockWorkspaceDelegate: WorkspaceDelegate {
         self.append("fetching repo: \(repository)")
     }
 
-    public func fetchingDidFinish(repository: String, fetchDetails: RepositoryManager.FetchDetails?, diagnostic: Diagnostic?) {
+    public func fetchingDidFinish(repository: String, fetchDetails: RepositoryManager.FetchDetails?, diagnostic: Diagnostic?, duration: DispatchTimeInterval) {
         self.append("finished fetching repo: \(repository)")
     }
 
@@ -608,8 +612,16 @@ public final class MockWorkspaceDelegate: WorkspaceDelegate {
         self.append("creating working copy for: \(url)")
     }
 
+    public func didCreateWorkingCopy(repository url: String, at path: AbsolutePath, error: Diagnostic?) {
+        self.append("finished creating working copy for: \(url)")
+    }
+
     public func willCheckOut(repository url: String, revision: String, at path: AbsolutePath) {
         self.append("checking out repo: \(url)")
+    }
+
+    public func didCheckOut(repository url: String, revision: String, at path: AbsolutePath, error: Diagnostic?) {
+        self.append("finsihed checking out repo: \(url)")
     }
 
     public func removing(repository: String) {
@@ -626,6 +638,26 @@ public final class MockWorkspaceDelegate: WorkspaceDelegate {
 
     public func didLoadManifest(packagePath: AbsolutePath, url: String, version: Version?, packageKind: PackageReference.Kind, manifest: Manifest?, diagnostics: [Diagnostic]) {
         self.append("did load manifest for \(packageKind) package: \(url)")
+    }
+
+    public func willComputeVersion(package: PackageIdentity, location: String) {
+        // noop
+    }
+
+    public func didComputeVersion(package: PackageIdentity, location: String, version: String, duration: DispatchTimeInterval) {
+        // noop
+    }
+
+    public func resolvedFileChanged() {
+        // noop
+    }
+
+    public func downloadingBinaryArtifact(from url: String, bytesDownloaded: Int64, totalBytesToDownload: Int64?) {
+        // noop
+    }
+
+    public func didDownloadBinaryArtifacts() {
+        // noop
     }
 
     private func append(_ event: String) {

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -31,7 +31,7 @@ class MiscellaneousTestCase: XCTestCase {
 
         fixture(name: "DependencyResolution/External/Simple") { prefix in
             let (output, _) = try executeSwiftBuild(prefix.appending(component: "Bar"))
-            XCTAssertMatch(output, .regex("Resolving .* at 1\\.2\\.3"))
+            XCTAssertMatch(output, .regex("Computed .* at 1\\.2\\.3"))
             XCTAssertMatch(output, .contains("Compiling Foo Foo.swift"))
             XCTAssertMatch(output, .contains("Merging module Foo"))
             XCTAssertMatch(output, .contains("Compiling Bar main.swift"))

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -1102,14 +1102,13 @@ final class PubgrubTests: XCTestCase {
             var events = [String]()
             let lock = Lock()
 
-
             func willResolve(term: Term) {
                 self.lock.withLock {
                     self.events.append("willResolve '\(term.node.package.identity)'")
                 }
             }
 
-            func didResolve(term: Term, version: Version) {
+            func didResolve(term: Term, version: Version, duration: DispatchTimeInterval) {
                 self.lock.withLock {
                     self.events.append("didResolve '\(term.node.package.identity)' at '\(version)'")
                 }
@@ -1119,16 +1118,16 @@ final class PubgrubTests: XCTestCase {
 
             func conflict(conflict: Incompatibility) {}
 
-            func satisfied(term: Term, by: Assignment, incompatibility: Incompatibility) {}
+            func satisfied(term: Term, by assignment: Assignment, incompatibility: Incompatibility) {}
 
-            func partiallySatisfied(term: Term, by: Assignment, incompatibility: Incompatibility, difference: Term) {}
+            func partiallySatisfied(term: Term, by assignment: Assignment, incompatibility: Incompatibility, difference: Term) {}
 
             func failedToResolve(incompatibility: Incompatibility) {}
 
-            func computed(bindings: [DependencyResolver.Binding]) {
-                let decision = bindings.sorted(by: { $0.package.identity < $1.package.identity }).map { "'\($0.package.identity)' at '\($0.binding)'" }
+            func solved(result: [DependencyResolver.Binding]) {
+                let decisions = result.sorted(by: { $0.package.identity < $1.package.identity }).map { "'\($0.package.identity)' at '\($0.binding)'" }
                 self.lock.withLock {
-                    self.events.append("computed: \(decision.joined(separator: ", "))")
+                    self.events.append("solved: \(decisions.joined(separator: ", "))")
                 }
             }
         }
@@ -1160,7 +1159,7 @@ final class PubgrubTests: XCTestCase {
         XCTAssertTrue(delegate.events.contains("didResolve 'foo' at '1.1.0'"), "\(delegate.events)")
         XCTAssertTrue(delegate.events.contains("willResolve 'bar'"), "\(delegate.events)")
         XCTAssertTrue(delegate.events.contains("didResolve 'bar' at '2.0.1'"), "\(delegate.events)")
-        XCTAssertTrue(delegate.events.contains("computed: 'bar' at '2.0.1', 'foo' at '1.1.0'"), "\(delegate.events)")
+        XCTAssertTrue(delegate.events.contains("solved: 'bar' at '2.0.1', 'foo' at '1.1.0'"), "\(delegate.events)")
     }
 }
 

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -135,8 +135,12 @@ private class MockResolverDelegate: RepositoryManagerDelegate {
         self.fetched += [handle.repository]
     }
 
-    func fetchingDidFinish(handle: RepositoryManager.RepositoryHandle, fetchDetails: RepositoryManager.FetchDetails?, error: Swift.Error?) {
+    func fetchingDidFinish(handle: RepositoryManager.RepositoryHandle, fetchDetails: RepositoryManager.FetchDetails?, error: Swift.Error?, duration: DispatchTimeInterval) {
     }
+
+    func handleWillUpdate(handle: RepositoryManager.RepositoryHandle) {}
+
+    func handleDidUpdate(handle: RepositoryManager.RepositoryHandle, duration: DispatchTimeInterval) {}
 }
 
 // Some handy versions & ranges.

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -220,7 +220,7 @@ private class DummyRepositoryManagerDelegate: RepositoryManagerDelegate {
         self.willFetchGroup?.leave()
     }
 
-    func fetchingDidFinish(handle: RepositoryManager.RepositoryHandle, fetchDetails: RepositoryManager.FetchDetails?, error: Swift.Error?) {
+    func fetchingDidFinish(handle: RepositoryManager.RepositoryHandle, fetchDetails: RepositoryManager.FetchDetails?, error: Swift.Error?, duration: DispatchTimeInterval) {
         self.fetchedLock.withLock {
             _didFetch += [(repository: handle.repository, fetchDetails: fetchDetails)]
         }
@@ -234,7 +234,7 @@ private class DummyRepositoryManagerDelegate: RepositoryManagerDelegate {
         self.willUpdateGroup?.leave()
     }
 
-    func handleDidUpdate(handle: RepositoryManager.RepositoryHandle) {
+    func handleDidUpdate(handle: RepositoryManager.RepositoryHandle, duration: DispatchTimeInterval) {
         self.fetchedLock.withLock {
             _didUpdate += [handle.repository]
         }


### PR DESCRIPTION
motivation: when resolving packages, the output is lacking key information about computing the appropriate package version. this can mislead users about what SwiftPM is doing and where the time is spent.

changes:
1. expose willComputeVersion/didComputeVersion on WorkspaceDelegate
2. use willComputeVersion/didComputeVersion in SwiftTool::ToolWorkspaceDelegate to print information about the version computation stage
3. add duration information to WorkspaceDelegate::fetchingDidFinish and WorkspaceDelegate::repositoryDidUpdate
4. print duration infortmation SwiftTool::ToolWorkspaceDelegate about fetching and updating, in addition to computing
5. remove empty delegates since they are potentialy hiding dperecations
6. adjust test
