### PR TITLE
Add Mac Catalyst as a supported platform

### DIFF
--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -426,6 +426,8 @@ extension PackageModel.Platform {
         switch name.lowercased() {
         case let name where name.contains("macos"):
             self = PackageModel.Platform.macOS
+        case let name where name.contains("maccatalyst"):
+            self = PackageModel.Platform.macCatalyst
         case let name where name.contains("ios"):
             self = PackageModel.Platform.iOS
         case let name where name.contains("tvos"):

--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -22,6 +22,9 @@ public struct Platform: Encodable, Equatable {
     /// The macOS platform.
     public static let macOS: Platform = Platform(name: "macos")
 
+    /// The Mac Catalyst platform.
+    public static let macCatalyst: Platform = Platform(name: "maccatalyst")
+
     /// The iOS platform.
     public static let iOS: Platform = Platform(name: "ios")
 
@@ -100,6 +103,29 @@ public struct SupportedPlatform: Encodable, Equatable {
     /// - Parameter versionString: The minimum deployment target as a string representation of two or three dot-separated integers, such as `10.10.1`.
     public static func macOS(_ versionString: String) -> SupportedPlatform {
         return SupportedPlatform(platform: .macOS, version: SupportedPlatform.MacOSVersion(string: versionString).version)
+    }
+
+    /// Configures the minimum deployment target version for the Mac Catalyst platform.
+    ///
+    /// - Since: First available in PackageDescription 5.5
+    ///
+    /// - Parameter version: The minimum deployment target that the package supports.
+    @available(_PackageDescription, introduced: 5.5)
+    public static func macCatalyst(_ version: SupportedPlatform.MacCatalystVersion) -> SupportedPlatform {
+        return SupportedPlatform(platform: .macCatalyst, version: version.version)
+    }
+
+    /// Configures the minimum deployment target version for the Mac Catalyst platform
+    /// using a version string.
+    ///
+    /// The version string must be a series of two or three dot-separated integers, such as `13.0` or `13.0.1`.
+    ///
+    /// - Since: First available in PackageDescription 5.5
+    ///
+    /// - Parameter versionString: The minimum deployment target as a string representation of two or three dot-separated integers, such as `13.0.1`.
+    @available(_PackageDescription, introduced: 5.5)
+    public static func macCatalyst(_ versionString: String) -> SupportedPlatform {
+        return SupportedPlatform(platform: .macCatalyst, version: SupportedPlatform.MacCatalystVersion(string: versionString).version)
     }
 
     /// Configures the minimum deployment target version for the iOS platform.
@@ -288,6 +314,31 @@ extension SupportedPlatform {
         /// - Since: First available in PackageDescription 5.3
         @available(_PackageDescription, introduced: 5.3)
         public static let v14: TVOSVersion = .init(string: "14.0")
+    }
+
+    /// The supported Mac Catalyst version.
+    public struct MacCatalystVersion: Encodable, AppleOSVersion {
+        fileprivate static let name = "macCatalyst"
+        fileprivate static let minimumMajorVersion = 13
+
+        /// The underlying version representation.
+        let version: String
+
+        fileprivate init(uncheckedVersion version: String) {
+            self.version = version
+        }
+
+        /// The value that represents Mac Catalyst 13.0.
+        ///
+        /// - Since: First available in PackageDescription 5.5
+        @available(_PackageDescription, introduced: 5.5)
+        public static let v13: MacCatalystVersion = .init(string: "13.0")
+
+        /// The value that represents Mac Catalyst 14.0.
+        ///
+        /// - Since: First available in PackageDescription 5.5
+        @available(_PackageDescription, introduced: 5.5)
+        public static let v14: MacCatalystVersion = .init(string: "14.0")
     }
 
     /// The supported iOS version.

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -772,7 +772,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             }
 
             let version = try Self._packageDescriptionMinimumDeploymentTarget.memoize {
-                (try MinimumDeploymentTarget.computeMinimumDeploymentTarget(of: macOSPackageDescriptionPath))?.versionString ?? "10.15"
+                (try MinimumDeploymentTarget.computeMinimumDeploymentTarget(of: macOSPackageDescriptionPath, platform: .macOS))?.versionString ?? "10.15"
             }
             cmd += ["-target", "\(triple.tripleString(forPlatformVersion: version))"]
             #endif

--- a/Sources/PackageLoading/MinimumDeploymentTarget.swift
+++ b/Sources/PackageLoading/MinimumDeploymentTarget.swift
@@ -24,21 +24,31 @@ public struct MinimumDeploymentTarget {
         }
     }
 
-    static func computeMinimumDeploymentTarget(of binaryPath: AbsolutePath) throws -> PlatformVersion? {
+    static func computeMinimumDeploymentTarget(of binaryPath: AbsolutePath, platform: PackageModel.Platform) throws -> PlatformVersion? {
+        guard let (_, platformName) = platform.sdkNameAndPlatform else {
+            return nil
+        }
+
         let runResult = try Process.popen(arguments: ["/usr/bin/xcrun", "vtool", "-show-build", binaryPath.pathString])
-        guard let versionString = try runResult.utf8Output().components(separatedBy: "\n").first(where: { $0.contains("minos") })?.components(separatedBy: " ").last else { return nil }
-        return PlatformVersion(versionString)
+        var lines = try runResult.utf8Output().components(separatedBy: "\n")
+        while !lines.isEmpty {
+            let first = lines.removeFirst()
+            if first.contains("platform \(platformName)"), let line = lines.first, line.contains("minos") {
+                return line.components(separatedBy: " ").last.map(PlatformVersion.init(stringLiteral:))
+            }
+        }
+        return nil
     }
 
-    static func computeXCTestMinimumDeploymentTarget(with runResult: ProcessResult) throws -> PlatformVersion? {
+    static func computeXCTestMinimumDeploymentTarget(with runResult: ProcessResult, platform: PackageModel.Platform) throws -> PlatformVersion? {
         guard let output = try runResult.utf8Output().spm_chuzzle() else { return nil }
         let sdkPath = try AbsolutePath(validating: output)
         let xcTestPath = sdkPath.appending(RelativePath("Developer/Library/Frameworks/XCTest.framework/XCTest"))
-        return try computeMinimumDeploymentTarget(of: xcTestPath)
+        return try computeMinimumDeploymentTarget(of: xcTestPath, platform: platform)
     }
 
     static func computeXCTestMinimumDeploymentTarget(for platform: PackageModel.Platform) -> PlatformVersion {
-        guard let sdkName = platform.sdkName else {
+        guard let (sdkName, _) = platform.sdkNameAndPlatform else {
             return platform.oldestSupportedVersion
         }
 
@@ -47,7 +57,7 @@ public struct MinimumDeploymentTarget {
         do {
             let runResult = try Process.popen(arguments: ["/usr/bin/xcrun", "--sdk", sdkName, "--show-sdk-platform-path"])
 
-            if let version = try computeXCTestMinimumDeploymentTarget(with: runResult) {
+            if let version = try computeXCTestMinimumDeploymentTarget(with: runResult, platform: platform) {
                 return version
             }
         } catch { } // we do not treat this a fatal and instead use the fallback minimum deployment target
@@ -58,16 +68,18 @@ public struct MinimumDeploymentTarget {
 }
 
 private extension PackageModel.Platform {
-    var sdkName: String? {
+    var sdkNameAndPlatform: (String, String)? {
         switch self {
         case .macOS:
-            return "macosx"
+            return ("macosx", "MACOS")
+        case .macCatalyst:
+            return ("macosx", "MACCATALYST")
         case .iOS:
-            return "iphoneos"
+            return ("iphoneos", "IOS")
         case .tvOS:
-            return "appletvos"
+            return ("appletvos", "TVOS")
         case .watchOS:
-            return "watchos"
+            return ("watchos", "WATCHOS")
         case .driverKit:
             return nil // DriverKit does not support XCTest.
         default:

--- a/Sources/PackageLoading/PlatformRegistry.swift
+++ b/Sources/PackageLoading/PlatformRegistry.swift
@@ -31,6 +31,6 @@ public final class PlatformRegistry {
 
     /// The static list of known platforms.
     private static var _knownPlatforms: [Platform] {
-        return [.macOS, .iOS, .tvOS, .watchOS, .linux, .windows, .android, .wasi, .driverKit]
+        return [.macOS, .macCatalyst, .iOS, .tvOS, .watchOS, .linux, .windows, .android, .wasi, .driverKit]
     }
 }

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -104,6 +104,8 @@ fileprivate extension SourceCodeFragment {
         switch platform.platformName {
         case "macos":
             self.init(enum: "macOS", string: platform.version)
+        case "maccatalyst":
+            self.init(enum: "macCatalyst", string: platform.version)
         case "ios":
             self.init(enum: "iOS", string: platform.version)
         case "tvos":
@@ -298,6 +300,7 @@ fileprivate extension SourceCodeFragment {
         let platformNodes: [SourceCodeFragment] = condition.platformNames.map { platformName in
             switch platformName {
             case "macos": return SourceCodeFragment(enum: "macOS")
+            case "maccatalyst": return SourceCodeFragment(enum: "macCatalyst")
             case "ios": return SourceCodeFragment(enum: "iOS")
             case "tvos": return SourceCodeFragment(enum: "tvOS")
             case "watchos": return SourceCodeFragment(enum: "watchOS")

--- a/Sources/PackageModel/Platform.swift
+++ b/Sources/PackageModel/Platform.swift
@@ -26,6 +26,7 @@ public struct Platform: Equatable, Hashable, Codable {
     }
     
     public static let macOS: Platform = Platform(name: "macos", oldestSupportedVersion: "10.10")
+    public static let macCatalyst: Platform = Platform(name: "maccatalyst", oldestSupportedVersion: "13.0")
     public static let iOS: Platform = Platform(name: "ios", oldestSupportedVersion: "9.0")
     public static let tvOS: Platform = Platform(name: "tvos", oldestSupportedVersion: "9.0")
     public static let watchOS: Platform = Platform(name: "watchos", oldestSupportedVersion: "2.0")

--- a/Sources/SPMTestSupport/PIFTester.swift
+++ b/Sources/SPMTestSupport/PIFTester.swift
@@ -265,7 +265,12 @@ public final class PIFBuildSettingsTester {
             Array(buildSettings.multipleValueSettings.keys.map { $0.rawValue })
         XCTAssert(uncheckedKeys.isEmpty, "settings are left unchecked: \(uncheckedKeys)", file: file, line: line)
 
-        for (platform, settings) in buildSettings.platformSpecificSettings {
+        for (platform, settings) in buildSettings.platformSpecificSingleValueSettings {
+            let uncheckedKeys = Array(settings.keys.map { $0.rawValue })
+            XCTAssert(uncheckedKeys.isEmpty, "\(platform) settings are left unchecked: \(uncheckedKeys)", file: file, line: line)
+        }
+
+        for (platform, settings) in buildSettings.platformSpecificMultipleValueSettings {
             let uncheckedKeys = Array(settings.keys.map { $0.rawValue })
             XCTAssert(uncheckedKeys.isEmpty, "\(platform) settings are left unchecked: \(uncheckedKeys)", file: file, line: line)
         }

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -459,6 +459,8 @@ extension PackageModel.Platform {
         switch self {
         case .macOS:
             return "macOS"
+        case .macCatalyst:
+            return "macCatalyst"
         case .iOS:
             return "iOS"
         case .tvOS:
@@ -479,7 +481,7 @@ extension SupportedPlatform {
             guard self.version.patch == 0 else {
                 return false
             }
-        } else if [Platform.macOS, .iOS, .watchOS, .tvOS, .driverKit].contains(platform) {
+        } else if [Platform.macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .driverKit].contains(platform) {
             guard self.version.minor == 0, self.version.patch == 0 else {
                 return false
             }
@@ -492,6 +494,8 @@ extension SupportedPlatform {
             return (10...15).contains(version.minor)
         case .macOS:
             return (11...11).contains(version.major)
+        case .macCatalyst:
+            return (13...14).contains(version.major)
         case .iOS:
             return (8...14).contains(version.major)
         case .tvOS:

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -256,6 +256,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         let firstTarget = package.targets.first(where: { $0.type != .test })?.underlyingTarget ?? package.targets.first?.underlyingTarget
         settings[.MACOSX_DEPLOYMENT_TARGET] = firstTarget?.deploymentTarget(for: .macOS)
         settings[.IPHONEOS_DEPLOYMENT_TARGET] = firstTarget?.deploymentTarget(for: .iOS)
+        settings[.IPHONEOS_DEPLOYMENT_TARGET, for: .macCatalyst] = firstTarget?.deploymentTarget(for: .macCatalyst)
         settings[.TVOS_DEPLOYMENT_TARGET] = firstTarget?.deploymentTarget(for: .tvOS)
         settings[.WATCHOS_DEPLOYMENT_TARGET] = firstTarget?.deploymentTarget(for: .watchOS)
         settings[.DRIVERKIT_DEPLOYMENT_TARGET] = firstTarget?.deploymentTarget(for: .driverKit)
@@ -1340,6 +1341,9 @@ extension Target {
     func deploymentTarget(for platform: PackageModel.Platform) -> String? {
         if let supportedPlatform = getSupportedPlatform(for: platform) {
             return supportedPlatform.version.versionString
+        } else if platform == .macCatalyst {
+            // If there is no deployment target specified for Mac Catalyst, fall back to the iOS deployment target.
+            return deploymentTarget(for: .iOS)
         } else if platform.oldestSupportedVersion != .unknown {
             return platform.oldestSupportedVersion.versionString
         } else {
@@ -1470,6 +1474,9 @@ extension Array where Element == PackageConditionProtocol {
             case .macOS:
                 result += PIF.PlatformFilter.macOSFilters
 
+            case .macCatalyst:
+                result += PIF.PlatformFilter.macCatalystFilters
+
             case .iOS:
                 result += PIF.PlatformFilter.iOSFilters
 
@@ -1504,6 +1511,11 @@ extension PIF.PlatformFilter {
 
     /// macOS platform filters.
     public static let macOSFilters: [PIF.PlatformFilter] = [.init(platform: "macos")]
+
+    /// Mac Catalyst platform filters.
+    public static let macCatalystFilters: [PIF.PlatformFilter] = [
+        .init(platform: "ios", environment: "maccatalyst")
+    ]
 
     /// iOS platform filters.
     public static let iOSFilters: [PIF.PlatformFilter] = [
@@ -1553,6 +1565,7 @@ private extension PIF.BuildSettings.Platform {
         switch platform {
         case .iOS: return .iOS
         case .linux: return .linux
+        case .macCatalyst: return .macCatalyst
         case .macOS: return .macOS
         case .tvOS: return .tvOS
         case .watchOS: return .watchOS

--- a/Tests/PackageLoadingTests/MinimumDeploymentTargetTests.swift
+++ b/Tests/PackageLoadingTests/MinimumDeploymentTargetTests.swift
@@ -22,7 +22,7 @@ class MinimumDeploymentTargetTests: XCTestCase {
                                    output: "".asResult,
                                    stderrOutput: "xcodebuild: error: SDK \"macosx\" cannot be located.".asResult)
 
-        XCTAssertNil(try MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(with: result))
+        XCTAssertNil(try MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(with: result, platform: .macOS))
     }
 
     func testThrowsWithNonPathOutput() throws {
@@ -32,7 +32,7 @@ class MinimumDeploymentTargetTests: XCTestCase {
                                    output: "some string".asResult,
                                    stderrOutput: "".asResult)
 
-        XCTAssertThrowsError(try MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(with: result))
+        XCTAssertThrowsError(try MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(with: result, platform: .macOS))
     }
 
     func testThrowsWithErrorForOutput() throws {
@@ -42,7 +42,7 @@ class MinimumDeploymentTargetTests: XCTestCase {
                                    output: .failure(DummyError()),
                                    stderrOutput: "".asResult)
 
-        XCTAssertThrowsError(try MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(with: result))
+        XCTAssertThrowsError(try MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(with: result, platform: .macOS))
     }
 #endif
 }

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -1680,6 +1680,7 @@ class PackageBuilderTests: XCTestCase {
         var expectedPlatforms = [
             "linux": "0.0",
             "macos": "10.12",
+            "maccatalyst": "13.0",
             "ios": "9.0",
             "tvos": "9.0",
             "driverkit": "19.0",
@@ -1736,6 +1737,7 @@ class PackageBuilderTests: XCTestCase {
 
         expectedPlatforms = [
             "macos": "10.12",
+            "maccatalyst": "13.0",
             "tvos": "10.0",
             "linux": "0.0",
             "ios": "9.0",


### PR DESCRIPTION
This adds Mac Catalyst as a support platform, so that a minimum deployment target can be specified and conditional build settings can be configured.

(just like the earlier DriverKit patch)

rdar://60376383