### PR TITLE
[Collections] Include more package metadata in CLI output

### DIFF
--- a/Sources/Commands/SwiftPackageCollectionsTool.swift
+++ b/Sources/Commands/SwiftPackageCollectionsTool.swift
@@ -286,6 +286,8 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
                         let stars = optionalRow("Stars", result.package.watchersCount?.description)
                         let readme = optionalRow("Readme", result.package.readmeURL?.absoluteString)
                         let authors = optionalRow("Authors", result.package.authors?.map { $0.username }.joined(separator: ", "))
+                        let license =  optionalRow("License", result.package.license.map { "\($0.type) (\($0.url))" })
+                        let languages = optionalRow("Languages", result.package.languages?.joined(separator: ", "))
                         let latestVersion = optionalRow("\(String(repeating: "-", count: 60))\n\(indent())Latest Version", printVersion(result.package.latestVersion))
 
                         if jsonOptions.json {
@@ -293,7 +295,7 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
                         } else {
                             print("""
                                 \(description)
-                                Available Versions: \(versions)\(stars)\(readme)\(authors)\(latestVersion)
+                                Available Versions: \(versions)\(readme)\(license)\(authors)\(stars)\(languages)\(latestVersion)
                             """)
                         }
                     }


### PR DESCRIPTION
Motivation:
The collection API implementation fetches additional package metadata via GitHub APIs but we aren't showing all of it in the CLI.

Modifications:

Add license and languages. Reorder line items. e.g., the updated output of `describe https://github.com/apple/swift-nio`:

```
    Description: Event-driven network application framework for high performance protocol servers & clients, non-blocking.
    Available Versions: 2.29.0, 2.28.0, 2.27.0, 1.14.2, 1.14.1, 1.14.0
    Readme: https://raw.githubusercontent.com/apple/swift-nio/main/README.md
    License: Apache-2.0 (https://raw.githubusercontent.com/apple/swift-nio/main/LICENSE.txt)
    Authors: weissi, normanmaurer, Lukasa, compnerd, glbrntt, PeterAdams-A, tomerd, tigerpixel, kevinclark, fabianfett, BasThomas, Davidde94, gwynne, helje5, ktoso, ddunbar, ianpartridge, hassila, tanner0101, 2bjake, Mordil, shekhar-rajak, adamnemecek, AndriusA, toffaletti, agnosticdev, slashmo, adtrevor, Bouke, cpriebe
    Stars: 6450
    Languages: Ruby, Swift, DTrace, C, Dockerfile, Shell, Python
    ------------------------------------------------------------
    Latest Version: 2.29.0
        Tools Version: 5.0.0
            Package Name: swift-nio
            Modules: _NIO1APIShims, NIO, _NIOConcurrency, NIOFoundationCompat, NIOConcurrencyHelpers, NIOHTTP1, NIOTLS, NIOWebSocket, NIOTestUtils
            Products: NIO, _NIO1APIShims, _NIOConcurrency, NIOTLS, NIOHTTP1, NIOConcurrencyHelpers, NIOFoundationCompat, NIOWebSocket, NIOTestUtils
```

rdar://77533967
