### PR TITLE
Remove a remaining stray reference to PACKAGE_DESCRIPTION_4

### DIFF
--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -775,7 +775,6 @@ public final class Target {
         )
     }
 
-  #if !PACKAGE_DESCRIPTION_4
     /// Creates a system library target.
     ///
     /// Use system library targets to adapt a library installed on the system to work with Swift packages.
@@ -915,7 +914,6 @@ public final class Target {
           type: .plugin,
           pluginCapability: capability)
     }
-  #endif
 }
 
 extension Target: Encodable {


### PR DESCRIPTION
This was left over after unifying the two flavors of PackageDescription.

Because the condition was `#if !PACKAGE_DESCRIPTION_4`, there is actually no semantic difference, but is should be cleaned up.
