### PR TITLE
[5.5] Change symlink error to warning

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -137,9 +137,18 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
             component: buildParameters.configuration.dirname
         )
         if localFileSystem.exists(oldBuildPath) {
-            try localFileSystem.removeFileTree(oldBuildPath)
+            do { try localFileSystem.removeFileTree(oldBuildPath) }
+            catch {
+                diagnostics.emit(warning: "unable to delete \(oldBuildPath), skip creating symbolic link: \(error)")
+                return
+            }
         }
-        try localFileSystem.createSymbolicLink(oldBuildPath, pointingAt: buildParameters.buildPath, relative: true)
+
+        do {
+            try localFileSystem.createSymbolicLink(oldBuildPath, pointingAt: buildParameters.buildPath, relative: true)
+        } catch {
+            diagnostics.emit(warning: "unable to create symbolic link at \(oldBuildPath): \(error)")
+        }
     }
 
     /// Compute the llbuild target name using the given subset.


### PR DESCRIPTION
If linking `oldBuildPath` fails, SwiftPM will emit a warning instead of an error. (Cherrypicked from #3490)

### Motivation:

Symlinking `oldBuildPath` is not a vital step of `swift build`, but emitting an error will depress the `run` and `test` commands. This largely troubled Windows users, since symlinking requires elevated privileges on Windows.

### Modifications:

Codes of linking `oldBuildPath` is now wrapped with `do-catch` to capture the error and change it into a warning.

### Result:

If linking `oldBuildPath` fails, SwiftPM will emit a warning instead of an error.