### PR TITLE
add a couple of availability flags on new data structures

### DIFF
--- a/Sources/PackageDescription/PackageRequirement.swift
+++ b/Sources/PackageDescription/PackageRequirement.swift
@@ -169,6 +169,7 @@ extension Package.Dependency {
     /// can't be added as dependencies to packages that use version-based
     /// dependency requirements; you should remove commit-based dependency
     /// requirements before publishing a version of your package.
+    @available(_PackageDescription, introduced: 5.6)
     public enum SourceControlRequirement {
         case exact(Version)
         case range(Range<Version>)
@@ -222,6 +223,7 @@ extension Package.Dependency {
     /// can't be added as dependencies to packages that use version-based
     /// dependency requirements; you should remove commit-based dependency
     /// requirements before publishing a version of your package.
+    @available(_PackageDescription, introduced: 999)
     public enum RegistryRequirement {
         case exact(Version)
         case range(Range<Version>)


### PR DESCRIPTION
motivation: new data structures should not be exposed pre-maturily

changes: add availability flag on RegistryRequirement and SourceControlRequirement
