### PR TITLE
resolve warning from recent Version constructor changes

### DIFF
--- a/Sources/Commands/SwiftPackageCollectionsTool.swift
+++ b/Sources/Commands/SwiftPackageCollectionsTool.swift
@@ -271,7 +271,7 @@ public struct SwiftPackageCollectionsTool: ParsableCommand {
                     let result = try tsc_await { collections.getPackageMetadata(reference, callback: $0) }
 
                     if let versionString = version {
-                        guard let version = TSCUtility.Version(string: versionString), let result = result.package.versions.first(where: { $0.version == version }), let printedResult = printVersion(result) else {
+                        guard let version = TSCUtility.Version(versionString), let result = result.package.versions.first(where: { $0.version == version }), let printedResult = printVersion(result) else {
                             throw CollectionsError.invalidVersionString(versionString)
                         }
 

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -976,7 +976,7 @@ extension SwiftPackageTool.Config {
 
 extension SwiftPackageTool {
     struct ResolveOptions: ParsableArguments {
-        @Option(help: "The version to resolve at", transform: { Version(string: $0) })
+        @Option(help: "The version to resolve at", transform: { Version($0) })
         var version: Version?
         
         @Option(help: "The branch to resolve at")

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -461,18 +461,18 @@ extension PackageDependency.SourceControl.Requirement {
 
         case "range":
             let lowerBoundString = try json.get(String.self, forKey: "lowerBound")
-            guard let lowerBound = Version(string: lowerBoundString) else {
+            guard let lowerBound = Version(lowerBoundString) else {
                 throw InternalError("invalid version \(lowerBoundString)")
             }
             let upperBoundString = try json.get(String.self, forKey: "upperBound")
-            guard let upperBound = Version(string: upperBoundString) else {
+            guard let upperBound = Version(upperBoundString) else {
                 throw InternalError("invalid version \(upperBoundString)")
             }
             self = .range(lowerBound ..< upperBound)
 
         case "exact":
             let versionString = try json.get(String.self, forKey: "identifier")
-            guard let version = Version(string: versionString) else {
+            guard let version = Version(versionString) else {
                 throw InternalError("invalid version \(versionString)")
             }
             self = .exact(version)
@@ -489,18 +489,18 @@ extension PackageDependency.Registry.Requirement {
         switch type {
         case "range":
             let lowerBoundString = try json.get(String.self, forKey: "lowerBound")
-            guard let lowerBound = Version(string: lowerBoundString) else {
+            guard let lowerBound = Version(lowerBoundString) else {
                 throw InternalError("invalid version \(lowerBoundString)")
             }
             let upperBoundString = try json.get(String.self, forKey: "upperBound")
-            guard let upperBound = Version(string: upperBoundString) else {
+            guard let upperBound = Version(upperBoundString) else {
                 throw InternalError("invalid version \(upperBoundString)")
             }
             self = .range(lowerBound ..< upperBound)
 
         case "exact":
             let versionString = try json.get(String.self, forKey: "identifier")
-            guard let version = Version(string: versionString) else {
+            guard let version = Version(versionString) else {
                 throw InternalError("invalid version \(versionString)")
             }
             self = .exact(version)

--- a/Sources/SPMTestSupport/MockDependencyGraph.swift
+++ b/Sources/SPMTestSupport/MockDependencyGraph.swift
@@ -50,7 +50,7 @@ public extension MockDependencyGraph {
             let (container, version) = value
             guard case .string(let str) = version else { fatalError() }
             let package = PackageReference.remote(identity: PackageIdentity(url: container.lowercased()), location: "/\(container)")
-            return (package, Version(string: str)!)
+            return (package, Version(str)!)
         })
         self.name = name
         self.constraints = constraints.map(PackageContainerConstraint.init(json:))
@@ -67,7 +67,7 @@ private extension MockPackageContainer {
         var depByVersion: [Version: [(container: String, versionRequirement: VersionSetSpecifier)]] = [:]
         for (version, deps) in versions {
             guard case .array(let depArray) = deps else { fatalError() }
-            depByVersion[Version(string: version)!] = depArray
+            depByVersion[Version(version)!] = depArray
                 .map(PackageContainerConstraint.init(json:))
                 .map { constraint in
                     switch constraint.requirement {
@@ -109,11 +109,11 @@ private extension VersionSetSpecifier {
             switch arr.count {
             case 1:
                 guard case .string(let str) = arr[0] else { fatalError() }
-                self = .exact(Version(string: str)!)
+                self = .exact(Version(str)!)
             case 2:
                 let versions = arr.map { json -> Version in
                     guard case .string(let str) = json else { fatalError() }
-                    return Version(string: str)!
+                    return Version(str)!
                 }
                 self = .range(versions[0] ..< versions[1])
             default: fatalError()

--- a/Sources/SPMTestSupport/MockPackageContainer.swift
+++ b/Sources/SPMTestSupport/MockPackageContainer.swift
@@ -92,7 +92,7 @@ public class MockPackageContainer: PackageContainer {
         dependencies: [String: [Dependency]] = [:]
     ) {
         self.package = package
-        self._versions = dependencies.keys.compactMap(Version.init(string:)).sorted()
+        self._versions = dependencies.keys.compactMap(Version.init(_:)).sorted()
         self.dependencies = dependencies
     }
 }

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -120,7 +120,7 @@ public final class MockWorkspace {
             let versions: [String?] = packageKind == .remote ? package.versions : [nil]
             let manifestPath = packagePath.appending(component: Manifest.filename)
             for version in versions {
-                let v = version.flatMap(Version.init(string:))
+                let v = version.flatMap(Version.init(_:))
                 manifests[.init(url: packageLocation, version: v)] = Manifest(
                     name: package.name,
                     path: manifestPath,

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -2106,7 +2106,7 @@ public class MockContainer: PackageContainer {
     ) {
         self.package = package
         self.dependencies = dependencies
-        let versions = dependencies.keys.compactMap(Version.init(string:))
+        let versions = dependencies.keys.compactMap(Version.init(_:))
         self._versions = versions
             .sorted()
             .map(BoundVersion.version)

--- a/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
+++ b/Tests/PackageGraphTests/RepositoryPackageContainerProviderTests.swift
@@ -48,7 +48,7 @@ private class MockRepository: Repository {
     }
 
     func resolveRevision(tag: String) throws -> Revision {
-        assert(self.versions.index(forKey: Version(string: tag)!) != nil)
+        assert(self.versions.index(forKey: Version(tag)!) != nil)
         return Revision(identifier: tag)
     }
 
@@ -69,7 +69,7 @@ private class MockRepository: Repository {
     }
 
     func openFileView(revision: Revision) throws -> FileSystem {
-        assert(self.versions.index(forKey: Version(string: revision.identifier)!) != nil)
+        assert(self.versions.index(forKey: Version(revision.identifier)!) != nil)
         // This is used for reading the tools version.
         return self.fs
     }


### PR DESCRIPTION
motivation: less warnings

changes: use Version(_:) instead of the recently deprecated Version(string:)
