### PR TITLE
Change symlink error to warning

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -136,10 +136,14 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         let oldBuildPath = buildParameters.dataPath.parentDirectory.appending(
             component: buildParameters.configuration.dirname
         )
-        if localFileSystem.exists(oldBuildPath) {
-            try localFileSystem.removeFileTree(oldBuildPath)
+        do {
+            if localFileSystem.exists(oldBuildPath) {
+                try? localFileSystem.removeFileTree(oldBuildPath)
+            }
+            try localFileSystem.createSymbolicLink(oldBuildPath, pointingAt: buildParameters.buildPath, relative: true)
+        } catch {
+            diagnostics.emit(warning: "unable to link \(oldBuildPath): \(error)")
         }
-        try localFileSystem.createSymbolicLink(oldBuildPath, pointingAt: buildParameters.buildPath, relative: true)
     }
 
     /// Compute the llbuild target name using the given subset.

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -136,10 +136,15 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         let oldBuildPath = buildParameters.dataPath.parentDirectory.appending(
             component: buildParameters.configuration.dirname
         )
-        do {
-            if localFileSystem.exists(oldBuildPath) {
-                try? localFileSystem.removeFileTree(oldBuildPath)
+        if localFileSystem.exists(oldBuildPath) {
+            do { try localFileSystem.removeFileTree(oldBuildPath) }
+            catch {
+                diagnostics.emit(warning: "unable to delete \(oldBuildPath), skip creating symbolic link: \(error)")
+                return
             }
+        }
+
+        do {
             try localFileSystem.createSymbolicLink(oldBuildPath, pointingAt: buildParameters.buildPath, relative: true)
         } catch {
             diagnostics.emit(warning: "unable to create symbolic link at \(oldBuildPath): \(error)")

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -142,7 +142,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
             }
             try localFileSystem.createSymbolicLink(oldBuildPath, pointingAt: buildParameters.buildPath, relative: true)
         } catch {
-            diagnostics.emit(warning: "unable to link \(oldBuildPath): \(error)")
+            diagnostics.emit(warning: "unable to create symbolic link at \(oldBuildPath): \(error)")
         }
     }
 


### PR DESCRIPTION
If linking `oldBuildPath` fails, SwiftPM will emit a warning instead of an error.

### Motivation:

Symlinking `oldBuildPath` is not a vital step of `swift build`, but emitting an error will depress the `run` and `test` commands. This largely troubled Windows users, since symlinking requires elevated privileges on Windows.

### Modifications:

Codes of linking `oldBuildPath` is now wrapped with `do-catch` to capture the error and change it into a warning.

### Result:

If linking `oldBuildPath` fails, SwiftPM will emit a warning instead of an error.
