### PR TITLE
fix a bug where resoved files looses package name case

### DIFF
--- a/Sources/PackageGraph/PinsStore.swift
+++ b/Sources/PackageGraph/PinsStore.swift
@@ -131,9 +131,8 @@ extension PinsStore: JSONSerializable {
         let pinsWithOriginalLocations = self.pins.map { pin -> Pin in
             let url = self.mirrors.originalURL(for: pin.packageRef.location) ?? pin.packageRef.location
             let identity = PackageIdentity(url: url) // FIXME: pin store should also encode identity
-            return Pin(packageRef: .remote(identity: identity, location: url), state: pin.state)
+            return Pin(packageRef: .init(identity: identity, kind: pin.packageRef.kind, location: url, name: pin.packageRef.name), state: pin.state)
         }
-
         return JSON([
             "pins": pinsWithOriginalLocations.sorted(by: { $0.packageRef.identity < $1.packageRef.identity }).toJSON(),
         ])
@@ -170,7 +169,7 @@ extension PinsStore: SimplePersistanceProtocol {
         let pinsWithMirroredLocations = pins.map { pin -> Pin in
             let url = self.mirrors.effectiveURL(for: pin.packageRef.location)
             let identity = PackageIdentity(url: url) // FIXME: pin store should also encode identity
-            return Pin(packageRef: .remote(identity: identity, location: url), state: pin.state)
+            return Pin(packageRef: .init(identity: identity, kind: pin.packageRef.kind, location: url, name: pin.packageRef.name), state: pin.state)
         }
         self.pinsMap = try Dictionary(pinsWithMirroredLocations.map({ ($0.packageRef.identity, $0) }), uniquingKeysWith: { first, _ in throw StringError("duplicated entry for package \"\(first.packageRef.name)\"") })
     }

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -1276,7 +1276,7 @@ class PackageGraphTests: XCTestCase {
 
         let fs = InMemoryFileSystem(emptyFiles: [])
         let store = try PinsStore(pinsFile: AbsolutePath("/pins"), fileSystem: fs, mirrors: .init())
-        XCTAssertThrows(StringError("duplicated entry for package \"yams\""), { try store.restore(from: json) })
+        XCTAssertThrows(StringError("duplicated entry for package \"Yams\""), { try store.restore(from: json) })
     }
 
     func testTargetDependencies_Pre52() throws {


### PR DESCRIPTION
motivation: fixing dar://52529014 and rdar://52529011 caused a regression in resolved files serialization in which package name lost its original form, causing slight difference between resolved files in 5.4 and 5.5

changes: update serialization code to correctly preserve the package original name when constructing the package ref from the mirrors
