### PR TITLE
Enable lenient parsing of Git version tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Note: This is in reverse chronological order, so newer entries are added to the 
 
 Swift v.Next
  -----------
+ * [#3649]
+     Semantic version dependencies can now be resolved against Git tag names that contain only major and minor version identifiers.  A tag with the form `X.Y` will be treated as `X.Y.0`. This improves compatibility with existing repositories.
 
 
 

--- a/Sources/Basics/Version+Extensions.swift
+++ b/Sources/Basics/Version+Extensions.swift
@@ -16,9 +16,9 @@ extension Version {
     /// - Parameter tag: A version string possibly prepended with "v".
     public init?(tag: String) {
         if tag.first == "v" {
-            self.init(string: String(tag.dropFirst()))
+            try? self.init(versionString: String(tag.dropFirst()), usesLenientParsing: true)
         } else {
-            self.init(string: tag)
+            try? self.init(versionString: tag, usesLenientParsing: true)
         }
     }
 }

--- a/Sources/PackageGraph/RepositoryPackageContainer.swift
+++ b/Sources/PackageGraph/RepositoryPackageContainer.swift
@@ -96,9 +96,23 @@ public class RepositoryPackageContainer: PackageContainer, CustomStringConvertib
             let knownVersionsWithDuplicates = Git.convertTagsToVersionMap(try repository.getTags())
 
             return knownVersionsWithDuplicates.mapValues({ tags -> String in
-                if tags.count == 2 {
+                if tags.count > 1 {
                     // FIXME: Warn if the two tags point to different git references.
-                    return tags.first(where: { !$0.hasPrefix("v") })!
+                    
+                    // If multiple tags are present with the same semantic version (e.g. v1.0.0, 1.0.0, 1.0) reconcile which one we prefer.
+                    // Prefer the most specific tag, e.g. 1.0.0 is preferred over 1.0.
+                    // Sort the tags so the most specific tag is first, order is ascending so the most specific tag will be last
+                    let tagsSortedBySpecificity = tags.sorted {
+                        let componentCounts = ($0.components(separatedBy: ".").count, $1.components(separatedBy: ".").count)
+                        if componentCounts.0 == componentCounts.1 {
+                            //if they are both have the same number of components, favor the one without a v prefix.
+                            //this matches previously defined behavior
+                            //this assumes we can only enter this situation because one tag has a v prefix and the other does not.
+                            return $0.hasPrefix("v")
+                        }
+                        return componentCounts.0 < componentCounts.1
+                    }
+                    return tagsSortedBySpecificity.last!
                 }
                 assert(tags.count == 1, "Unexpected number of tags")
                 return tags[0]

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -341,6 +341,12 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         try repo.commit()
         try repo.tag(name: "v1.0.0")
         try repo.tag(name: "1.0.0")
+        try repo.tag(name: "v1.1.0")
+        try repo.tag(name: "1.1.0")
+        try repo.tag(name: "1.1")
+        try repo.tag(name: "1.2")
+        try repo.tag(name: "1.3")
+        try repo.tag(name: "1.3.0")
         try repo.tag(name: "1.0.1")
         try repo.tag(name: "v1.0.2")
         try repo.tag(name: "1.0.4")
@@ -366,7 +372,7 @@ class RepositoryPackageContainerProviderTests: XCTestCase {
         let ref = PackageReference.remote(identity: PackageIdentity(path: repoPath), location: repoPath.pathString)
         let container = try provider.getContainer(for: ref, skipUpdate: false)
         let v = try container.toolsVersionsAppropriateVersionsDescending().map { $0 }
-        XCTAssertEqual(v, ["2.0.1", "1.0.4", "1.0.2", "1.0.1", "1.0.0"])
+        XCTAssertEqual(v, ["2.0.1", "1.3.0", "1.2.0", "1.1.0", "1.0.4", "1.0.2", "1.0.1", "1.0.0"])
     }
 
     func testDependencyConstraints() throws {


### PR DESCRIPTION
### Motivation:

While implementing SPM manifests in existing Git repos, I found many were using two component tags where the patch version was 0. The intention behind this change is to better support that Git tagging pattern without retraining existing teams, or causing SPM integration to be disruptive to existing tagging practices.

### Modifications:

Lenient parsing was added to swift-tools-support-core at apple/swift-tools-support-core#212. The tag based initializer for Version was altered to use this new lenient initializer.

It’s possible for two tags with the same meaning but different literal strings to be present in the same repository. This case did exist previously. Tags like v2.0.0 and 2.0.0 could conflict, and a decision about which tag to use would be required.
- Previous behavior was that a tag without a v-prefix would be preferred over one with a v-prefix. This behavior was maintained.
- A tag with more version components/more specificity is preferred. For example, 2.0.0 will be preferred over 2.0.

### Result:

Git tags with two version components will now be supported and parsed as if there was a patch version of .0 appended to the end.
