### PR TITLE
Implement dependency resolution through package registry

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -154,6 +154,7 @@ let package = Package(
             /** Primitive Package model objects */
             name: "PackageModel",
             dependencies: ["SwiftToolsSupport-auto", "Basics"]),
+
         .target(
             /** Package model conventions and loading support */
             name: "PackageLoading",

--- a/Sources/Commands/SwiftPackageRegistryTool.swift
+++ b/Sources/Commands/SwiftPackageRegistryTool.swift
@@ -152,22 +152,3 @@ public struct SwiftPackageRegistryTool: ParsableCommand {
         }
     }
 }
-
-// MARK: -
-
-private extension SwiftTool {
-    func getRegistriesConfig() throws -> Workspace.Configuration.Registries {
-        let localRegistriesFile = try Workspace.DefaultLocations.registriesConfigurationFile(forRootPackage: self.getPackageRoot())
-
-        let workspace = try getActiveWorkspace()
-        let sharedRegistriesFile = workspace.location.sharedConfigurationDirectory.map {
-            Workspace.DefaultLocations.registriesConfigurationFile(at: $0)
-        }
-
-        return try .init(
-            localRegistriesFile: localRegistriesFile,
-            sharedRegistriesFile: sharedRegistriesFile,
-            fileSystem: localFileSystem
-        )
-    }
-}

--- a/Sources/Commands/SwiftPackageRegistryTool.swift
+++ b/Sources/Commands/SwiftPackageRegistryTool.swift
@@ -24,7 +24,7 @@ import Foundation
 import PackageRegistry
 
 private enum RegistryConfigurationError: Swift.Error {
-    case missingScope(String? = nil)
+    case missingScope(PackageIdentity.Scope? = nil)
     case invalidURL(String)
 }
 
@@ -90,6 +90,8 @@ public struct SwiftPackageRegistryTool: ParsableCommand {
                 throw RegistryConfigurationError.invalidURL(self.url)
             }
 
