### PR TITLE
[5.5] Make the lookup of the PackageDescription dylib fall back on the versioned location if needed

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -938,7 +938,18 @@ public final class ManifestLoader: ManifestLoaderProtocol {
     /// Returns the runtime path given the manifest version and path to libDir.
     private func runtimePath(for version: ToolsVersion) -> AbsolutePath {
         // Bin dir will be set when developing swiftpm without building all of the runtimes.
-        return resources.binDir ?? resources.libDir.appending(component: "ManifestAPI")
+        if let binDir = resources.binDir {
+            return binDir
+        }
+        
+        // Otherwise we use the standard location of the manifest API in the toolchain, if it exists.
+        let manifestAPIDir = resources.libDir.appending(component: "ManifestAPI")
+        if localFileSystem.exists(manifestAPIDir) {
+            return manifestAPIDir
+        }
+        
+        // Otherwise, fall back on the old location (this would indicate that we're using an old toolchain).
+        return resources.libDir.appending(version.runtimeSubpath)
     }
 
     /// Returns path to the manifest database inside the given cache directory.


### PR DESCRIPTION
This is the 5.5 nomination of https://github.com/apple/swift-package-manager/pull/3560.

This makes the use of the Manifest API directory (the directory in which PackageDescription.dylib and its interface is located) more robust, so that it works with mismatching toolchains.  This is a little tricky to unit-test from inside the codebase, since it involves having an old toolchain compared with the expected one.  Existing unit tests make sure there are no regressions.

(cherry picked from commit 7e0f5e627c4d68dc05593e1b2ca8698bc6b20d51)
