### PR TITLE
[APIDiff] Add baseline management flags

### DIFF
--- a/Sources/Commands/APIDigester.swift
+++ b/Sources/Commands/APIDigester.swift
@@ -64,7 +64,9 @@ struct APIDigesterBaselineDumper {
     }
 
     /// Emit the API baseline files and return the path to their directory.
-    func emitAPIBaseline(for modulesToDiff: Set<String>, baselineDir: AbsolutePath?) throws -> AbsolutePath {
+    func emitAPIBaseline(for modulesToDiff: Set<String>,
+                         at baselineDir: AbsolutePath?,
+                         force: Bool) throws -> AbsolutePath {
         var modulesToDiff = modulesToDiff
         let apiDiffDir = inputBuildParameters.apiDiff
         let baselineDir = (baselineDir ?? apiDiffDir).appending(component: baselineTreeish)
@@ -72,10 +74,10 @@ struct APIDigesterBaselineDumper {
             baselineDir.appending(component: module + ".json")
         }
 
-        for module in modulesToDiff {
-            if localFileSystem.exists(baselinePath(module)) {
-                // If this baseline already exists, we don't need to regenerate it.
-                modulesToDiff.remove(module)
+        if !force {
+            // Baselines which already exist don't need to be regenerated.
+            modulesToDiff = modulesToDiff.filter {
+                !localFileSystem.exists(baselinePath($0))
             }
         }
 

--- a/Sources/Commands/APIDigester.swift
+++ b/Sources/Commands/APIDigester.swift
@@ -64,10 +64,10 @@ struct APIDigesterBaselineDumper {
     }
 
     /// Emit the API baseline files and return the path to their directory.
-    func emitAPIBaseline(for modulesToDiff: Set<String>) throws -> AbsolutePath {
+    func emitAPIBaseline(for modulesToDiff: Set<String>, baselineDir: AbsolutePath?) throws -> AbsolutePath {
         var modulesToDiff = modulesToDiff
         let apiDiffDir = inputBuildParameters.apiDiff
-        let baselineDir = apiDiffDir.appending(component: baselineTreeish)
+        let baselineDir = (baselineDir ?? apiDiffDir).appending(component: baselineTreeish)
         let baselinePath: (String)->AbsolutePath = { module in
             baselineDir.appending(component: module + ".json")
         }

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -316,8 +316,12 @@ extension SwiftPackageTool {
                 help: "One or more targets to include in the API comparison. If present, only the specified targets (and any products specified using `--products`) will be compared.")
         var targets: [String] = []
 
-        @Option(help: "The path to a directory used to store API baseline files. If unspecified, a temporary directory will be used")
-        var baselineDir: AbsolutePath?
+        @Option(name: .customLong("baseline-dir"),
+                help: "The path to a directory used to store API baseline files. If unspecified, a temporary directory will be used.")
+        var overrideBaselineDir: AbsolutePath?
+
+        @Flag(help: "Regenerate the API baseline, even if an existing one is available.")
+        var regenerateBaseline: Bool = false
 
         func run(_ swiftTool: SwiftTool) throws {
             let apiDigesterPath = try swiftTool.getToolchain().getSwiftAPIDigester()
@@ -344,7 +348,9 @@ extension SwiftPackageTool {
                 apiDigesterTool: apiDigesterTool,
                 diags: swiftTool.diagnostics
             )
-            let baselineDir = try baselineDumper.emitAPIBaseline(for: modulesToDiff, baselineDir: baselineDir)
+            let baselineDir = try baselineDumper.emitAPIBaseline(for: modulesToDiff,
+                                                                 at: overrideBaselineDir,
+                                                                 force: regenerateBaseline)
 
             let results = ThreadSafeArrayStore<SwiftAPIDigester.ComparisonResult>()
             let group = DispatchGroup()

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -316,6 +316,9 @@ extension SwiftPackageTool {
                 help: "One or more targets to include in the API comparison. If present, only the specified targets (and any products specified using `--products`) will be compared.")
         var targets: [String] = []
 
+        @Option(help: "The path to a directory used to store API baseline files. If unspecified, a temporary directory will be used")
+        var baselineDir: AbsolutePath?
+
         func run(_ swiftTool: SwiftTool) throws {
             let apiDigesterPath = try swiftTool.getToolchain().getSwiftAPIDigester()
             let apiDigesterTool = SwiftAPIDigester(tool: apiDigesterPath)
@@ -341,7 +344,7 @@ extension SwiftPackageTool {
                 apiDigesterTool: apiDigesterTool,
                 diags: swiftTool.diagnostics
             )
-            let baselineDir = try baselineDumper.emitAPIBaseline(for: modulesToDiff)
+            let baselineDir = try baselineDumper.emitAPIBaseline(for: modulesToDiff, baselineDir: baselineDir)
 
             let results = ThreadSafeArrayStore<SwiftAPIDigester.ComparisonResult>()
             let group = DispatchGroup()

--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -323,4 +323,35 @@ final class APIDiffTests: XCTestCase {
         throw XCTSkip("Test unsupported on current platform")
         #endif
     }
+
+    func testBaselineDirOverride() throws {
+        #if os(macOS)
+        guard (try? Resources.default.toolchain.getSwiftAPIDigester()) != nil else {
+            throw XCTSkip("swift-api-digester not available")
+        }
+        fixture(name: "Miscellaneous/APIDiff/") { prefix in
+            let packageRoot = prefix.appending(component: "Foo")
+            // Overwrite the existing decl.
+            try localFileSystem.writeFileContents(packageRoot.appending(component: "Foo.swift")) {
+                $0 <<< "public let foo = 42"
+            }
+
+            let baselineDir = prefix.appending(component: "Baselines")
+
+            XCTAssertThrowsError(try execute(["experimental-api-diff", "1.2.3",
+                                              "--baseline-dir", baselineDir.pathString],
+                                             packagePath: packageRoot)) { error in
+                guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
+                    XCTFail("Unexpected error")
+                    return
+                }
+                XCTAssertTrue(output.contains("1 breaking change detected in Foo"))
+                XCTAssertTrue(output.contains("💔 API breakage: func foo() has been removed"))
+                XCTAssertTrue(localFileSystem.exists(baselineDir.appending(components: "1.2.3", "Foo.json")))
+            }
+        }
+        #else
+        throw XCTSkip("Test unsupported on current platform")
+        #endif
+    }
 }


### PR DESCRIPTION
Add flags that can be used to manage API baselines

### Motivation:

In some environments, it can be useful to check API baseline files into source control, those of tagged versions for example.

### Modifications:

- `--baseline-dir` can be used to choose a directory to emit API baselines in
- `--regenerate-baseline` wil cause the tool to ignore preexisting baseline files

### Result:

It's now possible to choose a directory to emit baseline file to and then check them in