### PR TITLE
Parse XCbuild stderr only if stdout is empty

### DIFF
--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -103,8 +103,6 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
 
         arguments += buildParameters.xcbuildFlags
 
-        let delegate = createBuildDelegate()
-        
         let process = Process(arguments: arguments, outputRedirection: .collect)
         try process.launch()
         let result = try process.waitUntilExit()
@@ -119,10 +117,15 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         
         let stdout = try result.output.get()
         if !stdout.isEmpty {
-            try delegate.parse(bytes: result.output.get())
+            let delegate = createBuildDelegate()
+            delegate.parse(bytes: stdout)
         } else {
             let stderr = try result.utf8stderrOutput()
-            self.diagnostics.emit(StringError(stderr))
+            if !stderr.isEmpty {
+                diagnostics.emit(StringError(stderr))
+            } else {
+                diagnostics.emit(StringError("Unknown error: stdout and stderr are empty"))
+            }
         }
     }
 

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -112,7 +112,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         }, stderr: { bytes in
             stderrBuffer.append(contentsOf: bytes)
         })
-                                                             
+
         let process = Process(arguments: arguments, outputRedirection: redirection)
         try process.launch()
         let result = try process.waitUntilExit()


### PR DESCRIPTION
SwiftPM parses all stderr output from XCBuild that shouldn't lead to a build failure, but emits it as an error diagnostic, which does lead to it. Diagnostics are already available via the parseable JSON output on stdout, not textually via stderr.

### Motivation:
Resolves rdar://75751711 (SwiftPM is parsing _ALL_ stderr output from XCBuild into an error diagnostic that fails the build).

### Modifications:
This change parses XCBuild stderr and emits error only if stdout is empty. 

### Result:
If XCBuild stdout is not empty, stderr is now ignored, else it will throw a build error. 
