### PR TITLE
Unify the two versions of PackageDescription into a single one using availability annotations instead of compile conditionals

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -113,19 +113,25 @@ let package = Package(
         ),
     ],
     targets: [
-        // The `PackageDescription` targets define the API which is available to
-        // the `Package.swift` manifest files. We build the latest API version
-        // here which is used when building and running swiftpm without the
-        // bootstrap script.
+        // The `PackageDescription` target provides the API that is available
+        // to `Package.swift` manifests. Here we build a debug version of the
+        // library; the bootstrap scripts build the deployable version.
         .target(
-            /** Package Definition API */
             name: "PackageDescription",
             swiftSettings: [
-                .define("PACKAGE_DESCRIPTION_4_2"),
+                .unsafeFlags(["-package-description-version", "999.0"]),
+                .unsafeFlags(["-enable-library-evolution"])
             ]),
-        
+
+        // The `PackagePlugin` target provides the API that is available to
+        // plugin scripts. Here we build a debug version of the library; the
+        // bootstrap scripts build the deployable version.
         .target(
-            name: "PackagePlugin"),
+            name: "PackagePlugin",
+            swiftSettings: [
+                .unsafeFlags(["-package-description-version", "999.0"]),
+                .unsafeFlags(["-enable-library-evolution"])
+            ]),
 
         // MARK: SwiftPM specific support libraries
 

--- a/Sources/PackageDescription/CMakeLists.txt
+++ b/Sources/PackageDescription/CMakeLists.txt
@@ -1,75 +1,73 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-foreach(PACKAGE_DESCRIPTION_VERSION 4 4_2)
-    add_library(PD${PACKAGE_DESCRIPTION_VERSION}
-        BuildSettings.swift
-        LanguageStandardSettings.swift
-        PackageDescription.swift
-        PackageDependency.swift
-        PackageRequirement.swift
-        Product.swift
-        Resource.swift
-        SupportedPlatforms.swift
-        Target.swift
-        Version.swift
-        Version+StringLiteralConvertible.swift)
+add_library(PackageDescription
+  BuildSettings.swift
+  LanguageStandardSettings.swift
+  PackageDescription.swift
+  PackageDependency.swift
+  PackageRequirement.swift
+  Product.swift
+  Resource.swift
+  SupportedPlatforms.swift
+  Target.swift
+  Version.swift
+  Version+StringLiteralConvertible.swift)
 
-    target_compile_definitions(PD${PACKAGE_DESCRIPTION_VERSION} PRIVATE
-        PACKAGE_DESCRIPTION_${PACKAGE_DESCRIPTION_VERSION})
+target_compile_options(PackageDescription PUBLIC
+  $<$<COMPILE_LANGUAGE:Swift>:-package-description-version$<SEMICOLON>999.0>)
+target_compile_options(PackageDescription PUBLIC
+  $<$<COMPILE_LANGUAGE:Swift>:-enable-library-evolution>)
 
-    if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
-        set(SWIFT_INTERFACE_PATH ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}/PackageDescription.swiftinterface)
-        target_compile_options(PD${PACKAGE_DESCRIPTION_VERSION} PUBLIC
-            $<$<COMPILE_LANGUAGE:Swift>:-enable-library-evolution>)
-        target_compile_options(PD${PACKAGE_DESCRIPTION_VERSION} PUBLIC
-            $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${SWIFT_INTERFACE_PATH}>)
-        target_link_options(PD${PACKAGE_DESCRIPTION_VERSION} PRIVATE
-            "SHELL:-Xlinker -install_name -Xlinker @rpath/libPackageDescription.dylib")
-    endif()
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
+  set(SWIFT_INTERFACE_PATH ${CMAKE_BINARY_DIR}/pm/ManifestAPI/PackageDescription.swiftinterface)
+  target_compile_options(PackageDescription PUBLIC
+    $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${SWIFT_INTERFACE_PATH}>)
+  target_link_options(PackageDescription PRIVATE
+    "SHELL:-Xlinker -install_name -Xlinker @rpath/libPackageDescription.dylib")
+endif()
 
-    set_target_properties(PD${PACKAGE_DESCRIPTION_VERSION} PROPERTIES
-        Swift_MODULE_NAME PackageDescription
-        Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}
-        INSTALL_NAME_DIR \\@rpath
-        OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}
-        OUTPUT_NAME PackageDescription
-        ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}
-        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}
-        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}
-    )
+set_target_properties(PackageDescription PROPERTIES
+    Swift_MODULE_NAME PackageDescription
+    Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
+    INSTALL_NAME_DIR \\@rpath
+    OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
+    OUTPUT_NAME PackageDescription
+    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
+)
 
