### PR TITLE
Change branch dependencies on TSC, LLBuild, and SwiftDriver from `main` to `release/5.5`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -335,7 +335,7 @@ let package = Package(
 // this right now.
 
 /// When not using local dependencies, the branch to use for llbuild and TSC repositories.
-let relatedDependenciesBranch = "main"
+let relatedDependenciesBranch = "release/5.5"
 
 if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {


### PR DESCRIPTION
This switches the branch dependencies for `swift-tools-support-core`, `swift-llbuild`, and `swift-driver` (as we do for every release branch).  This will be come more important as `main` starts to diverge from `release/5.5`.

This depends on https://github.com/apple/swift-driver/pull/626