### PR TITLE
deprecate name attribute on package dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ import class Foundation.ProcessInfo
 
 
 /** SwiftPMDataModel is the subset of SwiftPM product that includes just its data model.
-This allowis some clients (such as IDEs) that use SwiftPM's data model but not its build system
+This allows some clients (such as IDEs) that use SwiftPM's data model but not its build system
 to not have to depend on SwiftDriver, SwiftLLBuild, etc. We should probably have better names here,
 though that could break some clients.
 */
@@ -33,7 +33,7 @@ let swiftPMDataModelProduct = (
     ]
 )
 
-/** The `libSwiftPM` set of interfaces to programatically work with Swift
+/** The `libSwiftPM` set of interfaces to programmatically work with Swift
  packages.  `libSwiftPM` includes all of the SwiftPM code except the
  command line tools, while `libSwiftPMDataModel` includes only the data model.
 

--- a/Sources/Commands/Describe.swift
+++ b/Sources/Commands/Describe.swift
@@ -6,7 +6,7 @@
 
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import TSCBasic
 import PackageModel
@@ -58,7 +58,7 @@ fileprivate struct DescribedPackage: Encodable {
         self.name = package.manifestName // TODO: rename property to manifestName?
         self.path = package.path.pathString
         self.toolsVersion = "\(package.manifest.toolsVersion.major).\(package.manifest.toolsVersion.minor)"
-            + (package.manifest.toolsVersion.patch == 0 ? "" : ".\(package.manifest.toolsVersion.patch)")
+        + (package.manifest.toolsVersion.patch == 0 ? "" : ".\(package.manifest.toolsVersion.patch)")
         self.dependencies = package.manifest.dependencies.map { DescribedPackageDependency(from: $0) }
         self.defaultLocalization = package.manifest.defaultLocalization
         self.platforms = package.manifest.platforms.map { DescribedPlatformRestriction(from: $0) }
@@ -100,16 +100,16 @@ fileprivate struct DescribedPackage: Encodable {
     
     /// Represents a package dependency for the sole purpose of generating a description.
     enum DescribedPackageDependency: Encodable {
-        case fileSystem(name: String?, path: AbsolutePath)
-        case sourceControl(name: String?, location: String, requirement: PackageDependency.SourceControl.Requirement)
+        case fileSystem(path: AbsolutePath)
+        case sourceControl(location: String, requirement: PackageDependency.SourceControl.Requirement)
         case registry(identity: PackageIdentity, requirement: PackageDependency.Registry.Requirement)
 
         init(from dependency: PackageDependency) {
             switch dependency {
             case .fileSystem(let settings):
-                self = .fileSystem(name: dependency.explicitNameForTargetDependencyResolutionOnly, path: settings.path)
+                self = .fileSystem(path: settings.path)
             case .sourceControl(let settings):
-                self = .sourceControl(name: dependency.explicitNameForTargetDependencyResolutionOnly, location: settings.location, requirement: settings.requirement)
+                self = .sourceControl(location: settings.location, requirement: settings.requirement)
             case .registry(let settings):
                 self = .registry(identity: settings.identity, requirement: settings.requirement)
             }
@@ -117,7 +117,6 @@ fileprivate struct DescribedPackage: Encodable {
 
         private enum CodingKeys: CodingKey {
             case type
-            case name
             case path
             case url
             case requirement
@@ -133,20 +132,17 @@ fileprivate struct DescribedPackage: Encodable {
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             switch self {
-            case .fileSystem(let name, let path):
+            case .fileSystem(let path):
                 try container.encode(Kind.fileSystem, forKey: .type)
-                try container.encode(name, forKey: .name)
                 try container.encode(path, forKey: .path)
-            case .sourceControl(let name, let location, let requirement):
+            case .sourceControl(let location, let requirement):
                 try container.encode(Kind.sourceControl, forKey: .type)
-                try container.encode(name, forKey: .name)
                 try container.encode(location, forKey: .url)
                 try container.encode(requirement, forKey: .requirement)
             case .registry(let identity, let requirement):
                 try container.encode(Kind.registry, forKey: .type)
                 try container.encode(identity, forKey: .identity)
                 try container.encode(requirement, forKey: .requirement)
-
             }
         }
     }
@@ -287,7 +283,7 @@ public struct PlainTextEncoder {
         
         func unkeyedContainer() -> UnkeyedEncodingContainer {
             return PlainTextUnkeyedEncodingContainer(outputStream: outputStream, formattingOptions: formattingOptions, userInfo: userInfo, codingPath: codingPath)
-       }
+        }
         
         func singleValueContainer() -> SingleValueEncodingContainer {
             return TextSingleValueEncodingContainer(outputStream: outputStream, formattingOptions: formattingOptions, userInfo: userInfo, codingPath: codingPath)

--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -127,6 +127,8 @@ extension Package {
     }
 }
 
+// MARK: - file system
+
 extension Package.Dependency {
     /// Adds a package dependency to a local package on the filesystem.
     ///
@@ -136,11 +138,10 @@ extension Package.Dependency {
     /// on multiple tightly coupled packages.
     ///
     /// - Parameter path: The path of the package.
-    @available(_PackageDescription, obsoleted: 5.2)
     public static func package(
         path: String
     ) -> Package.Dependency {
-        return .package(name: nil, path: path)
+        return .init(name: nil, path: path)
     }
 
     /// Adds a package dependency to a local package on the filesystem.
@@ -153,9 +154,9 @@ extension Package.Dependency {
     /// - Parameters
     ///   - name: The name of the Swift package or `nil` to deduce the name from path.
     ///   - path: The local path to the package.
-    @available(_PackageDescription, introduced: 5.2)
+    @available(_PackageDescription, introduced: 5.2, deprecated: 5.6, message: "use package(path:) instead")
     public static func package(
-        name: String? = nil,
+        name: String,
         path: String
     ) -> Package.Dependency {
         return .init(name: name, path: path)
@@ -184,12 +185,11 @@ extension Package.Dependency {
     ///     - name: The name of the package, or nil to deduce it from the URL.
     ///     - url: The valid Git URL of the package.
     ///     - version: The minimum version requirement.
-    @available(_PackageDescription, obsoleted: 5.2)
     public static func package(
         url: String,
         from version: Version
     ) -> Package.Dependency {
-        return .package(name: nil, url: url, from: version)
+        return .package(url: url, .upToNextMajor(from: version))
     }
 
     /// Adds a package dependency that uses the version requirement, starting with the given minimum version,
@@ -211,15 +211,30 @@ extension Package.Dependency {
     ///     - name: The name of the package, or nil to deduce it from the URL.
     ///     - url: The valid Git URL of the package.
     ///     - version: The minimum version requirement.
-    @available(_PackageDescription, introduced: 5.2)
+    @available(_PackageDescription, introduced: 5.2, deprecated: 5.6, message: "use package(url:from:) instead")
     public static func package(
-        name: String? = nil,
+        name: String,
         url: String,
         from version: Version
     ) -> Package.Dependency {
         return .package(name: name, url: url, .upToNextMajor(from: version))
     }
-    
+
+    /// Adds a remote package dependency given a branch requirement.
+    ///
+    ///    .package(url: "https://example.com/example-package.git", branch: "main"),
+    ///
+    /// - Parameters:
+    ///     - url: The valid Git URL of the package.
+    ///     - branch: A dependency requirement. See static methods on `Package.Dependency.Requirement` for available options.
+    @available(_PackageDescription, introduced: 5.5)
+    public static func package(
+        url: String,
+        branch: String
+    ) -> Package.Dependency {
+        return .package(url: url, requirement: .branch(branch))
+    }
+
     /// Adds a remote package dependency given a branch requirement.
     ///
     ///    .package(url: "https://example.com/example-package.git", branch: "main"),
@@ -228,9 +243,9 @@ extension Package.Dependency {
     ///     - name: The name of the package, or nil to deduce it from the URL.
     ///     - url: The valid Git URL of the package.
     ///     - branch: A dependency requirement. See static methods on `Package.Dependency.Requirement` for available options.
-    @available(_PackageDescription, introduced: 5.5)
+    @available(_PackageDescription, introduced: 5.5, deprecated: 5.6, message: "use package(url:branch:) instead")
     public static func package(
-        name: String? = nil,
+        name: String,
         url: String,
         branch: String
     ) -> Package.Dependency {
@@ -242,12 +257,27 @@ extension Package.Dependency {
     ///    .package(url: "https://example.com/example-package.git", revision: "aa681bd6c61e22df0fd808044a886fc4a7ed3a65"),
     ///
     /// - Parameters:
-    ///     - name: The name of the package, or nil to deduce it from the URL.
     ///     - url: The valid Git URL of the package.
     ///     - revision: A dependency requirement. See static methods on `Package.Dependency.Requirement` for available options.
     @available(_PackageDescription, introduced: 5.5)
     public static func package(
-        name: String? = nil,
+        url: String,
+        revision: String
+    ) -> Package.Dependency {
+        return .package(url: url, requirement: .revision(revision))
+    }
+
+    /// Adds a remote package dependency given a revision requirement.
+    ///
+    ///    .package(url: "https://example.com/example-package.git", revision: "aa681bd6c61e22df0fd808044a886fc4a7ed3a65"),
+    ///
+    /// - Parameters:
+    ///     - name: The name of the package, or nil to deduce it from the URL.
+    ///     - url: The valid Git URL of the package.
+    ///     - revision: A dependency requirement. See static methods on `Package.Dependency.Requirement` for available options.
+    @available(_PackageDescription, introduced: 5.5, deprecated: 5.6, message: "use package(url:revision:) instead")
+    public static func package(
+        name: String,
         url: String,
         revision: String
     ) -> Package.Dependency {
@@ -266,12 +296,11 @@ extension Package.Dependency {
     ///     - name: The name of the package, or nil to deduce it from the URL.
     ///     - url: The valid Git URL of the package.
     ///     - range: The custom version range requirement.
-    @available(_PackageDescription, obsoleted: 5.2)
     public static func package(
         url: String,
         _ range: Range<Version>
     ) -> Package.Dependency {
-        return .package(name: nil, url: url, range)
+        return .package(name: nil, url: url, requirement: .range(range))
     }
 
     /// Adds a package dependency starting with a specific minimum version, up to
@@ -286,9 +315,9 @@ extension Package.Dependency {
     ///     - name: The name of the package, or `nil` to deduce it from the URL.
     ///     - url: The valid Git URL of the package.
     ///     - range: The custom version range requirement.
-    @available(_PackageDescription, introduced: 5.2)
+    @available(_PackageDescription, introduced: 5.2, deprecated: 5.6, message: "use package(url:_:) instead")
     public static func package(
-        name: String? = nil,
+        name: String,
         url: String,
         _ range: Range<Version>
     ) -> Package.Dependency {
@@ -307,12 +336,11 @@ extension Package.Dependency {
     ///     - name: The name of the package, or `nil` to deduce it from the URL.
     ///     - url: The valid Git URL of the package.
     ///     - range: The closed version range requirement.
-    @available(_PackageDescription, obsoleted: 5.2)
     public static func package(
         url: String,
         _ range: ClosedRange<Version>
     ) -> Package.Dependency {
-        return .package(name: nil, url: url, range)
+        return .package(name: nil, url: url, closedRange: range)
     }
 
     /// Adds a package dependency starting with a specific minimum version, going
@@ -327,19 +355,27 @@ extension Package.Dependency {
     ///     - name: The name of the package, or `nil` to deduce it from the URL.
     ///     - url: The valid Git URL of the package.
     ///     - range: The closed version range requirement.
-    @available(_PackageDescription, introduced: 5.2)
+    @available(_PackageDescription, introduced: 5.2, deprecated: 5.6, message: "use package(url:_:) instead")
     public static func package(
-        name: String? = nil,
+        name: String,
         url: String,
         _ range: ClosedRange<Version>
     ) -> Package.Dependency {
+        return .package(name: name, url: url, closedRange: range)
+    }
+
+    private static func package(
+        name: String?,
+        url: String,
+        closedRange: ClosedRange<Version>
+    ) -> Package.Dependency {
         // Increase upperbound's patch version by one.
-        let upper = range.upperBound
+        let upper = closedRange.upperBound
         let upperBound = Version(
             upper.major, upper.minor, upper.patch + 1,
             prereleaseIdentifiers: upper.prereleaseIdentifiers,
             buildMetadataIdentifiers: upper.buildMetadataIdentifiers)
-        return .package(name: name, url: url, range.lowerBound ..< upperBound)
+        return .package(name: name, url: url, requirement: .range(closedRange.lowerBound ..< upperBound))
     }
 
     /// Adds a package dependency that uses the exact version requirement.
@@ -363,33 +399,7 @@ extension Package.Dependency {
         url: String,
         exact version: Version
     ) -> Package.Dependency {
-        return .package(name: nil, url: url, exact: version)
-    }
-
-    /// Adds a package dependency that uses the exact version requirement.
-    ///
-    /// This is the recommended way to specify a remote package dependency.
-    /// It allows you to specify the minimum version you require, allows updates that include bug fixes
-    /// and backward-compatible feature updates, but requires you to explicitly update to a new major version of the dependency.
-    /// This approach provides the maximum flexibility on which version to use,
-    /// while making sure you don't update to a version with breaking changes,
-    /// and helps to prevent conflicts in your dependency graph.
-    ///
-    /// The following example instruct the Swift Package Manager to use version `1.2.3`.
-    ///
-    ///    .package(url: "https://example.com/example-package.git", exact: "1.2.3"),
-    ///
-    /// - Parameters:
-    ///     - name: The name of the package, or `nil` to deduce it from the URL.
-    ///     - url: The valid Git URL of the package.
-    ///     - version: The minimum version requirement.
-    @available(_PackageDescription, introduced: 5.6)
-    public static func package(
-        name: String? = nil,
-        url: String,
-        exact version: Version
-    ) -> Package.Dependency {
-        return .init(name: name, location: url, requirement: .exact(version))
+        return .package(url: url, requirement: .exact(version))
     }
 
     /// Adds a remote package dependency given a version requirement.
@@ -398,13 +408,12 @@ extension Package.Dependency {
     ///     - name: The name of the package, or nil to deduce it from the URL.
     ///     - url: The valid Git URL of the package.
     ///     - requirement: A dependency requirement. See static methods on `Package.Dependency.Requirement` for available options.
-    @available(_PackageDescription, obsoleted: 5.2, deprecated: 5.6)
+    @available(_PackageDescription, deprecated: 5.6, message: "use specific requirement APIs instead")
     public static func package(
         url: String,
         _ requirement: Package.Dependency.Requirement
     ) -> Package.Dependency {
-        precondition(!requirement.isLocalPackage, "Use `.package(path:)` API to declare a local package dependency")
-        return .init(name: nil, url: url, requirement: requirement)
+        return .package(name: nil, url: url, requirement)
     }
 
     /// Adds a remote package dependency with a given version requirement.
@@ -413,9 +422,9 @@ extension Package.Dependency {
     ///     - name: The name of the package, or `nil` to deduce it from the URL.
     ///     - url: The valid Git URL of the package.
     ///     - requirement: A dependency requirement. See static methods on `Package.Dependency.Requirement` for available options.
-    @available(_PackageDescription, introduced: 5.2, deprecated: 5.6)
+    @available(_PackageDescription, introduced: 5.2, deprecated: 5.6, message: "use specific requirement APIs instead")
     public static func package(
-        name: String? = nil,
+        name: String?,
         url: String,
         _ requirement: Package.Dependency.Requirement
     ) -> Package.Dependency {
@@ -424,7 +433,6 @@ extension Package.Dependency {
     }
 
     // intentionally private to hide enum detail
-    @available(_PackageDescription, introduced: 5.6)
     private static func package(
         name: String? = nil,
         url: String,
@@ -541,16 +549,15 @@ extension Package.Dependency {
     }
 }
 
-
 // MARK: - common APIs used by mistake as unavailable to provide better error messages.
 
 extension Package.Dependency {
-    @available(*, unavailable, message: "use package(url:_:) with the .exact(Version) initializer instead")
+    @available(*, unavailable, message: "use package(url:exact:) instead")
     public static func package(url: String, version: Version) -> Package.Dependency {
         fatalError()
     }
 
-    @available(*, unavailable, message: "use package(url:_:) without the range label instead")
+    @available(*, unavailable, message: "use package(url:_:) instead")
     public static func package(url: String, range: Range<Version>) -> Package.Dependency {
         fatalError()
     }

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -421,7 +421,7 @@ private func createResolvedPackages(
                 // explicitly reference the package containing the product, or for the product, package and
                 // dependency to share the same name. We don't check this in manifest loading for root-packages so
                 // we can provide a more detailed diagnostic here.
-                if packageBuilder.package.manifest.toolsVersion >= .v5_2 && productRef.package == nil{
+                if packageBuilder.package.manifest.toolsVersion >= .v5_2 && productRef.package == nil {
                     let referencedPackageIdentity = product.packageBuilder.package.identity
                     guard let referencedPackageDependency = (packageBuilder.package.manifest.dependencies.first { package in
                         return package.identity == referencedPackageIdentity
@@ -433,7 +433,7 @@ private func createResolvedPackages(
                         let error = PackageGraphError.productDependencyMissingPackage(
                             productName: productRef.name,
                             targetName: targetBuilder.target.name,
-                            packageDependency: referencedPackageDependency
+                            packageIdentifier: referencedPackageName
                         )
                         diagnostics.emit(error, location: package.diagnosticLocation)
                     }

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -16,6 +16,8 @@ import Foundation
 import SourceControl
 
 enum ManifestJSONParser {
+    private static let filePrefix = "file://"
+
     struct Result {
         var name: String
         var defaultLocalization: String?
@@ -28,7 +30,6 @@ enum ManifestJSONParser {
         var products: [ProductDescription] = []
         var cxxLanguageStandard: String?
         var cLanguageStandard: String?
-        var errors: [String] = []
     }
 
     static func parse(
@@ -39,30 +40,34 @@ enum ManifestJSONParser {
         fileSystem: FileSystem
     ) throws -> ManifestJSONParser.Result {
         let json = try JSON(string: jsonString)
+
+        let errors: [String] = try json.get("errors")
+        guard errors.isEmpty else {
+            throw ManifestParseError.runtimeManifestErrors(errors)
+        }
+
         let package = try json.getJSON("package")
-        var result = Self.Result(name: try package.get(String.self, forKey: "name"))
-        result.defaultLocalization = try? package.get(String.self, forKey: "defaultLocalization")
-        result.pkgConfig = package.get("pkgConfig")
-        result.platforms = try Self.parsePlatforms(package)
-        result.swiftLanguageVersions = try Self.parseSwiftLanguageVersion(package)
-        result.products = try package.getArray("products").map(ProductDescription.init(v4:))
-        result.providers = try? package.getArray("providers").map(SystemPackageProviderDescription.init(v4:))
-        result.targets = try package.getArray("targets").map(Self.parseTarget(json:))
-        result.dependencies = try package.getArray("dependencies").map({
-            try PackageDependency(
-                v4: $0,
+        var manifest = Self.Result(name: try package.get(String.self, forKey: "name"))
+        manifest.defaultLocalization = try? package.get(String.self, forKey: "defaultLocalization")
+        manifest.pkgConfig = package.get("pkgConfig")
+        manifest.platforms = try Self.parsePlatforms(package)
+        manifest.swiftLanguageVersions = try Self.parseSwiftLanguageVersion(package)
+        manifest.products = try package.getArray("products").map(ProductDescription.init(v4:))
+        manifest.providers = try? package.getArray("providers").map(SystemPackageProviderDescription.init(v4:))
+        manifest.targets = try package.getArray("targets").map(Self.parseTarget(json:))
+        manifest.dependencies = try package.getArray("dependencies").map{
+            try Self.parseDependency(
+                json: $0,
                 toolsVersion: toolsVersion,
                 packageLocation: packageLocation,
                 identityResolver: identityResolver,
                 fileSystem: fileSystem
             )
-        })
+        }
+        manifest.cxxLanguageStandard = package.get("cxxLanguageStandard")
+        manifest.cLanguageStandard = package.get("cLanguageStandard")
 
-        result.cxxLanguageStandard = package.get("cxxLanguageStandard")
-        result.cLanguageStandard = package.get("cLanguageStandard")
-
-        result.errors = try json.get("errors")
-        return result
+        return manifest
     }
 
     private static func parseSwiftLanguageVersion(_ package: JSON) throws -> [SwiftLanguageVersion]?  {
@@ -77,6 +82,152 @@ enum ManifestJSONParser {
             }
             return languageVersion
         }
+    }
+
+    private static func parseDependency(
+        json: JSON,
+        toolsVersion: ToolsVersion,
+        packageLocation: String,
+        identityResolver: IdentityResolver,
+        fileSystem: TSCBasic.FileSystem
+    ) throws -> PackageDependency {
+        if let kindJSON = try? json.getJSON("kind") {
+            // new format introduced 7/2021
+            let type: String = try kindJSON.get("type")
+            if type == "fileSystem" {
+                let name: String? = kindJSON.get("name")
+                let path: String = try kindJSON.get("path")
+                return try Self.makeFileSystemDependency(
+                    packageLocation: packageLocation,
+                    at: path,
+                    name: name,
+                    identityResolver: identityResolver,
+                    fileSystem: fileSystem)
+            } else if type == "sourceControl" {
+                let name: String? = kindJSON.get("name")
+                let location: String = try kindJSON.get("location")
+                let requirementJSON: JSON = try kindJSON.get("requirement")
+                let requirement = try PackageDependency.SourceControl.Requirement(v4: requirementJSON)
+                return try Self.makeSourceControlDependency(
+                    packageLocation: packageLocation,
+                    at: location,
+                    name: name,
+                    requirement: requirement,
+                    identityResolver: identityResolver,
+                    fileSystem: fileSystem)
+            } else if type == "registry" {
+                let identity: String = try kindJSON.get("identity")
+                let requirementJSON: JSON = try kindJSON.get("requirement")
+                let requirement = try PackageDependency.Registry.Requirement(v4: requirementJSON)
+                return .registry(identity: .plain(identity), requirement: requirement, productFilter: .everything)
+            } else {
+                throw InternalError("Unknown dependency type \(kindJSON)")
+            }
+        } else {
+            // old format, deprecated 7/2021 but may be stored in caches, etc
+            let name: String? = json.get("name")
+            let url: String = try json.get("url")
+
+            // backwards compatibility 2/2021
+            let requirementJSON: JSON = try json.get("requirement")
+            let requirementType: String = try requirementJSON.get(String.self, forKey: "type")
+            switch requirementType {
+            case "localPackage":
+                return try Self.makeFileSystemDependency(
+                    packageLocation: packageLocation,
+                    at: url,
+                    name: name,
+                    identityResolver: identityResolver,
+                    fileSystem: fileSystem)
+
+            default:
+                let requirement = try PackageDependency.SourceControl.Requirement(v4: requirementJSON)
+                return try Self.makeSourceControlDependency(
+                    packageLocation: packageLocation,
+                    at: url,
+                    name: name,
+                    requirement: requirement,
+                    identityResolver: identityResolver,
+                    fileSystem: fileSystem)
+            }
+        }
+    }
+
+    private static func makeFileSystemDependency(
+        packageLocation: String,
+        at location: String,
+        name: String?,
+        identityResolver: IdentityResolver,
+        fileSystem: TSCBasic.FileSystem
+    ) throws -> PackageDependency {
+        let location = try fixDependencyLocation(fileSystem: fileSystem, packageLocation: packageLocation, dependencyLocation: location)
+        let path: AbsolutePath
+        do {
+            path = try AbsolutePath(validating: location)
+        } catch PathValidationError.invalidAbsolutePath(let path) {
+            throw ManifestParseError.invalidManifestFormat("'\(path)' is not a valid path for path-based dependencies; use relative or absolute path instead.", diagnosticFile: nil)
+        }
+        let identity = identityResolver.resolveIdentity(for: path)
+        return .fileSystem(identity: identity,
+                           nameForTargetDependencyResolutionOnly: name,
+                           path: path,
+                           productFilter: .everything)
+    }
+
+    private static func makeSourceControlDependency(
+        packageLocation: String,
+        at location: String,
+        name: String?,
+        requirement: PackageDependency.SourceControl.Requirement,
+        identityResolver: IdentityResolver,
+        fileSystem: TSCBasic.FileSystem
+    ) throws -> PackageDependency {
+        var location = try fixDependencyLocation(fileSystem: fileSystem, packageLocation: packageLocation, dependencyLocation: location)
+        // a remote package that specifies a location and no identity is deemed to be from source control (git)
+        // a package in a git location, may be a remote URL or on disk
+        // if local, validate location is in fact a git repo
+        if let localPath = try? AbsolutePath(validating: location), fileSystem.exists(localPath) {
+            let gitRepoProvider = GitRepositoryProvider()
+            guard gitRepoProvider.isValidDirectory(location) else {
+                throw StringError("Cannot clone from local directory \(localPath)\nPlease git init or use \"path:\" for \(location)")
+            }
+        }
+
+        // location mapping (aka mirrors)
+        location = identityResolver.resolveLocation(from: location)
+        // in the future this will check with the registries for the identity of the URL
+        let identity = identityResolver.resolveIdentity(for: location)
+        return .sourceControl(identity: identity,
+                              nameForTargetDependencyResolutionOnly: name,
+                              location: location,
+                              requirement: requirement,
+                              productFilter: .everything)
+    }
+
+    private static func fixDependencyLocation(fileSystem: TSCBasic.FileSystem, packageLocation: String, dependencyLocation: String) throws -> String {
+        // If base URL is remote (http/ssh), we can't do any "fixing".
+        if URL.scheme(packageLocation) != nil {
+            return dependencyLocation
+        }
+
+        if dependencyLocation.hasPrefix("~/") {
+            // If the dependency URL starts with '~/', try to expand it.
+            return fileSystem.homeDirectory.appending(RelativePath(String(dependencyLocation.dropFirst(2)))).pathString
+        } else if dependencyLocation.hasPrefix(filePrefix) {
+            // FIXME: SwiftPM can't handle file locations with file:// scheme so we need to
+            // strip that. We need to design a Location data structure for SwiftPM.
+            let location = String(dependencyLocation.dropFirst(filePrefix.count))
+            if location.first != "/" {
+                throw ManifestParseError.invalidManifestFormat("file:// URLs cannot be relative, did you mean to use `.package(path:)`?", diagnosticFile: nil)
+            }
+            return AbsolutePath(location).pathString
+        } else if URL.scheme(dependencyLocation) == nil {
+            // If the dependency URL is not remote, try to "fix" it.
+            // If the URL has no scheme, we treat it as a path (either absolute or relative to the base URL).
+            return AbsolutePath(dependencyLocation, relativeTo: AbsolutePath(packageLocation)).pathString
+        }
+
+        return dependencyLocation
     }
 
     private static func parsePlatforms(_ package: JSON) throws -> [PlatformDescription] {
@@ -357,156 +508,6 @@ extension PackageDependency.Registry.Requirement {
         default:
             throw InternalError("invalid dependency requirement \(type)")
         }
-    }
-}
-
-extension PackageDependency {
-    private static let filePrefix = "file://"
-
-    fileprivate init(
-        v4 json: JSON,
-        toolsVersion: ToolsVersion,
-        packageLocation: String,
-        identityResolver: IdentityResolver,
-        fileSystem: TSCBasic.FileSystem
-    ) throws {
-        if let kindJSON = try? json.getJSON("kind") {
-            // new format introduced 7/2021
-            let type: String = try kindJSON.get("type")
-            if type == "fileSystem" {
-                let name: String? = kindJSON.get("name")
-                let path: String = try kindJSON.get("path")
-                self = try Self.makeFileSystemDependency(
-                    packageLocation: packageLocation,
-                    name: name,
-                    at: path,
-                    identityResolver: identityResolver,
-                    fileSystem: fileSystem)
-            } else if type == "sourceControl" {
-                let name: String? = kindJSON.get("name")
-                let location: String = try kindJSON.get("location")
-                let requirementJSON: JSON = try kindJSON.get("requirement")
-                let requirement = try SourceControl.Requirement(v4: requirementJSON)
-                self = try Self.makeSourceControlDependency(
-                    packageLocation: packageLocation,
-                    name: name,
-                    at: location,
-                    requirement: requirement,
-                    identityResolver: identityResolver,
-                    fileSystem: fileSystem)
-            } else if type == "registry" {
-                let identity: String = try kindJSON.get("identity")
-                let requirementJSON: JSON = try kindJSON.get("requirement")
-                let requirement = try Registry.Requirement(v4: requirementJSON)
-                self = .registry(identity: .plain(identity), requirement: requirement, productFilter: .everything)
-            } else {
-                throw InternalError("Unknown dependency type \(kindJSON)")
-            }
-        } else {
-            // old format, deprecated 7/2021 but may be stored in caches, etc
-            let name: String? = json.get("name")
-            let url: String = try json.get("url")
-
-            // backwards compatibility 2/2021
-            let requirementJSON: JSON = try json.get("requirement")
-            let requirementType: String = try requirementJSON.get(String.self, forKey: "type")
-            switch requirementType {
-            case "localPackage":
-                self = try Self.makeFileSystemDependency(
-                    packageLocation: packageLocation,
-                    name: name,
-                    at: url,
-                    identityResolver: identityResolver,
-                    fileSystem: fileSystem)
-
-            default:
-                let requirement = try SourceControl.Requirement(v4: requirementJSON)
-                self = try Self.makeSourceControlDependency(
-                    packageLocation: packageLocation,
-                    name: name,
-                    at: url,
-                    requirement: requirement,
-                    identityResolver: identityResolver,
-                    fileSystem: fileSystem)
-            }
-        }
-    }
-
-    private static func makeFileSystemDependency(
-        packageLocation: String,
-        name: String?,
-        at location: String,
-        identityResolver: IdentityResolver,
-        fileSystem: TSCBasic.FileSystem
-    ) throws -> PackageDependency {
-        let location = try Self.fixLocation(fileSystem: fileSystem, packageLocation: packageLocation, dependencyLocation: location)
-        let path: AbsolutePath
-        do {
-            path = try AbsolutePath(validating: location)
-        } catch PathValidationError.invalidAbsolutePath(let path) {
-            throw ManifestParseError.invalidManifestFormat("'\(path)' is not a valid path for path-based dependencies; use relative or absolute path instead.", diagnosticFile: nil)
-        }
-        let identity = identityResolver.resolveIdentity(for: path)
-        return .fileSystem(identity: identity,
-                           name: name,
-                           path: path,
-                           productFilter: .everything)
-    }
-
-    private static func makeSourceControlDependency(
-        packageLocation: String,
-        name: String?,
-        at location: String,
-        requirement: SourceControl.Requirement,
-        identityResolver: IdentityResolver,
-        fileSystem: TSCBasic.FileSystem
-    ) throws -> PackageDependency {
-        var location = try Self.fixLocation(fileSystem: fileSystem, packageLocation: packageLocation, dependencyLocation: location)
-        // a remote package that specifies a location and no identity is deemed to be from source control (git)
-        // a package in a git location, may be a remote URL or on disk
-        // if local, validate location is in fact a git repo
-        if let localPath = try? AbsolutePath(validating: location), fileSystem.exists(localPath) {
-            let gitRepoProvider = GitRepositoryProvider()
-            guard gitRepoProvider.isValidDirectory(location) else {
-                throw StringError("Cannot clone from local directory \(localPath)\nPlease git init or use \"path:\" for \(location)")
-            }
-        }
-
-        // location mapping (aka mirrors)
-        location = identityResolver.resolveLocation(from: location)
-        // in the future this will check with the registries for the identity of the URL
-        let identity = identityResolver.resolveIdentity(for: location)
-        return .sourceControl(identity: identity,
-                              name: name,
-                              location: location,
-                              requirement: requirement,
-                              productFilter: .everything)
-    }
-
-    private static func fixLocation(fileSystem: TSCBasic.FileSystem, packageLocation: String, dependencyLocation: String) throws -> String {
-        // If base URL is remote (http/ssh), we can't do any "fixing".
-        if URL.scheme(packageLocation) != nil {
-            return dependencyLocation
-        }
-
-        if dependencyLocation.hasPrefix("~/") {
-            // If the dependency URL starts with '~/', try to expand it.
-            return fileSystem.homeDirectory.appending(RelativePath(String(dependencyLocation.dropFirst(2)))).pathString
-        } else if dependencyLocation.hasPrefix(filePrefix) {
-            // FIXME: SwiftPM can't handle file locations with file:// scheme so we need to
-            // strip that. We need to design a Location data structure for SwiftPM.
-            let location = String(dependencyLocation.dropFirst(filePrefix.count))
-            if location.first != "/" {
-                throw ManifestParseError.invalidManifestFormat("file:// URLs cannot be relative, did you mean to use `.package(path:)`?", diagnosticFile: nil)
-            }
-            return AbsolutePath(location).pathString
-        } else if URL.scheme(dependencyLocation) == nil {
-            // If the dependency URL is not remote, try to "fix" it.
-            // If the URL has no scheme, we treat it as a path (either absolute or relative to the base URL).
-            return AbsolutePath(dependencyLocation, relativeTo: AbsolutePath(packageLocation)).pathString
-        }
-
-        return dependencyLocation
     }
 }
 

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -343,10 +343,6 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                                                                   packageLocation: packageLocation,
                                                                   identityResolver: identityResolver,
                                                                   fileSystem: fileSystem)
-                // Throw if we encountered any runtime errors.
-                guard parsedManifest.errors.isEmpty else {
-                    throw ManifestParseError.runtimeManifestErrors(parsedManifest.errors)
-                }
 
                 // Convert legacy system packages to the current target‐based model.
                 var products = parsedManifest.products

--- a/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
@@ -14,14 +14,14 @@ import TSCBasic
 public enum PackageDependency: Equatable {
     public struct FileSystem: Equatable, Encodable {
         public let identity: PackageIdentity
-        public let name: String?
+        public let nameForTargetDependencyResolutionOnly: String?
         public let path: AbsolutePath
         public let productFilter: ProductFilter
     }
 
     public struct SourceControl: Equatable, Encodable {
         public let identity: PackageIdentity
-        public let name: String?
+        public let nameForTargetDependencyResolutionOnly: String?
         public let location: String
         public let requirement: Requirement
         public let productFilter: ProductFilter
@@ -67,9 +67,9 @@ public enum PackageDependency: Equatable {
     public var nameForTargetDependencyResolutionOnly: String {
         switch self {
         case .fileSystem(let settings):
-            return settings.name ?? LegacyPackageIdentity.computeDefaultName(fromURL: settings.path.pathString)
+            return settings.nameForTargetDependencyResolutionOnly ?? LegacyPackageIdentity.computeDefaultName(fromURL: settings.path.pathString)
         case .sourceControl(let settings):
-            return settings.name ?? LegacyPackageIdentity.computeDefaultName(fromURL: settings.location)
+            return settings.nameForTargetDependencyResolutionOnly ?? LegacyPackageIdentity.computeDefaultName(fromURL: settings.location)
         case .registry:
             return self.identity.description
         }
@@ -80,9 +80,9 @@ public enum PackageDependency: Equatable {
     public var explicitNameForTargetDependencyResolutionOnly: String? {
         switch self {
         case .fileSystem(let settings):
-            return settings.name
+            return settings.nameForTargetDependencyResolutionOnly
         case .sourceControl(let settings):
-            return settings.name
+            return settings.nameForTargetDependencyResolutionOnly
         case .registry:
             return nil
         }
@@ -114,12 +114,12 @@ public enum PackageDependency: Equatable {
         switch self {
         case .fileSystem(let settings):
             return .fileSystem(identity: settings.identity,
-                               name: settings.name,
+                               nameForTargetDependencyResolutionOnly: settings.nameForTargetDependencyResolutionOnly,
                                path: settings.path,
                                productFilter: productFilter)
         case .sourceControl(let settings):
             return .sourceControl(identity: settings.identity,
-                                  name: settings.name,
+                                  nameForTargetDependencyResolutionOnly: settings.nameForTargetDependencyResolutionOnly,
                                   location: settings.location,
                                   requirement: settings.requirement,
                                   productFilter: productFilter)
@@ -131,27 +131,27 @@ public enum PackageDependency: Equatable {
     }
 
     public static func fileSystem(identity: PackageIdentity,
-                                  name: String?,
+                                  nameForTargetDependencyResolutionOnly: String?,
                                   path: AbsolutePath,
                                   productFilter: ProductFilter
     ) -> Self {
         .fileSystem (
             .init(identity: identity,
-                  name: name,
+                  nameForTargetDependencyResolutionOnly: nameForTargetDependencyResolutionOnly,
                   path: path,
                   productFilter: productFilter)
         )
     }
 
     public static func sourceControl(identity: PackageIdentity,
-                                     name: String?,
+                                     nameForTargetDependencyResolutionOnly: String?,
                                      location: String,
                                      requirement: SourceControl.Requirement,
                                      productFilter: ProductFilter
     ) -> Self {
         .sourceControl (
             .init(identity: identity,
-                  name: name,
+                  nameForTargetDependencyResolutionOnly: nameForTargetDependencyResolutionOnly,
                   location: location,
                   requirement: requirement,
                   productFilter: productFilter)

--- a/Sources/SPMTestSupport/MockDependency.swift
+++ b/Sources/SPMTestSupport/MockDependency.swift
@@ -14,21 +14,14 @@ import TSCBasic
 
 public struct MockDependency {
     public typealias Requirement = PackageDependency.SourceControl.Requirement
-    
-    public let name: String?
+
+    public let deprecatedName: String?
     public let path: String
     public let requirement: Requirement?
     public let products: ProductFilter
     
-    init(name: String, requirement: Requirement?, products: ProductFilter = .everything) {
-        self.name = name
-        self.path = name
-        self.requirement = requirement
-        self.products = products
-    }
-    
-    init(name: String?, path: String, requirement: Requirement?, products: ProductFilter = .everything) {
-        self.name = name
+    init(deprecatedName: String? = nil, path: String, requirement: Requirement?, products: ProductFilter = .everything) {
+        self.deprecatedName = deprecatedName
         self.path = path
         self.requirement = requirement
         self.products = products
@@ -41,31 +34,28 @@ public struct MockDependency {
         let identity = identityResolver.resolveIdentity(for: location)
         if let requirement = self.requirement {
             return .scm(identity: identity,
-                        name: self.name,
+                        deprecatedName: self.deprecatedName,
                         location: location,
                         requirement: requirement,
                         productFilter: self.products)
         } else {
             return .local(identity: identity,
-                          name: self.name,
+                          deprecatedName: self.deprecatedName,
                           path: location,
                           productFilter: self.products)
         }
     }
     
-    public static func local(name: String? = nil, path: String, products: ProductFilter = .everything) -> MockDependency {
-        MockDependency(name: name, path: path, requirement: nil, products: products)
+    public static func local(path: String, products: ProductFilter = .everything) -> MockDependency {
+        MockDependency(path: path, requirement: nil, products: products)
     }
-    
-    public static func local(name: String, products: ProductFilter = .everything) -> MockDependency {
-        MockDependency(name: name, requirement: nil, products: products)
+
+    public static func scm(path: String, requirement: Requirement, products: ProductFilter = .everything) -> MockDependency {
+        MockDependency(path: path, requirement: requirement, products: products)
     }
-    
-    public static func git(name: String? = nil, path: String, requirement: Requirement, products: ProductFilter = .everything) -> MockDependency {
-        MockDependency(name: name, path: path, requirement: requirement, products: products)
+
+    public static func scmWithDeprecatedName(name: String, path: String, requirement: Requirement, products: ProductFilter = .everything) -> MockDependency {
+        MockDependency(deprecatedName: name, path: path, requirement: requirement, products: products)
     }
-    
-    public static func git(name: String, requirement: Requirement, products: ProductFilter = .everything) -> MockDependency {
-        MockDependency(name: name, requirement: requirement, products: products)
-    }
+
 }

--- a/Sources/SPMTestSupport/PackageDependencyDescriptionExtensions.swift
+++ b/Sources/SPMTestSupport/PackageDependencyDescriptionExtensions.swift
@@ -13,61 +13,61 @@ import TSCBasic
 
 public extension PackageDependency {
     static func fileSystem(identity: PackageIdentity? = nil,
-                           name: String? = nil,
+                           deprecatedName: String? = nil,
                            path: String,
                            productFilter: ProductFilter = .everything
     ) -> Self {
         return .fileSystem(identity: identity,
-                           name: name,
+                           deprecatedName: deprecatedName,
                            path: AbsolutePath(path),
                            productFilter: productFilter)
     }
 
     static func fileSystem(identity: PackageIdentity? = nil,
-                           name: String? = nil,
+                           deprecatedName: String? = nil,
                            path: AbsolutePath,
                            productFilter: ProductFilter = .everything
     ) -> Self {
         let identity = identity ?? PackageIdentity(url: path.pathString)
         return .fileSystem(identity: identity,
-                           name: name,
+                           nameForTargetDependencyResolutionOnly: deprecatedName,
                            path: path,
                            productFilter: productFilter)
     }
 
     // backwards compatibility with existing tests
     static func local(identity: PackageIdentity? = nil,
-                      name: String? = nil,
+                      deprecatedName: String? = nil,
                       path: String,
                       productFilter: ProductFilter = .everything
     ) -> Self {
         return .fileSystem(identity: identity,
-                           name: name,
+                           deprecatedName: deprecatedName,
                            path: AbsolutePath(path),
                            productFilter: productFilter)
     }
 
     // backwards compatibility with existing tests
     static func local(identity: PackageIdentity? = nil,
-                      name: String? = nil,
+                      deprecatedName: String? = nil,
                       path: AbsolutePath,
                       productFilter: ProductFilter = .everything
     ) -> Self {
         return .fileSystem(identity: identity,
-                           name: name,
+                           deprecatedName: deprecatedName,
                            path: path,
                            productFilter: productFilter)
     }
 
     static func sourceControl(identity: PackageIdentity? = nil,
-                              name: String? = nil,
+                              deprecatedName: String? = nil,
                               location: String,
                               requirement: SourceControl.Requirement,
                               productFilter: ProductFilter = .everything
     ) -> Self {
         let identity = identity ?? PackageIdentity(url: location)
         return .sourceControl(identity: identity,
-                              name: name,
+                              nameForTargetDependencyResolutionOnly: deprecatedName,
                               location: location,
                               requirement: requirement,
                               productFilter: productFilter)
@@ -75,13 +75,13 @@ public extension PackageDependency {
 
     // backwards compatibility with existing tests
     static func scm(identity: PackageIdentity? = nil,
-                    name: String? = nil,
+                    deprecatedName: String? = nil,
                     location: String,
                     requirement: SourceControl.Requirement,
                     productFilter: ProductFilter = .everything
     ) -> Self {
         return .sourceControl(identity: identity,
-                              name: name,
+                              deprecatedName: deprecatedName,
                               location: location,
                               requirement: requirement,
                               productFilter: productFilter)

--- a/Sources/SPMTestSupport/Resources.swift
+++ b/Sources/SPMTestSupport/Resources.swift
@@ -60,9 +60,4 @@ public class Resources: ManifestResourceProvider {
       #endif
         toolchain = try! UserToolchain(destination: Destination.hostDestination(binDir))
     }
-
-    /// True if SwiftPM has PackageDescription 4 runtime available.
-    public static var havePD4Runtime: Bool {
-        return Resources.default.binDir == nil
-    }
 }

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -358,8 +358,8 @@ final class PackageToolTests: XCTestCase {
             packageLocation: "/PackageA",
             v: .v5_3,
             dependencies: [
-                .local(name: "PackageB", path: "/PackageB"),
-                .local(name: "PackageC", path: "/PackageC"),
+                .local(path: "/PackageB"),
+                .local(path: "/PackageC"),
             ],
             products: [
                 .init(name: "exe", type: .executable, targets: ["TargetA"])
@@ -376,8 +376,8 @@ final class PackageToolTests: XCTestCase {
             packageLocation: "/PackageB",
             v: .v5_3,
             dependencies: [
-                .local(name: "PackageC", path: "/PackageC"),
-                .local(name: "PackageD", path: "/PackageD"),
+                .local(path: "/PackageC"),
+                .local(path: "/PackageD"),
             ],
             products: [
                 .init(name: "PackageB", type: .library(.dynamic), targets: ["TargetB"])
@@ -394,7 +394,7 @@ final class PackageToolTests: XCTestCase {
             packageLocation: "/PackageC",
             v: .v5_3,
             dependencies: [
-                .local(name: "PackageD", path: "/PackageD"),
+                .local(path: "/PackageD"),
             ],
             products: [
                 .init(name: "PackageC", type: .library(.dynamic), targets: ["TargetC"])

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -39,7 +39,7 @@ class PackageGraphPerfTests: XCTestCasePerf {
             } else {
                 let depName = "Foo\(pkg + 1)"
                 let depUrl = "/\(depName)"
-                dependencies = [.scm(name: depName, location: depUrl, requirement: .upToNextMajor(from: "1.0.0"))]
+                dependencies = [.scm(deprecatedName: depName, location: depUrl, requirement: .upToNextMajor(from: "1.0.0"))]
                 targets = [try TargetDescription(name: name, dependencies: [.byName(name: depName, condition: nil)], path: ".")]
             }
             // Create manifest.

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -721,7 +721,7 @@ class PackageGraphTests: XCTestCase {
                     packageLocation: "/Foo",
                     v: .v5_2,
                     dependencies: [
-                        .scm(name: "Bar", location: "/Bar", requirement: .branch("master")),
+                        .scm(location: "/Bar", requirement: .branch("master")),
                         .scm(location: "/BizPath", requirement: .exact("1.2.3")),
                         .scm(location: "/FizPath", requirement: .upToNextMajor(from: "1.1.2")),
                     ],
@@ -807,7 +807,7 @@ class PackageGraphTests: XCTestCase {
                     packageLocation: "/Foo",
                     v: .v5_2,
                     dependencies: [
-                        .scm(name: "UnBar", location: "/Bar", requirement: .branch("master")),
+                        .scm(deprecatedName: "UnBar", location: "/Bar", requirement: .branch("master")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: [.product(name: "BarProduct", package: "UnBar")]),
@@ -1123,7 +1123,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Foo",
                     dependencies: [
-                        .scm(name: "Baar", location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(deprecatedName: "Baar", location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: ["Baar"]),
@@ -1258,7 +1258,7 @@ class PackageGraphTests: XCTestCase {
                     packageLocation: "/Root",
                     v: .v5_2,
                     dependencies: [
-                        .scm(name: "Immediate", location: "/Immediate", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(location: "/Immediate", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     targets: [
                         TargetDescription(name: "Root", dependencies: [
@@ -1274,12 +1274,10 @@ class PackageGraphTests: XCTestCase {
                     v: .v5_2,
                     dependencies: [
                         .scm(
-                            name: "Transitive",
                             location: "/Transitive",
                             requirement: .upToNextMajor(from: "1.0.0")
                         ),
                         .scm(
-                            name: "Nonexistent",
                             location: "/Nonexistent",
                             requirement: .upToNextMajor(from: "1.0.0")
                         )
@@ -1306,7 +1304,6 @@ class PackageGraphTests: XCTestCase {
                     v: .v5_2,
                     dependencies: [
                         .scm(
-                            name: "Nonexistent",
                             location: "/Nonexistent",
                             requirement: .upToNextMajor(from: "1.0.0")
                         )
@@ -1608,7 +1605,7 @@ class PackageGraphTests: XCTestCase {
                 packageLocation: "/Foo",
                 v: .v5_2,
                 dependencies: [
-                    .scm(name: "Bar", location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                    .scm(deprecatedName: "Bar", location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                 ],
                 targets: [
                     TargetDescription(name: "Foo", dependencies: ["ProductBar"]),
@@ -1800,7 +1797,7 @@ class PackageGraphTests: XCTestCase {
                 packageLocation: "/Foo",
                 v: .v5_2,
                 dependencies: [
-                    .scm(name: "Bar", location: "/Some-Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                    .scm(deprecatedName: "Bar", location: "/Some-Bar", requirement: .upToNextMajor(from: "1.0.0")),
                 ],
                 targets: [
                     TargetDescription(name: "Foo", dependencies: ["Bar"]),
@@ -1840,7 +1837,7 @@ class PackageGraphTests: XCTestCase {
                 packageLocation: "/Foo",
                 v: .v5_2,
                 dependencies: [
-                    .scm(name: "Bar", location: "/Some-Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                    .scm(deprecatedName: "Bar", location: "/Some-Bar", requirement: .upToNextMajor(from: "1.0.0")),
                 ],
                 targets: [
                     TargetDescription(name: "Foo", dependencies: ["ProductBar"]),
@@ -1903,7 +1900,7 @@ class PackageGraphTests: XCTestCase {
                 packageLocation: "/Foo",
                 v: .v5_2,
                 dependencies: [
-                    .scm(name: "Bar", location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                    .scm(deprecatedName: "Bar", location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                 ],
                 targets: [
                     TargetDescription(name: "Foo", dependencies: ["ProductBar"]),
@@ -1941,7 +1938,7 @@ class PackageGraphTests: XCTestCase {
         do {
             let fixedManifests = [
                 try manifests[0].withDependencies([
-                    .scm(name: "Some-Bar", location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                    .scm(deprecatedName: "Some-Bar", location: "/Bar", requirement: .upToNextMajor(from: "1.0.0")),
                 ]).withTargets([
                     TargetDescription(name: "Foo", dependencies: [.product(name: "ProductBar", package: "Some-Bar")]),
                 ]),

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -376,9 +376,9 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         #endif
 
         let dependencies: [PackageDependency] = [
-            .scm(name: "Bar1", location: "/Bar1", requirement: .upToNextMajor(from: "1.0.0")),
-            .scm(name: "Bar2", location: "/Bar2", requirement: .upToNextMajor(from: "1.0.0")),
-            .scm(name: "Bar3", location: "/Bar3", requirement: .upToNextMajor(from: "1.0.0")),
+            .scm(location: "/Bar1", requirement: .upToNextMajor(from: "1.0.0")),
+            .scm(location: "/Bar2", requirement: .upToNextMajor(from: "1.0.0")),
+            .scm(location: "/Bar3", requirement: .upToNextMajor(from: "1.0.0")),
         ]
 
         let products = [
@@ -392,27 +392,27 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         ]
 
         let v5ProductMapping: [String: ProductFilter] = [
-            "Bar1": .specific(["Bar1", "Bar3"]),
-            "Bar2": .specific(["B2", "Bar1", "Bar3"]),
-            "Bar3": .specific(["Bar1", "Bar3"]),
+            "bar1": .specific(["Bar1", "Bar3"]),
+            "bar2": .specific(["B2", "Bar1", "Bar3"]),
+            "bar3": .specific(["Bar1", "Bar3"]),
         ]
         let v5Constraints = try dependencies.map {
             PackageContainerConstraint(
                 package: $0.createPackageRef(),
                 requirement: try $0.toConstraintRequirement(),
-                products: v5ProductMapping[$0.nameForTargetDependencyResolutionOnly]!
+                products: v5ProductMapping[$0.identity.description]!
             )
         }
         let v5_2ProductMapping: [String: ProductFilter] = [
-            "Bar1": .specific(["Bar1"]),
-            "Bar2": .specific(["B2"]),
-            "Bar3": .specific(["Bar3"]),
+            "bar1": .specific(["Bar1"]),
+            "bar2": .specific(["B2"]),
+            "bar3": .specific(["Bar3"]),
         ]
         let v5_2Constraints = try dependencies.map {
             PackageContainerConstraint(
                 package: $0.createPackageRef(),
                 requirement: try $0.toConstraintRequirement(),
-                products: v5_2ProductMapping[$0.nameForTargetDependencyResolutionOnly]!
+                products: v5_2ProductMapping[$0.identity.description]!
             )
         }
 

--- a/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
@@ -22,17 +22,14 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testTrivial() throws {
-        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
-
-        let stream = BufferedOutputByteStream()
-        stream <<< """
+        let manifest = """
             import PackageDescription
             let package = Package(
                 name: "Trivial"
             )
             """
 
-        loadManifest(stream.bytes) { manifest in
+        loadManifest(manifest) { manifest in
             XCTAssertEqual(manifest.name, "Trivial")
             XCTAssertEqual(manifest.toolsVersion, .v4)
             XCTAssertEqual(manifest.targets, [])
@@ -41,10 +38,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testTargetDependencies() throws {
-        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
-
-        let stream = BufferedOutputByteStream()
-        stream <<< """
+        let manifest = """
             import PackageDescription
             let package = Package(
                 name: "Trivial",
@@ -62,7 +56,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        loadManifest(stream.bytes) { manifest in
+        loadManifest(manifest) { manifest in
             XCTAssertEqual(manifest.name, "Trivial")
             let foo = manifest.targetMap["foo"]!
             XCTAssertEqual(foo.name, "foo")
@@ -85,48 +79,40 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testCompatibleSwiftVersions() throws {
-        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
-
-        var stream = BufferedOutputByteStream()
-        stream <<< """
+        var manifest = """
             import PackageDescription
             let package = Package(
                name: "Foo",
                swiftLanguageVersions: [3, 4]
             )
             """
-        loadManifest(stream.bytes) { manifest in
+        loadManifest(manifest) { manifest in
             XCTAssertEqual(manifest.swiftLanguageVersions?.map({$0.rawValue}), ["3", "4"])
         }
 
-        stream = BufferedOutputByteStream()
-        stream <<< """
+        manifest = """
             import PackageDescription
             let package = Package(
                name: "Foo",
                swiftLanguageVersions: []
             )
             """
-        loadManifest(stream.bytes) { manifest in
+        loadManifest(manifest) { manifest in
             XCTAssertEqual(manifest.swiftLanguageVersions, [])
         }
 
-        stream = BufferedOutputByteStream()
-        stream <<< """
+        manifest = """
             import PackageDescription
             let package = Package(
                name: "Foo")
             """
-        loadManifest(stream.bytes) { manifest in
+        loadManifest(manifest) { manifest in
             XCTAssertEqual(manifest.swiftLanguageVersions, nil)
         }
     }
 
     func testPackageDependencies() throws {
-        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
-
-        let stream = BufferedOutputByteStream()
-        stream <<< """
+        let manifest = """
             import PackageDescription
             let package = Package(
                name: "Foo",
@@ -140,7 +126,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
                ]
             )
             """
-        loadManifest(stream.bytes, toolsVersion: ToolsVersion(string: "5.5")) { manifest in
+        loadManifest(manifest, toolsVersion: ToolsVersion(string: "5.5")) { manifest in
         let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
             XCTAssertEqual(deps["foo1"], .scm(location: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
             XCTAssertEqual(deps["foo2"], .scm(location: "/foo2", requirement: .upToNextMajor(from: "1.0.0")))
@@ -152,10 +138,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testProducts() throws {
-        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
-
-        let stream = BufferedOutputByteStream()
-        stream <<< """
+        let manifest = """
             import PackageDescription
             let package = Package(
                 name: "Foo",
@@ -170,7 +153,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
                 ]
             )
             """
-        loadManifest(stream.bytes) { manifest in
+        loadManifest(manifest) { manifest in
             let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })
             // Check tool.
             let tool = products["tool"]!
@@ -191,10 +174,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testSystemPackage() throws {
-        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
-
-        let stream = BufferedOutputByteStream()
-        stream <<< """
+        let manifest = """
             import PackageDescription
             let package = Package(
                name: "Copenssl",
@@ -205,7 +185,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
                ]
             )
             """
-        loadManifest(stream.bytes) { manifest in
+        loadManifest(manifest) { manifest in
             XCTAssertEqual(manifest.name, "Copenssl")
             XCTAssertEqual(manifest.pkgConfig, "openssl")
             XCTAssertEqual(manifest.providers, [
@@ -216,10 +196,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testCTarget() throws {
-        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
-
-        let stream = BufferedOutputByteStream()
-        stream <<< """
+        let manifest = """
             import PackageDescription
             let package = Package(
                name: "libyaml",
@@ -232,7 +209,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
                ]
             )
             """
-        loadManifest(stream.bytes) { manifest in
+        loadManifest(manifest) { manifest in
             let foo = manifest.targetMap["Foo"]!
             XCTAssertEqual(foo.publicHeadersPath, "inc")
 
@@ -242,10 +219,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testTargetProperties() throws {
-        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
-
-        let stream = BufferedOutputByteStream()
-        stream <<< """
+        let manifest = """
             import PackageDescription
             let package = Package(
                name: "libyaml",
@@ -261,7 +235,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
                ]
             )
             """
-        loadManifest(stream.bytes) { manifest in
+        loadManifest(manifest) { manifest in
             let foo = manifest.targetMap["Foo"]!
             XCTAssertEqual(foo.publicHeadersPath, "inc")
             XCTAssertEqual(foo.path, "foo/z")
@@ -277,10 +251,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testUnavailableAPIs() throws {
-        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
-
-        let stream = BufferedOutputByteStream()
-        stream.write("""
+        let manifest = """
             import PackageDescription
             let package = Package(
                name: "Foo",
@@ -291,9 +262,9 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
                    .package(url: "/foo4", range: "1.0.0"..<"1.5.0"),
                ]
             )
-            """)
+            """
         do {
-            try loadManifestThrowing(stream.bytes) { manifest in
+            try loadManifestThrowing(manifest) { manifest in
                 XCTFail("this package should not load successfully")
             }
             XCTFail("this package should not load successfully")
@@ -304,8 +275,6 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testLanguageStandards() throws {
-        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
-
         let stream = BufferedOutputByteStream()
         stream <<< """
             import PackageDescription
@@ -326,8 +295,6 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testManifestWithWarnings() throws {
-        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
-
         let fs = InMemoryFileSystem()
         let manifestPath = AbsolutePath.root.appending(component: Manifest.filename)
         let stream = BufferedOutputByteStream()
@@ -365,8 +332,6 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testDuplicateTargets() throws {
-        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
-
         let manifest = """
             import PackageDescription
 
@@ -388,8 +353,6 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testEmptyProductTargets() throws {
-        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
-
         let manifest = """
             import PackageDescription
 
@@ -410,8 +373,6 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testProductTargetNotFound() throws {
-        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
-
         let manifest = """
             import PackageDescription
 

--- a/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
@@ -21,8 +21,8 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
         .v4
     }
 
-    func testTrivial() {
-        guard Resources.havePD4Runtime else { return }
+    func testTrivial() throws {
+        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
 
         let stream = BufferedOutputByteStream()
         stream <<< """
@@ -40,8 +40,8 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
         }
     }
 
-    func testTargetDependencies() {
-        guard Resources.havePD4Runtime else { return }
+    func testTargetDependencies() throws {
+        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
 
         let stream = BufferedOutputByteStream()
         stream <<< """
@@ -85,7 +85,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testCompatibleSwiftVersions() throws {
-        guard Resources.havePD4Runtime else { return }
+        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
 
         var stream = BufferedOutputByteStream()
         stream <<< """
@@ -123,7 +123,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testPackageDependencies() throws {
-        guard Resources.havePD4Runtime else { return }
+        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
 
         let stream = BufferedOutputByteStream()
         stream <<< """
@@ -151,8 +151,8 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
         }
     }
 
-    func testProducts() {
-        guard Resources.havePD4Runtime else { return }
+    func testProducts() throws {
+        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
 
         let stream = BufferedOutputByteStream()
         stream <<< """
@@ -190,8 +190,8 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
         }
     }
 
-    func testSystemPackage() {
-        guard Resources.havePD4Runtime else { return }
+    func testSystemPackage() throws {
+        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
 
         let stream = BufferedOutputByteStream()
         stream <<< """
@@ -215,8 +215,8 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
         }
     }
 
-    func testCTarget() {
-        guard Resources.havePD4Runtime else { return }
+    func testCTarget() throws {
+        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
 
         let stream = BufferedOutputByteStream()
         stream <<< """
@@ -241,8 +241,8 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
         }
     }
 
-    func testTargetProperties() {
-        guard Resources.havePD4Runtime else { return }
+    func testTargetProperties() throws {
+        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
 
         let stream = BufferedOutputByteStream()
         stream <<< """
@@ -277,7 +277,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testUnavailableAPIs() throws {
-        guard Resources.havePD4Runtime else { return }
+        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
 
         let stream = BufferedOutputByteStream()
         stream.write("""
@@ -294,17 +294,17 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             """)
         do {
             try loadManifestThrowing(stream.bytes) { manifest in
-                XCTFail("this package should not load succesfully")
+                XCTFail("this package should not load successfully")
             }
-            XCTFail("this package should not load succesfully")
+            XCTFail("this package should not load successfully")
         } catch ManifestParseError.invalidManifestFormat(let error, _) {
-            XCTAssert(error.contains("error: 'package(url:version:)' is unavailable: use package(url:_:) with the .exact(Version) initializer instead\n"), "\(error)")
-            XCTAssert(error.contains("error: 'package(url:range:)' is unavailable: use package(url:_:) without the range label instead\n"), "\(error)")
+            XCTAssert(error.contains("error: 'package(url:version:)' is unavailable: use package(url:exact:) instead\n"), "\(error)")
+            XCTAssert(error.contains("error: 'package(url:range:)' is unavailable: use package(url:_:) instead\n"), "\(error)")
         }
     }
 
-    func testLanguageStandards() {
-        guard Resources.havePD4Runtime else { return }
+    func testLanguageStandards() throws {
+        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
 
         let stream = BufferedOutputByteStream()
         stream <<< """
@@ -326,7 +326,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testManifestWithWarnings() throws {
-        guard Resources.havePD4Runtime else { return }
+        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
 
         let fs = InMemoryFileSystem()
         let manifestPath = AbsolutePath.root.appending(component: Manifest.filename)
@@ -365,7 +365,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testDuplicateTargets() throws {
-        guard Resources.havePD4Runtime else { return }
+        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
 
         let manifest = """
             import PackageDescription
@@ -388,7 +388,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testEmptyProductTargets() throws {
-        guard Resources.havePD4Runtime else { return }
+        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
 
         let manifest = """
             import PackageDescription
@@ -410,7 +410,7 @@ class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testProductTargetNotFound() throws {
-        guard Resources.havePD4Runtime else { return }
+        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
 
         let manifest = """
             import PackageDescription

--- a/Tests/PackageLoadingTests/PD_5_5_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_5_LoadingTests.swift
@@ -22,8 +22,7 @@ class PackageDescription5_5LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testPackageDependencies() throws {
-        let stream = BufferedOutputByteStream()
-        stream <<< """
+        let manifest = """
             import PackageDescription
             let package = Package(
                name: "Foo",
@@ -33,7 +32,7 @@ class PackageDescription5_5LoadingTests: PackageDescriptionLoadingTests {
                ]
             )
             """
-        loadManifest(stream.bytes, toolsVersion: .v5_5) { manifest in
+        loadManifest(manifest, toolsVersion: .v5_5) { manifest in
         let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
             XCTAssertEqual(deps["foo5"], .scm(location: "/foo5", requirement: .branch("main")))
             XCTAssertEqual(deps["foo7"], .scm(location: "/foo7", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))

--- a/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
@@ -1,12 +1,12 @@
 /*
  This source file is part of the Swift.org open source project
-
+ 
  Copyright (c) 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
-
+ 
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import PackageModel
 import TSCBasic
@@ -48,28 +48,27 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
             )
             """
         loadManifest(manifest, toolsVersion: self.toolsVersion) { manifest in
-        let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-            XCTAssertEqual(deps["foo1"], .sourceControl(identity: .plain("foo1"), name: "foo1", location: "http://localhost/foo1", requirement: .range("1.1.1" ..< "2.0.0")))
-            XCTAssertEqual(deps["foo2"], .sourceControl(identity: .plain("foo2"), name: nil, location: "http://localhost/foo2", requirement: .range("1.1.1" ..< "2.0.0")))
-            XCTAssertEqual(deps["bar1"], .sourceControl(identity: .plain("bar1"), name: "bar1", location: "http://localhost/bar1", requirement: .range("1.1.1" ..< "2.0.0")))
-            XCTAssertEqual(deps["bar2"], .sourceControl(identity: .plain("bar2"), name: nil, location: "http://localhost/bar2", requirement: .range("1.1.1" ..< "2.0.0")))
-            XCTAssertEqual(deps["baz1"], .sourceControl(identity: .plain("baz1"), name: "baz1", location: "http://localhost/baz1", requirement: .range("1.1.1" ..< "1.2.0")))
-            XCTAssertEqual(deps["baz2"], .sourceControl(identity: .plain("baz2"), name: nil, location: "http://localhost/baz2", requirement: .range("1.1.1" ..< "1.2.0")))
-            XCTAssertEqual(deps["qux1"], .sourceControl(identity: .plain("qux1"), name: "qux1", location: "http://localhost/qux1", requirement: .exact("1.1.1")))
-            XCTAssertEqual(deps["qux2"], .sourceControl(identity: .plain("qux2"), name: nil, location: "http://localhost/qux2", requirement: .exact("1.1.1")))
-            XCTAssertEqual(deps["qux3"], .sourceControl(identity: .plain("qux3"), name: nil, location: "http://localhost/qux3", requirement: .exact("1.1.1")))
-            XCTAssertEqual(deps["quux1"], .sourceControl(identity: .plain("quux1"), name: "quux1", location: "http://localhost/quux1", requirement: .branch("main")))
-            XCTAssertEqual(deps["quux2"], .sourceControl(identity: .plain("quux2"), name: nil, location: "http://localhost/quux2", requirement: .branch("main")))
-            XCTAssertEqual(deps["quux3"], .sourceControl(identity: .plain("quux3"), name: nil, location: "http://localhost/quux3", requirement: .branch("main")))
-            XCTAssertEqual(deps["quuz1"], .sourceControl(identity: .plain("quuz1"), name: "quuz1", location: "http://localhost/quuz1", requirement: .revision("abcdefg")))
-            XCTAssertEqual(deps["quuz2"], .sourceControl(identity: .plain("quuz2"), name: nil, location: "http://localhost/quuz2", requirement: .revision("abcdefg")))
-            XCTAssertEqual(deps["quuz3"], .sourceControl(identity: .plain("quuz3"), name: nil, location: "http://localhost/quuz3", requirement: .revision("abcdefg")))
+            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
+            XCTAssertEqual(deps["foo1"], .sourceControl(identity: .plain("foo1"), deprecatedName: "foo1", location: "http://localhost/foo1", requirement: .range("1.1.1" ..< "2.0.0")))
+            XCTAssertEqual(deps["foo2"], .sourceControl(identity: .plain("foo2"), location: "http://localhost/foo2", requirement: .range("1.1.1" ..< "2.0.0")))
+            XCTAssertEqual(deps["bar1"], .sourceControl(identity: .plain("bar1"), deprecatedName: "bar1", location: "http://localhost/bar1", requirement: .range("1.1.1" ..< "2.0.0")))
+            XCTAssertEqual(deps["bar2"], .sourceControl(identity: .plain("bar2"), location: "http://localhost/bar2", requirement: .range("1.1.1" ..< "2.0.0")))
+            XCTAssertEqual(deps["baz1"], .sourceControl(identity: .plain("baz1"), deprecatedName: "baz1", location: "http://localhost/baz1", requirement: .range("1.1.1" ..< "1.2.0")))
+            XCTAssertEqual(deps["baz2"], .sourceControl(identity: .plain("baz2"), location: "http://localhost/baz2", requirement: .range("1.1.1" ..< "1.2.0")))
+            XCTAssertEqual(deps["qux1"], .sourceControl(identity: .plain("qux1"), deprecatedName: "qux1", location: "http://localhost/qux1", requirement: .exact("1.1.1")))
+            XCTAssertEqual(deps["qux2"], .sourceControl(identity: .plain("qux2"), location: "http://localhost/qux2", requirement: .exact("1.1.1")))
+            XCTAssertEqual(deps["qux3"], .sourceControl(identity: .plain("qux3"), location: "http://localhost/qux3", requirement: .exact("1.1.1")))
+            XCTAssertEqual(deps["quux1"], .sourceControl(identity: .plain("quux1"), deprecatedName: "quux1", location: "http://localhost/quux1", requirement: .branch("main")))
+            XCTAssertEqual(deps["quux2"], .sourceControl(identity: .plain("quux2"), location: "http://localhost/quux2", requirement: .branch("main")))
+            XCTAssertEqual(deps["quux3"], .sourceControl(identity: .plain("quux3"), location: "http://localhost/quux3", requirement: .branch("main")))
+            XCTAssertEqual(deps["quuz1"], .sourceControl(identity: .plain("quuz1"), deprecatedName: "quuz1", location: "http://localhost/quuz1", requirement: .revision("abcdefg")))
+            XCTAssertEqual(deps["quuz2"], .sourceControl(identity: .plain("quuz2"), location: "http://localhost/quuz2", requirement: .revision("abcdefg")))
+            XCTAssertEqual(deps["quuz3"], .sourceControl(identity: .plain("quuz3"), location: "http://localhost/quuz3", requirement: .revision("abcdefg")))
         }
     }
 
     func testBuildToolPluginTarget() throws {
-        let stream = BufferedOutputByteStream()
-        stream <<< """
+        let manifest = """
             import PackageDescription
             let package = Package(
                name: "Foo",
@@ -82,15 +81,14 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        loadManifest(stream.bytes) { manifest in
+        loadManifest(manifest) { manifest in
             XCTAssertEqual(manifest.targets[0].type, .plugin)
             XCTAssertEqual(manifest.targets[0].pluginCapability, .buildTool)
         }
     }
 
     func testPluginTargetCustomization() throws {
-        let stream = BufferedOutputByteStream()
-        stream <<< """
+        let manifest = """
             import PackageDescription
             let package = Package(
                name: "Foo",
@@ -106,7 +104,7 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        loadManifest(stream.bytes) { manifest in
+        loadManifest(manifest) { manifest in
             XCTAssertEqual(manifest.targets[0].type, .plugin)
             XCTAssertEqual(manifest.targets[0].pluginCapability, .buildTool)
             XCTAssertEqual(manifest.targets[0].path, "Sources/Foo")

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -42,7 +42,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo", "Bar"]),
                     ],
                     dependencies: [
-                        .git(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -71,8 +71,8 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let deps: [MockDependency] = [
-            .git(name: "Quix", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Quix"])),
-            .git(name: "Baz", requirement: .exact("1.0.0"), products: .specific(["Baz"])),
+            .scm(path: "./Quix", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Quix"])),
+            .scm(path: "./Baz", requirement: .exact("1.0.0"), products: .specific(["Baz"])),
         ]
         workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
@@ -193,7 +193,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
                 MockPackage(
@@ -203,7 +203,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Baz", requirement: .exact("1.0.1")),
+                        .scm(path: "./Baz", requirement: .exact("1.0.1")),
                     ]
                 ),
             ],
@@ -250,7 +250,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: nil, path: "bazzz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "bazzz", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -318,7 +318,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -428,7 +428,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "BarPackage", path: "bar-package", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scmWithDeprecatedName(name: "BarPackage", path: "bar-package", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -486,7 +486,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -547,7 +547,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
                 MockPackage(
@@ -628,7 +628,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -690,7 +690,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "A", targets: ["A"]),
                     ],
                     dependencies: [
-                        .git(name: "AA", requirement: .exact("1.0.0")),
+                        .scm(path: "./AA", requirement: .exact("1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -703,7 +703,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "A", targets: ["A"]),
                     ],
                     dependencies: [
-                        .git(name: "AA", requirement: .exact("2.0.0")),
+                        .scm(path: "./AA", requirement: .exact("2.0.0")),
                     ],
                     versions: ["1.0.1"]
                 ),
@@ -723,7 +723,7 @@ final class WorkspaceTests: XCTestCase {
         // Resolve when A = 1.0.0.
         do {
             let deps: [MockDependency] = [
-                .git(name: "A", requirement: .exact("1.0.0"), products: .specific(["A"])),
+                .scm(path: "./A", requirement: .exact("1.0.0"), products: .specific(["A"])),
             ]
             workspace.checkPackageGraph(deps: deps) { graph, diagnostics in
                 PackageGraphTester(graph) { result in
@@ -746,7 +746,7 @@ final class WorkspaceTests: XCTestCase {
         // Resolve when A = 1.0.1.
         do {
             let deps: [MockDependency] = [
-                .git(name: "A", requirement: .exact("1.0.1"), products: .specific(["A"])),
+                .scm(path: "./A", requirement: .exact("1.0.1"), products: .specific(["A"])),
             ]
             workspace.checkPackageGraph(deps: deps) { graph, diagnostics in
                 PackageGraphTester(graph) { result in
@@ -786,7 +786,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "A", targets: ["A"]),
                     ],
                     dependencies: [
-                        .git(name: "AA", requirement: .exact("1.0.0")),
+                        .scm(path: "./AA", requirement: .exact("1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -799,7 +799,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "B", targets: ["B"]),
                     ],
                     dependencies: [
-                        .git(name: "AA", requirement: .exact("2.0.0")),
+                        .scm(path: "./AA", requirement: .exact("2.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -817,8 +817,8 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let deps: [MockDependency] = [
-            .git(name: "A", requirement: .exact("1.0.0"), products: .specific(["A"])),
-            .git(name: "B", requirement: .exact("1.0.0"), products: .specific(["B"])),
+            .scm(path: "./A", requirement: .exact("1.0.0"), products: .specific(["A"])),
+            .scm(path: "./B", requirement: .exact("1.0.0"), products: .specific(["B"])),
         ]
         workspace.checkPackageGraph(deps: deps) { _, diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
@@ -884,8 +884,8 @@ final class WorkspaceTests: XCTestCase {
                     targets: [MockTarget(name: "A")],
                     products: [],
                     dependencies: [
-                        .git(name: "B", requirement: v1Requirement),
-                        .git(name: "C", requirement: v1Requirement),
+                        .scm(path: "./B", requirement: v1Requirement),
+                        .scm(path: "./C", requirement: v1Requirement),
                     ]
                 ),
             ],
@@ -941,8 +941,8 @@ final class WorkspaceTests: XCTestCase {
                     targets: [MockTarget(name: "A")],
                     products: [],
                     dependencies: [
-                        .git(name: "B", requirement: v1Requirement),
-                        .git(name: "C", requirement: branchRequirement),
+                        .scm(path: "./B", requirement: v1Requirement),
+                        .scm(path: "./C", requirement: branchRequirement),
                     ]
                 ),
             ],
@@ -1000,7 +1000,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [MockTarget(name: "A")],
                     products: [],
                     dependencies: [
-                        .git(name: "C", requirement: .revision("hello")),
+                        .scm(path: "./C", requirement: .revision("hello")),
                     ]
                 ),
             ],
@@ -1051,8 +1051,8 @@ final class WorkspaceTests: XCTestCase {
                     targets: [MockTarget(name: "A")],
                     products: [],
                     dependencies: [
-                        .git(name: "B", requirement: v1Requirement),
-                        .git(name: "C", requirement: masterRequirement),
+                        .scm(path: "./B", requirement: v1Requirement),
+                        .scm(path: "./C", requirement: masterRequirement),
                     ]
                 ),
             ],
@@ -1113,8 +1113,8 @@ final class WorkspaceTests: XCTestCase {
                     targets: [MockTarget(name: "A")],
                     products: [],
                     dependencies: [
-                        .git(name: "B", requirement: v1Requirement),
-                        .local(name: "C"),
+                        .scm(path: "./B", requirement: v1Requirement),
+                        .local(path: "./C"),
                     ]
                 ),
             ],
@@ -1176,8 +1176,8 @@ final class WorkspaceTests: XCTestCase {
                     targets: [MockTarget(name: "A")],
                     products: [],
                     dependencies: [
-                        .git(name: "B", requirement: v1Requirement),
-                        .local(name: "C"),
+                        .scm(path: "./B", requirement: v1Requirement),
+                        .local(path: "./C"),
                     ]
                 ),
             ],
@@ -1238,8 +1238,8 @@ final class WorkspaceTests: XCTestCase {
                     targets: [MockTarget(name: "A")],
                     products: [],
                     dependencies: [
-                        .git(name: "B", requirement: v1Requirement),
-                        .git(name: "C", requirement: v2Requirement),
+                        .scm(path: "./B", requirement: v1Requirement),
+                        .scm(path: "./C", requirement: v2Requirement),
                     ]
                 ),
             ],
@@ -1297,8 +1297,8 @@ final class WorkspaceTests: XCTestCase {
                     targets: [MockTarget(name: "A")],
                     products: [],
                     dependencies: [
-                        .git(name: "B", requirement: v1Requirement),
-                        .git(name: "C", requirement: v2Requirement),
+                        .scm(path: "./B", requirement: v1Requirement),
+                        .scm(path: "./C", requirement: v2Requirement),
                     ]
                 ),
             ],
@@ -1378,7 +1378,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Root", targets: ["Root"]),
                     ],
                     dependencies: [
-                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -1392,7 +1392,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -1421,7 +1421,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Do an intial run, capping at Foo at 1.0.0.
         let deps: [MockDependency] = [
-            .git(name: "Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
+            .scm(path: "./Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
@@ -1476,7 +1476,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Root", targets: ["Root"]),
                     ],
                     dependencies: [
-                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -1506,7 +1506,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Do an intial run, capping at Foo at 1.0.0.
         let deps: [MockDependency] = [
-            .git(name: "Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
+            .scm(path: "./Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
         ]
 
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
@@ -1569,7 +1569,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Root", targets: ["Root"]),
                     ],
                     dependencies: [
-                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -1583,7 +1583,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.5.0"]
                 ),
@@ -1596,7 +1596,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        .git(name: "Bar", requirement: .upToNextMinor(from: "1.0.0")),
+                        .scm(path: "./Bar", requirement: .upToNextMinor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -1615,7 +1615,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Do an intial run, capping at Foo at 1.0.0.
         let deps: [MockDependency] = [
-            .git(name: "Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
+            .scm(path: "./Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -1673,7 +1673,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Root", targets: ["Root"]),
                     ],
                     dependencies: [
-                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -1750,7 +1750,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
                 MockPackage(
@@ -1760,7 +1760,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -1820,10 +1820,10 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(name: "Bam", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Bam", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -1837,8 +1837,8 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -1852,7 +1852,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Baz", targets: ["Baz"]),
                     ],
                     dependencies: [
-                        .git(name: "Bam", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Bam", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -1886,7 +1886,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Foo", requirement: .branch("develop")),
+                        .scm(path: "./Foo", requirement: .branch("develop")),
                     ]
                 ),
             ],
@@ -1920,7 +1920,7 @@ final class WorkspaceTests: XCTestCase {
 
         // We request Bar via revision.
         let deps: [MockDependency] = [
-            .git(name: "Bar", requirement: .revision(barRevision), products: .specific(["Bar"])),
+            .scm(path: "./Bar", requirement: .revision(barRevision), products: .specific(["Bar"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
@@ -1950,7 +1950,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2023,7 +2023,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2069,7 +2069,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2172,8 +2172,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2280,7 +2280,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2346,7 +2346,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let deps: [MockDependency] = [
-            .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
+            .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
         ]
         let ws = workspace.getOrCreateWorkspace()
 
@@ -2404,8 +2404,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2434,7 +2434,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let deps: [MockDependency] = [
-            .git(name: "Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
+            .scm(path: "./Foo", requirement: .exact("1.0.0"), products: .specific(["Foo"])),
         ]
         // Load the graph.
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
@@ -2525,7 +2525,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2549,7 +2549,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: [nil]
                 ),
@@ -2579,7 +2579,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         let deps: [MockDependency] = [
-            .local(name: "Foo", products: .specific(["Foo"])),
+            .local(path: "./Foo", products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
@@ -2612,7 +2612,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        .git(name: "Bar", requirement: .exact("1.0.0"))
+                        .scm(path: "./Bar", requirement: .exact("1.0.0"))
                     ]
                 ),
             ],
@@ -2651,7 +2651,7 @@ final class WorkspaceTests: XCTestCase {
         case .sourceControl(let settings):
             let updatedDependency: PackageDependency = .sourceControl(
                 identity: settings.identity,
-                name: settings.name,
+                nameForTargetDependencyResolutionOnly: settings.nameForTargetDependencyResolutionOnly,
                 location: settings.location,
                 requirement: .exact("1.5.0"),
                 productFilter: settings.productFilter
@@ -2695,7 +2695,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2751,7 +2751,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Try resolving a bad graph.
         let deps: [MockDependency] = [
-            .git(name: "Bar", requirement: .exact("1.1.0"), products: .specific(["Bar"])),
+            .scm(path: "./Bar", requirement: .exact("1.1.0"), products: .specific(["Bar"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
@@ -2777,7 +2777,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Root", targets: ["Root"]),
                     ],
                     dependencies: [
-                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2825,8 +2825,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .local(name: "Bar"),
-                        .git(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .local(path: "./Bar"),
+                        .scm(path: "./Baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2850,7 +2850,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Baz", targets: ["Baz"]),
                     ],
                     dependencies: [
-                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0", "1.5.0"]
                 ),
@@ -2903,7 +2903,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2917,7 +2917,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Bar", targets: ["Bar"]),
                     ],
                     dependencies: [
-                        .local(name: "Baz"),
+                        .local(path: "./Baz"),
                     ],
                     versions: ["1.0.0", "1.5.0", nil]
                 ),
@@ -2963,7 +2963,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -2994,7 +2994,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Override with local package and run update.
         let deps: [MockDependency] = [
-            .local(name: "Bar", products: .specific(["Bar"])),
+            .local(path: "./Bar", products: .specific(["Bar"])),
         ]
         workspace.checkUpdate(roots: ["Foo"], deps: deps) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3027,7 +3027,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .local(name: nil, path: "Bar"),
+                        .local(path: "Bar"),
                     ]
                 ),
             ],
@@ -3082,7 +3082,7 @@ final class WorkspaceTests: XCTestCase {
         // without running swift package update.
 
         var deps: [MockDependency] = [
-            .git(name: "Foo", requirement: .branch("develop"), products: .specific(["Foo"])),
+            .scm(path: "./Foo", requirement: .branch("develop"), products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
@@ -3096,7 +3096,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         deps = [
-            .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
+            .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3106,7 +3106,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         deps = [
-            .git(name: "Foo", requirement: .branch("develop"), products: .specific(["Foo"])),
+            .scm(path: "./Foo", requirement: .branch("develop"), products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3151,7 +3151,7 @@ final class WorkspaceTests: XCTestCase {
         // without running swift package update.
 
         var deps: [MockDependency] = [
-            .local(name: "Foo", products: .specific(["Foo"])),
+            .local(path: "./Foo", products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
@@ -3165,7 +3165,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         deps = [
-            .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
+            .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3175,7 +3175,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         deps = [
-            .local(name: "Foo", products: .specific(["Foo"])),
+            .local(path: "./Foo", products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3231,7 +3231,7 @@ final class WorkspaceTests: XCTestCase {
         // different locations works correctly.
 
         var deps: [MockDependency] = [
-            .local(name: "Foo", products: .specific(["Foo"])),
+            .local(path: "./Foo", products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
@@ -3245,7 +3245,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         deps = [
-            .local(name: "Foo2", products: .specific(["Foo"])),
+            .local(path: "./Foo2", products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3301,7 +3301,7 @@ final class WorkspaceTests: XCTestCase {
         // different locations works correctly.
 
         var deps: [MockDependency] = [
-            .local(name: "Foo", products: .specific(["Foo"])),
+            .local(path: "./Foo", products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
@@ -3319,7 +3319,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         deps = [
-            .local(name: "Nested/Foo", products: .specific(["Foo"])),
+            .local(path: "./Nested/Foo", products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3365,7 +3365,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let deps: [MockDependency] = [
-            .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
+            .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Foo"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3411,7 +3411,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        .git(name: "Dep", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Dep", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -3426,7 +3426,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Dep", targets: ["Dep"]),
                     ],
                     dependencies: [
-                        .git(path: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0", "1.5.0"],
                     toolsVersion: .v5
@@ -3465,7 +3465,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let deps: [MockDependency] = [
-            .git(name: "Bam", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Bar"])),
+            .scm(path: "./Bam", requirement: .upToNextMajor(from: "1.0.0"), products: .specific(["Bar"])),
         ]
 
         workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
@@ -3499,7 +3499,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -3513,7 +3513,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Bar", targets: ["Bar"]),
                     ],
                     dependencies: [
-                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -3526,7 +3526,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Bar", targets: ["Bar"]),
                     ],
                     dependencies: [
-                        .git(name: nil, path: "Nested/Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "Nested/Foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.1.0"],
                     toolsVersion: .v5
@@ -3569,7 +3569,7 @@ final class WorkspaceTests: XCTestCase {
         // dependencies.
 
         var deps: [MockDependency] = [
-            .git(name: "Bar", requirement: .exact("1.0.0"), products: .specific(["Bar"])),
+            .scm(path: "./Bar", requirement: .exact("1.0.0"), products: .specific(["Bar"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
@@ -3593,7 +3593,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         deps = [
-            .git(name: "Bar", requirement: .exact("1.1.0"), products: .specific(["Bar"])),
+            .scm(path: "./Bar", requirement: .exact("1.1.0"), products: .specific(["Bar"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { graph, diagnostics in
             PackageGraphTester(graph) { result in
@@ -3628,8 +3628,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -3659,7 +3659,7 @@ final class WorkspaceTests: XCTestCase {
 
         // Load the initial graph.
         let deps: [MockDependency] = [
-            .git(name: "Bar", requirement: .revision("develop"), products: .specific(["Bar"])),
+            .scm(path: "./Bar", requirement: .revision("develop"), products: .specific(["Bar"])),
         ]
         workspace.checkPackageGraph(roots: ["Root"], deps: deps) { _, diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
@@ -3744,8 +3744,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -3795,7 +3795,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .local(name: "Foo"),
+                        .local(path: "./Foo"),
                     ]
                 ),
             ],
@@ -3822,7 +3822,7 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testSimpleAPI() throws {
-        guard Resources.havePD4Runtime else { return }
+        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
 
         // This verifies that the simplest possible loading APIs are available for package clients.
 
@@ -3890,7 +3890,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Foo", requirement: .branch("develop")),
+                        .scm(path: "./Foo", requirement: .branch("develop")),
                     ]
                 ),
             ],
@@ -3904,7 +3904,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        .local(name: "Local"),
+                        .local(path: "./Local"),
                     ],
                     versions: ["develop"]
                 ),
@@ -3963,7 +3963,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         let deps: [MockDependency] = [
-            .git(name: "bazzz", requirement: .exact("1.0.0"), products: .specific(["Baz"])),
+            .scm(path: "./bazzz", requirement: .exact("1.0.0"), products: .specific(["Baz"])),
         ]
 
         workspace.checkPackageGraphFailure(roots: ["Overridden/bazzz-master"], deps: deps) { diagnostics in
@@ -3998,8 +3998,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .local(name: "Bar"),
-                        .git(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .local(path: "./Bar"),
+                        .scm(path: "./Baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -4023,7 +4023,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Baz", targets: ["Baz"]),
                     ],
                     dependencies: [
-                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0", "1.5.0"]
                 ),
@@ -4054,8 +4054,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Foo", requirement: .branch("master")),
-                        .git(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Foo", requirement: .branch("master")),
+                        .scm(path: "./Baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ]
                 ),
             ],
@@ -4069,7 +4069,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo"]),
                     ],
                     dependencies: [
-                        .git(name: "Bar", requirement: .branch("master")),
+                        .scm(path: "./Bar", requirement: .branch("master")),
                     ],
                     versions: ["master", nil]
                 ),
@@ -4092,7 +4092,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Baz", targets: ["Baz"]),
                     ],
                     dependencies: [
-                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0", nil]
                 ),
@@ -4164,9 +4164,9 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "Foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(name: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(name: "TestHelper1", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./TestHelper1", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5_2
                 ),
@@ -4183,8 +4183,8 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "Foo", targets: ["Foo1"]),
                     ],
                     dependencies: [
-                        .git(name: "TestHelper2", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(name: "Baz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./TestHelper2", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Baz", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"],
                     toolsVersion: .v5_2
@@ -4198,8 +4198,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: barProducts,
                     dependencies: [
-                        .git(name: "TestHelper2", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(name: "Biz", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./TestHelper2", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "./Biz", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"],
                     toolsVersion: .v5_2
@@ -4393,8 +4393,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "A", requirement: .exact("1.0.0")),
-                        .git(name: "B", requirement: .exact("1.0.0")),
+                        .scm(path: "./A", requirement: .exact("1.0.0")),
+                        .scm(path: "./B", requirement: .exact("1.0.0")),
                     ]
                 ),
             ],
@@ -4574,8 +4574,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "A", requirement: .exact("1.0.0")),
-                        .git(name: "B", requirement: .exact("1.0.0")),
+                        .scm(path: "./A", requirement: .exact("1.0.0")),
+                        .scm(path: "./B", requirement: .exact("1.0.0")),
                     ]
                 ),
             ],
@@ -4826,7 +4826,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "A", requirement: .exact("1.0.0")),
+                        .scm(path: "./A", requirement: .exact("1.0.0")),
                     ]
                 ),
             ],
@@ -4945,7 +4945,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "A", requirement: .exact("1.0.0")),
+                        .scm(path: "./A", requirement: .exact("1.0.0")),
                     ]
                 ),
             ],
@@ -5012,7 +5012,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "A", requirement: .exact("1.0.0")),
+                        .scm(path: "./A", requirement: .exact("1.0.0")),
                     ]
                 ),
             ],
@@ -5183,8 +5183,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "A", requirement: .exact("1.0.0")),
-                        .git(name: "B", requirement: .exact("1.0.0")),
+                        .scm(path: "./A", requirement: .exact("1.0.0")),
+                        .scm(path: "./B", requirement: .exact("1.0.0")),
                     ]
                 ),
             ],
@@ -5309,7 +5309,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "A", requirement: .exact("1.0.0")),
+                        .scm(path: "./A", requirement: .exact("1.0.0")),
                     ]
                 ),
             ],
@@ -5382,7 +5382,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "A", requirement: .exact("1.0.0")),
+                        .scm(path: "./A", requirement: .exact("1.0.0")),
                     ]
                 ),
             ],
@@ -5422,7 +5422,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "A", requirement: .exact("1.0.0")),
+                        .scm(path: "./A", requirement: .exact("1.0.0")),
                     ]
                 ),
             ],
@@ -5562,7 +5562,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "A", requirement: .exact("1.0.0")),
+                        .scm(path: "./A", requirement: .exact("1.0.0")),
                     ]
                 ),
             ],
@@ -5640,7 +5640,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "A", requirement: .exact("1.0.0")),
+                        .scm(path: "./A", requirement: .exact("1.0.0")),
                     ]
                 ),
             ],
@@ -5716,7 +5716,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "A", requirement: .exact("1.0.0")),
+                        .scm(path: "./A", requirement: .exact("1.0.0")),
                     ]
                 ),
             ],
@@ -5776,8 +5776,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "FooUtilityPackage", path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(name: "BarUtilityPackage", path: "bar/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scmWithDeprecatedName(name: "FooUtilityPackage", path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scmWithDeprecatedName(name: "BarUtilityPackage", path: "bar/utility", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -5838,8 +5838,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "FooPackage", path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(name: "FooPackage", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scmWithDeprecatedName(name: "FooPackage", path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scmWithDeprecatedName(name: "FooPackage", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -5900,8 +5900,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -5957,8 +5957,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -6014,8 +6014,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "MyPackage1", path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(name: "MyPackage2", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scmWithDeprecatedName(name: "MyPackage1", path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scmWithDeprecatedName(name: "MyPackage2", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -6080,8 +6080,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -6137,8 +6137,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5_3
                 ),
@@ -6203,8 +6203,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5_3
                 ),
@@ -6260,8 +6260,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(name: "foo", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scmWithDeprecatedName(name: "foo", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -6321,8 +6321,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(name: "foo", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scmWithDeprecatedName(name: "foo", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -6382,8 +6382,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "FooUtilityPackage", path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(name: "BarPackage", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scmWithDeprecatedName(name: "FooUtilityPackage", path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scmWithDeprecatedName(name: "BarPackage", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -6412,7 +6412,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "BarProduct", targets: ["BarTarget"]),
                     ],
                     dependencies: [
-                        .git(name: "OtherUtilityPackage", path: "other/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scmWithDeprecatedName(name: "OtherUtilityPackage", path: "other/utility", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -6462,8 +6462,8 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: nil, path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
-                        .git(name: nil, path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -6492,7 +6492,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "BarProduct", targets: ["BarTarget"]),
                     ],
                     dependencies: [
-                        .git(name: nil, path: "other-foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "other-foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -6541,7 +6541,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "FooUtilityPackage", path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scmWithDeprecatedName(name: "FooUtilityPackage", path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -6559,7 +6559,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "FooUtilityProduct", targets: ["FooUtilityTarget"]),
                     ],
                     dependencies: [
-                        .git(name: "BarPackage", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scmWithDeprecatedName(name: "BarPackage", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -6575,7 +6575,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "BarProduct", targets: ["BarTarget"]),
                     ],
                     dependencies: [
-                        .git(name: "OtherUtilityPackage", path: "other/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scmWithDeprecatedName(name: "OtherUtilityPackage", path: "other/utility", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -6624,7 +6624,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -6642,7 +6642,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "FooUtilityProduct", targets: ["FooUtilityTarget"]),
                     ],
                     dependencies: [
-                        .git(path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"],
                     toolsVersion: .v5
@@ -6659,7 +6659,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "BarProduct", targets: ["BarTarget"]),
                     ],
                     dependencies: [
-                        .git(path: "other/utility", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scm(path: "other/utility", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"],
                     toolsVersion: .v5
@@ -6710,7 +6710,7 @@ final class WorkspaceTests: XCTestCase {
                     ],
                     products: [],
                     dependencies: [
-                        .git(name: "BarPackage", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scmWithDeprecatedName(name: "BarPackage", path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     toolsVersion: .v5
                 ),
@@ -6728,7 +6728,7 @@ final class WorkspaceTests: XCTestCase {
                         MockProduct(name: "BarProduct", targets: ["BarTarget"]),
                     ],
                     dependencies: [
-                        .git(name: "FooPackage", path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
+                        .scmWithDeprecatedName(name: "FooPackage", path: "foo", requirement: .upToNextMajor(from: "1.0.0")),
                     ],
                     versions: ["1.0.0"]
                 ),

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3822,8 +3822,6 @@ final class WorkspaceTests: XCTestCase {
     }
 
     func testSimpleAPI() throws {
-        try XCTSkipIf(!Resources.havePD4Runtime, "test is only supported when PD4 runtime is available")
-
         // This verifies that the simplest possible loading APIs are available for package clients.
 
         // This checkout of the SwiftPM package.

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -60,7 +60,7 @@ class PIFBuilderTests: XCTestCase {
                         packageLocation: "/A",
                         v: .v5_2,
                         dependencies: [
-                            .scm(name: "B", location: "/B", requirement: .branch("master")),
+                            .scm(location: "/B", requirement: .branch("master")),
                         ],
                         products: [
                             .init(name: "alib", type: .library(.static), targets: ["A2"]),
@@ -119,7 +119,7 @@ class PIFBuilderTests: XCTestCase {
                     defaultLocalization: "fr",
                     v: .v5_2,
                     dependencies: [
-                        .scm(name: "Bar", location: "/Bar", requirement: .branch("master")),
+                        .scm(location: "/Bar", requirement: .branch("master")),
                     ],
                     targets: [
                         .init(name: "foo", dependencies: [.product(name: "BarLib", package: "Bar")]),
@@ -389,7 +389,7 @@ class PIFBuilderTests: XCTestCase {
                     v: .v5_2,
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
-                        .scm(name: "Bar", location: "/Bar", requirement: .branch("master")),
+                        .scm(location: "/Bar", requirement: .branch("master")),
                     ],
                     targets: [
                         .init(name: "foo", dependencies: [
@@ -715,7 +715,7 @@ class PIFBuilderTests: XCTestCase {
                     v: .v5_2,
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
-                        .scm(name: "Bar", location: "/Bar", requirement: .branch("master")),
+                        .scm(location: "/Bar", requirement: .branch("master")),
                     ],
                     targets: [
                         .init(name: "FooTests", dependencies: [
@@ -943,7 +943,7 @@ class PIFBuilderTests: XCTestCase {
                     v: .v5_2,
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
-                        .scm(name: "Bar", location: "/Bar", requirement: .branch("master")),
+                        .scm(location: "/Bar", requirement: .branch("master")),
                     ],
                     products: [
                         .init(name: "FooLib1", type: .library(.static), targets: ["FooLib1"]),
@@ -1140,7 +1140,7 @@ class PIFBuilderTests: XCTestCase {
                     cxxLanguageStandard: "c++14",
                     swiftLanguageVersions: [.v4_2, .v5],
                     dependencies: [
-                        .scm(name: "Bar", location: "/Bar", requirement: .branch("master")),
+                        .scm(location: "/Bar", requirement: .branch("master")),
                     ],
                     targets: [
                         .init(name: "FooLib1", dependencies: ["SystemLib", "FooLib2"]),

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -357,7 +357,7 @@ class GenerateXcodeprojTests: XCTestCase {
                         path: fooPackagePath.pathString,
                         packageLocation: fooPackagePath.pathString,
                         dependencies: [
-                            .local(name: "Bar", path: barPackagePath)
+                            .local(path: barPackagePath)
                         ],
                         targets: [
                             TargetDescription(name: "Foo", dependencies: [

--- a/Tests/XcodeprojTests/PackageGraphTests.swift
+++ b/Tests/XcodeprojTests/PackageGraphTests.swift
@@ -61,7 +61,7 @@ class PackageGraphTests: XCTestCase {
                     packageKind: .root,
                     packageLocation: "/Bar",
                     dependencies: [
-                        .scm(name: "Foo", location: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
+                        .scm(location: "/Foo", requirement: .upToNextMajor(from: "1.0.0"))
                     ],
                     targets: [
                         TargetDescription(name: "Bar", dependencies: ["Foo"]),


### PR DESCRIPTION
motivation: follow-on work to the change in 5.5 that _allows_ users to not specify a name on the dependency, this soft-deprecates the ability to do so

changes:
* emit a deprecation warning when using the name attribute on a dependency
* refactor the dependency::name attribute to dependency::deprecatedName to reflect the fact it was deprecated and prevent using it in downstream logic
* cleanup the internal API
* cleanup and add tests