-    if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-      if(Foundation_FOUND)
-        target_link_libraries(PD${PACKAGE_DESCRIPTION_VERSION} PRIVATE
-          Foundation)
-      endif()
-      target_link_options(PD${PACKAGE_DESCRIPTION_VERSION} PRIVATE
-        "SHELL:-no-toolchain-stdlib-rpath")
-      set_target_properties(PD${PACKAGE_DESCRIPTION_VERSION} PROPERTIES
-          BUILD_WITH_INSTALL_RPATH TRUE
-          INSTALL_RPATH "$ORIGIN/../../$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
-    endif()
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  if(Foundation_FOUND)
+    target_link_libraries(PackageDescription PRIVATE
+      Foundation)
+  endif()
+  target_link_options(PackageDescription PRIVATE
+    "SHELL:-no-toolchain-stdlib-rpath")
+  set_target_properties(PackageDescription PROPERTIES
+    BUILD_WITH_INSTALL_RPATH TRUE
+    INSTALL_RPATH "$ORIGIN/../../$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
+endif()
 
-    if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
-        install(FILES
-            ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}/PackageDescription.swiftinterface
-            ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}/PackageDescription.swiftdoc
-            DESTINATION lib/swift/pm/${PACKAGE_DESCRIPTION_VERSION}
-        )
-    else()
-        install(FILES
-            ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}/PackageDescription.swiftmodule
-            ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}/PackageDescription.swiftdoc
-            DESTINATION lib/swift/pm/${PACKAGE_DESCRIPTION_VERSION}
-        )
-    endif()
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
+  install(FILES
+    ${CMAKE_BINARY_DIR}/pm/ManifestAPI/PackageDescription.swiftinterface
+    ${CMAKE_BINARY_DIR}/pm/ManifestAPI/PackageDescription.swiftdoc
+    DESTINATION lib/swift/pm/ManifestAPI
+  )
+else()
+  install(FILES
+    ${CMAKE_BINARY_DIR}/pm/ManifestAPI/PackageDescription.swiftmodule
+    ${CMAKE_BINARY_DIR}/pm/ManifestAPI/PackageDescription.swiftdoc
+    DESTINATION lib/swift/pm/ManifestAPI
+  )
+endif()
 
-    install(TARGETS PD${PACKAGE_DESCRIPTION_VERSION}
-      DESTINATION lib/swift/pm/${PACKAGE_DESCRIPTION_VERSION})
-endforeach()
+install(TARGETS PackageDescription
+  DESTINATION lib/swift/pm/ManifestAPI)

--- a/Sources/PackageDescription/LanguageStandardSettings.swift
+++ b/Sources/PackageDescription/LanguageStandardSettings.swift
@@ -144,7 +144,6 @@ public enum CXXLanguageStandard: String, Encodable {
     case gnucxx20 = "gnu++20"
 }
 
-#if !PACKAGE_DESCRIPTION_4
 /// The version of the Swift language to use for compiling Swift sources in the package.
 public enum SwiftVersion {
     @available(_PackageDescription, introduced: 4, obsoleted: 5)
@@ -187,4 +186,3 @@ extension SwiftVersion: Encodable {
         try container.encode(value)
     }
 }
-#endif

--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -147,11 +147,7 @@ extension Package.Dependency {
         url: String,
         _ range: Range<Version>
     ) -> Package.Dependency {
-      #if PACKAGE_DESCRIPTION_4
         return .init(name: nil, url: url, requirement: .rangeItem(range))
-      #else
-        return .init(name: nil, url: url, requirement: ._rangeItem(range))
-      #endif
     }
 
     /// Adds a package dependency starting with a specific minimum version, up to
@@ -172,11 +168,7 @@ extension Package.Dependency {
         url: String,
         _ range: Range<Version>
     ) -> Package.Dependency {
-      #if PACKAGE_DESCRIPTION_4
         return .init(name: name, url: url, requirement: .rangeItem(range))
-      #else
-        return .init(name: name, url: url, requirement: ._rangeItem(range))
-      #endif
     }
 
     /// Adds a package dependency starting with a specific minimum version, going
