### PR TITLE
[5.5][Collections] Sort packages by name instead of identity

### DIFF
--- a/Sources/PackageCollections/Model/Package.swift
+++ b/Sources/PackageCollections/Model/Package.swift
@@ -268,3 +268,9 @@ extension PackageCollectionsModel.Package.Version {
         self.manifests[self.defaultToolsVersion]
     }
 }
+
+extension Model.Package {
+    var displayName: String {
+        self.latestVersion?.packageName ?? self.reference.identity.description
+    }
+}

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -331,7 +331,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
                 }
 
                 let result = PackageCollectionsModel.PackageSearchResult(
-                    items: packageCollections.sorted { $0.key.identity < $1.key.identity }
+                    items: packageCollections.sorted { $0.value.package.displayName < $1.value.package.displayName }
                         .map { entry in
                             .init(package: entry.value.package, collections: Array(entry.value.collections))
                         }

--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -352,8 +352,8 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                         }
 
                     // FTS results are not sorted by relevance at all (FTS5 supports ORDER BY rank but FTS4 requires additional SQL function)
-                    // Sort by package identity for consistent ordering in results
-                    let result = Model.PackageSearchResult(items: packageCollections.sorted { $0.key < $1.key }.map { entry in
+                    // Sort by package name for consistent ordering in results
+                    let result = Model.PackageSearchResult(items: packageCollections.sorted { $0.value.package.displayName < $1.value.package.displayName }.map { entry in
                         .init(package: entry.value.package, collections: Array(entry.value.collections))
                     })
                     callback(.success(result))
@@ -393,8 +393,8 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                         }
                     }
 
-                    // Sort by package identity for consistent ordering in results
-                    let result = Model.PackageSearchResult(items: packageCollections.sorted { $0.key.identity < $1.key.identity }.map { entry in
+                    // Sort by package name for consistent ordering in results
+                    let result = Model.PackageSearchResult(items: packageCollections.sorted { $0.value.package.displayName < $1.value.package.displayName }.map { entry in
                         .init(package: entry.value.package, collections: Array(entry.value.collections))
                     })
                     callback(.success(result))


### PR DESCRIPTION
https://github.com/apple/swift-package-manager/pull/3599 for 5.5