### PR TITLE
[5.5] Allow a custom manifest loader to provide custom environment variables when compiling the manifest

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -42,8 +42,11 @@ public protocol ManifestResourceProvider {
     /// The bin directory.
     var binDir: AbsolutePath? { get }
 
-    /// Extra flags to pass the Swift compiler.
+    /// Extra flags to pass the Swift compiler (if not specified, no additional arguments are passed).
     var swiftCompilerFlags: [String] { get }
+    
+    /// Custom environment to pass to the Swift compiler (if not specified, the inherited environment is passed).
+    var swiftCompilerEnvironment: [String: String] { get }
 
     /// XCTest Location
     var xctestLocation: AbsolutePath? { get }
@@ -62,6 +65,10 @@ public extension ManifestResourceProvider {
 
     var swiftCompilerFlags: [String] {
         return []
+    }
+    
+    var swiftCompilerEnvironment: [String: String] {
+        return ProcessEnv.vars
     }
 
     var xctestLocation: AbsolutePath? {
@@ -807,9 +814,11 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 #endif
                 let compiledManifestFile = tmpDir.appending(component: "\(packageIdentity)-manifest\(executableSuffix)")
                 cmd += ["-o", compiledManifestFile.pathString]
+ 
+                 let compilerEnv = resources.swiftCompilerEnvironment
 
                 // Compile the manifest.
-                let compilerResult = try Process.popen(arguments: cmd)
+                let compilerResult = try Process.popen(arguments: cmd, environment: compilerEnv)
                 let compilerOutput = try (compilerResult.utf8Output() + compilerResult.utf8stderrOutput()).spm_chuzzle()
                 manifestParseResult.compilerOutput = compilerOutput
 

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -666,8 +666,8 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             stream <<< packageIdentity
             stream <<< manifestContents
             stream <<< toolsVersion.description
-            for key in env.keys.sorted(by: >) {
-                stream <<< key <<< env[key]! // forced unwrap safe
+            for (key, value) in env.sorted(by: { $0.key > $1.key }) {
+                stream <<< key <<< value
             }
             stream <<< swiftpmVersion
             return stream.bytes.sha256Checksum

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -114,8 +114,10 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner {
         command += sources.paths.map { $0.pathString }
         let compiledExec = cacheDir.appending(component: "compiled-plugin")
         command += ["-o", compiledExec.pathString]
+        
+        let compilerEnv = resources.swiftCompilerEnvironment
 
-        let result = try Process.popen(arguments: command)
+        let result = try Process.popen(arguments: command, environment: compilerEnv)
         let output = try (result.utf8Output() + result.utf8stderrOutput()).spm_chuzzle() ?? ""
         if result.exitStatus != .terminated(code: 0) {
             // TODO: Make this a proper error.


### PR DESCRIPTION
Extend the ManifestLoaderProtocol to allow a custom manifest loader to provide custom environment variables when compiling the manifest.

### Motivation:

Clients of libSwiftPM can already provide a set of custom flags to pass to the Swift compiler when compiling and linking the manifest. This extends this support to allow custom environment entries as well. There's no immediate use for this in SwiftPM itself, but it could be used in the future, and some clients need this.

### Modifications:

- add a new property to ManifestLoadersProtocol that contains a string-to-string mapping
- use it when compiling manifests and plugin scripts
- add a unit tests that uses this functionality for a toy purpose (for testing)

### Result:

Clients of libSwiftPM can specify environment entries.  Note that this does not affect the environment that is passed when running the compiled manifest.
