### PR TITLE
improve location of config directory

### DIFF
--- a/Sources/Basics/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem+Extensions.swift
@@ -9,6 +9,9 @@
  */
 
 import TSCBasic
+import class Foundation.FileManager
+
+// MARK: - user level
 
 extension FileSystem {
     /// SwiftPM directory under user's home directory (~/.swiftpm)
@@ -17,13 +20,93 @@ extension FileSystem {
     }
 }
 
+
+// MARK: - cache
+
 extension FileSystem {
+    private var idiomaticUserCacheDirectory: AbsolutePath? {
+        // in TSC: FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)
+        self.cachesDirectory
+    }
+
     /// SwiftPM cache directory under user's caches directory (if exists)
     public var swiftPMCacheDirectory: AbsolutePath {
-        if let cachesDirectory = self.cachesDirectory {
-            return cachesDirectory.appending(component: "org.swift.swiftpm")
+        if let path = self.idiomaticUserCacheDirectory {
+            return path.appending(component: "org.swift.swiftpm")
         } else {
-            return self.dotSwiftPM.appending(component: "cache")
+            return self.dotSwiftPMCachesDirectory
         }
+    }
+
+    fileprivate var dotSwiftPMCachesDirectory: AbsolutePath {
+        return self.dotSwiftPM.appending(component: "cache")
+    }
+}
+
+extension FileSystem {
+    public func getOrCreateSwiftPMCacheDirectory() throws -> AbsolutePath {
+        let idiomaticCacheDirectory = self.swiftPMCacheDirectory
+        // Create idiomatic if necessary
+        if !self.exists(idiomaticCacheDirectory) {
+            try self.createDirectory(idiomaticCacheDirectory, recursive: true)
+        }
+        // Create ~/.swiftpm if necessary
+        if !self.exists(self.dotSwiftPM) {
+            try self.createDirectory(self.dotSwiftPM, recursive: true)
+        }
+        // Create ~/.swiftpm/cache symlink if necessary
+        if !self.exists(self.dotSwiftPMCachesDirectory, followSymlink: false) {
+            try self.createSymbolicLink(dotSwiftPMCachesDirectory, pointingAt: idiomaticCacheDirectory, relative: false)
+        }
+        return idiomaticCacheDirectory
+    }
+}
+
+// MARK: - config
+
+extension FileSystem {
+    private var idiomaticUserConfigDirectory: AbsolutePath? {
+        return FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first.flatMap { AbsolutePath($0.path) }
+    }
+
+    /// SwiftPM config directory under user's config directory (if exists)
+    public var swiftPMConfigDirectory: AbsolutePath {
+        if let path = self.idiomaticUserConfigDirectory {
+            return path.appending(component: "org.swift.swiftpm")
+        } else {
+            return self.dotSwiftPMConfigDirectory
+        }
+    }
+
+    fileprivate var dotSwiftPMConfigDirectory: AbsolutePath {
+        return self.dotSwiftPM.appending(component: "config")
+    }
+}
+
+extension FileSystem {
+    public func getOrCreateSwiftPMConfigDirectory() throws -> AbsolutePath {
+        let idiomaticConfigDirectory = self.swiftPMConfigDirectory
+
+        // temporary 5.5, remove on next version: transition from ~/.swiftpm/config to idiomatic location + symbolic link
+        if idiomaticConfigDirectory != self.dotSwiftPMConfigDirectory &&
+            self.exists(self.dotSwiftPMConfigDirectory) && self.isDirectory(self.dotSwiftPMConfigDirectory) &&
+            !self.exists(idiomaticConfigDirectory) {
+            print("transitioning \(self.dotSwiftPMConfigDirectory) to \(idiomaticConfigDirectory)")
+            try self.move(from: self.dotSwiftPMConfigDirectory, to: idiomaticConfigDirectory)
+        }
+
+        // Create idiomatic if necessary
+        if !self.exists(idiomaticConfigDirectory) {
+            try self.createDirectory(idiomaticConfigDirectory, recursive: true)
+        }
+        // Create ~/.swiftpm if necessary
+        if !self.exists(self.dotSwiftPM) {
+            try self.createDirectory(self.dotSwiftPM, recursive: true)
+        }
+        // Create ~/.swiftpm/config symlink if necessary
+        if !self.exists(self.dotSwiftPMConfigDirectory, followSymlink: false) {
+            try self.createSymbolicLink(dotSwiftPMConfigDirectory, pointingAt: idiomaticConfigDirectory, relative: false)
+        }
+        return idiomaticConfigDirectory
     }
 }

--- a/Sources/Commands/Options.swift
+++ b/Sources/Commands/Options.swift
@@ -139,6 +139,10 @@ public struct SwiftToolOptions: ParsableArguments {
     @Option(help: "Specify the shared cache directory")
     var cachePath: AbsolutePath?
 
+    // TODO: add actual help when ready to be used
+    @Option(help: .hidden)
+    var configPath: AbsolutePath?
+
     /// Disables repository caching.
     @Flag(name: .customLong("repository-cache"), inversion: .prefixedEnableDisable, help: "Use a shared cache when fetching repositories")
     var useRepositoriesCache: Bool = true

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -489,23 +489,26 @@ public class SwiftTool {
         }
 
         do {
-            // Create the default cache directory.
-            let idiomaticCachePath = fileSystem.swiftPMCacheDirectory
-            if !fileSystem.exists(idiomaticCachePath) {
-                try fileSystem.createDirectory(idiomaticCachePath, recursive: true)
-            }
-            // Create ~/.swiftpm if necessary
-            if !fileSystem.exists(fileSystem.dotSwiftPM) {
-                try fileSystem.createDirectory(fileSystem.dotSwiftPM, recursive: true)
-            }
-            // Create ~/.swiftpm/cache symlink if necessary
-            let dotSwiftPMCachesPath = fileSystem.dotSwiftPM.appending(component: "cache")
-            if !fileSystem.exists(dotSwiftPMCachesPath, followSymlink: false) {
-                try fileSystem.createSymbolicLink(dotSwiftPMCachesPath, pointingAt: idiomaticCachePath, relative: false)
-            }
-            return idiomaticCachePath
+            return try fileSystem.getOrCreateSwiftPMCacheDirectory()
         } catch {
             self.diagnostics.emit(warning: "Failed creating default cache locations, \(error)")
+            return nil
+        }
+    }
+
+    private func getConfigPath(fileSystem: FileSystem = localFileSystem) throws -> AbsolutePath? {
+        if let explicitConfigPath = options.configPath {
+            // Create the explicit config path if necessary
+            if !fileSystem.exists(explicitConfigPath) {
+                try fileSystem.createDirectory(explicitConfigPath, recursive: true)
+            }
+            return explicitConfigPath
+        }
+
+        do {
+            return try fileSystem.getOrCreateSwiftPMConfigDirectory()
+        } catch {
+            self.diagnostics.emit(warning: "Failed creating default config locations, \(error)")
             return nil
         }
     }
@@ -520,6 +523,7 @@ public class SwiftTool {
         let delegate = ToolWorkspaceDelegate(self.stdoutStream, isVerbose: isVerbose, diagnostics: diagnostics)
         let provider = GitRepositoryProvider(processSet: processSet)
         let cachePath = self.options.useRepositoriesCache ? try self.getCachePath() : .none
+        _  = try self.getConfigPath() // TODO: actually use this in the workspace 
         let isXcodeBuildSystemEnabled = self.options.buildSystem == .xcode
         let workspace = Workspace(
             dataPath: buildPath,

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -53,7 +53,7 @@ struct JSONPackageCollectionProvider: PackageCollectionProvider {
         self.decoder = JSONDecoder.makeWithDefaults()
         self.validator = JSONModel.Validator(configuration: configuration.validator)
         self.signatureValidator = signatureValidator ?? PackageCollectionSigning(
-            trustedRootCertsDir: configuration.trustedRootCertsDir ?? fileSystem.dotSwiftPM.appending(components: "config", "trust-root-certs").asURL,
+            trustedRootCertsDir: configuration.trustedRootCertsDir ?? fileSystem.swiftPMConfigDirectory.appending(component: "trust-root-certs").asURL,
             additionalTrustedRootCerts: sourceCertPolicy.allRootCerts,
             callbackQueue: .sharedConcurrent,
             diagnosticsEngine: diagnosticsEngine

--- a/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
+++ b/Sources/PackageCollections/Storage/FilePackageCollectionsSourcesStorage.swift
@@ -27,8 +27,7 @@ struct FilePackageCollectionsSourcesStorage: PackageCollectionsSourcesStorage {
     init(fileSystem: FileSystem = localFileSystem, path: AbsolutePath? = nil, diagnosticsEngine: DiagnosticsEngine? = nil) {
         self.fileSystem = fileSystem
 
-        let name = "collections"
-        self.path = path ?? fileSystem.dotSwiftPM.appending(components: "config", "\(name).json")
+        self.path = path ?? fileSystem.swiftPMConfigDirectory.appending(component: "collections.json")
         self.diagnosticsEngine = diagnosticsEngine
         self.encoder = JSONEncoder.makeWithDefaults()
         self.decoder = JSONDecoder.makeWithDefaults()


### PR DESCRIPTION
motivation: use more idiomatic location for SwiftPM config

changes:
* on darwin platforms, use ~/Library/org.swift.swiftpm to store SwiftPM configs, which is more idiomatic
* if idiomatic config directory is different from ~/.swift/config, create a symlink ~/.swift/config -> idiomatic
* add temporary transition code for beta users of 5.5 that may already have ~/.swift/config in place
* refactor and centralize the computation of config directory
* refactor and centralize the computation of cache directory (no functional changes)
