### PR TITLE
[5.5] fix a bug in test discovery where tests define in extensions break the discovery

### DIFF
--- a/Fixtures/Miscellaneous/TestDiscovery/Extensions/Package.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Extensions/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "Simple",
+    targets: [
+        .target(name: "Simple"),
+        .testTarget(name: "SimpleTests", dependencies: ["Simple"]),
+    ]
+)

--- a/Fixtures/Miscellaneous/TestDiscovery/Extensions/Sources/Simple/Simple.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Extensions/Sources/Simple/Simple.swift
@@ -1,0 +1,3 @@
+struct Simple {
+
+}

--- a/Fixtures/Miscellaneous/TestDiscovery/Extensions/Tests/SimpleTests/SwiftTests1.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Extensions/Tests/SimpleTests/SwiftTests1.swift
@@ -1,0 +1,7 @@
+import XCTest
+@testable import Simple
+
+class SimpleTests1: XCTestCase {
+    func testExample1() {
+    }
+}

--- a/Fixtures/Miscellaneous/TestDiscovery/Extensions/Tests/SimpleTests/SwiftTests2.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Extensions/Tests/SimpleTests/SwiftTests2.swift
@@ -1,0 +1,7 @@
+import XCTest
+@testable import Simple
+
+class SimpleTests2: XCTestCase {
+    func testExample2() {
+    }
+}

--- a/Fixtures/Miscellaneous/TestDiscovery/Extensions/Tests/SimpleTests/SwiftTests3.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Extensions/Tests/SimpleTests/SwiftTests3.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import Simple
+
+extension SimpleTests1 {
+    func testExample1_a() {
+    }
+}
+
+extension SimpleTests2 {
+    func testExample2_a() {
+    }
+}

--- a/Fixtures/Miscellaneous/TestDiscovery/Extensions/Tests/SimpleTests/SwiftTests4.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/Extensions/Tests/SimpleTests/SwiftTests4.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import Simple
+
+class SimpleTests4: XCTestCase {
+    func testExample() {
+    }
+
+    func testExample1() {
+    }
+
+    func testExample2() {
+    }
+}

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -83,4 +83,23 @@ class TestDiscoveryTests: XCTestCase {
         }
         #endif
     }
+
+    func testTestExtensions() throws {
+        #if os(macOS)
+        try XCTSkipIf(true)
+        #else
+        fixture(name: "Miscellaneous/TestDiscovery/Extensions") { path in
+            let (stdout, _) = try executeSwiftTest(path, extraArgs: ["--enable-test-discovery"])
+            XCTAssertTrue(stdout.contains("Merging module Simple"), stdout)
+            XCTAssertTrue(stdout.contains("SimpleTests1.testExample1"), stdout)
+            XCTAssertTrue(stdout.contains("SimpleTests1.testExample1_a"), stdout)
+            XCTAssertTrue(stdout.contains("SimpleTests2.testExample2"), stdout)
+            XCTAssertTrue(stdout.contains("SimpleTests2.testExample2_a"), stdout)
+            XCTAssertTrue(stdout.contains("SimpleTests4.testExample"), stdout)
+            XCTAssertTrue(stdout.contains("SimpleTests4.testExample1"), stdout)
+            XCTAssertTrue(stdout.contains("SimpleTests4.testExample2"), stdout)
+            XCTAssertTrue(stdout.contains("Executed 7 tests"), stdout)
+        }
+        #endif
+    }
 }


### PR DESCRIPTION
bring #3433 to 5.5
