### PR TITLE
Add tools version 5.6 and set it as the current version for `main` branch

### DIFF
--- a/Sources/Basics/SwiftVersion.swift
+++ b/Sources/Basics/SwiftVersion.swift
@@ -63,7 +63,7 @@ public struct SwiftVersion {
 extension SwiftVersion {
     /// The current version of the package manager.
     public static let currentVersion = SwiftVersion(
-        version: (5, 5, 0),
+        version: (5, 6, 0),
         isDevelopment: true,
         buildIdentifier: getBuildIdentifier()
     )

--- a/Sources/PackageModel/ToolsVersion.swift
+++ b/Sources/PackageModel/ToolsVersion.swift
@@ -24,6 +24,7 @@ public struct ToolsVersion: Equatable, Hashable, Codable {
     public static let v5_3 = ToolsVersion(version: "5.3.0")
     public static let v5_4 = ToolsVersion(version: "5.4.0")
     public static let v5_5 = ToolsVersion(version: "5.5.0")
+    public static let v5_6 = ToolsVersion(version: "5.6.0")
     public static let vNext = ToolsVersion(version: "999.0.0")
 
     /// The current tools version in use.


### PR DESCRIPTION
Add tools version 5.6 and set it as the current version for `main` branch

### Motivation:

It's not clear yet whether this will be the next version, but we need a new version in order to remove the gates for the plugin support.  We can always adjust it later when the next version of Swift gets an official version number.

### Modifications:

- add `v5_6` enum
- set 5.6.0 as the current SwiftPM version (but keep it marked as being in development)

A separate PR will adjust the plugin availability.