### PR TITLE
`SPMTestSupport` should not depend on `Build`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -253,7 +253,7 @@ let package = Package(
         .target(
             /** SwiftPM test support library */
             name: "SPMTestSupport",
-            dependencies: ["SwiftToolsSupport-auto", "Basics", "Build", "TSCTestSupport", "PackageGraph", "PackageLoading", "SourceControl", "Workspace", "Xcodeproj", "XCBuildSupport"]),
+            dependencies: ["SwiftToolsSupport-auto", "Basics", "TSCTestSupport", "PackageGraph", "PackageLoading", "SourceControl", "Workspace", "Xcodeproj", "XCBuildSupport"]),
 
         // MARK: SwiftPM tests
 

--- a/Sources/SPMTestSupport/Resources.swift
+++ b/Sources/SPMTestSupport/Resources.swift
@@ -13,7 +13,6 @@ import SPMBuildCore
 import Foundation
 import PackageLoading
 import Workspace
-import Build
 
 #if os(macOS)
 private func bundleRoot() -> AbsolutePath {
@@ -66,6 +65,4 @@ public class Resources: ManifestResourceProvider {
     public static var havePD4Runtime: Bool {
         return Resources.default.binDir == nil
     }
-    
-    public let swiftCompilerSupportsRenamingMainSymbol = SwiftTargetBuildDescription.checkSupportedFrontendFlags(flags: ["entry-point-function-name"], fs: localFileSystem)
 }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -562,7 +562,9 @@ class MiscellaneousTestCase: XCTestCase {
     
     func testTestsCanLinkAgainstExecutable() throws {
         // Check if the host compiler supports the '-entry-point-function-name' flag.
-        try XCTSkipUnless(Resources.default.swiftCompilerSupportsRenamingMainSymbol, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #if swift(<5.5)
+        try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #endif
         
         fixture(name: "Miscellaneous/TestableExe") { prefix in
             do {

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -16,7 +16,9 @@ class PluginTests: XCTestCase {
     
     func testUseOfBuildToolPluginTargetByExecutableInSamePackage() throws {
         // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 5.5.
-        try XCTSkipUnless(Resources.default.swiftCompilerSupportsRenamingMainSymbol, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #if swift(<5.5)
+        try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #endif
         
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
@@ -35,7 +37,9 @@ class PluginTests: XCTestCase {
 
     func testUseOfBuildToolPluginProductByExecutableAcrossPackages() throws {
         // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 5.5.
-        try XCTSkipUnless(Resources.default.swiftCompilerSupportsRenamingMainSymbol, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #if swift(<5.5)
+        try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #endif
 
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
@@ -54,7 +58,9 @@ class PluginTests: XCTestCase {
 
     func testUseOfPrebuildPluginTargetByExecutableAcrossPackages() throws {
         // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 5.5.
-        try XCTSkipUnless(Resources.default.swiftCompilerSupportsRenamingMainSymbol, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #if swift(<5.5)
+        try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #endif
 
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
@@ -73,7 +79,9 @@ class PluginTests: XCTestCase {
 
     func testContrivedTestCases() throws {
         // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 5.5.
-        try XCTSkipUnless(Resources.default.swiftCompilerSupportsRenamingMainSymbol, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #if swift(<5.5)
+        try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #endif
         
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
@@ -92,7 +100,10 @@ class PluginTests: XCTestCase {
 
     func testPluginScriptSandbox() throws {
         // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 5.5.
-        try XCTSkipUnless(Resources.default.swiftCompilerSupportsRenamingMainSymbol, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #if swift(<5.5)
+        try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #endif
+
         #if os(macOS)
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
@@ -110,7 +121,10 @@ class PluginTests: XCTestCase {
 
     func testUseOfVendedBinaryTool() throws {
         // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 5.5.
-        try XCTSkipUnless(Resources.default.swiftCompilerSupportsRenamingMainSymbol, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #if swift(<5.5)
+        try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #endif
+
         #if os(macOS)
         fixture(name: "Miscellaneous/Plugins") { path in
             do {

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -86,13 +86,13 @@ class InitTests: XCTestCase {
                 ["FooTests"])
             
             // If we have a compiler that supports `-entry-point-function-name`, we try building it (we need that flag now).
-            if (Resources.default.swiftCompilerSupportsRenamingMainSymbol) {
-                XCTAssertBuilds(path)
-                let triple = Resources.default.toolchain.triple
-                let binPath = path.appending(components: ".build", triple.tripleString, "debug")
-                XCTAssertFileExists(binPath.appending(component: "Foo"))
-                XCTAssertFileExists(binPath.appending(components: "Foo.swiftmodule"))
-            }
+            #if swift(>=5.5)
+            XCTAssertBuilds(path)
+            let triple = Resources.default.toolchain.triple
+            let binPath = path.appending(components: ".build", triple.tripleString, "debug")
+            XCTAssertFileExists(binPath.appending(component: "Foo"))
+            XCTAssertFileExists(binPath.appending(components: "Foo.swiftmodule"))
+            #endif
         }
     }
 


### PR DESCRIPTION
### Motivation:

In https://github.com/apple/swift-package-manager/pull/3398, we introduced a way to check whether a compiler supports specific flags. This functionality relies on the Swift Driver and therefore the `Build` module which isn't available on all platforms and therefore shouldn't be used by `SPMTestSupport`. 

For example, llbuild does not currently work on iOS and the Swift Driver doesn't support Windows at this time.

Moreover, we should also not proliferate use of the `Build` module to parts of the code base that should be separate from an actual build process, in order to keep the separation between the full SwiftPM library and the data model variant.

### Modifications:

This change removes the dependency and replaces the check in tests with a check for the 5.5 Swift compiler instead.

### Result:

Tests can be compiled and run again on platforms that didn't support this.
