### PR TITLE
rdar://69448176 (Fix and re-enable test related to "ParallelTestsPkg")

### DIFF
--- a/Tests/FunctionalTests/CFamilyTargetTests.swift
+++ b/Tests/FunctionalTests/CFamilyTargetTests.swift
@@ -86,9 +86,6 @@ class CFamilyTargetTestCase: XCTestCase {
     }
 
     func testObjectiveCPackageWithTestTarget() throws {
-        // <rdar://problem/70382477> Fix and re-enable tests which run `swift test` on newly created packages
-        try XCTSkipIf(true)
-
       #if os(macOS)
         fixture(name: "CFamilyTargets/ObjCmacOSPackage") { prefix in
             // Build the package.

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -213,9 +213,6 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testSwiftTestParallel() throws {
-        // <rdar://problem/69448176> Fix and re-enable test related to "ParallelTestsPkg"
-        try XCTSkipIf(true)
-
         fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
           // First try normal serial testing.
           do {
@@ -261,9 +258,6 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testSwiftTestFilter() throws {
-        // <rdar://problem/69448176> Fix and re-enable test related to "ParallelTestsPkg"
-        try XCTSkipIf(true)
-
         fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
             let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--filter", ".*1", "-l"], packagePath: prefix)
             XCTAssertMatch(stdout, .contains("testExample1"))
@@ -280,9 +274,6 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testSwiftTestSkip() throws {
-        // <rdar://problem/69448176> Fix and re-enable test related to "ParallelTestsPkg"
-        try XCTSkipIf(true)
-        
         fixture(name: "Miscellaneous/ParallelTestsPkg") { prefix in
             let (stdout, _) = try SwiftPMProduct.SwiftTest.execute(["--skip", "ParallelTestsTests", "-l"], packagePath: prefix)
             XCTAssertNoMatch(stdout, .contains("testExample1"))

--- a/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
+++ b/Tests/FunctionalTests/SwiftPMXCTestHelperTests.swift
@@ -17,9 +17,6 @@ import Workspace
 
 class SwiftPMXCTestHelperTests: XCTestCase {
     func testBasicXCTestHelper() throws {
-        // <rdar://problem/70382477> Fix and re-enable tests which run `swift test` on newly created packages
-        try XCTSkipIf(true)
-
       #if os(macOS)
         fixture(name: "Miscellaneous/SwiftPMXCTestHelper") { prefix in
             // Build the package.

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -235,9 +235,6 @@ class InitTests: XCTestCase {
     }
     
     func testNonC99NameExecutablePackage() throws {
-        // <rdar://problem/70382477> Fix and re-enable tests which run `swift test` on newly created packages
-        try XCTSkipIf(true)
-
         try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDirPath in
             XCTAssertTrue(localFileSystem.isDirectory(tempDirPath))
             


### PR DESCRIPTION
We disabled these a while ago due to issues we had with using XCTest from the sueprior with an inferior SwiftPM. The underlying compiler issue should be fixed at this point and we can re-enable the tests.
