### PR TITLE
improve cached manifest error handling

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -324,25 +324,17 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
                 // Validate that the file exists.
                 guard fileSystem.isFile(path) else {
-                    throw PackageModel.Package.Error.noManifest(
-                        at: path, version: version?.description)
+                    throw PackageModel.Package.Error.noManifest(at: path, version: version?.description)
                 }
 
-                // Get the JSON string for the manifest.
-                let jsonString = try self.loadJSONString(
+                let parsedManifest = try self.parseAndCacheManifest(
                     at: path,
                     packageIdentity: packageIdentity,
+                    packageLocation: packageLocation,
                     toolsVersion: toolsVersion,
+                    identityResolver: identityResolver,
                     fileSystem: fileSystem,
-                    diagnostics: diagnostics
-                )
-
-                // Load the manifest from JSON.
-                let parsedManifest = try ManifestJSONParser.parse(v4: jsonString,
-                                                                  toolsVersion: toolsVersion,
-                                                                  packageLocation: packageLocation,
-                                                                  identityResolver: identityResolver,
-                                                                  fileSystem: fileSystem)
+                    diagnostics: diagnostics)
 
                 // Convert legacy system packages to the current target‐based model.
                 var products = parsedManifest.products
@@ -541,27 +533,18 @@ public final class ManifestLoader: ManifestLoaderProtocol {
     }
 
     /// Load the JSON string for the given manifest.
-    private func loadJSONString(
-        at path: AbsolutePath,
+    private func parseManifest(
+        _ result: CompilationResult,
         packageIdentity: PackageIdentity,
+        packageLocation: String,
         toolsVersion: ToolsVersion,
+        identityResolver: IdentityResolver,
         fileSystem: FileSystem,
         diagnostics: DiagnosticsEngine?
-    ) throws -> String {
-
-        let cacheKey = try ManifestCacheKey(
-            packageIdentity: packageIdentity,
-            manifestPath: path,
-            toolsVersion: toolsVersion,
-            env: ProcessEnv.vars,
-            swiftpmVersion: SwiftVersion.currentVersion.displayString,
-            fileSystem: fileSystem
-        )
-
-        let result = self.parseAndCacheManifest(key: cacheKey, diagnostics: diagnostics)
+    ) throws -> ManifestJSONParser.Result {
         // Throw now if we weren't able to parse the manifest.
-        guard let parsedManifest = result.parsedManifest else {
-            let errors = result.errorOutput ?? result.compilerOutput ?? "Unknown error parsing manifest for \(packageIdentity)"
+        guard let manifestJSON = result.manifestJSON, !manifestJSON.isEmpty else {
+            let errors = result.errorOutput ?? result.compilerOutput ?? "Missing or empty JSON output from manifest compilation for \(packageIdentity)"
             throw ManifestParseError.invalidManifestFormat(errors, diagnosticFile: result.diagnosticFile)
         }
 
@@ -577,49 +560,85 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             }
         }
 
-        return parsedManifest
+        return try ManifestJSONParser.parse(v4: manifestJSON,
+                                            toolsVersion: toolsVersion,
+                                            packageLocation: packageLocation,
+                                            identityResolver: identityResolver,
+                                            fileSystem: fileSystem)
     }
 
