### PR TITLE
Fix new package XCTest file formatting and include throws keyword

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -356,19 +356,15 @@ public final class InitPackage {
                 @testable import \(moduleName)
 
                 final class \(moduleName)Tests: XCTestCase {
-                    func testExample() {
+                    func testExample() throws {
                         // This is an example of a functional test case.
                         // Use XCTAssert and related functions to verify your tests produce the correct
                         // results.
                         XCTAssertEqual(\(typeName)().text, "Hello, World!")
                     }
-
-            """
-
-            stream <<< """
                 }
 
-            """
+                """
         }
     }
 
@@ -421,10 +417,6 @@ public final class InitPackage {
                         return Bundle.main.bundleURL
                       #endif
                     }
-
-                """
-
-            stream <<< """
                 }
 
                 """

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -127,9 +127,19 @@ class InitTests: XCTestCase {
             XCTAssertTrue(readmeContents.hasPrefix("# Foo\n"))
 
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "Foo")), ["Foo.swift"])
+
+            let tests = path.appending(component: "Tests")
             XCTAssertEqual(
-                try fs.getDirectoryContents(path.appending(component: "Tests")).sorted(),
+                try fs.getDirectoryContents(tests).sorted(),
                 ["FooTests"])
+
+            let testFile = tests.appending(component: "FooTests").appending(component: "FooTests.swift")
+            let testFileContents = try localFileSystem.readFileContents(testFile).description
+            XCTAssertTrue(testFileContents.hasPrefix("import XCTest"), """
+                          Validates formatting of XCTest source file, in particular that it does not contain leading whitespace:
+                          \(testFileContents)
+                          """)
+            XCTAssertTrue(testFileContents.contains("func testExample() throws"), "Contents:\n\(testFileContents)")
 
             // Try building it
             XCTAssertBuilds(path)


### PR DESCRIPTION
Motivation: Fix formatting of the XCTest source file in newly `init`'ed library packages, and include the
`throws` keyword on the example XCTest method as a convenience to users and to promote use of throwing
XCTest methods.

Changes:
- Fix a bug in the formatting of XCTest source files in `InitPackage`, where the closing `"""` string
  terminator was outdented one level too far, which resulted in the file contents being indented unnecessarily.
- Include the `throws` keyword on `func testExample()` in the new Library type package template.
- Modify an existing test to validate these improvements.

rdar://77209458
rdar://77209464