### PR TITLE
Add .netrc to default .gitignore

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -261,6 +261,7 @@ public final class InitPackage {
                 xcuserdata/
                 DerivedData/
                 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+                .netrc
 
                 """
         }


### PR DESCRIPTION
This PR adds `.netrc` to the `.gitignore` file in the new project template.

### Motivation:

As discussed in https://github.com/apple/swift-evolution/pull/1319, a user may inadvertently expose credentials by checking in their project's `.netrc` file. Adding this entry to the `.gitignore` file in the new project template significantly minimizes the possibility of the user leaking credentials in the future.

### Modifications:

```diff
+ .netrc
```

### Result:

After this change, all future projects created by running `swift package init` will default to ignoring `.netrc` files.

Existing packages will be unaffected.