-    fileprivate func parseAndCacheManifest(key: ManifestCacheKey, diagnostics: DiagnosticsEngine?) -> ManifestParseResult {
-        let cache = self.databaseCacheDir.map { cacheDir -> SQLiteBackedCache<ManifestParseResult> in
+    private func parseAndCacheManifest(
+        at path: AbsolutePath,
+        packageIdentity: PackageIdentity,
+        packageLocation: String,
+        toolsVersion: ToolsVersion,
+        identityResolver: IdentityResolver,
+        fileSystem: FileSystem,
+        diagnostics: DiagnosticsEngine?
+    ) throws -> ManifestJSONParser.Result {
+        let cache = self.databaseCacheDir.map { cacheDir -> SQLiteBackedCache<CompilationResult> in
             let path = Self.manifestCacheDBPath(cacheDir)
             var configuration = SQLiteBackedCacheConfiguration()
             // FIXME: expose as user-facing configuration
             configuration.maxSizeInMegabytes = 100
             configuration.truncateWhenFull = true
-            return SQLiteBackedCache<ManifestParseResult>(tableName: "MANIFEST_CACHE", location: .path(path), configuration: configuration, diagnosticsEngine: diagnostics)
+            return SQLiteBackedCache<CompilationResult>(tableName: "MANIFEST_CACHE", location: .path(path), configuration: configuration, diagnosticsEngine: diagnostics)
         }
 
         // TODO: we could wrap the failure here with diagnostics if it wasn't optional throughout
         defer { try? cache?.close() }
 
+        let key = try CacheKey(
+            packageIdentity: packageIdentity,
+            manifestPath: path,
+            toolsVersion: toolsVersion,
+            env: ProcessEnv.vars,
+            swiftpmVersion: SwiftVersion.currentVersion.displayString,
+            fileSystem: fileSystem
+        )
+
         do {
-            if let result = try cache?.get(key: key.sha256Checksum) {
-                return result
+            // try to get it from the cache
+            if let result = try cache?.get(key: key.sha256Checksum), let manifestJSON = result.manifestJSON, !manifestJSON.isEmpty {
+                return try self.parseManifest(
+                    result,
+                    packageIdentity: packageIdentity,
+                    packageLocation: packageLocation,
+                    toolsVersion: toolsVersion,
+                    identityResolver: identityResolver,
+                    fileSystem: fileSystem,
+                    diagnostics: diagnostics)
             }
         } catch {
-            diagnostics?.emit(.warning("failed loading manifest for '\(key.packageIdentity)' from cache: \(error)"))
+            diagnostics?.emit(.warning("failed loading cached manifest for '\(key.packageIdentity)': \(error)"))
         }
 
-        let result = self.parse(packageIdentity: key.packageIdentity,
-                                manifestPath: key.manifestPath,
-                                manifestContents: key.manifestContents,
-                                toolsVersion: key.toolsVersion)
+        // shells out and compiles the manifest, finally output a JSON
+        let result = self.compileManifestToJSON(packageIdentity: key.packageIdentity,
+                                                manifestPath: key.manifestPath,
+                                                manifestContents: key.manifestContents,
+                                                toolsVersion: key.toolsVersion)
 
-        // only cache successfully parsed manifests,
-        // this is important for swift-pm development
-        if !result.hasErrors {
-            do {
-                try cache?.put(key: key.sha256Checksum, value: result)
-            } catch {
-                diagnostics?.emit(.warning("failed storing manifest for '\(key.packageIdentity)' in cache: \(error)"))
-            }
+        // only cache successfully parsed manifests
+        let parseManifest = try self.parseManifest(
+            result,
+            packageIdentity: packageIdentity,
+            packageLocation: packageLocation,
+            toolsVersion: toolsVersion,
+            identityResolver: identityResolver,
+            fileSystem: fileSystem,
+            diagnostics: diagnostics)
+
+        do {
+            try cache?.put(key: key.sha256Checksum, value: result)
+        } catch {
+            diagnostics?.emit(.warning("failed storing manifest for '\(key.packageIdentity)' in cache: \(error)"))
         }
 
-        return result
+        return parseManifest
     }
 
-    internal struct ManifestCacheKey: Hashable {
+    internal struct CacheKey: Hashable {
         let packageIdentity: PackageIdentity
         let manifestPath: AbsolutePath
         let manifestContents: [UInt8]
@@ -670,11 +689,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         }
     }
 
-    internal struct ManifestParseResult: Codable {
-        var hasErrors: Bool {
-            return parsedManifest == nil
-        }
-
+    internal struct CompilationResult: Codable {
         /// The path to the diagnostics file (.dia).
         ///
         /// This is only present if serialized diagnostics are enabled.
@@ -685,211 +700,219 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         /// This would contain the errors and warnings produced when loading the manifest file.
         var compilerOutput: String?
 
-        /// The parsed manifest in JSON format.
-        var parsedManifest: String?
+        /// The manifest in JSON format.
+        var manifestJSON: String?
 
         /// Any non-compiler error that might have occurred during manifest loading.
         ///
         /// For e.g., we could have failed to spawn the process or create temporary file.
         var errorOutput: String? {
             didSet {
-                assert(parsedManifest == nil)
+                assert(self.manifestJSON == nil)
             }
+        }
+
+        var hasErrors: Bool {
+            return self.manifestJSON == nil
         }
     }
 
-    /// Parse the manifest at the given path to JSON.
-    fileprivate func parse(
+    /// Compiler the manifest at the given path and retrieve the JSON.
+    fileprivate func compileManifestToJSON(
         packageIdentity: PackageIdentity,
         manifestPath: AbsolutePath,
         manifestContents: [UInt8],
         toolsVersion: ToolsVersion
-    ) -> ManifestParseResult {
-        /// Helper method for parsing the manifest.
-        func _parse(
-            path manifestPath: AbsolutePath,
-            toolsVersion: ToolsVersion,
-            manifestParseResult: inout ManifestParseResult
-        ) throws {
-            self.delegate?.willParse(manifest: manifestPath)
+    ) -> CompilationResult {
 
-            // The compiler has special meaning for files with extensions like .ll, .bc etc.
-            // Assert that we only try to load files with extension .swift to avoid unexpected loading behavior.
-            assert(manifestPath.extension == "swift",
-                   "Manifest files must contain .swift suffix in their name, given: \(manifestPath).")
-
-            // For now, we load the manifest by having Swift interpret it directly.
-            // Eventually, we should have two loading processes, one that loads only
-            // the declarative package specification using the Swift compiler directly
-            // and validates it.
-
-            // Compute the path to runtime we need to load.
-            let runtimePath = self.runtimePath(for: toolsVersion)
-
-            // FIXME: Workaround for the module cache bug that's been haunting Swift CI
-            // <rdar://problem/48443680>
-            let moduleCachePath = (ProcessEnv.vars["SWIFTPM_MODULECACHE_OVERRIDE"] ?? ProcessEnv.vars["SWIFTPM_TESTS_MODULECACHE"]).flatMap{ AbsolutePath.init($0) }
-
-            var cmd: [String] = []
-            cmd += [resources.swiftCompiler.pathString]
-            cmd += verbosity.ccArgs
-
-            let macOSPackageDescriptionPath: AbsolutePath
-            // If we got the binDir that means we could be developing SwiftPM in Xcode
-            // which produces a framework for dynamic package products.
-            let packageFrameworkPath = runtimePath.appending(component: "PackageFrameworks")
-            if resources.binDir != nil, localFileSystem.exists(packageFrameworkPath)  {
-                cmd += [
-                    "-F", packageFrameworkPath.pathString,
-                    "-framework", "PackageDescription",
-                    "-Xlinker", "-rpath", "-Xlinker", packageFrameworkPath.pathString,
-                ]
-
-                macOSPackageDescriptionPath = packageFrameworkPath.appending(RelativePath("PackageDescription.framework/PackageDescription"))
-            } else {
-                cmd += [
-                    "-L", runtimePath.pathString,
-                    "-lPackageDescription",
-                ]
-#if !os(Windows)
-                // -rpath argument is not supported on Windows,
-                // so we add runtimePath to PATH when executing the manifest instead
-                cmd += ["-Xlinker", "-rpath", "-Xlinker", runtimePath.pathString]
-#endif
-
-                // note: this is not correct for all platforms, but we only actually use it on macOS.
-                macOSPackageDescriptionPath = runtimePath.appending(RelativePath("libPackageDescription.dylib"))
-            }
-
-            // Use the same minimum deployment target as the PackageDescription library (with a fallback of 10.15).
-            #if os(macOS)
-            let triple = Self._hostTriple.memoize {
-                Triple.getHostTriple(usingSwiftCompiler: resources.swiftCompiler)
-            }
-
-            let version = try Self._packageDescriptionMinimumDeploymentTarget.memoize {
-                (try MinimumDeploymentTarget.computeMinimumDeploymentTarget(of: macOSPackageDescriptionPath, platform: .macOS))?.versionString ?? "10.15"
-            }
-            cmd += ["-target", "\(triple.tripleString(forPlatformVersion: version))"]
-            #endif
-
-            // Add any extra flags required as indicated by the ManifestLoader.
-            cmd += resources.swiftCompilerFlags
-
-            cmd += self.interpreterFlags(for: toolsVersion)
-            if let moduleCachePath = moduleCachePath {
-                cmd += ["-module-cache-path", moduleCachePath.pathString]
-            }
-
-            // Add the arguments for emitting serialized diagnostics, if requested.
-            if self.serializedDiagnostics, let databaseCacheDir = self.databaseCacheDir {
-                let diaDir = databaseCacheDir.appending(component: "ManifestLoading")
-                let diagnosticFile = diaDir.appending(component: "\(packageIdentity).dia")
-                try localFileSystem.createDirectory(diaDir, recursive: true)
-                cmd += ["-Xfrontend", "-serialize-diagnostics-path", "-Xfrontend", diagnosticFile.pathString]
-                manifestParseResult.diagnosticFile = diagnosticFile
-            }
-
-            cmd += [manifestPath.pathString]
-
-            cmd += self.extraManifestFlags
-
-            try withTemporaryDirectory(removeTreeOnDeinit: true) { tmpDir in
-                // Set path to compiled manifest executable.
-#if os(Windows)
-                let executableSuffix = ".exe"
-#else
-                let executableSuffix = ""
-#endif
-                let compiledManifestFile = tmpDir.appending(component: "\(packageIdentity)-manifest\(executableSuffix)")
-                cmd += ["-o", compiledManifestFile.pathString]
-
-                // Compile the manifest.
-                let compilerResult = try Process.popen(arguments: cmd)
-                let compilerOutput = try (compilerResult.utf8Output() + compilerResult.utf8stderrOutput()).spm_chuzzle()
-                manifestParseResult.compilerOutput = compilerOutput
-
-                // Return now if there was an error.
-                if compilerResult.exitStatus != .terminated(code: 0) {
-                    return
-                }
-
-                // Pass an open file descriptor of a file to which the JSON representation of the manifest will be written.
-                let jsonOutputFile = tmpDir.appending(component: "\(packageIdentity)-output.json")
-                guard let jsonOutputFileDesc = fopen(jsonOutputFile.pathString, "w") else {
-                    throw StringError("couldn't create the manifest's JSON output file")
-                }
-
-                cmd = [compiledManifestFile.pathString]
-#if os(Windows)
-                // NOTE: `_get_osfhandle` returns a non-owning, unsafe,
-                // unretained HANDLE.  DO NOT invoke `CloseHandle` on `hFile`.
-                let hFile: Int = _get_osfhandle(_fileno(jsonOutputFileDesc))
-                cmd += ["-handle", "\(String(hFile, radix: 16))"]
-#else
-                cmd += ["-fileno", "\(fileno(jsonOutputFileDesc))"]
-#endif
-                // If enabled, run command in a sandbox.
-                // This provides some safety against arbitrary code execution when parsing manifest files.
-                // We only allow the permissions which are absolutely necessary.
-                if isManifestSandboxEnabled {
-                    let cacheDirectories = [self.databaseCacheDir, moduleCachePath].compactMap{ $0 }
-                    let strictness: Sandbox.Strictness = toolsVersion < .v5_3 ? .manifest_pre_53 : .default
-                    cmd = Sandbox.apply(command: cmd, writableDirectories: cacheDirectories, strictness: strictness)
-                }
-
-                // Run the compiled manifest.
-                var environment = ProcessEnv.vars
-#if os(Windows)
-                let windowsPathComponent = runtimePath.pathString.replacingOccurrences(of: "/", with: "\\")
-                environment["Path"] = "\(windowsPathComponent);\(environment["Path"] ?? "")"
-#endif
-                let runResult = try Process.popen(arguments: cmd, environment: environment)
-                fclose(jsonOutputFileDesc)
-                let runOutput = try (runResult.utf8Output() + runResult.utf8stderrOutput()).spm_chuzzle()
-                if let runOutput = runOutput {
-                    // Append the runtime output to any compiler output we've received.
-                    manifestParseResult.compilerOutput = (manifestParseResult.compilerOutput ?? "") + runOutput
-                }
-
-                // Return now if there was an error.
-                if runResult.exitStatus != .terminated(code: 0) {
-                    manifestParseResult.errorOutput = runOutput
-                    return
-                }
-
-                // Read the JSON output that was emitted by libPackageDescription.
-                guard let jsonOutput = try localFileSystem.readFileContents(jsonOutputFile).validDescription else {
-                    throw StringError("the manifest's JSON output has invalid encoding")
-                }
-                manifestParseResult.parsedManifest = jsonOutput
-            }
-        }
-
-        var manifestParseResult = ManifestParseResult()
+        var result = CompilationResult()
         do {
             if localFileSystem.isFile(manifestPath) {
-                try _parse(
-                    path: manifestPath,
+                try self.compileManifestToJSON(
+                    at: manifestPath,
+                    packageIdentity: packageIdentity,
                     toolsVersion: toolsVersion,
-                    manifestParseResult: &manifestParseResult
+                    result: &result
                 )
             } else {
                 try withTemporaryFile(suffix: ".swift") { tempFile in
                     try localFileSystem.writeFileContents(tempFile.path, bytes: ByteString(manifestContents))
-                    try _parse(
-                        path: tempFile.path,
+                    try self.compileManifestToJSON(
+                        at: tempFile.path,
+                        packageIdentity: packageIdentity,
                         toolsVersion: toolsVersion,
-                        manifestParseResult: &manifestParseResult
+                        result: &result
                     )
                 }
             }
         } catch {
-            assert(manifestParseResult.parsedManifest == nil)
-            manifestParseResult.errorOutput = error.localizedDescription
+            assert(result.manifestJSON == nil)
+            result.errorOutput = error.localizedDescription
         }
 
-        return manifestParseResult
+        return result
+    }
+
+    /// Helper method for compiling the manifest.
+    func compileManifestToJSON(
+        at manifestPath: AbsolutePath,
+        packageIdentity: PackageIdentity,
+        toolsVersion: ToolsVersion,
+        result: inout CompilationResult
+    ) throws {
+        self.delegate?.willParse(manifest: manifestPath)
+
+        // The compiler has special meaning for files with extensions like .ll, .bc etc.
+        // Assert that we only try to load files with extension .swift to avoid unexpected loading behavior.
+        assert(manifestPath.extension == "swift",
+               "Manifest files must contain .swift suffix in their name, given: \(manifestPath).")
+
+        // For now, we load the manifest by having Swift interpret it directly.
+        // Eventually, we should have two loading processes, one that loads only
+        // the declarative package specification using the Swift compiler directly
+        // and validates it.
+
+        // Compute the path to runtime we need to load.
+        let runtimePath = self.runtimePath(for: toolsVersion)
+
+        // FIXME: Workaround for the module cache bug that's been haunting Swift CI
+        // <rdar://problem/48443680>
+        let moduleCachePath = (ProcessEnv.vars["SWIFTPM_MODULECACHE_OVERRIDE"] ?? ProcessEnv.vars["SWIFTPM_TESTS_MODULECACHE"]).flatMap{ AbsolutePath.init($0) }
+
+        var cmd: [String] = []
+        cmd += [resources.swiftCompiler.pathString]
+        cmd += verbosity.ccArgs
+
+        let macOSPackageDescriptionPath: AbsolutePath
+        // If we got the binDir that means we could be developing SwiftPM in Xcode
+        // which produces a framework for dynamic package products.
+        let packageFrameworkPath = runtimePath.appending(component: "PackageFrameworks")
+        if resources.binDir != nil, localFileSystem.exists(packageFrameworkPath)  {
+            cmd += [
+                "-F", packageFrameworkPath.pathString,
+                "-framework", "PackageDescription",
+                "-Xlinker", "-rpath", "-Xlinker", packageFrameworkPath.pathString,
+            ]
+
+            macOSPackageDescriptionPath = packageFrameworkPath.appending(RelativePath("PackageDescription.framework/PackageDescription"))
+        } else {
+            cmd += [
+                "-L", runtimePath.pathString,
+                "-lPackageDescription",
+            ]
+#if !os(Windows)
+            // -rpath argument is not supported on Windows,
+            // so we add runtimePath to PATH when executing the manifest instead
+            cmd += ["-Xlinker", "-rpath", "-Xlinker", runtimePath.pathString]
+#endif
+
+            // note: this is not correct for all platforms, but we only actually use it on macOS.
+            macOSPackageDescriptionPath = runtimePath.appending(RelativePath("libPackageDescription.dylib"))
+        }
+
+        // Use the same minimum deployment target as the PackageDescription library (with a fallback of 10.15).
+#if os(macOS)
+        let triple = Self._hostTriple.memoize {
+            Triple.getHostTriple(usingSwiftCompiler: resources.swiftCompiler)
+        }
+
+        let version = try Self._packageDescriptionMinimumDeploymentTarget.memoize {
+            (try MinimumDeploymentTarget.computeMinimumDeploymentTarget(of: macOSPackageDescriptionPath, platform: .macOS))?.versionString ?? "10.15"
+        }
+        cmd += ["-target", "\(triple.tripleString(forPlatformVersion: version))"]
+#endif
+
+        // Add any extra flags required as indicated by the ManifestLoader.
+        cmd += resources.swiftCompilerFlags
+
+        cmd += self.interpreterFlags(for: toolsVersion)
+        if let moduleCachePath = moduleCachePath {
+            cmd += ["-module-cache-path", moduleCachePath.pathString]
+        }
+
+        // Add the arguments for emitting serialized diagnostics, if requested.
+        if self.serializedDiagnostics, let databaseCacheDir = self.databaseCacheDir {
+            let diaDir = databaseCacheDir.appending(component: "ManifestLoading")
+            let diagnosticFile = diaDir.appending(component: "\(packageIdentity).dia")
+            try localFileSystem.createDirectory(diaDir, recursive: true)
+            cmd += ["-Xfrontend", "-serialize-diagnostics-path", "-Xfrontend", diagnosticFile.pathString]
+            result.diagnosticFile = diagnosticFile
+        }
+
+        cmd += [manifestPath.pathString]
+
+        cmd += self.extraManifestFlags
+
+        try withTemporaryDirectory(removeTreeOnDeinit: true) { tmpDir in
+            // Set path to compiled manifest executable.
+#if os(Windows)
+            let executableSuffix = ".exe"
+#else
+            let executableSuffix = ""
+#endif
+            let compiledManifestFile = tmpDir.appending(component: "\(packageIdentity)-manifest\(executableSuffix)")
+            cmd += ["-o", compiledManifestFile.pathString]
+
+            // Compile the manifest.
+            let compilerResult = try Process.popen(arguments: cmd)
+            let compilerOutput = try (compilerResult.utf8Output() + compilerResult.utf8stderrOutput()).spm_chuzzle()
+            result.compilerOutput = compilerOutput
+
+            // Return now if there was an error.
+            if compilerResult.exitStatus != .terminated(code: 0) {
+                return
+            }
+
+            // Pass an open file descriptor of a file to which the JSON representation of the manifest will be written.
+            let jsonOutputFile = tmpDir.appending(component: "\(packageIdentity)-output.json")
+            guard let jsonOutputFileDesc = fopen(jsonOutputFile.pathString, "w") else {
+                throw StringError("couldn't create the manifest's JSON output file")
+            }
+
+            cmd = [compiledManifestFile.pathString]
+#if os(Windows)
+            // NOTE: `_get_osfhandle` returns a non-owning, unsafe,
+            // unretained HANDLE.  DO NOT invoke `CloseHandle` on `hFile`.
+            let hFile: Int = _get_osfhandle(_fileno(jsonOutputFileDesc))
+            cmd += ["-handle", "\(String(hFile, radix: 16))"]
+#else
+            cmd += ["-fileno", "\(fileno(jsonOutputFileDesc))"]
+#endif
+            // If enabled, run command in a sandbox.
+            // This provides some safety against arbitrary code execution when parsing manifest files.
+            // We only allow the permissions which are absolutely necessary.
+            if isManifestSandboxEnabled {
+                let cacheDirectories = [self.databaseCacheDir, moduleCachePath].compactMap{ $0 }
+                let strictness: Sandbox.Strictness = toolsVersion < .v5_3 ? .manifest_pre_53 : .default
+                cmd = Sandbox.apply(command: cmd, writableDirectories: cacheDirectories, strictness: strictness)
+            }
+
+            // Run the compiled manifest.
+            var environment = ProcessEnv.vars
+#if os(Windows)
+            let windowsPathComponent = runtimePath.pathString.replacingOccurrences(of: "/", with: "\\")
+            environment["Path"] = "\(windowsPathComponent);\(environment["Path"] ?? "")"
+#endif
+            let runResult = try Process.popen(arguments: cmd, environment: environment)
+            fclose(jsonOutputFileDesc)
+            let runOutput = try (runResult.utf8Output() + runResult.utf8stderrOutput()).spm_chuzzle()
+            if let runOutput = runOutput {
+                // Append the runtime output to any compiler output we've received.
+                result.compilerOutput = (result.compilerOutput ?? "") + runOutput
+            }
+
+            // Return now if there was an error.
+            if runResult.exitStatus != .terminated(code: 0) {
+                result.errorOutput = runOutput
+                return
+            }
+
+            // Read the JSON output that was emitted by libPackageDescription.
+            guard let jsonOutput = try localFileSystem.readFileContents(jsonOutputFile).validDescription else {
+                throw StringError("the manifest's JSON output has invalid encoding")
+            }
+            result.manifestJSON = jsonOutput
+        }
     }
 
     /// Returns path to the sdk, if possible.

--- a/Tests/PackageLoadingTests/ManifestLoaderSQLiteCacheTests.swift
+++ b/Tests/PackageLoadingTests/ManifestLoaderSQLiteCacheTests.swift
@@ -20,7 +20,7 @@ class ManifestLoaderSQLiteCacheTests: XCTestCase {
     func testHappyCase() throws {
         try testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending(component: "test.db")
-            let storage = SQLiteBackedCache<ManifestLoader.CompilationResult>(tableName: "manifests", path: path)
+            let storage = SQLiteBackedCache<ManifestLoader.EvaluationResult>(tableName: "manifests", path: path)
             defer { XCTAssertNoThrow(try storage.close()) }
 
             let mockManifests = try makeMockManifests(fileSystem: localFileSystem, rootPath: tmpPath)
@@ -42,8 +42,8 @@ class ManifestLoaderSQLiteCacheTests: XCTestCase {
     }
 }
 
-private func makeMockManifests(fileSystem: FileSystem, rootPath: AbsolutePath, count: Int = Int.random(in: 50 ..< 100)) throws -> [ManifestLoader.CacheKey: ManifestLoader.CompilationResult] {
-    var manifests = [ManifestLoader.CacheKey: ManifestLoader.CompilationResult]()
+private func makeMockManifests(fileSystem: FileSystem, rootPath: AbsolutePath, count: Int = Int.random(in: 50 ..< 100)) throws -> [ManifestLoader.CacheKey: ManifestLoader.EvaluationResult] {
+    var manifests = [ManifestLoader.CacheKey: ManifestLoader.EvaluationResult]()
     for index in 0 ..< count {
         let manifestPath = rootPath.appending(components: "\(index)", "Package.swift")
 
@@ -66,8 +66,8 @@ private func makeMockManifests(fileSystem: FileSystem, rootPath: AbsolutePath, c
                                               env: [:],
                                               swiftpmVersion: SwiftVersion.currentVersion.displayString,
                                               fileSystem: fileSystem)
-        manifests[key] = ManifestLoader.CompilationResult(compilerOutput: "mock-output-\(index)",
-                                                          manifestJSON: "{ 'name': 'mock-manifest-\(index)' }")
+        manifests[key] = ManifestLoader.EvaluationResult(compilerOutput: "mock-output-\(index)",
+                                                         manifestJSON: "{ 'name': 'mock-manifest-\(index)' }")
     }
 
     return manifests


### PR DESCRIPTION
motivation: is some development cases, the cached version of the manifest may persist even though is not-parsable and break dependency resolution

changes: refactor caching logic to first try and parse the cached JSON and fall back to trying to re-evaluate the manifest into JSON if it's not parsable.
