### PR TITLE
Fix warnings generated when testing.

### DIFF
--- a/Fixtures/Miscellaneous/TestableExe/Package.swift
+++ b/Fixtures/Miscellaneous/TestableExe/Package.swift
@@ -4,13 +4,13 @@ import PackageDescription
 let package = Package(
     name: "TestableExe",
     targets: [
-        .target(
+        .executableTarget(
             name: "TestableExe1"
         ),
-        .target(
+        .executableTarget(
             name: "TestableExe2"
         ),
-        .target(
+        .executableTarget(
             name: "TestableExe3"
         ),
         .testTarget(


### PR DESCRIPTION
We should be using .executableTarget, not .target, for executables.