### PR TITLE
Print reason for requiring resolution in verbose mode

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -148,56 +148,9 @@ private class ToolWorkspaceDelegate: WorkspaceDelegate {
         guard isVerbose else { return }
 
         queue.sync {
-            self.stdoutStream <<< "Running resolver because "
-
-            switch reason {
-            case .forced:
-                self.stdoutStream <<< "it was forced"
-            case .newPackages(let packages):
-                let dependencies = packages.lazy.map({ "'\($0.location)'" }).joined(separator: ", ")
-                self.stdoutStream <<< "the following dependencies were added: \(dependencies)"
-            case .packageRequirementChange(let package, let state, let requirement):
-                self.stdoutStream <<< "dependency '\(package.name)' was "
-
-                switch state {
-                case .checkout(let checkoutState)?:
-                    switch checkoutState.requirement {
-                    case .versionSet(.exact(let version)):
-                        self.stdoutStream <<< "resolved to '\(version)'"
-                    case .versionSet(_):
-                        // Impossible
-                        break
-                    case .revision(let revision):
-                        self.stdoutStream <<< "resolved to '\(revision)'"
-                    case .unversioned:
-                        self.stdoutStream <<< "unversioned"
-                    }
-                case .edited?:
-                    self.stdoutStream <<< "edited"
-                case .local?:
-                    self.stdoutStream <<< "versioned"
-                case nil:
-                    self.stdoutStream <<< "root"
-                }
-
-                self.stdoutStream <<< " but now has a "
-
-                switch requirement {
-                case .versionSet:
-                    self.stdoutStream <<< "different version-based"
-                case .revision:
-                    self.stdoutStream <<< "different revision-based"
-                case .unversioned:
-                    self.stdoutStream <<< "unversioned"
-                }
-
-                self.stdoutStream <<< " requirement."
-            default:
-                self.stdoutStream <<< " requirements have changed."
-            }
-
+            self.stdoutStream <<< Workspace.format(workspaceResolveReason: reason)
             self.stdoutStream <<< "\n"
-            stdoutStream.flush()
+            self.stdoutStream.flush()
         }
     }
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2033,11 +2033,13 @@ extension Workspace {
             pinsStore: pinsStore
         )
 
-        if precomputationResult.isRequired {
+        if case let .required(reason) = precomputationResult {
+            let reasonString = Self.format(workspaceResolveReason: reason)
+
             if !fileSystem.exists(self.location.resolvedVersionsFile) {
-                diagnostics.emit(error: "a resolved file is required when automatic dependency resolution is disabled and should be placed at \(self.location.resolvedVersionsFile.pathString)")
+                diagnostics.emit(error: "a resolved file is required when automatic dependency resolution is disabled and should be placed at \(self.location.resolvedVersionsFile.pathString). \(reasonString)")
             } else {
-                diagnostics.emit(error: "an out-of-date resolved file was detected at \(self.location.resolvedVersionsFile.pathString), which is not allowed when automatic dependency resolution is disabled; please make sure to update the file to reflect the changes in dependencies")
+                diagnostics.emit(error: "an out-of-date resolved file was detected at \(self.location.resolvedVersionsFile.pathString), which is not allowed when automatic dependency resolution is disabled; please make sure to update the file to reflect the changes in dependencies. \(reasonString)")
             }
         }
 
@@ -2813,6 +2815,58 @@ extension Workspace {
 
         // Save the state.
         try state.saveState()
+    }
+
+    public static func format(workspaceResolveReason reason: WorkspaceResolveReason) -> String {
+        var result = "Running resolver because "
+
+        switch reason {
+        case .forced:
+            result.append("it was forced")
+        case .newPackages(let packages):
+            let dependencies = packages.lazy.map({ "'\($0.location)'" }).joined(separator: ", ")
+            result.append("the following dependencies were added: \(dependencies)")
+        case .packageRequirementChange(let package, let state, let requirement):
+            result.append("dependency '\(package.name)' was ")
+
+            switch state {
+            case .checkout(let checkoutState)?:
+                switch checkoutState.requirement {
+                case .versionSet(.exact(let version)):
+                    result.append("resolved to '\(version)'")
+                case .versionSet(_):
+                    // Impossible
+                    break
+                case .revision(let revision):
+                    result.append("resolved to '\(revision)'")
+                case .unversioned:
+                    result.append("unversioned")
+                }
+            case .edited?:
+                result.append("edited")
+            case .local?:
+                result.append("versioned")
+            case nil:
+                result.append("root")
+            }
+
+            result.append(" but now has a ")
+
+            switch requirement {
+            case .versionSet:
+                result.append("different version-based")
+            case .revision:
+                result.append("different revision-based")
+            case .unversioned:
+                result.append("unversioned")
+            }
+
+            result.append(" requirement.")
+        default:
+            result.append(" requirements have changed.")
+        }
+
+        return result
     }
 }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3685,7 +3685,7 @@ final class WorkspaceTests: XCTestCase {
         // Check force resolve. This should produce an error because the resolved file is out-of-date.
         workspace.checkPackageGraphFailure(roots: ["Root"], forceResolvedVersions: true) { diagnostics in
             DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: "an out-of-date resolved file was detected at /tmp/ws/Package.resolved, which is not allowed when automatic dependency resolution is disabled; please make sure to update the file to reflect the changes in dependencies", checkContains: true, behavior: .error)
+                result.check(diagnostic: "an out-of-date resolved file was detected at /tmp/ws/Package.resolved, which is not allowed when automatic dependency resolution is disabled; please make sure to update the file to reflect the changes in dependencies. Running resolver because  requirements have changed.", checkContains: true, behavior: .error)
             }
         }
         workspace.checkManagedDependencies { result in
@@ -3769,9 +3769,9 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraphFailure(roots: ["Root"], forceResolvedVersions: true) { diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                result.check(diagnostic: "a resolved file is required when automatic dependency resolution is disabled and should be placed at /tmp/ws/Package.resolved", checkContains: true, behavior: .error)
-            }
+            guard let diagnostic = diagnostics.diagnostics.first else { return XCTFail("unexpectedly got no diagnostics") }
+            // rdar://82544922 (`WorkspaceResolveReason` is non-deterministic)
+            XCTAssertTrue(diagnostic.message.text.hasPrefix("a resolved file is required when automatic dependency resolution is disabled and should be placed at /tmp/ws/Package.resolved. Running resolver because the following dependencies were added:"), "unexpected diagnostic message")
         }
     }
 


### PR DESCRIPTION
When running SwiftPM while requiring a resolved file, print some more verbose info on why SwiftPM decided the existing file was out-of-date or why a resolved file was required.

### Motivation:

We have been seeing some unexplained issues in CI related to resolved files where this would help us to debug them. It can also generally be helpful for folks. 

### Modifications:

If resolution is required and we are in verbose mode, append a reason to the diagnostic about the resolved file being out-of-date.

### Result:

This is a pretty basic translation from `WorkspaceResolveReason` into prose which may need some improvements in the future, but it's a start at least.
