### PR TITLE
BuildSettingCondition should offer a Mac Catalyst condition (amend)

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1056,6 +1056,9 @@ public final class PackageBuilder {
             let oldestSupportedVersion: PlatformVersion
             if let xcTestMinimumDeploymentTarget = xcTestMinimumDeploymentTargets[platform], isTest {
                 oldestSupportedVersion = xcTestMinimumDeploymentTarget
+            } else if platform == .macCatalyst, let iOS = supportedPlatforms.first(where: { $0.platform == .iOS }) {
+                // If there was no deployment target specified for Mac Catalyst, fall back to the iOS deployment target.
+                oldestSupportedVersion = max(platform.oldestSupportedVersion, iOS.version)
             } else {
                 oldestSupportedVersion = platform.oldestSupportedVersion
             }


### PR DESCRIPTION
We also need Mac Catalyst to fall back to iOS in PackageBuilder

rdar://60376383

PR for release/5.5: #3460