### PR TITLE
PackageCollectionsSigning: correct `BoringSSLCertificate.keyType(of:)`

### DIFF
--- a/Sources/PackageCollectionsSigning/Certificate/Certificate.swift
+++ b/Sources/PackageCollectionsSigning/Certificate/Certificate.swift
@@ -181,7 +181,7 @@ final class BoringSSLCertificate {
     }
 
     private func keyType(of key: UnsafeMutablePointer<EVP_PKEY>) throws -> KeyType {
-        let algorithm = CCryptoBoringSSL_OBJ_obj2nid(self.underlying.pointee.cert_info.pointee.key.pointee.algor.pointee.algorithm)
+        let algorithm = CCryptoBoringSSL_EVP_PKEY_id(key)
 
         switch algorithm {
         case NID_rsaEncryption:


### PR DESCRIPTION
This function takes a named argument which is the `EVP_PKEY` and checks
the underlying public key type (expected to be one of RSA or EC).
However, instead of checking the key type of the given public key, it
was always returning the key type of the underlying certificate.  This
happened to give the correct result as the current usage always used the
same object to get the key.  This corrects that and uses the proper
accessors for the value.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
