### PR TITLE
Improve diagnostics for file URLs with hostnames

### DIFF
--- a/Sources/PackageLoading/PackageDescription4Loader.swift
+++ b/Sources/PackageLoading/PackageDescription4Loader.swift
@@ -347,7 +347,7 @@ extension PackageDependencyDescription {
                 // strip that. We need to design a Location data structure for SwiftPM.
                 let location = String(dependencyLocation.dropFirst(filePrefix.count))
                 if location.first != "/" {
-                    throw ManifestParseError.invalidManifestFormat("file:// URLs cannot be relative, did you mean to use `.package(path:)`?", diagnosticFile: nil)
+                    throw ManifestParseError.invalidManifestFormat("file:// URLs with hostnames are not supported, are you missing a '/'?", diagnosticFile: nil)
                 }
                 return AbsolutePath(location).pathString
             } else if URL.scheme(dependencyLocation) == nil {

--- a/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD4_2LoadingTests.swift
@@ -499,24 +499,31 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
         }
     }
 
-    func testURLContainsNotAbsolutePath() throws {
-        let stream = BufferedOutputByteStream()
-        stream <<< """
-        import PackageDescription
-        let package = Package(
-            name: "Trivial",
-            dependencies: [
-                .package(url: "file://../best", from: "1.0.0"),
-            ],
-            targets: [
-                .target(
-                    name: "foo",
-                    dependencies: []),
-            ]
-        )
-        """
+    func testFileURLsWithHostnames() throws {
+        let urls = [
+          "file://../best", // Possible attempt at a relative path.
+          "file://somehost/bar", // Obviously non-local.
+          "file://localhost/bar" // Local but non-trivial (e.g. on Windows, the path is a UNC path).
+        ]
+        for url in urls {
+            let stream = BufferedOutputByteStream()
+            stream <<< """
+            import PackageDescription
+            let package = Package(
+                name: "Trivial",
+                dependencies: [
+                    .package(url: "\(url)", from: "1.0.0"),
+                ],
+                targets: [
+                    .target(
+                        name: "foo",
+                        dependencies: []),
+                ]
+            )
+            """
 
-        XCTAssertManifestLoadThrows(ManifestParseError.invalidManifestFormat("file:// URLs cannot be relative, did you mean to use `.package(path:)`?", diagnosticFile: nil), stream.bytes)
+            XCTAssertManifestLoadThrows(ManifestParseError.invalidManifestFormat("file:// URLs with hostnames are not supported, are you missing a '/'?", diagnosticFile: nil), stream.bytes)
+        }
     }
 
     func testCacheInvalidationOnEnv() throws {


### PR DESCRIPTION
Improve the diagnostics added in #3625 and add tests for more file URLs with hostnames.

CC @neonichu 

### Motivation:

Previous diagnostic was not entirely clear - the change in the previous patch ensures that _all_ file URLs with hostnames are now rejected. That's a good thing.

- On POSIX systems, remote filesystems are typically mounted within the local filesystem, so there's no obvious interpretation of a file URL with a hostname.
- On Windows, they require UNC paths - even for `localhost` - which is non-trivial kind of path that SwiftPM seems to not support right now.

This patch doesn't change the functionality from the previous patch; it only makes clear what the limitation is.

### Modifications:

Reworded diagnostic, added tests.

### Result:

Clearer diagnostic, more tests.
