### PR TITLE
[5.4] fix silent crash when output from compiler is too large

### DIFF
--- a/Sources/Build/BuildDelegate.swift
+++ b/Sources/Build/BuildDelegate.swift
@@ -553,18 +553,22 @@ public final class BuildDelegate: BuildSystemDelegate, SwiftCompilerOutputParser
             }
 
             if let output = message.standardOutput {
-                // Scoop out any errors from the output, so they can later be passed to the advice provider in case of failure.
-                let regex = try! RegEx(pattern: #".*(error:[^\n]*)\n.*"#, options: .dotMatchesLineSeparators)
-                for match in regex.matchGroups(in: output) {
-                    self.errorMessagesByTarget[parser.targetName] = (self.errorMessagesByTarget[parser.targetName] ?? []) + [match[0]]
-                }
-                
+                // first we want to print the output so users have it handy
                 if !self.isVerbose {
                     self.progressAnimation.clear()
                 }
 
                 self.outputStream <<< output
                 self.outputStream.flush()
+
+                // next we want to try and scoop out any errors from the output (if reasonable size, otherwise this will be very slow),
+                // so they can later be passed to the advice provider in case of failure.
+                if output.utf8.count < 1024 * 10 {
+                    let regex = try! RegEx(pattern: #".*(error:[^\n]*)\n.*"#, options: .dotMatchesLineSeparators)
+                    for match in regex.matchGroups(in: output) {
+                        self.errorMessagesByTarget[parser.targetName] = (self.errorMessagesByTarget[parser.targetName] ?? []) + [match[0]]
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
brings #3478 to 5.4