### PR TITLE
Simplify minimum deployment target on Darwin platforms (still requiring macOS 10.15+, adding iOS 13+)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,15 +13,6 @@
 import PackageDescription
 import class Foundation.ProcessInfo
 
-// We default to a 10.10 minimum deployment target for clients of libSwiftPM,
-// but allow overriding it when building for a toolchain.
-
-let macOSPlatform: SupportedPlatform
-if let deploymentTarget = ProcessInfo.processInfo.environment["SWIFTPM_MACOS_DEPLOYMENT_TARGET"] {
-    macOSPlatform = .macOS(deploymentTarget)
-} else {
-    macOSPlatform = .macOS(.v10_15)
-}
 
 /** SwiftPMDataModel is the subset of SwiftPM product that includes just its data model.
 This allowis some clients (such as IDEs) that use SwiftPM's data model but not its build system
@@ -64,7 +55,10 @@ let autoProducts = [swiftPMProduct, swiftPMDataModelProduct]
 
 let package = Package(
     name: "SwiftPM",
-    platforms: [macOSPlatform],
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13)
+    ],
     products:
         autoProducts.flatMap {
           [


### PR DESCRIPTION
Simplify the deployment targets on Darwin platforms, setting the minimum deployment target to macOS 10.15 and iOS 13 or later on Darwin platforms.  The environment variables were needed during a transitional phase, and SwiftPM already required macOS 10.15 or later on macOS.  Note that non-Darwin platforms are unaffected.

### Motivation:

This simplifies the logic while keeping the same macOS 10.15 dependency, and aligns SwiftPM with the ToolsSupportCore requirements in https://github.com/apple/swift-tools-support-core/pull/225.

See comment in https://github.com/apple/swift-package-manager/pull/3552#issuecomment-861841741

### Modifications:

Set macOS 10.15 and iOS 13 as minimum deployment targets.

### Result:

No change for macOS, v13 required for iOS.
