### PR TITLE
Improve diagnostics error when a product declared in a package is also used as a dependency

### DIFF
--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -397,11 +397,19 @@ private func createResolvedPackages(
                     // found errors when there are more important errors to
                     // resolve (like authentication issues).
                     if !diagnostics.hasErrors {
+                        // Emit error if a product (not target) declared in the package is also a productRef (dependency)
+                        let declProductsAsDependency = package.products.filter { product in
+                            product.name == productRef.name
+                        }.map {$0.targets}.flatMap{$0}.filter { t in
+                            t.name != productRef.name
+                        }
+                        
                         let error = PackageGraphError.productDependencyNotFound(
                             package: package.identity.description,
                             targetName: targetBuilder.target.name,
                             dependencyProductName: productRef.name,
-                            dependencyPackageName: productRef.package
+                            dependencyPackageName: productRef.package,
+                            dependencyProductInDecl: !declProductsAsDependency.isEmpty
                         )
                         diagnostics.emit(error, location: package.diagnosticLocation)
                     }

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -602,6 +602,29 @@ class PackageGraphTests: XCTestCase {
         }
     }
     
+    func testExecutableTargetDependency() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+                "/XYZ/Sources/XYZ/main.swift",
+                "/XYZ/Tests/XYZTests/tests.swift"
+        )
+        let diagnostics = DiagnosticsEngine()
+        _ = try loadPackageGraph(fs: fs,
+                                 diagnostics: diagnostics,
+                                 manifests: [
+                    Manifest.createV4Manifest(
+                        name: "XYZ",
+                        path: "/XYZ",
+                        packageKind: .root,
+                        packageLocation: "/XYZ",
+                        targets: [
+                            TargetDescription(name: "XYZ", dependencies: [], type: .executable),
+                            TargetDescription(name: "XYZTests", dependencies: ["XYZ"], type: .test),
+                        ]),
+                    ]
+        )
+        DiagnosticsEngineTester(diagnostics) { _ in }
+    }
+    
     func testSameProductAndTargetNames() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Foo/Sources/Foo/src.swift",


### PR DESCRIPTION
A product declared in a package should not be used as a dependency. This PR improves diagnostics in such case. 

### Motivation:

Resolves rdar://71912826 ([SR-13913]: Library product name must match target name??) 

### Modifications:

This PR checks if a target dependency includes a product declared in the same package, checks the targets of that product, and throws an error if invalid with an improved diagnostics.  

### Result:

It throws an error with improved diagnostics preventing using a product declared in the same package as a dependency. 
