### PR TITLE
Do not require `--enable-test-discovery` anymore on Linux

### DIFF
--- a/IntegrationTests/Tests/LinuxMain.swift
+++ b/IntegrationTests/Tests/LinuxMain.swift
@@ -1,1 +1,0 @@
-fatalError("Use `swift test --enable-test-discovery` to run tests")

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,1 +1,0 @@
-fatalError("Use `swift test --enable-test-discovery` to run tests")

--- a/Utilities/Docker/docker-compose.yaml
+++ b/Utilities/Docker/docker-compose.yaml
@@ -48,7 +48,7 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -cl "swift test --enable-test-discovery --parallel"
+    command: /bin/bash -cl "swift test --parallel"
 
   bootstrap-clean:
     <<: *common

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -335,7 +335,6 @@ def test(args):
     note("Testing")
     parse_test_args(args)
     cmd = [os.path.join(args.bin_dir, "swift-test")]
-    cmd.append("--enable-test-discovery")
     if args.parallel:
         cmd.append("--parallel")
     for arg in args.filter:

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -15,9 +15,9 @@ set -x
 # Perform package update in order to get the latest commits for the dependencies.
 swift package update
 swift build -c $CONFIGURATION
-swift test -c $CONFIGURATION --parallel --enable-test-discovery
+swift test -c $CONFIGURATION --parallel
 
 # Run the integration tests with just built SwiftPM.
 export SWIFTPM_BIN_DIR=$(swift build -c $CONFIGURATION --show-bin-path)
 cd IntegrationTests
-$SWIFTPM_BIN_DIR/swift-test --parallel --enable-test-discovery
+$SWIFTPM_BIN_DIR/swift-test --parallel


### PR DESCRIPTION
We have made the flag default a while ago, so we can assume that it'll be passed as default.
