### PR TITLE
[PubgrubTests] Handle duplicate product keys in `DependencyGraphBuilder.serve`

### DIFF
--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -2193,7 +2193,7 @@ class DependencyGraphBuilder {
             let packageDependencies: [MockContainer.Dependency] = filteredDependencies.map {
                 (container: reference(for: $0), requirement: $1.0, products: $1.1)
             }
-            container.dependencies[version.description, default: [:]][product] = packageDependencies
+            container.dependencies[version.description, default: [:]][product, default: []] += packageDependencies
         }
         self.containers[package] = container
     }

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -2166,7 +2166,7 @@ class DependencyGraphBuilder {
         _ package: String,
         at version: Version,
         toolsVersion: ToolsVersion? = nil,
-        with dependencies: OrderedDictionary<String, OrderedDictionary<String, (PackageRequirement, ProductFilter)>> = [:]
+        with dependencies: KeyValuePairs<String, OrderedDictionary<String, (PackageRequirement, ProductFilter)>> = [:]
     ) {
         serve(package, at: .version(version), toolsVersion: toolsVersion, with: dependencies)
     }
@@ -2175,7 +2175,7 @@ class DependencyGraphBuilder {
         _ package: String,
         at version: BoundVersion,
         toolsVersion: ToolsVersion? = nil,
-        with dependencies: OrderedDictionary<String, OrderedDictionary<String, (PackageRequirement, ProductFilter)>> = [:]
+        with dependencies: KeyValuePairs<String, OrderedDictionary<String, (PackageRequirement, ProductFilter)>> = [:]
     ) {
         let packageReference = reference(for: package)
         let container = self.containers[package] ?? MockContainer(package: packageReference)


### PR DESCRIPTION
This PR fixes 2 places where `DependencyGraphBuilder.serve` mishandles `dependencies` with duplicate keys (`product`s). 

1. [One of the callers] of the function passes in a dictionary literal with duplicate keys. Although the logic in this function suggests that duplicate keys are allowed, `TSCBasic.OrderedDictionary` preserves only [the final] of all duplicate keys' values in a dictionary literal. In addition, with #3533, Swift Collections' `OrderedDictionary` [traps] on duplicate keys. `KeyValuePairs` seems like the right replacement that allows duplicate keys.

2. Because of the duplicate keys, when `dependencies` are iterated, the same `product` can appear more than once, each time with possibly different `filteredDependencies`. In each iteration, the `filteredDependencies` associated with the `product` is mapped to `packageDependencies`, which is then assigned to the value in a different dictionary keyed by the same `product`, overriding any existing value from a possible previous assignment. Changing the assignment to an appending operation preserves all previous values.

[one of the callers]: https://github.com/apple/swift-package-manager/blob/20eba126ffa32088abb46d642bd0481dbae212ef/Tests/PackageGraphTests/PubgrubTests.swift#L472-L475
[the final]: https://github.com/apple/swift-tools-support-core/blob/21a79185b2ea8f89b9253ed8cdf2338bf564c499/Sources/TSCBasic/OrderedDictionary.swift#L97-L99
[traps]: https://github.com/apple/swift-collections/blob/c0549b6284aadd5fd13156316f43fcb43c7fca77/Sources/OrderedCollections/OrderedDictionary/OrderedDictionary%2BInitializers.swift#L88-L91