### PR TITLE
Change the order of Workspace toolchain C/Swift flags to match the command-line, and document the different ways to pass these flags to SPM

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -21,6 +21,7 @@
   * [Setting the Build Configuration](#setting-the-build-configuration)
     * [Debug](#debug)
     * [Release](#release)
+    * [Additional Flags](#additional-flags)
   * [Depending on Apple Modules](#depending-on-apple-modules)
   * [Creating C Language Targets](#creating-c-language-targets)
   * [Using Shell Completion Scripts](#using-shell-completion-scripts)
@@ -693,6 +694,22 @@ built with following flags in release mode:
 A C language target is built with following flags in release mode:
 
 * `-O2`: Compile with optimizations.
+
+### Additional Flags
+
+You can pass more flags to the C, C++, or Swift compilers in three different ways:
+
+* Command-line flags passed to these tools: flags like `-Xcc` or `-Xswiftc` are used to
+  pass C or Swift flags to all targets, as shown with `-Xlinker` above.
+* Target-specific flags in the manifest: options like `cSettings` or `swiftSettings` are
+  used for fine-grained control of compilation flags for particular targets.
+* A destination JSON file: once you have a set of working command-line flags that you
+  want applied to all targets, you can collect them in a JSON file and pass them in through
+  `extra-cc-flags` and `extra-swiftc-flags` with `--destination example.json`. Take a
+  look at `Utilities/build_ubuntu_cross_compilation_toolchain` for an example.
+
+One difference is that C flags passed in the `-Xcc` command-line or manifest's `cSettings`
+are supplied to the Swift compiler too for convenience, but `extra-cc-flags` aren't.
 
 ## Depending on Apple Modules
 

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -330,7 +330,6 @@ public final class ClangTargetBuildDescription {
             args += ["-fobjc-arc"]
         }
         args += buildParameters.targetTripleArgs(for: target)
-        args += buildParameters.toolchain.extraCCFlags
         args += ["-g"]
         if buildParameters.triple.isWindows() {
             args += ["-gcodeview"]
@@ -373,6 +372,7 @@ public final class ClangTargetBuildDescription {
             args += ["-include", resourceAccessorHeaderFile.pathString]
         }
 
+        args += buildParameters.toolchain.extraCCFlags
         // User arguments (from -Xcc and -Xcxx below) should follow generated arguments to allow user overrides
         args += buildParameters.flags.cCompilerFlags
 
@@ -724,7 +724,6 @@ public final class SwiftTargetBuildDescription {
         }
 
         args += buildParameters.indexStoreArguments(for: target)
-        args += buildParameters.toolchain.extraSwiftCFlags
         args += optimizationArguments
         args += testingArguments
         args += ["-g"]
@@ -791,6 +790,7 @@ public final class SwiftTargetBuildDescription {
             args += ["-emit-module-interface-path", parseableModuleInterfaceOutputPath.pathString]
         }
 
+        args += buildParameters.toolchain.extraSwiftCFlags
         // User arguments (from -Xswiftc) should follow generated arguments to allow user overrides
         args += buildParameters.swiftCompilerFlags
         return args
@@ -907,7 +907,6 @@ public final class SwiftTargetBuildDescription {
         result += ["-swift-version", swiftVersion.rawValue]
 
         result += buildParameters.indexStoreArguments(for: target)
-        result += buildParameters.toolchain.extraSwiftCFlags
         result += optimizationArguments
         result += testingArguments
         result += ["-g"]
@@ -919,6 +918,7 @@ public final class SwiftTargetBuildDescription {
         result += buildParameters.sanitizers.compileSwiftFlags()
         result += ["-parseable-output"]
         result += self.buildSettingsFlags()
+        result += buildParameters.toolchain.extraSwiftCFlags
         result += buildParameters.swiftCompilerFlags
         return result
     }
@@ -1165,7 +1165,6 @@ public final class ProductBuildDescription {
     /// The arguments to link and create this product.
     public func linkArguments() throws -> [String] {
         var args = [buildParameters.toolchain.swiftCompiler.pathString]
-        args += buildParameters.toolchain.extraSwiftCFlags
         args += buildParameters.sanitizers.linkSwiftFlags()
         args += additionalFlags
 
@@ -1286,6 +1285,7 @@ public final class ProductBuildDescription {
         // building for Darwin in debug configuration.
         args += swiftASTs.flatMap{ ["-Xlinker", "-add_ast_path", "-Xlinker", $0.pathString] }
 
+        args += buildParameters.toolchain.extraSwiftCFlags
         // User arguments (from -Xlinker and -Xswiftc) should follow generated arguments to allow user overrides
         args += buildParameters.linkerFlags
         args += stripInvalidArguments(buildParameters.swiftCompilerFlags)


### PR DESCRIPTION
### Motivation:

C Flags passed in through a destination JSON are now passed in _before_ a package's internal flags, which can cause problems, as was fixed for the command-line flags with #1365. Also, C flags passed in through a destination JSON are _not_ passed in to the Swift compiler, while command-line `-Xcc` flags are.

### Modifications:

Moved all the Workspace toolchain flags to right before the command-line flags, so they can still be overriden by the command-line, and documented the discrepancy between `-Xcc` command-line flags and the destination JSON. 

### Result:

Fixes issues with the flag ordering and documents how C flags are passed in differently, between the command-line and the Workspace toolchain. 

I hit this because I was passing in a sysroot with prebuilt library dependencies like SQLite when cross-compiling SPM itself for Android with a native linux SPM, and it all works fine when [that sysroot include directory is passed in on the command-line](https://github.com/termux/termux-packages/blob/master/packages/swift/swiftpm-Utilities-bootstrap#L149). I then tried [submitting a pull to move that sysroot include to a destination JSON file](https://github.com/apple/swift/pull/36917/files#diff-cc09c8923370b808ebb7439cf4be9d2dde15e81796e80161576ae4cee0502ae7R196) and it worked when the sysroot was minimal with only a few libraries, but fails when using [the much larger Termux sysroot which also has a cross-compiled LLVM](https://github.com/buttaface/termux-packages/blob/swift55/packages/swift/swift-vend-swiftpm-flags.patch#L241):
```
/home/butta/.termux-build/_cache/android-r21d-api-24-v4/bin/aarch64-linux-android-clang -target aarch64-unknown-linux-android --sysroot /home/butta/.termux-build/_cache/android-r21d-api-24-v4/sysroot -fPIC -I/data/data/com.termux/files/usr/include -g -O2 -DSWIFT_PACKAGE=1 -fblocks -I /home/butta/.termux-build/swift/src/llbuild/lib/llvm/Support/include -I /home/butta/.termux-build/swift/src/llbuild/lib/llvm/Demangle/include -fmodule-map-file=/home/butta/.termux-build/swift/build/swiftpm-android-aarch64/aarch64-unknown-linux-android/release/llvmDemangle.build/module.modulemap -MD -MT dependencies -MF /home/butta/.termux-build/swift/build/swiftpm-android-aarch64/aarch64-unknown-linux-android/release/llvmSupport.build/raw_ostream.cpp.d -std=c++14 -c /home/butta/.termux-build/swift/src/llbuild/lib/llvm/Support/raw_ostream.cpp -o /home/butta/.termux-build/swift/build/swiftpm-android-aarch64/aarch64-unknown-linux-android/release/llvmSupport.build/raw_ostream.cpp.o
In file included from /home/butta/.termux-build/swift/src/llbuild/lib/llvm/Support/raw_ostream.cpp:18:
/home/butta/.termux-build/swift/src/llbuild/lib/llvm/Support/include/llvm/Config/config.h:356:9: warning: 'LLVM_DEFAULT_TARGET_TRIPLE' macro redefined [-Wmacro-redefined]
#define LLVM_DEFAULT_TARGET_TRIPLE ""
        ^
/data/data/com.termux/files/usr/include/llvm/Config/llvm-config.h:21:9: note: previous definition is here
#define LLVM_DEFAULT_TARGET_TRIPLE "aarch64-unknown-linux-android24"
        ^
/home/butta/.termux-build/swift/src/llbuild/lib/llvm/Support/raw_ostream.cpp:74:21: error: use of undeclared identifier 'InternalBuffer'
  if (BufferMode == InternalBuffer)
                    ^
```
The problem seems to be that the sysroot include from the JSON flag is passed in before the llbuild package source paths and overrides them, but the command-line `-Xcc` flag is passed in later and doesn't have that problem. This pull is an attempt to fix this by moving the destination JSON flags right before the command-line flags and after the Swift package's source paths instead, just as in #1365.

The Workspace flags were [initially passed right before the command-line flags](https://github.com/apple/swift-package-manager/pull/889/files#diff-13eb4b18e8a4f2de8467dae905be6bdc133208159aded4aa6dbb6a03be21c6bdR130), but #1365 [separated the two](https://github.com/apple/swift-package-manager/pull/1365/files#diff-13eb4b18e8a4f2de8467dae905be6bdc133208159aded4aa6dbb6a03be21c6bdL180). This pull brings them back together.

As for not passing in `-Xcc` command-line flags to the Swift compiler, that is currently how the Workspace toolchain flags work so this gets them both working the same way. I'm not sure if this change is the best way to handle this, so it is a tentative solution.

I'll add some tests once it's agreed upon how to deal with these issues.