### PR TITLE
Allow a custom manifest loader to provide custom environment variables

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -763,7 +763,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             cmd += ["-o", compiledManifestFile.pathString]
 
             // Compile the manifest.
-            let compilerResult = try Process.popen(arguments: cmd)
+            let compilerResult = try Process.popen(arguments: cmd, environment: toolchain.swiftCompilerEnvironment)
             let compilerOutput = try (compilerResult.utf8Output() + compilerResult.utf8stderrOutput()).spm_chuzzle()
             result.compilerOutput = compilerOutput
 

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -590,8 +590,8 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             stream <<< packageIdentity
             stream <<< manifestContents
             stream <<< toolsVersion.description
-            for key in env.keys.sorted(by: >) {
-                stream <<< key <<< env[key]! // forced unwrap safe
+            for (key, value) in env.sorted(by: { $0.key > $1.key }) {
+                stream <<< key <<< value
             }
             stream <<< swiftpmVersion
             return stream.bytes.sha256Checksum

--- a/Sources/PackageModel/ToolchainConfiguration.swift
+++ b/Sources/PackageModel/ToolchainConfiguration.swift
@@ -21,6 +21,9 @@ public struct ToolchainConfiguration {
     /// Extra arguments to pass the Swift compiler (defaults to the empty string).
     public var swiftCompilerFlags: [String]
 
+    /// Environment to pass to the Swift compiler (defaults to the inherited environment).
+    public var swiftCompilerEnvironment: [String: String]
+
     /// The path of the library resources.
     public var libDir: AbsolutePath
 
@@ -47,6 +50,7 @@ public struct ToolchainConfiguration {
     public init(
         swiftCompiler: AbsolutePath,
         swiftCompilerFlags: [String] = [],
+        swiftCompilerEnvironment: [String: String] = ProcessEnv.vars,
         libDir: AbsolutePath? = nil,
         binDir: AbsolutePath? = nil,
         sdkRoot: AbsolutePath? = nil,
@@ -54,6 +58,7 @@ public struct ToolchainConfiguration {
     ) {
         self.swiftCompiler = swiftCompiler
         self.swiftCompilerFlags = swiftCompilerFlags
+        self.swiftCompilerEnvironment = swiftCompilerEnvironment
         self.libDir = libDir ?? Self.libDir(forBinDir: swiftCompiler.parentDirectory)
         self.binDir = binDir
         self.sdkRoot = sdkRoot

--- a/Sources/PackageModel/ToolchainConfiguration.swift
+++ b/Sources/PackageModel/ToolchainConfiguration.swift
@@ -10,30 +10,30 @@
 
 import TSCBasic
 
-/// Toolchain configuration required for evaluation os swift code such as the manifests or plugins
+/// Toolchain configuration required for evaluation of swift code such as the manifests or plugins
 ///
 /// These requirements are abstracted out to make it easier to add support for
 /// using the package manager with alternate toolchains in the future.
 public struct ToolchainConfiguration {
     /// The path of the swift compiler.
-    public let swiftCompiler: AbsolutePath
+    public var swiftCompiler: AbsolutePath
 
-    /// Extra flags to pass the Swift compiler.
-    public let swiftCompilerFlags: [String]
+    /// Extra arguments to pass the Swift compiler (defaults to the empty string).
+    public var swiftCompilerFlags: [String]
 
     /// The path of the library resources.
-    public let libDir: AbsolutePath
+    public var libDir: AbsolutePath
 
     /// The bin directory.
-    public let binDir: AbsolutePath?
+    public var binDir: AbsolutePath?
 
     /// The path to SDK root.
     ///
     /// If provided, it will be passed to the swift interpreter.
-    public let sdkRoot: AbsolutePath?
+    public var sdkRoot: AbsolutePath?
 
     /// XCTest Location
-    public let xctestLocation: AbsolutePath?
+    public var xctestLocation: AbsolutePath?
 
     /// Creates the set of manifest resources associated with a `swiftc` executable.
     ///

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -114,7 +114,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
         let compiledExec = cacheDir.appending(component: "compiled-plugin")
         command += ["-o", compiledExec.pathString]
 
-        let result = try Process.popen(arguments: command)
+        let result = try Process.popen(arguments: command, environment: toolchain.swiftCompilerEnvironment)
         let output = try (result.utf8Output() + result.utf8stderrOutput()).spm_chuzzle() ?? ""
         if result.exitStatus != .terminated(code: 0) {
             // TODO: Make this a proper error.

--- a/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
@@ -547,4 +547,53 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
             XCTAssertEqual(manifest.dependencies, [])
         }
     }
+
+    func testManifestLoaderEnvironment() throws {
+        try testWithTemporaryDirectory { path in
+            let fs = localFileSystem
+
+            let packagePath = path.appending(component: "pkg")
+            let manifestPath = packagePath.appending(component: "Package.swift")
+            try fs.writeFileContents(manifestPath) { stream in
+                stream <<< """
+                // swift-tools-version:5
+                import PackageDescription
+
+                let package = Package(
+                    name: "Trivial",
+                    targets: [
+                        .target(
+                            name: "foo",
+                            dependencies: []),
+                    ]
+                )
+                """
+            }
+
+            let moduleTraceFilePath = path.appending(component: "swift-module-trace")
+            var toolchain = ToolchainConfiguration.default
+            toolchain.swiftCompilerEnvironment["SWIFT_LOADED_MODULE_TRACE_FILE"] = moduleTraceFilePath.pathString
+            let manifestLoader = ManifestLoader(
+                toolchain: toolchain,
+                serializedDiagnostics: true,
+                isManifestSandboxEnabled: false,
+                cacheDir: nil)
+
+            let diagnostics = DiagnosticsEngine()
+            let manifest = try manifestLoader.load(
+                at: manifestPath.parentDirectory,
+                packageKind: .local,
+                packageLocation: manifestPath.pathString,
+                toolsVersion: .v5,
+                fileSystem: fs,
+                diagnostics: diagnostics
+            )
+
+            XCTAssertTrue(diagnostics.diagnostics.isEmpty)
+            XCTAssertEqual(manifest.name, "Trivial")
+
+            let moduleTraceJSON = try XCTUnwrap(try localFileSystem.readFileContents(moduleTraceFilePath).validDescription)
+            XCTAssert(moduleTraceJSON.contains("PackageDescription"))
+        }
+    }
 }


### PR DESCRIPTION
Extend `ToolchainConfiguration` to allow a customization of the environment used when compiling package manifests.

### Motivation:

Clients of libSwiftPM can already provide a set of custom flags to pass to the Swift compiler when compiling and linking the manifest.  This extends this support to allow custom environment entries as well.  There's no immediate use for this in SwiftPM, but it could be used in the future, and there are clients that want to do so

### Modifications:

- add a new property to `ToolchainConfiguration` that contains a string-to-string mapping
- default it to `ProcessEnv.vars` to maintain status quo — this happens to not be needed on Darwin but is needed on Linux
- use it when compiling manifests and plugin scripts
- add a unit tests that uses this functionality for a toy purpose (for testing)

A separate but related change (in a separate commit) is to make the properties of `ToolchainConfiguration` be mutable, so that clients can use `ToolchainConfiguration.default` and then mutate a single property without having to instantiate a new struct and pass all the properties from `ToolchainConfigratuion.default`.

### Result:

Clients of libSwiftPM can customize the environment used when compiling package manifests.
