### PR TITLE
Add .swiftpm/config/registries.json to default .gitignore

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -260,6 +260,7 @@ public final class InitPackage {
                 /*.xcodeproj
                 xcuserdata/
                 DerivedData/
+                .swiftpm/config
                 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 
                 """

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -260,7 +260,7 @@ public final class InitPackage {
                 /*.xcodeproj
                 xcuserdata/
                 DerivedData/
-                .swiftpm/config
+                .swiftpm/config/registries.json
                 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 
                 """


### PR DESCRIPTION
This PR adds `.swiftpm/config` to the `.gitignore` file in the new project template.

## Motivation:

As discussed in SE-0292, a user may inadvertently reveal the existence of a private registry or expose hardcoded credentials by checking in their project's `.swiftpm/config` file or directory. Adding this entry to the `.gitignore` file in the new project template significantly minimize the possibility of the user leaking credentials in the future.

## Modifications:

```diff
+ .swiftpm/config
```

## Result:

After this change, all future projects created by running swift package init will default to ignoring `.swiftpm/config` files (which covers both the file `.swiftpm/config` if it's a file, and the contents of the directory if `.swiftpm/config/` is a directory).

Existing packages will be unaffected.