### PR TITLE
Ignore .docc files rather than emitting warnings, since it's useful to have them in packages without warnings

### DIFF
--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -661,4 +661,38 @@ class TargetSourcesBuilderTests: XCTestCase {
 
         XCTAssertEqual(diags.diagnostics.map { $0.description }, ["found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target\n    /Foo.xcdatamodel\n"])
     }
+
+    func testIgnoredFileTypesDoNoCauseWarnings() throws {
+        let target = try TargetDescription(
+            name: "Foo",
+            path: nil,
+            exclude: [],
+            sources: ["File.swift"],
+            resources: [],
+            publicHeadersPath: nil,
+            type: .regular
+        )
+
+        let fs = InMemoryFileSystem()
+        fs.createEmptyFiles(at: .root, files: [
+            "/File.swift",
+            "/Foo.docc"
+        ])
+
+        let diags = DiagnosticsEngine()
+
+        let builder = TargetSourcesBuilder(
+            packageName: "",
+            packagePath: .root,
+            target: target,
+            path: .root,
+            defaultLocalization: nil,
+            toolsVersion: .v5_5,
+            fs: fs,
+            diags: diags
+        )
+        _ = try builder.run()
+
+        XCTAssertTrue(diags.diagnostics.isEmpty)
+    }
 }


### PR DESCRIPTION
Ignore `.docc` files rather than emitting warnings, since it's useful to have them in packages without warnings.

### Motivation:

Unlike other Xcode-specific file types, such as Storyboards and Asset Catalogs, the .docc bundles are not needed for correctness during the build, and should therefore not trigger warnings.

### Modifications:

- introduced a list of ignored file types in `TargetSourceBuilder`
- add that list to the end so it is only used if `additionalFileTypes` doesn't contain those types
- add a unit test

### Result:

Building a package does not emit warnings for .docc bundles.

rdar://78133445
