### PR TITLE
[Collections] Fix auth token lookup

### DIFF
--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -19,6 +19,8 @@ import PackageModel
 import TSCBasic
 
 struct GitHubPackageMetadataProvider: PackageMetadataProvider {
+    private static let apiHostPrefix = "api."
+
     public var name: String = "GitHub"
 
     var configuration: Configuration
@@ -179,7 +181,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
                     let owner = String(url[ownerRange])
                     let repo = String(url[repoRange])
 
-                    return URL(string: "https://api.\(host)/repos/\(owner)/\(repo)")
+                    return URL(string: "https://\(Self.apiHostPrefix)\(host)/repos/\(owner)/\(repo)")
                 }
             }
             return nil
@@ -194,7 +196,8 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
         options.validResponseCodes = validResponseCodes
         options.authorizationProvider = { url in
             url.host.flatMap { host in
-                self.configuration.authTokens()?[.github(host)].flatMap { token in
+                let host = host.hasPrefix(Self.apiHostPrefix) ? String(host.dropFirst(Self.apiHostPrefix.count)) : host
+                return self.configuration.authTokens()?[.github(host)].flatMap { token in
                     "token \(token)"
                 }
             }

--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -209,7 +209,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
         try testWithTemporaryDirectory { tmpPath in
             let repoURL = "https://github.com/octocat/Hello-World.git"
             let apiURL = URL(string: "https://api.github.com/repos/octocat/Hello-World")!
-            let authTokens = [AuthTokenType.github("api.github.com"): "foo"]
+            let authTokens = [AuthTokenType.github("github.com"): "foo"]
 
             let handler: HTTPClient.Handler = { request, _, completion in
                 if request.headers.get("Authorization").first == "token \(authTokens.first!.value)" {
@@ -335,7 +335,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
         httpClient.configuration.requestHeaders!.add(name: "Cache-Control", value: "no-cache")
         var configuration = GitHubPackageMetadataProvider.Configuration()
         if let token = ProcessEnv.vars["GITHUB_API_TOKEN"] {
-            configuration.authTokens = { [.github("api.github.com"): token] }
+            configuration.authTokens = { [.github("github.com"): token] }
         }
         configuration.apiLimitWarningThreshold = 50
         configuration.cacheTTLInSeconds = -1 // Disable cache so we hit the API


### PR DESCRIPTION
Motivation:
In `AuthTokenType` `host` is the GitHub host (e.g., `github.com`), but when we look up auth token we use the GitHub API host (e.g., `api.github.com`). As a result the auth tokens are not used.

Modification:
Look up auth tokens with GitHub host by removing `api.` prefix.

rdar://77293200
