### PR TITLE
[SR-14718] Only pass `-enable-library-evolution` for PackageDescription and PackagePlugin on macOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -115,7 +115,7 @@ let package = Package(
             name: "PackageDescription",
             swiftSettings: [
                 .unsafeFlags(["-package-description-version", "999.0"]),
-                .unsafeFlags(["-enable-library-evolution"])
+                .unsafeFlags(["-enable-library-evolution"], .when(platforms: [.macOS]))
             ]),
 
         // The `PackagePlugin` target provides the API that is available to
@@ -125,7 +125,7 @@ let package = Package(
             name: "PackagePlugin",
             swiftSettings: [
                 .unsafeFlags(["-package-description-version", "999.0"]),
-                .unsafeFlags(["-enable-library-evolution"])
+                .unsafeFlags(["-enable-library-evolution"], .when(platforms: [.macOS]))
             ]),
 
         // MARK: SwiftPM specific support libraries

--- a/Sources/PackageDescription/CMakeLists.txt
+++ b/Sources/PackageDescription/CMakeLists.txt
@@ -21,10 +21,10 @@ add_library(PackageDescription
 
 target_compile_options(PackageDescription PUBLIC
   $<$<COMPILE_LANGUAGE:Swift>:-package-description-version$<SEMICOLON>999.0>)
-target_compile_options(PackageDescription PUBLIC
-  $<$<COMPILE_LANGUAGE:Swift>:-enable-library-evolution>)
 
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
+  target_compile_options(PackageDescription PUBLIC
+    $<$<COMPILE_LANGUAGE:Swift>:-enable-library-evolution>)
   set(SWIFT_INTERFACE_PATH ${CMAKE_BINARY_DIR}/pm/ManifestAPI/PackageDescription.swiftinterface)
   target_compile_options(PackageDescription PUBLIC
     $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${SWIFT_INTERFACE_PATH}>)

--- a/Sources/PackagePlugin/CMakeLists.txt
+++ b/Sources/PackagePlugin/CMakeLists.txt
@@ -17,10 +17,10 @@ add_library(PackagePlugin
 
 target_compile_options(PackagePlugin PUBLIC
   $<$<COMPILE_LANGUAGE:Swift>:-package-description-version$<SEMICOLON>999.0>)
-target_compile_options(PackagePlugin PUBLIC
-  $<$<COMPILE_LANGUAGE:Swift>:-enable-library-evolution>)
   
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
+  target_compile_options(PackagePlugin PUBLIC
+    $<$<COMPILE_LANGUAGE:Swift>:-enable-library-evolution>)
   set(SWIFT_INTERFACE_PATH ${CMAKE_BINARY_DIR}/pm/PluginAPI/PackagePlugin.swiftinterface)
   target_compile_options(PackagePlugin PUBLIC
     $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${SWIFT_INTERFACE_PATH}>)


### PR DESCRIPTION
### Motivation:

Because PackageDescription unintentionally exports Foundation (for which a fix was attempted but then reverted after it broke some packages — see SR-14718), we can only enable library evolution on Darwin platforms.

### Modifications:

- conditionalize passing of `-enable-library-evolution` on the macOS platform

rdar://78827075
