### PR TITLE
Avoid calling `supportedFrontendFlags` on Windows

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -693,6 +693,10 @@ public final class SwiftTargetBuildDescription {
     }
     
     public static func checkSupportedFrontendFlags(flags: Set<String>, fs: FileSystem) -> Bool {
+        // The new driver is not supported on Windows, yet, so we should avoid calling into it there.
+        #if os(Windows)
+        return false
+        #else
         do {
             let executor = try SPMSwiftDriverExecutor(resolver: ArgsResolver(fileSystem: fs), fileSystem: fs, env: [:])
             let driver = try Driver(args: ["swiftc"], executor: executor)
@@ -700,6 +704,7 @@ public final class SwiftTargetBuildDescription {
         } catch {
             return false
         }
+        #endif
     }
     
     /// The arguments needed to compile this target.


### PR DESCRIPTION
The new driver does not support Windows, yet, so the check for `supportedFrontendFlags` needs to be conditional to non-Windows.
