### PR TITLE
Rename experimental-api-diff -> dianose-api-breaking-changes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -259,7 +259,7 @@ let package = Package(
             dependencies: ["Build", "SPMTestSupport"]),
         .testTarget(
             name: "CommandsTests",
-            dependencies: ["swift-build", "swift-package", "swift-test", "swift-run", "Commands", "Workspace", "SPMTestSupport", "Build"]),
+            dependencies: ["swift-build", "swift-package", "swift-test", "swift-run", "Commands", "Workspace", "SPMTestSupport", "Build", "SourceControl"]),
         .testTarget(
             name: "WorkspaceTests",
             dependencies: ["Workspace", "SPMTestSupport"]),

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -334,6 +334,10 @@ extension SwiftPackageTool {
             let apiDigesterPath = try swiftTool.getToolchain().getSwiftAPIDigester()
             let apiDigesterTool = SwiftAPIDigester(tool: apiDigesterPath)
 
+            let packageRoot = try swiftOptions.packagePath ?? swiftTool.getPackageRoot()
+            let repository = GitRepository(path: packageRoot)
+            let baselineRevision = try repository.resolveRevision(identifier: treeish)
+
             // We turn build manifest caching off because we need the build plan.
             let buildOp = try swiftTool.createBuildOperation(cacheBuildManifest: false)
 
@@ -347,7 +351,7 @@ extension SwiftPackageTool {
             // Dump JSON for the baseline package.
             let workspace = try swiftTool.getActiveWorkspace()
             let baselineDumper = try APIDigesterBaselineDumper(
-                baselineTreeish: treeish,
+                baselineRevision: baselineRevision,
                 packageRoot: swiftTool.getPackageRoot(),
                 buildParameters: buildOp.buildParameters,
                 manifestLoader: workspace.manifestLoader,

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -41,6 +41,7 @@ public struct SwiftPackageTool: ParsableCommand {
             Format.self,
             
             APIDiff.self,
+            DeprecatedAPIDiff.self,
             DumpSymbolGraph.self,
             DumpPIF.self,
             DumpPackage.self,
@@ -287,13 +288,27 @@ extension SwiftPackageTool {
             }
         }
     }
+
+    struct DeprecatedAPIDiff: ParsableCommand {
+        static let configuration = CommandConfiguration(commandName: "experimental-api-diff",
+                                                        abstract: "Deprecated - use `swift package diagnose-api-breaking-changes` instead",
+                                                        shouldDisplay: false)
+
+        @Argument(parsing: .unconditionalRemaining)
+        var args: [String] = []
+
+        func run() throws {
+            print("`swift package experimental-api-diff` has been renamed to `swift package diagnose-api-breaking-changes`")
+            throw ExitCode.failure
+        }
+    }
     
     struct APIDiff: SwiftCommand {
         static let configuration = CommandConfiguration(
-            commandName: "experimental-api-diff",
+            commandName: "diagnose-api-breaking-changes",
             abstract: "Diagnose API-breaking changes to Swift modules in a package",
             discussion: """
-            The experimental-api-diff command can be used to compare the Swift API of \
+            The diagnose-api-breaking-changes command can be used to compare the Swift API of \
             a package to a baseline revision, diagnosing any breaking changes which have \
             been introduced. By default, it compares every Swift module from the baseline \
             revision which is part of a library product. For packages with many targets, this \

--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -51,7 +51,7 @@ final class APIDiffTests: XCTestCase {
             try localFileSystem.writeFileContents(packageRoot.appending(component: "Foo.swift")) {
                 $0 <<< "public let foo = 42"
             }
-            XCTAssertThrowsError(try execute(["experimental-api-diff", "1.2.3"], packagePath: packageRoot)) { error in
+            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)) { error in
                 guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
                     XCTFail("Unexpected error")
                     return
@@ -72,7 +72,7 @@ final class APIDiffTests: XCTestCase {
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Qux", "Qux.swift")) {
                 $0 <<< "public class Qux<T, U> { private let x = 1 }"
             }
-            XCTAssertThrowsError(try execute(["experimental-api-diff", "1.2.3", "-j", "2"], packagePath: packageRoot)) { error in
+            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3", "-j", "2"], packagePath: packageRoot)) { error in
                 guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
                     XCTFail("Unexpected error")
                     return
@@ -100,7 +100,7 @@ final class APIDiffTests: XCTestCase {
             try localFileSystem.writeFileContents(customAllowlistPath) {
                 $0 <<< "API breakage: class Qux has generic signature change from <T> to <T, U>\n"
             }
-            XCTAssertThrowsError(try execute(["experimental-api-diff", "1.2.3", "-j", "2",
+            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3", "-j", "2",
                                               "--breakage-allowlist-path", customAllowlistPath.pathString],
                                              packagePath: packageRoot)) { error in
                 guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
@@ -133,7 +133,7 @@ final class APIDiffTests: XCTestCase {
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Qux", "Qux.swift")) {
                 $0 <<< "public class Qux<T, U> { private let x = 1 }"
             }
-            XCTAssertThrowsError(try execute(["experimental-api-diff", "1.2.3"], packagePath: packageRoot)) { error in
+            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)) { error in
                 guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
                     XCTFail("Unexpected error")
                     return
@@ -169,7 +169,7 @@ final class APIDiffTests: XCTestCase {
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Qux", "Qux.swift")) {
                 $0 <<< "public class Qux<T, U> { private let x = 1 }"
             }
-            XCTAssertThrowsError(try execute(["experimental-api-diff", "1.2.3", "--products", "One", "--targets", "Bar"],
+            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3", "--products", "One", "--targets", "Bar"],
                                              packagePath: packageRoot)) { error in
                 guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
                     XCTFail("Unexpected error")
@@ -189,7 +189,7 @@ final class APIDiffTests: XCTestCase {
             }
 
             // Diff a target which didn't have a baseline generated as part of the first invocation
-            XCTAssertThrowsError(try execute(["experimental-api-diff", "1.2.3", "--targets", "Baz"],
+            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3", "--targets", "Baz"],
                                              packagePath: packageRoot)) { error in
                 guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
                     XCTFail("Unexpected error")
@@ -209,7 +209,7 @@ final class APIDiffTests: XCTestCase {
             }
 
             // Test diagnostics
-            XCTAssertThrowsError(try execute(["experimental-api-diff", "1.2.3", "--targets", "NotATarget", "Exec",
+            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3", "--targets", "NotATarget", "Exec",
                                               "--products", "NotAProduct", "Exec"],
                                              packagePath: packageRoot)) { error in
                 guard case SwiftPMProductError.executionFailure(error: _, output: _, stderr: let stderr) = error else {
@@ -240,7 +240,7 @@ final class APIDiffTests: XCTestCase {
                 }
                 """
             }
-            XCTAssertThrowsError(try execute(["experimental-api-diff", "1.2.3"], packagePath: packageRoot)) { error in
+            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)) { error in
                 guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
                     XCTFail("Unexpected error")
                     return
@@ -250,7 +250,7 @@ final class APIDiffTests: XCTestCase {
             }
 
             // Report an error if we explicitly ask to diff a C-family target
-            XCTAssertThrowsError(try execute(["experimental-api-diff", "1.2.3", "--targets", "Foo"], packagePath: packageRoot)) { error in
+            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3", "--targets", "Foo"], packagePath: packageRoot)) { error in
                 guard case SwiftPMProductError.executionFailure(error: _, output: _, stderr: let stderr) = error else {
                     XCTFail("Unexpected error")
                     return
@@ -269,7 +269,7 @@ final class APIDiffTests: XCTestCase {
             try localFileSystem.writeFileContents(packageRoot.appending(components: "Sources", "Baz", "Baz.swift")) {
                 $0 <<< "public func bar() -> Int { 100 }"
             }
-            let (output, _) = try execute(["experimental-api-diff", "1.2.3"], packagePath: packageRoot)
+            let (output, _) = try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)
             XCTAssertTrue(output.contains("No breaking changes detected in Baz"))
             XCTAssertTrue(output.contains("No breaking changes detected in Qux"))
         }
@@ -302,7 +302,7 @@ final class APIDiffTests: XCTestCase {
                 )
                 """
             }
-            let (output, _) = try execute(["experimental-api-diff", "1.2.3"], packagePath: packageRoot)
+            let (output, _) = try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)
             XCTAssertTrue(output.contains("No breaking changes detected in Baz"))
             XCTAssertTrue(output.contains("No breaking changes detected in Qux"))
             XCTAssertTrue(output.contains("Skipping Foo because it does not exist in the baseline"))
@@ -313,7 +313,7 @@ final class APIDiffTests: XCTestCase {
         try skipIfApiDigesterUnsupported()
         fixture(name: "Miscellaneous/APIDiff/") { prefix in
             let packageRoot = prefix.appending(component: "Foo")
-            XCTAssertThrowsError(try execute(["experimental-api-diff", "7.8.9"], packagePath: packageRoot)) { error in
+            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "7.8.9"], packagePath: packageRoot)) { error in
                 guard case SwiftPMProductError.executionFailure(error: _, output: _, stderr: let stderr) = error else {
                     XCTFail("Unexpected error")
                     return
@@ -336,7 +336,7 @@ final class APIDiffTests: XCTestCase {
                 }
                 try repo.stage(file: "Foo.swift")
                 try repo.commit(message: "Add foo")
-                XCTAssertThrowsError(try execute(["experimental-api-diff", "main", "--baseline-dir", baselineDir.pathString],
+                XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "main", "--baseline-dir", baselineDir.pathString],
                                                  packagePath: packageRoot)) { error in
                     guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
                         XCTFail("Unexpected error")
@@ -354,7 +354,7 @@ final class APIDiffTests: XCTestCase {
                 try repo.stage(file: "Foo.swift")
                 try repo.commit(message: "Add foo")
                 try repo.checkout(revision: .init(identifier: "feature"))
-                let (output, _) = try execute(["experimental-api-diff", "main", "--baseline-dir", baselineDir.pathString],
+                let (output, _) = try execute(["diagnose-api-breaking-changes", "main", "--baseline-dir", baselineDir.pathString],
                                               packagePath: packageRoot)
                 XCTAssertTrue(output.contains("No breaking changes detected in Foo"))
             }
@@ -374,7 +374,7 @@ final class APIDiffTests: XCTestCase {
             let repo = GitRepository(path: packageRoot)
             let revision = try repo.resolveRevision(identifier: "1.2.3")
 
-            XCTAssertThrowsError(try execute(["experimental-api-diff", "1.2.3",
+            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3",
                                               "--baseline-dir", baselineDir.pathString],
                                              packagePath: packageRoot)) { error in
                 guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
@@ -408,7 +408,7 @@ final class APIDiffTests: XCTestCase {
                 $0 <<< "Old Baseline"
             }
 
-            XCTAssertThrowsError(try execute(["experimental-api-diff", "1.2.3",
+            XCTAssertThrowsError(try execute(["diagnose-api-breaking-changes", "1.2.3",
                                               "--baseline-dir", baselineDir.pathString,
                                               "--regenerate-baseline"],
                                              packagePath: packageRoot)) { error in
@@ -421,6 +421,17 @@ final class APIDiffTests: XCTestCase {
                 XCTAssertTrue(localFileSystem.exists(fooBaselinePath))
                 XCTAssertNotEqual((try! localFileSystem.readFileContents(fooBaselinePath)).description, "Old Baseline")
             }
+        }
+    }
+
+    func testOldName() throws {
+        XCTAssertThrowsError(try execute(["experimental-api-diff", "1.2.3", "--regenerate-baseline"],
+                                         packagePath: nil)) { error in
+            guard case SwiftPMProductError.executionFailure(error: _, output: let output, stderr: _) = error else {
+                XCTFail("Unexpected error")
+                return
+            }
+            XCTAssertTrue(output.contains("`swift package experimental-api-diff` has been renamed to `swift package diagnose-api-breaking-changes`"))
         }
     }
 }


### PR DESCRIPTION
Now that this feature is tested on CI and the basic functionality is in place, I think it makes sense to drop the 'experimental' from its name. There are still a number of potential improvements, but no major issues that I know of

### Motivation:

Rename experimental-api-diff -> dianose-api-breaking-changes to reflect its status as a more officially supported feature.

### Modifications:

- Rename experimental-api-diff -> dianose-api-breaking-changes
- Add a stub command to notify users of the new name if they try to use the old one
- Update tests

### Result:

No functional changes other than the new name

This PR builds on #3622 just so I could avoid some merge conflicts in the tests
