### PR TITLE
[SR-14782] `swift package describe` is omitting product dependencies from per-target output

### DIFF
--- a/Sources/Commands/Describe.swift
+++ b/Sources/Commands/Describe.swift
@@ -155,6 +155,7 @@ fileprivate struct DescribedPackage: Encodable {
         let sources: [String]
         let resources: [PackageModel.Resource]?
         let targetDependencies: [String]?
+        let productDependencies: [String]?
         let productMemberships: [String]?
         
         init(from target: Target, in package: Package, productMemberships: [String]?) {
@@ -166,7 +167,10 @@ fileprivate struct DescribedPackage: Encodable {
             self.path = target.sources.root.relative(to: package.path).pathString
             self.sources = target.sources.relativePaths.map{ $0.pathString }
             self.resources = target.resources.isEmpty ? nil : target.resources
-            self.targetDependencies = target.dependencies.isEmpty ? nil : target.dependencies.compactMap{ $0.target?.name }
+            let targetDependencies = target.dependencies.compactMap{ $0.target }
+            self.targetDependencies = targetDependencies.isEmpty ? nil : targetDependencies.map{ $0.name }
+            let productDependencies = target.dependencies.compactMap{ $0.product }
+            self.productDependencies = productDependencies.isEmpty ? nil : productDependencies.map{ $0.name }
             self.productMemberships = productMemberships
         }
     }

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -254,6 +254,21 @@ final class PackageToolTests: XCTestCase {
             XCTAssert(textChunk6.contains("Path: Sources/CExec"), textChunk6)
             XCTAssert(textChunk6.contains("Sources:\n        main.c"), textChunk6)
         }
+
+        fixture(name: "DependencyResolution/External/Simple/Bar") { prefix in
+            // Generate the JSON description.
+            let jsonResult = try SwiftPMProduct.SwiftPackage.executeProcess(["describe", "--type=json"], packagePath: prefix)
+            let jsonOutput = try jsonResult.utf8Output()
+            let json = try JSON(bytes: ByteString(encodingAsUTF8: jsonOutput))
+
+            // Check that product dependencies and memberships are as expected.
+            XCTAssertEqual(json["name"]?.string, "Bar")
+            let jsonTarget = try XCTUnwrap(json["targets"]?.array?[0])
+            XCTAssertEqual(jsonTarget["product_memberships"]?.array?[0].stringValue, "Bar")
+            XCTAssertEqual(jsonTarget["product_dependencies"]?.array?[0].stringValue, "Foo")
+            XCTAssertNil(jsonTarget["target_dependencies"])
+        }
+
     }
     
     func testDescribePackageUsingPlugins() throws {


### PR DESCRIPTION
While `swift package describe` had an entry for `target_dependencies` in the output of each target, it omitted `product_dependencies`.

### Motivation:

Currently (while we still have the distinction between products and targets in the SwiftPM package model) we should include both kinds of dependencies in the package description output format.

### Modifications:

- add product dependencies to the per-target outputs (because of how this is done, the same code automatically works for both JSON and plain text output)
