### PR TITLE
[Collections] testPopulateTargetTrie sometimes gets stuck

### DIFF
--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -504,7 +504,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
             var matchingCollections = Set<Model.CollectionIdentifier>()
 
             // Trie is more performant for target search; use it if available
-            if self.targetTrieReady {
+            if self.populateTargetTrieLock.withLock({ self.targetTrieReady }) {
                 do {
                     switch type {
                     case .exactMatch:

--- a/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -231,10 +231,8 @@ class PackageCollectionsStorageTests: XCTestCase {
             do {
                 try tsc_await { callback in storage2.populateTargetTrie(callback: callback) }
 
-                do {
-                    let searchResult = try tsc_await { callback in storage2.searchTargets(query: targetName, type: .exactMatch, callback: callback) }
-                    XCTAssert(searchResult.items.count > 0, "should get results")
-                }
+                let searchResult = try tsc_await { callback in storage2.searchTargets(query: targetName, type: .exactMatch, callback: callback) }
+                XCTAssert(searchResult.items.count > 0, "should get results")
             } catch {
                 // It's possible that some platforms don't have support FTS
                 XCTAssertEqual(false, storage2.useSearchIndices.get(), "populateTargetTrie should fail only if FTS is not available")


### PR DESCRIPTION
Motivation:
`PackageCollectionsStorageTests/testPopulateTargetTrie` gets stuck sometimes because `targetTrieReady` is already set and `callback` is only invoked in the body of `memoize`.

https://ci.swift.org/job/oss-swift-package-ubuntu-20_04-aarch64/79/console

Modifications:
Rearrange logic in `populateTargetTrie` such that `callback` is invoked outside of `memoize` body.

Also, add `populateTargetTrieLock` to prevent more than one thread from calling `memoize` at the same time.

