### PR TITLE
[Collections] 'describe' package matching is too loose

### DIFF
--- a/Sources/PackageCollections/PackageCollections+Storage.swift
+++ b/Sources/PackageCollections/PackageCollections+Storage.swift
@@ -11,11 +11,11 @@
 import TSCBasic
 
 extension PackageCollections {
-    public struct Storage: Closable {
+    struct Storage: Closable {
         let sources: PackageCollectionsSourcesStorage
         let collections: PackageCollectionsStorage
 
-        public init(sources: PackageCollectionsSourcesStorage, collections: PackageCollectionsStorage) {
+        init(sources: PackageCollectionsSourcesStorage, collections: PackageCollectionsStorage) {
             self.sources = sources
             self.collections = collections
         }
@@ -23,7 +23,7 @@ extension PackageCollections {
 }
 
 extension PackageCollections.Storage {
-    public func close() throws {
+    func close() throws {
         var errors = [Error]()
 
         let tryClose = { (item: Any) in

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -599,6 +599,6 @@ private struct UnknownProvider: Error {
 
 private extension PackageReference {
     var canonicalLocation: String {
-        self.location.hasSuffix(".git") ? String(self.location.dropLast(4)) : self.location
+        (self.location.hasSuffix(".git") ? String(self.location.dropLast(4)) : self.location).lowercased()
     }
 }

--- a/Sources/PackageCollections/Storage/PackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/PackageCollectionsStorage.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -53,7 +53,9 @@ public protocol PackageCollectionsStorage {
                         query: String,
                         callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult, Error>) -> Void)
 
-    /// Returns `PackageSearchResult.Item` for the given package identity.
+    /// Returns packages for the given package identity.
+    ///
+    /// Since a package identity can be associated with more than one repository URL, the result may contain multiple items.
     ///
     /// - Parameters:
     ///   - identifier: The package identifier
@@ -61,7 +63,7 @@ public protocol PackageCollectionsStorage {
     ///   - callback: The closure to invoke when result becomes available
     func findPackage(identifier: PackageIdentity,
                      collectionIdentifiers: [PackageCollectionsModel.CollectionIdentifier]?,
-                     callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult.Item, Error>) -> Void)
+                     callback: @escaping (Result<(packages: [PackageCollectionsModel.Package], collections: [PackageCollectionsModel.CollectionIdentifier]), Error>) -> Void)
 
     /// Returns `TargetSearchResult` for the given search criteria.
     ///

--- a/Sources/PackageCollectionsModel/Formats/v1.md
+++ b/Sources/PackageCollectionsModel/Formats/v1.md
@@ -27,7 +27,7 @@ To begin, define the top-level metadata about the collection:
 
 Each item in the `packages` array is a package object with the following properties:
 
-* `url`: The URL of the package. Currently only Git repository URLs are supported.
+* `url`: The URL of the package. Currently only Git repository URLs are supported. URL should be HTTPS and may contain `.git` suffix.
 * `summary`: A description of the package. **Optional.**
 * `keywords`: An array of keywords that the package is associated with. **Optional.**
 * `readmeURL`: The URL of the package's README. **Optional.**


### PR DESCRIPTION
Motivation:
rdar://79069839

To distinguish between package vs. collection URL, we first search for it as if it were a package URL. The package search, however, is done using `PackageIdentity` and not the actual URL itself. The problem with identity is that it only uses the last URL path component, so `bar/foo` and `baz/foo` would end up with the same identity `foo`.

Modifications:
Update `findPackage` to allow multiple results since a package identity (the way it is) can be associated with multiple repository URLs. Caller of `findPackage` should then filter out packages by repository URL if needed.
