### PR TITLE
Error on relative file URLs

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -15,7 +15,7 @@ import TSCUtility
 import Foundation
 public typealias FileSystem = TSCBasic.FileSystem
 
-public enum ManifestParseError: Swift.Error {
+public enum ManifestParseError: Swift.Error, Equatable {
     /// The manifest contains invalid format.
     case invalidManifestFormat(String, diagnosticFile: AbsolutePath?)
 

--- a/Sources/PackageLoading/PackageDescription4Loader.swift
+++ b/Sources/PackageLoading/PackageDescription4Loader.swift
@@ -345,7 +345,11 @@ extension PackageDependencyDescription {
             } else if dependencyLocation.hasPrefix(filePrefix) {
                 // FIXME: SwiftPM can't handle file locations with file:// scheme so we need to
                 // strip that. We need to design a Location data structure for SwiftPM.
-                return AbsolutePath(String(dependencyLocation.dropFirst(filePrefix.count)), relativeTo: AbsolutePath(packageLocation)).pathString
+                let location = String(dependencyLocation.dropFirst(filePrefix.count))
+                if location.first != "/" {
+                    throw ManifestParseError.invalidManifestFormat("file:// URLs cannot be relative, did you mean to use `.package(path:)`?", diagnosticFile: nil)
+                }
+                return AbsolutePath(location).pathString
             } else if URL.scheme(dependencyLocation) == nil {
                 // If the dependency URL is not remote, try to "fix" it.
                 // If the URL has no scheme, we treat it as a path (either absolute or relative to the base URL).

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -516,18 +516,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
         )
         """
 
-        try loadManifestThrowing(stream.bytes) { manifest in
-            if let dep = manifest.dependencies.first {
-                switch dep {
-                case .scm(let scm):
-                    XCTAssertEqual(scm.location, "/best")
-                default:
-                    XCTFail("dependency was expected to be remote")
-                }
-            } else {
-                XCTFail("manifest had no dependencies")
-            }
-        }
+        XCTAssertManifestLoadThrows(ManifestParseError.invalidManifestFormat("file:// URLs cannot be relative, did you mean to use `.package(path:)`?", diagnosticFile: nil), stream.bytes)
     }
 
     func testCacheInvalidationOnEnv() throws {


### PR DESCRIPTION
It turns out that relative file URLs actually do not exist, see [here](https://github.com/apple/swift-package-manager/pull/3604#issuecomment-881715869) for more discussion. Instead we will now error and guide users to using a local package reference.