@@ -202,11 +194,7 @@ extension Package.Dependency {
             upper.major, upper.minor, upper.patch + 1,
             prereleaseIdentifiers: upper.prereleaseIdentifiers,
             buildMetadataIdentifiers: upper.buildMetadataIdentifiers)
-      #if PACKAGE_DESCRIPTION_4
         return .init(name: nil, url: url, requirement: .rangeItem(range.lowerBound..<upperBound))
-      #else
-        return .init(name: nil, url: url, requirement: ._rangeItem(range.lowerBound..<upperBound))
-      #endif
     }
 
     /// Adds a package dependency starting with a specific minimum version, going
@@ -233,14 +221,9 @@ extension Package.Dependency {
             upper.major, upper.minor, upper.patch + 1,
             prereleaseIdentifiers: upper.prereleaseIdentifiers,
             buildMetadataIdentifiers: upper.buildMetadataIdentifiers)
-      #if PACKAGE_DESCRIPTION_4
         return .init(name: name, url: url, requirement: .rangeItem(range.lowerBound..<upperBound))
-      #else
-        return .init(name: name, url: url, requirement: ._rangeItem(range.lowerBound..<upperBound))
-      #endif
     }
 
-  #if !PACKAGE_DESCRIPTION_4
     /// Adds a package dependency to a local package on the filesystem.
     ///
     /// The Swift Package Manager uses the package dependency as-is
@@ -253,7 +236,7 @@ extension Package.Dependency {
     public static func package(
         path: String
     ) -> Package.Dependency {
-        return .init(name: nil, url: path, requirement: ._localPackageItem)
+        return .init(name: nil, url: path, requirement: .localPackageItem)
     }
 
     /// Adds a package dependency to a local package on the filesystem.
@@ -271,9 +254,8 @@ extension Package.Dependency {
         name: String? = nil,
         path: String
     ) -> Package.Dependency {
-        return .init(name: name, url: path, requirement: ._localPackageItem)
+        return .init(name: name, url: path, requirement: .localPackageItem)
     }
-  #endif
 }
 
 // Mark common APIs used by mistake as unavailable to provide better error messages.

