### PR TITLE
[Plugins] Include Plugins in `Manifest.targetsRequired`

### DIFF
--- a/Tests/PackageModelTests/ManifestTests.swift
+++ b/Tests/PackageModelTests/ManifestTests.swift
@@ -22,8 +22,9 @@ class ManifestTests: XCTestCase {
         let targets = [
             try TargetDescription(name: "Foo", dependencies: ["Bar"]),
             try TargetDescription(name: "Bar", dependencies: ["Baz"]),
-            try TargetDescription(name: "Baz", dependencies: []),
+            try TargetDescription(name: "Baz", dependencies: ["MyPlugin"]),
             try TargetDescription(name: "FooBar", dependencies: []),
+            try TargetDescription(name: "MyPlugin", type: .plugin, pluginCapability: .buildTool)
         ]
 
         do {
@@ -42,6 +43,7 @@ class ManifestTests: XCTestCase {
                 "Baz",
                 "Foo",
                 "FooBar",
+                "MyPlugin"
             ])
         }
 


### PR DESCRIPTION
Include Plugins in `Manifest.targetsRequired`

### Motivation:

Fixes SR-14343. As Plugins are modeled as a dependency they also must be included the list of required targets for a product.

### Modifications:

Changed the implementation of `Manifest.targetsRequired` to include plugins 

### Result:

SR-14343 is fixed
