### PR TITLE
Improve diagnostic when automatic resolution is disabled

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1857,7 +1857,11 @@ extension Workspace {
         )
 
         if precomputationResult.isRequired {
-            diagnostics.emit(error: "cannot update Package.resolved file because automatic resolution is disabled")
+            if !fileSystem.exists(resolvedFile) {
+                diagnostics.emit(error: "a resolved file is required when automatic dependency resolution is disabled and should be placed at \(resolvedFile.pathString)")
+            } else {
+                diagnostics.emit(error: "an out-of-date resolved file was detected at \(resolvedFile.pathString), which is not allowed when automatic dependency resolution is disabled; please make sure to update the file to reflect the changes in dependencies")
+            }
         }
 
         try self.updateBinaryArtifacts(manifests: currentManifests, addedOrUpdatedPackages: [], diagnostics: diagnostics)


### PR DESCRIPTION
- Show the exact path where we looked for a resolved file
- Special case if there wasn't a file to begin with

rdar://81172549
