### PR TITLE
RFC: configuration utilities

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -129,6 +129,10 @@ let package = Package(
             dependencies: ["SwiftToolsSupport-auto"]),
 
         .target(
+            name: "Configurations",
+            dependencies: ["SwiftToolsSupport-auto", "Basics"]),
+
+        .target(
             /** The llbuild manifest model */
             name: "LLBuildManifest",
             dependencies: ["SwiftToolsSupport-auto", "Basics"]),
@@ -151,7 +155,7 @@ let package = Package(
         .target(
             /** Package model conventions and loading support */
             name: "PackageLoading",
-            dependencies: ["SwiftToolsSupport-auto", "Basics", "PackageModel", "SourceControl"]),
+            dependencies: ["SwiftToolsSupport-auto", "Basics", "Configurations", "PackageModel", "SourceControl"]),
 
         // MARK: Package Dependency Resolution
 
@@ -182,7 +186,7 @@ let package = Package(
         .target(
             /** Data structures and support for package collections */
             name: "PackageCollections",
-            dependencies: ["SwiftToolsSupport-auto", "Basics", "PackageModel", "SourceControl", "PackageCollectionsModel", "PackageCollectionsSigning"]),
+            dependencies: ["SwiftToolsSupport-auto", "Basics", "Configurations", "PackageModel", "SourceControl", "PackageCollectionsModel", "PackageCollectionsSigning"]),
 
         // MARK: Package Manager Functionality
 
@@ -206,7 +210,7 @@ let package = Package(
         .target(
             /** High level functionality */
             name: "Workspace",
-            dependencies: ["SwiftToolsSupport-auto", "Basics", "SPMBuildCore", "PackageGraph", "PackageModel", "SourceControl", "Xcodeproj"]),
+            dependencies: ["SwiftToolsSupport-auto", "Basics", "Configurations", "SPMBuildCore", "PackageGraph", "PackageModel", "SourceControl", "Xcodeproj"]),
 
         // MARK: Commands
 

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -9,6 +9,7 @@
 add_subdirectory(Basics)
 add_subdirectory(Build)
 add_subdirectory(Commands)
+add_subdirectory(Configurations)
 add_subdirectory(LLBuildManifest)
 add_subdirectory(PackageCollections)
 add_subdirectory(PackageCollectionsModel)

--- a/Sources/Commands/SwiftPackageCollectionsTool.swift
+++ b/Sources/Commands/SwiftPackageCollectionsTool.swift
@@ -10,6 +10,7 @@
 
 import ArgumentParser
 import Basics
+import Configurations
 import Foundation
 import PackageCollections
 import PackageModel
