### PR TITLE
`swift build --build-system xcode` is hardcoding "x86_64" rather than using the build destination arch

### DIFF
--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -127,7 +127,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
             platform: "macosx",
             sdk: "macosx",
             sdkVariant: nil,
-            targetArchitecture: "x86_64",
+            targetArchitecture: buildParameters.triple.arch.rawValue,
             supportedArchitectures: [],
             disableOnlyActiveArch: true
         )

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -282,6 +282,19 @@ final class BuildToolTests: XCTestCase {
         }
     }
 
+    func testXcodeBuildSystemDefaultSettings() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test requires `xcbuild` and is therefore only supported on macOS")
+        #endif
+        fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { path in
+            // Try building using XCBuild with default parameters.  This should succeed.  We build verbosely so we get full command lines.
+            let defaultOutput = try execute(["-c", "debug", "-v"], packagePath: path).stdout
+            
+            // Look for certain things in the output from XCBuild.
+            XCTAssert(defaultOutput.contains("-target \(Resources.default.toolchain.triple.tripleString)"), defaultOutput)
+        }
+    }
+
     func testXcodeBuildSystemOverrides() throws {
         #if !os(macOS)
         try XCTSkipIf(true, "test requires `xcbuild` and is therefore only supported on macOS")


### PR DESCRIPTION
When using the `xcode` build system, SwiftPM isn't passing down the same architecture that the native build system would have used.  This has probably been masked in practice by the `xcode` build system only being used by default when multiple architectures are involved, in which case an overriding set of architectures is passed down.

This is a follow-on to https://github.com/apple/swift-package-manager/pull/3596

rdar://80334540
