### PR TITLE
[Collections] Improve error message when package collection download times out

### DIFF
--- a/Sources/Commands/SwiftPackageCollectionsTool.swift
+++ b/Sources/Commands/SwiftPackageCollectionsTool.swift
@@ -327,7 +327,7 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
                             """)
                         }
                     } catch {
-                        print("Failed to get metadata. The given URL neither belongs to a valid collection nor a package in an imported collection.")
+                        print("Failed to get metadata. The given URL either belongs to a collection that is invalid or unavailable, or a package that is not found in any of the imported collections.")
                     }
                 }
             }


### PR DESCRIPTION
Update error message to cover the case when collection is not available (e.g., due to network problems)

rdar://77031755

This replaces https://github.com/apple/swift-package-manager/pull/3426