### PR TITLE
WIP: Add linkage of SwiftSyntax, to set the stage for future PRs that need it.

### DIFF
--- a/Sources/PackageSyntax/Lib.swift
+++ b/Sources/PackageSyntax/Lib.swift
@@ -1,0 +1,7 @@
+import SwiftSyntax
+
+public func DoSomethingWithSwiftSyntax() throws -> String {
+    let parsed = try SyntaxParser.parse(source: "let abc = 42")
+    print(parsed)
+    return parsed.description
+}

--- a/Tests/PackageSyntaxTests/PackageSyntaxTest.swift
+++ b/Tests/PackageSyntaxTests/PackageSyntaxTest.swift
@@ -1,0 +1,22 @@
+/*
+  This source file is part of the Swift.org open source project
+
+  Copyright (c) 2021 Apple Inc. and the Swift project authors
+  Licensed under Apache License v2.0 with Runtime Library Exception
+
+  See http://swift.org/LICENSE.txt for license information
+  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+  */
+
+import XCTest
+
+import PackageSyntax
+import SPMTestSupport
+
+final class PackageSyntaxTests: XCTestCase {
+     
+    func testDoingSomethingWithSwiftSyntax() throws {
+        XCTAssertEqual(try DoSomethingWithSwiftSyntax(), "description")
+    }
+}
+ 


### PR DESCRIPTION
The way in which this is done is based on #3034 but it's possible we'll need to tweak it.  It's not great to only get the dependency in 5.5 or later but there might not be much to do about that if the compiler ABI changed.

The idea here is to shake out the issues around this separately, so that the PRs that need SwiftSyntax can focus on just their changes.