### PR TITLE
Do not print workspace-state diagnostic to stdout

### DIFF
--- a/Sources/Workspace/WorkspaceState.swift
+++ b/Sources/Workspace/WorkspaceState.swift
@@ -63,7 +63,8 @@ public final class WorkspaceState: SimplePersistanceProtocol {
             try self.persistence.restoreState(self)
         } catch {
             // FIXME: We should emit a warning here using the diagnostic engine.
-            print("\(error)")
+            TSCBasic.stderrStream.write("\(error)\n")
+            TSCBasic.stderrStream.flush()
         }
     }
 


### PR DESCRIPTION
We should not be printing diagnostics to stdout.

This should really use the diagnostics engine as the FIXME says, but that will require a more involved refactoring, since just passing one in `Workspace.init` feels off if so many of the methods also take one as an argument.

rdar://80085064
