### PR TITLE
Fix pluralization of 'package-collection refresh' text

### DIFF
--- a/Sources/Commands/SwiftPackageCollectionsTool.swift
+++ b/Sources/Commands/SwiftPackageCollectionsTool.swift
@@ -100,7 +100,7 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
             let collections = try with { collections in
                 try tsc_await { collections.refreshCollections(callback: $0) }
             }
-            print("Refreshed \(collections.count) configured package collections.")
+            print("Refreshed \(collections.count) configured package collection\(collections.count == 1 ? "" : "s").")
         }
     }
 


### PR DESCRIPTION
An exceedingly minor grammar fix: conditionally pluralize the `package-collection refresh` response based on the number of collections that were refreshed.

### Motivation:

Use correct grammar in user-facing messages.

### Modifications:

Changed the output of `package-collection refresh` to say "Refreshed _n_ configured package collection[s]." instead of always pluralizing "collections".

### Result:

If only one collection is refreshed, the output of this command will now say "collection" instead of "collections".
