### PR TITLE
[5.5][Collections] Dedupe package versions in GitHub metadata (#3504)

### DIFF
--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -549,7 +549,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
     internal static func mergedPackageMetadata(package: Model.Package,
                                                basicMetadata: Model.PackageBasicMetadata?) -> Model.Package {
         // This dictionary contains recent releases and might not contain everything that's in package.versions.
-        let basicVersionMetadata = basicMetadata.map { Dictionary(uniqueKeysWithValues: $0.versions.map { ($0.version, $0) }) } ?? [:]
+        let basicVersionMetadata = basicMetadata.map { Dictionary($0.versions.map { ($0.version, $0) }, uniquingKeysWith: { first, _ in first }) } ?? [:]
         var versions = package.versions.map { packageVersion -> Model.Package.Version in
             let versionMetadata = basicVersionMetadata[packageVersion.version]
             return .init(version: packageVersion.version,


### PR DESCRIPTION
https://github.com/apple/swift-package-manager/pull/3504 for 5.5