### PR TITLE
Basic OpenBSD support.

### DIFF
--- a/Sources/Basics/DispatchTimeInterval+Extensions.swift
+++ b/Sources/Basics/DispatchTimeInterval+Extensions.swift
@@ -59,7 +59,7 @@ extension DispatchTimeInterval {
 }
 
 // remove when available to all platforms
-#if os(Linux) || os(Windows) || os(Android)
+#if os(Linux) || os(Windows) || os(Android) || os(OpenBSD)
 extension DispatchTime {
     public func distance(to: DispatchTime) -> DispatchTimeInterval {
         let duration = to.uptimeNanoseconds - self.uptimeNanoseconds

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -380,7 +380,7 @@ public class SwiftTool {
               #if os(Windows)
                 // Exit as if by signal()
                 TerminateProcess(GetCurrentProcess(), 3)
-              #elseif os(macOS)
+              #elseif os(macOS) || os(OpenBSD)
                 // Install the default signal handler.
                 var action = sigaction()
                 action.__sigaction_u.__sa_handler = SIG_DFL

--- a/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift
@@ -459,6 +459,8 @@ extension PackageModel.Platform {
             self = PackageModel.Platform.windows
         case let name where name.contains("wasi"):
             self = PackageModel.Platform.wasi
+        case let name where name.contains("openbsd"):
+            self = PackageModel.Platform.openbsd
         default:
             return nil
         }

--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -51,6 +51,10 @@ public struct Platform: Encodable, Equatable {
     /// The WebAssembly System Interface platform.
     @available(_PackageDescription, introduced: 5.3)
     public static let wasi: Platform = Platform(name: "wasi")
+
+    /// The OpenBSD platform.
+    @available(_PackageDescription, introduced: 999.0)
+    public static let openbsd: Platform = Platform(name: "openbsd")
 }
 
 /// A platform that the Swift package supports.

--- a/Sources/PackageLoading/PlatformRegistry.swift
+++ b/Sources/PackageLoading/PlatformRegistry.swift
@@ -31,6 +31,6 @@ public final class PlatformRegistry {
 
     /// The static list of known platforms.
     private static var _knownPlatforms: [Platform] {
-        return [.macOS, .macCatalyst, .iOS, .tvOS, .watchOS, .linux, .windows, .android, .wasi, .driverKit]
+        return [.macOS, .macCatalyst, .iOS, .tvOS, .watchOS, .linux, .windows, .android, .wasi, .driverKit, .openbsd]
     }
 }

--- a/Sources/PackageModel/Platform.swift
+++ b/Sources/PackageModel/Platform.swift
@@ -35,6 +35,7 @@ public struct Platform: Equatable, Hashable, Codable {
     public static let android: Platform = Platform(name: "android", oldestSupportedVersion: .unknown)
     public static let windows: Platform = Platform(name: "windows", oldestSupportedVersion: .unknown)
     public static let wasi: Platform = Platform(name: "wasi", oldestSupportedVersion: .unknown)
+    public static let openbsd: Platform = Platform(name: "openbsd", oldestSupportedVersion: .unknown)
 
 }
 

--- a/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
+++ b/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
@@ -76,7 +76,7 @@ fileprivate extension Triple.OS {
     /// Returns a representation of the receiver that can be compared with platform strings declared in an XCFramework.
     var asXCFrameworkPlatformString: String? {
         switch self {
-        case .darwin, .linux, .wasi, .windows:
+        case .darwin, .linux, .wasi, .windows, .openbsd:
             return nil // XCFrameworks do not support any of these platforms today.
         case .macOS:
             return "macos"

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -148,6 +148,8 @@ public struct BuildParameters: Encodable {
             return .wasi
         } else if self.triple.isWindows() {
             return .windows
+        } else if self.triple.isOpenBSD() {
+            return .openbsd
         } else {
             return .linux
         }

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -28,7 +28,7 @@ func makeMockSources(count: Int = Int.random(in: 5 ... 10)) -> [PackageCollectio
 }
 
 func makeMockCollections(count: Int = Int.random(in: 50 ... 100), maxPackages: Int = 50, signed: Bool = true) -> [PackageCollectionsModel.Collection] {
-    let platforms: [PackageModel.Platform] = [.macOS, .iOS, .tvOS, .watchOS, .linux, .android, .windows, .wasi]
+    let platforms: [PackageModel.Platform] = [.macOS, .iOS, .tvOS, .watchOS, .linux, .android, .windows, .wasi, .openbsd]
     let supportedPlatforms: [PackageModel.SupportedPlatform] = [
         .init(platform: .macOS, version: .init("10.15")),
         .init(platform: .iOS, version: .init("13")),

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -1688,6 +1688,7 @@ class PackageBuilderTests: XCTestCase {
             "android": "0.0",
             "windows": "0.0",
             "wasi": "0.0",
+            "openbsd": "0.0",
         ]
 
         PackageBuilderTester(manifest, in: fs) { package, _ in
@@ -1746,6 +1747,7 @@ class PackageBuilderTests: XCTestCase {
             "android": "0.0",
             "windows": "0.0",
             "wasi": "0.0",
+	    "openbsd": "0.0",
         ]
 
         PackageBuilderTester(manifest, in: fs) { package, _ in

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -776,9 +776,12 @@ def get_swiftpm_flags(args):
     # TensorFlow).
     if platform.system() == "Darwin":
         swift_library_rpath_prefix = "@executable_path/../"
-    elif platform.system() == 'Linux':
+    elif platform.system() == 'Linux' or platform.system() == 'OpenBSD':
         # `$ORIGIN` is an ELF construct.
         swift_library_rpath_prefix = "$ORIGIN/../"
+    if platform.system() == 'OpenBSD':
+        build_flags.extend(["-Xlinker", "-z", "-Xlinker", "origin"])
+
     platform_path = None
     for path in args.target_info["paths"]["runtimeLibraryPaths"]:
         platform_path = re.search(r"(lib/swift/([^/]+))$", path)
@@ -811,6 +814,10 @@ def get_swiftpm_flags(args):
     # Don't use GNU strerror_r on Android.
     if 'ANDROID_DATA' in os.environ:
         build_flags.extend(["-Xswiftc", "-Xcc", "-Xswiftc", "-U_GNU_SOURCE"])
+
+    if platform.system() == "OpenBSD":
+        build_flags.extend(["-Xcc", "-I/usr/local/include"])
+        build_flags.extend(["-Xlinker", "-L/usr/local/lib"])
 
     # On ELF platforms, remove the host toolchain's stdlib absolute rpath from
     # installed executables and shared libraries.


### PR DESCRIPTION
Pepper in the right conditionals throughout.

The unversioned triple issue is still necessary for the bootstrap script
(and only the bootstrap script) which we will deal with separately.

### Motivation:

Permit SPM to build on this platform.

### Modifications:

* `Sources/Basics/DispatchTimeInterval+Extensions.swift`: add the platform to the `#if` to make the extension available
* `Sources/PackageCollections/Providers/JSONPackageCollectionProvider.swift`: add the platform to the switch -- likely not required to build but we might as well extend this now we are enabling the platform.
* `Sources/PackageDescription/SupportedPlatforms.swift`: add the static var for the platform. Please let me know here if the 5.4 availability annotation needs revision here.
* `Sources/PackageLoading/PlatformRegistry.swift`: add to the known platform list.
* `Sources/PackageModel/Platform.swift`: add the static var for the platform.
* `Sources/SPMBuildCore/BinaryTarget+Extensions.swift`: indeed XCFrameworks is unsupported
* `Sources/SPMBuildCore/BuildParameters.swift`: add the case for BuildParameters `currentPlatform`.
* `Utilities/bootstrap`: required flags for a successful build since sqlite3 is not part of the base system, additional flags are required (but again, the unversioned triple problem remains).
* `Tests/PackageCollectionsTests/Utility.swift` and `Tests/PackageLoadingTests/PackageBuilderTests.swift` modified to match.

### Result:

* SPM handles the new cases being introduced in TSC.
* SPM can build on OpenBSD.