### PR TITLE
A small step toward building a toolchain on M1 Mac

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -805,7 +805,7 @@ def get_swiftpm_flags(args):
 
     build_target = get_build_target(args)
     cross_compile_hosts = args.cross_compile_hosts
-    if "macosx-arm64" in cross_compile_hosts:
+    if cross_compile_hosts is not None:
         build_flags += ["--arch", "x86_64", "--arch", "arm64"]
     elif cross_compile_hosts:
         error("cannot cross-compile for %s" % cross_compile_hosts)

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -805,7 +805,7 @@ def get_swiftpm_flags(args):
 
     build_target = get_build_target(args)
     cross_compile_hosts = args.cross_compile_hosts
-    if (build_target == 'x86_64-apple-macosx' or build_target == 'arm64-apple-macosx') and "macosx-arm64" in cross_compile_hosts:
+    if "macosx-arm64" in cross_compile_hosts:
         build_flags += ["--arch", "x86_64", "--arch", "arm64"]
     elif cross_compile_hosts:
         error("cannot cross-compile for %s" % cross_compile_hosts)

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -805,7 +805,7 @@ def get_swiftpm_flags(args):
 
     build_target = get_build_target(args)
     cross_compile_hosts = args.cross_compile_hosts
-    if build_target == 'x86_64-apple-macosx' and "macosx-arm64" in cross_compile_hosts:
+    if (build_target == 'x86_64-apple-macosx' or build_target == 'arm64-apple-macosx') and "macosx-arm64" in cross_compile_hosts:
         build_flags += ["--arch", "x86_64", "--arch", "arm64"]
     elif cross_compile_hosts:
         error("cannot cross-compile for %s" % cross_compile_hosts)


### PR DESCRIPTION
Minor change removing impediment to building Swift toolchain on M1 Mac

### Motivation:

Would like to be able to work on the Swift compiler on an M1 Mac.

### Modifications:

Very small change for when swift/utils/build-toolchain is run on M1 Mac.

### Result:

Will not be prevented from building toolchain on M1 Mac.
