### PR TITLE
Revert "Use implementation-only imports"

### DIFF
--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -16,7 +16,7 @@
 @_implementationOnly import ucrt
 @_implementationOnly import struct WinSDK.HANDLE
 #endif
-@_implementationOnly import Foundation
+import Foundation
 
 /// The configuration of a Swift package.
 ///

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-@_implementationOnly import Foundation
+import Foundation
 
 /// A target, the basic building block of a Swift package.
 ///


### PR DESCRIPTION
Reverts apple/swift-package-manager#3404

Reverting because it this does have impact on existing manifests,  see: apple/swift-standard-library-preview#4