--- a/Sources/PackageDescription/PackageRequirement.swift
+++ b/Sources/PackageDescription/PackageRequirement.swift
@@ -24,11 +24,7 @@ extension Package.Dependency.Requirement: Encodable {
     /// - Parameters:
     ///      - version: The exact version of the dependency for this requirement.
     public static func exact(_ version: Version) -> Package.Dependency.Requirement {
-      #if PACKAGE_DESCRIPTION_4
         return .exactItem(version)
-      #else
-        return ._exactItem(version)
-      #endif
     }
 
     /// Returns a requirement for a source control revision such as the hash of a commit.
@@ -45,11 +41,7 @@ extension Package.Dependency.Requirement: Encodable {
     /// - Parameters:
     ///     - ref: The Git revision, usually a commit hash.
     public static func revision(_ ref: String) -> Package.Dependency.Requirement {
-      #if PACKAGE_DESCRIPTION_4
         return .revisionItem(ref)
-      #else
-        return ._revisionItem(ref)
-      #endif
     }
 
     /// Returns a requirement for a source control branch.
@@ -67,11 +59,7 @@ extension Package.Dependency.Requirement: Encodable {
     /// - Parameters:
     ///     - name: The name of the branch.
     public static func branch(_ name: String) -> Package.Dependency.Requirement {
-      #if PACKAGE_DESCRIPTION_4
         return .branchItem(name)
-      #else
-        return ._branchItem(name)
-      #endif
     }
 
     /// Returns a requirement for a version range, starting at the given minimum
@@ -80,11 +68,7 @@ extension Package.Dependency.Requirement: Encodable {
     /// - Parameters:
     ///     - version: The minimum version for the version range.
     public static func upToNextMajor(from version: Version) -> Package.Dependency.Requirement {
-      #if PACKAGE_DESCRIPTION_4
         return .rangeItem(version..<Version(version.major + 1, 0, 0))
-      #else
-        return ._rangeItem(version..<Version(version.major + 1, 0, 0))
-      #endif
     }
 
     /// Returns a requirement for a version range, starting at the given minimum
@@ -93,11 +77,7 @@ extension Package.Dependency.Requirement: Encodable {
     /// - Parameters:
     ///     - version: The minimum version for the version range.
     public static func upToNextMinor(from version: Version) -> Package.Dependency.Requirement {
-      #if PACKAGE_DESCRIPTION_4
         return .rangeItem(version..<Version(version.major, version.minor + 1, 0))
-      #else
-        return ._rangeItem(version..<Version(version.major, version.minor + 1, 0))
-      #endif
     }
 
     private enum CodingKeys: CodingKey {
@@ -117,7 +97,6 @@ extension Package.Dependency.Requirement: Encodable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-      #if PACKAGE_DESCRIPTION_4
         switch self {
         case .rangeItem(let range):
             try container.encode(Kind.range, forKey: .type)
@@ -135,24 +114,5 @@ extension Package.Dependency.Requirement: Encodable {
         case .localPackageItem:
             try container.encode(Kind.localPackage, forKey: .type)
         }
-      #else
-        switch self {
-        case ._rangeItem(let range):
-            try container.encode(Kind.range, forKey: .type)
-            try container.encode(range.lowerBound, forKey: .lowerBound)
-            try container.encode(range.upperBound, forKey: .upperBound)
-        case ._exactItem(let version):
-            try container.encode(Kind.exact, forKey: .type)
-            try container.encode(version, forKey: .identifier)
-        case ._branchItem(let identifier):
-            try container.encode(Kind.branch, forKey: .type)
-            try container.encode(identifier, forKey: .identifier)
-        case ._revisionItem(let identifier):
-            try container.encode(Kind.revision, forKey: .type)
-            try container.encode(identifier, forKey: .identifier)
-        case ._localPackageItem:
-            try container.encode(Kind.localPackage, forKey: .type)
-        }
-      #endif
     }
 }

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -36,15 +36,9 @@ public final class Target {
 
     /// The different types of a target's dependency on another entity.
     public enum Dependency {
-      #if PACKAGE_DESCRIPTION_4
-        case targetItem(name: String)
-        case productItem(name: String, package: String?)
-        case byNameItem(name: String)
-      #else
-        case _targetItem(name: String, condition: TargetDependencyCondition?)
-        case _productItem(name: String, package: String?, condition: TargetDependencyCondition?)
-        case _byNameItem(name: String, condition: TargetDependencyCondition?)
-      #endif
+        case targetItem(name: String, condition: TargetDependencyCondition?)
+        case productItem(name: String, package: String?, condition: TargetDependencyCondition?)
+        case byNameItem(name: String, condition: TargetDependencyCondition?)
     }
 
     /// The name of the target.
@@ -991,11 +985,7 @@ extension Target.Dependency {
     ///   - name: The name of the target.
     @available(_PackageDescription, obsoleted: 5.3)
     public static func target(name: String) -> Target.Dependency {
-      #if PACKAGE_DESCRIPTION_4
-        return .targetItem(name: name)
-      #else
-        return ._targetItem(name: name, condition: nil)
-      #endif
+        return .targetItem(name: name, condition: nil)
     }
 
     /// Creates a dependency on a product from a package dependency.
@@ -1005,11 +995,7 @@ extension Target.Dependency {
     ///   - package: The name of the package.
     @available(_PackageDescription, obsoleted: 5.2, message: "the 'package' argument is mandatory as of tools version 5.2")
     public static func product(name: String, package: String? = nil) -> Target.Dependency {
-      #if PACKAGE_DESCRIPTION_4
-        return .productItem(name: name, package: package)
-      #else
-        return ._productItem(name: name, package: package, condition: nil)
-      #endif
+        return .productItem(name: name, package: package, condition: nil)
     }
 
     /// Creates a dependency that resolves to either a target or a product with the specified name.
@@ -1020,14 +1006,9 @@ extension Target.Dependency {
     /// The Swift Package Manager creates the by-name dependency after it has loaded the package graph.
     @available(_PackageDescription, obsoleted: 5.3)
     public static func byName(name: String) -> Target.Dependency {
-      #if PACKAGE_DESCRIPTION_4
-        return .byNameItem(name: name)
-      #else
-        return ._byNameItem(name: name, condition: nil)
-      #endif
+        return .byNameItem(name: name, condition: nil)
     }
 
-  #if !PACKAGE_DESCRIPTION_4
     /// Creates a dependency on a product from a package dependency.
     ///
     /// - parameters:
@@ -1038,7 +1019,7 @@ extension Target.Dependency {
         name: String,
         package: String
     ) -> Target.Dependency {
-        return ._productItem(name: name, package: package, condition: nil)
+        return .productItem(name: name, package: package, condition: nil)
     }
 
     /// Creates a dependency on a target in the same package.
@@ -1049,7 +1030,7 @@ extension Target.Dependency {
     ///       dependency for a specific platform.
     @available(_PackageDescription, introduced: 5.3)
     public static func target(name: String, condition: TargetDependencyCondition? = nil) -> Target.Dependency {
-        return ._targetItem(name: name, condition: condition)
+        return .targetItem(name: name, condition: condition)
     }
 
     /// Creates a target dependency on a product from a package dependency.
@@ -1065,7 +1046,7 @@ extension Target.Dependency {
         package: String,
         condition: TargetDependencyCondition? = nil
     ) -> Target.Dependency {
-        return ._productItem(name: name, package: package, condition: condition)
+        return .productItem(name: name, package: package, condition: condition)
     }
 
     /// Creates a by-name dependency that resolves to either a target or a product but after the Swift Package Manager
@@ -1077,9 +1058,8 @@ extension Target.Dependency {
     ///       dependency for a specific platform.
     @available(_PackageDescription, introduced: 5.3)
     public static func byName(name: String, condition: TargetDependencyCondition? = nil) -> Target.Dependency {
-        return ._byNameItem(name: name, condition: condition)
+        return .byNameItem(name: name, condition: condition)
     }
-  #endif
 }
 
 extension Target.PluginCapability {
@@ -1124,11 +1104,7 @@ extension Target.Dependency: ExpressibleByStringLiteral {
     /// - parameters:
     ///   - value: A string literal.
     public init(stringLiteral value: String) {
-      #if PACKAGE_DESCRIPTION_4
-        self = .byNameItem(name: value)
-      #else
-        self = ._byNameItem(name: value, condition: nil)
-      #endif
+        self = .byNameItem(name: value, condition: nil)
     }
 }
 

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -938,7 +938,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
     /// Returns the runtime path given the manifest version and path to libDir.
     private func runtimePath(for version: ToolsVersion) -> AbsolutePath {
         // Bin dir will be set when developing swiftpm without building all of the runtimes.
-        return resources.binDir ?? resources.libDir.appending(version.runtimeSubpath)
+        return resources.binDir ?? resources.libDir.appending(component: "ManifestAPI")
     }
 
     /// Returns path to the manifest database inside the given cache directory.

--- a/Sources/PackagePlugin/CMakeLists.txt
+++ b/Sources/PackagePlugin/CMakeLists.txt
@@ -7,60 +7,63 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(PackagePlugin
-    PublicAPI/CommandConstructor.swift
-    PublicAPI/DiagnosticsEmitter.swift
-    PublicAPI/FileList.swift
-    PublicAPI/Globals.swift
-    PublicAPI/Path.swift
-    PublicAPI/TargetBuildContext.swift
-    ImplementationDetails.swift)
+  PublicAPI/CommandConstructor.swift
+  PublicAPI/DiagnosticsEmitter.swift
+  PublicAPI/FileList.swift
+  PublicAPI/Globals.swift
+  PublicAPI/Path.swift
+  PublicAPI/TargetBuildContext.swift
+  ImplementationDetails.swift)
+
+target_compile_options(PackagePlugin PUBLIC
+  $<$<COMPILE_LANGUAGE:Swift>:-package-description-version$<SEMICOLON>999.0>)
+target_compile_options(PackagePlugin PUBLIC
+  $<$<COMPILE_LANGUAGE:Swift>:-enable-library-evolution>)
   
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
-    set(SWIFT_INTERFACE_PATH ${CMAKE_BINARY_DIR}/pm/PackagePlugin.swiftinterface)
-    target_compile_options(PackagePlugin PUBLIC
-        $<$<COMPILE_LANGUAGE:Swift>:-enable-library-evolution>)
-    target_compile_options(PackagePlugin PUBLIC
-        $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${SWIFT_INTERFACE_PATH}>)
-    target_link_options(PackagePlugin PRIVATE
-        "SHELL:-Xlinker -install_name -Xlinker @rpath/libPackagePlugin.dylib")
+  set(SWIFT_INTERFACE_PATH ${CMAKE_BINARY_DIR}/pm/PluginAPI/PackagePlugin.swiftinterface)
+  target_compile_options(PackagePlugin PUBLIC
+    $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${SWIFT_INTERFACE_PATH}>)
+  target_link_options(PackagePlugin PRIVATE
+    "SHELL:-Xlinker -install_name -Xlinker @rpath/libPackagePlugin.dylib")
 endif()
 
 set_target_properties(PackagePlugin PROPERTIES
-    Swift_MODULE_NAME PackagePlugin
-    Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/pm
-    INSTALL_NAME_DIR \\@rpath
-    OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm
-    OUTPUT_NAME PackagePlugin
-    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm
-    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm
+  Swift_MODULE_NAME PackagePlugin
+  Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/pm/PluginAPI
+  INSTALL_NAME_DIR \\@rpath
+  OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/PluginAPI
+  OUTPUT_NAME PackagePlugin
+  ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/PluginAPI
+  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/PluginAPI
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/PluginAPI
 )
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    if(Foundation_FOUND)
-        target_link_libraries(PackagePlugin PRIVATE
-            Foundation)
-    endif()
-    target_link_options(PackagePlugin PRIVATE
-        "SHELL:-no-toolchain-stdlib-rpath")
-    set_target_properties(PackagePlugin PROPERTIES
-        BUILD_WITH_INSTALL_RPATH TRUE
-        INSTALL_RPATH "$ORIGIN/../../$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
+  if(Foundation_FOUND)
+    target_link_libraries(PackagePlugin PRIVATE
+      Foundation)
+  endif()
+  target_link_options(PackagePlugin PRIVATE
+    "SHELL:-no-toolchain-stdlib-rpath")
+  set_target_properties(PackagePlugin PROPERTIES
+    BUILD_WITH_INSTALL_RPATH TRUE
+    INSTALL_RPATH "$ORIGIN/../../$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
 endif()
 
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
-    install(FILES
-        ${CMAKE_BINARY_DIR}/pm/PackagePlugin.swiftinterface
-        ${CMAKE_BINARY_DIR}/pm/PackagePlugin.swiftdoc
-        DESTINATION lib/swift/pm
-    )
+  install(FILES
+    ${CMAKE_BINARY_DIR}/pm/PluginAPI/PackagePlugin.swiftinterface
+    ${CMAKE_BINARY_DIR}/pm/PluginAPI/PackagePlugin.swiftdoc
+    DESTINATION lib/swift/pm/PluginAPI
+  )
 else()
-    install(FILES
-        ${CMAKE_BINARY_DIR}/pm/PackagePlugin.swiftmodule
-        ${CMAKE_BINARY_DIR}/pm/PackagePlugin.swiftdoc
-        DESTINATION lib/swift/pm
-    )
+  install(FILES
+    ${CMAKE_BINARY_DIR}/pm/PluginAPI/PackagePlugin.swiftmodule
+    ${CMAKE_BINARY_DIR}/pm/PluginAPI/PackagePlugin.swiftdoc
+    DESTINATION lib/swift/pm/PluginAPI
+  )
 endif()
 
 install(TARGETS PackagePlugin
-    DESTINATION lib/swift/pm)
+  DESTINATION lib/swift/pm/PluginAPI)

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -50,7 +50,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
         // FIXME: Much of this is copied from the ManifestLoader and should be consolidated.
 
         // Bin dir will be set when developing swiftpm without building all of the runtimes.
-        let runtimePath = self.resources.binDir ?? self.resources.libDir
+        let runtimePath = self.resources.binDir ?? self.resources.libDir.appending(component: "PluginAPI")
 
         // Compile the package plugin script.
         var command = [resources.swiftCompiler.pathString]

--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -81,7 +81,7 @@ public func xcodeProject(
         var interpreterFlags = manifestLoader.interpreterFlags(for: package.manifest.toolsVersion)
         if !interpreterFlags.isEmpty {
             // Patch the interpreter flags to use Xcode supported toolchain macro instead of the resolved path.
-            interpreterFlags[3] = "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/\(package.manifest.toolsVersion.runtimeSubpath.pathString)"
+            interpreterFlags[3] = "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/ManifestAPI"
         }
         pdTarget.buildSettings.common.OTHER_SWIFT_FLAGS += interpreterFlags
         pdTarget.buildSettings.common.SWIFT_VERSION = package.manifest.toolsVersion.swiftLanguageVersion.xcodeBuildSettingValue

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -98,7 +98,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             guard case let ManifestParseError.invalidManifestFormat(output, _) = error else {
                 return XCTFail()
             }
-            XCTAssertMatch(output, .and(.or(.contains("expected argument type"), .contains("expected element type")), .contains("SwiftVersion")))
+            XCTAssertMatch(output, .and(.contains("'init(name:pkgConfig:providers:products:dependencies:targets:swiftLanguageVersions:cLanguageStandard:cxxLanguageStandard:)' is unavailable"), .contains("was obsoleted in PackageDescription 4.2")))
         }
 
         // Check when Swift language versions is empty.

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -397,22 +397,21 @@ def install_swiftpm(prefix, args):
     runtime_lib_dest = os.path.join(prefix, "lib", "swift", "pm")
     runtime_lib_src = os.path.join(args.bootstrap_dir, "pm")
 
-    for runtime in ["4", "4_2"]:
-        files_to_install = ["libPackageDescription" + g_shared_lib_ext]
-        if platform.system() == 'Darwin':
-            files_to_install.append("PackageDescription.swiftinterface")
-        else:
-            files_to_install.append("PackageDescription.swiftmodule")
-        files_to_install.append("PackageDescription.swiftdoc")
+    files_to_install = ["libPackageDescription" + g_shared_lib_ext]
+    if platform.system() == 'Darwin':
+        files_to_install.append("PackageDescription.swiftinterface")
+    else:
+        files_to_install.append("PackageDescription.swiftmodule")
+    files_to_install.append("PackageDescription.swiftdoc")
 
-        for file in files_to_install:
-            src = os.path.join(runtime_lib_src, runtime, file)
-            dest = os.path.join(runtime_lib_dest, runtime, file)
-            mkdir_p(os.path.dirname(dest))
+    for file in files_to_install:
+        src = os.path.join(runtime_lib_src, "ManifestAPI", file)
+        dest = os.path.join(runtime_lib_dest, "ManifestAPI", file)
+        mkdir_p(os.path.dirname(dest))
 
-            note("Installing %s to %s" % (src, dest))
+        note("Installing %s to %s" % (src, dest))
 
-            file_util.copy_file(src, dest, update=1)
+        file_util.copy_file(src, dest, update=1)
 
     files_to_install = ["libPackagePlugin" + g_shared_lib_ext]
     if platform.system() == 'Darwin':
@@ -422,8 +421,8 @@ def install_swiftpm(prefix, args):
     files_to_install.append("PackagePlugin.swiftdoc")
 
     for file in files_to_install:
-        src = os.path.join(runtime_lib_src, file)
-        dest = os.path.join(runtime_lib_dest, file)
+        src = os.path.join(runtime_lib_src, "PluginAPI", file)
+        dest = os.path.join(runtime_lib_dest, "PluginAPI", file)
         mkdir_p(os.path.dirname(dest))
 
         note("Installing %s to %s" % (src, dest))


### PR DESCRIPTION
Replace the compile-time conditionals in PackageDescription with availability annotations, and build a single runtime library that can be used for all package tools versions.

### Motivation:

This is preparatory work for https://github.com/apple/swift-package-manager/pull/3431 and will also make it easier for clients of libSwiftPM, since only one version of PackageDescription needs to be built.

### Background:

The runtime support library for PackageDescription is currently built twice:  once for SwiftPM 4.0 and another time for 4.2 and later.  This is done using compile-time conditionals, producing two separate binaries in the file system.  Code in the manifest loader chooses between them based on the declared tools version of the package.

Having two versions of the library has several problems:
- it makes the build scripts more complicated; this is true for the bootstrap script, the CMake files, and the XBS build script
- it makes the runtime code more complicated, and because PackageDescription 4 isn’t encountered as much, errors can go undetected
- because SwiftPM doesn’t support building multiple version of the same target, only 4.2 and later is available in debug builds

We can unify the two versions using @availability annotations, so that we only need one PackageDescription library.  We should still keep it in a separate subdirectory from the PackagePlugins runtime support library.  Instead of using the names “4” and “4_2” as the subdirectory names, we should take this opportunity to separate them based on something more meaningful, such as “ManifestAPI” and “PluginAPI”.

### Modifications:

- replace compile-time conditionals with availability annotations
- adjust the package manifest to pass `-package-description-version 5.5` and `-enable-library-evolution`
- adjust a unit test to account for a different error message now when using 4.2 and trying to use ints for SwiftLanguageVersion

### Result:

This builds PackageDescription libraries that aren't dependent on the compile time condition.

rdar://77441062