+            let scope = try scope.map(PackageIdentity.Scope.init(validating:))
+
             // TODO: Require login if password is specified
 
             let set: (inout RegistryConfiguration) throws -> Void = { configuration in
@@ -125,6 +127,8 @@ public struct SwiftPackageRegistryTool: ParsableCommand {
         var scope: String?
 
         func run(_ swiftTool: SwiftTool) throws {
+            let scope = try scope.map(PackageIdentity.Scope.init(validating:))
+
             let unset: (inout RegistryConfiguration) throws -> Void = { configuration in
                 if let scope = scope {
                     guard let _ = configuration.scopedRegistries[scope] else {
@@ -150,7 +154,6 @@ public struct SwiftPackageRegistryTool: ParsableCommand {
 }
 
 // MARK: -
-
 
 private extension SwiftTool {
     func getRegistriesConfig() throws -> Workspace.Configuration.Registries {

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -579,6 +579,7 @@ public class SwiftTool {
                 sharedConfigurationDirectory: sharedConfigurationDirectory
             ),
             mirrors: self.getMirrorsConfig(sharedConfigurationDirectory: sharedConfigurationDirectory).mirrors,
+            registries: try? self.getRegistriesConfig(sharedConfigurationDirectory: sharedConfigurationDirectory).configuration,
             authorizationProvider: self.getAuthorizationProvider(),
             customManifestLoader: self.getManifestLoader(), // FIXME: doe we really need to customize it?
             customRepositoryProvider: provider, // FIXME: doe we really need to customize it?

--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -480,6 +480,21 @@ public class SwiftTool {
         return newPath
     }
 
+    func getRegistriesConfig(sharedConfigurationDirectory: AbsolutePath? = nil) throws -> Workspace.Configuration.Registries {
+        let localRegistriesFile = try Workspace.DefaultLocations.registriesConfigurationFile(forRootPackage: self.getPackageRoot())
+
+        let sharedConfigurationDirectory = try sharedConfigurationDirectory ?? self.getSharedConfigurationDirectory()
+        let sharedRegistriesFile = sharedConfigurationDirectory.map {
+            Workspace.DefaultLocations.registriesConfigurationFile(at: $0)
+        }
+
+        return try .init(
+            localRegistriesFile: localRegistriesFile,
+            sharedRegistriesFile: sharedRegistriesFile,
+            fileSystem: localFileSystem
+        )
+    }
+
     func getAuthorizationProvider() throws -> AuthorizationProvider? {
         // currently only single provider: netrc
         return try self.getNetrcConfig()?.get()

--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -8,6 +8,8 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+import Foundation
+
 // MARK: - file system
 
 extension Package {
@@ -546,6 +548,11 @@ extension Package.Dependency {
         identity: String,
         requirement: Package.Dependency.RegistryRequirement
     ) -> Package.Dependency {
+        let pattern = #"\A[a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d])){0,38}\.[a-zA-Z0-9](?:[a-zA-Z0-9]|[-_](?=[a-zA-Z0-9])){0,99}\z"#
+        if identity.range(of: pattern, options: .regularExpression) == nil {
+            errors.append("Invalid package identifier: \(identity)")
+        }
+
         return .init(identity: identity, requirement: requirement)
     }
 }

--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -29,7 +29,7 @@ extension Package {
         public enum Kind {
             case fileSystem(name: String?, path: String)
             case sourceControl(name: String?, location: String, requirement: SourceControlRequirement)
-            case registry(identity: String, requirement: RegistryRequirement)
+            case registry(id: String, requirement: RegistryRequirement)
         }
 
         @available(_PackageDescription, introduced: 5.6)
@@ -83,7 +83,7 @@ extension Package {
                     case .revision(let revision):
                         return .revisionItem(revision)
                     }
-                case .registry(identity: _, requirement: let requirement):
+                case .registry(id: _, requirement: let requirement):
                     switch requirement {
                     case .exact(let version):
                         return .exactItem(version)
@@ -123,8 +123,8 @@ extension Package {
             self.init(kind: .sourceControl(name: name, location: location, requirement: requirement))
         }
 
-        convenience init(identity: String, requirement: RegistryRequirement) {
-            self.init(kind: .registry(identity: identity, requirement: requirement))
+        convenience init(id: String, requirement: RegistryRequirement) {
+            self.init(kind: .registry(id: id, requirement: requirement))
         }
     }
 }
@@ -461,17 +461,17 @@ extension Package.Dependency {
     /// The following example allows the Swift Package Manager to select a version
     /// like a  `1.2.3`, `1.2.4`, or `1.3.0`, but not `2.0.0`.
     ///
-    ///    .package(identity: "scope.name", from: "1.2.3"),
+    ///    .package(id: "scope.name", from: "1.2.3"),
     ///
     /// - Parameters:
-    ///     - identity: The identity of the package.
+    ///     - id: The identity of the package.
     ///     - version: The minimum version requirement.
     @available(_PackageDescription, introduced: 999)
     public static func package(
-        identity: String,
+        id: String,
         from version: Version
     ) -> Package.Dependency {
-        return .package(identity: identity, .upToNextMajor(from: version))
+        return .package(id: id, .upToNextMajor(from: version))
     }
 
     /// Adds a package dependency that uses the exact version requirement.
@@ -485,17 +485,17 @@ extension Package.Dependency {
     ///
     /// The following example instruct the Swift Package Manager to use version `1.2.3`.
     ///
-    ///    .package(identity: "scope.name", exact: "1.2.3"),
+    ///    .package(id: "scope.name", exact: "1.2.3"),
     ///
     /// - Parameters:
-    ///     - identity: The identity of the package.
+    ///     - id: The identity of the package.
     ///     - version: The minimum version requirement.
     @available(_PackageDescription, introduced: 999)
     public static func package(
-        identity: String,
+        id: String,
         exact version: Version
     ) -> Package.Dependency {
-        return .package(identity: identity, requirement: .exact(version))
+        return .package(id: id, requirement: .exact(version))
     }
 
     /// Adds a package dependency starting with a specific minimum version, up to
@@ -504,17 +504,17 @@ extension Package.Dependency {
     /// The following example allows the Swift Package Manager to pick
     /// versions `1.2.3`, `1.2.4`, `1.2.5`, but not `1.2.6`.
     ///
-    ///     .package(identity: "scope.name", "1.2.3"..<"1.2.6"),
+    ///     .package(id: "scope.name", "1.2.3"..<"1.2.6"),
     ///
     /// - Parameters:
-    ///     - identity: The identity of the package.
+    ///     - id: The identity of the package.
     ///     - range: The custom version range requirement.
     @available(_PackageDescription, introduced: 999)
     public static func package(
-        identity: String,
+        id: String,
         _ range: Range<Version>
     ) -> Package.Dependency {
-        return .package(identity: identity, requirement: .range(range))
+        return .package(id: id, requirement: .range(range))
     }
 
     /// Adds a package dependency starting with a specific minimum version, going
@@ -523,14 +523,14 @@ extension Package.Dependency {
     /// The following example allows the Swift Package Manager to pick
     /// versions 1.2.3, 1.2.4, 1.2.5, as well as 1.2.6.
     ///
-    ///     .package(identity: "scope.name", "1.2.3"..."1.2.6"),
+    ///     .package(id: "scope.name", "1.2.3"..."1.2.6"),
     ///
     /// - Parameters:
-    ///     - identity: The identity of the package.
+    ///     - id: The identity of the package.
     ///     - range: The closed version range requirement.
     @available(_PackageDescription, introduced: 999)
     public static func package(
-        identity: String,
+        id: String,
         _ range: ClosedRange<Version>
     ) -> Package.Dependency {
         // Increase upperbound's patch version by one.
@@ -539,21 +539,21 @@ extension Package.Dependency {
             upper.major, upper.minor, upper.patch + 1,
             prereleaseIdentifiers: upper.prereleaseIdentifiers,
             buildMetadataIdentifiers: upper.buildMetadataIdentifiers)
-        return .package(identity: identity, range.lowerBound ..< upperBound)
+        return .package(id: id, range.lowerBound ..< upperBound)
     }
 
     // intentionally private to hide enum detail
     @available(_PackageDescription, introduced: 999)
     private static func package(
-        identity: String,
+        id: String,
         requirement: Package.Dependency.RegistryRequirement
     ) -> Package.Dependency {
         let pattern = #"\A[a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d])){0,38}\.[a-zA-Z0-9](?:[a-zA-Z0-9]|[-_](?=[a-zA-Z0-9])){0,99}\z"#
-        if identity.range(of: pattern, options: .regularExpression) == nil {
-            errors.append("Invalid package identifier: \(identity)")
+        if id.range(of: pattern, options: .regularExpression) == nil {
+            errors.append("Invalid package identifier: \(id)")
         }
 
-        return .init(identity: identity, requirement: requirement)
+        return .init(id: id, requirement: requirement)
     }
 }
 

--- a/Sources/PackageGraph/CMakeLists.txt
+++ b/Sources/PackageGraph/CMakeLists.txt
@@ -14,7 +14,6 @@ add_library(PackageGraph
   DependencyResolver.swift
   Diagnostics.swift
   GraphLoadingNode.swift
-  LocalPackageContainer.swift
   PackageContainer.swift
   PackageGraph.swift
   PackageGraph+Loading.swift
@@ -27,7 +26,6 @@ add_library(PackageGraph
   Pubgrub/PartialSolution.swift
   Pubgrub/PubgrubDependencyResolver.swift
   Pubgrub/Term.swift
-  RepositoryPackageContainer.swift
   ResolvedPackage.swift
   ResolvedProduct.swift
   ResolvedTarget.swift

--- a/Sources/PackageGraph/CheckoutState.swift
+++ b/Sources/PackageGraph/CheckoutState.swift
@@ -8,9 +8,8 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
-import TSCBasic
-import SourceControl
-import TSCUtility
+import struct SourceControl.Revision // FIXME: remove this dependency
+import struct TSCUtility.Version
 
 /// A checkout state represents the current state of a repository.
 ///

--- a/Sources/PackageGraph/DependencyMirrors.swift
+++ b/Sources/PackageGraph/DependencyMirrors.swift
@@ -9,9 +9,7 @@
 */
 
 import Foundation
-
 import TSCBasic
-import TSCUtility
 
 /// A collection of dependency mirrors.
 public final class DependencyMirrors: Equatable {

--- a/Sources/PackageGraph/GraphLoadingNode.swift
+++ b/Sources/PackageGraph/GraphLoadingNode.swift
@@ -8,10 +8,9 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
-import TSCBasic
 import PackageLoading
 import PackageModel
-import TSCUtility
+import TSCBasic
 
 /// A node used while loading the packages in a resolved graph.
 ///

--- a/Sources/PackageGraph/PackageContainer.swift
+++ b/Sources/PackageGraph/PackageContainer.swift
@@ -9,9 +9,7 @@
  */
 
 import Dispatch
-import PackageLoading
 import PackageModel
-import SourceControl
 import struct TSCUtility.Version
 
 /// A container of packages.
@@ -104,7 +102,7 @@ extension PackageContainer {
     }
 }
 
-// MARK: -
+// MARK: - PackageContainerConstraint
 
 /// An individual constraint onto a container.
 public struct PackageContainerConstraint: Equatable, Hashable {
@@ -139,7 +137,7 @@ extension PackageContainerConstraint: CustomStringConvertible {
     }
 }
 
-// MARK: -
+// MARK: - PackageContainerProvider
 
 /// An interface for resolving package containers.
 public protocol PackageContainerProvider {

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -11,9 +11,7 @@
 import Basics
 import PackageLoading
 import PackageModel
-import SourceControl
 import TSCBasic
-import TSCUtility
 
 extension PackageGraph {
 

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -231,7 +231,7 @@ private func createResolvedPackages(
         var dependenciesByNameForTargetDependencyResolution = [String: ResolvedPackageBuilder]()
 
         // Establish the manifest-declared package dependencies.
-        package.manifest.dependenciesRequired(for: packageBuilder.productFilter).forEach { dependency in
+        try package.manifest.dependenciesRequired(for: packageBuilder.productFilter).forEach { dependency in
             // FIXME: change this validation logic to use identity instead of location
             let dependencyLocation: String
             switch dependency {
@@ -244,9 +244,12 @@ private func createResolvedPackages(
                 case .remote(let url):
                     dependencyLocation = url.absoluteString
                 }
-            case .registry:
-                // FIXME
-                fatalError("registry based dependencies not implemented yet")
+            case .registry(let settings):
+                guard let _ = settings.identity.scopeAndName else {
+                    throw InternalError("invalid package identifier \(settings.identity)")
+                }
+
+                dependencyLocation = "\(settings.identity)"
             }
 
             // Otherwise, look it up by its identity.

--- a/Sources/PackageGraph/PackageGraph.swift
+++ b/Sources/PackageGraph/PackageGraph.swift
@@ -8,8 +8,8 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
-import TSCBasic
 import PackageModel
+import TSCBasic
 
 enum PackageGraphError: Swift.Error {
     /// Indicates a non-root package with no targets.

--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -10,9 +10,8 @@
 
 import Basics
 import PackageModel
-import SourceControl
 import TSCBasic
-import TSCUtility
+import enum TSCUtility.Git
 
 /// Represents the input to the package graph root.
 public struct PackageGraphRootInput {

--- a/Sources/PackageGraph/PackageModel+Extensions.swift
+++ b/Sources/PackageGraph/PackageModel+Extensions.swift
@@ -9,7 +9,6 @@
 */
 
 import PackageModel
-import SourceControl
 
 extension PackageDependency {
     /// Create the package reference object for the dependency.

--- a/Sources/PackageGraph/PackageModel+Extensions.swift
+++ b/Sources/PackageGraph/PackageModel+Extensions.swift
@@ -25,10 +25,10 @@ extension PackageDependency {
             case .remote(let url):
                 packageKind = .remoteSourceControl(url)
             }
-        case .registry:
-            // FIXME
-            fatalError("registry based dependencies not implemented yet")
+        case .registry(let settings):
+            packageKind = .registry(settings.identity)
         }
+
         return PackageReference(identity: self.identity, kind: packageKind)
     }
 }

--- a/Sources/PackageGraph/PinsStore.swift
+++ b/Sources/PackageGraph/PinsStore.swift
@@ -11,7 +11,7 @@
 import Basics
 import Foundation
 import PackageModel
-import SourceControl
+import struct SourceControl.Revision // FIXME: remove this dependency
 import TSCBasic
 
 public final class PinsStore {

--- a/Sources/PackageGraph/Version+Extensions.swift
+++ b/Sources/PackageGraph/Version+Extensions.swift
@@ -8,7 +8,7 @@ See http://swift.org/LICENSE.txt for license information
 See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import TSCUtility
+import struct TSCUtility.Version
 
 extension Version {
     func nextPatch() -> Version {

--- a/Sources/PackageGraph/VersionSetSpecifier.swift
+++ b/Sources/PackageGraph/VersionSetSpecifier.swift
@@ -8,7 +8,7 @@ See http://swift.org/LICENSE.txt for license information
 See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import TSCUtility
+import struct TSCUtility.Version
 
 /// An abstract definition for a set of versions.
 public enum VersionSetSpecifier: Hashable {

--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -11,7 +11,6 @@
 import Basics
 import PackageModel
 import TSCBasic
-import TSCUtility
 
 extension Basics.Diagnostic {
     static func targetHasNoSources(targetPath: String, target: String) -> Self {

--- a/Sources/PackageLoading/IdentityResolver.swift
+++ b/Sources/PackageLoading/IdentityResolver.swift
@@ -47,6 +47,8 @@ public struct DefaultIdentityResolver: IdentityResolver {
             return try self.resolveIdentity(for: path)
         case .remoteSourceControl(let url):
             return try self.resolveIdentity(for: url)
+        case .registry(let identity):
+            return identity
         }
     }
 

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -11,7 +11,7 @@
 import Basics
 import Foundation
 import PackageModel
-import SourceControl
+import SourceControl // FIXME: remove this dependency
 import TSCBasic
 import TSCUtility
 
@@ -231,6 +231,9 @@ enum ManifestJSONParser {
         case .localSourceControl(let path):
             packagePath = path
         case .remoteSourceControl:
+            // nothing to fix
+            return dependencyLocation
+        case .registry:
             // nothing to fix
             return dependencyLocation
         }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -9,11 +9,12 @@
 */
 
 import Basics
-import TSCBasic
-import PackageModel
-import TSCUtility
 import Foundation
-public typealias FileSystem = TSCBasic.FileSystem
+import PackageModel
+import TSCBasic
+import struct TSCUtility.Triple
+import enum TSCUtility.Diagnostics
+import var TSCUtility.verbosity
 
 public enum ManifestParseError: Swift.Error, Equatable {
     /// The manifest contains invalid format.

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -12,7 +12,7 @@ import Basics
 import Dispatch
 import PackageModel
 import TSCBasic
-import TSCUtility
+//import TSCUtility
 
 /// An error in the structure or layout of a package.
 public enum ModuleError: Swift.Error {

--- a/Sources/PackageLoading/Target+PkgConfig.swift
+++ b/Sources/PackageLoading/Target+PkgConfig.swift
@@ -9,8 +9,8 @@
 */
 
 import Basics
-import TSCBasic
 import PackageModel
+import TSCBasic
 import TSCUtility
 
 /// Wrapper struct containing result of a pkgConfig query.

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -12,7 +12,7 @@ import Basics
 import Foundation
 import PackageModel
 import TSCBasic
-import TSCUtility
+//import TSCUtility
 
 /// A utility to compute the source/resource files of a target.
 public struct TargetSourcesBuilder {

--- a/Sources/PackageLoading/ToolsVersionLoader.swift
+++ b/Sources/PackageLoading/ToolsVersionLoader.swift
@@ -12,7 +12,7 @@ import Basics
 import Foundation
 import PackageModel
 import TSCBasic
-import TSCUtility
+//import TSCUtility
 
 /// Protocol for the manifest loader interface.
 public protocol ToolsVersionLoaderProtocol {

--- a/Sources/PackageModel/PackageIdentity.swift
+++ b/Sources/PackageModel/PackageIdentity.swift
@@ -63,6 +63,17 @@ public struct PackageIdentity: CustomStringConvertible {
     public static func plain(_ value: String) -> PackageIdentity {
         PackageIdentity(value)
     }
+
+    // TODO: formalize package registry identifier
+    public var scopeAndName: (String, String)? {
+        let components = description.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: true)
+        guard let scope = components.first,
+              let name = components.last,
+              components.count == 2
+        else { return nil }
+
+        return (String(scope), String(name))
+    }
 }
 
 extension PackageIdentity: Equatable, Comparable {

--- a/Sources/PackageModel/PackageIdentity.swift
+++ b/Sources/PackageModel/PackageIdentity.swift
@@ -65,14 +65,14 @@ public struct PackageIdentity: CustomStringConvertible {
     }
 
     // TODO: formalize package registry identifier
-    public var scopeAndName: (String, String)? {
+    public var scopeAndName: (Scope, Name)? {
         let components = description.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: true)
-        guard let scope = components.first,
-              let name = components.last,
-              components.count == 2
+        guard components.count == 2,
+              let scope = Scope(components.first),
+              let name = Name(components.last)
         else { return nil }
 
-        return (String(scope), String(name))
+        return (scope, name)
     }
 }
 
@@ -160,6 +160,11 @@ extension PackageIdentity {
             self = scope
         }
 
+        fileprivate init?(_ substring: String.SubSequence?) {
+            guard let substring = substring else { return nil }
+            self.init(String(substring))
+        }
+
         // MARK: - Equatable & Comparable
 
         private func compare(to other: Scope) -> ComparisonResult {
@@ -235,6 +240,11 @@ extension PackageIdentity {
         public init?(_ description: String) {
             guard let name = try? Name(validating: description) else { return nil }
             self = name
+        }
+
+        fileprivate init?(_ substring: String.SubSequence?) {
+            guard let substring = substring else { return nil }
+            self.init(String(substring))
         }
 
         // MARK: - Equatable & Comparable

--- a/Sources/PackageModel/PackageReference.swift
+++ b/Sources/PackageModel/PackageReference.swift
@@ -16,7 +16,7 @@ import TSCUtility
 /// A package reference.
 ///
 /// This represents a reference to a package containing its identity and location.
-public struct PackageReference: Encodable {
+public struct PackageReference {
     /// The kind of package reference.
     public enum Kind: Equatable {
         /// A root package.
@@ -31,6 +31,9 @@ public struct PackageReference: Encodable {
         /// A remote source package.
         case remoteSourceControl(Foundation.URL)
 
+        /// A package from  a registry.
+        case registry(PackageIdentity)
+
         // FIXME: we should not need this
         //@available(*, deprecated)
         public var locationString: String {
@@ -43,6 +46,9 @@ public struct PackageReference: Encodable {
                 return path.pathString
             case .remoteSourceControl(let url):
                 return url.absoluteString
+            case .registry(let identity):
+                // FIXME: this is a placeholder
+                return identity.description
             }
         }
 
@@ -75,7 +81,7 @@ public struct PackageReference: Encodable {
     /// The kind of package: root, local, or remote.
     public let kind: Kind
 
-    /// Create a package reference given its identity and repository.
+    /// Create a package reference given its identity and kind.
     public init(identity: PackageIdentity, kind: Kind, name: String? = nil) {
         self.identity = identity
         self.kind = kind
@@ -88,6 +94,9 @@ public struct PackageReference: Encodable {
             self.name = name ?? LegacyPackageIdentity.computeDefaultName(fromPath: path)
         case .remoteSourceControl(let url):
             self.name = name ?? LegacyPackageIdentity.computeDefaultName(fromURL: url)
+        case .registry(let identity):
+            // FIXME: this is a placeholder
+            self.name = name ?? identity.description
         }
     }
 
@@ -104,13 +113,16 @@ public struct PackageReference: Encodable {
         PackageReference(identity: identity, kind: .fileSystem(path))
     }
 
-
     public static func localSourceControl(identity: PackageIdentity, path: AbsolutePath) -> PackageReference {
         PackageReference(identity: identity, kind: .localSourceControl(path))
     }
 
     public static func remoteSourceControl(identity: PackageIdentity, url: Foundation.URL) -> PackageReference {
         PackageReference(identity: identity, kind: .remoteSourceControl(url))
+    }
+
+    public static func registry(identity: PackageIdentity) -> PackageReference {
+        PackageReference(identity: identity, kind: .registry(identity))
     }
 }
 
@@ -136,7 +148,7 @@ extension PackageReference: CustomStringConvertible {
 
 extension PackageReference.Kind: Encodable {
     private enum CodingKeys: String, CodingKey {
-        case root, fileSystem, localSourceControl, remoteSourceControl
+        case root, fileSystem, localSourceControl, remoteSourceControl,registry
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -154,6 +166,9 @@ extension PackageReference.Kind: Encodable {
         case .remoteSourceControl(let url):
             var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .remoteSourceControl)
             try unkeyedContainer.encode(url)
+        case .registry:
+            var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .registry)
+            try unkeyedContainer.encode(self.isRoot)
         }
     }
 }

--- a/Sources/PackageRegistry/CMakeLists.txt
+++ b/Sources/PackageRegistry/CMakeLists.txt
@@ -7,6 +7,7 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(PackageRegistry
+  Registry.swift
   RegistryConfiguration.swift)
 target_link_libraries(PackageRegistry PUBLIC
   TSCBasic

--- a/Sources/PackageRegistry/CMakeLists.txt
+++ b/Sources/PackageRegistry/CMakeLists.txt
@@ -12,7 +12,8 @@ target_link_libraries(PackageRegistry PUBLIC
   TSCBasic
   PackageLoading
   PackageModel
-  TSCUtility)
+  TSCUtility
+  Basics)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(PackageRegistry PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/PackageRegistry/CMakeLists.txt
+++ b/Sources/PackageRegistry/CMakeLists.txt
@@ -8,7 +8,8 @@
 
 add_library(PackageRegistry
   Registry.swift
-  RegistryConfiguration.swift)
+  RegistryConfiguration.swift
+  RegistryManager.swift)
 target_link_libraries(PackageRegistry PUBLIC
   TSCBasic
   PackageLoading

--- a/Sources/PackageRegistry/CMakeLists.txt
+++ b/Sources/PackageRegistry/CMakeLists.txt
@@ -9,7 +9,8 @@
 add_library(PackageRegistry
   Registry.swift
   RegistryConfiguration.swift
-  RegistryManager.swift)
+  RegistryManager.swift
+  SourceArchiver.swift)
 target_link_libraries(PackageRegistry PUBLIC
   TSCBasic
   PackageLoading

--- a/Sources/PackageRegistry/Registry.swift
+++ b/Sources/PackageRegistry/Registry.swift
@@ -1,0 +1,19 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import struct Foundation.URL
+
+public struct Registry: Hashable, Codable {
+    public var url: Foundation.URL
+
+    public init(url: Foundation.URL) {
+        self.url = url
+    }
+}

--- a/Sources/PackageRegistry/RegistryConfiguration.swift
+++ b/Sources/PackageRegistry/RegistryConfiguration.swift
@@ -13,15 +13,7 @@ import Foundation
 public struct RegistryConfiguration: Hashable {
     public typealias Scope = String
 
-    public struct Registry: Hashable {
-        public var url: Foundation.URL
-
-        public init(url: Foundation.URL) {
-            self.url = url
-        }
-    }
-
-    public enum Version: Int {
+    public enum Version: Int, Codable {
         case v1 = 1
     }
 
@@ -47,6 +39,10 @@ public struct RegistryConfiguration: Hashable {
         for (scope, registry) in other.scopedRegistries {
             self.scopedRegistries[scope] = registry
         }
+    }
+    
+    public func registry(for scope: Scope) -> Registry? {
+        return scopedRegistries[scope] ?? defaultRegistry
     }
 }
 
@@ -108,6 +104,3 @@ extension RegistryConfiguration: Codable {
         }
     }
 }
-
-extension RegistryConfiguration.Version: Codable {}
-extension RegistryConfiguration.Registry: Codable {}

--- a/Sources/PackageRegistry/RegistryManager.swift
+++ b/Sources/PackageRegistry/RegistryManager.swift
@@ -22,10 +22,11 @@ import struct Foundation.URLQueryItem
 import Dispatch
 
 public enum RegistryError: Error {
+    case unknown
     case registryNotConfigured(scope: PackageIdentity.Scope)
     case invalidPackage(PackageReference)
     case invalidOperation
-    case invalidResponse
+    case invalidResponse(HTTPClientResponse)
     case invalidURL
     case invalidChecksum(expected: String, actual: String)
 }
@@ -99,7 +100,7 @@ public final class RegistryManager {
                         .sorted(by: >)
                     return versions
                 } else {
-                    throw RegistryError.invalidResponse
+                    throw RegistryError.invalidResponse(response)
                 }
             })
         }
@@ -179,7 +180,7 @@ public final class RegistryManager {
                         completion: completion
                     )
                 } else {
-                    throw RegistryError.invalidResponse
+                    throw RegistryError.unknown
                 }
             } catch {
                 queue.async {
@@ -262,7 +263,7 @@ public final class RegistryManager {
                         completion(.failure(error))
                     }
                 } else {
-                    completion(.failure(RegistryError.invalidResponse))
+                    completion(.failure(RegistryError.invalidResponse(response)))
                 }
             case .failure(let error):
                 completion(.failure(error))

--- a/Sources/PackageRegistry/RegistryManager.swift
+++ b/Sources/PackageRegistry/RegistryManager.swift
@@ -1,0 +1,296 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Basics
+import PackageLoading
+import PackageModel
+
+import TSCBasic
+import TSCUtility
+
+import struct Foundation.URL
+import struct Foundation.URLComponents
+import struct Foundation.URLQueryItem
+
+import Dispatch
+
+public enum RegistryError: Error {
+    case registryNotConfigured(scope: String)
+    case invalidPackage(PackageReference)
+    case invalidOperation
+    case invalidResponse
+    case invalidURL
+    case invalidChecksum(expected: String, actual: String)
+}
+
+public final class RegistryManager {
+    internal static var archiverFactory: (FileSystem) -> Archiver = { fileSystem in
+        return ZipArchiver(fileSystem: fileSystem)
+    }
+
+    private static let sharedClient: HTTPClientProtocol = HTTPClient()
+
+    var configuration: RegistryConfiguration
+    var client: HTTPClientProtocol
+    var identityResolver: IdentityResolver
+    var authorizationProvider: HTTPClientAuthorizationProvider?
+    var diagnosticEngine: DiagnosticsEngine?
+
+    public init(configuration: RegistryConfiguration,
+                identityResolver: IdentityResolver,
+                authorizationProvider: HTTPClientAuthorizationProvider? = nil,
+                diagnosticEngine: DiagnosticsEngine? = nil)
+    {
+        self.configuration = configuration
+        self.client = Self.sharedClient
+        self.identityResolver = identityResolver
+        self.authorizationProvider = authorizationProvider
+        self.diagnosticEngine = diagnosticEngine
+    }
+
+    public func fetchVersions(
+        of package: PackageReference,
+        on queue: DispatchQueue,
+        completion: @escaping (Result<[Version], Error>) -> Void
+    ) {
+        guard case let (scope, name)? = package.identity.scopeAndName else {
+            return completion(.failure(RegistryError.invalidPackage(package)))
+        }
+
+        guard let registry = configuration.registry(for: scope) else {
+            return completion(.failure(RegistryError.registryNotConfigured(scope: scope)))
+        }
+
+        var components = URLComponents(url: registry.url, resolvingAgainstBaseURL: true)
+        components?.appendPathComponents(scope, name)
+
+        guard let url = components?.url else {
+            return completion(.failure(RegistryError.invalidURL))
+        }
+
+        var request = HTTPClient.Request(
+            method: .get,
+            url: url,
+            headers: [
+                "Accept": "application/vnd.swift.registry.v1+json"
+            ]
+        )
+
+        request.options.authorizationProvider = authorizationProvider
+
+        client.execute(request, progress: nil) { result in
+            completion(result.tryMap { response in
+                if response.statusCode == 200,
+                   response.headers.get("Content-Version").first == "1",
+                   response.headers.get("Content-Type").first?.hasPrefix("application/json") == true,
+                   let data = response.body,
+                   case .dictionary(let payload) = try? JSON(data: data),
+                   case .dictionary(let releases) = payload["releases"]
+                {
+                    let versions = releases.filter { (try? $0.value.getJSON("problem")) == nil }
+                        .compactMap { Version($0.key) }
+                        .sorted(by: >)
+                    return versions
+                } else {
+                    throw RegistryError.invalidResponse
+                }
+            })
+        }
+    }
+
+    public func fetchManifest(
+        for version: Version,
+        of package: PackageReference,
+        using manifestLoader: ManifestLoaderProtocol,
+        toolsVersion: ToolsVersion = .currentToolsVersion,
+        swiftLanguageVersion: SwiftLanguageVersion? = nil,
+        on queue: DispatchQueue,
+        completion: @escaping (Result<Manifest, Error>) -> Void
+    ) {
+        guard case let (scope, name)? = package.identity.scopeAndName else {
+            return completion(.failure(RegistryError.invalidPackage(package)))
+        }
+
+        guard let registry = configuration.registry(for: scope) else {
+            return completion(.failure(RegistryError.registryNotConfigured(scope: scope)))
+        }
+
+        var components = URLComponents(url: registry.url, resolvingAgainstBaseURL: true)
+        components?.appendPathComponents(scope, name, "\(version)", "Package.swift")
+        if let swiftLanguageVersion = swiftLanguageVersion {
+            components?.queryItems = [
+                URLQueryItem(name: "swift-version", value: swiftLanguageVersion.rawValue)
+            ]
+        }
+
+        guard let url = components?.url else {
+            return completion(.failure(RegistryError.invalidURL))
+        }
+
+        var request = HTTPClient.Request(
+            method: .get,
+            url: url,
+            headers: [
+                "Accept": "application/vnd.swift.registry.v1+swift"
+            ]
+        )
+
+        request.options.authorizationProvider = authorizationProvider
+
+        client.execute(request, progress: nil) { result in
+            do {
+                if case .failure(let error) = result {
+                    throw error
+                } else if case .success(let response) = result,
+                   response.statusCode == 200,
+                   response.headers.get("Content-Version").first == "1",
+                   response.headers.get("Content-Type").first?.hasPrefix("text/x-swift") == true,
+                   let data = response.body
+                {
+                    let fileSystem = InMemoryFileSystem()
+
+                    let filename: String
+                    if let swiftLanguageVersion = swiftLanguageVersion {
+                        filename = Manifest.basename + "@swift-\(swiftLanguageVersion).swift"
+                    } else {
+                        filename = Manifest.basename + ".swift"
+                    }
+
+                    try fileSystem.writeFileContents(.root.appending(component: filename), bytes: ByteString(data))
+                    manifestLoader.load(
+                        at: .root,
+                        packageIdentity: package.identity,
+                        packageKind: .registry(package.identity),
+                        packageLocation: package.location,
+                        version: version,
+                        revision: nil,
+                        toolsVersion: .currentToolsVersion,
+                        identityResolver: self.identityResolver,
+                        fileSystem: fileSystem,
+                        diagnostics: self.diagnosticEngine,
+                        on: .sharedConcurrent,
+                        completion: completion
+                    )
+                } else {
+                    throw RegistryError.invalidResponse
+                }
+            } catch {
+                queue.async {
+                    completion(.failure(error))
+                }
+            }
+        }
+    }
+
+    public func downloadSourceArchive(
+        for version: Version,
+        of package: PackageReference,
+        into fileSystem: FileSystem,
+        at destinationPath: AbsolutePath,
+        expectedChecksum: ByteString? = nil,
+        on queue: DispatchQueue,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        guard case let (scope, name)? = package.identity.scopeAndName else {
+            return completion(.failure(RegistryError.invalidPackage(package)))
+        }
+
+        guard let registry = configuration.registry(for: scope) else {
+            return completion(.failure(RegistryError.registryNotConfigured(scope: scope)))
+        }
+
+        var components = URLComponents(url: registry.url, resolvingAgainstBaseURL: true)
+        components?.appendPathComponents(scope, name, "\(version).zip")
+
+        guard let url = components?.url else {
+            return completion(.failure(RegistryError.invalidURL))
+        }
+
+        var request = HTTPClient.Request(
+            method: .get,
+            url: url,
+            headers: [
+                "Accept": "application/vnd.swift.registry.v1+zip"
+            ]
+        )
+
+        request.options.authorizationProvider = authorizationProvider
+
+        client.execute(request, progress: nil) { result in
+            switch result {
+            case .success(let response):
+                if response.statusCode == 200,
+                   response.headers.get("Content-Version").first == "1",
+                   response.headers.get("Content-Type").first?.hasPrefix("application/zip") == true,
+                   let digest = response.headers.get("Digest").first,
+                   let data = response.body
+                {
+                    do {
+                        let contents = ByteString(data)
+                        let advertisedChecksum = digest.spm_dropPrefix("sha-256=")
+                        let actualChecksum = SHA256().hash(contents).hexadecimalRepresentation
+
+                        guard (expectedChecksum?.hexadecimalRepresentation ?? actualChecksum) == actualChecksum,
+                              advertisedChecksum == actualChecksum
+                        else {
+                            throw RegistryError.invalidChecksum(
+                                expected: expectedChecksum?.hexadecimalRepresentation ?? advertisedChecksum,
+                                actual: actualChecksum
+                            )
+                        }
+
+                        try fileSystem.createDirectory(destinationPath, recursive: true)
+
+                        let archivePath = destinationPath.withExtension("zip")
+                        try fileSystem.writeFileContents(archivePath, bytes: contents)
+
+                        let archiver = Self.archiverFactory(fileSystem)
+                        // TODO: Bail if archive contains relative paths or overlapping files
+                        archiver.extract(from: archivePath, to: destinationPath) { result in
+                            completion(result)
+                            try? fileSystem.removeFileTree(archivePath)
+                        }
+                    } catch {
+                        try? fileSystem.removeFileTree(destinationPath)
+                        completion(.failure(error))
+                    }
+                } else {
+                    completion(.failure(RegistryError.invalidResponse))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+}
+
+private extension String {
+    /// Drops the given suffix from the string, if present.
+    func spm_dropPrefix(_ prefix: String) -> String {
+        if hasPrefix(prefix) {
+            return String(dropFirst(prefix.count))
+        }
+        return self
+    }
+}
+
+private extension AbsolutePath {
+    func withExtension(_ extension: String) -> AbsolutePath {
+        guard !self.isRoot else { return self }
+        let `extension` = `extension`.spm_dropPrefix(".")
+        return AbsolutePath(self, RelativePath("..")).appending(component: "\(basename).\(`extension`)")
+    }
+}
+
+private extension URLComponents {
+    mutating func appendPathComponents(_ components: String...) {
+        path += (path.last == "/" ? "" : "/") + components.joined(separator: "/")
+    }
+}

--- a/Sources/PackageRegistry/RegistryManager.swift
+++ b/Sources/PackageRegistry/RegistryManager.swift
@@ -32,7 +32,7 @@ public enum RegistryError: Error {
 
 public final class RegistryManager {
     internal static var archiverFactory: (FileSystem) -> Archiver = { fileSystem in
-        return ZipArchiver(fileSystem: fileSystem)
+        return SourceArchiver(fileSystem: fileSystem)
     }
 
     private static let sharedClient: HTTPClientProtocol = HTTPClient()

--- a/Sources/PackageRegistry/RegistryManager.swift
+++ b/Sources/PackageRegistry/RegistryManager.swift
@@ -22,7 +22,7 @@ import struct Foundation.URLQueryItem
 import Dispatch
 
 public enum RegistryError: Error {
-    case registryNotConfigured(scope: String)
+    case registryNotConfigured(scope: PackageIdentity.Scope)
     case invalidPackage(PackageReference)
     case invalidOperation
     case invalidResponse
@@ -69,7 +69,7 @@ public final class RegistryManager {
         }
 
         var components = URLComponents(url: registry.url, resolvingAgainstBaseURL: true)
-        components?.appendPathComponents(scope, name)
+        components?.appendPathComponents("\(scope)", "\(name)")
 
         guard let url = components?.url else {
             return completion(.failure(RegistryError.invalidURL))
@@ -123,7 +123,7 @@ public final class RegistryManager {
         }
 
         var components = URLComponents(url: registry.url, resolvingAgainstBaseURL: true)
-        components?.appendPathComponents(scope, name, "\(version)", "Package.swift")
+        components?.appendPathComponents("\(scope)", "\(name)", "\(version)", "Package.swift")
         if let swiftLanguageVersion = swiftLanguageVersion {
             components?.queryItems = [
                 URLQueryItem(name: "swift-version", value: swiftLanguageVersion.rawValue)
@@ -207,7 +207,7 @@ public final class RegistryManager {
         }
 
         var components = URLComponents(url: registry.url, resolvingAgainstBaseURL: true)
-        components?.appendPathComponents(scope, name, "\(version).zip")
+        components?.appendPathComponents("\(scope)", "\(name)", "\(version).zip")
 
         guard let url = components?.url else {
             return completion(.failure(RegistryError.invalidURL))

--- a/Sources/PackageRegistry/SourceArchiver.swift
+++ b/Sources/PackageRegistry/SourceArchiver.swift
@@ -1,0 +1,72 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Basics
+import TSCBasic
+import TSCUtility
+
+import Dispatch
+
+/// An `Archiver` that handles source archives.
+///
+/// Source archives created with `swift package archive-source`
+/// have a top-level directory prefix (for example, `LinkedList-1.1.1/`).
+/// Unfortunately, the `unzip` command used by `ZipArchiver` doesn't have an option for
+/// ignoring this top-level prefix.
+/// Rather than performing additional (possibly unsafe) file system operations,
+/// this `Archiver` delegates to `tar`, which has a built-in `--strip-components=` option.
+struct SourceArchiver: Archiver {
+    public var supportedExtensions: Set<String> { ["zip"] }
+
+    /// The file-system implementation used for various file-system operations and checks.
+    private let fileSystem: FileSystem
+
+    /// Creates a `SourceArchiver`.
+    ///
+    /// - Parameters:
+    ///   - fileSystem: The file-system to used by the `SourceArchiver`.
+    public init(fileSystem: FileSystem = localFileSystem) {
+        self.fileSystem = fileSystem
+    }
+
+    public func extract(
+        from archivePath: AbsolutePath,
+        to destinationPath: AbsolutePath,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        guard fileSystem.exists(archivePath) else {
+            completion(.failure(FileSystemError(.noEntry, archivePath)))
+            return
+        }
+
+        guard fileSystem.isDirectory(destinationPath) else {
+            completion(.failure(FileSystemError(.notDirectory, destinationPath)))
+            return
+        }
+
+        // TODO: consider calling `libarchive` or some other library directly instead of spawning a process
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let result = try Process.popen(args: "bsdtar",
+                                                     "--strip-components=1",
+                                                     "-xvf",
+                                                     archivePath.pathString,
+                                                     "-C", destinationPath.pathString)
+                guard result.exitStatus == .terminated(code: 0) else {
+                    throw try StringError(result.utf8stderrOutput())
+                }
+
+                completion(.success(()))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+}

--- a/Sources/SPMTestSupport/MockManifestLoader.swift
+++ b/Sources/SPMTestSupport/MockManifestLoader.swift
@@ -8,15 +8,14 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import func XCTest.XCTFail
-import Dispatch
-
 import Basics
-import TSCBasic
+import Dispatch
 import PackageModel
 import PackageLoading
 import PackageGraph
+import TSCBasic
 import TSCUtility
+import func XCTest.XCTFail
 
 public enum MockManifestLoaderError: Swift.Error {
     case unknownRequest(String)
@@ -82,7 +81,7 @@ extension ManifestLoader {
         packageKind: PackageModel.PackageReference.Kind,
         toolsVersion: PackageModel.ToolsVersion,
         identityResolver: IdentityResolver = DefaultIdentityResolver(),
-        fileSystem: PackageLoading.FileSystem,
+        fileSystem: TSCBasic.FileSystem,
         diagnostics: TSCBasic.DiagnosticsEngine? = nil
     ) throws -> Manifest{
         let packageIdentity: PackageIdentity
@@ -100,6 +99,10 @@ extension ManifestLoader {
         case .remoteSourceControl(let url):
             packageIdentity = try identityResolver.resolveIdentity(for: url)
             packageLocation = url.absoluteString
+        case .registry(let identity):
+            packageIdentity = identity
+            // FIXME: placeholder
+            packageLocation = identity.description
         }
         return try tsc_await {
             self.load(at: path,

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -777,6 +777,8 @@ extension PackageReference.Kind {
             return "localSourceControl"
         case .remoteSourceControl:
             return "remoteSourceControl"
+        case .registry:
+            return "registry"
         }
     }
 }

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -248,3 +248,5 @@ public func loadPackageGraph(
         fileSystem: fs
     )
 }
+
+public let emptyZipFile = ByteString([0x80, 0x75, 0x05, 0x06] + [UInt8](repeating: 0x00, count: 18))

--- a/Sources/Workspace/CMakeLists.txt
+++ b/Sources/Workspace/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(Workspace
   InitPackage.swift
   ManagedArtifact.swift
   ManagedDependency.swift
+  RegistryPackageContainer.swift
   ResolvedFileWatcher.swift
   ResolverPrecomputationProvider.swift
   SourceControlPackageContainer.swift

--- a/Sources/Workspace/CMakeLists.txt
+++ b/Sources/Workspace/CMakeLists.txt
@@ -10,11 +10,13 @@ add_library(Workspace
   DefaultPluginScriptRunner.swift
   Destination.swift
   Diagnostics.swift
+  FileSystemPackageContainer.swift
   InitPackage.swift
   ManagedArtifact.swift
   ManagedDependency.swift
   ResolvedFileWatcher.swift
   ResolverPrecomputationProvider.swift
+  SourceControlPackageContainer.swift
   ToolsVersionSpecificationRewriter.swift
   UserToolchain.swift
   Workspace.swift

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -133,6 +133,10 @@ extension Diagnostic.Message {
         .warning("dependency '\(packageName)' is missing; cloning again")
     }
 
+    static func downloadedDependencyMissing(packageName: String, version: Version) -> Diagnostic.Message {
+        .warning("dependency '\(packageName)' at version \(version) was downloaded from a registry but is missing; downloading again")
+    }
+
     static func artifactChecksumChanged(targetName: String) -> Diagnostic.Message {
         .error("artifact of binary target '\(targetName)' has changed checksum; this is a potential security risk so the new artifact won't be downloaded")
     }

--- a/Sources/Workspace/FileSystemPackageContainer.swift
+++ b/Sources/Workspace/FileSystemPackageContainer.swift
@@ -8,22 +8,20 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Dispatch
-
 import Basics
-import TSCBasic
+import Dispatch
+import PackageGraph
 import PackageLoading
 import PackageModel
-import SourceControl
-import TSCUtility
+import TSCBasic
 
-/// Local package container.
+/// Local file system package container.
 ///
 /// This class represent packages that are referenced locally in the file system.
 /// There is no need to perform any git operations on such packages and they
 /// should be used as-is. In fact, they might not even have a git repository.
 /// Examples: Root packages, local dependencies, edited packages.
-public final class LocalPackageContainer: PackageContainer {
+internal struct FileSystemPackageContainer: PackageContainer {
     public let package: PackageReference
     private let identityResolver: IdentityResolver
     private let manifestLoader: ManifestLoaderProtocol
@@ -129,8 +127,8 @@ public final class LocalPackageContainer: PackageContainer {
     }
 }
 
-extension LocalPackageContainer: CustomStringConvertible  {
+extension FileSystemPackageContainer: CustomStringConvertible  {
     public var description: String {
-        return "LocalPackageContainer(\(self.package.identity))"
+        return "FileSystemPackageContainer(\(self.package.identity))"
     }
 }

--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -32,6 +32,9 @@ extension Workspace {
             /// for top of the tree style development.
             case edited(basedOn: ManagedDependency?, unmanagedPath: AbsolutePath?)
 
+            /// The dependency is downloaded from a registry.
+            case downloaded(version: Version)
+
             // The dependency is a local package.
             case local
 
@@ -64,6 +67,12 @@ extension Workspace {
         /// Returns true if the dependency is edited.
         public var isEdited: Bool {
             if case .edited = self.state { return true }
+            return false
+        }
+
+        /// Returns true if the dependency is downloaded.
+        public var isDownloaded: Bool {
+            if case .downloaded = state { return true }
             return false
         }
 
@@ -116,6 +125,19 @@ extension Workspace {
                 packageRef: packageRef,
                 state: .checkout(state),
                 subpath: subpath
+            )
+        }
+
+        /// Create a remote dependency checked out
+        public static func downloaded(
+            packageRef: PackageReference,
+            version: Version
+        ) -> ManagedDependency {
+            return ManagedDependency(
+                packageRef: packageRef,
+                state: .downloaded(version: version),
+                // FIXME: This is just a fake entry, we should fix it.
+                subpath: RelativePath(packageRef.identity.description)
             )
         }
 

--- a/Sources/Workspace/RegistryPackageContainer.swift
+++ b/Sources/Workspace/RegistryPackageContainer.swift
@@ -1,0 +1,117 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Basics
+import Dispatch
+import PackageGraph
+import PackageLoading
+import PackageModel
+import PackageRegistry
+import SourceControl
+import TSCBasic
+import TSCUtility
+
+public class RegistryPackageContainer: PackageContainer {
+    public let package: PackageReference
+
+    private let registryManager: RegistryManager
+    private let identityResolver: IdentityResolver
+    private let manifestLoader: ManifestLoaderProtocol
+    private let toolsVersionLoader: ToolsVersionLoaderProtocol
+    private let currentToolsVersion: ToolsVersion
+
+    private var knownVersionsCache = ThreadSafeBox<[Version]>()
+    private var toolsVersionsCache = ThreadSafeKeyValueStore<Version, ToolsVersion>()
+    private var validToolsVersionsCache = ThreadSafeKeyValueStore<Version, Bool>()
+    private var manifestsCache = ThreadSafeKeyValueStore<Version, Manifest>()
+
+    public init(
+        package: PackageReference,
+        identityResolver: IdentityResolver,
+        manager: RegistryManager,
+        manifestLoader: ManifestLoaderProtocol,
+        toolsVersionLoader: ToolsVersionLoaderProtocol,
+        currentToolsVersion: ToolsVersion
+    ) {
+        self.package = package
+        self.identityResolver = identityResolver
+        self.registryManager = manager
+        self.manifestLoader = manifestLoader
+        self.toolsVersionLoader = toolsVersionLoader
+        self.currentToolsVersion = currentToolsVersion
+    }
+
+    // MARK: - PackageContainer
+
+    public func isToolsVersionCompatible(at version: Version) -> Bool {
+        validToolsVersionsCache.memoize(version) {
+            do {
+                let toolsVersion = try self.toolsVersion(for: version)
+                try toolsVersion.validateToolsVersion(currentToolsVersion, packageIdentity: package.identity)
+                return true
+            } catch {
+                return false
+            }
+        }
+    }
+
+    public func toolsVersion(for version: Version) throws -> ToolsVersion {
+        // TODO: Refactor ToolsVersionLoaderProtocol to support loading from string
+        // TODO: Add support for version-specific manifests
+        toolsVersionsCache.memoize(version) {
+            return .currentToolsVersion
+        }
+    }
+
+    public func versionsDescending() throws -> [Version] {
+        try knownVersionsCache.memoize {
+            let versions = try temp_await { self.registryManager.fetchVersions(of: self.package, on: .sharedConcurrent, completion: $0) }
+            return versions.sorted(by: <)
+        }
+    }
+
+    public func versionsAscending() throws -> [Version] {
+        try versionsDescending().reversed()
+    }
+
+    public func toolsVersionsAppropriateVersionsDescending() throws -> [Version] {
+        try versionsDescending().filter(isToolsVersionCompatible(at:))
+    }
+
+    public func getDependencies(at version: Version, productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
+        let manifest = try manifestsCache.memoize(version) {
+            try temp_await { registryManager.fetchManifest(for: version, of: self.package, using: self.manifestLoader, on: .sharedConcurrent, completion: $0) }
+        }
+
+        return try manifest.dependencyConstraints(productFilter: productFilter)
+    }
+
+    public func getDependencies(at revision: String, productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
+        assertionFailure("this method shouldn't be called") // FIXME: remove
+        return []
+    }
+
+    public func getUnversionedDependencies(productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
+        assertionFailure("this method shouldn't be called") // FIXME: remove
+        return []
+    }
+
+    public func getUpdatedIdentifier(at boundVersion: BoundVersion) throws -> PackageReference {
+        return package
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension RegistryPackageContainer: CustomStringConvertible {
+    public var description: String {
+        return "RegistryPackageContainer(\(package.identity))"
+    }
+}

--- a/Sources/Workspace/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/SourceControlPackageContainer.swift
@@ -8,21 +8,17 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Dispatch
 import Basics
-import TSCBasic
+import Dispatch
+import PackageGraph
 import PackageLoading
 import PackageModel
 import SourceControl
+import TSCBasic
 import TSCUtility
 
-enum RepositoryPackageResolutionError: Swift.Error {
-    /// A requested repository could not be cloned.
-    case unavailableRepository
-}
-
 /// Adaptor to expose an individual repository as a package container.
-public class RepositoryPackageContainer: PackageContainer, CustomStringConvertible {
+internal final class SourceControlPackageContainer: PackageContainer, CustomStringConvertible {
     public typealias Constraint = PackageContainerConstraint
 
     // A wrapper for getDependencies() errors. This adds additional information
@@ -37,14 +33,14 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
 
         /// The actual error that occurred.
         public let underlyingError: Error
-        
+
         /// Optional suggestion for how to resolve the error.
         public let suggestion: String?
-        
+
         public var diagnosticLocation: DiagnosticLocation? {
             return PackageLocation.Remote(url: self.url, reference: self.reference)
         }
-        
+
         /// Description shown for errors of this kind.
         public var description: String {
             var desc = "\(underlyingError) in \(self.url)"
@@ -75,9 +71,10 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
     /// valid or not.
     internal var validToolsVersionsCache = ThreadSafeKeyValueStore<Version, Bool>()
 
-    init(
+    public init(
         package: PackageReference,
         identityResolver: IdentityResolver,
+        repositorySpecifier: RepositorySpecifier,
         repository: Repository,
         manifestLoader: ManifestLoaderProtocol,
         toolsVersionLoader: ToolsVersionLoaderProtocol,
@@ -85,16 +82,13 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
     ) throws {
         self.package = package
         self.identityResolver = identityResolver
-        guard let repositorySpecifier = package.repositorySpecifier else {
-            throw InternalError("invalid package type \(package.kind)")
-        }
         self.repositorySpecifier = repositorySpecifier
         self.repository = repository
         self.manifestLoader = manifestLoader
         self.toolsVersionLoader = toolsVersionLoader
         self.currentToolsVersion = currentToolsVersion
     }
-    
+
     // Compute the map of known versions.
     private func knownVersions() throws -> [Version: String] {
         try self.knownVersionsCache.memoize() {
@@ -103,7 +97,7 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
             return knownVersionsWithDuplicates.mapValues({ tags -> String in
                 if tags.count > 1 {
                     // FIXME: Warn if the two tags point to different git references.
-                    
+
                     // If multiple tags are present with the same semantic version (e.g. v1.0.0, 1.0.0, 1.0) reconcile which one we prefer.
                     // Prefer the most specific tag, e.g. 1.0.0 is preferred over 1.0.
                     // Sort the tags so the most specific tag is first, order is ascending so the most specific tag will be last
@@ -128,7 +122,7 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
     public func versionsAscending() throws -> [Version] {
         [Version](try self.knownVersions().keys).sorted()
     }
-    
+
     /// The available version list (in reverse order).
     public func toolsVersionsAppropriateVersionsDescending() throws -> [Version] {
         let reversedVersions = try self.versionsDescending()
@@ -350,97 +344,11 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
     }
 
     public var description: String {
-        return "RepositoryPackageContainer(\(self.package.location))"
+        return "SourceControlPackageContainer(\(self.package.location))"
     }
 }
 
-/// Adaptor for exposing repositories as PackageContainerProvider instances.
-///
-/// This is the root class for bridging the manifest & SCM systems into the
-/// interfaces used by the `DependencyResolver` algorithm.
-public class RepositoryPackageContainerProvider: PackageContainerProvider {
-    let fileSystem: FileSystem
-    let repositoryManager: RepositoryManager
-    let manifestLoader: ManifestLoaderProtocol
-    let identityResolver: IdentityResolver
-
-    /// The tools version currently in use. Only the container versions less than and equal to this will be provided by
-    /// the container.
-    let currentToolsVersion: ToolsVersion
-
-    /// The tools version loader.
-    let toolsVersionLoader: ToolsVersionLoaderProtocol
-
-    /// Create a repository-based package provider.
-    ///
-    /// - Parameters:
-    ///   - repositoryManager: The repository manager responsible for providing repositories.
-    ///   - manifestLoader: The manifest loader instance.
-    ///   - currentToolsVersion: The current tools version in use.
-    ///   - toolsVersionLoader: The tools version loader.
-    public init(
-        fileSystem: FileSystem,
-        repositoryManager: RepositoryManager,
-        identityResolver: IdentityResolver,
-        manifestLoader: ManifestLoaderProtocol,
-        currentToolsVersion: ToolsVersion = ToolsVersion.currentToolsVersion,
-        toolsVersionLoader: ToolsVersionLoaderProtocol = ToolsVersionLoader()
-    ) {
-        self.fileSystem = fileSystem
-        self.repositoryManager = repositoryManager
-        self.identityResolver = identityResolver
-        self.manifestLoader = manifestLoader
-        self.currentToolsVersion = currentToolsVersion
-        self.toolsVersionLoader = toolsVersionLoader
-    }
-
-    public func getContainer(
-        for package: PackageReference,
-        skipUpdate: Bool,
-        on queue: DispatchQueue,
-        completion: @escaping (Result<PackageContainer, Swift.Error>) -> Void
-    ) {
-        if let repositorySpecifier = package.repositorySpecifier {
-            // Resolve the container using the repository manager.
-            repositoryManager.lookup(repository: repositorySpecifier, skipUpdate: skipUpdate, on: queue) { result in
-                queue.async {
-                    // Create the container wrapper.
-                    let result = result.tryMap { handle -> PackageContainer in
-                        // Open the repository.
-                        //
-                        // FIXME: Do we care about holding this open for the lifetime of the container.
-                        let repository = try handle.open()
-                        return try RepositoryPackageContainer(
-                            package: package,
-                            identityResolver: self.identityResolver,
-                            repository: repository,
-                            manifestLoader: self.manifestLoader,
-                            toolsVersionLoader: self.toolsVersionLoader,
-                            currentToolsVersion: self.currentToolsVersion
-                        )
-                    }
-                    completion(result)
-                }
-            }
-        } else  {
-            // If the container is local, just create and return a local package container.
-            do {
-                let container = try LocalPackageContainer(
-                    package: package,
-                    identityResolver: self.identityResolver,
-                    manifestLoader: self.manifestLoader,
-                    toolsVersionLoader: self.toolsVersionLoader,
-                    currentToolsVersion: self.currentToolsVersion,
-                    fileSystem: self.fileSystem)
-                completion(.success(container))
-            } catch {
-                completion(.failure(error))
-            }
-        }
-    }
-}
-
-extension Git {
+fileprivate extension Git {
     static func convertTagsToVersionMap(_ tags: [String]) -> [Version: [String]] {
         // First, check if we need to restrict the tag set to version-specific tags.
         var knownVersions: [Version: [String]] = [:]
@@ -472,17 +380,15 @@ extension Git {
     }
 }
 
-private extension PackageReference {
-    var repositorySpecifier: RepositorySpecifier? {
+fileprivate extension PackageReference {
+    func makeRepositorySpecifier() throws -> RepositorySpecifier {
         switch self.kind {
-        case .root:
-            return .none
-        case .fileSystem:
-            return .none
         case .localSourceControl(let path):
             return .init(path: path)
         case .remoteSourceControl(let url):
             return .init(url: url)
+        default:
+            throw StringError("invalid dependency kind \(self.kind)")
         }
     }
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -15,6 +15,7 @@ import Foundation
 import PackageLoading
 import PackageModel
 import PackageGraph
+import PackageRegistry
 import SourceControl
 
 public typealias Diagnostic = TSCBasic.Diagnostic
@@ -203,6 +204,10 @@ public class Workspace {
     // var for backwards compatibility with deprecated initializers, remove with them
     fileprivate var repositoryManager: RepositoryManager
 
+    /// The registry manager.
+    // var for backwards compatibility with deprecated initializers, remove with them
+    fileprivate var registryManager: RegistryManager?
+
     /// The http client used for downloading binary artifacts.
     fileprivate let httpClient: HTTPClient
 
@@ -264,11 +269,13 @@ public class Workspace {
         fileSystem: FileSystem,
         location: Location,
         mirrors: DependencyMirrors? = .none,
+        registries: RegistryConfiguration? = .none,
         authorizationProvider: AuthorizationProvider? = .none,
         customToolsVersion: ToolsVersion? = .none,
         customManifestLoader: ManifestLoaderProtocol? = .none,
         customRepositoryManager: RepositoryManager? = .none,
         customRepositoryProvider: RepositoryProvider? = .none,
+        customRegistryManager: RegistryManager? = .none,
         customIdentityResolver: IdentityResolver? = .none,
         customHTTPClient: HTTPClient? = .none,
         customArchiver: Archiver? = .none,
@@ -287,6 +294,8 @@ public class Workspace {
             toolchain: UserToolchain(destination: .hostDestination()).configuration,
             cacheDir: location.sharedManifestsCacheDirectory
         )
+        let mirrors = mirrors ?? DependencyMirrors()
+        let identityResolver = customIdentityResolver ?? DefaultIdentityResolver(locationMapper: mirrors.effectiveURL(for:))
         let repositoryProvider = customRepositoryProvider ?? GitRepositoryProvider()
         let sharedRepositoriesCacheEnabled = sharedRepositoriesCacheEnabled ?? true
         let repositoryManager = customRepositoryManager ?? RepositoryManager(
@@ -296,11 +305,17 @@ public class Workspace {
             delegate: delegate.map(WorkspaceRepositoryManagerDelegate.init(workspaceDelegate:)),
             cachePath: sharedRepositoriesCacheEnabled ? location.sharedRepositoriesCacheDirectory : .none
         )
+        let registryManager = customRegistryManager ?? registries.map { configuration in
+            RegistryManager(configuration: configuration,
+                            identityResolver: identityResolver,
+                            authorizationProvider: authorizationProvider?.httpAuthorizationHeader(for:),
+                            diagnosticEngine: nil)
+        }
+
         // FIXME: use workspace scope when migrating workspace to new observability API
         let httpClient = customHTTPClient ?? HTTPClient(observabilityScope: ObservabilitySystem.topScope)
         let archiver = customArchiver ?? ZipArchiver()
-        let mirrors = mirrors ?? DependencyMirrors()
-        let identityResolver = customIdentityResolver ?? DefaultIdentityResolver(locationMapper: mirrors.effectiveURL(for:))
+
         var checksumAlgorithm = customChecksumAlgorithm ?? SHA256()
         #if canImport(CryptoKit)
         if checksumAlgorithm is SHA256, #available(macOS 10.15, *) {
@@ -325,6 +340,7 @@ public class Workspace {
         self.httpClient = httpClient
         self.archiver = archiver
         self.repositoryManager = repositoryManager
+        self.registryManager = registryManager
         self.identityResolver = identityResolver
         self.checksumAlgorithm = checksumAlgorithm
 

--- a/Sources/Workspace/WorkspaceConfiguration.swift
+++ b/Sources/Workspace/WorkspaceConfiguration.swift
@@ -47,6 +47,17 @@ extension Workspace {
             self.workingDirectory.appending(component: "checkouts")
         }
 
+        /// Path to store the dependencies downloaded from a registry.
+        public var sourceArchivesDirectory: AbsolutePath {
+            self.workingDirectory.appending(component: "source-archives")
+        }
+
+        /// Returns the path to store a source archive for a given version of a dependency downloaded from a registry.
+        public func sourceArchivesSubdirectory(for package: PackageReference, at version: Version) -> AbsolutePath {
+            self.sourceArchivesDirectory.appending(subpath(for: package))
+                                        .appending(component: version.description.lowercased())
+        }
+
         /// Path to the downloaded binary artifacts.
         public var artifactsDirectory: AbsolutePath {
             self.workingDirectory.appending(component: "artifacts")
@@ -70,6 +81,14 @@ extension Workspace {
         /// Path to the shared registries configuration.
         public var sharedRegistriesConfigurationFile: AbsolutePath? {
             self.sharedConfigurationDirectory.map { DefaultLocations.registriesConfigurationFile(at: $0) }
+        }
+
+        private func subpath(for package: PackageReference) -> RelativePath {
+            if case let (scope, name)? = package.identity.scopeAndName {
+                return RelativePath(scope.description.lowercased()).appending(component: name.description.lowercased())
+            } else {
+                return RelativePath(package.identity.description.lowercased())
+            }
         }
 
         /// Create a new workspace location.

--- a/Sources/Workspace/WorkspaceState.swift
+++ b/Sources/Workspace/WorkspaceState.swift
@@ -354,6 +354,10 @@ fileprivate struct WorkspaceStateStorage {
                 case .remoteSourceControl(let url):
                     self.kind = .remoteSourceControl
                     self.location = url.absoluteString
+                case .registry:
+                    self.kind = .registry
+                    // FIXME: placeholder
+                    self.location = self.identity.description
                 }
                 self.name = reference.name
             }
@@ -363,6 +367,7 @@ fileprivate struct WorkspaceStateStorage {
                 case fileSystem
                 case localSourceControl
                 case remoteSourceControl
+                case registry
             }
         }
     }
@@ -391,6 +396,7 @@ extension Workspace.ManagedArtifact {
 
 extension PackageModel.PackageReference {
     fileprivate init(_ reference: WorkspaceStateStorage.V4.PackageReference) throws {
+        let identity = PackageIdentity.plain(reference.identity)
         let kind: PackageModel.PackageReference.Kind
         switch reference.kind {
         case .root:
@@ -404,10 +410,12 @@ extension PackageModel.PackageReference {
                 throw StringError("invalid url \(reference.location)")
             }
             kind = .remoteSourceControl(url)
+        case .registry:
+            kind = .registry(identity)
         }
 
         self.init(
-            identity: .plain(reference.identity),
+            identity: identity,
             kind: kind,
             name: reference.name
         )

--- a/Tests/CommandsTests/PackageRegistryToolTests.swift
+++ b/Tests/CommandsTests/PackageRegistryToolTests.swift
@@ -161,6 +161,23 @@ final class PackageRegistryToolTests: XCTestCase {
         }
     }
 
+    func testSetInvalidScope() throws {
+        fixture(name: "DependencyResolution/External/Simple") { prefix in
+            let packageRoot = prefix.appending(component: "Bar")
+            let configurationFilePath = packageRoot.appending(RelativePath(".swiftpm/configuration/registries.json"))
+
+            XCTAssertFalse(localFileSystem.exists(configurationFilePath))
+
+            // Set default registry
+            do {
+                let result = try execute(["set", "--scope", "_invalid_", "\(defaultRegistryBaseURL)"], packagePath: packageRoot)
+                XCTAssertNotEqual(result.exitStatus, .terminated(code: 0))
+            }
+
+            XCTAssertFalse(localFileSystem.exists(configurationFilePath))
+        }
+    }
+
     func testUnsetMissingEntry() throws {
         fixture(name: "DependencyResolution/External/Simple") { prefix in
             let packageRoot = prefix.appending(component: "Bar")

--- a/Tests/PackageLoadingTests/PDLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDLoadingTests.swift
@@ -57,7 +57,7 @@ class PackageDescriptionLoadingTests: XCTestCase {
             packagePath = path
         case .localSourceControl(let path):
             packagePath = path
-        case .remoteSourceControl:
+        case .remoteSourceControl, .registry:
             throw InternalError("invalid package kind \(packageKind)")
         }
 
@@ -210,7 +210,7 @@ class PackageDescriptionLoadingTests: XCTestCase {
             packagePath = path
         case .localSourceControl(let path):
             packagePath = path
-        case .remoteSourceControl:
+        case .remoteSourceControl, .registry:
             throw InternalError("invalid package kind \(packageKind)")
         }
 

--- a/Tests/PackageRegistryTests/RegistryManagerTests.swift
+++ b/Tests/PackageRegistryTests/RegistryManagerTests.swift
@@ -1,0 +1,212 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import XCTest
+
+import SPMTestSupport
+import TSCBasic
+
+import Basics
+import PackageLoading
+import PackageModel
+@testable import PackageRegistry
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+final class RegistryManagerTests: XCTestCase {
+    private var registryManager: RegistryManager!
+
+    class override func setUp() {
+        RegistryManager.archiverFactory = { _ in
+            return MockArchiver()
+        }
+
+        super.setUp()
+    }
+
+    override func setUp() {
+        let identityResolver = DefaultIdentityResolver()
+        let diagnosticsEngine = DiagnosticsEngine()
+
+        var configuration = RegistryConfiguration()
+        configuration.defaultRegistry = Registry(url: URL(string: "https://packages.example.com/")!)
+
+        registryManager = RegistryManager(configuration: configuration,
+                                          identityResolver: identityResolver,
+                                          diagnosticEngine: diagnosticsEngine)
+    }
+
+    // MARK: -
+
+    func testFetchVersions() {
+        let identity: PackageIdentity = .plain("mona.LinkedList")
+        let package = PackageReference(identity: identity, kind: .registry(identity))
+
+        registryManager.client = HTTPClient { request, _, completion in
+            XCTAssertEqual(request.url.absoluteString, "https://packages.example.com/mona/LinkedList")
+            XCTAssertEqual(request.headers.get("Accept").first, "application/vnd.swift.registry.v1+json")
+
+            let body = #"""
+            {
+                "releases": {
+                    "1.1.1": {
+                        "url": "https://packages.example.com/mona/LinkedList/1.1.1"
+                    },
+                    "1.1.0": {
+                        "url": "https://packages.example.com/mona/LinkedList/1.1.0",
+                        "problem": {
+                            "status": 410,
+                            "title": "Gone",
+                            "detail": "this release was removed from the registry"
+                        }
+                    },
+                    "1.0.0": {
+                        "url": "https://packages.example.com/mona/LinkedList/1.0.0"
+                    }
+                }
+            }
+
+            """#.data(using: .utf8)!
+
+            let headers: HTTPClientHeaders = [
+                "Content-Version": "1",
+                "Content-Type": "application/json",
+                "Content-Length": "\(body.count)"
+            ]
+
+            let response = HTTPClientResponse(statusCode: 200, headers: headers, body: body)
+
+            completion(.success(response))
+        }
+
+        let expectation = XCTestExpectation(description: "fetch versions")
+
+        registryManager.fetchVersions(of: package, on: .sharedConcurrent) { result in
+            defer { expectation.fulfill() }
+
+            guard case .success(let versions) = result else {
+                return XCTAssertResultSuccess(result)
+            }
+
+            XCTAssertEqual(versions, ["1.1.1", "1.0.0"])
+            XCTAssertFalse(versions.contains("1.1.0"), "problematic releases shouldn't be included")
+        }
+
+        wait(for: [expectation], timeout: 10.0)
+    }
+
+    func testFetchManifest() {
+        let identity: PackageIdentity = .plain("mona.LinkedList")
+        let package = PackageReference(identity: identity, kind: .registry(identity))
+
+        registryManager.client = HTTPClient { request, _, completion in
+            XCTAssertEqual(request.url.absoluteString, "https://packages.example.com/mona/LinkedList/1.1.1/Package.swift")
+            XCTAssertEqual(request.headers.get("Accept").first, "application/vnd.swift.registry.v1+swift")
+
+            let body = #"""
+            // swift-tools-version:5.0
+            import PackageDescription
+
+            let package = Package(
+                name: "LinkedList",
+                products: [
+                    .library(name: "LinkedList", targets: ["LinkedList"])
+                ],
+                targets: [
+                    .target(name: "LinkedList"),
+                    .testTarget(name: "LinkedListTests", dependencies: ["LinkedList"]),
+                ],
+                swiftLanguageVersions: [.v4, .v5]
+            )
+
+            """#.data(using: .utf8)!
+
+            let headers: HTTPClientHeaders = [
+                "Content-Version": "1",
+                "Content-Disposition": #"attachment; filename="Package.swift""#,
+                "Content-Type": "text/x-swift",
+                "Content-Length": "\(body.count)"
+            ]
+
+            let response = HTTPClientResponse(statusCode: 200, headers: headers, body: body)
+
+            completion(.success(response))
+        }
+
+        let expectation = XCTestExpectation(description: "fetch manifest")
+
+        let manifestLoader = ManifestLoader(toolchain: .default)
+        registryManager.fetchManifest(for: "1.1.1", of: package, using: manifestLoader, on: .sharedConcurrent) { result in
+            defer { expectation.fulfill() }
+
+            guard case .success(let manifest) = result else {
+                return XCTAssertResultSuccess(result)
+            }
+            
+            XCTAssertEqual(manifest.name, "LinkedList")
+
+            XCTAssertEqual(manifest.products.count, 1)
+            XCTAssertEqual(manifest.products.first?.name, "LinkedList")
+            XCTAssertEqual(manifest.products.first?.type, .library(.automatic))
+
+            XCTAssertEqual(manifest.targets.count, 2)
+            XCTAssertEqual(manifest.targets.first?.name, "LinkedList")
+            XCTAssertEqual(manifest.targets.first?.type, .regular)
+            XCTAssertEqual(manifest.targets.last?.name, "LinkedListTests")
+            XCTAssertEqual(manifest.targets.last?.type, .test)
+
+            XCTAssertEqual(manifest.swiftLanguageVersions, [.v4, .v5])
+        }
+        wait(for: [expectation], timeout: 10.0)
+    }
+
+    func testDownloadSourceArchive() {
+        let identity: PackageIdentity = .plain("mona.LinkedList")
+        let package = PackageReference(identity: identity, kind: .registry(identity))
+
+        registryManager.client = HTTPClient { request, _, completion in
+            XCTAssertEqual(request.url.absoluteString, "https://packages.example.com/mona/LinkedList/1.1.1.zip")
+            XCTAssertEqual(request.headers.get("Accept").first, "application/vnd.swift.registry.v1+zip")
+
+            let body = Data(emptyZipFile.contents)
+
+            let headers: HTTPClientHeaders = [
+                "Content-Version": "1",
+                "Content-Disposition": #"attachment; filename="LinkedList-1.1.1.zip""#,
+                "Content-Type": "application/zip",
+                "Content-Length": "\(body.count)",
+                "Digest": "sha-256=bc6c9a5d2f2226cfa1ef4fad8344b10e1cc2e82960f468f70d9ed696d26b3283"
+            ]
+
+            let response = HTTPClientResponse(statusCode: 200, headers: headers, body: body)
+
+            completion(.success(response))
+        }
+
+        let expectation = XCTestExpectation(description: "download source archive")
+
+        let fileSystem = InMemoryFileSystem()
+        let path = AbsolutePath("/LinkedList-1.1.1")
+        registryManager.downloadSourceArchive(for: "1.1.1", of: package, into: fileSystem, at: path, on: .sharedConcurrent) { result in
+            defer { expectation.fulfill() }
+
+            guard case .success = result else { return XCTAssertResultSuccess(result) }
+
+            XCTAssertNoThrow {
+                let data = try fileSystem.readFileContents(path)
+                XCTAssertEqual(data, emptyZipFile)
+            }
+        }
+        wait(for: [expectation], timeout: 10.0)
+    }
+}


### PR DESCRIPTION
This PR builds on top of https://github.com/apple/swift-package-manager/pull/3635 to implement dependency resolution through a registry service.

### Motivation:

Implement [SE-0292](https://github.com/apple/swift-evolution/blob/main/proposals/0292-package-registry-service.md).

### Modifications:

- [x] Add `PackageRegistry` library and test target containing the `RegistryManager` client implementation.
- [x] Add `RegistryPackageContainer` class to `PackageGraph` module
- [x] Update `Workspace` to provide `RegistryPackageContainer` if the package is declared with a registry identifier (**Currently WIP with hardcoded registry URL**)
- [x] Update `PubGrubDependencyResolver` to support registry packages

### Result:

With this change, Swift Package Manager will be able to resolve package dependencies through a configured registry service.