### PR TITLE
Skip `testCacheInvalidationOnEnv` for now

### DIFF
--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -500,6 +500,11 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testCacheInvalidationOnEnv() throws {
+        #if os(Linux)
+        // rdar://79415639 (Test Case 'PackageDescription4_2LoadingTests.testCacheInvalidationOnEnv' failed)
+        try XCTSkipIf(true)
+        #endif
+
         try testWithTemporaryDirectory { path in
             let fs = localFileSystem
 


### PR DESCRIPTION
This test is failing on the aarch64 CI for unknown reasons, we will skip it for now until we can fix it. Since that is targetting Linux, we only skip the test there for now.
