### PR TITLE
Temporarily revert the 5.5 merge of unifying PackageDescription 4.0 and 4.2+ since it broke Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -113,25 +113,19 @@ let package = Package(
         ),
     ],
     targets: [
-        // The `PackageDescription` target provides the API that is available
-        // to `Package.swift` manifests. Here we build a debug version of the
-        // library; the bootstrap scripts build the deployable version.
+        // The `PackageDescription` targets define the API which is available to
+        // the `Package.swift` manifest files. We build the latest API version
+        // here which is used when building and running swiftpm without the
+        // bootstrap script.
         .target(
+            /** Package Definition API */
             name: "PackageDescription",
             swiftSettings: [
-                .unsafeFlags(["-package-description-version", "999.0"]),
-                .unsafeFlags(["-enable-library-evolution"])
+                .define("PACKAGE_DESCRIPTION_4_2"),
             ]),
-
-        // The `PackagePlugin` target provides the API that is available to
-        // plugin scripts. Here we build a debug version of the library; the
-        // bootstrap scripts build the deployable version.
+        
         .target(
-            name: "PackagePlugin",
-            swiftSettings: [
-                .unsafeFlags(["-package-description-version", "999.0"]),
-                .unsafeFlags(["-enable-library-evolution"])
-            ]),
+            name: "PackagePlugin"),
 
         // MARK: SwiftPM specific support libraries
 

--- a/Sources/PackageDescription/CMakeLists.txt
+++ b/Sources/PackageDescription/CMakeLists.txt
@@ -1,73 +1,75 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-add_library(PackageDescription
-  BuildSettings.swift
-  LanguageStandardSettings.swift
-  PackageDescription.swift
-  PackageDependency.swift
-  PackageRequirement.swift
-  Product.swift
-  Resource.swift
-  SupportedPlatforms.swift
-  Target.swift
-  Version.swift
-  Version+StringLiteralConvertible.swift)
+foreach(PACKAGE_DESCRIPTION_VERSION 4 4_2)
+    add_library(PD${PACKAGE_DESCRIPTION_VERSION}
+        BuildSettings.swift
+        LanguageStandardSettings.swift
+        PackageDescription.swift
+        PackageDependency.swift
+        PackageRequirement.swift
+        Product.swift
+        Resource.swift
+        SupportedPlatforms.swift
+        Target.swift
+        Version.swift
+        Version+StringLiteralConvertible.swift)
 
-target_compile_options(PackageDescription PUBLIC
-  $<$<COMPILE_LANGUAGE:Swift>:-package-description-version$<SEMICOLON>999.0>)
-target_compile_options(PackageDescription PUBLIC
-  $<$<COMPILE_LANGUAGE:Swift>:-enable-library-evolution>)
+    target_compile_definitions(PD${PACKAGE_DESCRIPTION_VERSION} PRIVATE
+        PACKAGE_DESCRIPTION_${PACKAGE_DESCRIPTION_VERSION})
 
-if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
-  set(SWIFT_INTERFACE_PATH ${CMAKE_BINARY_DIR}/pm/ManifestAPI/PackageDescription.swiftinterface)
-  target_compile_options(PackageDescription PUBLIC
-    $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${SWIFT_INTERFACE_PATH}>)
-  target_link_options(PackageDescription PRIVATE
-    "SHELL:-Xlinker -install_name -Xlinker @rpath/libPackageDescription.dylib")
-endif()
+    if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
+        set(SWIFT_INTERFACE_PATH ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}/PackageDescription.swiftinterface)
+        target_compile_options(PD${PACKAGE_DESCRIPTION_VERSION} PUBLIC
+            $<$<COMPILE_LANGUAGE:Swift>:-enable-library-evolution>)
+        target_compile_options(PD${PACKAGE_DESCRIPTION_VERSION} PUBLIC
+            $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${SWIFT_INTERFACE_PATH}>)
+        target_link_options(PD${PACKAGE_DESCRIPTION_VERSION} PRIVATE
+            "SHELL:-Xlinker -install_name -Xlinker @rpath/libPackageDescription.dylib")
+    endif()
 
-set_target_properties(PackageDescription PROPERTIES
-    Swift_MODULE_NAME PackageDescription
-    Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
-    INSTALL_NAME_DIR \\@rpath
-    OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
-    OUTPUT_NAME PackageDescription
-    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
-    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
-)
+    set_target_properties(PD${PACKAGE_DESCRIPTION_VERSION} PROPERTIES
+        Swift_MODULE_NAME PackageDescription
+        Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}
+        INSTALL_NAME_DIR \\@rpath
+        OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}
+        OUTPUT_NAME PackageDescription
+        ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}
+    )
 
