### PR TITLE
Do pass explicit empty argument to `-XCTest`

### DIFF
--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -284,9 +284,10 @@ public struct SwiftTestTool: SwiftCommand {
                 // If there were no matches, emit a warning.
                 if tests.isEmpty {
                     swiftTool.diagnostics.emit(.noMatchingTests)
+                    xctestArg = "''"
+                } else {
+                    xctestArg = tests.map { $0.specifier }.joined(separator: ",")
                 }
-
-                xctestArg = tests.map { $0.specifier }.joined(separator: ",")
             }
 
             let runner = TestRunner(


### PR DESCRIPTION
Right now if no tests are matching after filter/skip/etc, we pass no argument to `XCTest` which actually crashes the `xctest` CLI. This makes it so we instead pass an explicit empty argument to it.
