### PR TITLE
[Collections] Use persistent cache for GitHub package metadata

### DIFF
--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See http://swift.org/LICENSE.txt for license information
@@ -17,7 +17,8 @@ add_library(Basics
   HTTPClient.swift
   JSON+Extensions.swift
   Sandbox.swift
-  SwiftVersion.swift)
+  SwiftVersion.swift
+  SQLiteBackedCache.swift)
 target_link_libraries(Basics PUBLIC
   TSCBasic
   TSCUtility)

--- a/Sources/Basics/SQLiteBackedCache.swift
+++ b/Sources/Basics/SQLiteBackedCache.swift
@@ -29,6 +29,13 @@ public final class SQLiteBackedCache<Value: Codable>: Closable {
     private let jsonEncoder: JSONEncoder
     private let jsonDecoder: JSONDecoder
 
+    /// Creates a SQLite-backed cache.
+    ///
+    /// - Parameters:
+    ///   - tableName: The SQLite table name. Must follow SQLite naming rules (e.g., no spaces).
+    ///   - location: SQLite.Location
+    ///   - configuration: Optional. Configuration for the cache.
+    ///   - diagnosticsEngine: DiagnosticsEngine
     public init(tableName: String, location: SQLite.Location, configuration: SQLiteBackedCacheConfiguration = .init(), diagnosticsEngine: DiagnosticsEngine? = nil) {
         self.tableName = tableName
         self.location = location
@@ -44,6 +51,13 @@ public final class SQLiteBackedCache<Value: Codable>: Closable {
         self.jsonDecoder = JSONDecoder.makeWithDefaults()
     }
 
+    /// Creates a SQLite-backed cache.
+    ///
+    /// - Parameters:
+    ///   - tableName: The SQLite table name. Must follow SQLite naming rules (e.g., no spaces).
+    ///   - path: The path of the SQLite database.
+    ///   - configuration: Optional. Configuration for the cache.
+    ///   - diagnosticsEngine: DiagnosticsEngine
     public convenience init(tableName: String, path: AbsolutePath, configuration: SQLiteBackedCacheConfiguration = .init(), diagnosticsEngine: DiagnosticsEngine? = nil) {
         self.init(tableName: tableName, location: .path(path), configuration: configuration, diagnosticsEngine: diagnosticsEngine)
     }

--- a/Sources/Basics/SQLiteBackedCache.swift
+++ b/Sources/Basics/SQLiteBackedCache.swift
@@ -1,0 +1,246 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Foundation
+
+import TSCBasic
+import TSCUtility
+
+/// SQLite backed persistent cache.
+public final class SQLiteBackedCache<Value: Codable>: Closable {
+    public typealias Key = String
+
+    public let name: String
+    public let fileSystem: TSCBasic.FileSystem
+    public let location: SQLite.Location
+    public let configuration: SQLiteBackedCacheConfiguration
+
+    private var state = State.idle
+    private let stateLock = Lock()
+
+    private let diagnosticsEngine: DiagnosticsEngine?
+    private let jsonEncoder: JSONEncoder
+    private let jsonDecoder: JSONDecoder
+
+    public init(name: String, location: SQLite.Location, configuration: SQLiteBackedCacheConfiguration = .init(), diagnosticsEngine: DiagnosticsEngine? = nil) {
+        self.name = name
+        self.location = location
+        switch self.location {
+        case .path, .temporary:
+            self.fileSystem = localFileSystem
+        case .memory:
+            self.fileSystem = InMemoryFileSystem()
+        }
+        self.configuration = configuration
+        self.diagnosticsEngine = diagnosticsEngine
+        self.jsonEncoder = JSONEncoder.makeWithDefaults()
+        self.jsonDecoder = JSONDecoder.makeWithDefaults()
+    }
+
+    public convenience init(name: String, path: AbsolutePath, configuration: SQLiteBackedCacheConfiguration = .init(), diagnosticsEngine: DiagnosticsEngine? = nil) {
+        self.init(name: name, location: .path(path), configuration: configuration, diagnosticsEngine: diagnosticsEngine)
+    }
+
+    deinit {
+        // TODO: we could wrap the failure here with diagnostics if it wasn't optional throughout
+        try? self.withStateLock {
+            if case .connected(let db) = self.state {
+                assertionFailure("db should be closed")
+                try db.close()
+            }
+        }
+    }
+
+    public func close() throws {
+        try self.withStateLock {
+            if case .connected(let db) = self.state {
+                try db.close()
+            }
+            self.state = .disconnected
+        }
+    }
+
+    public func put(key: Key, value: Value, replace: Bool = false) throws {
+        do {
+            let query = "INSERT OR \(replace ? "REPLACE" : "IGNORE") INTO \(self.name) VALUES (?, ?);"
+            try self.executeStatement(query) { statement -> Void in
+                let data = try self.jsonEncoder.encode(value)
+                let bindings: [SQLite.SQLiteValue] = [
+                    .string(key),
+                    .blob(data),
+                ]
+                try statement.bind(bindings)
+                try statement.step()
+            }
+        } catch (let error as SQLite.Errors) where error == .databaseFull {
+            if !self.configuration.truncateWhenFull {
+                throw error
+            }
+            self.diagnosticsEngine?.emit(.warning("truncating \(self.name) cache database since it reached max size of \(self.configuration.maxSizeInBytes ?? 0) bytes"))
+            try self.executeStatement("DELETE FROM \(self.name);") { statement -> Void in
+                try statement.step()
+            }
+            try self.put(key: key, value: value, replace: replace)
+        } catch {
+            throw error
+        }
+    }
+
+    public func get(key: Key) throws -> Value? {
+        let query = "SELECT value FROM \(self.name) WHERE key = ? LIMIT 1;"
+        return try self.executeStatement(query) { statement -> Value? in
+            try statement.bind([.string(key)])
+            let data = try statement.step()?.blob(at: 0)
+            return try data.flatMap {
+                try self.jsonDecoder.decode(Value.self, from: $0)
+            }
+        }
+    }
+
+    public func remove(key: Key) throws {
+        let query = "DELETE FROM \(self.name) WHERE key = ? LIMIT 1;"
+        try self.executeStatement(query) { statement in
+            try statement.bind([.string(key)])
+            try statement.step()
+        }
+    }
+
+    private func executeStatement<T>(_ query: String, _ body: (SQLite.PreparedStatement) throws -> T) throws -> T {
+        try self.withDB { db in
+            let result: Result<T, Error>
+            let statement = try db.prepare(query: query)
+            do {
+                result = .success(try body(statement))
+            } catch {
+                result = .failure(error)
+            }
+            try statement.finalize()
+            switch result {
+            case .failure(let error):
+                throw error
+            case .success(let value):
+                return value
+            }
+        }
+    }
+
+    private func withDB<T>(_ body: (SQLite) throws -> T) throws -> T {
+        let createDB = { () throws -> SQLite in
+            let db = try SQLite(location: self.location, configuration: self.configuration.underlying)
+            try self.createSchemaIfNecessary(db: db)
+            return db
+        }
+
+        let db = try self.withStateLock { () -> SQLite in
+            let db: SQLite
+            switch (self.location, self.state) {
+            case (.path(let path), .connected(let database)):
+                if self.fileSystem.exists(path) {
+                    db = database
+                } else {
+                    try database.close()
+                    try self.fileSystem.createDirectory(path.parentDirectory, recursive: true)
+                    db = try createDB()
+                }
+            case (.path(let path), _):
+                if !self.fileSystem.exists(path) {
+                    try self.fileSystem.createDirectory(path.parentDirectory, recursive: true)
+                }
+                db = try createDB()
+            case (_, .connected(let database)):
+                db = database
+            case (_, _):
+                db = try createDB()
+            }
+            self.state = .connected(db)
+            return db
+        }
+
+        // FIXME: workaround linux sqlite concurrency issues causing CI failures
+        #if os(Linux)
+        return try self.withStateLock {
+            return try body(db)
+        }
+        #else
+        return try body(db)
+        #endif
+    }
+
+    private func createSchemaIfNecessary(db: SQLite) throws {
+        let table = """
+            CREATE TABLE IF NOT EXISTS \(self.name) (
+                key STRING PRIMARY KEY NOT NULL,
+                value BLOB NOT NULL
+            );
+        """
+
+        try db.exec(query: table)
+        try db.exec(query: "PRAGMA journal_mode=WAL;")
+    }
+
+    private func withStateLock<T>(_ body: () throws -> T) throws -> T {
+        switch self.location {
+        case .path(let path):
+            if !self.fileSystem.exists(path.parentDirectory) {
+                try self.fileSystem.createDirectory(path.parentDirectory)
+            }
+            return try self.fileSystem.withLock(on: path, type: .exclusive, body)
+        case .memory, .temporary:
+            return try self.stateLock.withLock(body)
+        }
+    }
+
+    private enum State {
+        case idle
+        case connected(SQLite)
+        case disconnected
+    }
+}
+
+public struct SQLiteBackedCacheConfiguration {
+    public var truncateWhenFull: Bool
+
+    fileprivate var underlying: SQLite.Configuration
+
+    public init() {
+        self.underlying = .init()
+        self.truncateWhenFull = true
+        self.maxSizeInMegabytes = 100
+        // see https://www.sqlite.org/c3ref/busy_timeout.html
+        self.busyTimeoutMilliseconds = 1000
+    }
+
+    public var maxSizeInMegabytes: Int? {
+        get {
+            self.underlying.maxSizeInMegabytes
+        }
+        set {
+            self.underlying.maxSizeInMegabytes = newValue
+        }
+    }
+
+    public var maxSizeInBytes: Int? {
+        get {
+            self.underlying.maxSizeInBytes
+        }
+        set {
+            self.underlying.maxSizeInBytes = newValue
+        }
+    }
+
+    public var busyTimeoutMilliseconds: Int32 {
+        get {
+            self.underlying.busyTimeoutMilliseconds
+        }
+        set {
+            self.underlying.busyTimeoutMilliseconds = newValue
+        }
+    }
+}

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -65,6 +65,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
         if self.storageContainer.owned {
             try self.storageContainer.storage.close()
         }
+        try self.metadataProvider.close()
     }
 
     // MARK: - Collections

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -27,27 +27,37 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
     private let diagnosticsEngine: DiagnosticsEngine?
     private let decoder: JSONDecoder
 
-    private let cache: ThreadSafeKeyValueStore<PackageReference, (package: Model.PackageBasicMetadata, timestamp: DispatchTime)>?
+    private let cache: SQLiteBackedCache<CacheValue>?
 
     init(configuration: Configuration = .init(), httpClient: HTTPClient? = nil, diagnosticsEngine: DiagnosticsEngine? = nil) {
         self.configuration = configuration
         self.httpClient = httpClient ?? Self.makeDefaultHTTPClient(diagnosticsEngine: diagnosticsEngine)
         self.diagnosticsEngine = diagnosticsEngine
         self.decoder = JSONDecoder.makeWithDefaults()
-        self.cache = configuration.cacheTTLInSeconds > 0 ? .init() : nil
+        if configuration.cacheTTLInSeconds > 0 {
+            var cacheConfig = SQLiteBackedCacheConfiguration()
+            cacheConfig.maxSizeInMegabytes = configuration.cacheSizeInMegabytes
+            self.cache = SQLiteBackedCache<CacheValue>(name: "github_cache", path: configuration.cacheDir.appending(component: "package-metadata.db"), configuration: cacheConfig, diagnosticsEngine: diagnosticsEngine)
+        } else {
+            self.cache = nil
+        }
+    }
+
+    func close() throws {
+        try self.cache?.close()
     }
 
     func get(_ reference: PackageReference, callback: @escaping (Result<Model.PackageBasicMetadata, Error>) -> Void) {
         guard reference.kind == .remote else {
             return callback(.failure(Errors.invalidReferenceType(reference)))
         }
-        guard let baseURL = self.apiURL(reference.location) else {
+        guard let baseURL = Self.apiURL(reference.location) else {
             return callback(.failure(Errors.invalidGitURL(reference.location)))
         }
 
-        if let cachedMetadata = self.cache?[reference] {
-            if cachedMetadata.timestamp + DispatchTimeInterval.seconds(self.configuration.cacheTTLInSeconds) > DispatchTime.now() {
-                return callback(.success(cachedMetadata.package))
+        if let cached = try? self.cache?.get(key: reference.identity.description) {
+            if cached.dispatchTime + DispatchTimeInterval.seconds(self.configuration.cacheTTLInSeconds) > DispatchTime.now() {
+                return callback(.success(cached.package))
             }
         }
 
@@ -144,22 +154,12 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
                         processedAt: Date()
                     )
 
-                    if let cache = self.cache {
-                        cache[reference] = (model, DispatchTime.now())
-
-                        if cache.count > self.configuration.cacheSize {
-                            DispatchQueue.sharedConcurrent.async {
-                                // Delete oldest entries with some room for growth
-                                let sortedCacheEntries = cache.get().sorted { $0.value.timestamp < $1.value.timestamp }
-                                let deleteCount = sortedCacheEntries.count - (self.configuration.cacheSize / 2)
-                                self.diagnosticsEngine?.emit(note: "Cache size limit exceeded, deleting the oldest \(deleteCount) entries")
-
-                                for index in 0 ..< deleteCount {
-                                    _ = cache.removeValue(forKey: sortedCacheEntries[index].key)
-                                }
-                            }
-                        }
+                    do {
+                        try self.cache?.put(key: reference.identity.description, value: CacheValue(package: model, timestamp: DispatchTime.now()), replace: true)
+                    } catch {
+                        self.diagnosticsEngine?.emit(.warning("Failed to save GitHub metadata for package \(reference) to cache: \(error)"))
                     }
+
                     callback(.success(model))
                 }
             } catch {
@@ -168,7 +168,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
         }
     }
 
-    internal func apiURL(_ url: String) -> Foundation.URL? {
+    internal static func apiURL(_ url: String) -> Foundation.URL? {
         do {
             let regex = try NSRegularExpression(pattern: #"([^/@]+)[:/]([^:/]+)/([^/.]+)(\.git)?$"#, options: .caseInsensitive)
             if let match = regex.firstMatch(in: url, options: [], range: NSRange(location: 0, length: url.count)) {
@@ -214,17 +214,20 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
     public struct Configuration {
         public var apiLimitWarningThreshold: Int
         public var authTokens: [AuthTokenType: String]?
+        public var cacheDir: AbsolutePath
+        public var cacheSizeInMegabytes: Int
         public var cacheTTLInSeconds: Int
-        public var cacheSize: Int
 
         public init(authTokens: [AuthTokenType: String]? = nil,
                     apiLimitWarningThreshold: Int? = nil,
+                    cacheDir: AbsolutePath? = nil,
                     cacheTTLInSeconds: Int? = nil,
-                    cacheSize: Int? = nil) {
+                    cacheSizeInMegabytes: Int? = nil) {
             self.authTokens = authTokens
             self.apiLimitWarningThreshold = apiLimitWarningThreshold ?? 5
+            self.cacheDir = cacheDir.map(resolveSymlinks) ?? localFileSystem.swiftPMCacheDirectory.appending(components: "package-metadata")
+            self.cacheSizeInMegabytes = cacheSizeInMegabytes ?? 10
             self.cacheTTLInSeconds = cacheTTLInSeconds ?? 3600
-            self.cacheSize = cacheSize ?? 1000
         }
     }
 
@@ -235,6 +238,20 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
         case permissionDenied(URL)
         case invalidAuthToken(URL)
         case apiLimitsExceeded(URL, Int)
+    }
+
+    struct CacheValue: Codable {
+        let package: Model.PackageBasicMetadata
+        let timestamp: UInt64
+
+        var dispatchTime: DispatchTime {
+            DispatchTime(uptimeNanoseconds: self.timestamp)
+        }
+
+        init(package: Model.PackageBasicMetadata, timestamp: DispatchTime) {
+            self.package = package
+            self.timestamp = timestamp.uptimeNanoseconds
+        }
     }
 }
 

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -37,7 +37,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
         if configuration.cacheTTLInSeconds > 0 {
             var cacheConfig = SQLiteBackedCacheConfiguration()
             cacheConfig.maxSizeInMegabytes = configuration.cacheSizeInMegabytes
-            self.cache = SQLiteBackedCache<CacheValue>(name: "github_cache", path: configuration.cacheDir.appending(component: "package-metadata.db"), configuration: cacheConfig, diagnosticsEngine: diagnosticsEngine)
+            self.cache = SQLiteBackedCache<CacheValue>(tableName: "github_cache", path: configuration.cacheDir.appending(component: "package-metadata.db"), configuration: cacheConfig, diagnosticsEngine: diagnosticsEngine)
         } else {
             self.cache = nil
         }

--- a/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
@@ -10,11 +10,13 @@
 
 import struct Foundation.Date
 import struct Foundation.URL
+
 import PackageModel
+import TSCBasic
 import TSCUtility
 
 /// `PackageBasicMetadata` provider
-protocol PackageMetadataProvider {
+protocol PackageMetadataProvider: Closable {
     /// The name of the provider
     var name: String { get }
 
@@ -27,7 +29,7 @@ protocol PackageMetadataProvider {
 }
 
 extension Model {
-    struct PackageBasicMetadata: Equatable {
+    struct PackageBasicMetadata: Equatable, Codable {
         let summary: String?
         let keywords: [String]?
         let versions: [PackageBasicVersionMetadata]
@@ -39,7 +41,7 @@ extension Model {
         let processedAt: Date
     }
 
-    struct PackageBasicVersionMetadata: Equatable {
+    struct PackageBasicVersionMetadata: Equatable, Codable {
         let version: TSCUtility.Version
         let title: String?
         let summary: String?

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -591,7 +591,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             // FIXME: expose as user-facing configuration
             configuration.maxSizeInMegabytes = 100
             configuration.truncateWhenFull = true
-            return SQLiteBackedCache<ManifestParseResult>(name: "MANIFEST_CACHE", location: .path(path), configuration: configuration, diagnosticsEngine: diagnostics)
+            return SQLiteBackedCache<ManifestParseResult>(tableName: "MANIFEST_CACHE", location: .path(path), configuration: configuration, diagnosticsEngine: diagnostics)
         }
 
         // TODO: we could wrap the failure here with diagnostics if it wasn't optional throughout

--- a/Tests/BasicsTests/SQLiteBackedCacheTests.swift
+++ b/Tests/BasicsTests/SQLiteBackedCacheTests.swift
@@ -1,0 +1,186 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+@testable import Basics
+import TSCBasic
+import TSCTestSupport
+import TSCUtility
+import XCTest
+
+final class SQLiteBackedCacheTests: XCTestCase {
+    func testHappyCase() throws {
+        try testWithTemporaryDirectory { tmpPath in
+            let path = tmpPath.appending(component: "test.db")
+            let cache = SQLiteBackedCache<String>(name: "SQLiteBackedCacheTest", path: path)
+            defer { XCTAssertNoThrow(try cache.close()) }
+
+            let mockData = try makeMockData(fileSystem: localFileSystem, rootPath: tmpPath)
+            try mockData.forEach { key, value in
+                _ = try cache.put(key: key, value: value)
+            }
+
+            try mockData.forEach { key, _ in
+                let result = try cache.get(key: key)
+                XCTAssertEqual(mockData[key], result)
+            }
+
+            let key = mockData.first!.key
+
+            _ = try cache.put(key: key, value: "foobar", replace: false)
+            XCTAssertEqual(mockData[key], try cache.get(key: key))
+
+            _ = try cache.put(key: key, value: "foobar", replace: true)
+            XCTAssertEqual("foobar", try cache.get(key: key))
+
+            try cache.remove(key: key)
+            XCTAssertNil(try cache.get(key: key))
+
+            guard case .path(let cachePath) = cache.location else {
+                return XCTFail("invalid location \(cache.location)")
+            }
+
+            XCTAssertTrue(cache.fileSystem.exists(cachePath), "expected file to be written")
+        }
+    }
+
+    func testFileDeleted() throws {
+        try testWithTemporaryDirectory { tmpPath in
+            let path = tmpPath.appending(component: "test.db")
+            let cache = SQLiteBackedCache<String>(name: "SQLiteBackedCacheTest", path: path)
+            defer { XCTAssertNoThrow(try cache.close()) }
+
+            let mockData = try makeMockData(fileSystem: localFileSystem, rootPath: tmpPath)
+            try mockData.forEach { key, value in
+                _ = try cache.put(key: key, value: value)
+            }
+
+            try mockData.forEach { key, _ in
+                let result = try cache.get(key: key)
+                XCTAssertEqual(mockData[key], result)
+            }
+
+            guard case .path(let cachePath) = cache.location else {
+                return XCTFail("invalid location \(cache.location)")
+            }
+
+            XCTAssertTrue(cache.fileSystem.exists(cachePath), "expected file to exist at \(cachePath)")
+            try cache.fileSystem.removeFileTree(cachePath)
+
+            let key = mockData.first!.key
+
+            do {
+                let result = try cache.get(key: key)
+                XCTAssertNil(result)
+            }
+
+            do {
+                XCTAssertNoThrow(try cache.put(key: key, value: mockData[key]!))
+                let result = try cache.get(key: key)
+                XCTAssertEqual(mockData[key], result)
+            }
+
+            XCTAssertTrue(cache.fileSystem.exists(cachePath), "expected file to exist at \(cachePath)")
+        }
+    }
+
+    func testFileCorrupt() throws {
+        try testWithTemporaryDirectory { tmpPath in
+            let path = tmpPath.appending(component: "test.db")
+            let cache = SQLiteBackedCache<String>(name: "SQLiteBackedCacheTest", path: path)
+            defer { XCTAssertNoThrow(try cache.close()) }
+
+            let mockData = try makeMockData(fileSystem: localFileSystem, rootPath: tmpPath)
+            try mockData.forEach { key, value in
+                _ = try cache.put(key: key, value: value)
+            }
+
+            try mockData.forEach { key, _ in
+                let result = try cache.get(key: key)
+                XCTAssertEqual(mockData[key], result)
+            }
+
+            guard case .path(let cachePath) = cache.location else {
+                return XCTFail("invalid location \(cache.location)")
+            }
+
+            try cache.close()
+
+            XCTAssertTrue(cache.fileSystem.exists(cachePath), "expected file to exist at \(path)")
+            try cache.fileSystem.writeFileContents(cachePath, bytes: ByteString("blah".utf8))
+
+            XCTAssertThrowsError(try cache.get(key: mockData.first!.key), "expected error") { error in
+                XCTAssert("\(error)".contains("is not a database"), "Expected file is not a database error")
+            }
+
+            XCTAssertThrowsError(try cache.put(key: mockData.first!.key, value: mockData.first!.value), "expected error") { error in
+                XCTAssert("\(error)".contains("is not a database"), "Expected file is not a database error")
+            }
+        }
+    }
+
+    func testMaxSizeNotHandled() throws {
+        try testWithTemporaryDirectory { tmpPath in
+            let path = tmpPath.appending(component: "test.db")
+            var configuration = SQLiteBackedCacheConfiguration()
+            configuration.maxSizeInBytes = 1024 * 3
+            configuration.truncateWhenFull = false
+            let cache = SQLiteBackedCache<String>(name: "SQLiteBackedCacheTest", path: path, configuration: configuration)
+            defer { XCTAssertNoThrow(try cache.close()) }
+
+            func create() throws {
+                let mockData = try makeMockData(fileSystem: localFileSystem, rootPath: tmpPath, count: 500)
+                try mockData.forEach { key, value in
+                    _ = try cache.put(key: key, value: value)
+                }
+            }
+
+            XCTAssertThrowsError(try create(), "expected error") { error in
+                XCTAssertEqual(error as? SQLite.Errors, .databaseFull, "Expected 'databaseFull' error")
+            }
+        }
+    }
+
+    func testMaxSizeHandled() throws {
+        try testWithTemporaryDirectory { tmpPath in
+            let path = tmpPath.appending(component: "test.db")
+            var configuration = SQLiteBackedCacheConfiguration()
+            configuration.maxSizeInBytes = 1024 * 3
+            configuration.truncateWhenFull = true
+            let cache = SQLiteBackedCache<String>(name: "SQLiteBackedCacheTest", path: path, configuration: configuration)
+            defer { XCTAssertNoThrow(try cache.close()) }
+
+            var keys = [String]()
+            let mockData = try makeMockData(fileSystem: localFileSystem, rootPath: tmpPath, count: 500)
+            try mockData.forEach { key, value in
+                _ = try cache.put(key: key, value: value)
+                keys.append(key)
+            }
+
+            do {
+                let result = try cache.get(key: mockData.first!.key)
+                XCTAssertNil(result)
+            }
+
+            do {
+                let result = try cache.get(key: keys.last!)
+                XCTAssertEqual(mockData[keys.last!], result)
+            }
+        }
+    }
+}
+
+private func makeMockData(fileSystem: FileSystem, rootPath: AbsolutePath, count: Int = Int.random(in: 50 ..< 100)) throws -> [String: String] {
+    var data = [String: String]()
+    let value = UUID().uuidString
+    for index in 0 ..< count {
+        data["\(index)"] = "\(index) \(value)"
+    }
+    return data
+}

--- a/Tests/BasicsTests/SQLiteBackedCacheTests.swift
+++ b/Tests/BasicsTests/SQLiteBackedCacheTests.swift
@@ -18,7 +18,7 @@ final class SQLiteBackedCacheTests: XCTestCase {
     func testHappyCase() throws {
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending(component: "test.db")
-            let cache = SQLiteBackedCache<String>(name: "SQLiteBackedCacheTest", path: path)
+            let cache = SQLiteBackedCache<String>(tableName: "SQLiteBackedCacheTest", path: path)
             defer { XCTAssertNoThrow(try cache.close()) }
 
             let mockData = try makeMockData(fileSystem: localFileSystem, rootPath: tmpPath)
@@ -53,7 +53,7 @@ final class SQLiteBackedCacheTests: XCTestCase {
     func testFileDeleted() throws {
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending(component: "test.db")
-            let cache = SQLiteBackedCache<String>(name: "SQLiteBackedCacheTest", path: path)
+            let cache = SQLiteBackedCache<String>(tableName: "SQLiteBackedCacheTest", path: path)
             defer { XCTAssertNoThrow(try cache.close()) }
 
             let mockData = try makeMockData(fileSystem: localFileSystem, rootPath: tmpPath)
@@ -93,7 +93,7 @@ final class SQLiteBackedCacheTests: XCTestCase {
     func testFileCorrupt() throws {
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending(component: "test.db")
-            let cache = SQLiteBackedCache<String>(name: "SQLiteBackedCacheTest", path: path)
+            let cache = SQLiteBackedCache<String>(tableName: "SQLiteBackedCacheTest", path: path)
             defer { XCTAssertNoThrow(try cache.close()) }
 
             let mockData = try makeMockData(fileSystem: localFileSystem, rootPath: tmpPath)
@@ -131,7 +131,7 @@ final class SQLiteBackedCacheTests: XCTestCase {
             var configuration = SQLiteBackedCacheConfiguration()
             configuration.maxSizeInBytes = 1024 * 3
             configuration.truncateWhenFull = false
-            let cache = SQLiteBackedCache<String>(name: "SQLiteBackedCacheTest", path: path, configuration: configuration)
+            let cache = SQLiteBackedCache<String>(tableName: "SQLiteBackedCacheTest", path: path, configuration: configuration)
             defer { XCTAssertNoThrow(try cache.close()) }
 
             func create() throws {
@@ -153,7 +153,7 @@ final class SQLiteBackedCacheTests: XCTestCase {
             var configuration = SQLiteBackedCacheConfiguration()
             configuration.maxSizeInBytes = 1024 * 3
             configuration.truncateWhenFull = true
-            let cache = SQLiteBackedCache<String>(name: "SQLiteBackedCacheTest", path: path, configuration: configuration)
+            let cache = SQLiteBackedCache<String>(tableName: "SQLiteBackedCacheTest", path: path, configuration: configuration)
             defer { XCTAssertNoThrow(try cache.close()) }
 
             var keys = [String]()

--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -22,255 +22,300 @@ import TSCUtility
 class GitHubPackageMetadataProviderTests: XCTestCase {
     func testBaseURL() throws {
         let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")
-        let provider = GitHubPackageMetadataProvider()
 
         do {
-            let sshURLRetVal = provider.apiURL("git@github.com:octocat/Hello-World.git")
+            let sshURLRetVal = GitHubPackageMetadataProvider.apiURL("git@github.com:octocat/Hello-World.git")
             XCTAssertEqual(apiURL, sshURLRetVal)
         }
 
         do {
-            let httpsURLRetVal = provider.apiURL("https://github.com/octocat/Hello-World.git")
+            let httpsURLRetVal = GitHubPackageMetadataProvider.apiURL("https://github.com/octocat/Hello-World.git")
             XCTAssertEqual(apiURL, httpsURLRetVal)
         }
 
         do {
-            let httpsURLRetVal = provider.apiURL("https://github.com/octocat/Hello-World")
+            let httpsURLRetVal = GitHubPackageMetadataProvider.apiURL("https://github.com/octocat/Hello-World")
             XCTAssertEqual(apiURL, httpsURLRetVal)
         }
 
-        XCTAssertNil(provider.apiURL("bad/Hello-World.git"))
+        XCTAssertNil(GitHubPackageMetadataProvider.apiURL("bad/Hello-World.git"))
     }
 
     func testGood() throws {
-        let repoURL = "https://github.com/octocat/Hello-World.git"
-        let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
-        let releasesURL = URL(string: "https://api.github.com/repos/octocat/Hello-World/releases?per_page=20")!
+        try testWithTemporaryDirectory { tmpPath in
+            let repoURL = "https://github.com/octocat/Hello-World.git"
+            let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
+            let releasesURL = URL(string: "https://api.github.com/repos/octocat/Hello-World/releases?per_page=20")!
 
-        fixture(name: "Collections") { directoryPath in
-            let handler: HTTPClient.Handler = { request, _, completion in
-                switch (request.method, request.url) {
-                case (.get, apiURL):
-                    let path = directoryPath.appending(components: "GitHub", "metadata.json")
-                    let data = Data(try! localFileSystem.readFileContents(path).contents)
-                    completion(.success(.init(statusCode: 200,
-                                              headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
-                                              body: data)))
-                case (.get, releasesURL):
-                    let path = directoryPath.appending(components: "GitHub", "releases.json")
-                    let data = Data(try! localFileSystem.readFileContents(path).contents)
-                    completion(.success(.init(statusCode: 200,
-                                              headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
-                                              body: data)))
-                case (.get, apiURL.appendingPathComponent("contributors")):
-                    let path = directoryPath.appending(components: "GitHub", "contributors.json")
-                    let data = Data(try! localFileSystem.readFileContents(path).contents)
-                    completion(.success(.init(statusCode: 200,
-                                              headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
-                                              body: data)))
-                case (.get, apiURL.appendingPathComponent("readme")):
-                    let path = directoryPath.appending(components: "GitHub", "readme.json")
-                    let data = Data(try! localFileSystem.readFileContents(path).contents)
-                    completion(.success(.init(statusCode: 200,
-                                              headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
-                                              body: data)))
-                case (.get, apiURL.appendingPathComponent("license")):
-                    let path = directoryPath.appending(components: "GitHub", "license.json")
-                    let data = Data(try! localFileSystem.readFileContents(path).contents)
-                    completion(.success(.init(statusCode: 200,
-                                              headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
-                                              body: data)))
-                case (.get, apiURL.appendingPathComponent("languages")):
-                    let path = directoryPath.appending(components: "GitHub", "languages.json")
-                    let data = Data(try! localFileSystem.readFileContents(path).contents)
-                    completion(.success(.init(statusCode: 200,
-                                              headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
-                                              body: data)))
-                default:
-                    XCTFail("method and url should match")
+            fixture(name: "Collections") { directoryPath in
+                let handler: HTTPClient.Handler = { request, _, completion in
+                    switch (request.method, request.url) {
+                    case (.get, apiURL):
+                        let path = directoryPath.appending(components: "GitHub", "metadata.json")
+                        let data = Data(try! localFileSystem.readFileContents(path).contents)
+                        completion(.success(.init(statusCode: 200,
+                                                  headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
+                                                  body: data)))
+                    case (.get, releasesURL):
+                        let path = directoryPath.appending(components: "GitHub", "releases.json")
+                        let data = Data(try! localFileSystem.readFileContents(path).contents)
+                        completion(.success(.init(statusCode: 200,
+                                                  headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
+                                                  body: data)))
+                    case (.get, apiURL.appendingPathComponent("contributors")):
+                        let path = directoryPath.appending(components: "GitHub", "contributors.json")
+                        let data = Data(try! localFileSystem.readFileContents(path).contents)
+                        completion(.success(.init(statusCode: 200,
+                                                  headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
+                                                  body: data)))
+                    case (.get, apiURL.appendingPathComponent("readme")):
+                        let path = directoryPath.appending(components: "GitHub", "readme.json")
+                        let data = Data(try! localFileSystem.readFileContents(path).contents)
+                        completion(.success(.init(statusCode: 200,
+                                                  headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
+                                                  body: data)))
+                    case (.get, apiURL.appendingPathComponent("license")):
+                        let path = directoryPath.appending(components: "GitHub", "license.json")
+                        let data = Data(try! localFileSystem.readFileContents(path).contents)
+                        completion(.success(.init(statusCode: 200,
+                                                  headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
+                                                  body: data)))
+                    case (.get, apiURL.appendingPathComponent("languages")):
+                        let path = directoryPath.appending(components: "GitHub", "languages.json")
+                        let data = Data(try! localFileSystem.readFileContents(path).contents)
+                        completion(.success(.init(statusCode: 200,
+                                                  headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
+                                                  body: data)))
+                    default:
+                        XCTFail("method and url should match")
+                    }
                 }
+
+                var httpClient = HTTPClient(handler: handler)
+                httpClient.configuration.circuitBreakerStrategy = .none
+                httpClient.configuration.retryStrategy = .none
+                var configuration = GitHubPackageMetadataProvider.Configuration()
+                configuration.cacheDir = tmpPath
+                let provider = GitHubPackageMetadataProvider(configuration: configuration, httpClient: httpClient)
+                defer { XCTAssertNoThrow(try provider.close()) }
+
+                let reference = PackageReference(repository: RepositorySpecifier(url: repoURL))
+                let metadata = try tsc_await { callback in provider.get(reference, callback: callback) }
+
+                XCTAssertEqual(metadata.summary, "This your first repo!")
+                XCTAssertEqual(metadata.versions.count, 1)
+                XCTAssertEqual(metadata.versions[0].version, TSCUtility.Version("1.0.0"))
+                XCTAssertEqual(metadata.versions[0].title, "1.0.0")
+                XCTAssertEqual(metadata.versions[0].summary, "Description of the release")
+                XCTAssertEqual(metadata.authors, [PackageCollectionsModel.Package.Author(username: "octocat",
+                                                                                         url: URL(string: "https://api.github.com/users/octocat")!,
+                                                                                         service: .init(name: "GitHub"))])
+                XCTAssertEqual(metadata.readmeURL, URL(string: "https://raw.githubusercontent.com/octokit/octokit.rb/master/README.md"))
+                XCTAssertEqual(metadata.license?.type, PackageCollectionsModel.LicenseType.MIT)
+                XCTAssertEqual(metadata.license?.url, URL(string: "https://raw.githubusercontent.com/benbalter/gman/master/LICENSE?lab=true"))
+                XCTAssertEqual(metadata.watchersCount, 80)
+                XCTAssertEqual(metadata.languages, ["Swift", "Shell", "C"])
             }
-
-            var httpClient = HTTPClient(handler: handler)
-            httpClient.configuration.circuitBreakerStrategy = .none
-            httpClient.configuration.retryStrategy = .none
-            let provider = GitHubPackageMetadataProvider(httpClient: httpClient)
-            let reference = PackageReference(repository: RepositorySpecifier(url: repoURL))
-            let metadata = try tsc_await { callback in provider.get(reference, callback: callback) }
-
-            XCTAssertEqual(metadata.summary, "This your first repo!")
-            XCTAssertEqual(metadata.versions.count, 1)
-            XCTAssertEqual(metadata.versions[0].version, TSCUtility.Version("1.0.0"))
-            XCTAssertEqual(metadata.versions[0].title, "1.0.0")
-            XCTAssertEqual(metadata.versions[0].summary, "Description of the release")
-            XCTAssertEqual(metadata.authors, [PackageCollectionsModel.Package.Author(username: "octocat",
-                                                                                     url: URL(string: "https://api.github.com/users/octocat")!,
-                                                                                     service: .init(name: "GitHub"))])
-            XCTAssertEqual(metadata.readmeURL, URL(string: "https://raw.githubusercontent.com/octokit/octokit.rb/master/README.md"))
-            XCTAssertEqual(metadata.license?.type, PackageCollectionsModel.LicenseType.MIT)
-            XCTAssertEqual(metadata.license?.url, URL(string: "https://raw.githubusercontent.com/benbalter/gman/master/LICENSE?lab=true"))
-            XCTAssertEqual(metadata.watchersCount, 80)
-            XCTAssertEqual(metadata.languages, ["Swift", "Shell", "C"])
         }
     }
 
     func testRepoNotFound() throws {
-        let repoURL = "https://github.com/octocat/Hello-World.git"
+        try testWithTemporaryDirectory { tmpPath in
+            let repoURL = "https://github.com/octocat/Hello-World.git"
 
-        let handler: HTTPClient.Handler = { _, _, completion in
-            completion(.success(.init(statusCode: 404)))
-        }
+            let handler: HTTPClient.Handler = { _, _, completion in
+                completion(.success(.init(statusCode: 404)))
+            }
 
-        var httpClient = HTTPClient(handler: handler)
-        httpClient.configuration.circuitBreakerStrategy = .none
-        httpClient.configuration.retryStrategy = .none
-        let provider = GitHubPackageMetadataProvider(httpClient: httpClient)
-        let reference = PackageReference(repository: RepositorySpecifier(url: repoURL))
-        XCTAssertThrowsError(try tsc_await { callback in provider.get(reference, callback: callback) }, "should throw error") { error in
-            XCTAssert(error is NotFoundError, "\(error)")
+            var httpClient = HTTPClient(handler: handler)
+            httpClient.configuration.circuitBreakerStrategy = .none
+            httpClient.configuration.retryStrategy = .none
+            var configuration = GitHubPackageMetadataProvider.Configuration()
+            configuration.cacheDir = tmpPath
+            let provider = GitHubPackageMetadataProvider(configuration: configuration, httpClient: httpClient)
+            defer { XCTAssertNoThrow(try provider.close()) }
+
+            let reference = PackageReference(repository: RepositorySpecifier(url: repoURL))
+            XCTAssertThrowsError(try tsc_await { callback in provider.get(reference, callback: callback) }, "should throw error") { error in
+                XCTAssert(error is NotFoundError, "\(error)")
+            }
         }
     }
 
     func testOthersNotFound() throws {
-        let repoURL = "https://github.com/octocat/Hello-World.git"
-        let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
+        try testWithTemporaryDirectory { tmpPath in
+            let repoURL = "https://github.com/octocat/Hello-World.git"
+            let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
 
-        fixture(name: "Collections") { directoryPath in
-            let path = directoryPath.appending(components: "GitHub", "metadata.json")
-            let data = try Data(localFileSystem.readFileContents(path).contents)
-            let handler: HTTPClient.Handler = { request, _, completion in
-                switch (request.method, request.url) {
-                case (.get, apiURL):
-                    completion(.success(.init(statusCode: 200,
-                                              headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
-                                              body: data)))
-                default:
-                    completion(.success(.init(statusCode: 500)))
+            fixture(name: "Collections") { directoryPath in
+                let path = directoryPath.appending(components: "GitHub", "metadata.json")
+                let data = try Data(localFileSystem.readFileContents(path).contents)
+                let handler: HTTPClient.Handler = { request, _, completion in
+                    switch (request.method, request.url) {
+                    case (.get, apiURL):
+                        completion(.success(.init(statusCode: 200,
+                                                  headers: .init([.init(name: "Content-Length", value: "\(data.count)")]),
+                                                  body: data)))
+                    default:
+                        completion(.success(.init(statusCode: 500)))
+                    }
                 }
+
+                var httpClient = HTTPClient(handler: handler)
+                httpClient.configuration.circuitBreakerStrategy = .none
+                httpClient.configuration.retryStrategy = .none
+                var configuration = GitHubPackageMetadataProvider.Configuration()
+                configuration.cacheDir = tmpPath
+                let provider = GitHubPackageMetadataProvider(configuration: configuration, httpClient: httpClient)
+                defer { XCTAssertNoThrow(try provider.close()) }
+
+                let reference = PackageReference(repository: RepositorySpecifier(url: repoURL))
+                let metadata = try tsc_await { callback in provider.get(reference, callback: callback) }
+
+                XCTAssertEqual(metadata.summary, "This your first repo!")
+                XCTAssertEqual(metadata.versions, [])
+                XCTAssertNil(metadata.authors)
+                XCTAssertNil(metadata.readmeURL)
+                XCTAssertEqual(metadata.watchersCount, 80)
             }
-
-            var httpClient = HTTPClient(handler: handler)
-            httpClient.configuration.circuitBreakerStrategy = .none
-            httpClient.configuration.retryStrategy = .none
-            let provider = GitHubPackageMetadataProvider(httpClient: httpClient)
-            let reference = PackageReference(repository: RepositorySpecifier(url: repoURL))
-            let metadata = try tsc_await { callback in provider.get(reference, callback: callback) }
-
-            XCTAssertEqual(metadata.summary, "This your first repo!")
-            XCTAssertEqual(metadata.versions, [])
-            XCTAssertNil(metadata.authors)
-            XCTAssertNil(metadata.readmeURL)
-            XCTAssertEqual(metadata.watchersCount, 80)
         }
     }
 
     func testPermissionDenied() throws {
-        let repoURL = "https://github.com/octocat/Hello-World.git"
-        let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
+        try testWithTemporaryDirectory { tmpPath in
+            let repoURL = "https://github.com/octocat/Hello-World.git"
+            let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
 
-        let handler: HTTPClient.Handler = { _, _, completion in
-            completion(.success(.init(statusCode: 401)))
-        }
-
-        var httpClient = HTTPClient(handler: handler)
-        httpClient.configuration.circuitBreakerStrategy = .none
-        httpClient.configuration.retryStrategy = .none
-        let provider = GitHubPackageMetadataProvider(httpClient: httpClient)
-        let reference = PackageReference(repository: RepositorySpecifier(url: repoURL))
-        XCTAssertThrowsError(try tsc_await { callback in provider.get(reference, callback: callback) }, "should throw error") { error in
-            XCTAssertEqual(error as? GitHubPackageMetadataProvider.Errors, .permissionDenied(apiURL))
-        }
-    }
-
-    func testInvalidAuthToken() throws {
-        let repoURL = "https://github.com/octocat/Hello-World.git"
-        let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
-        let authTokens = [AuthTokenType.github("api.github.com"): "foo"]
-
-        let handler: HTTPClient.Handler = { request, _, completion in
-            if request.headers.get("Authorization").first == "token \(authTokens.first!.value)" {
+            let handler: HTTPClient.Handler = { _, _, completion in
                 completion(.success(.init(statusCode: 401)))
-            } else {
-                XCTFail("expected correct authorization header")
-                completion(.success(.init(statusCode: 500)))
             }
-        }
-
-        var httpClient = HTTPClient(handler: handler)
-        httpClient.configuration.circuitBreakerStrategy = .none
-        httpClient.configuration.retryStrategy = .none
-        var provider = GitHubPackageMetadataProvider(httpClient: httpClient)
-        provider.configuration.authTokens = authTokens
-        let reference = PackageReference(repository: RepositorySpecifier(url: repoURL))
-        XCTAssertThrowsError(try tsc_await { callback in provider.get(reference, callback: callback) }, "should throw error") { error in
-            XCTAssertEqual(error as? GitHubPackageMetadataProvider.Errors, .invalidAuthToken(apiURL))
-        }
-    }
-
-    func testAPILimit() throws {
-        let repoURL = "https://github.com/octocat/Hello-World.git"
-        let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
-
-        let total = 5
-        var remaining = total
-
-        fixture(name: "Collections") { directoryPath in
-            let path = directoryPath.appending(components: "GitHub", "metadata.json")
-            let data = try Data(localFileSystem.readFileContents(path).contents)
-            let handler: HTTPClient.Handler = { request, _, completion in
-                var headers = HTTPClientHeaders()
-                headers.add(name: "X-RateLimit-Limit", value: "\(total)")
-                headers.add(name: "X-RateLimit-Remaining", value: "\(remaining)")
-                if remaining == 0 {
-                    completion(.success(.init(statusCode: 403, headers: headers)))
-                } else if request.url == apiURL {
-                    remaining = remaining - 1
-                    headers.add(name: "Content-Length", value: "\(data.count)")
-                    completion(.success(.init(statusCode: 200,
-                                              headers: headers,
-                                              body: data)))
-                } else {
-                    completion(.success(.init(statusCode: 500)))
-                }
-            }
-
-            // Disable cache so we hit the API
-            let configuration = GitHubPackageMetadataProvider.Configuration(cacheTTLInSeconds: -1)
 
             var httpClient = HTTPClient(handler: handler)
             httpClient.configuration.circuitBreakerStrategy = .none
             httpClient.configuration.retryStrategy = .none
-
+            var configuration = GitHubPackageMetadataProvider.Configuration()
+            configuration.cacheDir = tmpPath
             let provider = GitHubPackageMetadataProvider(configuration: configuration, httpClient: httpClient)
+            defer { XCTAssertNoThrow(try provider.close()) }
+
             let reference = PackageReference(repository: RepositorySpecifier(url: repoURL))
-            for index in 0 ... total * 2 {
-                if index >= total {
-                    XCTAssertThrowsError(try tsc_await { callback in provider.get(reference, callback: callback) }, "should throw error") { error in
-                        XCTAssertEqual(error as? GitHubPackageMetadataProvider.Errors, .apiLimitsExceeded(apiURL, total))
-                    }
+            XCTAssertThrowsError(try tsc_await { callback in provider.get(reference, callback: callback) }, "should throw error") { error in
+                XCTAssertEqual(error as? GitHubPackageMetadataProvider.Errors, .permissionDenied(apiURL))
+            }
+        }
+    }
+
+    func testInvalidAuthToken() throws {
+        try testWithTemporaryDirectory { tmpPath in
+            let repoURL = "https://github.com/octocat/Hello-World.git"
+            let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
+            let authTokens = [AuthTokenType.github("api.github.com"): "foo"]
+
+            let handler: HTTPClient.Handler = { request, _, completion in
+                if request.headers.get("Authorization").first == "token \(authTokens.first!.value)" {
+                    completion(.success(.init(statusCode: 401)))
                 } else {
-                    XCTAssertNoThrow(try tsc_await { callback in provider.get(reference, callback: callback) })
+                    XCTFail("expected correct authorization header")
+                    completion(.success(.init(statusCode: 500)))
+                }
+            }
+
+            var httpClient = HTTPClient(handler: handler)
+            httpClient.configuration.circuitBreakerStrategy = .none
+            httpClient.configuration.retryStrategy = .none
+            var configuration = GitHubPackageMetadataProvider.Configuration()
+            configuration.cacheDir = tmpPath
+            var provider = GitHubPackageMetadataProvider(configuration: configuration, httpClient: httpClient)
+            provider.configuration.authTokens = authTokens
+            defer { XCTAssertNoThrow(try provider.close()) }
+
+            let reference = PackageReference(repository: RepositorySpecifier(url: repoURL))
+            XCTAssertThrowsError(try tsc_await { callback in provider.get(reference, callback: callback) }, "should throw error") { error in
+                XCTAssertEqual(error as? GitHubPackageMetadataProvider.Errors, .invalidAuthToken(apiURL))
+            }
+        }
+    }
+
+    func testAPILimit() throws {
+        try testWithTemporaryDirectory { tmpPath in
+            let repoURL = "https://github.com/octocat/Hello-World.git"
+            let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
+
+            let total = 5
+            var remaining = total
+
+            fixture(name: "Collections") { directoryPath in
+                let path = directoryPath.appending(components: "GitHub", "metadata.json")
+                let data = try Data(localFileSystem.readFileContents(path).contents)
+                let handler: HTTPClient.Handler = { request, _, completion in
+                    var headers = HTTPClientHeaders()
+                    headers.add(name: "X-RateLimit-Limit", value: "\(total)")
+                    headers.add(name: "X-RateLimit-Remaining", value: "\(remaining)")
+                    if remaining == 0 {
+                        completion(.success(.init(statusCode: 403, headers: headers)))
+                    } else if request.url == apiURL {
+                        remaining = remaining - 1
+                        headers.add(name: "Content-Length", value: "\(data.count)")
+                        completion(.success(.init(statusCode: 200,
+                                                  headers: headers,
+                                                  body: data)))
+                    } else {
+                        completion(.success(.init(statusCode: 500)))
+                    }
+                }
+
+                // Disable cache so we hit the API
+                let configuration = GitHubPackageMetadataProvider.Configuration(cacheDir: tmpPath, cacheTTLInSeconds: -1)
+
+                var httpClient = HTTPClient(handler: handler)
+                httpClient.configuration.circuitBreakerStrategy = .none
+                httpClient.configuration.retryStrategy = .none
+
+                let provider = GitHubPackageMetadataProvider(configuration: configuration, httpClient: httpClient)
+                defer { XCTAssertNoThrow(try provider.close()) }
+
+                let reference = PackageReference(repository: RepositorySpecifier(url: repoURL))
+                for index in 0 ... total * 2 {
+                    if index >= total {
+                        XCTAssertThrowsError(try tsc_await { callback in provider.get(reference, callback: callback) }, "should throw error") { error in
+                            XCTAssertEqual(error as? GitHubPackageMetadataProvider.Errors, .apiLimitsExceeded(apiURL, total))
+                        }
+                    } else {
+                        XCTAssertNoThrow(try tsc_await { callback in provider.get(reference, callback: callback) })
+                    }
                 }
             }
         }
     }
 
     func testInvalidURL() throws {
-        fixture(name: "Collections") { _ in
-            let provider = GitHubPackageMetadataProvider()
-            let reference = PackageReference(repository: RepositorySpecifier(url: UUID().uuidString))
-            XCTAssertThrowsError(try tsc_await { callback in provider.get(reference, callback: callback) }, "should throw error") { error in
-                XCTAssertEqual(error as? GitHubPackageMetadataProvider.Errors, .invalidGitURL(reference.location))
+        try testWithTemporaryDirectory { tmpPath in
+            fixture(name: "Collections") { _ in
+                var configuration = GitHubPackageMetadataProvider.Configuration()
+                configuration.cacheDir = tmpPath
+                let provider = GitHubPackageMetadataProvider(configuration: configuration)
+                defer { XCTAssertNoThrow(try provider.close()) }
+
+                let reference = PackageReference(repository: RepositorySpecifier(url: UUID().uuidString))
+                XCTAssertThrowsError(try tsc_await { callback in provider.get(reference, callback: callback) }, "should throw error") { error in
+                    XCTAssertEqual(error as? GitHubPackageMetadataProvider.Errors, .invalidGitURL(reference.location))
+                }
             }
         }
     }
 
     func testInvalidRef() throws {
-        fixture(name: "Collections") { _ in
-            let provider = GitHubPackageMetadataProvider()
-            let reference = PackageReference.local(identity: .init(path: AbsolutePath("/")), path: .root)
-            XCTAssertThrowsError(try tsc_await { callback in provider.get(reference, callback: callback) }, "should throw error") { error in
-                XCTAssertEqual(error as? GitHubPackageMetadataProvider.Errors, .invalidReferenceType(reference))
+        try testWithTemporaryDirectory { tmpPath in
+            fixture(name: "Collections") { _ in
+                var configuration = GitHubPackageMetadataProvider.Configuration()
+                configuration.cacheDir = tmpPath
+                let provider = GitHubPackageMetadataProvider(configuration: configuration)
+                defer { XCTAssertNoThrow(try provider.close()) }
+
+                let reference = PackageReference.local(identity: .init(path: AbsolutePath("/")), path: .root)
+                XCTAssertThrowsError(try tsc_await { callback in provider.get(reference, callback: callback) }, "should throw error") { error in
+                    XCTAssertEqual(error as? GitHubPackageMetadataProvider.Errors, .invalidReferenceType(reference))
+                }
             }
         }
     }
@@ -293,7 +338,10 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
             configuration.authTokens = [.github("api.github.com"): token]
         }
         configuration.apiLimitWarningThreshold = 50
+        configuration.cacheTTLInSeconds = -1 // Disable cache so we hit the API
         let provider = GitHubPackageMetadataProvider(configuration: configuration, httpClient: httpClient)
+        defer { XCTAssertNoThrow(try provider.close()) }
+
         let reference = PackageReference(repository: RepositorySpecifier(url: repoURL))
         for _ in 0 ... 60 {
             let metadata = try tsc_await { callback in provider.get(reference, callback: callback) }

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -1318,6 +1318,8 @@ final class PackageCollectionsTests: XCTestCase {
                 callback(.failure(TerribleThing()))
             }
 
+            func close() throws {}
+
             struct TerribleThing: Error {}
         }
 

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -164,6 +164,8 @@ struct MockMetadataProvider: PackageMetadataProvider {
             callback(.failure(NotFoundError("\(reference)")))
         }
     }
+
+    func close() throws {}
 }
 
 struct MockCollectionSignatureValidator: PackageCollectionSignatureValidator {

--- a/Tests/PackageLoadingTests/ManifestLoaderSQLiteCacheTests.swift
+++ b/Tests/PackageLoadingTests/ManifestLoaderSQLiteCacheTests.swift
@@ -1,12 +1,12 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import Basics
 @testable import PackageLoading
@@ -20,17 +20,16 @@ class ManifestLoaderSQLiteCacheTests: XCTestCase {
     func testHappyCase() throws {
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending(component: "test.db")
-            let storage = SQLiteManifestCache(path: path)
+            let storage = SQLiteBackedCache<ManifestLoader.ManifestParseResult>(name: "manifests", path: path)
             defer { XCTAssertNoThrow(try storage.close()) }
-
 
             let mockManifests = try makeMockManifests(fileSystem: localFileSystem, rootPath: tmpPath)
             try mockManifests.forEach { key, manifest in
-                _ = try storage.put(key: key, manifest: manifest)
+                _ = try storage.put(key: key.sha256Checksum, value: manifest)
             }
 
             try mockManifests.forEach { key, manifest in
-                let result = try storage.get(key: key)
+                let result = try storage.get(key: key.sha256Checksum)
                 XCTAssertEqual(result?.parsedManifest, manifest.parsedManifest)
             }
 
@@ -41,132 +40,9 @@ class ManifestLoaderSQLiteCacheTests: XCTestCase {
             XCTAssertTrue(storage.fileSystem.exists(storagePath), "expected file to be written")
         }
     }
-
-    func testFileDeleted() throws {
-        try testWithTemporaryDirectory { tmpPath in
-            let path = tmpPath.appending(component: "test.db")
-            let storage = SQLiteManifestCache(path: path)
-            defer { XCTAssertNoThrow(try storage.close()) }
-
-            let mockManifests = try makeMockManifests(fileSystem: localFileSystem, rootPath: tmpPath)
-            try mockManifests.forEach {  key, manifest in
-                _ = try storage.put(key: key, manifest: manifest)
-            }
-
-            try mockManifests.forEach { key, manifest in
-                let result = try storage.get(key: key)
-                XCTAssertEqual(result?.parsedManifest, manifest.parsedManifest)
-            }
-
-            guard case .path(let storagePath) = storage.location else {
-                return XCTFail("invalid location \(storage.location)")
-            }
-
-            XCTAssertTrue(storage.fileSystem.exists(storagePath), "expected file to exist at \(storagePath)")
-            try storage.fileSystem.removeFileTree(storagePath)
-
-            do {
-                let result = try storage.get(key: mockManifests.first!.key)
-                XCTAssertNil(result)
-            }
-
-            do {
-                XCTAssertNoThrow(try storage.put(key: mockManifests.first!.key, manifest: mockManifests.first!.value))
-                let result = try storage.get(key: mockManifests.first!.key)
-                XCTAssertEqual(result?.parsedManifest, mockManifests.first!.value.parsedManifest)
-            }
-
-            XCTAssertTrue(storage.fileSystem.exists(storagePath), "expected file to exist at \(storagePath)")
-        }
-    }
-
-    func testFileCorrupt() throws {
-        try testWithTemporaryDirectory { tmpPath in
-            let path = tmpPath.appending(component: "test.db")
-            let storage = SQLiteManifestCache(path: path)
-            defer { XCTAssertNoThrow(try storage.close()) }
-
-            let mockManifests = try makeMockManifests(fileSystem: localFileSystem, rootPath: tmpPath)
-            try mockManifests.forEach {  key, manifest in
-                _ = try storage.put(key: key, manifest: manifest)
-            }
-
-            try mockManifests.forEach { key, manifest in
-                let result = try storage.get(key: key)
-                XCTAssertEqual(result?.parsedManifest, manifest.parsedManifest)
-            }
-
-            guard case .path(let storagePath) = storage.location else {
-                return XCTFail("invalid location \(storage.location)")
-            }
-
-            try storage.close()
-
-            XCTAssertTrue(storage.fileSystem.exists(storagePath), "expected file to exist at \(path)")
-            try storage.fileSystem.writeFileContents(storagePath, bytes: ByteString("blah".utf8))
-
-            XCTAssertThrowsError(try storage.get(key: mockManifests.first!.key), "expected error", { error in
-                XCTAssert("\(error)".contains("is not a database"), "Expected file is not a database error")
-            })
-
-            XCTAssertThrowsError(try storage.put(key: mockManifests.first!.key, manifest: mockManifests.first!.value), "expected error", { error in
-                XCTAssert("\(error)".contains("is not a database"), "Expected file is not a database error")
-            })
-        }
-    }
-
-    func testMaxSizeNotHandled() throws {
-        try testWithTemporaryDirectory { tmpPath in
-            let path = tmpPath.appending(component: "test.db")
-            var configuration = SQLiteManifestCache.Configuration()
-            configuration.maxSizeInBytes = 1024 * 3
-            configuration.truncateWhenFull = false
-            let storage = SQLiteManifestCache(location: .path(path), configuration: configuration)
-            defer { XCTAssertNoThrow(try storage.close()) }
-
-            func create() throws {
-                let mockManifests = try makeMockManifests(fileSystem: localFileSystem, rootPath: tmpPath, count: 50)
-                try mockManifests.forEach {  key, manifest in
-                    _ = try storage.put(key: key, manifest: manifest)
-                }
-            }
-
-            XCTAssertThrowsError(try create(), "expected error", { error in
-                XCTAssertEqual(error as? SQLite.Errors, .databaseFull, "Expected 'databaseFull' error")
-            })
-        }
-    }
-
-    func testMaxSizeHandled() throws {
-        try testWithTemporaryDirectory { tmpPath in
-            let path = tmpPath.appending(component: "test.db")
-            var configuration = SQLiteManifestCache.Configuration()
-            configuration.maxSizeInBytes = 1024 * 3
-            configuration.truncateWhenFull = true
-            let storage = SQLiteManifestCache(location: .path(path), configuration: configuration)
-            defer { XCTAssertNoThrow(try storage.close()) }
-
-            var keys = [ManifestLoader.ManifestCacheKey]()
-            let mockManifests = try makeMockManifests(fileSystem: localFileSystem, rootPath: tmpPath, count: 50)
-            try mockManifests.forEach { key, manifest in
-                _ = try storage.put(key: key, manifest: manifest)
-                keys.append(key)
-            }
-
-            do {
-                let result = try storage.get(key: mockManifests.first!.key)
-                XCTAssertNil(result)
-            }
-
-            do {
-                let result = try storage.get(key: keys.last!)
-                XCTAssertEqual(result?.parsedManifest, mockManifests[keys.last!]?.parsedManifest)
-            }
-        }
-    }
 }
 
-fileprivate func makeMockManifests(fileSystem: FileSystem, rootPath: AbsolutePath, count: Int = Int.random(in: 50 ..< 100)) throws -> [ManifestLoader.ManifestCacheKey: ManifestLoader.ManifestParseResult] {
+private func makeMockManifests(fileSystem: FileSystem, rootPath: AbsolutePath, count: Int = Int.random(in: 50 ..< 100)) throws -> [ManifestLoader.ManifestCacheKey: ManifestLoader.ManifestParseResult] {
     var manifests = [ManifestLoader.ManifestCacheKey: ManifestLoader.ManifestParseResult]()
     for index in 0 ..< count {
         let manifestPath = rootPath.appending(components: "\(index)", "Package.swift")
@@ -183,7 +59,7 @@ fileprivate func makeMockManifests(fileSystem: FileSystem, rootPath: AbsolutePat
             )
             """
         }
-        let key = try ManifestLoader.ManifestCacheKey(packageIdentity: PackageIdentity.init(path: manifestPath),
+        let key = try ManifestLoader.ManifestCacheKey(packageIdentity: PackageIdentity(path: manifestPath),
                                                       manifestPath: manifestPath,
                                                       toolsVersion: ToolsVersion.currentToolsVersion,
                                                       env: [:],
@@ -195,4 +71,3 @@ fileprivate func makeMockManifests(fileSystem: FileSystem, rootPath: AbsolutePat
 
     return manifests
 }
-

--- a/Tests/PackageLoadingTests/ManifestLoaderSQLiteCacheTests.swift
+++ b/Tests/PackageLoadingTests/ManifestLoaderSQLiteCacheTests.swift
@@ -20,7 +20,7 @@ class ManifestLoaderSQLiteCacheTests: XCTestCase {
     func testHappyCase() throws {
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending(component: "test.db")
-            let storage = SQLiteBackedCache<ManifestLoader.ManifestParseResult>(name: "manifests", path: path)
+            let storage = SQLiteBackedCache<ManifestLoader.ManifestParseResult>(tableName: "manifests", path: path)
             defer { XCTAssertNoThrow(try storage.close()) }
 
             let mockManifests = try makeMockManifests(fileSystem: localFileSystem, rootPath: tmpPath)


### PR DESCRIPTION
Motivation:
Currently we use transient in-memory cache for storing GitHub package metadata.

Modifications:
- Add generic `SQLiteBackedCache` in Basics
- Change `ManifestLoader` to use `SQLiteBackedCache`
- Change `GitHubPackageMetadataProvider` to use `SQLiteBackedCache`
- Adjust tests
