### PR TITLE
Respect `SWIFT_TOOLCHAIN_MACOS_DEPLOYMENT_TARGET` if it is set in the environment

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ import class Foundation.ProcessInfo
 // but allow overriding it when building for a toolchain.
 
 let macOSPlatform: SupportedPlatform
-if let deploymentTarget = ProcessInfo.processInfo.environment["SWIFTPM_MACOS_DEPLOYMENT_TARGET"] {
+if let deploymentTarget = ProcessInfo.processInfo.environment["SWIFT_TOOLCHAIN_MACOS_DEPLOYMENT_TARGET"] ?? ProcessInfo.processInfo.environment["SWIFTPM_MACOS_DEPLOYMENT_TARGET"] {
     macOSPlatform = .macOS(deploymentTarget)
 } else {
     macOSPlatform = .macOS(.v10_15)


### PR DESCRIPTION
This makes the SwiftPM manifest respect `SWIFT_TOOLCHAIN_MACOS_DEPLOYMENT_TARGET` in preference over the existing `SWIFTPM_MACOS_DEPLOYMENT_TARGET`, which is still used as fallback.

### Motivation:

Rather than having every unrelated package use `SWIFTPM_MACOS_DEPLOYMENT_TARGET`, we have started to use the more neutral `SWIFT_TOOLCHAIN_MACOS_DEPLOYMENT_TARGET ` (see for example https://github.com/apple/swift-tools-support-core/pull/220) so that one setting can control all the packages that make up the toolchain.

### Modifications:

- modify Package.swift to first look for `SWIFT_TOOLCHAIN_MACOS_DEPLOYMENT_TARGET`

### Result:

`SWIFT_TOOLCHAIN_MACOS_DEPLOYMENT_TARGET` will be respected if it is set, otherwise `SWIFTPM_MACOS_DEPLOYMENT_TARGET ` will be respected, otherwise the default is used.
