### PR TITLE
Fix APIDiff test suite

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -259,7 +259,7 @@ let package = Package(
             dependencies: ["Build", "SPMTestSupport"]),
         .testTarget(
             name: "CommandsTests",
-            dependencies: ["swift-build", "swift-package", "swift-test", "swift-run", "Commands", "Workspace", "SPMTestSupport"]),
+            dependencies: ["swift-build", "swift-package", "swift-test", "swift-run", "Commands", "Workspace", "SPMTestSupport", "Build"]),
         .testTarget(
             name: "WorkspaceTests",
             dependencies: ["Workspace", "SPMTestSupport"]),

--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -40,8 +40,6 @@ final class APIDiffTests: XCTestCase {
     }
 
     func testSimpleAPIDiff() throws {
-        throw XCTSkip("Fix this test")
-        
         try skipIfApiDigesterUnsupported()
         fixture(name: "Miscellaneous/APIDiff/") { prefix in
             let packageRoot = prefix.appending(component: "Foo")
@@ -61,8 +59,6 @@ final class APIDiffTests: XCTestCase {
     }
 
     func testMultiTargetAPIDiff() throws {
-        throw XCTSkip("Fix this test")
-
         try skipIfApiDigesterUnsupported()
         fixture(name: "Miscellaneous/APIDiff/") { prefix in
             let packageRoot = prefix.appending(component: "Bar")
@@ -87,8 +83,6 @@ final class APIDiffTests: XCTestCase {
     }
 
     func testBreakageAllowlist() throws {
-        throw XCTSkip("Fix this test")
-
         #if os(macOS)
         guard (try? Resources.default.toolchain.getSwiftAPIDigester()) != nil else {
             throw XCTSkip("swift-api-digester not available")
@@ -126,8 +120,6 @@ final class APIDiffTests: XCTestCase {
     }
 
     func testCheckVendedModulesOnly() throws {
-        throw XCTSkip("Fix this test")
-        
         try skipIfApiDigesterUnsupported()
         fixture(name: "Miscellaneous/APIDiff/") { prefix in
             let packageRoot = prefix.appending(component: "NonAPILibraryTargets")
@@ -164,8 +156,6 @@ final class APIDiffTests: XCTestCase {
     }
 
     func testFilters() throws {
-        throw XCTSkip("Fix this test")
-
         try skipIfApiDigesterUnsupported()
         fixture(name: "Miscellaneous/APIDiff/") { prefix in
             let packageRoot = prefix.appending(component: "NonAPILibraryTargets")
@@ -238,8 +228,6 @@ final class APIDiffTests: XCTestCase {
     }
 
     func testAPIDiffOfModuleWithCDependency() throws {
-        throw XCTSkip("Fix this test")
-
         try skipIfApiDigesterUnsupported()
         fixture(name: "Miscellaneous/APIDiff/") { prefix in
             let packageRoot = prefix.appending(component: "CTargetDep")
@@ -338,8 +326,6 @@ final class APIDiffTests: XCTestCase {
     }
 
     func testBaselineDirOverride() throws {
-        throw XCTSkip("Fix this test")
-
         #if os(macOS)
         guard (try? Resources.default.toolchain.getSwiftAPIDigester()) != nil else {
             throw XCTSkip("swift-api-digester not available")
@@ -371,8 +357,6 @@ final class APIDiffTests: XCTestCase {
     }
 
     func testRegenerateBaseline() throws {
-        throw XCTSkip("Fix this test")
-
         #if os(macOS)
         guard (try? Resources.default.toolchain.getSwiftAPIDigester()) != nil else {
             throw XCTSkip("swift-api-digester not available")


### PR DESCRIPTION
Reenable the APIDiff tests

### Motivation:

Reenable the APIDiff tests

### Modifications:

- Check supported frontend flags to determine if a toolchain is compatible.

### Result:

APIDiff tests should pass or be skipped instead of failing with toolchains from 2021-05-14 - 2021-06-28
