### PR TITLE
enhance configuraiton for authentication providers 

### DIFF
--- a/Sources/Basics/AuthorizationProvider.swift
+++ b/Sources/Basics/AuthorizationProvider.swift
@@ -1,0 +1,26 @@
+/*
+ This source file is part of the Swift.org open source project
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Foundation
+
+public protocol AuthorizationProvider {
+    func authentication(for url: URL) -> (user: String, password: String)?
+}
+
+extension AuthorizationProvider {
+    public func httpAuthorizationHeader(for url: URL) -> String? {
+        guard let (user, password) = self.authentication(for: url) else {
+            return nil
+        }
+        let authString = "\(user):\(password)"
+        guard let authData = authString.data(using: .utf8) else {
+            return nil
+        }
+        return "Basic \(authData.base64EncodedString())"
+    }
+}

--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -7,6 +7,7 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(Basics
+  AuthorizationProvider.swift
   ByteString+Extensions.swift
   ConcurrencyHelpers.swift
   Dictionary+Extensions.swift

--- a/Tests/BasicsTests/AuthorizationProviderTests.swift
+++ b/Tests/BasicsTests/AuthorizationProviderTests.swift
@@ -1,0 +1,35 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Basics
+import TSCBasic
+import XCTest
+
+final class AuthorizationProviderTests: XCTestCase {
+    func testBasicAPIs() {
+        struct TestProvider: AuthorizationProvider {
+            let map: [URL: (user: String, password: String)]
+
+            func authentication(for url: URL) -> (user: String, password: String)? {
+                return self.map[url]
+            }
+        }
+
+        let url = URL(string: "http://\(UUID().uuidString)")!
+        let user = UUID().uuidString
+        let password = UUID().uuidString
+        let provider = TestProvider(map: [url: (user: user, password: password)])
+
+        let auth = provider.authentication(for: url)
+        XCTAssertEqual(auth?.user, user)
+        XCTAssertEqual(auth?.password, password)
+        XCTAssertEqual(provider.httpAuthorizationHeader(for: url), "Basic " + "\(user):\(password)".data(using: .utf8)!.base64EncodedString())
+    }
+}


### PR DESCRIPTION
motivation: support custom authentican providers, not just netrc

changes:
* reafactor and seperate out the auth data model from the loading/saving mutation utility
* adjust call sites
* add tests