-if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  if(Foundation_FOUND)
-    target_link_libraries(PackageDescription PRIVATE
-      Foundation)
-  endif()
-  target_link_options(PackageDescription PRIVATE
-    "SHELL:-no-toolchain-stdlib-rpath")
-  set_target_properties(PackageDescription PROPERTIES
-    BUILD_WITH_INSTALL_RPATH TRUE
-    INSTALL_RPATH "$ORIGIN/../../$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
-endif()
+    if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+      if(Foundation_FOUND)
+        target_link_libraries(PD${PACKAGE_DESCRIPTION_VERSION} PRIVATE
+          Foundation)
+      endif()
+      target_link_options(PD${PACKAGE_DESCRIPTION_VERSION} PRIVATE
+        "SHELL:-no-toolchain-stdlib-rpath")
+      set_target_properties(PD${PACKAGE_DESCRIPTION_VERSION} PROPERTIES
+          BUILD_WITH_INSTALL_RPATH TRUE
+          INSTALL_RPATH "$ORIGIN/../../$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
+    endif()
 
-if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
-  install(FILES
-    ${CMAKE_BINARY_DIR}/pm/ManifestAPI/PackageDescription.swiftinterface
-    ${CMAKE_BINARY_DIR}/pm/ManifestAPI/PackageDescription.swiftdoc
-    DESTINATION lib/swift/pm/ManifestAPI
-  )
-else()
-  install(FILES
-    ${CMAKE_BINARY_DIR}/pm/ManifestAPI/PackageDescription.swiftmodule
-    ${CMAKE_BINARY_DIR}/pm/ManifestAPI/PackageDescription.swiftdoc
-    DESTINATION lib/swift/pm/ManifestAPI
-  )
-endif()
+    if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
+        install(FILES
+            ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}/PackageDescription.swiftinterface
+            ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}/PackageDescription.swiftdoc
+            DESTINATION lib/swift/pm/${PACKAGE_DESCRIPTION_VERSION}
+        )
+    else()
+        install(FILES
+            ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}/PackageDescription.swiftmodule
+            ${CMAKE_BINARY_DIR}/pm/${PACKAGE_DESCRIPTION_VERSION}/PackageDescription.swiftdoc
+            DESTINATION lib/swift/pm/${PACKAGE_DESCRIPTION_VERSION}
+        )
+    endif()
 
-install(TARGETS PackageDescription
-  DESTINATION lib/swift/pm/ManifestAPI)
+    install(TARGETS PD${PACKAGE_DESCRIPTION_VERSION}
+      DESTINATION lib/swift/pm/${PACKAGE_DESCRIPTION_VERSION})
+endforeach()

--- a/Sources/PackageDescription/LanguageStandardSettings.swift
+++ b/Sources/PackageDescription/LanguageStandardSettings.swift
@@ -144,6 +144,7 @@ public enum CXXLanguageStandard: String, Encodable {
     case gnucxx20 = "gnu++20"
 }
 
+#if !PACKAGE_DESCRIPTION_4
 /// The version of the Swift language to use for compiling Swift sources in the package.
 public enum SwiftVersion {
     @available(_PackageDescription, introduced: 4, obsoleted: 5)
@@ -186,3 +187,4 @@ extension SwiftVersion: Encodable {
         try container.encode(value)
     }
 }
+#endif

--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -147,7 +147,11 @@ extension Package.Dependency {
         url: String,
         _ range: Range<Version>
     ) -> Package.Dependency {
+      #if PACKAGE_DESCRIPTION_4
         return .init(name: nil, url: url, requirement: .rangeItem(range))
+      #else
+        return .init(name: nil, url: url, requirement: ._rangeItem(range))
+      #endif
     }
 
     /// Adds a package dependency starting with a specific minimum version, up to
@@ -168,7 +172,11 @@ extension Package.Dependency {
         url: String,
         _ range: Range<Version>
     ) -> Package.Dependency {
+      #if PACKAGE_DESCRIPTION_4
         return .init(name: name, url: url, requirement: .rangeItem(range))
+      #else
+        return .init(name: name, url: url, requirement: ._rangeItem(range))
+      #endif
     }
 
     /// Adds a package dependency starting with a specific minimum version, going
@@ -194,7 +202,11 @@ extension Package.Dependency {
             upper.major, upper.minor, upper.patch + 1,
             prereleaseIdentifiers: upper.prereleaseIdentifiers,
             buildMetadataIdentifiers: upper.buildMetadataIdentifiers)
+      #if PACKAGE_DESCRIPTION_4
         return .init(name: nil, url: url, requirement: .rangeItem(range.lowerBound..<upperBound))
+      #else
+        return .init(name: nil, url: url, requirement: ._rangeItem(range.lowerBound..<upperBound))
+      #endif
     }
 
     /// Adds a package dependency starting with a specific minimum version, going
@@ -221,9 +233,14 @@ extension Package.Dependency {
             upper.major, upper.minor, upper.patch + 1,
             prereleaseIdentifiers: upper.prereleaseIdentifiers,
             buildMetadataIdentifiers: upper.buildMetadataIdentifiers)
