### PR TITLE
[Collections] Throw error instead of preconditionFailure after storage closed

### DIFF
--- a/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/GitHubPackageMetadataProvider.swift
@@ -23,7 +23,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
 
     public var name: String = "GitHub"
 
-    var configuration: Configuration
+    let configuration: Configuration
 
     private let httpClient: HTTPClient
     private let diagnosticsEngine: DiagnosticsEngine?

--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -760,7 +760,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
     }
 
     internal func populateTargetTrie(callback: @escaping (Result<Void, Error>) -> Void = { _ in }) {
-        DispatchQueue.sharedConcurrent.async(group: nil, qos: .background, flags: .assignCurrentContext, execute: {
+        DispatchQueue.sharedConcurrent.async(group: nil, qos: .background, flags: .assignCurrentContext) {
             self.targetTrieReady.memoize {
                 do {
                     // since running on low priority thread make sure the database has not already gone away
@@ -771,6 +771,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                     default:
                         break
                     }
+
                     // Use FTS to build the trie
                     let query = "SELECT collection_id_blob_base64, package_repository_url, name FROM \(Self.targetsFTSName);"
                     try self.executeStatement(query) { statement in
@@ -802,7 +803,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                     return false
                 }
             }
-        })
+        }
     }
 
     // for testing
@@ -842,7 +843,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
             let db: SQLite
             switch (self.location, self.state) {
             case (_, .disconnecting), (_, .disconnected):
-                preconditionFailure("DB id disconnecting or disconnected")
+                throw StringError("DB is disconnecting or disconnected")
             case (.path(let path), .connected(let database)):
                 if self.fileSystem.exists(path) {
                     db = database

--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -265,8 +265,8 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
             httpClient.configuration.retryStrategy = .none
             var configuration = GitHubPackageMetadataProvider.Configuration()
             configuration.cacheDir = tmpPath
-            var provider = GitHubPackageMetadataProvider(configuration: configuration, httpClient: httpClient)
-            provider.configuration.authTokens = { authTokens }
+            configuration.authTokens = { authTokens }
+            let provider = GitHubPackageMetadataProvider(configuration: configuration, httpClient: httpClient)
             defer { XCTAssertNoThrow(try provider.close()) }
 
             let reference = PackageReference(repository: RepositorySpecifier(url: repoURL))


### PR DESCRIPTION
Motivation:
With https://github.com/apple/swift-package-manager/pull/3505, the code does `preconditionFailure` when trying to execute DB statement after connection is disconnected. In `populateTargetTrie` we check connection state before calling `executeStatement`, but it's still possible for storage to close _after_ the check but _before_ `executeStatement`. This might have caused rdar://78513692.

Modifications:
- Throw error instead of `preconditionFailure`
- Unrelated: `GitHubPackageMetadataProvider.configuration` doesn't need to be var
