### PR TITLE
[5.5] Make the struct in the default template public

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -291,8 +291,11 @@ public final class InitPackage {
         switch packageType {
         case .library:
             content = """
-                struct \(typeName) {
-                    var text = "Hello, World!"
+                public struct \(typeName) {
+                    public private(set) var text = "Hello, World!"
+
+                    public init() {
+                    }
                 }
 
                 """


### PR DESCRIPTION
This makes it easier to use it from clients which makes for a better default experience.

rdar://77110377

(cherry picked from commit fae7303169891815682c4088b5dae83d2f7bcdd7)