### PR TITLE
un-deprecate name argument on file-system (aka local) dependencies

### DIFF
--- a/Sources/Commands/Describe.swift
+++ b/Sources/Commands/Describe.swift
@@ -100,16 +100,16 @@ fileprivate struct DescribedPackage: Encodable {
     
     /// Represents a package dependency for the sole purpose of generating a description.
     enum DescribedPackageDependency: Encodable {
-        case fileSystem(path: AbsolutePath)
-        case sourceControl(location: String, requirement: PackageDependency.SourceControl.Requirement)
+        case fileSystem(identity: PackageIdentity, path: AbsolutePath)
+        case sourceControl(identity: PackageIdentity, location: String, requirement: PackageDependency.SourceControl.Requirement)
         case registry(identity: PackageIdentity, requirement: PackageDependency.Registry.Requirement)
 
         init(from dependency: PackageDependency) {
             switch dependency {
             case .fileSystem(let settings):
-                self = .fileSystem(path: settings.path)
+                self = .fileSystem(identity: settings.identity, path: settings.path)
             case .sourceControl(let settings):
-                self = .sourceControl(location: settings.location, requirement: settings.requirement)
+                self = .sourceControl(identity: settings.identity, location: settings.location, requirement: settings.requirement)
             case .registry(let settings):
                 self = .registry(identity: settings.identity, requirement: settings.requirement)
             }
@@ -132,11 +132,13 @@ fileprivate struct DescribedPackage: Encodable {
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             switch self {
-            case .fileSystem(let path):
+            case .fileSystem(let identity, let path):
                 try container.encode(Kind.fileSystem, forKey: .type)
+                try container.encode(identity, forKey: .identity)
                 try container.encode(path, forKey: .path)
-            case .sourceControl(let location, let requirement):
+            case .sourceControl(let identity, let location, let requirement):
                 try container.encode(Kind.sourceControl, forKey: .type)
+                try container.encode(identity, forKey: .identity)
                 try container.encode(location, forKey: .url)
                 try container.encode(requirement, forKey: .requirement)
             case .registry(let identity, let requirement):

--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -137,7 +137,8 @@ extension Package.Dependency {
     /// are especially useful during development of a new package or when working
     /// on multiple tightly coupled packages.
     ///
-    /// - Parameter path: The path of the package.
+    /// - Parameters
+    ///   - path: The file system path to the package.
     public static func package(
         path: String
     ) -> Package.Dependency {
@@ -152,9 +153,9 @@ extension Package.Dependency {
     /// on multiple tightly coupled packages.
     ///
     /// - Parameters
-    ///   - name: The name of the Swift package or `nil` to deduce the name from path.
-    ///   - path: The local path to the package.
-    @available(_PackageDescription, introduced: 5.2, deprecated: 5.6, message: "use package(path:) instead")
+    ///   - name: The name of the Swift package, used only for target dependencies lookup.
+    ///   - path: The file system path to the package.
+    @available(_PackageDescription, introduced: 5.2)
     public static func package(
         name: String,
         path: String


### PR DESCRIPTION
motivation: when using path based dependencies it could be useful to set a name (for target based package lookup), as the path may change depending on context

changes:
* remove recently added deprecation flag from .package(name:, path:) API
* update package describe command to include dependecy identity which is useful to know how the dependency can be address in target based package lookup

