### PR TITLE
PackageDescription: make underscored properties private

### DIFF
--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -62,11 +62,12 @@ public final class Target {
     ///
     /// The URL points to a ZIP file that contains an XCFramework at its root.
     /// Binary targets are only available on Apple Platforms.
+    @available(_PackageDescription, introduced: 5.3)
     public var url: String? {
         get { _url }
         set { _url = newValue }
     }
-    public var _url: String?
+    private var _url: String?
 
     /// The source files in this target.
     ///
@@ -170,7 +171,7 @@ public final class Target {
         get { _checksum }
         set { _checksum = newValue }
     }
-    public var _checksum: String?
+    private var _checksum: String?
 
     /// The usages of package plugins by the target.
     @available(_PackageDescription, introduced: 5.5)


### PR DESCRIPTION
This change makes a couple of underscored properties of `Target` private & adds a missing `@availability` attribute.

### Motivation:

`Target._url` & `Target._checksum` shouldn't be visible in the module interface of `PackageDescription`, since they are implementation details of `Target`. The user-facing properties do not have an underscore and are named `Target.url` & `Target.checksum`.
The `public` access modifier was probably a typo.
Also `Target.url` was introduced in SwiftPM 5.3, but was missing the corresponding `@availability` attribute.

### Modifications:

Replaced `public` with `private` & added an `@availability` attribute.

### Result:

Underscored properties are no longer exposed in the public module interface of `PackageDescription`.
