### PR TITLE
Enable package plugins with a 5.6 deployment target without a special environment variable

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/ContrivedTestPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/ContrivedTestPlugin/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.6
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.6
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/Plugins/MySourceGenClient/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/MySourceGenClient/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.6
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/Plugins/MySourceGenPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/MySourceGenPlugin/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.6
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/Plugins/SandboxTesterPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/SandboxTesterPlugin/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.6
 import PackageDescription
 
 let package = Package(

--- a/Sources/PackageDescription/Product.swift
+++ b/Sources/PackageDescription/Product.swift
@@ -190,7 +190,7 @@ public class Product: Encodable {
     /// - Parameters:
     ///     - name: The name of the plugin product.
     ///     - targets: The plugin targets to vend as a product.
-    @available(_PackageDescription, introduced: 5.5)
+    @available(_PackageDescription, introduced: 5.6)
     public static func plugin(
         name: String,
         targets: [String]

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -119,7 +119,7 @@ public final class Target {
     public let providers: [SystemPackageProvider]?
     
     /// The capability provided by a package plugin target.
-    @available(_PackageDescription, introduced: 5.5)
+    @available(_PackageDescription, introduced: 5.6)
     public var pluginCapability: PluginCapability? {
         get { return _pluginCapability }
         set { _pluginCapability = newValue }
@@ -174,7 +174,7 @@ public final class Target {
     private var _checksum: String?
     
     /// The usages of package plugins by the target.
-    @available(_PackageDescription, introduced: 5.5)
+    @available(_PackageDescription, introduced: 5.6)
     public var plugins: [PluginUsage]? {
         get { return _pluginUsages }
         set { _pluginUsages = newValue }
@@ -394,7 +394,7 @@ public final class Target {
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    @available(_PackageDescription, introduced: 5.3, obsoleted: 5.5)
+    @available(_PackageDescription, introduced: 5.3, obsoleted: 5.6)
     public static func target(
         name: String,
         dependencies: [Dependency] = [],
@@ -448,7 +448,7 @@ public final class Target {
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
     ///   - plugins: The plugins used by this target.
-    @available(_PackageDescription, introduced: 5.5)
+    @available(_PackageDescription, introduced: 5.6)
     public static func target(
         name: String,
         dependencies: [Dependency] = [],
@@ -504,7 +504,7 @@ public final class Target {
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    @available(_PackageDescription, introduced: 5.4, obsoleted: 5.5)
+    @available(_PackageDescription, introduced: 5.4, obsoleted: 5.6)
     public static func executableTarget(
         name: String,
         dependencies: [Dependency] = [],
@@ -559,7 +559,7 @@ public final class Target {
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
     ///   - plugins: The plugins used by this target.
-    @available(_PackageDescription, introduced: 5.5)
+    @available(_PackageDescription, introduced: 5.6)
     public static func executableTarget(
         name: String,
         dependencies: [Dependency] = [],
@@ -694,7 +694,7 @@ public final class Target {
     ///   - cxxSettings: The C++ settings for this target.
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
-    @available(_PackageDescription, introduced: 5.3, obsoleted: 5.5)
+    @available(_PackageDescription, introduced: 5.3, obsoleted: 5.6)
     public static func testTarget(
         name: String,
         dependencies: [Dependency] = [],
@@ -745,7 +745,7 @@ public final class Target {
     ///   - swiftSettings: The Swift settings for this target.
     ///   - linkerSettings: The linker settings for this target.
     ///   - plugins: The plugins used by this target.
-    @available(_PackageDescription, introduced: 5.5)
+    @available(_PackageDescription, introduced: 5.6)
     public static func testTarget(
         name: String,
         dependencies: [Dependency] = [],
@@ -896,7 +896,7 @@ public final class Target {
     /// on executables as well as binary targets. This is because of limitations
     /// in how SwiftPM constructs its build plan, and the goal is to remove this
     /// restriction in a future release.
-    @available(_PackageDescription, introduced: 5.5)
+    @available(_PackageDescription, introduced: 5.6)
     public static func plugin(
         name: String,
         capability: PluginCapability,
@@ -1006,7 +1006,7 @@ extension Target.PluginCapability {
     /// Specifies that the plugin provides a build tool capability. The plugin
     /// will be applied to each target that uses it and should create commands
     /// that will run before or during the build of the target.
-    @available(_PackageDescription, introduced: 5.5)
+    @available(_PackageDescription, introduced: 5.6)
     public static func buildTool() -> Target.PluginCapability {
         return ._buildTool
     }
@@ -1017,7 +1017,7 @@ extension Target.PluginUsage {
     ///
     /// - parameters:
     ///   - name: The name of the plugin target.
-    @available(_PackageDescription, introduced: 5.5)
+    @available(_PackageDescription, introduced: 5.6)
     public static func plugin(name: String) -> Target.PluginUsage {
         return ._pluginItem(name: name, package: nil)
     }
@@ -1027,7 +1027,7 @@ extension Target.PluginUsage {
     /// - parameters:
     ///   - name: The name of the plugin product.
     ///   - package: The name of the package in which it is defined.
-    @available(_PackageDescription, introduced: 5.5)
+    @available(_PackageDescription, introduced: 5.6)
     public static func plugin(name: String, package: String) -> Target.PluginUsage {
         return ._pluginItem(name: name, package: package)
     }

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -30,7 +30,6 @@ extension PackageGraph {
         diagnostics: DiagnosticsEngine,
         fileSystem: FileSystem = localFileSystem,
         shouldCreateMultipleTestProducts: Bool = false,
-        allowPluginTargets: Bool = false,
         createREPLProduct: Bool = false
     ) throws -> PackageGraph {
 
@@ -117,7 +116,6 @@ extension PackageGraph {
                         fileSystem: fileSystem,
                         diagnostics: diagnostics,
                         shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts,
-                        allowPluginTargets: allowPluginTargets,
                         createREPLProduct: manifest.packageKind == .root ? createREPLProduct : false
                     )
                     let package = try builder.construct()

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -69,9 +69,6 @@ public enum ModuleError: Swift.Error {
     /// Default localization not set in the presence of localized resources.
     case defaultLocalizationNotSet
 
-    /// A plugin target was declared but the feature flag isn't enabled.
-    case pluginTargetRequiresFeatureFlag(target: String)
-
     /// A plugin target didn't declare a capability.
     case pluginCapabilityNotDeclared(target: String)
 }
@@ -118,8 +115,6 @@ extension ModuleError: CustomStringConvertible {
             return "invalid header search path '\(path)'; header search path should not be outside the package root"
         case .defaultLocalizationNotSet:
             return "manifest property 'defaultLocalization' not set; it is required in the presence of localized resources"
-        case .pluginTargetRequiresFeatureFlag(let target):
-            return "plugin target '\(target)' cannot be used because the feature isn't enabled (set SWIFTPM_ENABLE_PLUGINS=1 in environment)"
         case .pluginCapabilityNotDeclared(let target):
             return "plugin target '\(target)' doesn't have a 'capability' property"
         }
@@ -244,10 +239,6 @@ public final class PackageBuilder {
     /// Temporary parameter controlling whether to warn about implicit executable targets when tools version is 5.4.
     private let warnAboutImplicitExecutableTargets: Bool
 
-    /// Temporary parameter controlling whether to allow package plugin targets (during bring-up, before proposal is accepted).
-    /// This is set if SWIFTPM_ENABLE_PLUGINS=1 or if the feature is enabled in the initializer (for use by unit tests).
-    private let allowPluginTargets: Bool
-    
     /// Create the special REPL product for this package.
     private let createREPLProduct: Bool
 
@@ -280,7 +271,6 @@ public final class PackageBuilder {
         diagnostics: DiagnosticsEngine,
         shouldCreateMultipleTestProducts: Bool = false,
         warnAboutImplicitExecutableTargets: Bool = true,
-        allowPluginTargets: Bool = false,
         createREPLProduct: Bool = false
     ) {
         self.identity = identity
@@ -293,7 +283,6 @@ public final class PackageBuilder {
         self.fileSystem = fileSystem
         self.diagnostics = diagnostics
         self.shouldCreateMultipleTestProducts = shouldCreateMultipleTestProducts
-        self.allowPluginTargets = allowPluginTargets || ProcessEnv.vars["SWIFTPM_ENABLE_PLUGINS"] == "1"
         self.createREPLProduct = createREPLProduct
         self.warnAboutImplicitExecutableTargets = warnAboutImplicitExecutableTargets
     }
@@ -857,9 +846,6 @@ public final class PackageBuilder {
         
         // Deal with package plugin targets.
         if potentialModule.type == .plugin {
-            guard allowPluginTargets else {
-                throw ModuleError.pluginTargetRequiresFeatureFlag(target: manifestTarget.name)
-            }
             guard let declaredCapability = manifestTarget.pluginCapability else {
                 throw ModuleError.pluginCapabilityNotDeclared(target: manifestTarget.name)
             }

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -226,7 +226,6 @@ public func loadPackageGraph(
     binaryArtifacts: [BinaryArtifact] = [],
     explicitProduct: String? = nil,
     shouldCreateMultipleTestProducts: Bool = false,
-    allowPluginTargets: Bool = false,
     createREPLProduct: Bool = false,
     useXCBuildFileRules: Bool = false
 ) throws -> PackageGraph {
@@ -245,7 +244,6 @@ public func loadPackageGraph(
         diagnostics: diagnostics,
         fileSystem: fs,
         shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts,
-        allowPluginTargets: allowPluginTargets,
         createREPLProduct: createREPLProduct
     )
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -662,7 +662,6 @@ extension Workspace {
         createREPLProduct: Bool = false,
         forceResolvedVersions: Bool = false,
         diagnostics: DiagnosticsEngine,
-        allowPluginTargets: Bool = false,
         xcTestMinimumDeploymentTargets: [PackageModel.Platform:PlatformVersion]? = nil
     ) throws -> PackageGraph {
 
@@ -700,7 +699,6 @@ extension Workspace {
             diagnostics: diagnostics,
             fileSystem: fileSystem,
             shouldCreateMultipleTestProducts: createMultipleTestProducts,
-            allowPluginTargets: allowPluginTargets,
             createREPLProduct: createREPLProduct
         )
     }

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -274,7 +274,7 @@ final class PackageToolTests: XCTestCase {
     func testDescribePackageUsingPlugins() throws {
         fixture(name: "Miscellaneous/Plugins/MySourceGenPlugin") { prefix in
             // Generate the JSON description.
-            let result = try SwiftPMProduct.SwiftPackage.executeProcess(["describe", "--type=json"], packagePath: prefix, env: ["SWIFTPM_ENABLE_PLUGINS": "1"])
+            let result = try SwiftPMProduct.SwiftPackage.executeProcess(["describe", "--type=json"], packagePath: prefix)
             XCTAssert(result.exitStatus == .terminated(code: 0), "`swift-package describe` failed: \(String(describing: try? result.utf8stderrOutput()))")
             let json = try JSON(bytes: ByteString(encodingAsUTF8: result.utf8Output()))
 

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -22,7 +22,7 @@ class PluginTests: XCTestCase {
         
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
-                let (stdout, _) = try executeSwiftBuild(path.appending(component: "MySourceGenPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"], env: ["SWIFTPM_ENABLE_PLUGINS": "1"])
+                let (stdout, _) = try executeSwiftBuild(path.appending(component: "MySourceGenPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
                 XCTAssert(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
                 XCTAssert(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
                 XCTAssert(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
@@ -43,7 +43,7 @@ class PluginTests: XCTestCase {
 
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
-                let (stdout, _) = try executeSwiftBuild(path.appending(component: "MySourceGenClient"), configuration: .Debug, extraArgs: ["--product", "MyTool"], env: ["SWIFTPM_ENABLE_PLUGINS": "1"])
+                let (stdout, _) = try executeSwiftBuild(path.appending(component: "MySourceGenClient"), configuration: .Debug, extraArgs: ["--product", "MyTool"])
                 XCTAssert(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
                 XCTAssert(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
                 XCTAssert(stdout.contains("Linking MyTool"), "stdout:\n\(stdout)")
@@ -64,7 +64,7 @@ class PluginTests: XCTestCase {
 
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
-                let (stdout, _) = try executeSwiftBuild(path.appending(component: "MySourceGenPlugin"), configuration: .Debug, extraArgs: ["--product", "MyOtherLocalTool"], env: ["SWIFTPM_ENABLE_PLUGINS": "1"])
+                let (stdout, _) = try executeSwiftBuild(path.appending(component: "MySourceGenPlugin"), configuration: .Debug, extraArgs: ["--product", "MyOtherLocalTool"])
                 XCTAssert(stdout.contains("Compiling MyOtherLocalTool bar.swift"), "stdout:\n\(stdout)")
                 XCTAssert(stdout.contains("Compiling MyOtherLocalTool baz.swift"), "stdout:\n\(stdout)")
                 XCTAssert(stdout.contains("Linking MyOtherLocalTool"), "stdout:\n\(stdout)")
@@ -85,7 +85,7 @@ class PluginTests: XCTestCase {
         
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
-                let (stdout, _) = try executeSwiftBuild(path.appending(component: "ContrivedTestPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"], env: ["SWIFTPM_ENABLE_PLUGINS": "1"])
+                let (stdout, _) = try executeSwiftBuild(path.appending(component: "ContrivedTestPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
                 XCTAssert(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
                 XCTAssert(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
                 XCTAssert(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
@@ -107,7 +107,7 @@ class PluginTests: XCTestCase {
         #if os(macOS)
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
-                let (stdout, _) = try executeSwiftBuild(path.appending(component: "SandboxTesterPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"], env: ["SWIFTPM_ENABLE_PLUGINS": "1"])
+                let (stdout, _) = try executeSwiftBuild(path.appending(component: "SandboxTesterPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
                 XCTAssert(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
                 XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
             }
@@ -128,7 +128,7 @@ class PluginTests: XCTestCase {
         #if os(macOS)
         fixture(name: "Miscellaneous/Plugins") { path in
             do {
-                let (stdout, _) = try executeSwiftBuild(path.appending(component: "MyBinaryToolPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"], env: ["SWIFTPM_ENABLE_PLUGINS": "1"])
+                let (stdout, _) = try executeSwiftBuild(path.appending(component: "MyBinaryToolPlugin"), configuration: .Debug, extraArgs: ["--product", "MyLocalTool"])
                 XCTAssert(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
                 XCTAssert(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
             }

--- a/Tests/PackageLoadingTests/PD_5_4_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_4_LoadingTests.swift
@@ -39,32 +39,4 @@ class PackageDescription5_4LoadingTests: PackageDescriptionLoadingTests {
             XCTAssertEqual(manifest.targets[0].type, .executable)
         }
     }
-    
-    func testPluginsAreUnavailable() throws {
-        let stream = BufferedOutputByteStream()
-        stream <<< """
-            import PackageDescription
-            let package = Package(
-               name: "Foo",
-               targets: [
-                   .plugin(
-                       name: "Foo",
-                       capability: .buildTool()
-                   ),
-               ]
-            )
-            """
-        do {
-            try loadManifestThrowing(stream.bytes) { _ in }
-            XCTFail("expected manifest loading to fail, but it succeeded")
-        }
-        catch {
-            guard case let ManifestParseError.invalidManifestFormat(message, _) = error else {
-                return XCTFail("expected an invalidManifestFormat error, but got: \(error)")
-            }
-
-            XCTAssertMatch(message, .contains("is unavailable"))
-            XCTAssertMatch(message, .contains("was introduced in PackageDescription 5.5"))
-        }
-    }
 }

--- a/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
@@ -9,6 +9,7 @@
 */
 
 import PackageModel
+import TSCBasic
 import XCTest
 
 class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
@@ -66,4 +67,51 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
         }
     }
 
+    func testBuildToolPluginTarget() throws {
+        let stream = BufferedOutputByteStream()
+        stream <<< """
+            import PackageDescription
+            let package = Package(
+               name: "Foo",
+               targets: [
+                   .plugin(
+                       name: "Foo",
+                       capability: .buildTool()
+                    )
+               ]
+            )
+            """
+
+        loadManifest(stream.bytes) { manifest in
+            XCTAssertEqual(manifest.targets[0].type, .plugin)
+            XCTAssertEqual(manifest.targets[0].pluginCapability, .buildTool)
+        }
+    }
+
+    func testPluginTargetCustomization() throws {
+        let stream = BufferedOutputByteStream()
+        stream <<< """
+            import PackageDescription
+            let package = Package(
+               name: "Foo",
+               targets: [
+                   .plugin(
+                       name: "Foo",
+                       capability: .buildTool(),
+                       path: "Sources/Foo",
+                       exclude: ["IAmOut.swift"],
+                       sources: ["CountMeIn.swift"]
+                    )
+               ]
+            )
+            """
+
+        loadManifest(stream.bytes) { manifest in
+            XCTAssertEqual(manifest.targets[0].type, .plugin)
+            XCTAssertEqual(manifest.targets[0].pluginCapability, .buildTool)
+            XCTAssertEqual(manifest.targets[0].path, "Sources/Foo")
+            XCTAssertEqual(manifest.targets[0].exclude, ["IAmOut.swift"])
+            XCTAssertEqual(manifest.targets[0].sources, ["CountMeIn.swift"])
+        }
+    }
 }

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -62,8 +62,7 @@ class PluginInvocationTests: XCTestCase {
                         ),
                     ]
                 )
-            ],
-            allowPluginTargets: true
+            ]
         )
         
         // Check the basic integrity before running plugins.

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -282,6 +282,6 @@ class ManifestSourceGenerationTests: XCTestCase {
                 ]
             )
             """
-        try testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_5)
+        try testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_6)
     }
 }


### PR DESCRIPTION
Enable package plugins with a 5.6 deployment target without a special environment variable.

This removes the `SWIFTPM_ENABLE_PLUGINS` environment variable and sets the availability annotations to 5.6.

### Motivation:

The goal is to make plugins available without special flags in the next version of SwiftPM.

### Modifications:

- remove `SWIFTPM_ENABLE_PLUGINS` and associated flags
- set availability annotations for package plugins as 5.6

### Result:

Package plugins can be used without special flags or environment variables.