### PR TITLE
Allow empty arrays of unsafe flags (already allowed in practice; this removes a debug assertion and adds a test)

### DIFF
--- a/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetBuildSettingDescription.swift
@@ -61,7 +61,6 @@ public enum TargetBuildSettingDescription {
                 assert(value.count == 1, "\(tool) \(name) \(value)")
                 break
             case .unsafeFlags:
-                assert(value.count >= 1, "\(tool) \(name) \(value)")
                 break
             }
 


### PR DESCRIPTION
Empty arrays of unsafe flags are currently only disallowed using an assertion, which is compiled out for release builds.  The result is that some packages fail assertions when run in debug mode even though they work fine in a tools release.  There is no reason to disallow this, and it's useful when programmatically building up lists of unsafe flags.
