### PR TITLE
refactor toolchain SwiftPM libraries path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -344,7 +344,7 @@ $> SWIFT_EXEC=/path/to/my/built/swiftc swift build
 
 SwiftPM computes the path of its runtime libraries relative to where it is
 installed. This path can be overridden by setting the environment variable
-`SWIFTPM_PD_LIBS` to a directory containing the libraries, or a colon-separated list of
+`SWIFTPM_CUSTOM_LIBS_DIR` to a directory containing the libraries, or a colon-separated list of
 absolute search paths. SwiftPM will choose the first
 path which exists on disk. If none of the paths are present on disk, it will fall
 back to built-in computation.

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -136,7 +136,7 @@ public struct SwiftRunTool: SwiftCommand {
             let arguments = buildOp.buildPlan!.createREPLArguments()
             print("Launching Swift REPL with arguments: \(arguments.joined(separator: " "))")
             try run(
-                swiftTool.getToolchain().swiftInterpreter,
+                swiftTool.getToolchain().swiftInterpreterPath,
                 originalWorkingDirectory: swiftTool.originalWorkingDirectory,
                 arguments: arguments)
 
@@ -171,7 +171,7 @@ public struct SwiftRunTool: SwiftCommand {
             if let executable = options.executable, isValidSwiftFilePath(executable) {
                 swiftTool.diagnostics.emit(.runFileDeprecation)
                 // Redirect execution to the toolchain's swift executable.
-                let swiftInterpreterPath = try swiftTool.getToolchain().swiftInterpreter
+                let swiftInterpreterPath = try swiftTool.getToolchain().swiftInterpreterPath
                 // Prepend the script to interpret to the arguments.
                 let arguments = [executable] + options.arguments
                 try run(

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -1039,10 +1039,9 @@ fileprivate func constructTestEnvironment(
         let codecovProfile = buildParameters.buildPath.appending(components: "codecov", "default%m.profraw")
         env["LLVM_PROFILE_FILE"] = codecovProfile.pathString
     }
-
   #if !os(macOS)
 #if os(Windows)
-    if let location = toolchain.manifestResources.xctestLocation {
+    if let location = toolchain.configuration.xctestPath {
       env["Path"] = "\(location.pathString);\(env["Path"] ?? "")"
     }
 #endif

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -695,14 +695,14 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         let macOSPackageDescriptionPath: AbsolutePath
         // if runtimePath is set to "PackageFrameworks" that means we could be developing SwiftPM in Xcode
         // which produces a framework for dynamic package products.
-        if runtimePath.basename == "PackageFrameworks" {
+        if runtimePath.extension == "framework" {
             cmd += [
-                "-F", runtimePath.pathString,
+                "-F", runtimePath.parentDirectory.pathString,
                 "-framework", "PackageDescription",
-                "-Xlinker", "-rpath", "-Xlinker", runtimePath.pathString,
+                "-Xlinker", "-rpath", "-Xlinker", runtimePath.parentDirectory.pathString,
             ]
 
-            macOSPackageDescriptionPath = runtimePath.appending(RelativePath("PackageDescription.framework/PackageDescription"))
+            macOSPackageDescriptionPath = runtimePath.appending(component: "PackageDescription")
         } else {
             cmd += [
                 "-L", runtimePath.pathString,
@@ -715,7 +715,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 #endif
 
             // note: this is not correct for all platforms, but we only actually use it on macOS.
-            macOSPackageDescriptionPath = runtimePath.appending(RelativePath("libPackageDescription.dylib"))
+            macOSPackageDescriptionPath = runtimePath.appending(component: "libPackageDescription.dylib")
         }
 
         // Use the same minimum deployment target as the PackageDescription library (with a fallback of 10.15).
@@ -854,8 +854,8 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         cmd += ["-swift-version", toolsVersion.swiftLanguageVersion.rawValue]
         // if runtimePath is set to "PackageFrameworks" that means we could be developing SwiftPM in Xcode
         // which produces a framework for dynamic package products.
-        if runtimePath.basename == "PackageFrameworks" {
-            cmd += ["-I", runtimePath.parentDirectory.pathString]
+        if runtimePath.extension == "framework" {
+            cmd += ["-I", runtimePath.parentDirectory.parentDirectory.pathString]
         } else {
             cmd += ["-I", runtimePath.pathString]
         }

--- a/Sources/PackageModel/ToolchainConfiguration.swift
+++ b/Sources/PackageModel/ToolchainConfiguration.swift
@@ -103,7 +103,7 @@ extension ToolchainConfiguration {
             )
         }
 
-        fileprivate init(swiftCompilerPath: AbsolutePath) {
+        public init(swiftCompilerPath: AbsolutePath) {
             let rootPath = swiftCompilerPath.parentDirectory.parentDirectory.appending(components: "lib", "swift", "pm")
             self.init(root: rootPath)
         }

--- a/Sources/SPMPackageEditor/PackageEditor.swift
+++ b/Sources/SPMPackageEditor/PackageEditor.swift
@@ -268,7 +268,7 @@ public final class PackageEditorContext {
 
         // Create toolchain.
         let hostToolchain = try UserToolchain(destination: .hostDestination())
-        self.manifestLoader = ManifestLoader(manifestResources: hostToolchain.manifestResources)
+        self.manifestLoader = ManifestLoader(manifestResources: hostToolchain.configuration)
 
         let repositoriesPath = buildDir.appending(component: "repositories")
         self.repositoryManager = RepositoryManager(

--- a/Sources/SPMTestSupport/Toolchain.swift
+++ b/Sources/SPMTestSupport/Toolchain.swift
@@ -35,10 +35,9 @@ extension ToolchainConfiguration {
         get {
             let toolchain = UserToolchain.default
             return .init(
-                swiftCompiler: toolchain.configuration.swiftCompiler,
+                swiftCompilerPath: toolchain.configuration.swiftCompilerPath,
                 swiftCompilerFlags: [],
-                libDir: toolchain.configuration.libDir,
-                binDir: toolchain.configuration.binDir
+                swiftPMLibrariesLocation: toolchain.configuration.swiftPMLibrariesLocation
             )
         }
     }

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -40,7 +40,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
     
     public var hostTriple: Triple {
         return Self._hostTriple.memoize {
-            Triple.getHostTriple(usingSwiftCompiler: self.toolchain.swiftCompiler)
+            Triple.getHostTriple(usingSwiftCompiler: self.toolchain.swiftCompilerPath)
         }
     }
 
@@ -48,28 +48,25 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
     fileprivate func compile(sources: Sources, toolsVersion: ToolsVersion, cacheDir: AbsolutePath) throws -> AbsolutePath {
         // FIXME: Much of this is copied from the ManifestLoader and should be consolidated.
 
-        // Bin dir will be set when developing swiftpm without building all of the runtimes.
-        let runtimePath = self.toolchain.binDir ?? self.toolchain.libDir.appending(component: "PluginAPI")
+        let runtimePath = self.toolchain.swiftPMLibrariesLocation.pluginAPI
 
         // Compile the package plugin script.
-        var command = [self.toolchain.swiftCompiler.pathString]
+        var command = [self.toolchain.swiftCompilerPath.pathString]
 
         // FIXME: Workaround for the module cache bug that's been haunting Swift CI
         // <rdar://problem/48443680>
         let moduleCachePath = ProcessEnv.vars["SWIFTPM_MODULECACHE_OVERRIDE"] ?? ProcessEnv.vars["SWIFTPM_TESTS_MODULECACHE"]
 
-        // If we got the binDir that means we could be developing SwiftPM in Xcode
-        // which produces a framework for dynamic package products.
-        let packageFrameworkPath = runtimePath.appending(component: "PackageFrameworks")
-
         let macOSPackageDescriptionPath: AbsolutePath
-        if self.toolchain.binDir != nil, localFileSystem.exists(packageFrameworkPath) {
+        // if runtimePath is set to "PackageFrameworks" that means we could be developing SwiftPM in Xcode
+        // which produces a framework for dynamic package products.
+        if runtimePath.basename == "PackageFrameworks" {
             command += [
-                "-F", packageFrameworkPath.pathString,
+                "-F", runtimePath.pathString,
                 "-framework", "PackagePlugin",
-                "-Xlinker", "-rpath", "-Xlinker", packageFrameworkPath.pathString,
+                "-Xlinker", "-rpath", "-Xlinker", runtimePath.pathString,
             ]
-            macOSPackageDescriptionPath = packageFrameworkPath.appending(RelativePath("PackagePlugin.framework/PackagePlugin"))
+            macOSPackageDescriptionPath = runtimePath.appending(RelativePath("PackagePlugin.framework/PackagePlugin"))
         } else {
             command += [
                 "-L", runtimePath.pathString,
@@ -99,9 +96,15 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
         command += self.toolchain.swiftCompilerFlags
 
         command += ["-swift-version", toolsVersion.swiftLanguageVersion.rawValue]
-        command += ["-I", runtimePath.pathString]
+        // if runtimePath is set to "PackageFrameworks" that means we could be developing SwiftPM in Xcode
+        // which produces a framework for dynamic package products.
+        if runtimePath.basename == "PackageFrameworks" {
+            command += ["-I", runtimePath.parentDirectory.pathString]
+        } else {
+            command += ["-I", runtimePath.pathString]
+        }
         #if os(macOS)
-        if let sdkRoot = self.toolchain.sdkRoot ?? self.sdkRoot() {
+        if let sdkRoot = self.toolchain.sdkRootPath ?? self.sdkRoot() {
             command += ["-sdk", sdkRoot.pathString]
         }
         #endif

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -60,13 +60,13 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
         let macOSPackageDescriptionPath: AbsolutePath
         // if runtimePath is set to "PackageFrameworks" that means we could be developing SwiftPM in Xcode
         // which produces a framework for dynamic package products.
-        if runtimePath.basename == "PackageFrameworks" {
+        if runtimePath.extension == "framework" {
             command += [
-                "-F", runtimePath.pathString,
+                "-F", runtimePath.parentDirectory.pathString,
                 "-framework", "PackagePlugin",
-                "-Xlinker", "-rpath", "-Xlinker", runtimePath.pathString,
+                "-Xlinker", "-rpath", "-Xlinker", runtimePath.parentDirectory.pathString,
             ]
-            macOSPackageDescriptionPath = runtimePath.appending(RelativePath("PackagePlugin.framework/PackagePlugin"))
+            macOSPackageDescriptionPath = runtimePath.appending(component: "PackagePlugin")
         } else {
             command += [
                 "-L", runtimePath.pathString,
@@ -79,7 +79,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
             #endif
 
             // note: this is not correct for all platforms, but we only actually use it on macOS.
-            macOSPackageDescriptionPath = runtimePath.appending(RelativePath("libPackagePlugin.dylib"))
+            macOSPackageDescriptionPath = runtimePath.appending(component: "libPackagePlugin.dylib")
         }
 
         // Use the same minimum deployment target as the PackageDescription library (with a fallback of 10.15).
@@ -98,8 +98,8 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
         command += ["-swift-version", toolsVersion.swiftLanguageVersion.rawValue]
         // if runtimePath is set to "PackageFrameworks" that means we could be developing SwiftPM in Xcode
         // which produces a framework for dynamic package products.
-        if runtimePath.basename == "PackageFrameworks" {
-            command += ["-I", runtimePath.parentDirectory.pathString]
+        if runtimePath.extension == "framework" {
+            command += ["-I", runtimePath.parentDirectory.parentDirectory.pathString]
         } else {
             command += ["-I", runtimePath.pathString]
         }

--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -90,8 +90,10 @@ public struct Destination: Encodable, Equatable {
         environment: [String:String] = ProcessEnv.vars
     ) throws -> Destination {
         // Select the correct binDir.
-        let customBinDir = ProcessEnv
-            .vars["SWIFTPM_CUSTOM_BINDIR"]
+        if ProcessEnv.vars["SWIFTPM_CUSTOM_BINDIR"] != nil {
+            print("SWIFTPM_CUSTOM_BINDIR was deprecated in favor of SWIFTPM_CUSTOM_BIN_DIR")
+        }
+        let customBinDir = (ProcessEnv.vars["SWIFTPM_CUSTOM_BIN_DIR"] ?? ProcessEnv.vars["SWIFTPM_CUSTOM_BINDIR"])
             .flatMap{ try? AbsolutePath(validating: $0) }
         let binDir = try customBinDir ?? binDir ?? Destination.hostBinDir(
             originalWorkingDirectory: originalWorkingDirectory)

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -432,6 +432,12 @@ public final class UserToolchain: Toolchain {
 
         let applicationPath = destination.binDir
 
+        // this is the normal case when using the toolchain
+        let librariesPath = applicationPath.parentDirectory.appending(components: "lib", "swift", "pm")
+        if localFileSystem.exists(librariesPath) {
+            return .init(root: librariesPath)
+        }
+
         // this tests if we are debugging / testing SwiftPM with Xcode
         let manifestFrameworksPath = applicationPath.appending(components: "PackageFrameworks", "PackageDescription.framework")
         let pluginFrameworksPath = applicationPath.appending(components: "PackageFrameworks", "PackagePlugin.framework")
@@ -448,12 +454,6 @@ public final class UserToolchain: Toolchain {
                 manifestAPI: applicationPath,
                 pluginAPI: applicationPath
             )
-        }
-
-        // this tests if we are debugging / testing SwiftPM with CMake / bootstrap
-        let cmakeLibrariesPath = applicationPath.parentDirectory.appending(components: "lib", "swift", "pm")
-        if localFileSystem.exists(cmakeLibrariesPath) {
-            return .init(root: cmakeLibrariesPath)
         }
 
         // default case - no custom location which will use the one from the toolchain

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -385,20 +385,20 @@ public final class UserToolchain: Toolchain {
             }
         }
 
-        let customSwiftPMLibrariesLocation = try Self.deriveCustomSwiftPMLibrariesLocation(swiftCompilerPath: swiftCompilerPath, destination: destination)
+        let swiftPMLibrariesLocation = try Self.deriveSwiftPMLibrariesLocation(swiftCompilerPath: swiftCompilerPath, destination: destination)
 
         let xctestPath = Self.deriveXCTestPath()
 
         self.configuration = .init(
             swiftCompilerPath: swiftCompilers.manifest,
             swiftCompilerFlags: self.extraSwiftCFlags,
-            swiftPMLibrariesLocation: customSwiftPMLibrariesLocation,
+            swiftPMLibrariesLocation: swiftPMLibrariesLocation,
             sdkRootPath: self.destination.sdk,
             xctestPath: xctestPath
         )
     }
 
-    private static func deriveCustomSwiftPMLibrariesLocation(
+    private static func deriveSwiftPMLibrariesLocation(
         swiftCompilerPath: AbsolutePath,
         destination: Destination
     ) throws -> ToolchainConfiguration.SwiftPMLibrariesLocation? {
@@ -443,8 +443,8 @@ public final class UserToolchain: Toolchain {
         let pluginFrameworksPath = applicationPath.appending(components: "PackageFrameworks", "PackagePlugin.framework")
         if localFileSystem.exists(manifestFrameworksPath) && localFileSystem.exists(pluginFrameworksPath) {
             return .init(
-                manifestAPI: manifestFrameworksPath.parentDirectory,
-                pluginAPI: pluginFrameworksPath.parentDirectory
+                manifestAPI: manifestFrameworksPath,
+                pluginAPI: pluginFrameworksPath
             )
         }
 
@@ -456,8 +456,8 @@ public final class UserToolchain: Toolchain {
             )
         }
 
-        // default case - no custom location which will use the one from the toolchain
-        return nil
+        // we are using a SwiftPM outside a toolchain, use the compiler path to compute the location
+        return .init(swiftCompilerPath: swiftCompilerPath)
     }
 
     // TODO: why is this only required on Windows? is there something better we can do?

--- a/Sources/Workspace/UserToolchain.swift
+++ b/Sources/Workspace/UserToolchain.swift
@@ -301,7 +301,7 @@ public final class UserToolchain: Toolchain {
                 : [])
         + destination.extraSwiftCFlags
     }
-    
+
     // MARK: - initializer
 
     public init(destination: Destination, environment: [String: String] = ProcessEnv.vars) throws {
@@ -448,6 +448,12 @@ public final class UserToolchain: Toolchain {
                 manifestAPI: applicationPath,
                 pluginAPI: applicationPath
             )
+        }
+
+        // this tests if we are debugging / testing SwiftPM with CMake / bootstrap
+        let cmakeLibrariesPath = applicationPath.parentDirectory.appending(components: "lib", "swift", "pm")
+        if localFileSystem.exists(cmakeLibrariesPath) {
+            return .init(root: cmakeLibrariesPath)
         }
 
         // default case - no custom location which will use the one from the toolchain

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -302,12 +302,12 @@ final class BuildToolTests: XCTestCase {
         fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { path in
             // Try building using XCBuild without specifying overrides.  This should succeed, and should use the default compiler path.
             let defaultOutput = try execute(["-c", "debug", "-v"], packagePath: path).stdout
-            XCTAssert(defaultOutput.contains(ToolchainConfiguration.default.swiftCompiler.pathString), defaultOutput)
+            XCTAssert(defaultOutput.contains(ToolchainConfiguration.default.swiftCompilerPath.pathString), defaultOutput)
 
             // Now try building using XCBuild while specifying a faulty compiler override.  This should fail.  Note that we need to set the executable to use for the manifest itself to the default one, since it defaults to SWIFT_EXEC if not provided.
             var overriddenOutput = ""
             do {
-                overriddenOutput = try execute(["-c", "debug", "-v"], environment: ["SWIFT_EXEC": "/usr/bin/false", "SWIFT_EXEC_MANIFEST": ToolchainConfiguration.default.swiftCompiler.pathString], packagePath: path).stdout
+                overriddenOutput = try execute(["-c", "debug", "-v"], environment: ["SWIFT_EXEC": "/usr/bin/false", "SWIFT_EXEC_MANIFEST": ToolchainConfiguration.default.swiftCompilerPath.pathString], packagePath: path).stdout
                 XCTFail("unexpected success (was SWIFT_EXEC not overridden properly?)")
             }
             catch SwiftPMProductError.executionFailure(let error, let stdout, _) {

--- a/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
+++ b/Tests/FunctionalPerformanceTests/BuildPerfTests.swift
@@ -21,7 +21,7 @@ class BuildPerfTests: XCTestCasePerf {
     @discardableResult
     func execute(args: [String] = [], packagePath: AbsolutePath) throws -> (stdout: String, stderr: String) {
         // FIXME: We should pass the SWIFT_EXEC at lower level.
-        return try SwiftPMProduct.SwiftBuild.execute(args + [], packagePath: packagePath, env: ["SWIFT_EXEC": ToolchainConfiguration.default.swiftCompiler.pathString])
+        return try SwiftPMProduct.SwiftBuild.execute(args + [], packagePath: packagePath, env: ["SWIFT_EXEC": ToolchainConfiguration.default.swiftCompilerPath.pathString])
     }
 
     func clean(packagePath: AbsolutePath) throws {

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -8,19 +8,17 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
-import XCTest
-
+import Basics
 import PackageGraph
 import PackageLoading
 import PackageModel
 import SourceControl
 import SPMBuildCore
+import SPMTestSupport
 import TSCBasic
 import TSCUtility
 @testable import Workspace
-import Basics
-
-import SPMTestSupport
+import XCTest
 
 final class WorkspaceTests: XCTestCase {
     func testBasics() throws {

--- a/Tests/XcodeprojTests/FunctionalTests.swift
+++ b/Tests/XcodeprojTests/FunctionalTests.swift
@@ -139,7 +139,7 @@ func XCTAssertXcodeBuild(project: AbsolutePath, file: StaticString = #file, line
             env["TOOLCHAINS"] = "default"
         }
         let xcconfig = project.appending(component: "overrides.xcconfig")
-        let swiftCompilerPath = ToolchainConfiguration.default.swiftCompiler
+        let swiftCompilerPath = ToolchainConfiguration.default.swiftCompilerPath
 
         // Override path to the Swift compiler.
         let stream = BufferedOutputByteStream()

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -589,7 +589,7 @@ def build_swiftpm_with_swiftpm(args, integrated_swift_driver):
 
     if args.bootstrap:
         note("Building SwiftPM (with a freshly built swift-build)")
-        swiftpm_args.append("SWIFTPM_PD_LIBS=" + os.path.join(args.bootstrap_dir, "pm"))
+        swiftpm_args.append("SWIFTPM_CUSTOM_LIBS_DIR=" + os.path.join(args.bootstrap_dir, "pm"))
         swiftpm_args.append(os.path.join(args.bootstrap_dir, "bin/swift-build"))
     else:
         note("Building SwiftPM (with a prebuilt swift-build)")


### PR DESCRIPTION
motivation: improve logic in how Manifest and Plugin APIs locations are derived

changes:
* rename fields on ToolchainConfiguration to better articulate their meaning
* change logic in UserToolchain to derive the SwiftPM libraries path more clearly and reliably
* adjust call-sites and test

