### PR TITLE
fix an edge case where binary artifacts have already been downloaded and linger or disk, causing secondary attempt to fail

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1664,13 +1664,14 @@ extension Workspace {
             defer { group.leave() }
 
             let parentDirectory =  self.artifactsPath.appending(component: artifact.packageRef.name)
+            let tempExtractionDirectory = self.artifactsPath.appending(components: "extract", artifact.targetName)
 
             do {
-                // remove if already exists, otherwise extraction may fail
-                if fileSystem.exists(parentDirectory) {
-                    try fileSystem.removeFileTree(parentDirectory)
-                }
                 try fileSystem.createDirectory(parentDirectory, recursive: true)
+                if fileSystem.exists(tempExtractionDirectory) {
+                    try fileSystem.removeFileTree(tempExtractionDirectory)
+                }
+                try fileSystem.createDirectory(tempExtractionDirectory, recursive: true)
             } catch {
                 tempDiagnostics.emit(error)
                 continue
@@ -1704,17 +1705,31 @@ extension Workspace {
                         }
 
                         group.enter()
-                        self.archiver.extract(from: archivePath, to: parentDirectory, completion: { extractResult in
+                        self.archiver.extract(from: archivePath, to: tempExtractionDirectory, completion: { extractResult in
                             defer { group.leave() }
 
                             switch extractResult {
                             case .success:
-                                let extractedFiles = tempDiagnostics.wrap { try self.fileSystem.getDirectoryContents(parentDirectory)
-                                    .map{ parentDirectory.appending(component: $0) }
-                                    .filter{ $0 != archivePath }
+                                var artifactPath: AbsolutePath? = nil
+                                tempDiagnostics.wrap {
+                                    // copy from temp location to actual location
+                                    let content = try self.fileSystem.getDirectoryContents(tempExtractionDirectory)
+                                    for file in content {
+                                        let source = tempExtractionDirectory.appending(component: file)
+                                        let destination = parentDirectory.appending(component: file)
+                                        if self.fileSystem.exists(destination) {
+                                            try self.fileSystem.removeFileTree(destination)
+                                        }
+                                        try self.fileSystem.copy(from: source, to: destination)
+                                        if destination.basenameWithoutExt == artifact.targetName {
+                                            artifactPath = destination
+                                        }
+                                    }
+                                    // remove temp location
+                                    try self.fileSystem.removeFileTree(tempExtractionDirectory)
                                 }
 
-                                guard let artifactPath = extractedFiles?.first(where: { $0.basenameWithoutExt == artifact.targetName }) else {
+                                guard let mainArtifactPath = artifactPath else {
                                     return tempDiagnostics.emit(.artifactNotFound(targetName: artifact.targetName, artifactName: artifact.targetName))
                                 }
 
@@ -1724,7 +1739,7 @@ extension Workspace {
                                         targetName: artifact.targetName,
                                         url: artifact.url.absoluteString,
                                         checksum: artifact.checksum,
-                                        path: artifactPath
+                                        path: mainArtifactPath
                                     )
                                 )
                             case .failure(let error):

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -4403,9 +4403,9 @@ final class WorkspaceTests: XCTestCase {
                 ByteString([0xB0]).hexadecimalRepresentation,
             ])
             XCTAssertEqual(workspace.archiver.extractions.map { $0.destinationPath }.sorted(), [
-                AbsolutePath("/tmp/ws/.build/artifacts/A"),
-                AbsolutePath("/tmp/ws/.build/artifacts/A"),
-                AbsolutePath("/tmp/ws/.build/artifacts/B")
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/A1"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/A2"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/B")
             ])
             XCTAssertEqual(
                 downloads.map { $0.value }.sorted(),
@@ -4660,9 +4660,9 @@ final class WorkspaceTests: XCTestCase {
                 ByteString([0xB0]).hexadecimalRepresentation,
             ])
             XCTAssertEqual(workspace.archiver.extractions.map { $0.destinationPath }.sorted(), [
-                AbsolutePath("/tmp/ws/.build/artifacts/A"),
-                AbsolutePath("/tmp/ws/.build/artifacts/A"),
-                AbsolutePath("/tmp/ws/.build/artifacts/B"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/A2"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/A3"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/B"),
             ])
             XCTAssertEqual(
                 downloads.map { $0.value }.sorted(),
@@ -4810,7 +4810,7 @@ final class WorkspaceTests: XCTestCase {
             "https://a.com/a1.zip",
         ])
         XCTAssertEqual(archiver.extractions.map { $0.destinationPath }.sorted(), [
-            AbsolutePath("/tmp/ws/.build/artifacts/A"),
+            AbsolutePath("/tmp/ws/.build/artifacts/extract/A1"),
         ])
         XCTAssertEqual(
             downloads.map { $0.1 }.sorted(),
@@ -4836,7 +4836,7 @@ final class WorkspaceTests: XCTestCase {
             "https://a.com/a1.zip", "https://a.com/a1.zip",
         ])
         XCTAssertEqual(archiver.extractions.map { $0.destinationPath }.sorted(), [
-            AbsolutePath("/tmp/ws/.build/artifacts/A"), AbsolutePath("/tmp/ws/.build/artifacts/A"),
+            AbsolutePath("/tmp/ws/.build/artifacts/extract/A1"), AbsolutePath("/tmp/ws/.build/artifacts/extract/A1"),
         ])
         XCTAssertEqual(
             downloads.map { $0.1 }.sorted(),
@@ -4874,7 +4874,7 @@ final class WorkspaceTests: XCTestCase {
         })
 
         let archiver = MockArchiver(handler: { _, _, destinationPath, completion in
-            XCTAssertEqual(destinationPath, AbsolutePath("/tmp/ws/.build/artifacts/A"))
+            XCTAssertEqual(destinationPath, AbsolutePath("/tmp/ws/.build/artifacts/extract/A2"))
             completion(.failure(DummyError()))
         })
 
@@ -5199,9 +5199,9 @@ final class WorkspaceTests: XCTestCase {
                 ).map{ $0.hexadecimalRepresentation }.sorted()
             )
             XCTAssertEqual(workspace.archiver.extractions.map { $0.destinationPath }.sorted(), [
-                AbsolutePath("/tmp/ws/.build/artifacts/A"),
-                AbsolutePath("/tmp/ws/.build/artifacts/A"),
-                AbsolutePath("/tmp/ws/.build/artifacts/B"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/A1"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/A2"),
+                AbsolutePath("/tmp/ws/.build/artifacts/extract/B"),
             ])
             XCTAssertEqual(
                 downloads.map { $0.value }.sorted(),


### PR DESCRIPTION
motivation: some users reported an edge case where the state is reset but the directory lingers, so that the secondary attempt to download and extract the ginary depedency fails

changes:
* extract the downloaded archive to a temporary location
* ensure the destination does not exist prior to moving it from the temporary extraction location to the desired location 
* adjust confusing (test only) function name 
* add and adjust tests

rdar://75975702
rdar://77011310
