### PR TITLE
[5.5] `SPMTestSupport` should not depend on `Build`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -258,7 +258,7 @@ let package = Package(
         .target(
             /** SwiftPM test support library */
             name: "SPMTestSupport",
-            dependencies: ["SwiftToolsSupport-auto", "Basics", "Build", "TSCTestSupport", "PackageGraph", "PackageLoading", "SourceControl", "Workspace", "Xcodeproj", "XCBuildSupport"]),
+            dependencies: ["SwiftToolsSupport-auto", "Basics", "TSCTestSupport", "PackageGraph", "PackageLoading", "SourceControl", "Workspace", "Xcodeproj", "XCBuildSupport"]),
 
         // MARK: SwiftPM tests
 

--- a/Sources/SPMTestSupport/Resources.swift
+++ b/Sources/SPMTestSupport/Resources.swift
@@ -13,7 +13,6 @@ import SPMBuildCore
 import Foundation
 import PackageLoading
 import Workspace
-import Build
 
 #if os(macOS)
 private func bundleRoot() -> AbsolutePath {
@@ -66,6 +65,4 @@ public class Resources: ManifestResourceProvider {
     public static var havePD4Runtime: Bool {
         return Resources.default.binDir == nil
     }
-    
-    public let swiftCompilerSupportsRenamingMainSymbol = SwiftTargetBuildDescription.checkSupportedFrontendFlags(flags: ["entry-point-function-name"], fs: localFileSystem)
 }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -603,7 +603,9 @@ class MiscellaneousTestCase: XCTestCase {
     
     func testTestsCanLinkAgainstExecutable() throws {
         // Check if the host compiler supports the '-entry-point-function-name' flag.
-        try XCTSkipUnless(Resources.default.swiftCompilerSupportsRenamingMainSymbol, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #if swift(<5.5)
+        try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #endif
         
         fixture(name: "Miscellaneous/TestableExe") { prefix in
             do {

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -16,7 +16,9 @@ class PluginTests: XCTestCase {
     
     func testUseOfBuildToolPluginTargetByExecutableInSamePackage() throws {
         // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 5.5.
-        try XCTSkipUnless(Resources.default.swiftCompilerSupportsRenamingMainSymbol, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #if swift(<5.5)
+        try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #endif
         
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
@@ -35,7 +37,9 @@ class PluginTests: XCTestCase {
 
     func testUseOfBuildToolPluginProductByExecutableAcrossPackages() throws {
         // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 5.5.
-        try XCTSkipUnless(Resources.default.swiftCompilerSupportsRenamingMainSymbol, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #if swift(<5.5)
+        try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #endif
 
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
@@ -54,7 +58,9 @@ class PluginTests: XCTestCase {
 
     func testUseOfPrebuildPluginTargetByExecutableAcrossPackages() throws {
         // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 5.5.
-        try XCTSkipUnless(Resources.default.swiftCompilerSupportsRenamingMainSymbol, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #if swift(<5.5)
+        try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #endif
 
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
@@ -73,7 +79,9 @@ class PluginTests: XCTestCase {
 
     func testContrivedTestCases() throws {
         // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 5.5.
-        try XCTSkipUnless(Resources.default.swiftCompilerSupportsRenamingMainSymbol, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #if swift(<5.5)
+        try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #endif
         
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
@@ -92,7 +100,10 @@ class PluginTests: XCTestCase {
 
     func testPluginScriptSandbox() throws {
         // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 5.5.
-        try XCTSkipUnless(Resources.default.swiftCompilerSupportsRenamingMainSymbol, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #if swift(<5.5)
+        try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #endif
+
         #if os(macOS)
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
@@ -110,7 +121,10 @@ class PluginTests: XCTestCase {
 
     func testUseOfVendedBinaryTool() throws {
         // Check if the host compiler supports the '-entry-point-function-name' flag.  It's not needed for this test but is needed to build any executable from a package that uses tools version 5.5.
-        try XCTSkipUnless(Resources.default.swiftCompilerSupportsRenamingMainSymbol, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #if swift(<5.5)
+        try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
+        #endif
+
         #if os(macOS)
         fixture(name: "Miscellaneous/Plugins") { path in
             do {

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -86,13 +86,13 @@ class InitTests: XCTestCase {
                 ["FooTests"])
             
             // If we have a compiler that supports `-entry-point-function-name`, we try building it (we need that flag now).
-            if (Resources.default.swiftCompilerSupportsRenamingMainSymbol) {
-                XCTAssertBuilds(path)
-                let triple = Resources.default.toolchain.triple
-                let binPath = path.appending(components: ".build", triple.tripleString, "debug")
-                XCTAssertFileExists(binPath.appending(component: "Foo"))
-                XCTAssertFileExists(binPath.appending(components: "Foo.swiftmodule"))
-            }
+            #if swift(>=5.5)
+            XCTAssertBuilds(path)
+            let triple = Resources.default.toolchain.triple
+            let binPath = path.appending(components: ".build", triple.tripleString, "debug")
+            XCTAssertFileExists(binPath.appending(component: "Foo"))
+            XCTAssertFileExists(binPath.appending(components: "Foo.swiftmodule"))
+            #endif
         }
     }
 


### PR DESCRIPTION
5.5 cherry-pick of https://github.com/apple/swift-package-manager/pull/3551