### PR TITLE
Document user facing api changes introduced in 3280 and 3641

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,12 @@ Swift 5.5
 
 * [#3292]
     Adding a dependency requirement can now be done with the convenience initializer `.package(url: String, branch: String)`.
-   
+
+* [#3280]
+    A more intuitive `.product(name:, package:)` syntax is now accepted, where `package` is the package name as defined by the package URL.
+
 * [#3316]
     Test targets can now link against executable targets as if they were libraries, so that they can test any data strutures or algorithms in them.  All the code in the executable except for the main entry point itself is available to the unit test.  Separate executables are still linked, and can be tested as a subprocess in the same way as before.  This feature is available to tests defined in packages that have a tools version of `5.5` or newer. 
-
-
 
 Swift 5.4
 -----------
@@ -150,3 +151,4 @@ Swift 3.0
 [#3310]: https://github.com/apple/swift-package-manager/pull/3310
 [#3316]: https://github.com/apple/swift-package-manager/pull/3316
 [#3410]: https://github.com/apple/swift-package-manager/pull/3410
+[#3280]: https://github.com/apple/swift-package-manager/pull/3280

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,10 +151,10 @@ Swift 3.0
 [#1489]: https://github.com/apple/swift-package-manager/pull/1489
 [#1604]: https://github.com/apple/swift-package-manager/pull/1604
 [#2937]: https://github.com/apple/swift-package-manager/pull/2937
+[#3280]: https://github.com/apple/swift-package-manager/pull/3280
 [#3292]: https://github.com/apple/swift-package-manager/pull/3292
 [#3310]: https://github.com/apple/swift-package-manager/pull/3310
 [#3316]: https://github.com/apple/swift-package-manager/pull/3316
 [#3410]: https://github.com/apple/swift-package-manager/pull/3410
-[#3280]: https://github.com/apple/swift-package-manager/pull/3280
 [#3641]: https://github.com/apple/swift-package-manager/pull/3641
 [#3649]: https://github.com/apple/swift-package-manager/pull/3649

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 Note: This is in reverse chronological order, so newer entries are added to the top.
 
-Swift v.Next
+Swift 5.6
  -----------
  * [#3649]
      Semantic version dependencies can now be resolved against Git tag names that contain only major and minor version identifiers.  A tag with the form `X.Y` will be treated as `X.Y.0`. This improves compatibility with existing repositories.
 
+* [#3641]
+     Soft deprecate `.pacakge(name:, url:)` dependency syntax in favour of `.pacakge(url:)`, given that an explciit `name` attribute is no longer needed for target depedendencies lookup.
 
+* [#3641]
+    Adding a dependency requirement can now be done with the convenience initializer `.package(url: String, exact: Version)`.
 
 Swift 5.5
  -----------
@@ -19,7 +23,7 @@ Swift 5.5
     Adding a dependency requirement can now be done with the convenience initializer `.package(url: String, branch: String)`.
 
 * [#3280]
-    A more intuitive `.product(name:, package:)` syntax is now accepted, where `package` is the package name as defined by the package URL.
+    A more intuitive `.product(name:, package:)` target depedendency syntax is now accepted, where `package` is the package identifier as defined by the package URL.
 
 * [#3316]
     Test targets can now link against executable targets as if they were libraries, so that they can test any data strutures or algorithms in them.  All the code in the executable except for the main entry point itself is available to the unit test.  Separate executables are still linked, and can be tested as a subprocess in the same way as before.  This feature is available to tests defined in packages that have a tools version of `5.5` or newer. 
@@ -152,3 +156,5 @@ Swift 3.0
 [#3316]: https://github.com/apple/swift-package-manager/pull/3316
 [#3410]: https://github.com/apple/swift-package-manager/pull/3410
 [#3280]: https://github.com/apple/swift-package-manager/pull/3280
+[#3641]: https://github.com/apple/swift-package-manager/pull/3641
+[#3649]: https://github.com/apple/swift-package-manager/pull/3649


### PR DESCRIPTION
motivation: document manifest API / behavior changes

changes: add reference to product package name lookup done in #3280