### PR TITLE
enable netrc on non-darwin platforms

### DIFF
--- a/Fixtures/DependencyResolution/External/XCFramework/Foo.xcframework/Info.plist
+++ b/Fixtures/DependencyResolution/External/XCFramework/Foo.xcframework/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>AvailableLibraries</key>
+    <array>
+        <dict>
+            <key>LibraryIdentifier</key>
+            <string>macos-x86_64</string>
+            <key>LibraryPath</key>
+            <string>Framework.framework</string>
+            <key>SupportedArchitectures</key>
+            <array>
+                <string>x86_64</string>
+            </array>
+            <key>SupportedPlatform</key>
+            <string>macos</string>
+        </dict>
+    </array>
+    <key>CFBundlePackageType</key>
+    <string>XFWK</string>
+    <key>XCFrameworkFormatVersion</key>
+    <string>1.0</string>
+</dict>
+</plist>

--- a/Fixtures/DependencyResolution/External/XCFramework/Foo/Foo.swift
+++ b/Fixtures/DependencyResolution/External/XCFramework/Foo/Foo.swift
@@ -1,0 +1,3 @@
+public func foo() {
+	{}()
+}

--- a/Fixtures/DependencyResolution/External/XCFramework/Package.swift
+++ b/Fixtures/DependencyResolution/External/XCFramework/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "Foo",
+    products: [
+        .library(name: "Foo", targets: ["Foo", "XCFramework"]),
+    ],
+    targets: [
+        .target(name: "Foo", path: "./Foo"),
+        .binaryTarget(name: "XCFramework", path: "./Foo.xcframework")
+    ]
+)

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -439,19 +439,6 @@ public class SwiftTool {
         if !options.archs.isEmpty && options.customCompileTriple != nil {
             diagnostics.emit(.mutuallyExclusiveArgumentsError(arguments: ["--arch", "--triple"]))
         }
-        
-        if options.netrcFilePath != nil {
-            // --netrc-file option only supported on macOS >=10.13
-            #if os(macOS)
-            if #available(macOS 10.13, *) {
-                // ok, check succeeds
-            } else {
-                diagnostics.emit(error: "'--netrc-file' option is only supported on macOS >=10.13")
-            }
-            #else
-            diagnostics.emit(error: "'--netrc-file' option is only supported on macOS >=10.13")
-            #endif
-        }
 
         // --enable-test-discovery should never be called on darwin based platforms
         #if canImport(Darwin)

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1589,10 +1589,8 @@ extension Workspace {
         let tempDiagnostics = DiagnosticsEngine()
         let result = ThreadSafeArrayStore<ManagedArtifact>()
 
-        var authProvider: AuthorizationProviding? = nil
-        #if os(macOS) // Netrc feature currently only supported on macOS
-        authProvider = try? Netrc.load(fromFileAtPath: netrcFilePath).get()
-        #endif
+        // FIXME: should this handle the error more gracefully?
+        let authProvider: AuthorizationProviding? = try? Netrc.load(fromFileAtPath: netrcFilePath).get()
 
         // zip files to download
         // stored in a thread-safe way as we may fetch more from "ari" files

--- a/Tests/BasicsTests/URLSessionHTTPClientTests.swift
+++ b/Tests/BasicsTests/URLSessionHTTPClientTests.swift
@@ -17,10 +17,7 @@ import FoundationNetworking
 #endif
 import TSCBasic
 import TSCTestSupport
-// // Netrc only available on macOS for now
-#if os(macOS)
 import struct TSCUtility.Netrc
-#endif
 import XCTest
 
 final class URLSessionHTTPClientTest: XCTestCase {


### PR DESCRIPTION
motivation:
* netrc functionality is useful on all platforms
* underlying functionality is avaialbe via https://github.com/apple/swift-tools-support-core/pull/210

changes:
* remove platforms restructions where appropriate
* add test fixute that actually exercises the netrc parsing logic
* adjust tests to run on all platforms
