### PR TITLE
Improve swift-run failure mode

### DIFF
--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -198,6 +198,8 @@ public struct SwiftRunTool: SwiftCommand {
                 try run(executablePath,
                         originalWorkingDirectory: swiftTool.originalWorkingDirectory,
                         arguments: options.arguments)
+            } catch Diagnostics.fatalError {
+                throw ExitCode.failure
             } catch let error as RunError {
                 swiftTool.diagnostics.emit(error)
                 throw ExitCode.failure


### PR DESCRIPTION
In the case that you used `swift run`, and your executable failed to
build, previously you would see this output, at the bottom of a
potentially long list of warnings:

```
error: fatalError
```

In some cases, especially with lots of build output, this makes it look
like your command ran, but your program failed, not the build.

This silences that message, since the point of that error is that some
other diagnostics should have been printed anyways.