### PR TITLE
[Collections] Dedupe package versions in GitHub metadata

### DIFF
--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -549,7 +549,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
     internal static func mergedPackageMetadata(package: Model.Package,
                                                basicMetadata: Model.PackageBasicMetadata?) -> Model.Package {
         // This dictionary contains recent releases and might not contain everything that's in package.versions.
-        let basicVersionMetadata = basicMetadata.map { Dictionary(uniqueKeysWithValues: $0.versions.map { ($0.version, $0) }) } ?? [:]
+        let basicVersionMetadata = basicMetadata.map { Dictionary($0.versions.map { ($0.version, $0) }, uniquingKeysWith: { first, _ in first }) } ?? [:]
         var versions = package.versions.map { packageVersion -> Model.Package.Version in
             let versionMetadata = basicVersionMetadata[packageVersion.version]
             return .init(version: packageVersion.version,

--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -760,7 +760,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
     }
 
     internal func populateTargetTrie(callback: @escaping (Result<Void, Error>) -> Void = { _ in }) {
-        DispatchQueue.sharedConcurrent.async(group: nil, qos: .background, flags: .assignCurrentContext, execute: {
+        DispatchQueue.sharedConcurrent.async(group: nil, qos: .background, flags: .assignCurrentContext) {
             self.targetTrieReady.memoize {
                 do {
                     // Use FTS to build the trie
@@ -794,7 +794,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                     return false
                 }
             }
-        })
+        }
     }
 
     // for testing

--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -760,7 +760,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
     }
 
     internal func populateTargetTrie(callback: @escaping (Result<Void, Error>) -> Void = { _ in }) {
-        DispatchQueue.sharedConcurrent.async(group: nil, qos: .background, flags: .assignCurrentContext) {
+        DispatchQueue.sharedConcurrent.async(group: nil, qos: .background, flags: .assignCurrentContext, execute: {
             self.targetTrieReady.memoize {
                 do {
                     // Use FTS to build the trie
@@ -794,7 +794,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                     return false
                 }
             }
-        }
+        })
     }
 
     // for testing


### PR DESCRIPTION
Motivation:
Package metadata returned by GitHub API may contain duplicate entries for the same tag. e.g., https://github.com/vapor/postgres-nio releases 1.5.0 and 1.5.1. This causes `getPackageMetadata` API to crash.

Modification:
Dedupe versions/tags when we construct dictionary from GitHub package versions array.
