### PR TITLE
Introduce the `snippet` target type

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1214,7 +1214,7 @@ public final class ProductBuildDescription {
                 let relativePath = "@rpath/\(buildParameters.binaryRelativePath(for: product).pathString)"
                 args += ["-Xlinker", "-install_name", "-Xlinker", relativePath]
             }
-        case .executable:
+        case .executable, .snippet:
             // Link the Swift stdlib statically, if requested.
             if buildParameters.shouldLinkStaticSwiftStdlib {
                 if buildParameters.triple.isDarwin() {
@@ -1256,7 +1256,7 @@ public final class ProductBuildDescription {
         if containsSwiftTargets {
           switch product.type {
           case .library, .plugin: break
-          case .test, .executable:
+          case .test, .executable, .snippet:
               if buildParameters.triple.isDarwin() {
                   let stdlib = buildParameters.toolchain.macosSwiftStdlib
                   args += ["-Xlinker", "-rpath", "-Xlinker", stdlib.pathString]
@@ -1732,7 +1732,7 @@ public class BuildPlan {
                 switch product.type {
                 case .library(.automatic), .library(.static), .plugin:
                     return product.targets.map { .target($0, conditions: []) }
-                case .library(.dynamic), .test, .executable:
+                case .library(.dynamic), .test, .executable, .snippet:
                     return []
                 }
             }
@@ -1754,7 +1754,7 @@ public class BuildPlan {
                 // In tool version .v5_5 or greater, we also include executable modules implemented in Swift in
                 // any test products... this is to allow testing of executables.  Note that they are also still
                 // built as separate products that the test can invoke as subprocesses.
-                case .executable:
+                case .executable, .snippet:
                     if product.targets.contains(target) {
                         staticTargets.append(target)
                     } else if product.type == .test && target.underlyingTarget is SwiftTarget {

--- a/Sources/Build/ManifestBuilder.swift
+++ b/Sources/Build/ManifestBuilder.swift
@@ -554,7 +554,7 @@ extension LLBuildManifestBuilder {
 
             case .product(let product, _):
                 switch product.type {
-                case .executable, .library(.dynamic):
+                case .executable, .snippet, .library(.dynamic):
                     guard let planProduct = plan.productMap[product] else {
                         throw InternalError("unknown product \(product)")
                     }
@@ -673,7 +673,7 @@ extension LLBuildManifestBuilder {
 
             case .product(let product, _):
                 switch product.type {
-                case .executable, .library(.dynamic):
+                case .executable, .snippet, .library(.dynamic):
                     guard let planProduct = plan.productMap[product] else {
                         throw InternalError("unknown product \(product)")
                     }
@@ -852,7 +852,7 @@ extension ResolvedProduct {
             return "\(name)-\(config).a"
         case .library(.automatic):
             throw InternalError("automatic library not supported")
-        case .executable:
+        case .executable, .snippet:
             return "\(name)-\(config).exe"
         case .plugin:
             throw InternalError("unexpectedly asked for the llbuild target name of a plugin product")

--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -14,6 +14,13 @@ add_library(Commands
   MultiRootSupport.swift
   Options.swift
   show-dependencies.swift
+  Snippets/CardEvent.swift
+  Snippets/Cards/SnippetCard.swift
+  Snippets/Cards/SnippetGroupCard.swift
+  Snippets/Cards/TopCard.swift
+  Snippets/CardStack.swift
+  Snippets/Card.swift
+  Snippets/Colorful.swift
   SwiftBuildTool.swift
   SwiftPackageCollectionsTool.swift
   SwiftPackageTool.swift

--- a/Sources/Commands/Snippets/Card.swift
+++ b/Sources/Commands/Snippets/Card.swift
@@ -1,0 +1,35 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// A terminal menu that takes up the whole terminal, accepting input and
+/// rendering in response.
+protocol Card {
+    /// Render the contents to be printed to the terminal.
+    func render() -> String
+
+    /// Accept a line of input from the user's terminal and provide
+    /// an optional ``CardEvent`` which can alter the card stack.
+    func acceptLineInput<S: StringProtocol>(_ line: S) -> CardEvent?
+
+    /// The input prompt to present to the user when accepting a line of input.
+    var inputPrompt: String? { get }
+}
+
+extension Card {
+    var defaultPrompt: String {
+        return "Press enter to continue."
+    }
+}
+
+extension Card {
+    var inputPrompt: String? {
+        return defaultPrompt
+    }
+}

--- a/Sources/Commands/Snippets/CardEvent.swift
+++ b/Sources/Commands/Snippets/CardEvent.swift
@@ -1,0 +1,22 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+/// An event that alters the card stack after some input from the user.
+enum CardEvent {
+    /// Pop the top card from the stack, providing an optional error that
+    /// may have occurred.
+    case pop(Swift.Error? = nil)
+
+    /// Push a new card onto the stack.
+    case push(Card)
+
+    /// Quit the program, providing an optional error that may have occurred.
+    case quit(Swift.Error? = nil)
+}

--- a/Sources/Commands/Snippets/CardStack.swift
+++ b/Sources/Commands/Snippets/CardStack.swift
@@ -1,0 +1,110 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import PackageModel
+import TSCBasic
+import PackageGraph
+
+fileprivate extension TerminalController {
+    func clearScreen() {
+        write("\u{001b}[2J")
+        write("\u{001b}[H")
+        flush()
+    }
+}
+
+/// A stack of "cards" to display one at a time at the command line.
+struct CardStack {
+    var terminal: TerminalController
+
+    /// The representation of a stack of cards.
+    var cards = [Card]()
+
+    /// The tool used for eventually building and running a chosen snippet.
+    var swiftTool: SwiftTool
+
+    /// When true, the escape sequence for clearing the terminal should be
+    /// printed first.
+    private var needsToClearScreen = true
+
+    init(package: ResolvedPackage, snippetGroups: [SnippetGroup], swiftTool: SwiftTool) {
+        self.terminal = TerminalController(stream: stdoutStream)!
+        self.cards = [TopCard(package: package, snippetGroups: snippetGroups, swiftTool: swiftTool)]
+        self.swiftTool = swiftTool
+    }
+
+    mutating func push(_ card: Card) {
+        cards.append(card)
+    }
+
+    mutating func pop() {
+        cards.removeLast()
+    }
+
+    mutating func clear() {
+        cards.removeAll()
+    }
+
+    func askForLineInput(prompt: String?) -> String? {
+        if let prompt = prompt {
+            print(brightBlack { prompt }.terminalString())
+        }
+        terminal.write(">>> ", inColor: .green, bold: true)
+        return readLine(strippingNewline: true)
+    }
+
+    mutating func run() {
+        var inputFinished = false
+        while !inputFinished {
+            guard let top = cards.last else {
+                break
+            }
+
+            if needsToClearScreen {
+                terminal.clearScreen()
+                needsToClearScreen = false
+            }
+
+            print(top.render())
+
+            // Assume input finished until proven otherwise, i.e. when readLine returns
+            // `nil`.
+            inputFinished = true
+
+            askForLine: while let line = askForLineInput(prompt: top.inputPrompt) {
+                inputFinished = false
+                let trimmedLine = String(line.drop { $0.isWhitespace }
+                                            .reversed()
+                                            .drop { $0.isWhitespace }
+                                            .reversed())
+                let response = top.acceptLineInput(trimmedLine)
+                switch response {
+                case .none:
+                    continue askForLine
+                case .push(let card):
+                    push(card)
+                    needsToClearScreen = true
+                    break askForLine
+                case let .pop(error):
+                    cards.removeLast()
+                    if let error = error {
+                        swiftTool.diagnostics.emit(error: error.localizedDescription)
+                        needsToClearScreen = false
+                    } else {
+                        needsToClearScreen = !cards.isEmpty
+                    }
+                    break askForLine
+                case .quit:
+                    return
+                }
+            }
+        }
+    }
+}

--- a/Sources/Commands/Snippets/Cards/SnippetCard.swift
+++ b/Sources/Commands/Snippets/Cards/SnippetCard.swift
@@ -1,0 +1,98 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import PackageModel
+import TSCBasic
+
+/// A card displaying a ``Snippet`` at the terminal.
+struct SnippetCard: Card {
+    enum Error: Swift.Error, CustomStringConvertible {
+        case cantRunSnippet(reason: String)
+
+        var description: String {
+            switch self {
+            case let .cantRunSnippet(reason):
+                return "Can't run snippet: \(reason)"
+            }
+        }
+    }
+    /// The snippet to display in the terminal.
+    var snippet: Snippet
+
+    /// The snippet's index within its group.
+    var number: Int
+
+    /// The tool used for eventually building and running a chosen snippet.
+    var swiftTool: SwiftTool
+
+    func render() -> String {
+        var rendered = colorized {
+            brightYellow {
+                "# "
+                snippet.name
+            }
+            "\n\n"
+        }.terminalString()
+
+        if !snippet.explanation.isEmpty {
+            rendered += brightBlack {
+                snippet.explanation
+                .split(separator: "\n", omittingEmptySubsequences: false)
+                .map { "// " + $0 }
+                .joined(separator: "\n")
+            }.terminalString()
+
+            rendered += "\n\n"
+        }
+
+        rendered += snippet.presentationCode
+
+        return rendered
+    }
+
+    var inputPrompt: String? {
+        return "\nRun this snippet? [R: run, or press Enter to return]"
+    }
+
+    func acceptLineInput<S>(_ line: S) -> CardEvent? where S : StringProtocol {
+        let trimmed = line.drop { $0.isWhitespace }.prefix { !$0.isWhitespace }.lowercased()
+        guard !trimmed.isEmpty else {
+            return .pop()
+        }
+
+        switch trimmed {
+        case "r", "run":
+            do {
+                try runExample()
+            } catch {
+                return .pop(SnippetCard.Error.cantRunSnippet(reason: error.localizedDescription))
+            }
+            break
+        case "c", "copy":
+            print("Unimplemented")
+            break
+        default:
+            break
+        }
+
+        return .pop()
+    }
+
+    func runExample() throws {
+        print("Building '\(snippet.path)'\n")
+        let buildSystem = try swiftTool.createBuildSystem(explicitProduct: snippet.name)
+        try buildSystem.build(subset: .product(snippet.name))
+        let executablePath = try swiftTool.buildParameters().buildPath.appending(component: snippet.name)
+        if let exampleTarget = try buildSystem.getPackageGraph().allTargets.first(where: { $0.name == snippet.name }) {
+            try ProcessEnv.chdir(exampleTarget.sources.paths[0].parentDirectory)
+        }
+        try exec(path: executablePath.pathString, args: [])
+    }
+}

--- a/Sources/Commands/Snippets/Cards/SnippetGroupCard.swift
+++ b/Sources/Commands/Snippets/Cards/SnippetGroupCard.swift
@@ -1,0 +1,79 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import PackageModel
+
+/// A card showing the snippets in a ``SnippetGroup``.
+struct SnippetGroupCard: Card {
+    /// The snippet group to display in the terminal.
+    var snippetGroup: SnippetGroup
+
+    /// The tool used for eventually building and running a chosen snippet.
+    var swiftTool: SwiftTool
+
+    var inputPrompt: String? {
+        return """
+
+            Choose a number or a name from the list of snippets.
+            To go back, press enter.
+            To exit, enter `q`.
+            """
+    }
+    
+    func acceptLineInput<S>(_ line: S) -> CardEvent? where S : StringProtocol {
+        if line.isEmpty || line.allSatisfy({ $0.isWhitespace }) {
+            return .pop()
+        }
+        if line.prefix(while: { !$0.isWhitespace }).lowercased() == "q" {
+            return .quit()
+        }
+        if let index = Int(line),
+           snippetGroup.snippets.indices.contains(index) {
+            return .push(SnippetCard(snippet: snippetGroup.snippets[index], number: index, swiftTool: swiftTool))
+        } else if let foundSnippetIndex = snippetGroup.snippets.firstIndex(where: { $0.name == line }) {
+            return .push(SnippetCard(snippet: snippetGroup.snippets[foundSnippetIndex], number: foundSnippetIndex, swiftTool: swiftTool))
+        } else {
+            print(red { "There is not a snippet by that name or index." })
+            return nil
+        }
+    }
+
+    func render() -> String {
+        precondition(!snippetGroup.snippets.isEmpty)
+
+        var rendered = brightYellow {
+            """
+            # \(snippetGroup.name)
+
+            
+            """
+        }.terminalString()
+
+        if !snippetGroup.explanation.isEmpty {
+            rendered += snippetGroup.explanation
+        }
+
+        rendered += "\n"
+        rendered += snippetGroup.snippets
+            .enumerated()
+            .map { pair -> String in
+                let (number, snippet) = pair
+                return brightCyan {
+                    "\(number). \(snippet.name)\n"
+                    plain {
+                      snippet.explanation.spm_multilineIndent(count: 3)
+                    }
+                }.terminalString()
+            }
+            .joined(separator: "\n\n")
+
+        return rendered
+    }
+}

--- a/Sources/Commands/Snippets/Cards/TopCard.swift
+++ b/Sources/Commands/Snippets/Cards/TopCard.swift
@@ -1,0 +1,151 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import PackageModel
+import PackageGraph
+
+/// The top menu card for a package's help contents, including snippets.
+struct TopCard: Card {
+    /// The root package that hosts the snippets.
+    let package: ResolvedPackage
+
+    /// The top-level snippet groups residing in the `Snippets` subdirectory.
+    let snippetGroups: [SnippetGroup]
+
+    /// The tool used for eventually building and running a chosen snippet.
+    let swiftTool: SwiftTool
+
+    init(package: ResolvedPackage, snippetGroups: [SnippetGroup], swiftTool: SwiftTool) {
+        self.package = package
+        self.snippetGroups = snippetGroups
+        self.swiftTool = swiftTool
+    }
+
+    var inputPrompt: String? {
+        return """
+            Choose a group by name or number.
+            To exit, enter 'q'.
+            """
+    }
+
+    func renderProducts() -> String {
+        let libraries = package.products
+            .filter {
+                guard case .library = $0.type else {
+                    return false
+                }
+                return true
+            }
+            .sorted { $0.name < $1.name }
+            .map { "- \($0.name) (library)" }
+
+        let executables = package.products
+            .filter { $0.type == .executable }
+            .sorted { $0.name < $1.name }
+            .map { "- \($0.name) (executable)" }
+
+        guard !(libraries.isEmpty && executables.isEmpty) else {
+            return ""
+        }
+
+        var rendered = brightCyan {
+            "\n## Products"
+            "\n\n"
+        }.terminalString()
+
+        rendered += (libraries + executables).joined(separator: "\n")
+
+        return rendered
+    }
+
+    func renderSnippets() -> String {
+        guard !snippetGroups.isEmpty else {
+            return ""
+        }
+        let snippetPreviews = snippetGroups.enumerated().map { pair -> String in
+            let (number, snippetGroup) = pair
+            let snippetNoun = snippetGroup.snippets.count > 1 ? "snippets" : "snippet"
+            let heading = "\(number). \(snippetGroup.name) (\(snippetGroup.snippets.count) \(snippetNoun))"
+            return colorized {
+                cyan {
+                    heading
+                    "\n"
+                }
+                if !snippetGroup.explanation.isEmpty {
+                    """
+                    \(snippetGroup.explanation.spm_multilineIndent(count: 3))
+                    """
+                }
+            }.terminalString()
+        }
+
+        return colorized {
+            brightCyan {
+                "\n## Snippets"
+            }
+            "\n\n"
+            snippetPreviews.joined(separator: "\n\n")
+          "\n"
+        }.terminalString()
+    }
+
+    func render() -> String {
+        let heading = brightYellow {
+            "# "
+            package.identity.description
+        }
+        return """
+        \(heading)
+        \(renderProducts())
+        \(renderSnippets())
+        """
+    }
+
+    func acceptLineInput<S>(_ line: S) -> CardEvent? where S : StringProtocol {
+        guard !line.isEmpty else {
+            print("\u{0007}")
+            return nil
+        }
+        if line.prefix(while: { !$0.isWhitespace }).lowercased() == "q" {
+            return .quit()
+        }
+        if let index = Int(line),
+           snippetGroups.indices.contains(index) {
+            return .push(SnippetGroupCard(snippetGroup: snippetGroups[index], swiftTool: swiftTool))
+        } else if let groupByName = snippetGroups.first(where: { $0.name == line }) {
+            return .push(SnippetGroupCard(snippetGroup: groupByName, swiftTool: swiftTool))
+        } else {
+            print(red { "There is not a group by that name or index." })
+            return nil
+        }
+    }
+}
+
+fileprivate extension Target.Kind {
+    var pluralDescription: String {
+        switch self {
+        case .executable:
+            return "executables"
+        case .library:
+            return "libraries"
+        case .systemModule:
+            return "system modules"
+        case .test:
+            return "tests"
+        case .binary:
+            return "binaries"
+        case .plugin:
+            return "plugins"
+        case .snippet:
+            return "snippets"
+        }
+    }
+}

--- a/Sources/Commands/Snippets/Colorful.swift
+++ b/Sources/Commands/Snippets/Colorful.swift
@@ -1,0 +1,224 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+public protocol Colorful: CustomStringConvertible {
+    func terminalString() -> String
+}
+
+extension Colorful {
+    public var description: String {
+        return terminalString()
+    }
+}
+
+extension Colorful where Self: RawRepresentable, RawValue: StringProtocol {
+    func terminalString() -> String {
+        return String(self.rawValue)
+    }
+}
+
+extension String: Colorful {
+    public func terminalString() -> String {
+        return self
+    }
+}
+
+extension Substring: Colorful {
+    public func terminalString() -> String {
+        return String(self)
+    }
+}
+
+extension Array: Colorful where Element == Colorful {
+    public func terminalString() -> String {
+        return self.map { $0.terminalString() }.joined()
+    }
+}
+
+extension Optional: CustomStringConvertible where Wrapped: Colorful {
+    public var description: String {
+        return terminalString()
+    }
+}
+
+extension Optional: Colorful where Wrapped: Colorful {
+    public func terminalString() -> String {
+        if let unwrapped = self {
+            return unwrapped.terminalString()
+        } else {
+            return ""
+        }
+    }
+}
+
+@resultBuilder
+public struct ColorBuilder {
+    public static func buildOptional(_ component: [Colorful]?) -> [Colorful] {
+        return component ?? []
+    }
+
+    public static func buildBlock(_ components: Colorful...) -> [Colorful] {
+        return components
+    }
+
+    public static func buildEither(first component: [Colorful]) -> [Colorful] {
+        return component
+    }
+
+    public static func buildEither(second component: [Colorful]) -> [Colorful] {
+        return component
+    }
+}
+
+protocol Color: Colorful {}
+
+enum Color4: String, Color {
+    case black = "\u{001b}[30m"
+    case red = "\u{001b}[31m"
+    case green = "\u{001b}[32m"
+    case yellow = "\u{001b}[33m"
+    case blue = "\u{001b}[34m"
+    case magenta = "\u{001b}[35m"
+    case cyan = "\u{001b}[36m"
+    case white = "\u{001b}[37m"
+
+    case brightBlack = "\u{001b}[30;1m"
+    case brightRed = "\u{001b}[31;1m"
+    case brightGreen = "\u{001b}[32;1m"
+    case brightYellow = "\u{001b}[33;1m"
+    case brightBlue = "\u{001b}[34;1m"
+    case brightMagenta = "\u{001b}[35;1m"
+    case brightCyan = "\u{001b}[36;1m"
+    case brightWhite = "\u{001b}[37;1m"
+
+    case reset = "\u{001b}[0m"
+
+    var bright: Color4 {
+        switch self {
+        case .black:
+            return .brightBlack
+        case .red:
+            return .brightRed
+        case .green:
+            return .brightGreen
+        case .yellow :
+            return .brightYellow
+        case .blue:
+            return .brightBlue
+        case .magenta:
+            return .brightMagenta
+        case .cyan:
+            return .brightCyan
+        case .white:
+            return .brightWhite
+        default:
+            return self
+        }
+    }
+
+    var description: String {
+        return self.rawValue
+    }
+}
+
+public func colorized(@ColorBuilder builder: () -> [Colorful]) -> Colorful {
+    return Colorized(.reset, builder)
+}
+
+public func plain(@ColorBuilder builder: () -> [Colorful]) -> Colorful {
+    return Colorized(.reset, builder)
+}
+
+public func black(@ColorBuilder builder: () -> [Colorful]) -> Colorful {
+    return Colorized(.black, builder)
+}
+
+public func brightBlack(@ColorBuilder builder: () -> [Colorful]) -> Colorful {
+    return Colorized(.brightBlack, builder)
+}
+
+public func red(@ColorBuilder builder: () -> [Colorful]) -> Colorful {
+    return Colorized(.red, builder)
+}
+
+public func brightRed(@ColorBuilder builder: () -> [Colorful]) -> Colorful {
+    return Colorized(.brightRed, builder)
+}
+
+public func green(@ColorBuilder builder: () -> [Colorful]) -> Colorful {
+    return Colorized(.green, builder)
+}
+
+public func brightGreen(@ColorBuilder builder: () -> [Colorful]) -> Colorful {
+    return Colorized(.brightGreen, builder)
+}
+
+public func yellow(@ColorBuilder builder: () -> [Colorful]) -> Colorful {
+    return Colorized(.yellow, builder)
+}
+
+public func brightYellow(@ColorBuilder builder: () -> [Colorful]) -> Colorful {
+    return Colorized(.brightYellow, builder)
+}
+
+public func blue(@ColorBuilder builder: () -> [Colorful]) -> Colorful {
+    return Colorized(.blue, builder)
+}
+
+public func brightBlue(@ColorBuilder builder: () -> [Colorful]) -> Colorful {
+    return Colorized(.brightBlue, builder)
+}
+
+public func magenta(@ColorBuilder builder: () -> [Colorful]) -> Colorful {
+    return Colorized(.magenta, builder)
+}
+
+public func brightMagenta(@ColorBuilder builder: () -> [Colorful]) -> Colorful {
+    return Colorized(.brightMagenta, builder)
+}
+
+public func cyan(@ColorBuilder builder: () -> [Colorful]) -> Colorful {
+    return Colorized(.cyan, builder)
+}
+
+public func brightCyan(@ColorBuilder builder: () -> [Colorful]) -> Colorful {
+    return Colorized(.brightCyan, builder)
+}
+
+public func white(@ColorBuilder builder: () -> [Colorful]) -> Colorful {
+    return Colorized(.white, builder)
+}
+
+public func brightWhite(@ColorBuilder builder: () -> [Colorful]) -> Colorful {
+    return Colorized(.brightWhite, builder)
+}
+
+struct Colorized: Colorful {
+    var color: Color
+    var items: [Colorful]
+
+    init(_ color: Color = Color4.reset, _ items: [Colorful]) {
+        self.color = color
+        self.items = items
+    }
+
+    init(_ color: Color4 = .reset, @ColorBuilder _ builder: () -> [Colorful]) {
+        self.color = color
+        self.items = builder()
+    }
+
+    func terminalString() -> String {
+        let inner = items.map { $0.terminalString() }.joined()
+        guard inner.hasSuffix(Color4.reset.rawValue) else {
+            return color.terminalString() + inner + Color4.reset.rawValue
+        }
+        return color.terminalString() + inner
+    }
+}

--- a/Sources/Commands/SwiftPackageTool.swift
+++ b/Sources/Commands/SwiftPackageTool.swift
@@ -22,6 +22,7 @@ import Xcodeproj
 import XCBuildSupport
 import Workspace
 import Foundation
+import PackageModel
 
 /// swift-package tool namespace
 public struct SwiftPackageTool: ParsableCommand {
@@ -59,7 +60,7 @@ public struct SwiftPackageTool: ParsableCommand {
             ComputeChecksum.self,
             ArchiveSource.self,
             CompletionTool.self,
-        ],
+        ] + (ProcessInfo.processInfo.environment["SWIFTPM_ENABLE_SNIPPETS"] == "1" ? [Learn.self] : [ParsableCommand.Type]()),
         helpNames: [.short, .long, .customLong("help", withSingleDash: true)])
 
     @OptionGroup()
@@ -639,7 +640,7 @@ extension SwiftPackageTool {
             dumpDependenciesOf(rootPackage: graph.rootPackages[0], mode: format, on: stream)
         }
     }
-    
+
     struct ToolsVersionCommand: SwiftCommand {
         static let configuration = CommandConfiguration(
             commandName: "tools-version",
@@ -1047,6 +1048,7 @@ extension SwiftPackageTool {
             case generateFishScript = "generate-fish-script"
             case listDependencies = "list-dependencies"
             case listExecutables = "list-executables"
+            case listSnippets = "list-snippets"
         }
 
         /// A dummy version of the root `swift` command, to act as a parent
@@ -1092,7 +1094,103 @@ extension SwiftPackageTool {
                     stdoutStream <<< "\(executable.name)\n"
                 }
                 stdoutStream.flush()
+            case .listSnippets:
+                let graph = try swiftTool.loadPackageGraph()
+                let package = graph.rootPackages[0].underlyingPackage
+                let executables = package.targets.filter { $0.type == .snippet }
+                for executable in executables {
+                    stdoutStream <<< "\(executable.name)\n"
+                }
+                stdoutStream.flush()
             }
+        }
+    }
+}
+
+extension SwiftPackageTool {
+    struct Learn: SwiftCommand {
+
+        @OptionGroup()
+        var swiftOptions: SwiftToolOptions
+
+        static let configuration = CommandConfiguration(abstract: "Learn about Swift and this package")
+
+        func files(in directory: AbsolutePath, fileExtension: String? = nil) throws -> [AbsolutePath] {
+            guard localFileSystem.isDirectory(directory) else {
+                return []
+            }
+
+            let files = try localFileSystem.getDirectoryContents(directory)
+                .map { directory.appending(RelativePath($0)) }
+                .filter { localFileSystem.isFile($0) }
+
+            guard let fileExtension = fileExtension else {
+                return files
+            }
+
+            return files.filter { $0.extension == fileExtension }
+        }
+
+        func subdirectories(in directory: AbsolutePath) throws -> [AbsolutePath] {
+            guard localFileSystem.isDirectory(directory) else {
+                return []
+            }
+            return try localFileSystem.getDirectoryContents(directory)
+                .map { directory.appending(RelativePath($0)) }
+                .filter { localFileSystem.isDirectory($0) }
+        }
+
+        func loadSnippetsAndSnippetGroups(from package: ResolvedPackage) throws -> [SnippetGroup] {
+            let snippetsDirectory = package.path.appending(component: "Snippets")
+            guard localFileSystem.isDirectory(snippetsDirectory) else {
+                return []
+            }
+
+            let topLevelSnippets = try files(in: snippetsDirectory, fileExtension: "swift")
+                .map { try Snippet(parsing: $0) }
+
+            let topLevelSnippetGroup = SnippetGroup(name: "Getting Started",
+                                                    baseDirectory: snippetsDirectory,
+                                                    snippets: topLevelSnippets,
+                                                    explanation: "")
+
+            let subdirectoryGroups = try subdirectories(in: snippetsDirectory)
+                .map { subdirectory -> SnippetGroup in
+                    let snippets = try files(in: subdirectory, fileExtension: "swift")
+                        .map { try Snippet(parsing: $0) }
+
+                    let explanationFile = subdirectory.appending(component: "Explanation.md")
+
+                    let snippetGroupExplanation: String
+                    if localFileSystem.isFile(explanationFile) {
+                        snippetGroupExplanation = try String(contentsOf: explanationFile.asURL)
+                    } else {
+                        snippetGroupExplanation = ""
+                    }
+
+                    return SnippetGroup(name: subdirectory.basename,
+                                        baseDirectory: subdirectory,
+                                        snippets: snippets,
+                                        explanation: snippetGroupExplanation)
+                }
+
+            let snippetGroups = [topLevelSnippetGroup] + subdirectoryGroups.sorted {
+                $0.baseDirectory.basename < $1.baseDirectory.basename
+            }
+
+            return snippetGroups.filter { !$0.snippets.isEmpty }
+        }
+
+        func run(_ swiftTool: SwiftTool) throws {
+            let graph = try swiftTool.loadPackageGraph()
+            let package = graph.rootPackages[0]
+            print(package.products.map { $0.description })
+
+            let snippetGroups = try loadSnippetsAndSnippetGroups(from: package)
+
+            var cardStack = CardStack(package: package, snippetGroups: snippetGroups, swiftTool: swiftTool)
+
+            cardStack.run()
         }
     }
 }

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -208,7 +208,7 @@ public struct SwiftRunTool: SwiftCommand {
     /// Returns the path to the correct executable based on options.
     private func findProductName(in graph: PackageGraph) throws -> String {
         if let executable = options.executable {
-            let executableExists = graph.allProducts.contains { $0.type == .executable && $0.name == executable }
+            let executableExists = graph.allProducts.contains { ($0.type == .executable || $0.type == .snippet) && $0.name == executable }
             guard executableExists else {
                 throw RunError.executableNotFound(executable)
             }
@@ -218,7 +218,7 @@ public struct SwiftRunTool: SwiftCommand {
         // If the executable is implicit, search through root products.
         let rootExecutables = graph.rootPackages
             .flatMap { $0.products }
-            .filter { $0.type == .executable }
+            .filter { $0.type == .executable || $0.type == .snippet }
             .map { $0.name }
 
         // Error out if the package contains no executables.

--- a/Sources/PackageGraph/ResolvedProduct.swift
+++ b/Sources/PackageGraph/ResolvedProduct.swift
@@ -36,8 +36,8 @@ public final class ResolvedProduct: ObjectIdentifierProtocol {
     ///
     /// Note: This property is only valid for executable products.
     public var executableModule: ResolvedTarget {
-        precondition(type == .executable, "This property should only be called for executable targets")
-        return targets.first(where: { $0.type == .executable })!
+        precondition(type == .executable || type == .snippet, "This property should only be called for executable targets")
+        return targets.first(where: { $0.type == .executable || $0.type == .snippet })!
     }
 
     public init(product: Product, targets: [ResolvedTarget]) {

--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -34,7 +34,7 @@ extension Diagnostic.Message {
         switch product.type {
         case .library(.automatic):
             typeString = ""
-        case .executable, .plugin, .test,
+        case .executable, .snippet, .plugin, .test,
              .library(.dynamic), .library(.static):
             typeString = " (\(product.type))"
         }

--- a/Sources/PackageModel/CMakeLists.txt
+++ b/Sources/PackageModel/CMakeLists.txt
@@ -27,6 +27,9 @@ add_library(PackageModel
   Platform.swift
   Product.swift
   Resource.swift
+  Snippets/Model/Snippet.swift
+  Snippets/Model/SnippetGroup.swift
+  Snippets/Parsing/PlainTextSnippetExtractor.swift
   Sources.swift
   SupportedLanguageExtension.swift
   SwiftLanguageVersion.swift

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -167,6 +167,8 @@ fileprivate extension SourceCodeFragment {
             self.init(enum: "library", subnodes: params, multiline: true)
         case .executable:
             self.init(enum: "executable", subnodes: params, multiline: true)
+        case .snippet:
+            self.init(enum: "sample", subnodes: params, multiline: true)
         case .plugin:
             self.init(enum: "plugin", subnodes: params, multiline: true)
         case .test:

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -49,7 +49,7 @@ public class Product: Codable {
 }
 
 /// The type of product.
-public enum ProductType: Equatable {
+public enum ProductType: Equatable, Hashable {
 
     /// The type of library.
     public enum LibraryType: String, Codable {
@@ -69,6 +69,9 @@ public enum ProductType: Equatable {
 
     /// An executable product.
     case executable
+
+    /// An executable code snippet.
+    case snippet
     
     /// An plugin product.
     case plugin
@@ -153,6 +156,8 @@ extension ProductType: CustomStringConvertible {
         switch self {
         case .executable:
             return "executable"
+        case .snippet:
+            return "snippet"
         case .test:
             return "test"
         case .library(let type):
@@ -185,7 +190,7 @@ extension ProductFilter: CustomStringConvertible {
 
 extension ProductType: Codable {
     private enum CodingKeys: String, CodingKey {
-        case library, executable, plugin, test
+        case library, executable, snippet, plugin, test
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -196,6 +201,8 @@ extension ProductType: Codable {
             try unkeyedContainer.encode(a1)
         case .executable:
             try container.encodeNil(forKey: .executable)
+        case .snippet:
+            try container.encodeNil(forKey: .snippet)
         case .plugin:
             try container.encodeNil(forKey: .plugin)
         case .test:
@@ -217,6 +224,8 @@ extension ProductType: Codable {
             self = .test
         case .executable:
             self = .executable
+        case .snippet:
+            self = .snippet
         case .plugin:
             self = .plugin
         }

--- a/Sources/PackageModel/Snippets/Model/Snippet.swift
+++ b/Sources/PackageModel/Snippets/Model/Snippet.swift
@@ -1,0 +1,34 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import TSCBasic
+
+public struct Snippet {
+    public var path: AbsolutePath
+    public var explanation: String
+    public var presentationCode: String
+    public var groupName: String? = nil
+
+    public var name: String {
+        path.basenameWithoutExt
+    }
+
+    init(parsing source: String, path: AbsolutePath) {
+        let extractor = PlainTextSnippetExtractor(source: source)
+        self.path = path
+        self.explanation = extractor.explanation
+        self.presentationCode = extractor.presentationCode
+    }
+
+    public init(parsing file: AbsolutePath) throws {
+        let source = try String(contentsOf: file.asURL)
+        self.init(parsing: source, path: file)
+    }
+}

--- a/Sources/PackageModel/Snippets/Model/SnippetGroup.swift
+++ b/Sources/PackageModel/Snippets/Model/SnippetGroup.swift
@@ -1,0 +1,28 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import TSCBasic
+
+public struct SnippetGroup {
+    public var name: String
+    public var baseDirectory: AbsolutePath
+    public var snippets: [Snippet]
+    public var explanation: String
+
+    public init(name: String, baseDirectory: AbsolutePath, snippets: [Snippet], explanation: String) {
+        self.name = name
+        self.baseDirectory = baseDirectory
+        self.snippets = snippets
+        self.explanation = explanation
+        for index in self.snippets.indices {
+            self.snippets[index].groupName = baseDirectory.basename
+        }
+    }
+}

--- a/Sources/PackageModel/Snippets/Parsing/PlainTextSnippetExtractor.swift
+++ b/Sources/PackageModel/Snippets/Parsing/PlainTextSnippetExtractor.swift
@@ -1,0 +1,142 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+fileprivate enum SnippetVisibility {
+    case shown
+    case hidden
+}
+
+fileprivate extension StringProtocol {
+    /// If the string is a line comment, attempt to parse
+    /// a ``SnippetVisibility`` with `mark: show` or `mark: hide`.
+    var parsedVisibilityMark: SnippetVisibility? {
+        guard var comment = parsedLineCommentText else {
+            return nil
+        }
+
+        comment = comment.drop { $0.isWhitespace }
+
+        if comment.lowercased().starts(with: "mark: show") {
+            return SnippetVisibility.shown
+        } else if comment.lowercased().starts(with: "mark: hide") {
+            return SnippetVisibility.hidden
+        } else {
+            return nil
+        }
+    }
+
+    /// If the string is a line comment starting with `"//"`, return the
+    /// contents with the comment marker stripped.
+    var parsedLineCommentText: Self.SubSequence? {
+        var trimmed = self.drop { $0.isWhitespace }
+        guard trimmed.starts(with: "//") else {
+            return nil
+        }
+        trimmed.removeFirst(2)
+        return trimmed
+    }
+
+    var isEmptyOrWhiteSpace: Bool {
+        return self.isEmpty || self.allSatisfy { $0.isWhitespace }
+    }
+}
+
+fileprivate extension String {
+    mutating func removeLeadingAndTrailingNewlines() {
+        while self.starts(with: "\n") {
+            self.removeFirst(1)
+        }
+        while self.suffix(1) == "\n" {
+            self.removeLast(1)
+        }
+    }
+
+    /// Returns a re-indented string with the most indentation removed
+    /// without changing the relative indentation between lines. This is
+    /// useful for re-indenting some inner part of a block of nested code.
+    mutating func trimExtraIndentation() {
+        var lines = self.split(separator: "\n", maxSplits: Int.max,
+                               omittingEmptySubsequences: false)
+        lines = Array(lines
+                        .drop(while: { $0.isEmptyOrWhiteSpace })
+                        .reversed()
+                        .drop(while: { $0.isEmptyOrWhiteSpace })
+                        .reversed())
+
+        let minimumIndentation = lines.map {
+            guard !$0.isEmpty else {
+                return Int.max
+            }
+            return $0.prefix { $0 == " " }.count
+        }.min() ?? 0
+
+        guard minimumIndentation > 0 else {
+            return
+        }
+
+        self = lines.map { $0.dropFirst(minimumIndentation) }
+            .joined(separator: "\n")
+    }
+}
+
+/// Extracts a ``Snippet`` structure from Swift source code.
+///
+/// - todo: In order to support different styles of comments, it might be
+///   better to adopt SwiftSyntax if possible in the future.
+struct PlainTextSnippetExtractor {
+    var source: String
+    var explanation = ""
+    var presentationCode = ""
+    private var currentVisibility = SnippetVisibility.shown
+
+    init(source: String) {
+        self.source = source
+        let lines = source.split(separator: "\n", omittingEmptySubsequences: false)
+
+        var lastExplanationLine = "..."
+        var lastPresentationCodeLine = "..."
+
+        for line in lines {
+            if let visibility = line.parsedVisibilityMark {
+                self.currentVisibility = visibility
+                continue
+            }
+
+            guard case .shown = currentVisibility else {
+                continue
+            }
+
+            if var comment = line.parsedLineCommentText,
+               comment.starts(with: "!") {
+                comment.removeFirst(1)
+                comment = comment.drop { $0.isWhitespace }
+                if lastExplanationLine.isEmptyOrWhiteSpace && comment.isEmptyOrWhiteSpace {
+                    continue
+                }
+                print(comment, to: &explanation)
+                lastExplanationLine = String(comment)
+            } else {
+                if lastPresentationCodeLine.isEmptyOrWhiteSpace && line.isEmptyOrWhiteSpace {
+                    continue
+                }
+                print(line, to: &presentationCode)
+                lastPresentationCodeLine = String(line)
+            }
+        }
+        self.explanation
+            .removeLeadingAndTrailingNewlines()
+
+        self.presentationCode
+            .removeLeadingAndTrailingNewlines()
+        
+        self.presentationCode
+            .trimExtraIndentation()
+    }
+}

--- a/Sources/PackageModel/Target.swift
+++ b/Sources/PackageModel/Target.swift
@@ -28,6 +28,7 @@ public class Target: ObjectIdentifierProtocol, PolymorphicCodableProtocol {
         case test
         case binary
         case plugin
+        case snippet
     }
 
     /// A reference to a product from a target dependency.

--- a/Sources/SPMBuildCore/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters.swift
@@ -280,7 +280,7 @@ public struct BuildParameters: Encodable {
     /// Returns the path to the binary of a product for the current build parameters, relative to the build directory.
     public func binaryRelativePath(for product: ResolvedProduct) -> RelativePath {
         switch product.type {
-        case .executable:
+        case .executable, .snippet:
             return RelativePath("\(product.name)\(triple.executableExtension)")
         case .library(.static):
             return RelativePath("lib\(product.name)\(triple.staticLibraryExtension)")

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -334,7 +334,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
 
     private func addTarget(for product: ResolvedProduct) {
         switch product.type {
-        case .executable, .test:
+        case .executable, .snippet, .test:
             addMainModuleTarget(for: product)
         case .library:
             addLibraryTarget(for: product)
@@ -349,7 +349,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
             try self.addLibraryTarget(for: target)
         case .systemModule:
             try self.addSystemTarget(for: target)
-        case .executable, .test:
+        case .executable, .snippet, .test:
             // Skip executable module targets and test module targets (they will have been dealt with as part of the
             // products to which they belong).
             return
@@ -1384,6 +1384,8 @@ extension ProductType {
         switch self {
         case .executable:
             return .executable
+        case .snippet:
+            return .snippet
         case .test:
             return .test
         case .library:

--- a/Sources/Xcodeproj/SchemesGenerator.swift
+++ b/Sources/Xcodeproj/SchemesGenerator.swift
@@ -81,7 +81,7 @@ public final class SchemesGenerator {
             switch $0.type {
             case .test, .systemModule, .binary, .plugin:
                 return false
-            case .executable, .library:
+            case .executable, .snippet, .library:
                 return true
             }
         })

--- a/Sources/Xcodeproj/Target+PBXProj.swift
+++ b/Sources/Xcodeproj/Target+PBXProj.swift
@@ -41,7 +41,7 @@ extension ResolvedTarget {
             return "com.apple.product-type.bundle.unit-test"
         case .library:
             return "com.apple.product-type.framework"
-        case .executable:
+        case .executable, .snippet:
             return "com.apple.product-type.tool"
         case .systemModule, .binary, .plugin:
             fatalError()
@@ -54,7 +54,7 @@ extension ResolvedTarget {
             return "compiled.mach-o.wrapper.cfbundle"
         case .library:
             return "wrapper.framework"
-        case .executable:
+        case .executable, .snippet:
             return "compiled.mach-o.executable"
         case .systemModule, .binary, .plugin:
             fatalError()
@@ -67,7 +67,7 @@ extension ResolvedTarget {
             return RelativePath("\(c99name).xctest")
         case .library:
             return RelativePath("\(c99name).framework")
-        case .executable:
+        case .executable, .snippet:
             return RelativePath(name)
         case .systemModule, .binary, .plugin:
             fatalError()
@@ -79,7 +79,7 @@ extension ResolvedTarget {
         case .library:
             // you can go without a lib prefix, but something unexpected will break
             return "'lib$(TARGET_NAME)'"
-        case .test, .executable:
+        case .test, .executable, .snippet:
             return "'$(TARGET_NAME)'"
         case .systemModule, .binary, .plugin:
             fatalError()

--- a/Sources/Xcodeproj/pbxproj.swift
+++ b/Sources/Xcodeproj/pbxproj.swift
@@ -385,7 +385,7 @@ public func xcodeProject(
         // FIXME: We should factor this out.
         let productType: Xcode.Target.ProductType
         switch target.type {
-        case .executable:
+        case .executable, .snippet:
             productType = .executable
         case .library:
             productType = .framework

--- a/Tests/PackageModelTests/SnippetTests.swift
+++ b/Tests/PackageModelTests/SnippetTests.swift
@@ -1,0 +1,157 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+@testable import PackageModel
+import TSCBasic
+import XCTest
+
+class SnippetTests: XCTestCase {
+    let fakeSourceFilePath = AbsolutePath("/fake/path/to/test.swift")
+
+    /// Test the contents of the ``Snippet`` model when parsing an empty file.
+    /// Currently, no errors are emitted and most things are either nil or empty.
+    func testEmptySourceFile() {
+        let source = ""
+        let snippet = Snippet(parsing: source, path: fakeSourceFilePath)
+        XCTAssertEqual(snippet.path, fakeSourceFilePath)
+        XCTAssertTrue(snippet.explanation.isEmpty)
+        XCTAssertTrue(snippet.presentationCode.isEmpty)
+        XCTAssertNil(snippet.groupName)
+        XCTAssertEqual("test", snippet.name)
+    }
+
+    /// Test the contents of the ``Snippet`` model when parsing a typical
+    /// source file.
+    func testBasic() {
+        let explanation = "This snippet does a foo. Try it when XYZ."
+        let presentationCode = """
+        import Module
+
+        func foo(x: X) {}
+        """
+
+        let source = """
+
+        //! \(explanation)
+
+        \(presentationCode)
+
+        // MARK: HIDE
+
+        print(foo(x: x()))
+        """
+
+        let snippet = Snippet(parsing: source, path: fakeSourceFilePath)
+
+        XCTAssertEqual(snippet.path, fakeSourceFilePath)
+        XCTAssertEqual(explanation, snippet.explanation)
+        XCTAssertEqual(presentationCode, snippet.presentationCode)
+        XCTAssertNil(snippet.groupName)
+        XCTAssertEqual("test", snippet.name)
+    }
+
+    /// Test that multiple consecutive newlines in a snippet's
+    /// presentation code is coalesced into no more than two newlines,
+    /// and test that newlines at the beginning and end of are stripped.
+    func testMultiNewlineCoalescing() {
+        let explanation = "This snippet does a foo. Try it when XYZ."
+        let presentationCode = """
+
+
+        import Module
+
+
+
+
+        func foo(x: X) {}
+
+
+        """
+
+        let source = """
+
+        //!
+        //! \(explanation)
+        //!
+
+        \(presentationCode)
+
+        // MARK: HIDE
+
+        print(foo(x: x()))
+        """
+
+        let expectedPresentationCode = """
+        import Module
+
+        func foo(x: X) {}
+        """
+
+        let snippet = Snippet(parsing: source, path: fakeSourceFilePath)
+        XCTAssertEqual(explanation, snippet.explanation)
+        XCTAssertEqual(expectedPresentationCode, snippet.presentationCode)
+    }
+
+    /// Test that toggling back and forth with `mark: hide` and `mark: show`
+    /// works as intended.
+    func testMarkHideShowToggle() {
+        let source = """
+        shown1
+
+        // mark: hide
+        hidden1
+
+        // mark: show
+        shown2
+
+        // mark: hide
+        hidden2
+
+        // mark: show
+        shown3
+        """
+
+        let expectedPresentationCode = """
+        shown1
+
+        shown2
+        
+        shown3
+        """
+
+        let snippet = Snippet(parsing: source, path: fakeSourceFilePath)
+        XCTAssertFalse(snippet.presentationCode.contains("hidden"))
+        XCTAssertFalse(snippet.explanation.contains("hidden"))
+        XCTAssertEqual(expectedPresentationCode, snippet.presentationCode)
+    }
+
+    /// Tests that extra indentation is removed when extracting some inner
+    /// part of nested code.
+    func testRemoveExtraIndentation() {
+        let source = """
+        // mark: hide
+        struct Outer {
+          struct Inner {
+            // mark: show
+            struct InnerInner {
+            }
+            // mark: hide
+          }
+        }
+        """
+
+        let expectedPresentationCode = """
+        struct InnerInner {
+        }
+        """
+        let snippet = Snippet(parsing: source, path: fakeSourceFilePath)
+        XCTAssertEqual(expectedPresentationCode, snippet.presentationCode)
+    }
+}


### PR DESCRIPTION
Snippets are small, focused pieces of example code for packages. They are meant
for current and potential package clients to read and try when exploring a
package.

Snippets build with the rest of a package so they don't get stale and
can run as an executable target with hidden "demo code" to illustrate and prove
that the snippets work (this does not mean that snippets are tests!).

Summary of changes:

- Add a `.snippet` product and target type
- Add the `Snippet` and `SnippetGroup` model to PackageModel
- When building a package in `PackageBuilder`, look for snippets in the
  `Snippets` subdirectory.
- Add the "card stack" terminal UIs for browsing a package's snippets
  - "Top" card: The top level menu that displays products and snippet groups
  - "Snippet Group" card: The menu that shows the snippets in a group
  - "Snippet" card: Displays a snippet's presentation code and offers
    to build and run the snippet.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
