### PR TITLE
Refine the change to ignore .docc files rather than emit warnings to avoid having multiple definitions for the same file extension

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -561,7 +561,7 @@ public class SwiftTool {
             config: try getSwiftPMConfig(),
             repositoryProvider: provider,
             netrcFilePath: try resolvedNetrcFilePath(),
-            additionalFileRules: isXcodeBuildSystemEnabled ? FileRuleDescription.xcbuildFileTypes : [],
+            additionalFileRules: isXcodeBuildSystemEnabled ? FileRuleDescription.xcbuildFileTypes : FileRuleDescription.swiftpmFileTypes,
             isResolverPrefetchingEnabled: options.shouldEnableResolverPrefetching,
             skipUpdate: options.skipDependencyUpdate,
             enableResolverTrace: options.enableResolverTrace,

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -239,7 +239,7 @@ public func loadPackageGraph(
     return try PackageGraph.load(
         root: graphRoot,
         identityResolver: identityResolver,
-        additionalFileRules: useXCBuildFileRules ? FileRuleDescription.xcbuildFileTypes : [],
+        additionalFileRules: useXCBuildFileRules ? FileRuleDescription.xcbuildFileTypes : FileRuleDescription.swiftpmFileTypes,
         externalManifests: externalManifests,
         binaryArtifacts: binaryArtifacts,
         diagnostics: diagnostics,

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -662,7 +662,7 @@ class TargetSourcesBuilderTests: XCTestCase {
         XCTAssertEqual(diags.diagnostics.map { $0.description }, ["found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target\n    /Foo.xcdatamodel\n"])
     }
 
-    func testIgnoredFileTypesDoNoCauseWarnings() throws {
+    func testDocCFilesDoNotCauseWarningOutsideXCBuild() throws {
         let target = try TargetDescription(
             name: "Foo",
             path: nil,
@@ -687,6 +687,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             target: target,
             path: .root,
             defaultLocalization: nil,
+            additionalFileRules: FileRuleDescription.swiftpmFileTypes,
             toolsVersion: .v5_5,
             fs: fs,
             diags: diags


### PR DESCRIPTION
Ignore .docc files rather than emitting warnings, since it's useful to have them in packages without warnings.

### Motivation

Unlike other Xcode-specific file types, such as Storyboards and Asset Catalogs, the .docc bundles are not needed for correctness during the build, and should therefore not trigger warnings.

This change does this in a cleaner way that uses either Xcode build system or SwiftPM build system rules rather than always adding a list of extensions to ignore.

### Changes

- change the ignored-types list to a swiftpm-build-system type list as peer of the one for xcode build system types
- have the caller choose which list, if any, to use

This is a refinement of the fix in #3609.

rdar://78133445