@@ -359,7 +360,9 @@ private extension JSONEncoder {
 
 private extension ParsableCommand {
     func with<T>(handler: (_ collections: PackageCollectionsProtocol) throws -> T) throws -> T {
-        let collections = PackageCollections()
+        let configuration = Configuration.Collections(fileSystem: localFileSystem) // FIXME: share across calls
+        let diagnosticsEngine = DiagnosticsEngine() // // FIXME: share across calls
+        let collections = PackageCollections(configuration: configuration, diagnosticsEngine: diagnosticsEngine)
         defer {
             do {
                 try collections.shutdown()

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -886,8 +886,6 @@ extension SwiftPackageTool.Config {
         var mirrorURL: String
         
         func run(_ swiftTool: SwiftTool) throws {
-            let config = try swiftTool.getSwiftPMConfig()
-
             if packageURL != nil {
                 swiftTool.diagnostics.emit(
                     warning: "'--package-url' option is deprecated; use '--original-url' instead")
@@ -898,8 +896,10 @@ extension SwiftPackageTool.Config {
                 throw ExitCode.failure
             }
 
-            config.mirrors.set(mirrorURL: mirrorURL, forURL: originalURL)
-            try config.saveState()
+            let config = try swiftTool.getSwiftPMConfiguration()
+            try config.mirrors.withMapping { mapping in
+                mapping.set(mirrorURL: mirrorURL, forURL: originalURL)
+            }
         }
     }
 
@@ -920,8 +920,6 @@ extension SwiftPackageTool.Config {
         var mirrorURL: String?
         
         func run(_ swiftTool: SwiftTool) throws {
-            let config = try swiftTool.getSwiftPMConfig()
-
             if packageURL != nil {
                 swiftTool.diagnostics.emit(
                     warning: "'--package-url' option is deprecated; use '--original-url' instead")
@@ -932,8 +930,10 @@ extension SwiftPackageTool.Config {
                 throw ExitCode.failure
             }
 
-            try config.mirrors.unset(originalOrMirrorURL: originalOrMirrorURL)
-            try config.saveState()
+            let config = try swiftTool.getSwiftPMConfiguration()
+            try config.mirrors.withMapping { mapping in
+                try mapping.unset(originalOrMirrorURL: originalOrMirrorURL)
+            }
         }
     }
 
@@ -951,8 +951,6 @@ extension SwiftPackageTool.Config {
         var originalURL: String?
 
         func run(_ swiftTool: SwiftTool) throws {
-            let config = try swiftTool.getSwiftPMConfig()
-
             if packageURL != nil {
                 swiftTool.diagnostics.emit(
                     warning: "'--package-url' option is deprecated; use '--original-url' instead")
@@ -963,6 +961,7 @@ extension SwiftPackageTool.Config {
                 throw ExitCode.failure
             }
 
+            let config = try swiftTool.getSwiftPMConfiguration()
             if let mirror = config.mirrors.mirrorURL(for: originalURL) {
                 print(mirror)
             } else {

--- a/Sources/Configurations/CMakeLists.txt
+++ b/Sources/Configurations/CMakeLists.txt
@@ -1,0 +1,34 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2021 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_library(Configurations
+  Configuration.swift
+  Configuration+Collections.swift
+  Configuration+ManifestLoading.swift
+  Configuration+Mirrors.swift
+  Configuration+Netrc.swift
+  Configuration+Resolution.swift
+  Locations.swift
+  Utilities.swift)
+target_link_libraries(Configurations PUBLIC
+  Basics
+  TSCBasic
+  TSCUtility)
+target_link_libraries(Configurations PRIVATE
+   TSCclibc)
+# NOTE(compnerd) workaround for CMake not setting up include flags yet
+set_target_properties(Configurations PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+if(USE_CMAKE_INSTALL)
+install(TARGETS Configurations
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
+endif()
+set_property(GLOBAL APPEND PROPERTY SwiftPM_EXPORTS Configurations)

--- a/Sources/Configurations/Configuration+Collections.swift
+++ b/Sources/Configurations/Configuration+Collections.swift
@@ -1,0 +1,130 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Basics
+import Foundation
+import TSCBasic
+
+extension Configuration {
+    public struct Collections {
+        private let fileSystem: FileSystem
+        public let path: AbsolutePath
+        public var authTokens: () -> [AuthTokenType: String]?
+
+        public init(fileSystem: FileSystem,
+                    path: AbsolutePath? = nil,
+                    authTokens: @escaping () -> [AuthTokenType: String]? = { nil }) {
+            self.fileSystem = fileSystem
+            self.path = path ?? fileSystem.swiftPMConfigDirectory.appending(component: "collections.json")
+            self.authTokens = authTokens
+        }
+
+        public struct Source: Equatable {
+            public let type: String
+            public let value: String
+            public let isTrusted: Bool?
+            public let skipSignatureCheck: Bool?
+
+            public init(type: String, value: String, isTrusted: Bool?, skipSignatureCheck: Bool?) {
+                self.type = type
+                self.value = value
+                self.isTrusted = isTrusted
+                self.skipSignatureCheck = skipSignatureCheck
+            }
+        }
+
+        public enum AuthTokenType: Hashable, Equatable {
+            case github(_ host: String)
+        }
+    }
+}
+
+extension Configuration.Collections {
+    @discardableResult
+    public func withSources(handler: (inout [Source]) throws  -> Void) throws -> [Source] {
+        if !self.fileSystem.exists(self.path.parentDirectory) {
+            try self.fileSystem.createDirectory(self.path.parentDirectory, recursive: true)
+        }
+        return try self.fileSystem.withLock(on: self.path.parentDirectory, type: .exclusive) {
+            let sources = try Self.load(self.path, fileSystem: self.fileSystem)
+            var updatedSources = sources
+            try handler(&updatedSources)
+            if updatedSources != sources {
+                try Self.save(updatedSources, to: self.path, fileSystem: self.fileSystem)
+            }
+            return updatedSources
+        }
+    }
+
+    public func sources() throws -> [Source] {
+        try self.withSources { _ in }
+    }
+}
+
+extension Configuration.Collections {
+    private static func load(_ path: AbsolutePath, fileSystem: FileSystem) throws -> [Source] {
+        guard fileSystem.exists(path) else {
+            return .init()
+        }
+        let data: Data = try fileSystem.readFileContents(path)
+        guard data.count > 0 else {
+            return .init()
+        }
+        let decoder = JSONDecoder.makeWithDefaults()
+        let container = try decoder.decode(Storage.Container.self, from: data)
+        return try container.sources()
+    }
+
+    private static func save(_ sources: [Source], to path: AbsolutePath, fileSystem: FileSystem) throws {
+        if !fileSystem.exists(path.parentDirectory) {
+            try fileSystem.createDirectory(path.parentDirectory, recursive: true)
+        }
+        let encoder = JSONEncoder.makeWithDefaults()
+        let container = Storage.Container(sources)
+        let data = try encoder.encode(container)
+        try fileSystem.writeFileContents(path, data: data)
+    }
+
+    private enum Storage {
+        struct Container: Codable {
+            var data: [Source]
+
+            init() {
+                self.data = .init()
+            }
+
+            init(_ from: [Configuration.Collections.Source]) {
+                self.data = from.map {
+                    Source(type: $0.type,
+                           value: $0.value,
+                           isTrusted: $0.isTrusted,
+                           skipSignatureCheck: $0.skipSignatureCheck)
+                }
+            }
+
+            func sources() throws -> [Configuration.Collections.Source] {
+                return self.data.map {
+                    Configuration.Collections.Source(type: $0.type,
+                                                     value: $0.value,
+                                                     isTrusted: $0.isTrusted,
+                                                     skipSignatureCheck: $0.skipSignatureCheck)
+
+                }
+            }
+        }
+
+        struct Source: Codable {
+            let type: String
+            let value: String
+            let isTrusted: Bool?
+            let skipSignatureCheck: Bool?
+        }
+    }
+}

--- a/Sources/Configurations/Configuration+ManifestLoading.swift
+++ b/Sources/Configurations/Configuration+ManifestLoading.swift
@@ -1,0 +1,32 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import TSCBasic
+
+extension Configuration {
+    public struct ManifestsLoading {
+        public var cachePath: AbsolutePath?
+        public var serializedDiagnostics: Bool
+        public var isManifestSandboxEnabled: Bool
+
+        public init(cachePath: AbsolutePath?,
+                    serializedDiagnostics: Bool? = .none,
+                    isManifestSandboxEnabled: Bool? = .none
+        ) {
+            self.cachePath = cachePath
+            self.serializedDiagnostics = serializedDiagnostics ?? false
+            self.isManifestSandboxEnabled = isManifestSandboxEnabled ?? true
+        }
+
+        public static func cachePath(rootCachePath: AbsolutePath) -> AbsolutePath {
+            return rootCachePath.appending(component: "manifests")
+        }
+    }
+}

--- a/Sources/Configurations/Configuration+Mirrors.swift
+++ b/Sources/Configurations/Configuration+Mirrors.swift
@@ -1,0 +1,141 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Basics
+import Foundation
+import TSCBasic
+
+extension Configuration {
+    public struct Mirrors {
+        private let fileSystem: FileSystem
+        private let path: AbsolutePath
+
+        public init(fileSystem: FileSystem, path: AbsolutePath? = nil) {
+            self.fileSystem = fileSystem
+            self.path = path ?? fileSystem.swiftPMConfigDirectory.appending(component: "mirrors.json")
+        }
+
+        public struct Mapping: Equatable {
+            fileprivate var index: [String: String]
+            fileprivate var reverseIndex: [String: String]
+
+            fileprivate init(_ index: [String: String]) {
+                self.index = index
+                self.reverseIndex = Dictionary(index.map { ($1, $0) }, uniquingKeysWith: { first, _ in first })
+            }
+
+            /// Sets a mirror URL for the given URL.
+            mutating public func set(mirrorURL: String, forURL url: String) {
+                self.index[url] = mirrorURL
+                self.reverseIndex[mirrorURL] = url
+            }
+
+            /// Unsets a mirror for the given URL.
+            /// - Parameter originalOrMirrorURL: The original URL or the mirrored URL
+            /// - Throws: `Error.mirrorNotFound` if no mirror exists for the provided URL.
+            mutating public func unset(originalOrMirrorURL: String) throws {
+                if let value = self.index[originalOrMirrorURL] {
+                    self.index[originalOrMirrorURL] = nil
+                    self.reverseIndex[value] = nil
+                } else if let mirror = self.index.first(where: { $0.value == originalOrMirrorURL }) {
+                    self.index[mirror.key] = nil
+                    self.reverseIndex[originalOrMirrorURL] = nil
+                } else {
+                    throw StringError("Mirror not found: '\(originalOrMirrorURL)'")
+                }
+            }
+        }
+    }
+}
+
+extension Configuration.Mirrors {
+    @discardableResult
+    public func withMapping(handler: (inout Mapping) throws -> Void) throws -> Mapping {
+        if !self.fileSystem.exists(self.path.parentDirectory) {
+            try self.fileSystem.createDirectory(self.path.parentDirectory, recursive: true)
+        }
+        return try self.fileSystem.withLock(on: self.path.parentDirectory, type: .exclusive) {
+            let mapping = Mapping(try Self.load(self.path, fileSystem: self.fileSystem))
+            var updatedMapping = mapping
+            try handler(&updatedMapping)
+            if updatedMapping != mapping {
+                try Self.save(updatedMapping.index, to: self.path, fileSystem: self.fileSystem)
+            }
+            return updatedMapping
+        }
+    }
+
+    /// Returns the mirrored URL for a package dependency URL.
+    /// - Parameter url: The original URL
+    /// - Returns: The mirrored URL, if one exists.
+    public func mirrorURL(for url: String) -> String? {
+        return self.mapping().index[url]
+    }
+
+    /// Returns the effective URL for a package dependency URL.
+    /// - Parameter url: The original URL
+    /// - Returns: The mirrored URL if it exists, otherwise the original URL.
+    public func effectiveURL(for url: String) -> String {
+        return self.mirrorURL(for: url) ?? url
+    }
+
+    /// Returns the original URL for a mirrored package dependency URL.
+    /// - Parameter url: The mirror URL
+    /// - Returns: The original URL, if one exists.
+    public func originalURL(for url: String) -> String? {
+        return self.mapping().reverseIndex[url]
+    }
+
+    private func mapping() -> Mapping {
+        // FIXME: try?
+        return (try? self.withMapping{ _ in }) ?? Mapping([:])
+    }
+}
+
+extension Configuration.Mirrors {
+    private static func load(_ path: AbsolutePath, fileSystem: FileSystem) throws -> [String: String] {
+        guard fileSystem.exists(path) else {
+            return [:]
+        }
+        let data: Data = try fileSystem.readFileContents(path)
+        let decoder = JSONDecoder.makeWithDefaults()
+        let mirrors = try decoder.decode(Mirrors.self, from: data)
+        let mirrorsMap = Dictionary(mirrors.object.map({ ($0.original, $0.mirror) }), uniquingKeysWith: { first, _ in first })
+        return mirrorsMap
+    }
+
+    private static func save(_ mirrors: [String: String], to path: AbsolutePath, fileSystem: FileSystem) throws {
+        if mirrors.isEmpty {
+            if fileSystem.exists(path) {
+                try fileSystem.removeFileTree(path)
+            }
+            return
+        }
+
+        let encoder = JSONEncoder.makeWithDefaults()
+        let mirrors = Mirrors(version: 1, object: mirrors.map { Mirror(original: $0, mirror: $1) })
+        let data = try encoder.encode(mirrors)
+        if !fileSystem.exists(path.parentDirectory) {
+            try fileSystem.createDirectory(path.parentDirectory, recursive: true)
+        }
+        try fileSystem.writeFileContents(path, data: data)
+    }
+
+    // FIXME: for backwards compatibility, do something nicer
+    private struct Mirrors: Codable {
+        var version: Int
+        var object: [Mirror]
+    }
+
+    private struct Mirror: Codable {
+        var original: String
+        var mirror: String
+    }
+}

--- a/Sources/Configurations/Configuration+Netrc.swift
+++ b/Sources/Configurations/Configuration+Netrc.swift
@@ -1,0 +1,61 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import TSCBasic
+import TSCUtility
+
+extension Configuration {
+    public struct Netrc {
+        private let fileSystem: FileSystem
+        private let path: AbsolutePath?
+
+        public init(fileSystem: FileSystem, path: AbsolutePath? = nil) {
+            self.fileSystem = fileSystem
+            self.path = path
+        }
+
+        public struct Settings: AuthorizationProviding {
+            private let underlying: TSCUtility.Netrc?
+
+            fileprivate init(_ underlying: TSCUtility.Netrc?) {
+                self.underlying = underlying
+            }
+
+            public var machines: [TSCUtility.Netrc.Machine] {
+                get {
+                    self.underlying?.machines ?? []
+                }
+            }
+            /// Basic authorization header string
+            /// - Parameter url: URI of network resource to be accessed
+            /// - Returns: (optional) Basic Authorization header string to be added to the request
+            public func authorization(for url: Foundation.URL) -> String? {
+                return self.underlying?.authorization(for: url)
+            }
+        }
+    }
+}
+
+extension Configuration.Netrc {
+    public func settings() throws -> Settings {
+        guard let path = self.path, self.fileSystem.exists(path) else {
+            return Settings(nil)
+        }
+        return try Settings.load(path, fileSystem: self.fileSystem)
+    }
+}
+
+extension Configuration.Netrc.Settings {
+    // FIXME: change TSC to take file system as well
+    static func load(_ path: AbsolutePath, fileSystem: FileSystem) throws -> Self {
+        return try .init(TSCUtility.Netrc.load(fromFileAtPath: path).get())
+    }
+}

--- a/Sources/Configurations/Configuration+Resolution.swift
+++ b/Sources/Configurations/Configuration+Resolution.swift
@@ -1,0 +1,46 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import TSCBasic
+
+extension Configuration {
+    public struct Resolution {
+        public var repositories: Repositories
+        public var prefetchingEnabled: Bool
+        public var tracingEnabled: Bool
+        public var skipUpdate: Bool
+
+        public init(
+            repositories: Repositories,
+            prefetchingEnabled: Bool? = .none,
+            tracingEnabled: Bool? = .none,
+            skipUpdate: Bool? = .none
+        ) {
+            self.repositories = repositories
+            self.prefetchingEnabled = prefetchingEnabled ?? false
+            self.tracingEnabled = tracingEnabled ?? false
+            self.skipUpdate = skipUpdate ?? false
+        }
+    }
+}
+
+extension Configuration.Resolution {
+    public struct Repositories {
+        public var cachePath: AbsolutePath?
+
+        public init(cachePath: AbsolutePath?) {
+            self.cachePath = cachePath
+        }
+
+        public static func cachePath(rootCachePath: AbsolutePath) -> AbsolutePath {
+            return rootCachePath.appending(component: "repositories")
+        }
+    }
+}

--- a/Sources/Configurations/Configuration.swift
+++ b/Sources/Configurations/Configuration.swift
@@ -1,0 +1,29 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+public struct Configuration {
+    public var resolution: Resolution
+    public var manifestsLoading: ManifestsLoading
+    public var mirrors: Mirrors
+    public var netrc: Netrc
+    public var collections: Collections
+
+    public init(resolution: Resolution,
+                manifestsLoading: ManifestsLoading,
+                mirrors: Mirrors,
+                netrc: Netrc,
+                collections: Collections) {
+        self.resolution = resolution
+        self.manifestsLoading = manifestsLoading
+        self.mirrors = mirrors
+        self.netrc = netrc
+        self.collections = collections
+    }
+}

--- a/Sources/Configurations/Locations.swift
+++ b/Sources/Configurations/Locations.swift
@@ -1,0 +1,69 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+//import Basics
+//import Foundation
+//import TSCBasic
+//import TSCUtility
+
+/*
+extension FileSystem {
+
+    func mirrorsFilePath() throws -> AbsolutePath {
+        // Look for the override in the environment.
+        if let envPath = ProcessEnv.vars["SWIFTPM_MIRROR_CONFIG"] {
+            return try AbsolutePath(validating: envPath)
+        }
+
+        // Otherwise, use the default path.
+        if let multiRootPackageDataFile = options.multirootPackageDataFile {
+            return multiRootPackageDataFile.appending(components: "xcshareddata", "swiftpm", "config")
+        }
+        return try getPackageRoot().appending(components: ".swiftpm", "config")
+    }
+
+    func netrcFilePath() throws -> AbsolutePath? {
+        guard options.netrc ||
+                options.netrcFilePath != nil ||
+                options.netrcOptional else { return nil }
+
+        let resolvedPath: AbsolutePath = options.netrcFilePath ?? AbsolutePath("\(NSHomeDirectory())/.netrc")
+        guard localFileSystem.exists(resolvedPath) else {
+            if !options.netrcOptional {
+                diagnostics.emit(error: "Cannot find mandatory .netrc file at \(resolvedPath.pathString).  To make .netrc file optional, use --netrc-optional flag.")
+                throw ExitCode.failure
+            } else {
+                diagnostics.emit(warning: "Did not find optional .netrc file at \(resolvedPath.pathString).")
+                return nil
+            }
+        }
+        return resolvedPath
+    }
+
+
+    private func getConfigPath(fileSystem: FileSystem) throws -> AbsolutePath? {
+        if let explicitConfigPath = options.configPath {
+            // Create the explicit config path if necessary
+            if !fileSystem.exists(explicitConfigPath) {
+                try fileSystem.createDirectory(explicitConfigPath, recursive: true)
+            }
+            return explicitConfigPath
+        }
+
+        do {
+            return try fileSystem.getOrCreateSwiftPMConfigDirectory()
+        } catch {
+            self.diagnostics.emit(warning: "Failed creating default config locations, \(error)")
+            return nil
+        }
+    }
+
+}
+*/

--- a/Sources/Configurations/Utilities.swift
+++ b/Sources/Configurations/Utilities.swift
@@ -1,0 +1,22 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import TSCBasic
+import Foundation
+
+extension FileSystem {
+    func readFileContents(_ path: AbsolutePath) throws -> Data {
+        return try Data(self.readFileContents(path).contents)
+    }
+
+    func writeFileContents(_ path: AbsolutePath, data: Data) throws {
+        return try self.writeFileContents(path, bytes: ByteString(data))
+    }
+}

--- a/Sources/PackageCollections/CMakeLists.txt
+++ b/Sources/PackageCollections/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(PackageCollections PUBLIC
   TSCBasic
   TSCUtility
   Basics
+  Configurations
   Crypto
   PackageCollectionsModel
   PackageCollectionsSigning

--- a/Sources/PackageCollections/PackageCollections+Configuration.swift
+++ b/Sources/PackageCollections/PackageCollections+Configuration.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+/*
 // TODO: how do we read default config values? ENV variables? user settings?
 extension PackageCollections {
     public struct Configuration {
@@ -27,3 +28,4 @@ extension PackageCollections {
 public enum AuthTokenType: Hashable {
     case github(_ host: String)
 }
+*/

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -9,6 +9,7 @@
  */
 
 import Basics
+import Configurations
 import PackageModel
 import TSCBasic
 
@@ -21,8 +22,8 @@ public struct PackageCollections: PackageCollectionsProtocol {
     static let isSupportedPlatform = false
     #endif
 
-    let configuration: Configuration
-    private let diagnosticsEngine: DiagnosticsEngine?
+    let configuration: Configuration.Collections
+    private let diagnosticsEngine: DiagnosticsEngine
     private let storageContainer: (storage: Storage, owned: Bool)
     private let collectionProviders: [Model.CollectionSourceType: PackageCollectionProvider]
     let metadataProvider: PackageMetadataProvider
@@ -32,8 +33,8 @@ public struct PackageCollections: PackageCollectionsProtocol {
     }
 
     // initialize with defaults
-    public init(configuration: Configuration = .init(), diagnosticsEngine: DiagnosticsEngine = DiagnosticsEngine()) {
-        let storage = Storage(sources: FilePackageCollectionsSourcesStorage(diagnosticsEngine: diagnosticsEngine),
+    public init(configuration: Configuration.Collections, diagnosticsEngine: DiagnosticsEngine) {
+        let storage = Storage(sources: FilePackageCollectionsSourcesStorage(configuration: configuration),
                               collections: SQLitePackageCollectionsStorage(diagnosticsEngine: diagnosticsEngine))
 
         let collectionProviders = [Model.CollectionSourceType.json: JSONPackageCollectionProvider(diagnosticsEngine: diagnosticsEngine)]
@@ -49,8 +50,8 @@ public struct PackageCollections: PackageCollectionsProtocol {
     }
 
     // internal initializer for testing
-    init(configuration: Configuration = .init(),
-         diagnosticsEngine: DiagnosticsEngine? = nil,
+    init(configuration: Configuration.Collections,
+         diagnosticsEngine: DiagnosticsEngine,
          storage: Storage,
          collectionProviders: [Model.CollectionSourceType: PackageCollectionProvider],
          metadataProvider: PackageMetadataProvider) {
@@ -368,7 +369,7 @@ public struct PackageCollections: PackageCollectionsProtocol {
                 self.metadataProvider.get(reference) { result in
                     switch result {
                     case .failure(let error):
-                        self.diagnosticsEngine?.emit(warning: "Failed fetching information about \(reference) from \(self.metadataProvider.name): \(error)")
+                        self.diagnosticsEngine.emit(warning: "Failed fetching information about \(reference) from \(self.metadataProvider.name): \(error)")
 
                         let provider: PackageMetadataProviderContext?
                         switch error {

--- a/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
+++ b/Sources/PackageCollections/Providers/PackageMetadataProvider.swift
@@ -8,12 +8,14 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+import Configurations
 import struct Foundation.Date
 import struct Foundation.URL
-
 import PackageModel
 import TSCBasic
 import TSCUtility
+
+public typealias AuthTokenType = Configurations.Configuration.Collections.AuthTokenType
 
 /// `PackageBasicMetadata` provider
 protocol PackageMetadataProvider: Closable {

--- a/Sources/PackageGraph/DependencyMirrors.swift
+++ b/Sources/PackageGraph/DependencyMirrors.swift
@@ -14,6 +14,7 @@ import TSCBasic
 import TSCUtility
 
 /// A collection of dependency mirrors.
+@available(*, deprecated)
 public final class DependencyMirrors {
 
     /// A dependency mirror error.
@@ -71,9 +72,9 @@ public final class DependencyMirrors {
     public func originalURL(for url: String) -> String? {
         return self.reverseIndex[url]
     }
-
 }
 
+@available(*, deprecated)
 extension DependencyMirrors: Collection {
     public typealias Index = Dictionary<String, String>.Index
     public typealias Element = String
@@ -95,12 +96,14 @@ extension DependencyMirrors: Collection {
     }
 }
 
+@available(*, deprecated)
 extension DependencyMirrors: ExpressibleByDictionaryLiteral {
     public convenience init(dictionaryLiteral elements: (String, String)...) {
         self.init(elements.map { Mirror(original: $0.0, mirror: $0.1) })
     }
 }
 
+@available(*, deprecated)
 extension DependencyMirrors: JSONMappable, JSONSerializable {
     public convenience init(json: JSON) throws {
         self.init(try [Mirror](json: json))
@@ -112,6 +115,7 @@ extension DependencyMirrors: JSONMappable, JSONSerializable {
     }
 }
 
+@available(*, deprecated)
 extension DependencyMirrors.Error: CustomStringConvertible {
     public var description: String {
         switch self {
@@ -122,6 +126,7 @@ extension DependencyMirrors.Error: CustomStringConvertible {
 }
 
 // MARK: -
+
 
 /// An individual repository mirror.
 private struct Mirror {

--- a/Sources/PackageGraph/PinsStore.swift
+++ b/Sources/PackageGraph/PinsStore.swift
@@ -8,10 +8,11 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import Configurations
+import PackageModel
 import TSCBasic
 import TSCUtility
 import SourceControl
-import PackageModel
 
 public final class PinsStore {
     public typealias PinsMap = [PackageIdentity: PinsStore.Pin]
@@ -43,7 +44,7 @@ public final class PinsStore {
     /// The filesystem to manage the pin file on.
     private var fileSystem: FileSystem
 
-    private let mirrors: DependencyMirrors
+    private let mirrors: Configuration.Mirrors
 
     /// The pins map.
     public fileprivate(set) var pinsMap: PinsMap
@@ -60,7 +61,7 @@ public final class PinsStore {
     /// - Parameters:
     ///   - pinsFile: Path to the pins file.
     ///   - fileSystem: The filesystem to manage the pin file on.
-    public init(pinsFile: AbsolutePath, fileSystem: FileSystem, mirrors: DependencyMirrors) throws {
+    public init(pinsFile: AbsolutePath, fileSystem: FileSystem, mirrors: Configuration.Mirrors) throws {
         self.pinsFile = pinsFile
         self.fileSystem = fileSystem
         self.persistence = SimplePersistence(

--- a/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
@@ -9,6 +9,7 @@
  */
 
 import Basics
+import Configurations
 import Dispatch
 import PackageModel
 import TSCBasic
@@ -115,16 +116,15 @@ public struct PubgrubDependencyResolver {
     private let delegate: DependencyResolverDelegate?
 
     public init(
+        configuration: Configuration.Resolution,
         provider: PackageContainerProvider,
         pinsMap: PinsStore.PinsMap = [:],
-        isPrefetchingEnabled: Bool = false,
-        skipUpdate: Bool = false,
         delegate: DependencyResolverDelegate? = nil
     ) {
         self.packageContainerProvider = provider
         self.pinsMap = pinsMap
-        self.isPrefetchingEnabled = isPrefetchingEnabled
-        self.skipUpdate = skipUpdate
+        self.isPrefetchingEnabled = configuration.prefetchingEnabled
+        self.skipUpdate = configuration.skipUpdate
         self.provider = ContainerProvider(provider: self.packageContainerProvider, skipUpdate: self.skipUpdate, pinsMap: self.pinsMap)
         self.delegate = delegate
     }

--- a/Sources/PackageLoading/CMakeLists.txt
+++ b/Sources/PackageLoading/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(PackageLoading
 target_link_libraries(PackageLoading PUBLIC
   TSCBasic
   Basics
+  Configurations
   PackageModel
   SourceControl
   TSCUtility)

--- a/Sources/Workspace/CMakeLists.txt
+++ b/Sources/Workspace/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(Workspace PUBLIC
   TSCBasic
   TSCUtility
   Basics
+  Configurations
   SPMBuildCore
   PackageGraph
   PackageLoading

--- a/Sources/Workspace/WorkspaceConfiguration.swift
+++ b/Sources/Workspace/WorkspaceConfiguration.swift
@@ -17,6 +17,7 @@ import PackageGraph
 
 extension Workspace {
     /// Manages a package workspace's configuration.
+    @available(*, deprecated)
     public final class Configuration {
         /// The path to the mirrors file.
         private let configFile: AbsolutePath?
@@ -91,12 +92,14 @@ extension Workspace {
     }
 }
 
+@available(*, deprecated)
 extension Workspace.Configuration: JSONSerializable {
     public func toJSON() -> JSON {
         return mirrors.toJSON()
     }
 }
 
+@available(*, deprecated)
 extension Workspace.Configuration: SimplePersistanceProtocol {
     public func restore(from json: JSON) throws {
         self.mirrors = try DependencyMirrors(json: json)

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -722,7 +722,7 @@ final class PackageToolTests: XCTestCase {
             // Try to pin bar at a branch.
             do {
                 try execute("resolve", "bar", "--branch", "YOLO")
-                let pinsStore = try PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem, mirrors: .init())
+                let pinsStore = try PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem, mirrors: .init(fileSystem: InMemoryFileSystem()))
                 let state = CheckoutState(revision: yoloRevision, branch: "YOLO")
                 let identity = PackageIdentity(path: barPath)
                 XCTAssertEqual(pinsStore.pinsMap[identity]?.state, state)
@@ -731,7 +731,7 @@ final class PackageToolTests: XCTestCase {
             // Try to pin bar at a revision.
             do {
                 try execute("resolve", "bar", "--revision", yoloRevision.identifier)
-                let pinsStore = try PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem, mirrors: .init())
+                let pinsStore = try PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem, mirrors: .init(fileSystem: InMemoryFileSystem()))
                 let state = CheckoutState(revision: yoloRevision)
                 let identity = PackageIdentity(path: barPath)
                 XCTAssertEqual(pinsStore.pinsMap[identity]?.state, state)
@@ -772,7 +772,7 @@ final class PackageToolTests: XCTestCase {
 
             // Test pins file.
             do {
-                let pinsStore = try PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem, mirrors: .init())
+                let pinsStore = try PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem, mirrors: .init(fileSystem: InMemoryFileSystem()))
                 XCTAssertEqual(pinsStore.pins.map{$0}.count, 2)
                 for pkg in ["bar", "baz"] {
                     let path = try SwiftPMProduct.packagePath(for: pkg, packageRoot: fooPath)
@@ -791,7 +791,7 @@ final class PackageToolTests: XCTestCase {
             // Try to pin bar.
             do {
                 try execute("resolve", "bar")
-                let pinsStore = try PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem, mirrors: .init())
+                let pinsStore = try PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem, mirrors: .init(fileSystem: InMemoryFileSystem()))
                 let identity = PackageIdentity(path: barPath)
                 XCTAssertEqual(pinsStore.pinsMap[identity]?.state.version, "1.2.3")
             }
@@ -815,7 +815,7 @@ final class PackageToolTests: XCTestCase {
             // We should be able to revert to a older version.
             do {
                 try execute("resolve", "bar", "--version", "1.2.3")
-                let pinsStore = try PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem, mirrors: .init())
+                let pinsStore = try PinsStore(pinsFile: pinsFile, fileSystem: localFileSystem, mirrors: .init(fileSystem: InMemoryFileSystem()))
                 let identity = PackageIdentity(path: barPath)
                 XCTAssertEqual(pinsStore.pinsMap[identity]?.state.version, "1.2.3")
                 try checkBar(5)
@@ -975,7 +975,7 @@ final class PackageToolTests: XCTestCase {
                 try execute(["config", "get-mirror", "--original-url", "git@github.com:apple/swift-package-manager.git"], packagePath: packageRoot)
             }
 
-            check(stderr: "error: mirror not found\n") {
+            check(stderr: "error: Mirror not found: 'foo'\n") {
                 try execute(["config", "unset-mirror", "--original-url", "foo"], packagePath: packageRoot)
             }
         }

--- a/Tests/PackageCollectionsTests/PackageCollectionsSourcesStorageTest.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsSourcesStorageTest.swift
@@ -16,7 +16,7 @@ import XCTest
 final class PackageCollectionsSourcesStorageTest: XCTestCase {
     func testHappyCase() throws {
         let mockFileSystem = InMemoryFileSystem()
-        let storage = FilePackageCollectionsSourcesStorage(fileSystem: mockFileSystem)
+        let storage = FilePackageCollectionsSourcesStorage(configuration: .init(fileSystem: mockFileSystem))
 
         try assertHappyCase(storage: storage)
 
@@ -29,7 +29,7 @@ final class PackageCollectionsSourcesStorageTest: XCTestCase {
         try testWithTemporaryDirectory { tmpPath in
             let fileSystem = localFileSystem
             let path = tmpPath.appending(component: "test.json")
-            let storage = FilePackageCollectionsSourcesStorage(fileSystem: fileSystem, path: path)
+            let storage = FilePackageCollectionsSourcesStorage(configuration: .init(fileSystem: fileSystem, path: path))
 
             try assertHappyCase(storage: storage)
 
@@ -101,7 +101,7 @@ final class PackageCollectionsSourcesStorageTest: XCTestCase {
 
     func testFileDeleted() throws {
         let mockFileSystem = InMemoryFileSystem()
-        let storage = FilePackageCollectionsSourcesStorage(fileSystem: mockFileSystem)
+        let storage = FilePackageCollectionsSourcesStorage(configuration: .init(fileSystem: mockFileSystem))
 
         let sources = makeMockSources()
 
@@ -125,7 +125,7 @@ final class PackageCollectionsSourcesStorageTest: XCTestCase {
 
     func testFileEmpty() throws {
         let mockFileSystem = InMemoryFileSystem()
-        let storage = FilePackageCollectionsSourcesStorage(fileSystem: mockFileSystem)
+        let storage = FilePackageCollectionsSourcesStorage(configuration: .init(fileSystem: mockFileSystem))
 
         let sources = makeMockSources()
 
@@ -150,7 +150,7 @@ final class PackageCollectionsSourcesStorageTest: XCTestCase {
 
     func testFileCorrupt() throws {
         let mockFileSystem = InMemoryFileSystem()
-        let storage = FilePackageCollectionsSourcesStorage(fileSystem: mockFileSystem)
+        let storage = FilePackageCollectionsSourcesStorage(configuration: .init(fileSystem: mockFileSystem))
 
         let sources = makeMockSources()
 

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -12,6 +12,7 @@ import Foundation
 import XCTest
 
 import Basics
+import Configurations
 @testable import PackageCollections
 import PackageModel
 import SourceControl
@@ -21,7 +22,7 @@ import TSCUtility
 final class PackageCollectionsTests: XCTestCase {
     func testUpdateAuthTokens() throws {
         let authTokens = ThreadSafeKeyValueStore<AuthTokenType, String>()
-        let configuration = PackageCollections.Configuration(authTokens: { authTokens.get() })
+        let configuration = Configuration.Collections(fileSystem: InMemoryFileSystem(), authTokens: { authTokens.get() })
 
         // This test doesn't use search at all and finishes quickly so disable target trie to prevent race
         let storageConfig = SQLitePackageCollectionsStorage.Configuration(initializeTargetTrie: false)
@@ -57,14 +58,13 @@ final class PackageCollectionsTests: XCTestCase {
     func testBasicRegistration() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
         let mockCollections = makeMockCollections()
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
             let list = try tsc_await { callback in packageCollections.listCollections(callback: callback) }
@@ -84,7 +84,6 @@ final class PackageCollectionsTests: XCTestCase {
     func testAddDuplicates() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
@@ -92,7 +91,7 @@ final class PackageCollectionsTests: XCTestCase {
 
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider([mockCollection])]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
             let list = try tsc_await { callback in packageCollections.listCollections(callback: callback) }
@@ -112,7 +111,6 @@ final class PackageCollectionsTests: XCTestCase {
     func testAddUnsigned() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
@@ -120,7 +118,7 @@ final class PackageCollectionsTests: XCTestCase {
 
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
             let list = try tsc_await { callback in packageCollections.listCollections(callback: callback) }
@@ -155,7 +153,6 @@ final class PackageCollectionsTests: XCTestCase {
     func testInvalidCollectionNotAdded() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         // This test doesn't use search at all and finishes quickly so disable target trie to prevent race
         let storageConfig = SQLitePackageCollectionsStorage.Configuration(initializeTargetTrie: false)
         let storage = makeMockStorage(storageConfig)
@@ -165,7 +162,7 @@ final class PackageCollectionsTests: XCTestCase {
 
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider([])]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
             let list = try tsc_await { callback in packageCollections.listCollections(callback: callback) }
@@ -193,7 +190,6 @@ final class PackageCollectionsTests: XCTestCase {
     func testCollectionPendingTrustConfirmIsKeptOnAdd() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         // This test doesn't use search at all and finishes quickly so disable target trie to prevent race
         let storageConfig = SQLitePackageCollectionsStorage.Configuration(initializeTargetTrie: false)
         let storage = makeMockStorage(storageConfig)
@@ -203,7 +199,7 @@ final class PackageCollectionsTests: XCTestCase {
 
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider([mockCollection])]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
             let list = try tsc_await { callback in packageCollections.listCollections(callback: callback) }
@@ -231,7 +227,6 @@ final class PackageCollectionsTests: XCTestCase {
     func testCollectionWithInvalidSignatureNotAdded() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         // This test doesn't use search at all and finishes quickly so disable target trie to prevent race
         let storageConfig = SQLitePackageCollectionsStorage.Configuration(initializeTargetTrie: false)
         let storage = makeMockStorage(storageConfig)
@@ -241,7 +236,7 @@ final class PackageCollectionsTests: XCTestCase {
 
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider([mockCollection], collectionsWithInvalidSignature: [mockCollection.source])]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
             let list = try tsc_await { callback in packageCollections.listCollections(callback: callback) }
@@ -269,14 +264,13 @@ final class PackageCollectionsTests: XCTestCase {
     func testDelete() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
         let mockCollections = makeMockCollections(count: 10)
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
             let list = try tsc_await { callback in packageCollections.listCollections(callback: callback) }
@@ -320,7 +314,6 @@ final class PackageCollectionsTests: XCTestCase {
     func testDeleteFromBothStorages() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
@@ -328,7 +321,7 @@ final class PackageCollectionsTests: XCTestCase {
 
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider([mockCollection])]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
             let list = try tsc_await { callback in packageCollections.listCollections(callback: callback) }
@@ -355,14 +348,13 @@ final class PackageCollectionsTests: XCTestCase {
     func testOrdering() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
         let mockCollections = makeMockCollections(count: 10)
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
             let list = try tsc_await { callback in packageCollections.listCollections(callback: callback) }
@@ -426,14 +418,13 @@ final class PackageCollectionsTests: XCTestCase {
     func testReorder() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
         let mockCollections = makeMockCollections(count: 3)
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
             let list = try tsc_await { callback in packageCollections.listCollections(callback: callback) }
@@ -528,7 +519,6 @@ final class PackageCollectionsTests: XCTestCase {
     func testUpdateTrust() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
@@ -536,7 +526,7 @@ final class PackageCollectionsTests: XCTestCase {
 
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
             let list = try tsc_await { callback in packageCollections.listCollections(callback: callback) }
@@ -579,7 +569,6 @@ final class PackageCollectionsTests: XCTestCase {
     func testList() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
@@ -588,7 +577,7 @@ final class PackageCollectionsTests: XCTestCase {
         let mockMetadata = makeMockPackageBasicMetadata()
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([mockPackage.reference: mockMetadata])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         try mockCollections.forEach { collection in
             _ = try tsc_await { callback in packageCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) }, callback: callback) }
@@ -601,7 +590,6 @@ final class PackageCollectionsTests: XCTestCase {
     func testListSubset() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
@@ -610,7 +598,7 @@ final class PackageCollectionsTests: XCTestCase {
         let mockMetadata = makeMockPackageBasicMetadata()
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([mockPackage.reference: mockMetadata])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         try mockCollections.forEach { collection in
             _ = try tsc_await { callback in packageCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) }, callback: callback) }
@@ -629,7 +617,6 @@ final class PackageCollectionsTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
@@ -638,7 +625,7 @@ final class PackageCollectionsTests: XCTestCase {
         let mockMetadata = makeMockPackageBasicMetadata()
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([mockPackage.reference: mockMetadata])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         let sync = DispatchGroup()
         mockCollections.forEach { collection in
@@ -659,7 +646,6 @@ final class PackageCollectionsTests: XCTestCase {
     func testPackageSearch() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
@@ -724,7 +710,7 @@ final class PackageCollectionsTests: XCTestCase {
 
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         try mockCollections.forEach { collection in
             _ = try tsc_await { callback in packageCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) }, callback: callback) }
@@ -794,14 +780,13 @@ final class PackageCollectionsTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
         let mockCollections = makeMockCollections(count: 1000, maxPackages: 20)
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         let sync = DispatchGroup()
         mockCollections.forEach { collection in
@@ -824,7 +809,6 @@ final class PackageCollectionsTests: XCTestCase {
     func testTargetsSearch() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
@@ -889,7 +873,7 @@ final class PackageCollectionsTests: XCTestCase {
 
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         try mockCollections.forEach { collection in
             _ = try tsc_await { callback in packageCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) }, callback: callback) }
@@ -926,14 +910,13 @@ final class PackageCollectionsTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
         let mockCollections = makeMockCollections(count: 1000)
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         let sync = DispatchGroup()
         mockCollections.forEach { collection in
@@ -956,14 +939,13 @@ final class PackageCollectionsTests: XCTestCase {
     func testHappyRefresh() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
         let mockCollections = makeMockCollections()
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         try mockCollections.forEach { collection in
             // save directly to storage to circumvent refresh on add
@@ -1005,7 +987,6 @@ final class PackageCollectionsTests: XCTestCase {
 
         struct MyError: Error, Equatable {}
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
@@ -1018,7 +999,7 @@ final class PackageCollectionsTests: XCTestCase {
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: provider]
 
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         XCTAssertThrowsError(try tsc_await { callback in packageCollections.addCollection(brokenSources.first!, order: nil, callback: callback) }, "expected error", { error in
             XCTAssertEqual(error as? MyError, expectedError, "expected error to match")
@@ -1052,14 +1033,13 @@ final class PackageCollectionsTests: XCTestCase {
     func testRefreshOne() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
         let mockCollections = makeMockCollections(count: 1)
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         try mockCollections.forEach { collection in
             // save directly to storage to circumvent refresh on add
@@ -1074,14 +1054,13 @@ final class PackageCollectionsTests: XCTestCase {
     func testRefreshOneTrustedUnsigned() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
         let mockCollections = makeMockCollections(count: 1, signed: false)
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         // User trusted
         let collection = try tsc_await { callback in packageCollections.addCollection(mockCollections[0].source, order: nil, trustConfirmationProvider: { _, cb in cb(true) }, callback: callback) }
@@ -1094,14 +1073,13 @@ final class PackageCollectionsTests: XCTestCase {
     func testRefreshOneNotFound() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
         let mockCollections = makeMockCollections(count: 1, signed: false)
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         // Don't add collection so it's not found in the config
         XCTAssertThrowsError(try tsc_await { callback in packageCollections.refreshCollection(mockCollections[0].source, callback: callback) }, "expected error") { error in
@@ -1112,14 +1090,13 @@ final class PackageCollectionsTests: XCTestCase {
     func testListTargets() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
         let mockCollections = makeMockCollections()
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
             let list = try tsc_await { callback in packageCollections.listCollections(callback: callback) }
@@ -1150,7 +1127,6 @@ final class PackageCollectionsTests: XCTestCase {
     func testFetchMetadataHappy() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
@@ -1159,7 +1135,7 @@ final class PackageCollectionsTests: XCTestCase {
         let mockMetadata = makeMockPackageBasicMetadata()
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([mockPackage.reference: mockMetadata])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
             let list = try tsc_await { callback in packageCollections.listCollections(callback: callback) }
@@ -1189,7 +1165,6 @@ final class PackageCollectionsTests: XCTestCase {
     func testFetchMetadataInOrder() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
@@ -1197,7 +1172,7 @@ final class PackageCollectionsTests: XCTestCase {
         let mockPackage = mockCollections.last!.packages.first!
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
             let list = try tsc_await { callback in packageCollections.listCollections(callback: callback) }
@@ -1227,7 +1202,6 @@ final class PackageCollectionsTests: XCTestCase {
     func testFetchMetadataInCollections() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
@@ -1235,7 +1209,7 @@ final class PackageCollectionsTests: XCTestCase {
         let mockPackage = mockCollections.last!.packages.first!
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
             let list = try tsc_await { callback in packageCollections.listCollections(callback: callback) }
@@ -1352,7 +1326,6 @@ final class PackageCollectionsTests: XCTestCase {
     func testFetchMetadataNotFoundInCollections() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
@@ -1360,7 +1333,7 @@ final class PackageCollectionsTests: XCTestCase {
         let mockMetadata = makeMockPackageBasicMetadata()
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider([])]
         let metadataProvider = MockMetadataProvider([mockPackage.reference: mockMetadata])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
             let list = try tsc_await { callback in packageCollections.listCollections(callback: callback) }
@@ -1375,7 +1348,6 @@ final class PackageCollectionsTests: XCTestCase {
     func testFetchMetadataNotFoundByProvider() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
@@ -1383,7 +1355,7 @@ final class PackageCollectionsTests: XCTestCase {
         let mockPackage = mockCollections.last!.packages.last!
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
             let list = try tsc_await { callback in packageCollections.listCollections(callback: callback) }
@@ -1429,7 +1401,6 @@ final class PackageCollectionsTests: XCTestCase {
             struct TerribleThing: Error {}
         }
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
@@ -1437,7 +1408,7 @@ final class PackageCollectionsTests: XCTestCase {
         let mockPackage = mockCollections.last!.packages.last!
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = BrokenMetadataProvider()
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
             let list = try tsc_await { callback in packageCollections.listCollections(callback: callback) }
@@ -1469,7 +1440,6 @@ final class PackageCollectionsTests: XCTestCase {
 
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
@@ -1478,7 +1448,7 @@ final class PackageCollectionsTests: XCTestCase {
         let mockMetadata = makeMockPackageBasicMetadata()
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([mockPackage.reference: mockMetadata])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         let sync = DispatchGroup()
         mockCollections.forEach { collection in
@@ -1499,7 +1469,6 @@ final class PackageCollectionsTests: XCTestCase {
     func testListPackages() throws {
         try skipIfUnsupportedPlatform()
 
-        let configuration = PackageCollections.Configuration()
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
 
@@ -1562,7 +1531,7 @@ final class PackageCollectionsTests: XCTestCase {
 
         let collectionProviders = [PackageCollectionsModel.CollectionSourceType.json: MockCollectionsProvider(mockCollections)]
         let metadataProvider = MockMetadataProvider([:])
-        let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
+        let packageCollections = PackageCollections(storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         try mockCollections.forEach { collection in
             _ = try tsc_await { callback in packageCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) }, callback: callback) }
@@ -1598,5 +1567,15 @@ private extension XCTestCase {
         if !PackageCollections.isSupportedPlatform {
             throw XCTSkip("Skipping test on unsupported platform")
         }
+    }
+}
+
+extension PackageCollections {
+    init(configuration: Configuration.Collections? = nil, storage: Storage, collectionProviders: [Model.CollectionSourceType : PackageCollectionProvider], metadataProvider: PackageMetadataProvider) {
+        self.init(configuration: configuration ?? Configuration.Collections(fileSystem: InMemoryFileSystem()),
+                  diagnosticsEngine: DiagnosticsEngine(),
+                  storage: storage,
+                  collectionProviders: collectionProviders,
+                  metadataProvider: metadataProvider)
     }
 }

--- a/Tests/PackageCollectionsTests/Utility.swift
+++ b/Tests/PackageCollectionsTests/Utility.swift
@@ -123,7 +123,7 @@ func makeMockPackageBasicMetadata() -> PackageCollectionsModel.PackageBasicMetad
 
 func makeMockStorage(_ collectionsStorageConfig: SQLitePackageCollectionsStorage.Configuration = .init()) -> PackageCollections.Storage {
     let mockFileSystem = InMemoryFileSystem()
-    return .init(sources: FilePackageCollectionsSourcesStorage(fileSystem: mockFileSystem),
+    return .init(sources: FilePackageCollectionsSourcesStorage(configuration: .init(fileSystem: mockFileSystem)),
                  collections: SQLitePackageCollectionsStorage(location: .memory, configuration: collectionsStorageConfig))
 }
 

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -54,7 +54,8 @@ class DependencyResolverRealWorldPerfTests: XCTestCasePerf {
 
         measure {
             for _ in 0 ..< N {
-                let resolver = PubgrubDependencyResolver(provider: provider)
+                // FIXME: default
+                let resolver = PubgrubDependencyResolver(configuration: .init(repositories: .init(cachePath: nil)), provider: provider)
                 switch resolver.solve(constraints: graph.constraints) {
                 case .success(let result):
                     let result: [(container: PackageReference, version: Version)] = result.compactMap {

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -1350,7 +1350,7 @@ class PackageGraphTests: XCTestCase {
         """)
 
         let fs = InMemoryFileSystem(emptyFiles: [])
-        let store = try PinsStore(pinsFile: AbsolutePath("/pins"), fileSystem: fs, mirrors: .init())
+        let store = try PinsStore(pinsFile: AbsolutePath("/pins"), fileSystem: fs, mirrors: .init(fileSystem: fs))
         XCTAssertThrows(StringError("duplicated entry for package \"Yams\""), { try store.restore(from: json) })
     }
 

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -2201,7 +2201,7 @@ class DependencyGraphBuilder {
     /// Creates a pins store with the given pins.
     func create(pinsStore pins: [String: (CheckoutState, ProductFilter)]) -> PinsStore {
         let fs = InMemoryFileSystem()
-        let store = try! PinsStore(pinsFile: AbsolutePath("/tmp/Package.resolved"), fileSystem: fs, mirrors: .init())
+        let store = try! PinsStore(pinsFile: AbsolutePath("/tmp/Package.resolved"), fileSystem: fs, mirrors: .init(fileSystem: fs))
 
         for (package, pin) in pins {
             store.pin(packageRef: reference(for: package), state: pin.0)
@@ -2300,5 +2300,23 @@ extension Result where Success == [DependencyResolver.Binding] {
             XCTFail("Unexpected result \(self)")
         }
         return nil
+    }
+}
+
+
+extension PubgrubDependencyResolver {
+    public init(
+        provider: PackageContainerProvider,
+        pinsMap: PinsStore.PinsMap = [:],
+        delegate: DependencyResolverDelegate? = nil
+    ) {
+        self.init(
+            // FIXME: no cache
+            configuration: .init(
+                repositories: .init(cachePath: nil)
+            ),
+            provider: provider,
+            pinsMap: pinsMap,
+            delegate: delegate)
     }
 }

--- a/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
+++ b/Tests/PackageLoadingPerformanceTests/ManifestLoadingTests.swift
@@ -15,7 +15,8 @@ import TSCBasic
 import XCTest
 
 class ManifestLoadingPerfTests: XCTestCasePerf {
-    let manifestLoader = ManifestLoader(toolchain: ToolchainConfiguration.default)
+    // FIXME: default config
+    let manifestLoader = ManifestLoader(configuration: .init(cachePath: nil), toolchain: ToolchainConfiguration.default)
 
     func write(_ bytes: ByteString, body: (AbsolutePath) -> ()) throws {
         try testWithTemporaryDirectory { tmpdir in

--- a/Tests/PackageLoadingTests/PDLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDLoadingTests.swift
@@ -17,7 +17,8 @@ import PackageModel
 import PackageLoading
 
 class PackageDescriptionLoadingTests: XCTestCase {
-    let manifestLoader = ManifestLoader(toolchain: ToolchainConfiguration.default)
+    // FIXME: default config
+    let manifestLoader = ManifestLoader(configuration: .init(cachePath: nil), toolchain: ToolchainConfiguration.default)
     
     var toolsVersion: ToolsVersion {
         fatalError("implement in subclass")

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -542,7 +542,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             let delegate = ManifestTestDelegate()
 
-            let manifestLoader = ManifestLoader(toolchain: ToolchainConfiguration.default, cacheDir: path, delegate: delegate)
+            let manifestLoader = ManifestLoader(configuration: .init(cachePath: path), toolchain: ToolchainConfiguration.default, delegate: delegate)
 
             func check(loader: ManifestLoader, expectCached: Bool) {
                 delegate.clear()
@@ -598,7 +598,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             let delegate = ManifestTestDelegate()
 
-            let manifestLoader = ManifestLoader(toolchain: ToolchainConfiguration.default, cacheDir: path, delegate: delegate)
+            let manifestLoader = ManifestLoader(configuration: .init(cachePath: path), toolchain: ToolchainConfiguration.default, delegate: delegate)
 
             func check(loader: ManifestLoader, expectCached: Bool) {
                 delegate.clear()
@@ -643,7 +643,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 check(loader: manifestLoader, expectCached: true)
             }
 
-            let noCacheLoader = ManifestLoader(toolchain: ToolchainConfiguration.default, delegate: delegate)
+            let noCacheLoader = ManifestLoader(configuration: .init(cachePath: nil), toolchain: ToolchainConfiguration.default, delegate: delegate)
             for _ in 0..<2 {
                 check(loader: noCacheLoader, expectCached: false)
             }
@@ -670,7 +670,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             let delegate = ManifestTestDelegate()
 
-            let manifestLoader = ManifestLoader(toolchain: ToolchainConfiguration.default, cacheDir: path, delegate: delegate)
+            let manifestLoader = ManifestLoader(configuration: .init(cachePath: path), toolchain: ToolchainConfiguration.default, delegate: delegate)
 
             func check(loader: ManifestLoader) throws {
                 let fs = InMemoryFileSystem()
@@ -775,7 +775,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             let diagnostics = DiagnosticsEngine()
             let delegate = ManifestTestDelegate()
-            let manifestLoader = ManifestLoader(toolchain: ToolchainConfiguration.default, cacheDir: path, delegate: delegate)
+            let manifestLoader = ManifestLoader(configuration: .init(cachePath: path), toolchain: ToolchainConfiguration.default, delegate: delegate)
             let identityResolver = DefaultIdentityResolver()
 
             // warm up caches
@@ -837,7 +837,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             let diagnostics = DiagnosticsEngine()
             let delegate = ManifestTestDelegate()
-            let manifestLoader = ManifestLoader(toolchain: ToolchainConfiguration.default, cacheDir: path, delegate: delegate)
+            let manifestLoader = ManifestLoader(configuration: .init(cachePath: path), toolchain: ToolchainConfiguration.default, delegate: delegate)
             let identityResolver = DefaultIdentityResolver()
 
             let sync = DispatchGroup()

--- a/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
@@ -362,9 +362,12 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
             }
 
             let loader = ManifestLoader(
-                toolchain: ToolchainConfiguration.default,
-                serializedDiagnostics: true,
-                cacheDir: path)
+                configuration: .init(
+                    cachePath: path,
+                    serializedDiagnostics: true
+                ),
+                toolchain: ToolchainConfiguration.default
+            )
 
             do {
                 _ = try loader.load(

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -21,7 +21,9 @@ class ManifestSourceGenerationTests: XCTestCase {
         try withTemporaryDirectory { packageDir in
             // Write the original manifest file contents, and load it.
             try fs.writeFileContents(packageDir.appending(component: Manifest.filename), bytes: ByteString(encodingAsUTF8: manifestContents))
-            let manifestLoader = ManifestLoader(toolchain: ToolchainConfiguration.default)
+
+            // FIXME: defaults
+            let manifestLoader = ManifestLoader(configuration: .init(cachePath: nil), toolchain: ToolchainConfiguration.default)
             let identityResolver = DefaultIdentityResolver()
             let manifest = try tsc_await {
                 manifestLoader.load(at: packageDir,

--- a/Tests/WorkspaceTests/PinsStoreTests.swift
+++ b/Tests/WorkspaceTests/PinsStoreTests.swift
@@ -8,15 +8,15 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import XCTest
-
-import TSCBasic
-import TSCUtility
+import Configurations
 import PackageModel
 import PackageGraph
-import SPMTestSupport
 import SourceControl
+import SPMTestSupport
+import TSCBasic
+import TSCUtility
 import Workspace
+import XCTest
 
 final class PinsStoreTests: XCTestCase {
 
@@ -40,7 +40,7 @@ final class PinsStoreTests: XCTestCase {
 
         let fs = InMemoryFileSystem()
         let pinsFile = AbsolutePath("/pinsfile.txt")
-        var store = try PinsStore(pinsFile: pinsFile, fileSystem: fs, mirrors: .init())
+        var store = try PinsStore(pinsFile: pinsFile, fileSystem: fs, mirrors: .init(fileSystem: fs))
         // Pins file should not be created right now.
         XCTAssert(!fs.exists(pinsFile))
         XCTAssert(store.pins.map{$0}.isEmpty)
@@ -51,7 +51,7 @@ final class PinsStoreTests: XCTestCase {
         XCTAssert(fs.exists(pinsFile))
 
         // Load the store again from disk.
-        let store2 = try PinsStore(pinsFile: pinsFile, fileSystem: fs, mirrors: .init())
+        let store2 = try PinsStore(pinsFile: pinsFile, fileSystem: fs, mirrors: .init(fileSystem: fs))
         // Test basics on the store.
         for s in [store, store2] {
             XCTAssert(s.pins.map{$0}.count == 1)
@@ -72,7 +72,7 @@ final class PinsStoreTests: XCTestCase {
         store.pin(packageRef: barRef, state: state)
         try store.saveState()
 
-        store = try PinsStore(pinsFile: pinsFile, fileSystem: fs, mirrors: .init())
+        store = try PinsStore(pinsFile: pinsFile, fileSystem: fs, mirrors: .init(fileSystem: fs))
         XCTAssert(store.pins.map{$0}.count == 2)
 
         // Test branch pin.
@@ -82,7 +82,7 @@ final class PinsStoreTests: XCTestCase {
                 state: CheckoutState(revision: revision, branch: "develop")
             )
             try store.saveState()
-            store = try PinsStore(pinsFile: pinsFile, fileSystem: fs, mirrors: .init())
+            store = try PinsStore(pinsFile: pinsFile, fileSystem: fs, mirrors: .init(fileSystem: fs))
 
             let barPin = store.pinsMap[bar]!
             XCTAssertEqual(barPin.state.branch, "develop")
@@ -95,7 +95,7 @@ final class PinsStoreTests: XCTestCase {
         do {
             store.pin(packageRef: barRef, state: CheckoutState(revision: revision))
             try store.saveState()
-            store = try PinsStore(pinsFile: pinsFile, fileSystem: fs, mirrors: .init())
+            store = try PinsStore(pinsFile: pinsFile, fileSystem: fs, mirrors: .init(fileSystem: fs))
 
             let barPin = store.pinsMap[bar]!
             XCTAssertEqual(barPin.state.branch, nil)
@@ -139,14 +139,14 @@ final class PinsStoreTests: XCTestCase {
                 """
         }
 
-        let store = try PinsStore(pinsFile: pinsFile, fileSystem: fs, mirrors: .init())
+        let store = try PinsStore(pinsFile: pinsFile, fileSystem: fs, mirrors: .init(fileSystem: fs))
         XCTAssertEqual(store.pinsMap.keys.map { $0.description }.sorted(), ["clang_c", "commandant"])
     }
 
     func testEmptyPins() throws {
         let fs = InMemoryFileSystem()
         let pinsFile = AbsolutePath("/pinsfile.txt")
-        let store = try PinsStore(pinsFile: pinsFile, fileSystem: fs, mirrors: .init())
+        let store = try PinsStore(pinsFile: pinsFile, fileSystem: fs, mirrors: .init(fileSystem: fs))
 
         try store.saveState()
         XCTAssertFalse(fs.exists(pinsFile))
@@ -180,14 +180,16 @@ final class PinsStoreTests: XCTestCase {
         let bazURL = "https://github.com/cool/baz.git"
         let bazIdentity = PackageIdentity(url: bazURL)
 
-        let mirrors = DependencyMirrors()
-        mirrors.set(mirrorURL: fooMirroredURL, forURL: fooURL)
-        mirrors.set(mirrorURL: barMirroredURL, forURL: barURL)
-
         let fileSystem = InMemoryFileSystem()
-        let pinsFile = AbsolutePath("/pins.txt")
 
-        let store = try PinsStore(pinsFile: pinsFile, fileSystem: fileSystem, mirrors: mirrors)
+        let configuration = Configuration.Mirrors(fileSystem: fileSystem)
+        try configuration.withMapping { mapping in
+            mapping.set(mirrorURL: fooMirroredURL, forURL: fooURL)
+            mapping.set(mirrorURL: barMirroredURL, forURL: barURL)
+        }
+
+        let pinsFile = AbsolutePath("/pins.txt")
+        let store = try PinsStore(pinsFile: pinsFile, fileSystem: fileSystem, mirrors: configuration)
 
         store.pin(packageRef: .remote(identity: fooIdentity, location: fooMirroredURL),
                   state: CheckoutState(revision: .init(identifier: "foo-revision"), version: v1))
@@ -200,15 +202,15 @@ final class PinsStoreTests: XCTestCase {
         try store.saveState()
         XCTAssert(fileSystem.exists(pinsFile))
 
-        // Load the store again from disk, with no mirrors
-        let store2 = try PinsStore(pinsFile: pinsFile, fileSystem: fileSystem, mirrors: .init())
+        // Load the store again from disk, with no mirrors (blank InMemoryFileSystem)
+        let store2 = try PinsStore(pinsFile: pinsFile, fileSystem: fileSystem, mirrors: .init(fileSystem: InMemoryFileSystem()))
         XCTAssert(store2.pinsMap.count == 3)
         XCTAssertEqual(store2.pinsMap[fooIdentity]!.packageRef.location, fooURL)
         XCTAssertEqual(store2.pinsMap[barIdentity]!.packageRef.location, barURL)
         XCTAssertEqual(store2.pinsMap[bazIdentity]!.packageRef.location, bazURL)
 
         // Load the store again from disk, with mirrors
-        let store3 = try PinsStore(pinsFile: pinsFile, fileSystem: fileSystem, mirrors: mirrors)
+        let store3 = try PinsStore(pinsFile: pinsFile, fileSystem: fileSystem, mirrors: configuration)
         XCTAssert(store3.pinsMap.count == 3)
         XCTAssertEqual(store3.pinsMap[fooIdentity]!.packageRef.location, fooMirroredURL)
         XCTAssertEqual(store3.pinsMap[barMirroredIdentity]!.packageRef.location, barMirroredURL)


### PR DESCRIPTION
motivation: with SE-0292 adding more configuration, refactor the configuration uttilities to their own module so they can be used consistently across the code

changes:
* create a new Configuration module
* refactor Collections sources storage to use the configuration module
* refactor Mirrors to use the configuraiton module
* refactor netrc to use the configuraiton module
* adjust and add tests
