### PR TITLE
fix docker SwiftPM cache setup

### DIFF
--- a/Utilities/Docker/docker-compose.yaml
+++ b/Utilities/Docker/docker-compose.yaml
@@ -26,7 +26,8 @@ services:
       # ssh, caches
       - ~/.ssh:/root/.ssh
       - ~/.cache:/root/.cache
-      - ~/.swiftpm:/root/.swiftpm
+      - ~/.swiftpm/cache:/root/.swiftpm/cache
+      - ~/.swiftpm/config:/root/.swiftpm/config
       # swift-package-manager code
       - ../..:/code/swift-package-manager:z
       # bootstrap script requires dependencies to be pre-fetched and in a specific place


### PR DESCRIPTION
motivation: fixed shared repositories cache between mac and linux using docker

changes: since ~/.swiftpm/cache is a symlink, define the volume mount there instead of the parent directory
