### PR TITLE
Update BuildToolTests.testBuildCompleteMessage

### DIFF
--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -252,8 +252,8 @@ final class BuildToolTests: XCTestCase {
                 let result = try execute([], packagePath: path)
                 #if os(macOS)
                 XCTAssertTrue(result.stdout.contains("[6/6] Build complete!"), result.stdout)
-                #elseif compiler(>=5.5)
-                XCTAssertTrue(result.stdout.contains("[12/12] Build complete!"), result.stdout)
+//                #elseif compiler(>=5.5)
+//                XCTAssertTrue(result.stdout.contains("[12/12] Build complete!"), result.stdout)
                 #else
                 XCTAssertTrue(result.stdout.contains("[8/8] Build complete!"), result.stdout)
                 #endif

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -252,10 +252,9 @@ final class BuildToolTests: XCTestCase {
                 let result = try execute([], packagePath: path)
                 #if os(macOS)
                 XCTAssertTrue(result.stdout.contains("[6/6] Build complete!"), result.stdout)
-//                #elseif compiler(>=5.5)
-//                XCTAssertTrue(result.stdout.contains("[12/12] Build complete!"), result.stdout)
                 #else
-                XCTAssertTrue(result.stdout.contains("[8/8] Build complete!"), result.stdout)
+                // Number must be greater than 0
+                XCTAssertMatch(result.stdout, .regex("\\[[1-9][0-9]*\\/[1-9][0-9]*\\] Build complete!"))
                 #endif
             }
 

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -250,12 +250,8 @@ final class BuildToolTests: XCTestCase {
         fixture(name: "DependencyResolution/Internal/Simple") { path in
             do {
                 let result = try execute([], packagePath: path)
-                #if os(macOS)
-                XCTAssertTrue(result.stdout.contains("[6/6] Build complete!"), result.stdout)
-                #else
                 // Number must be greater than 0
                 XCTAssertMatch(result.stdout, .regex("\\[[1-9][0-9]*\\/[1-9][0-9]*\\] Build complete!"))
-                #endif
             }
 
             do {

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -252,6 +252,8 @@ final class BuildToolTests: XCTestCase {
                 let result = try execute([], packagePath: path)
                 #if os(macOS)
                 XCTAssertTrue(result.stdout.contains("[6/6] Build complete!"), result.stdout)
+                #elseif compiler(>=5.5)
+                XCTAssertTrue(result.stdout.contains("[12/12] Build complete!"), result.stdout)
                 #else
                 XCTAssertTrue(result.stdout.contains("[8/8] Build complete!"), result.stdout)
                 #endif

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -250,12 +250,13 @@ final class BuildToolTests: XCTestCase {
         fixture(name: "DependencyResolution/Internal/Simple") { path in
             do {
                 let result = try execute([], packagePath: path)
-                // Number must be greater than 0
+                // Number of steps must be greater than 0. e.g., [8/8] Build complete!
                 XCTAssertMatch(result.stdout, .regex("\\[[1-9][0-9]*\\/[1-9][0-9]*\\] Build complete!"))
             }
 
             do {
                 let result = try execute([], packagePath: path)
+                // test second time, to make sure message is presented even when nothing to build (cached)
                 XCTAssertTrue(result.stdout.contains("[0/0] Build complete!"), result.stdout)
             }
         }


### PR DESCRIPTION
Motivation:
The build output on Linux has changed. Causing self hosted Linux test to fail ([example](https://ci.swift.org/job/swift-package-manager-self-hosted-Linux-smoke-test/2051/)):

```
21:29:49 Test Case 'BuildToolTests.testBuildCompleteMessage' started at 2021-05-13 04:29:06.495
21:29:49
/home/buildnode/jenkins/workspace/swift-package-manager-self-hosted-Linux-smoke-test/branch-main/swiftpm/Tests/CommandsTests/BuildToolTests.swift:256: error: BuildToolTests.testBuildCompleteMessage : XCTAssertTrue failed - [1/4] Compiling Bar Bar.swift
21:29:49 [3/6] Merging module Bar
21:29:49 [5/7] Wrapping AST for Bar for debugging
21:29:49 [6/9] Compiling Foo Foo.swift
21:29:49 [7/9] Compiling Foo main.swift
21:29:49 [9/11] Merging module Foo
21:29:49 [11/12] Wrapping AST for Foo for debugging
21:29:49 [12/12] Linking Foo
21:29:49 [12/12] Build complete!
21:29:49
21:29:49 Test Case 'BuildToolTests.testBuildCompleteMessage' failed (5.24 seconds)
```

Modification:
Update expected output in `BuildToolTests.testBuildCompleteMessage`.
