### PR TITLE
[Collections] PackageCollectionsTests.testUpdateAuthTokens sometimes causes signal 11

### DIFF
--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -61,7 +61,9 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
         self.encoder = JSONEncoder.makeWithDefaults()
         self.decoder = JSONDecoder.makeWithDefaults()
 
-        self.populateTargetTrie()
+        if configuration.initializeTargetTrie {
+            self.populateTargetTrie()
+        }
     }
 
     convenience init(path: AbsolutePath, diagnosticsEngine: DiagnosticsEngine? = nil) {
@@ -1018,12 +1020,15 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
 
     struct Configuration {
         var batchSize: Int
+        var initializeTargetTrie: Bool
 
         fileprivate var underlying: SQLite.Configuration
 
-        init() {
-            self.underlying = .init()
+        init(initializeTargetTrie: Bool = true) {
             self.batchSize = 100
+            self.initializeTargetTrie = initializeTargetTrie
+
+            self.underlying = .init()
             self.maxSizeInMegabytes = 100
             // see https://www.sqlite.org/c3ref/busy_timeout.html
             self.busyTimeoutMilliseconds = 1000

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -22,10 +22,13 @@ final class PackageCollectionsTests: XCTestCase {
     func testUpdateAuthTokens() throws {
         let authTokens = ThreadSafeKeyValueStore<AuthTokenType, String>()
         let configuration = PackageCollections.Configuration(authTokens: { authTokens.get() })
-        let storage = makeMockStorage()
+
+        // This test doesn't use storage at all and finishes quickly so disable target trie to prevent race
+        let storageConfig = SQLitePackageCollectionsStorage.Configuration(initializeTargetTrie: false)
+        let storage = makeMockStorage(storageConfig)
         defer { XCTAssertNoThrow(try storage.close()) }
 
-        // disable cache for this test to avoid setup/cleanup
+        // Disable cache for this test to avoid setup/cleanup
         let metadataProviderConfig = GitHubPackageMetadataProvider.Configuration(authTokens: configuration.authTokens, cacheTTLInSeconds: -1)
         let metadataProvider = GitHubPackageMetadataProvider(configuration: metadataProviderConfig)
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: [:], metadataProvider: metadataProvider)

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -121,10 +121,10 @@ func makeMockPackageBasicMetadata() -> PackageCollectionsModel.PackageBasicMetad
                  processedAt: Date())
 }
 
-func makeMockStorage() -> PackageCollections.Storage {
+func makeMockStorage(_ collectionsStorageConfig: SQLitePackageCollectionsStorage.Configuration = .init()) -> PackageCollections.Storage {
     let mockFileSystem = InMemoryFileSystem()
     return .init(sources: FilePackageCollectionsSourcesStorage(fileSystem: mockFileSystem),
-                 collections: SQLitePackageCollectionsStorage(location: .memory))
+                 collections: SQLitePackageCollectionsStorage(location: .memory, configuration: collectionsStorageConfig))
 }
 
 struct MockCollectionsProvider: PackageCollectionProvider {


### PR DESCRIPTION
Motivation:
rdar://78939220

`SQLitePackageCollectionsStorage.populateTargetTrie` is always called in the initializer and to be completed by a background thread. Looks like the crash could be caused by `populateTargetTrie` being run while `SQLitePackageCollectionsStorage` gets destroyed as part of `PackageCollections` deallocation.

Modifications:
Add option in `SQLitePackageCollectionsStorage.Configuration` to skip calling `populateTargetTrie` in tests to avoid the race between db destruction and `populateTargetTrie`. Not all tests need storage or make use of `populateTargetTrie`, and it's caused many crashes in CI already. We have added traps for db connection state but that doesn't seem to be enough.

Another approach is probably to use `withExtendedLifetime` in `testUpdateAuthTokens`, but I think it is better/easier to have the config option.