+      #if PACKAGE_DESCRIPTION_4
         return .init(name: name, url: url, requirement: .rangeItem(range.lowerBound..<upperBound))
+      #else
+        return .init(name: name, url: url, requirement: ._rangeItem(range.lowerBound..<upperBound))
+      #endif
     }
 
+  #if !PACKAGE_DESCRIPTION_4
     /// Adds a package dependency to a local package on the filesystem.
     ///
     /// The Swift Package Manager uses the package dependency as-is
@@ -236,7 +253,7 @@ extension Package.Dependency {
     public static func package(
         path: String
     ) -> Package.Dependency {
-        return .init(name: nil, url: path, requirement: .localPackageItem)
+        return .init(name: nil, url: path, requirement: ._localPackageItem)
     }
 
     /// Adds a package dependency to a local package on the filesystem.
@@ -254,8 +271,9 @@ extension Package.Dependency {
         name: String? = nil,
         path: String
     ) -> Package.Dependency {
-        return .init(name: name, url: path, requirement: .localPackageItem)
+        return .init(name: name, url: path, requirement: ._localPackageItem)
     }
+  #endif
 }
 
 // Mark common APIs used by mistake as unavailable to provide better error messages.

--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -122,14 +122,26 @@ public final class Package {
         /// dependency requirements; you should remove commit-based dependency
         /// requirements before publishing a version of your package.
         public enum Requirement {
+          #if PACKAGE_DESCRIPTION_4
             case exactItem(Version)
             case rangeItem(Range<Version>)
             case revisionItem(String)
             case branchItem(String)
             case localPackageItem
+          #else
+            case _exactItem(Version)
+            case _rangeItem(Range<Version>)
+            case _revisionItem(String)
+            case _branchItem(String)
+            case _localPackageItem
+          #endif
 
             var isLocalPackage: Bool {
+              #if PACKAGE_DESCRIPTION_4
                 if case .localPackageItem = self { return true }
+              #else
+                if case ._localPackageItem = self { return true }
+              #endif
                 return false
             }
         }
@@ -155,12 +167,14 @@ public final class Package {
     /// The name of the Swift package.
     public var name: String
 
+  #if !PACKAGE_DESCRIPTION_4
     /// The list of supported platforms with a custom deployment target.
     @available(_PackageDescription, introduced: 5)
     public var platforms: [SupportedPlatform]? {
         get { return _platforms }
         set { _platforms = newValue }
     }
+  #endif
     private var _platforms: [SupportedPlatform]?
 
     /// The default localization for resources.
@@ -189,8 +203,13 @@ public final class Package {
     /// The list of package dependencies.
     public var dependencies: [Dependency]
 
+  #if PACKAGE_DESCRIPTION_4
+    /// The list of Swift versions that this package is compatible with.
+    public var swiftLanguageVersions: [Int]?
+  #else
     /// The list of Swift versions that this package is compatible with.
     public var swiftLanguageVersions: [SwiftVersion]?
+  #endif
 
     /// The C language standard to use for all C targets in this package.
     public var cLanguageStandard: CLanguageStandard?
@@ -198,12 +217,13 @@ public final class Package {
     /// The C++ language standard to use for all C++ targets in this package.
     public var cxxLanguageStandard: CXXLanguageStandard?
 
+  #if PACKAGE_DESCRIPTION_4
     /// Initializes a Swift package with configuration options you provide.
     ///
     /// - Parameters:
     ///     - name: The name of the Swift package, or `nil`, if you want the Swift Package Manager to deduce the
     ///           name from the package’s Git URL.
-    ///     - pkgConfig: The name to use for C modules. If present, the Swift
+    ///     - pkgConfig: The name to use for C modules. If present, the Swift 
     ///           Package Manager searches for a `<name>.pc` file to get the
     ///           additional flags required for a system target.
     ///     - providers: The package providers for a system package.
@@ -213,7 +233,6 @@ public final class Package {
     ///     - swiftLanguageVersions: The list of Swift versions that this package is compatible with.
     ///     - cLanguageStandard: The C language standard to use for all C targets in this package.
     ///     - cxxLanguageStandard: The C++ language standard to use for all C++ targets in this package.
-    @available(_PackageDescription, obsoleted: 4.2)
     public init(
         name: String,
         pkgConfig: String? = nil,
@@ -231,12 +250,12 @@ public final class Package {
         self.products = products
         self.dependencies = dependencies
         self.targets = targets
-        self.swiftLanguageVersions = swiftLanguageVersions.map{ $0.map{ .version("\($0)") } }
+        self.swiftLanguageVersions = swiftLanguageVersions
         self.cLanguageStandard = cLanguageStandard
         self.cxxLanguageStandard = cxxLanguageStandard
         registerExitHandler()
     }
-
+  #else
     /// Initializes a Swift package with configuration options you provide.
     ///
     /// - Parameters:
@@ -359,6 +378,7 @@ public final class Package {
         self.cxxLanguageStandard = cxxLanguageStandard
         registerExitHandler()
     }
+  #endif
 
     private func registerExitHandler() {
         // Add a custom exit handler to cause the package's JSON representation
@@ -437,10 +457,14 @@ extension LanguageTag: CustomStringConvertible {
 /// The system package providers used in this Swift package.
 public enum SystemPackageProvider {
 
+  #if PACKAGE_DESCRIPTION_4
     case brewItem([String])
     case aptItem([String])
-    @available(_PackageDescription, introduced: 5.3)
-    case yumItem([String])
+  #else
+    case _brewItem([String])
+    case _aptItem([String])
+    case _yumItem([String])
+  #endif
 
     /// Creates a system package provider with a list of installable packages
     /// for users of the HomeBrew package manager on macOS.
@@ -448,7 +472,11 @@ public enum SystemPackageProvider {
     /// - Parameters:
     ///     - packages: The list of package names.
     public static func brew(_ packages: [String]) -> SystemPackageProvider {
+      #if PACKAGE_DESCRIPTION_4
         return .brewItem(packages)
+      #else
+        return ._brewItem(packages)
+      #endif
     }
 
     /// Creates a system package provider with a list of installable packages
@@ -457,9 +485,16 @@ public enum SystemPackageProvider {
     /// - Parameters:
     ///     - packages: The list of package names.
     public static func apt(_ packages: [String]) -> SystemPackageProvider {
+      #if PACKAGE_DESCRIPTION_4
         return .aptItem(packages)
+      #else
+        return ._aptItem(packages)
+      #endif
     }
 
+#if PACKAGE_DESCRIPTION_4
+// yum is not supported
+#else
     /// Creates a system package provider with a list of installable packages
     /// for users of the yum package manager on Red Hat Enterprise Linux or CentOS.
     ///
@@ -467,8 +502,9 @@ public enum SystemPackageProvider {
     ///     - packages: The list of package names.
     @available(_PackageDescription, introduced: 5.3)
     public static func yum(_ packages: [String]) -> SystemPackageProvider {
-        return .yumItem(packages)
+        return ._yumItem(packages)
     }
+#endif
 }
 
 // MARK: Package JSON serialization
@@ -492,19 +528,26 @@ extension Package: Encodable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(name, forKey: .name)
 
+      #if !PACKAGE_DESCRIPTION_4
         if let defaultLocalization = _defaultLocalization {
             try container.encode(defaultLocalization.tag, forKey: .defaultLocalization)
         }
         if let platforms = self._platforms {
             try container.encode(platforms, forKey: .platforms)
         }
+      #endif
 
         try container.encode(pkgConfig, forKey: .pkgConfig)
         try container.encode(providers, forKey: .providers)
         try container.encode(products, forKey: .products)
         try container.encode(dependencies, forKey: .dependencies)
         try container.encode(targets, forKey: .targets)
+      #if PACKAGE_DESCRIPTION_4
+        let slv = swiftLanguageVersions?.map({ String($0) })
+        try container.encode(slv, forKey: .swiftLanguageVersions)
+      #else
         try container.encode(swiftLanguageVersions, forKey: .swiftLanguageVersions)
+      #endif
         try container.encode(cLanguageStandard, forKey: .cLanguageStandard)
         try container.encode(cxxLanguageStandard, forKey: .cxxLanguageStandard)
     }
@@ -524,6 +567,7 @@ extension SystemPackageProvider: Encodable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
+      #if PACKAGE_DESCRIPTION_4
         switch self {
         case .brewItem(let packages):
             try container.encode(Name.brew, forKey: .name)
@@ -531,10 +575,20 @@ extension SystemPackageProvider: Encodable {
         case .aptItem(let packages):
             try container.encode(Name.apt, forKey: .name)
             try container.encode(packages, forKey: .values)
-        case .yumItem(let packages):
+        }
+      #else
+        switch self {
+        case ._brewItem(let packages):
+            try container.encode(Name.brew, forKey: .name)
+            try container.encode(packages, forKey: .values)
+        case ._aptItem(let packages):
+            try container.encode(Name.apt, forKey: .name)
+            try container.encode(packages, forKey: .values)
+        case ._yumItem(let packages):
             try container.encode(Name.yum, forKey: .name)
             try container.encode(packages, forKey: .values)
         }
+      #endif
     }
 }
 
@@ -572,21 +626,36 @@ extension Target.Dependency: Encodable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
+      #if PACKAGE_DESCRIPTION_4
         switch self {
-        case .targetItem(let name, let condition):
+        case .targetItem(let name):
+            try container.encode(Kind.target, forKey: .type)
+            try container.encode(name, forKey: .name)
+        case .productItem(let name, let package):
+            try container.encode(Kind.product, forKey: .type)
+            try container.encode(name, forKey: .name)
+            try container.encode(package, forKey: .package)
+        case .byNameItem(let name):
+            try container.encode(Kind.byName, forKey: .type)
+            try container.encode(name, forKey: .name)
+        }
+      #else
+        switch self {
+        case ._targetItem(let name, let condition):
             try container.encode(Kind.target, forKey: .type)
             try container.encode(name, forKey: .name)
             try container.encode(condition, forKey: .condition)
-        case .productItem(let name, let package, let condition):
+        case ._productItem(let name, let package, let condition):
             try container.encode(Kind.product, forKey: .type)
             try container.encode(name, forKey: .name)
             try container.encode(package, forKey: .package)
             try container.encode(condition, forKey: .condition)
-        case .byNameItem(let name, let condition):
+        case ._byNameItem(let name, let condition):
             try container.encode(Kind.byName, forKey: .type)
             try container.encode(name, forKey: .name)
             try container.encode(condition, forKey: .condition)
         }
+      #endif
     }
 }
 

--- a/Sources/PackageDescription/PackageRequirement.swift
+++ b/Sources/PackageDescription/PackageRequirement.swift
@@ -24,7 +24,11 @@ extension Package.Dependency.Requirement: Encodable {
     /// - Parameters:
     ///      - version: The exact version of the dependency for this requirement.
     public static func exact(_ version: Version) -> Package.Dependency.Requirement {
+      #if PACKAGE_DESCRIPTION_4
         return .exactItem(version)
+      #else
+        return ._exactItem(version)
+      #endif
     }
 
     /// Returns a requirement for a source control revision such as the hash of a commit.
@@ -41,7 +45,11 @@ extension Package.Dependency.Requirement: Encodable {
     /// - Parameters:
     ///     - ref: The Git revision, usually a commit hash.
     public static func revision(_ ref: String) -> Package.Dependency.Requirement {
+      #if PACKAGE_DESCRIPTION_4
         return .revisionItem(ref)
+      #else
+        return ._revisionItem(ref)
+      #endif
     }
 
     /// Returns a requirement for a source control branch.
@@ -59,7 +67,11 @@ extension Package.Dependency.Requirement: Encodable {
     /// - Parameters:
     ///     - name: The name of the branch.
     public static func branch(_ name: String) -> Package.Dependency.Requirement {
+      #if PACKAGE_DESCRIPTION_4
         return .branchItem(name)
+      #else
+        return ._branchItem(name)
+      #endif
     }
 
     /// Returns a requirement for a version range, starting at the given minimum
@@ -68,7 +80,11 @@ extension Package.Dependency.Requirement: Encodable {
     /// - Parameters:
     ///     - version: The minimum version for the version range.
     public static func upToNextMajor(from version: Version) -> Package.Dependency.Requirement {
+      #if PACKAGE_DESCRIPTION_4
         return .rangeItem(version..<Version(version.major + 1, 0, 0))
+      #else
+        return ._rangeItem(version..<Version(version.major + 1, 0, 0))
+      #endif
     }
 
     /// Returns a requirement for a version range, starting at the given minimum
@@ -77,7 +93,11 @@ extension Package.Dependency.Requirement: Encodable {
     /// - Parameters:
     ///     - version: The minimum version for the version range.
     public static func upToNextMinor(from version: Version) -> Package.Dependency.Requirement {
+      #if PACKAGE_DESCRIPTION_4
         return .rangeItem(version..<Version(version.major, version.minor + 1, 0))
+      #else
+        return ._rangeItem(version..<Version(version.major, version.minor + 1, 0))
+      #endif
     }
 
     private enum CodingKeys: CodingKey {
@@ -97,6 +117,7 @@ extension Package.Dependency.Requirement: Encodable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
+      #if PACKAGE_DESCRIPTION_4
         switch self {
         case .rangeItem(let range):
             try container.encode(Kind.range, forKey: .type)
@@ -114,5 +135,24 @@ extension Package.Dependency.Requirement: Encodable {
         case .localPackageItem:
             try container.encode(Kind.localPackage, forKey: .type)
         }
+      #else
+        switch self {
+        case ._rangeItem(let range):
+            try container.encode(Kind.range, forKey: .type)
+            try container.encode(range.lowerBound, forKey: .lowerBound)
+            try container.encode(range.upperBound, forKey: .upperBound)
+        case ._exactItem(let version):
+            try container.encode(Kind.exact, forKey: .type)
+            try container.encode(version, forKey: .identifier)
+        case ._branchItem(let identifier):
+            try container.encode(Kind.branch, forKey: .type)
+            try container.encode(identifier, forKey: .identifier)
+        case ._revisionItem(let identifier):
+            try container.encode(Kind.revision, forKey: .type)
+            try container.encode(identifier, forKey: .identifier)
+        case ._localPackageItem:
+            try container.encode(Kind.localPackage, forKey: .type)
+        }
+      #endif
     }
 }

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -36,9 +36,15 @@ public final class Target {
 
     /// The different types of a target's dependency on another entity.
     public enum Dependency {
-        case targetItem(name: String, condition: TargetDependencyCondition?)
-        case productItem(name: String, package: String?, condition: TargetDependencyCondition?)
-        case byNameItem(name: String, condition: TargetDependencyCondition?)
+      #if PACKAGE_DESCRIPTION_4
+        case targetItem(name: String)
+        case productItem(name: String, package: String?)
+        case byNameItem(name: String)
+      #else
+        case _targetItem(name: String, condition: TargetDependencyCondition?)
+        case _productItem(name: String, package: String?, condition: TargetDependencyCondition?)
+        case _byNameItem(name: String, condition: TargetDependencyCondition?)
+      #endif
     }
 
     /// The name of the target.
@@ -983,7 +989,11 @@ extension Target.Dependency {
     ///   - name: The name of the target.
     @available(_PackageDescription, obsoleted: 5.3)
     public static func target(name: String) -> Target.Dependency {
-        return .targetItem(name: name, condition: nil)
+      #if PACKAGE_DESCRIPTION_4
+        return .targetItem(name: name)
+      #else
+        return ._targetItem(name: name, condition: nil)
+      #endif
     }
 
     /// Creates a dependency on a product from a package dependency.
@@ -993,7 +1003,11 @@ extension Target.Dependency {
     ///   - package: The name of the package.
     @available(_PackageDescription, obsoleted: 5.2, message: "the 'package' argument is mandatory as of tools version 5.2")
     public static func product(name: String, package: String? = nil) -> Target.Dependency {
-        return .productItem(name: name, package: package, condition: nil)
+      #if PACKAGE_DESCRIPTION_4
+        return .productItem(name: name, package: package)
+      #else
+        return ._productItem(name: name, package: package, condition: nil)
+      #endif
     }
 
     /// Creates a dependency that resolves to either a target or a product with the specified name.
@@ -1004,9 +1018,14 @@ extension Target.Dependency {
     /// The Swift Package Manager creates the by-name dependency after it has loaded the package graph.
     @available(_PackageDescription, obsoleted: 5.3)
     public static func byName(name: String) -> Target.Dependency {
-        return .byNameItem(name: name, condition: nil)
+      #if PACKAGE_DESCRIPTION_4
+        return .byNameItem(name: name)
+      #else
+        return ._byNameItem(name: name, condition: nil)
+      #endif
     }
 
+  #if !PACKAGE_DESCRIPTION_4
     /// Creates a dependency on a product from a package dependency.
     ///
     /// - parameters:
@@ -1017,7 +1036,7 @@ extension Target.Dependency {
         name: String,
         package: String
     ) -> Target.Dependency {
-        return .productItem(name: name, package: package, condition: nil)
+        return ._productItem(name: name, package: package, condition: nil)
     }
 
     /// Creates a dependency on a target in the same package.
@@ -1028,7 +1047,7 @@ extension Target.Dependency {
     ///       dependency for a specific platform.
     @available(_PackageDescription, introduced: 5.3)
     public static func target(name: String, condition: TargetDependencyCondition? = nil) -> Target.Dependency {
-        return .targetItem(name: name, condition: condition)
+        return ._targetItem(name: name, condition: condition)
     }
 
     /// Creates a target dependency on a product from a package dependency.
@@ -1044,7 +1063,7 @@ extension Target.Dependency {
         package: String,
         condition: TargetDependencyCondition? = nil
     ) -> Target.Dependency {
-        return .productItem(name: name, package: package, condition: condition)
+        return ._productItem(name: name, package: package, condition: condition)
     }
 
     /// Creates a by-name dependency that resolves to either a target or a product but after the Swift Package Manager
@@ -1056,8 +1075,9 @@ extension Target.Dependency {
     ///       dependency for a specific platform.
     @available(_PackageDescription, introduced: 5.3)
     public static func byName(name: String, condition: TargetDependencyCondition? = nil) -> Target.Dependency {
-        return .byNameItem(name: name, condition: condition)
+        return ._byNameItem(name: name, condition: condition)
     }
+  #endif
 }
 
 extension Target.PluginCapability {
@@ -1102,7 +1122,11 @@ extension Target.Dependency: ExpressibleByStringLiteral {
     /// - parameters:
     ///   - value: A string literal.
     public init(stringLiteral value: String) {
-        self = .byNameItem(name: value, condition: nil)
+      #if PACKAGE_DESCRIPTION_4
+        self = .byNameItem(name: value)
+      #else
+        self = ._byNameItem(name: value, condition: nil)
+      #endif
     }
 }
 

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -938,7 +938,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
     /// Returns the runtime path given the manifest version and path to libDir.
     private func runtimePath(for version: ToolsVersion) -> AbsolutePath {
         // Bin dir will be set when developing swiftpm without building all of the runtimes.
-        return resources.binDir ?? resources.libDir.appending(component: "ManifestAPI")
+        return resources.binDir ?? resources.libDir.appending(version.runtimeSubpath)
     }
 
     /// Returns path to the manifest database inside the given cache directory.

--- a/Sources/PackagePlugin/CMakeLists.txt
+++ b/Sources/PackagePlugin/CMakeLists.txt
@@ -7,63 +7,60 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(PackagePlugin
-  PublicAPI/CommandConstructor.swift
-  PublicAPI/DiagnosticsEmitter.swift
-  PublicAPI/FileList.swift
-  PublicAPI/Globals.swift
-  PublicAPI/Path.swift
-  PublicAPI/TargetBuildContext.swift
-  ImplementationDetails.swift)
-
-target_compile_options(PackagePlugin PUBLIC
-  $<$<COMPILE_LANGUAGE:Swift>:-package-description-version$<SEMICOLON>999.0>)
-target_compile_options(PackagePlugin PUBLIC
-  $<$<COMPILE_LANGUAGE:Swift>:-enable-library-evolution>)
+    PublicAPI/CommandConstructor.swift
+    PublicAPI/DiagnosticsEmitter.swift
+    PublicAPI/FileList.swift
+    PublicAPI/Globals.swift
+    PublicAPI/Path.swift
+    PublicAPI/TargetBuildContext.swift
+    ImplementationDetails.swift)
   
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
-  set(SWIFT_INTERFACE_PATH ${CMAKE_BINARY_DIR}/pm/PluginAPI/PackagePlugin.swiftinterface)
-  target_compile_options(PackagePlugin PUBLIC
-    $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${SWIFT_INTERFACE_PATH}>)
-  target_link_options(PackagePlugin PRIVATE
-    "SHELL:-Xlinker -install_name -Xlinker @rpath/libPackagePlugin.dylib")
+    set(SWIFT_INTERFACE_PATH ${CMAKE_BINARY_DIR}/pm/PackagePlugin.swiftinterface)
+    target_compile_options(PackagePlugin PUBLIC
+        $<$<COMPILE_LANGUAGE:Swift>:-enable-library-evolution>)
+    target_compile_options(PackagePlugin PUBLIC
+        $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${SWIFT_INTERFACE_PATH}>)
+    target_link_options(PackagePlugin PRIVATE
+        "SHELL:-Xlinker -install_name -Xlinker @rpath/libPackagePlugin.dylib")
 endif()
 
 set_target_properties(PackagePlugin PROPERTIES
-  Swift_MODULE_NAME PackagePlugin
-  Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/pm/PluginAPI
-  INSTALL_NAME_DIR \\@rpath
-  OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/PluginAPI
-  OUTPUT_NAME PackagePlugin
-  ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/PluginAPI
-  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/PluginAPI
-  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/PluginAPI
+    Swift_MODULE_NAME PackagePlugin
+    Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/pm
+    INSTALL_NAME_DIR \\@rpath
+    OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm
+    OUTPUT_NAME PackagePlugin
+    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm
 )
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  if(Foundation_FOUND)
-    target_link_libraries(PackagePlugin PRIVATE
-      Foundation)
-  endif()
-  target_link_options(PackagePlugin PRIVATE
-    "SHELL:-no-toolchain-stdlib-rpath")
-  set_target_properties(PackagePlugin PROPERTIES
-    BUILD_WITH_INSTALL_RPATH TRUE
-    INSTALL_RPATH "$ORIGIN/../../$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
+    if(Foundation_FOUND)
+        target_link_libraries(PackagePlugin PRIVATE
+            Foundation)
+    endif()
+    target_link_options(PackagePlugin PRIVATE
+        "SHELL:-no-toolchain-stdlib-rpath")
+    set_target_properties(PackagePlugin PROPERTIES
+        BUILD_WITH_INSTALL_RPATH TRUE
+        INSTALL_RPATH "$ORIGIN/../../$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
 endif()
 
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
-  install(FILES
-    ${CMAKE_BINARY_DIR}/pm/PluginAPI/PackagePlugin.swiftinterface
-    ${CMAKE_BINARY_DIR}/pm/PluginAPI/PackagePlugin.swiftdoc
-    DESTINATION lib/swift/pm/PluginAPI
-  )
+    install(FILES
+        ${CMAKE_BINARY_DIR}/pm/PackagePlugin.swiftinterface
+        ${CMAKE_BINARY_DIR}/pm/PackagePlugin.swiftdoc
+        DESTINATION lib/swift/pm
+    )
 else()
-  install(FILES
-    ${CMAKE_BINARY_DIR}/pm/PluginAPI/PackagePlugin.swiftmodule
-    ${CMAKE_BINARY_DIR}/pm/PluginAPI/PackagePlugin.swiftdoc
-    DESTINATION lib/swift/pm/PluginAPI
-  )
+    install(FILES
+        ${CMAKE_BINARY_DIR}/pm/PackagePlugin.swiftmodule
+        ${CMAKE_BINARY_DIR}/pm/PackagePlugin.swiftdoc
+        DESTINATION lib/swift/pm
+    )
 endif()
 
 install(TARGETS PackagePlugin
-  DESTINATION lib/swift/pm/PluginAPI)
+    DESTINATION lib/swift/pm)

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -50,7 +50,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
         // FIXME: Much of this is copied from the ManifestLoader and should be consolidated.
 
         // Bin dir will be set when developing swiftpm without building all of the runtimes.
-        let runtimePath = self.resources.binDir ?? self.resources.libDir.appending(component: "PluginAPI")
+        let runtimePath = self.resources.binDir ?? self.resources.libDir
 
         // Compile the package plugin script.
         var command = [resources.swiftCompiler.pathString]

--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -81,7 +81,7 @@ public func xcodeProject(
         var interpreterFlags = manifestLoader.interpreterFlags(for: package.manifest.toolsVersion)
         if !interpreterFlags.isEmpty {
             // Patch the interpreter flags to use Xcode supported toolchain macro instead of the resolved path.
-            interpreterFlags[3] = "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/ManifestAPI"
+            interpreterFlags[3] = "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/\(package.manifest.toolsVersion.runtimeSubpath.pathString)"
         }
         pdTarget.buildSettings.common.OTHER_SWIFT_FLAGS += interpreterFlags
         pdTarget.buildSettings.common.SWIFT_VERSION = package.manifest.toolsVersion.swiftLanguageVersion.xcodeBuildSettingValue

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -98,7 +98,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             guard case let ManifestParseError.invalidManifestFormat(output, _) = error else {
                 return XCTFail()
             }
-            XCTAssertMatch(output, .and(.contains("'init(name:pkgConfig:providers:products:dependencies:targets:swiftLanguageVersions:cLanguageStandard:cxxLanguageStandard:)' is unavailable"), .contains("was obsoleted in PackageDescription 4.2")))
+            XCTAssertMatch(output, .and(.or(.contains("expected argument type"), .contains("expected element type")), .contains("SwiftVersion")))
         }
 
         // Check when Swift language versions is empty.

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -393,21 +393,22 @@ def install_swiftpm(prefix, args):
     runtime_lib_dest = os.path.join(prefix, "lib", "swift", "pm")
     runtime_lib_src = os.path.join(args.bootstrap_dir, "pm")
 
-    files_to_install = ["libPackageDescription" + g_shared_lib_ext]
-    if platform.system() == 'Darwin':
-        files_to_install.append("PackageDescription.swiftinterface")
-    else:
-        files_to_install.append("PackageDescription.swiftmodule")
-    files_to_install.append("PackageDescription.swiftdoc")
+    for runtime in ["4", "4_2"]:
+        files_to_install = ["libPackageDescription" + g_shared_lib_ext]
+        if platform.system() == 'Darwin':
+            files_to_install.append("PackageDescription.swiftinterface")
+        else:
+            files_to_install.append("PackageDescription.swiftmodule")
+        files_to_install.append("PackageDescription.swiftdoc")
 
-    for file in files_to_install:
-        src = os.path.join(runtime_lib_src, "ManifestAPI", file)
-        dest = os.path.join(runtime_lib_dest, "ManifestAPI", file)
-        mkdir_p(os.path.dirname(dest))
+        for file in files_to_install:
+            src = os.path.join(runtime_lib_src, runtime, file)
+            dest = os.path.join(runtime_lib_dest, runtime, file)
+            mkdir_p(os.path.dirname(dest))
 
-        note("Installing %s to %s" % (src, dest))
+            note("Installing %s to %s" % (src, dest))
 
-        file_util.copy_file(src, dest, update=1)
+            file_util.copy_file(src, dest, update=1)
 
     files_to_install = ["libPackagePlugin" + g_shared_lib_ext]
     if platform.system() == 'Darwin':
@@ -417,8 +418,8 @@ def install_swiftpm(prefix, args):
     files_to_install.append("PackagePlugin.swiftdoc")
 
     for file in files_to_install:
-        src = os.path.join(runtime_lib_src, "PluginAPI", file)
-        dest = os.path.join(runtime_lib_dest, "PluginAPI", file)
+        src = os.path.join(runtime_lib_src, file)
+        dest = os.path.join(runtime_lib_dest, file)
         mkdir_p(os.path.dirname(dest))
 
         note("Installing %s to %s" % (src, dest))


### PR DESCRIPTION
Temporarily revert "[5.5] Unify PackageDescription 4.0 and 4.2+ into a single library by using availability annotations instead of #if (#3492)"

This caused the Windows toolchains to break, so this temporarily reverts the change until the installer can be adjusted.

This will be brought back when the Windows toolchain has been adjusted.

This reverts commit d875e4ff27eea5a24fb9e43968d8a41ded92634c.
