### PR TITLE
PackageDescription: repair the build after #3635

### DIFF
--- a/Sources/PackageDescription/PackageDescription.swift
+++ b/Sources/PackageDescription/PackageDescription.swift
@@ -8,6 +8,14 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+#if canImport(Glibc)
+@_implementationOnly import Glibc
+#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+@_implementationOnly import Darwin.C
+#elseif os(Windows)
+@_implementationOnly import ucrt
+@_implementationOnly import struct WinSDK.HANDLE
+#endif
 import Foundation
 
 /// The configuration of a Swift package.


### PR DESCRIPTION
The C imports are important, particularly on Windows, where `HANDLE` is
not available without the platform SDK (`WinSDK` is roughly synonymous
to `Darwin`).

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
