### PR TITLE
[5.5] Remove a remaining stray reference to PACKAGE_DESCRIPTION_4

### DIFF
--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -777,7 +777,6 @@ public final class Target {
         )
     }
 
-  #if !PACKAGE_DESCRIPTION_4
     /// Creates a system library target.
     ///
     /// Use system library targets to adapt a library installed on the system to work with Swift packages.
@@ -914,7 +913,6 @@ public final class Target {
           type: .plugin,
           pluginCapability: capability)
     }
-  #endif
 }
 
 extension Target: Encodable {


### PR DESCRIPTION
Since the condition was `#if !PACKAGE_DESCRIPTION_4`, there is actually no semantic difference. (#3549)

This is the 5.5 nomination of https://github.com/apple/swift-package-manager/pull/3549.

(cherry picked from commit 27d72819e13e70cd14b7918489f53008741cb3ce)
