### PR TITLE
Add development-time assertions to catch errors where two llbuild commands are created with the same name

### DIFF
--- a/Sources/LLBuildManifest/BuildManifest.swift
+++ b/Sources/LLBuildManifest/BuildManifest.swift
@@ -50,6 +50,7 @@ public struct BuildManifest {
         inputs: [Node],
         outputs: [Node]
     ) {
+        assert(commands[name] == nil, "aleady had a command named '\(name)'")
         let tool = PhonyTool(inputs: inputs, outputs: outputs)
         commands[name] = Command(name: name, tool: tool)
     }
@@ -59,6 +60,7 @@ public struct BuildManifest {
         inputs: [Node],
         outputs: [Node]
     ) {
+        assert(commands[name] == nil, "aleady had a command named '\(name)'")
         let tool = TestDiscoveryTool(inputs: inputs, outputs: outputs)
         commands[name] = Command(name: name, tool: tool)
     }
@@ -68,6 +70,7 @@ public struct BuildManifest {
         inputs: [Node],
         outputs: [Node]
     ) {
+        assert(commands[name] == nil, "aleady had a command named '\(name)'")
         let tool = CopyTool(inputs: inputs, outputs: outputs)
         commands[name] = Command(name: name, tool: tool)
     }
@@ -77,6 +80,7 @@ public struct BuildManifest {
         inputs: [Node],
         outputs: [Node]
     ) {
+        assert(commands[name] == nil, "aleady had a command named '\(name)'")
         let tool = PackageStructureTool(inputs: inputs, outputs: outputs)
         commands[name] = Command(name: name, tool: tool)
     }
@@ -86,6 +90,7 @@ public struct BuildManifest {
         inputs: [Node],
         outputs: [Node]
     ) {
+        assert(commands[name] == nil, "aleady had a command named '\(name)'")
         let tool = ArchiveTool(inputs: inputs, outputs: outputs)
         commands[name] = Command(name: name, tool: tool)
     }
@@ -100,6 +105,7 @@ public struct BuildManifest {
         workingDirectory: String? = nil,
         allowMissingInputs: Bool = false
     ) {
+        assert(commands[name] == nil, "aleady had a command named '\(name)'")
         let tool = ShellTool(
             description: description,
             inputs: inputs,
@@ -120,6 +126,7 @@ public struct BuildManifest {
         outputs: [Node],
         arguments: [String]
     ) {
+        assert(commands[name] == nil, "aleady had a command named '\(name)'")
         let tool = SwiftFrontendTool(
                 moduleName: moduleName,
                 description: description,
@@ -138,6 +145,7 @@ public struct BuildManifest {
         arguments: [String],
         dependencies: String? = nil
     ) {
+        assert(commands[name] == nil, "aleady had a command named '\(name)'")
         let tool = ClangTool(
             description: description,
             inputs: inputs,
@@ -163,6 +171,7 @@ public struct BuildManifest {
         isLibrary: Bool,
         wholeModuleOptimization: Bool
     ) {
+        assert(commands[name] == nil, "aleady had a command named '\(name)'")
         let tool = SwiftCompilerTool(
             inputs: inputs,
             outputs: outputs,
@@ -177,7 +186,6 @@ public struct BuildManifest {
             isLibrary: isLibrary,
             wholeModuleOptimization: wholeModuleOptimization
         )
-      
         commands[name] = Command(name: name, tool: tool)
     }
 }


### PR DESCRIPTION
Otherwise this results in silently replacing some commands in the graph.  We can discuss whether a future improvement would be to make these internal errors reported at runtime.

### Motivation:

Without these assertions, adding two or more commands with the same name result in only the last of them remaining, which can lead to hard-to-diagnose build failures.  I have to not come across any cases of this happening intentionally, but there is currently a Linux-specific test failure that I need to look closer at.  It could be a bug that this is catching or could be that this needs to be made more lenient.  Even if the replacement behavior is intentional, it seems like the kind of thing that should be done explicitly in the code.  This was motivated by an unintentional replacement of a build command.

### Modifications:

- add development-time assertions to catch replacing commands in the llbuild manifest

### Result:

In debug builds and in tests, any replacement of llbuild commands will be made apparent.
