### PR TITLE
add docker file for swift 5.5

### DIFF
--- a/Utilities/Docker/docker-compose.2004.55.yaml
+++ b/Utilities/Docker/docker-compose.2004.55.yaml
@@ -11,26 +11,27 @@ version: "3"
 services:
 
   runtime-setup:
-    image: swift-package-manager:20.04-5.4
+    image: swift-package-manager:20.04-5.5
     build:
       args:
         ubuntu_version: "focal"
-        swift_version: "5.4"
+        swift_version: "5.5"
+        base_image: "swiftlang/swift:nightly-5.5-focal"
 
   build:
-    image: swift-package-manager:20.04-5.4
+    image: swift-package-manager:20.04-5.5
 
   test:
-    image: swift-package-manager:20.04-5.4
+    image: swift-package-manager:20.04-5.5
 
   bootstrap-clean:
-    image: swift-package-manager:20.04-5.4
+    image: swift-package-manager:20.04-5.5
 
   bootstrap-build:
-    image: swift-package-manager:20.04-5.4
+    image: swift-package-manager:20.04-5.5
 
   bootstrap-test:
-    image: swift-package-manager:20.04-5.4
+    image: swift-package-manager:20.04-5.5
 
   shell:
-    image: swift-package-manager:20.04-5.4
+    image: swift-package-manager:20.04-5.5


### PR DESCRIPTION
motivation: keep with the times

changes:
* update 5.4 docker file to use the release version instead of the development one
* add a 5.5 dockerfile
