### PR TITLE
[APIDiff] Support forwarding breakage allowlists to the api digester

### DIFF
--- a/Sources/Commands/APIDigester.swift
+++ b/Sources/Commands/APIDigester.swift
@@ -200,7 +200,7 @@ public struct SwiftAPIDigester {
         at baselinePath: AbsolutePath,
         for module: String,
         buildPlan: BuildPlan,
-        breakageAllowlistPath: AbsolutePath?
+        except breakageAllowlistPath: AbsolutePath?
     ) -> ComparisonResult? {
         var args = [
             "-diagnose-sdk",

--- a/Sources/Commands/APIDigester.swift
+++ b/Sources/Commands/APIDigester.swift
@@ -199,7 +199,8 @@ public struct SwiftAPIDigester {
     public func compareAPIToBaseline(
         at baselinePath: AbsolutePath,
         for module: String,
-        buildPlan: BuildPlan
+        buildPlan: BuildPlan,
+        breakageAllowlistPath: AbsolutePath?
     ) -> ComparisonResult? {
         var args = [
             "-diagnose-sdk",
@@ -207,6 +208,9 @@ public struct SwiftAPIDigester {
             "-module", module
         ]
         args.append(contentsOf: buildPlan.createAPIToolCommonArgs(includeLibrarySearchPaths: false))
+        if let breakageAllowlistPath = breakageAllowlistPath {
+            args.append(contentsOf: ["-breakage-allowlist-path", breakageAllowlistPath.pathString])
+        }
 
         return try? withTemporaryFile(deleteOnClose: false) { file in
             args.append(contentsOf: ["-serialize-diagnostics-path", file.path.pathString])

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -368,7 +368,7 @@ extension SwiftPackageTool {
                         at: moduleBaselinePath,
                         for: module,
                         buildPlan: buildOp.buildPlan!,
-                        breakageAllowlistPath: breakageAllowlistPath
+                        except: breakageAllowlistPath
                     ) {
                         results.append(comparisonResult)
                     }

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -305,6 +305,13 @@ extension SwiftPackageTool {
         @OptionGroup(_hiddenFromHelp: true)
         var swiftOptions: SwiftToolOptions
 
+        @Option(help: """
+        The path to a text file containing breaking changes which should be ignored by the API comparison. \
+        Each ignored breaking change in the file should appear on its own line and contain the exact message \
+        to be ignored (e.g. 'API breakage: func foo() has been removed').
+        """)
+        var breakageAllowlistPath: AbsolutePath?
+
         @Argument(help: "The baseline treeish to compare to (e.g. a commit hash, branch name, tag, etc.)")
         var treeish: String
 
@@ -360,7 +367,8 @@ extension SwiftPackageTool {
                     if let comparisonResult = apiDigesterTool.compareAPIToBaseline(
                         at: moduleBaselinePath,
                         for: module,
-                        buildPlan: buildOp.buildPlan!
+                        buildPlan: buildOp.buildPlan!,
+                        breakageAllowlistPath: breakageAllowlistPath
                     ) {
                         results.append(comparisonResult)
                     }


### PR DESCRIPTION
Add a --breakage-allowlist-path flag to allow ignoring specified breaking changes when running experimental-api-diff

### Motivation:

Sometimes, it's beneficial to be able to ignore certain API breaking changes when perfect API compatibility isn't necessary.

### Modifications:

- Adds a new --breakage-allowlist-path flag which is forwarded directly to the api digester's diagnose-sdk action. If the flag isn't specified, the tool will also check to see if api-breakage-allowlist.txt exists at the package root and use that.

### Result:

Users can choose to ignore certain API-breaking changes when running comparisons
