### PR TITLE
Do not test TSC in `bootstrap`

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -327,9 +327,6 @@ def test(args):
     for arg in args.filter:
         cmd.extend(["--filter", arg])
 
-    # Test TSC.
-    call_swiftpm(args, cmd, args.tsc_source_dir)
-
     # Test SwiftPM.
     call_swiftpm(args, cmd)
 


### PR DESCRIPTION
This seems like a leftover from the integrated TSC days. TSC has its own CI these days, so this shouldn't be necessary anymore.

Opening as a draft first, because we may need to adjust `build-script` to actually test TSC independently of SwiftPM's `bootstrap`.