### PR TITLE
Add document comment to PackageContainerConstraint function

### DIFF
--- a/Sources/PackageGraph/PackageModel+Extensions.swift
+++ b/Sources/PackageGraph/PackageModel+Extensions.swift
@@ -49,6 +49,8 @@ extension Manifest {
 }
 
 extension PackageContainerConstraint {
+    /// Constructs a structure of dependency nodes in a package.
+    /// - returns: An array of ``DependencyResolutionNode``
     internal func nodes() -> [DependencyResolutionNode] {
         switch products {
         case .everything:


### PR DESCRIPTION
Improves the documentation of the function `nodes` from `PackageContainerConstraint`.

### Motivation:

Further improves the documentation of Swift Package Manager. Makes it easier for developers to read inline docs of this particular function in particular and its module in general. 

### Modifications:

Added mark-up comments to the function `nodes` from `PackageContainerConstraint`.

### Result:

SPM's Documentation is improved.

---
Thank you! This is my first time opening a PR for SPM, so I would really appreciate any feedbacks or guidances!
