### PR TITLE
Avoid warnings when using SDKs without a Concurrency module

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -865,12 +865,20 @@ public class SwiftTool {
                 cachePath = try self.getCachePath().map{ $0.appending(component: "manifests") }
             }
 
+            let extraManifestFlags: [String]
+            // Disable the implicit concurrency import if the compiler in use supports it to avoid warnings if we are building against an older SDK that does not contain a Concurrency module.
+            if SwiftTargetBuildDescription.checkSupportedFrontendFlags(flags: ["disable-implicit-concurrency-module-import"], fs: localFileSystem) {
+                extraManifestFlags = self.options.manifestFlags + ["-Xfrontend", "-disable-implicit-concurrency-module-import"]
+            } else {
+                extraManifestFlags = self.options.manifestFlags
+            }
+
             return try ManifestLoader(
                 // Always use the host toolchain's resources for parsing manifest.
                 manifestResources: self._hostToolchain.get().manifestResources,
                 isManifestSandboxEnabled: !self.options.shouldDisableSandbox,
                 cacheDir: cachePath,
-                extraManifestFlags: self.options.manifestFlags
+                extraManifestFlags: extraManifestFlags
             )
         })
     }()


### PR DESCRIPTION
When mixing a newer compiler which does the implicit concurrency import with an older SDK that doesn't have a Concurrency module, manifest compilation is emitting warnings right now. This adds an extra flag to disable the implicit import if the flag is supported by the compiler in use.

rdar://78032108
