### PR TITLE
[Collections] Don't allow package.versions to be empty

### DIFF
--- a/Sources/PackageCollections/PackageCollections+Validation.swift
+++ b/Sources/PackageCollections/PackageCollections+Validation.swift
@@ -82,6 +82,11 @@ extension PackageCollectionModel.V1 {
         private func validate(package: Collection.Package, messages: inout [ValidationMessage]) {
             let packageID = PackageIdentity(url: package.url.absoluteString).description
 
+            guard !package.versions.isEmpty else {
+                messages.append(.error("Package \(packageID) does not have any versions.", property: "package.versions"))
+                return
+            }
+
             // Check for duplicate versions
             let nonUniqueVersions = Dictionary(grouping: package.versions, by: { $0.version }).filter { $1.count > 1 }.keys
             if !nonUniqueVersions.isEmpty {

--- a/Tests/PackageCollectionsTests/PackageCollectionValidationTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionValidationTests.swift
@@ -177,6 +177,38 @@ class PackageCollectionValidationTests: XCTestCase {
         XCTAssertNotNil(messages[0].message.range(of: "more than the recommended", options: .caseInsensitive))
     }
 
+    func test_validationFailed_noVersions() throws {
+        let packages = [
+            Model.Collection.Package(
+                url: URL(string: "https://package-collection-tests.com/repos/foobar.git")!,
+                summary: "Package Foobar",
+                keywords: ["test package"],
+                versions: [],
+                readmeURL: nil,
+                license: nil
+            ),
+        ]
+        let collection = Model.Collection(
+            name: "Test Package Collection",
+            overview: "A test package collection",
+            keywords: ["swift packages"],
+            packages: packages,
+            formatVersion: .v1_0,
+            revision: 3,
+            generatedAt: Date(),
+            generatedBy: .init(name: "Jane Doe")
+        )
+
+        let validator = Model.Validator()
+        let messages = validator.validate(collection: collection)!
+        XCTAssertEqual(1, messages.count)
+
+        guard case .error = messages[0].level else {
+            return XCTFail("Expected .error")
+        }
+        XCTAssertNotNil(messages[0].message.range(of: "does not have any versions", options: .caseInsensitive))
+    }
+
     func test_validationFailed_duplicateVersions_emptyProductsAndTargets() throws {
         let packages = [
             Model.Collection.Package(


### PR DESCRIPTION
Motivation:
Currently packages in a collection can have `versions` array be empty. Can't remember if this was intentional but a package that has no versions is not very useful.

Modification:
Update validation to fail when `package.versions` is empty.
