### PR TITLE
Fix integration test for Xcode 13

### DIFF
--- a/IntegrationTests/Fixtures/XCBuild/Libraries/Bar/Package.swift
+++ b/IntegrationTests/Fixtures/XCBuild/Libraries/Bar/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Bar",
     products: [
-        .library(name: "BarLib", type: .dynamic, targets: ["BarLib"]),
+        .library(name: "BarLibProduct", type: .dynamic, targets: ["BarLib"]),
     ],
     targets: [
         .target(name: "BarLib"),

--- a/IntegrationTests/Fixtures/XCBuild/Libraries/Foo/Package.swift
+++ b/IntegrationTests/Fixtures/XCBuild/Libraries/Foo/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Foo",
     products: [
-        .library(name: "FooLib", type: .static, targets: ["FooLib"]),
+        .library(name: "FooLibProduct", type: .static, targets: ["FooLib"]),
     ],
     dependencies: [
         .package(path: "../Bar")
@@ -13,7 +13,7 @@ let package = Package(
     targets: [
         .target(name: "FooLib", dependencies: ["CFooLib"]),
         .target(name: "CFooLib", dependencies: [
-            .product(name: "BarLib", package: "Bar"),
+            .product(name: "BarLibProduct", package: "Bar"),
         ]),
     ],
     swiftLanguageVersions: [.v4_2, .v5]


### PR DESCRIPTION
This fixes `Found multiple targets named 'FooLib'` which is happening in this test when using the XCBuild from Xcode 13. We should figure out separately what to do about that case, but for now it seems most practical to change the test in order to not block other work in SwiftPM.

See https://github.com/apple/swift-package-manager/pull/3684 for more context.
