### PR TITLE
Improve Package.swift not found diagnostic error SR-14829

### DIFF
--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -30,7 +30,7 @@ extension Error: CustomStringConvertible {
         case .invalidToolchain(let problem):
             return problem
         case .rootManifestFileNotFound:
-            return "root manifest not found"
+            return "Could not find \(Manifest.filename) in this folder or any of it's parent folders."
         }
     }
 }

--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -30,7 +30,7 @@ extension Error: CustomStringConvertible {
         case .invalidToolchain(let problem):
             return problem
         case .rootManifestFileNotFound:
-            return "Could not find \(Manifest.filename) in this directory or any of it's parent directories."
+            return "Could not find \(Manifest.filename) in this directory or any of its parent directories."
         }
     }
 }

--- a/Sources/Commands/Error.swift
+++ b/Sources/Commands/Error.swift
@@ -30,7 +30,7 @@ extension Error: CustomStringConvertible {
         case .invalidToolchain(let problem):
             return problem
         case .rootManifestFileNotFound:
-            return "Could not find \(Manifest.filename) in this folder or any of it's parent folders."
+            return "Could not find \(Manifest.filename) in this directory or any of it's parent directories."
         }
     }
 }

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1060,7 +1060,7 @@ final class PackageToolTests: XCTestCase {
                 XCTAssertEqual(result.exitStatus, .terminated(code: 1))
 
                 let stderrOutput = try result.utf8stderrOutput()
-                XCTAssert(stderrOutput.contains("error: Could not find Package.swift in this directory or any of it's parent directories."), #"actual: "\#(stderrOutput)""#)
+                XCTAssert(stderrOutput.contains("error: Could not find Package.swift in this directory or any of its parent directories."), #"actual: "\#(stderrOutput)""#)
             }
 
             // Runnning with output as absolute path to existing directory

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1060,7 +1060,7 @@ final class PackageToolTests: XCTestCase {
                 XCTAssertEqual(result.exitStatus, .terminated(code: 1))
 
                 let stderrOutput = try result.utf8stderrOutput()
-                XCTAssert(stderrOutput.contains("error: Could not find Package.swift in this folder or any of it's parent folders."), #"actual: "\#(stderrOutput)""#)
+                XCTAssert(stderrOutput.contains("error: Could not find Package.swift in this directory or any of it's parent directories."), #"actual: "\#(stderrOutput)""#)
             }
 
             // Runnning with output as absolute path to existing directory

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1060,7 +1060,7 @@ final class PackageToolTests: XCTestCase {
                 XCTAssertEqual(result.exitStatus, .terminated(code: 1))
 
                 let stderrOutput = try result.utf8stderrOutput()
-                XCTAssert(stderrOutput.contains("error: root manifest not found"), #"actual: "\#(stderrOutput)""#)
+                XCTAssert(stderrOutput.contains("error: Could not find Package.swift in this folder or any of it's parent folders."), #"actual: "\#(stderrOutput)""#)
             }
 
             // Runnning with output as absolute path to existing directory


### PR DESCRIPTION
Improve Package.swift not found diagnostic error

### Motivation:

The current error message when running swift-build in a folder that has no Package.swift file is not descriptive enough.
[SR-14829](https://bugs.swift.org/browse/SR-14829)
### Modifications:

Changed the error message and the relevant unit test.

### Result:
When running `swift-build ` in a folder that doesn't contain a Package.swift the below error is emitted:
error: `Could not find Package.swift in this folder or any of it's parent folders.`

@neonichu 
