### PR TITLE
[Collections] Add information about metadata provider to getPackageMetadata result

### DIFF
--- a/Sources/PackageCollections/Model/Package.swift
+++ b/Sources/PackageCollections/Model/Package.swift
@@ -238,7 +238,7 @@ extension PackageCollectionsModel.Package {
 }
 
 extension PackageCollectionsModel {
-    public typealias PackageMetadata = (package: PackageCollectionsModel.Package, collections: [PackageCollectionsModel.CollectionIdentifier])
+    public typealias PackageMetadata = (package: PackageCollectionsModel.Package, collections: [PackageCollectionsModel.CollectionIdentifier], provider: PackageMetadataProviderContext?)
 }
 
 // MARK: - Utilities

--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -170,6 +170,16 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
         }
     }
 
+    func getAuthTokenType(for reference: PackageReference) -> AuthTokenType? {
+        guard reference.kind == .remote, let baseURL = Self.apiURL(reference.location) else {
+            return nil
+        }
+
+        return baseURL.host.flatMap { host in
+            self.getAuthTokenType(for: host)
+        }
+    }
+
     internal static func apiURL(_ url: String) -> Foundation.URL? {
         do {
             let regex = try NSRegularExpression(pattern: #"([^/@]+)[:/]([^:/]+)/([^/.]+)(\.git)?$"#, options: .caseInsensitive)
@@ -196,13 +206,18 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
         options.validResponseCodes = validResponseCodes
         options.authorizationProvider = { url in
             url.host.flatMap { host in
-                let host = host.hasPrefix(Self.apiHostPrefix) ? String(host.dropFirst(Self.apiHostPrefix.count)) : host
-                return self.configuration.authTokens()?[.github(host)].flatMap { token in
+                let tokenType = self.getAuthTokenType(for: host)
+                return self.configuration.authTokens()?[tokenType].flatMap { token in
                     "token \(token)"
                 }
             }
         }
         return options
+    }
+
+    private func getAuthTokenType(for host: String) -> AuthTokenType {
+        let host = host.hasPrefix(Self.apiHostPrefix) ? String(host.dropFirst(Self.apiHostPrefix.count)) : host
+        return .github(host)
     }
 
     private static func makeDefaultHTTPClient(diagnosticsEngine: DiagnosticsEngine?) -> HTTPClient {
@@ -254,6 +269,24 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
         init(package: Model.PackageBasicMetadata, timestamp: DispatchTime) {
             self.package = package
             self.timestamp = timestamp.uptimeNanoseconds
+        }
+    }
+}
+
+extension PackageMetadataProviderError {
+    static func from(_ error: GitHubPackageMetadataProvider.Errors) -> PackageMetadataProviderError? {
+        switch error {
+        case .invalidResponse(_, let errorMessage):
+            return .invalidResponse(errorMessage: errorMessage)
+        case .permissionDenied:
+            return .permissionDenied
+        case .invalidAuthToken:
+            return .invalidAuthToken
+        case .apiLimitsExceeded:
+            return .apiLimitsExceeded
+        default:
+            // This metadata provider is not intended for the given package reference
+            return nil
         }
     }
 }

--- a/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
@@ -26,6 +26,12 @@ protocol PackageMetadataProvider: Closable {
     ///   - reference: The package's reference
     ///   - callback: The closure to invoke when result becomes available
     func get(_ reference: PackageReference, callback: @escaping (Result<PackageCollectionsModel.PackageBasicMetadata, Error>) -> Void)
+
+    /// Returns `AuthTokenType` for a package.
+    ///
+    /// - Parameters:
+    ///   - reference: The package's reference
+    func getAuthTokenType(for reference: PackageReference) -> AuthTokenType?
 }
 
 extension Model {
@@ -48,4 +54,23 @@ extension Model {
         let createdAt: Date
         let publishedAt: Date?
     }
+}
+
+public struct PackageMetadataProviderContext: Equatable {
+    public let authTokenType: AuthTokenType?
+    public let isAuthTokenConfigured: Bool
+    public internal(set) var error: PackageMetadataProviderError?
+
+    init(authTokenType: AuthTokenType?, isAuthTokenConfigured: Bool, error: PackageMetadataProviderError? = nil) {
+        self.authTokenType = authTokenType
+        self.isAuthTokenConfigured = isAuthTokenConfigured
+        self.error = error
+    }
+}
+
+public enum PackageMetadataProviderError: Error, Equatable {
+    case invalidResponse(errorMessage: String)
+    case permissionDenied
+    case invalidAuthToken
+    case apiLimitsExceeded
 }

--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -41,6 +41,43 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
         XCTAssertNil(GitHubPackageMetadataProvider.apiURL("bad/Hello-World.git"))
     }
 
+    func testAuthTokenType() throws {
+        let metadataProvider = GitHubPackageMetadataProvider()
+        let expectedAuthTokenType = AuthTokenType.github("github.com")
+
+        // Not remote
+        do {
+            let reference = PackageReference(repository: RepositorySpecifier(url: "file:///local/Hello-World.git"), kind: .local)
+            let authTokenType = metadataProvider.getAuthTokenType(for: reference)
+            XCTAssertNil(authTokenType)
+        }
+
+        // Invalid URL
+        do {
+            let reference = PackageReference(repository: RepositorySpecifier(url: "bad/Hello-World.git"))
+            let authTokenType = metadataProvider.getAuthTokenType(for: reference)
+            XCTAssertNil(authTokenType)
+        }
+
+        do {
+            let reference = PackageReference(repository: RepositorySpecifier(url: "git@github.com:octocat/Hello-World.git"))
+            let authTokenType = metadataProvider.getAuthTokenType(for: reference)
+            XCTAssertEqual(expectedAuthTokenType, authTokenType)
+        }
+
+        do {
+            let reference = PackageReference(repository: RepositorySpecifier(url: "https://github.com/octocat/Hello-World.git"))
+            let authTokenType = metadataProvider.getAuthTokenType(for: reference)
+            XCTAssertEqual(expectedAuthTokenType, authTokenType)
+        }
+
+        do {
+            let reference = PackageReference(repository: RepositorySpecifier(url: "https://github.com/octocat/Hello-World"))
+            let authTokenType = metadataProvider.getAuthTokenType(for: reference)
+            XCTAssertEqual(expectedAuthTokenType, authTokenType)
+        }
+    }
+
     func testGood() throws {
         try testWithTemporaryDirectory { tmpPath in
             let repoURL = "https://github.com/octocat/Hello-World.git"

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -1124,6 +1124,9 @@ final class PackageCollectionsTests: XCTestCase {
 
         let expectedMetadata = PackageCollections.mergedPackageMetadata(package: mockPackage, basicMetadata: mockMetadata)
         XCTAssertEqual(metadata.package, expectedMetadata, "package should match")
+
+        let expectedProvider = PackageMetadataProviderContext(authTokenType: nil, isAuthTokenConfigured: false, error: nil)
+        XCTAssertEqual(metadata.provider, expectedProvider, "provider should match")
     }
 
     func testFetchMetadataInOrder() throws {
@@ -1159,6 +1162,9 @@ final class PackageCollectionsTests: XCTestCase {
 
         let expectedMetadata = PackageCollections.mergedPackageMetadata(package: mockPackage, basicMetadata: nil)
         XCTAssertEqual(metadata.package, expectedMetadata, "package should match")
+
+        // MockMetadataProvider throws NotFoundError which would cause metadata.provider to be set to nil
+        XCTAssertNil(metadata.provider, "provider should be nil")
     }
 
     func testFetchMetadataInCollections() throws {
@@ -1193,6 +1199,9 @@ final class PackageCollectionsTests: XCTestCase {
 
         let expectedMetadata = PackageCollections.mergedPackageMetadata(package: mockPackage, basicMetadata: nil)
         XCTAssertEqual(metadata.package, expectedMetadata, "package should match")
+
+        // MockMetadataProvider throws NotFoundError which would cause metadata.provider to be set to nil
+        XCTAssertNil(metadata.provider, "provider should be nil")
     }
 
     func testMergedPackageMetadata() throws {
@@ -1339,6 +1348,9 @@ final class PackageCollectionsTests: XCTestCase {
 
         let expectedMetadata = PackageCollections.mergedPackageMetadata(package: mockPackage, basicMetadata: nil)
         XCTAssertEqual(metadata.package, expectedMetadata, "package should match")
+
+        // MockMetadataProvider throws NotFoundError which would cause metadata.provider to be set to nil
+        XCTAssertNil(metadata.provider, "provider should be nil")
     }
 
     func testFetchMetadataProviderError() throws {
@@ -1349,6 +1361,10 @@ final class PackageCollectionsTests: XCTestCase {
 
             func get(_ reference: PackageReference, callback: @escaping (Result<PackageCollectionsModel.PackageBasicMetadata, Error>) -> Void) {
                 callback(.failure(TerribleThing()))
+            }
+
+            func getAuthTokenType(for reference: PackageReference) -> AuthTokenType? {
+                nil
             }
 
             func close() throws {}
@@ -1383,6 +1399,9 @@ final class PackageCollectionsTests: XCTestCase {
         let metadata = try tsc_await { callback in packageCollections.getPackageMetadata(mockPackage.reference, callback: callback) }
         let expectedMetadata = PackageCollections.mergedPackageMetadata(package: mockPackage, basicMetadata: nil)
         XCTAssertEqual(metadata.package, expectedMetadata, "package should match")
+
+        // MockMetadataProvider throws unhandled error which would cause metadata.provider to be set to nil
+        XCTAssertNil(metadata.provider, "provider should be nil")
     }
 
     func testFetchMetadataPerformance() throws {

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -165,6 +165,10 @@ struct MockMetadataProvider: PackageMetadataProvider {
         }
     }
 
+    func getAuthTokenType(for reference: PackageReference) -> AuthTokenType? {
+        nil
+    }
+
     func close() throws {}
 }
 


### PR DESCRIPTION
Motivation:
`getPackageMetadata` requires the package being looked up to exist in at least one imported package collection. It tries to fetch additional metadata from third-party providers such as GitHub and combine it with local collection data. If GitHub APIs yield no result or fail, the error is silently ignored and the code proceeds with returning collection data only. Some of these GitHub API errors can be prevented--e.g., the rate-limit for authenticated requests is much higher than unauthenticated ones (5000 vs 60), so if we expose these GitHub errors, the caller can take preventive actions.

Modifications:
Add `provider: PackageMetadataProviderContext?` to `PackageMetadata` (which is a tuple type), which includes information such as `AuthTokenType` and whether the corresponding token is configured in `PackageCollections.Configuration`. If `provider` is `nil`, it means there is no third-party metadata provider for the package (i.e., we cannot obtain additional metadata from GitHub).

`PackageMetadataProviderContext` also includes `error: PackageMetadataProviderError` to indicate when a GitHub API error has occurred (e.g., rate-limit exceeded).

rdar://77620938
