### PR TITLE
make target dependency lookup case-insensitive

### DIFF
--- a/Fixtures/DependencyResolution/External/PackageLookupCaseInsensitive/dep/Package.swift
+++ b/Fixtures/DependencyResolution/External/PackageLookupCaseInsensitive/dep/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+  name: "Dep",
+  products: [
+    .library(name: "Dep", targets: ["Dep"]),
+  ],
+  targets: [
+    .target(name: "Dep", dependencies: []),
+  ]
+)

--- a/Fixtures/DependencyResolution/External/PackageLookupCaseInsensitive/dep/Sources/Dep/dep.swift
+++ b/Fixtures/DependencyResolution/External/PackageLookupCaseInsensitive/dep/Sources/Dep/dep.swift
@@ -1,0 +1,6 @@
+public struct dep {
+    public private(set) var text = "Hello, World!"
+
+    public init() {
+    }
+}

--- a/Fixtures/DependencyResolution/External/PackageLookupCaseInsensitive/pkg/Package.swift
+++ b/Fixtures/DependencyResolution/External/PackageLookupCaseInsensitive/pkg/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version:5.4
+
+import PackageDescription
+
+let package = Package(
+  name: "pkg",
+  products: [
+    .library(name: "pkg", targets: ["pkg"]),
+  ],
+  dependencies: [
+    .package(path: "../dep"),
+  ],
+  targets: [
+    .target(
+      name: "pkg",
+      dependencies: [.product(name: "Dep", package: "Dep")]),
+  ]
+)

--- a/Fixtures/DependencyResolution/External/PackageLookupCaseInsensitive/pkg/Sources/pkg/pkg.swift
+++ b/Fixtures/DependencyResolution/External/PackageLookupCaseInsensitive/pkg/Sources/pkg/pkg.swift
@@ -1,0 +1,6 @@
+public struct pkg {
+    public private(set) var text = "Hello, World!"
+
+    public init() {
+    }
+}

--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -274,7 +274,10 @@ public final class Manifest: ObjectIdentifierProtocol {
             return nil
         }
 
-        return self.dependencies.first(where: { $0.nameForTargetDependencyResolutionOnly == packageName })
+        return self.dependencies.first(where: {
+            // rdar://80594761 make sure validation is case insensitive
+            $0.nameForTargetDependencyResolutionOnly.lowercased() == packageName.lowercased()
+        })
     }
 
     /// Registers a required product with a particular dependency if possible, or registers it as unknown.
@@ -341,7 +344,7 @@ public final class Manifest: ObjectIdentifierProtocol {
     /// - Parameters:
     ///   - product: The product to try registering.
     ///   - package: The package to try associating it with.
-    ///   - registry: The registry in which to record the assocation.
+    ///   - registry: The registry in which to record the association.
     ///   - availablePackages: The set of available packages.
     ///
     /// - Returns: `true` if the particular dependency was found and the product was registered; `false` if no matching dependency was found and the product has not yet been handled.

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -133,4 +133,11 @@ class DependencyResolutionTests: XCTestCase {
             }
         }
     }
+
+    func testPackageLookupCaseInsensitive() throws {
+        fixture(name: "DependencyResolution/External/PackageLookupCaseInsensitive") { path in
+            let result = try SwiftPMProduct.SwiftPackage.executeProcess(["update"], packagePath: path.appending(component: "pkg"))
+            XCTAssert(result.exitStatus == .terminated(code: 0), try! result.utf8Output() + result.utf8stderrOutput())
+        }
+    }
 }


### PR DESCRIPTION
motivation: starting tools-version 5.2, SwiftPM validates the target depedenies by name but the validation is case sensitive

changes:
* udpate the validation to be non-case sensitive (the actual lookup is not case sensitive)
* add a test
