### PR TITLE
Fix resource bundle lookup

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -667,7 +667,7 @@ public final class SwiftTargetBuildDescription {
 
         extension Foundation.Bundle {
             static var module: Bundle = {
-                let mainPath = Bundle.main.bundlePath + "/" + "\(bundlePath.basename.asSwiftStringLiteralConstant)"
+                let mainPath = Bundle.main.bundleURL.appendingPathComponent("\(bundlePath.basename.asSwiftStringLiteralConstant)").path
                 let buildPath = "\(bundlePath.pathString.asSwiftStringLiteralConstant)"
 
                 let preferredBundle = Bundle(path: mainPath)

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -18,11 +18,10 @@ import Foundation
 import SPMBuildCore
 @_implementationOnly import SwiftDriver
 
-extension AbsolutePath {
-  fileprivate var asSwiftStringLiteralConstant: String {
-    return self.pathString.unicodeScalars
-              .reduce("", { $0 + $1.escaped(asASCII: false) })
-  }
+extension String {
+    fileprivate var asSwiftStringLiteralConstant: String {
+        return unicodeScalars.reduce("", { $0 + $1.escaped(asASCII: false) })
+    }
 }
 
 extension BuildParameters {
@@ -663,17 +662,13 @@ public final class SwiftTargetBuildDescription {
         guard let bundlePath = self.bundlePath else { return }
 
         let stream = BufferedOutputByteStream()
-
-        let mainPath: AbsolutePath =
-            AbsolutePath(Bundle.main.bundlePath).appending(component: bundlePath.basename)
-
         stream <<< """
         import class Foundation.Bundle
 
         extension Foundation.Bundle {
             static var module: Bundle = {
-                let mainPath = "\(mainPath.asSwiftStringLiteralConstant)"
-                let buildPath = "\(bundlePath.asSwiftStringLiteralConstant)"
+                let mainPath = Bundle.main.bundlePath + "\(bundlePath.basename.asSwiftStringLiteralConstant)"
+                let buildPath = "\(bundlePath.pathString.asSwiftStringLiteralConstant)"
 
                 let preferredBundle = Bundle(path: mainPath)
 

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -667,7 +667,7 @@ public final class SwiftTargetBuildDescription {
 
         extension Foundation.Bundle {
             static var module: Bundle = {
-                let mainPath = Bundle.main.bundlePath + "\(bundlePath.basename.asSwiftStringLiteralConstant)"
+                let mainPath = Bundle.main.bundlePath + "/" + "\(bundlePath.basename.asSwiftStringLiteralConstant)"
                 let buildPath = "\(bundlePath.pathString.asSwiftStringLiteralConstant)"
 
                 let preferredBundle = Bundle(path: mainPath)

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -2464,6 +2464,9 @@ final class BuildPlanTests: XCTestCase {
         let resourceAccessor = fooTarget.sources.first{ $0.basename == "resource_bundle_accessor.swift" }!
         let contents = try fs.readFileContents(resourceAccessor).cString
         XCTAssertTrue(contents.contains("extension Foundation.Bundle"), contents)
+        // Assert that `Bundle.main` is executed in the compiled binary (and not during compilation)
+        // See https://bugs.swift.org/browse/SR-14555 and https://github.com/apple/swift-package-manager/pull/2972/files#r623861646
+        XCTAssertTrue(contents.contains("let mainPath = Bundle.main.bundlePath +"), contents)
 
         let barTarget = try result.target(for: "Bar").swiftTarget()
         XCTAssertEqual(barTarget.objects.map{ $0.pathString }, [

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -2466,7 +2466,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertTrue(contents.contains("extension Foundation.Bundle"), contents)
         // Assert that `Bundle.main` is executed in the compiled binary (and not during compilation)
         // See https://bugs.swift.org/browse/SR-14555 and https://github.com/apple/swift-package-manager/pull/2972/files#r623861646
-        XCTAssertTrue(contents.contains("let mainPath = Bundle.main.bundlePath +"), contents)
+        XCTAssertTrue(contents.contains("let mainPath = Bundle.main."), contents)
 
         let barTarget = try result.target(for: "Bar").swiftTarget()
         XCTAssertEqual(barTarget.objects.map{ $0.pathString }, [


### PR DESCRIPTION
Fix the preferred lookup location for resource bundles.

### Motivation:

The preferred lookup location for resource bundles is next to the binary that is executed. This was previously achieved by searching next to `Bundle.main.bundlePath`. [This change](https://github.com/apple/swift-package-manager/pull/2972/files#diff-13eb4b18e8a4f2de8467dae905be6bdc133208159aded4aa6dbb6a03be21c6bdL584) moved the execution of `Bundle.main` outside of the generated bundle accessor code - and thus uses `Bundle.main` of the compilation process.

### Modifications:

Move the `Bundle.main` call back to the generated code.

### Result:

The preferred resource bundle lookup will again be the location of the compiled binary.
Fixes https://bugs.swift.org/browse/SR-14555.
