### PR TITLE
[APIDiff] Enable tests on non-Darwin

### DIFF
--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -27,11 +27,20 @@ final class APIDiffTests: XCTestCase {
         return try SwiftPMProduct.SwiftPackage.execute(args, packagePath: packagePath, env: environment)
     }
 
+    func skipIfApiDigesterUnsupported() throws {
+      guard let tool = try? Resources.default.toolchain.getSwiftAPIDigester() else {
+        throw XCTSkip("swift-api-digester unavailable")
+      }
+      guard localFileSystem.isSymlink(tool) else {
+        // The version of Swift with a supported swift-api-digester doesn't have
+        // a version number yet, so use whether or not the tool is a symlink to
+        // determine if it's from a recent snapshot.
+        throw XCTSkip("swift-api-digester is too old")
+      }
+    }
+
     func testSimpleAPIDiff() throws {
-        #if os(macOS)
-        guard (try? Resources.default.toolchain.getSwiftAPIDigester()) != nil else {
-            throw XCTSkip("swift-api-digester not available")
-        }
+        try skipIfApiDigesterUnsupported()
         fixture(name: "Miscellaneous/APIDiff/") { prefix in
             let packageRoot = prefix.appending(component: "Foo")
             // Overwrite the existing decl.
@@ -47,16 +56,10 @@ final class APIDiffTests: XCTestCase {
                 XCTAssertTrue(output.contains("💔 API breakage: func foo() has been removed"))
             }
         }
-        #else
-        throw XCTSkip("Test unsupported on current platform")
-        #endif
     }
 
     func testMultiTargetAPIDiff() throws {
-        #if os(macOS)
-        guard (try? Resources.default.toolchain.getSwiftAPIDigester()) != nil else {
-            throw XCTSkip("swift-api-digester not available")
-        }
+        try skipIfApiDigesterUnsupported()
         fixture(name: "Miscellaneous/APIDiff/") { prefix in
             let packageRoot = prefix.appending(component: "Bar")
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Baz", "Baz.swift")) {
@@ -77,16 +80,10 @@ final class APIDiffTests: XCTestCase {
                 XCTAssertTrue(output.contains("💔 API breakage: func bar() has been removed"))
             }
         }
-        #else
-        throw XCTSkip("Test unsupported on current platform")
-        #endif
     }
 
     func testCheckVendedModulesOnly() throws {
-        #if os(macOS)
-        guard (try? Resources.default.toolchain.getSwiftAPIDigester()) != nil else {
-            throw XCTSkip("swift-api-digester not available")
-        }
+        try skipIfApiDigesterUnsupported()
         fixture(name: "Miscellaneous/APIDiff/") { prefix in
             let packageRoot = prefix.appending(component: "NonAPILibraryTargets")
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Foo", "Foo.swift")) {
@@ -119,16 +116,10 @@ final class APIDiffTests: XCTestCase {
                 XCTAssertFalse(output.contains("💔 API breakage: var Qux.x has been removed"))
             }
         }
-        #else
-        throw XCTSkip("Test unsupported on current platform")
-        #endif
     }
 
     func testFilters() throws {
-        #if os(macOS)
-        guard (try? Resources.default.toolchain.getSwiftAPIDigester()) != nil else {
-            throw XCTSkip("swift-api-digester not available")
-        }
+        try skipIfApiDigesterUnsupported()
         fixture(name: "Miscellaneous/APIDiff/") { prefix in
             let packageRoot = prefix.appending(component: "NonAPILibraryTargets")
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Foo", "Foo.swift")) {
@@ -197,16 +188,10 @@ final class APIDiffTests: XCTestCase {
                 XCTAssertTrue(stderr.contains("'Exec' is not a library target"))
             }
         }
-        #else
-        throw XCTSkip("Test unsupported on current platform")
-        #endif
     }
 
     func testAPIDiffOfModuleWithCDependency() throws {
-        #if os(macOS)
-        guard (try? Resources.default.toolchain.getSwiftAPIDigester()) != nil else {
-            throw XCTSkip("swift-api-digester not available")
-        }
+        try skipIfApiDigesterUnsupported()
         fixture(name: "Miscellaneous/APIDiff/") { prefix in
             let packageRoot = prefix.appending(component: "CTargetDep")
             // Overwrite the existing decl.
@@ -239,16 +224,10 @@ final class APIDiffTests: XCTestCase {
                 XCTAssertTrue(stderr.contains("error: 'Foo' is not a Swift language target"))
             }
         }
-        #else
-        throw XCTSkip("Test unsupported on current platform")
-        #endif
     }
 
     func testNoBreakingChanges() throws {
-        #if os(macOS)
-        guard (try? Resources.default.toolchain.getSwiftAPIDigester()) != nil else {
-            throw XCTSkip("swift-api-digester not available")
-        }
+        try skipIfApiDigesterUnsupported()
         fixture(name: "Miscellaneous/APIDiff/") { prefix in
             let packageRoot = prefix.appending(component: "Bar")
             // Introduce an API-compatible change
@@ -259,16 +238,10 @@ final class APIDiffTests: XCTestCase {
             XCTAssertTrue(output.contains("No breaking changes detected in Baz"))
             XCTAssertTrue(output.contains("No breaking changes detected in Qux"))
         }
-        #else
-        throw XCTSkip("Test unsupported on current platform")
-        #endif
     }
 
     func testAPIDiffAfterAddingNewTarget() throws {
-        #if os(macOS)
-        guard (try? Resources.default.toolchain.getSwiftAPIDigester()) != nil else {
-            throw XCTSkip("swift-api-digester not available")
-        }
+        try skipIfApiDigesterUnsupported()
         fixture(name: "Miscellaneous/APIDiff/") { prefix in
             let packageRoot = prefix.appending(component: "Bar")
             try localFileSystem.createDirectory(packageRoot.appending(components: "Sources", "Foo"))
@@ -299,16 +272,10 @@ final class APIDiffTests: XCTestCase {
             XCTAssertTrue(output.contains("No breaking changes detected in Qux"))
             XCTAssertTrue(output.contains("Skipping Foo because it does not exist in the baseline"))
         }
-        #else
-        throw XCTSkip("Test unsupported on current platform")
-        #endif
     }
 
     func testBadTreeish() throws {
-        #if os(macOS)
-        guard (try? Resources.default.toolchain.getSwiftAPIDigester()) != nil else {
-            throw XCTSkip("swift-api-digester not available")
-        }
+        try skipIfApiDigesterUnsupported()
         fixture(name: "Miscellaneous/APIDiff/") { prefix in
             let packageRoot = prefix.appending(component: "Foo")
             XCTAssertThrowsError(try execute(["experimental-api-diff", "7.8.9"], packagePath: packageRoot)) { error in
@@ -319,8 +286,5 @@ final class APIDiffTests: XCTestCase {
                 XCTAssertTrue(stderr.contains("error: Couldn’t check out revision ‘7.8.9’"))
             }
         }
-        #else
-        throw XCTSkip("Test unsupported on current platform")
-        #endif
     }
 }


### PR DESCRIPTION
Enable the api diff tests on Linux once https://github.com/apple/swift/pull/37703 is merged

### Motivation:

Make sure experimental-api-diff is works and is tested on Linux

### Modifications:

This PR just enables tests, the cross-platform fix is in https://github.com/apple/swift/pull/37703

### Result:

API diff tests will run on all platforms
