### PR TITLE
refactor managed dependencies

### DIFF
--- a/Sources/PackageModel/PackageIdentity.swift
+++ b/Sources/PackageModel/PackageIdentity.swift
@@ -46,7 +46,7 @@ public struct PackageIdentity: CustomStringConvertible {
     }
 
     /// Creates a package identity from a URL.
-    /// - Parameter url: The package's URL.
+    /// - Parameter urlString: The package's URL.
     // FIXME: deprecate this
     public init(urlString: String) {
         self.description = Self.provider.init(urlString).description

--- a/Sources/PackageModel/PackageReference.swift
+++ b/Sources/PackageModel/PackageReference.swift
@@ -115,14 +115,16 @@ public struct PackageReference: Encodable {
 }
 
 extension PackageReference: Equatable {
+    // TODO: consider location as well?
     public static func ==(lhs: PackageReference, rhs: PackageReference) -> Bool {
         return lhs.identity == rhs.identity
     }
 }
 
 extension PackageReference: Hashable {
+    // TODO: consider location as well?
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(identity)
+        hasher.combine(self.identity)
     }
 }
 

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -229,7 +229,10 @@ public func loadPackageGraph(
     useXCBuildFileRules: Bool = false
 ) throws -> PackageGraph {
     let rootManifests = manifests.filter { $0.packageKind.isRoot }.spm_createDictionary{ ($0.path, $0) }
-    let externalManifests = manifests.filter { !$0.packageKind.isRoot }
+    let externalManifests = try manifests.filter { !$0.packageKind.isRoot }.reduce(into: OrderedDictionary<PackageIdentity, Manifest>()) { partial, item in
+        partial[try identityResolver.resolveIdentity(for: item.packageKind)] = item
+    }
+
     let packages = Array(rootManifests.keys)
     let input = PackageGraphRootInput(packages: packages)
     let graphRoot = PackageGraphRoot(input: input, manifests: rootManifests, explicitProduct: explicitProduct)

--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -14,195 +14,192 @@ import SourceControl
 import TSCBasic
 import TSCUtility
 
-/// An individual managed dependency.
-///
-/// Each dependency will have a checkout containing the sources at a
-/// particular revision, and may have an associated version.
-public class ManagedDependency {
-    /// Represents the state of the managed dependency.
-    public enum State: Equatable {
+extension Workspace {
+    /// An individual managed dependency.
+    ///
+    /// Each dependency will have a checkout containing the sources at a
+    /// particular revision, and may have an associated version.
+    final public class ManagedDependency {
+        /// Represents the state of the managed dependency.
+        public enum State: Equatable {
+            /// The dependency is a managed checkout.
+            case checkout(CheckoutState)
 
-        /// The dependency is a managed checkout.
-        case checkout(CheckoutState)
+            /// The dependency is in edited state.
+            ///
+            /// If the path is non-nil, the dependency is managed by a user and is
+            /// located at the path. In other words, this dependency is being used
+            /// for top of the tree style development.
+            case edited(basedOn: ManagedDependency?, unmanagedPath: AbsolutePath?)
 
-        /// The dependency is in edited state.
-        ///
-        /// If the path is non-nil, the dependency is managed by a user and is
-        /// located at the path. In other words, this dependency is being used
-        /// for top of the tree style development.
-        case edited(AbsolutePath?)
+            // The dependency is a local package.
+            case local
 
-        // The dependency is a local package.
-        case local
+            public static func == (lhs: Workspace.ManagedDependency.State, rhs: Workspace.ManagedDependency.State) -> Bool {
+                switch (lhs, rhs) {
+                case (.local, .local):
+                    return true
+                case (.checkout(let lState), .checkout(let rState)):
+                    return lState == rState
+                case (.edited(let lBasedOn, let lUnmanagedPath), .edited(let rBasedOn, let rUnmanagedPath)):
+                    return lBasedOn?.packageRef == rBasedOn?.packageRef && lUnmanagedPath == rUnmanagedPath
+                default:
+                    return false
+                }
+            }
+        }
+
+        /// The package reference.
+        public let packageRef: PackageReference
+
+        /// The state of the managed dependency.
+        public let state: State
 
         /// Returns true if state is checkout.
         var isCheckout: Bool {
-            if case .checkout = self { return true }
+            if case .checkout = self.state { return true }
             return false
         }
-    }
 
-    /// The package reference.
-    public let packageRef: PackageReference
-
-    /// The state of the managed dependency.
-    public let state: State
-
-    /// Returns true if the dependency is edited.
-    public var isEdited: Bool {
-        switch state {
-        case .checkout, .local:
+        /// Returns true if the dependency is edited.
+        public var isEdited: Bool {
+            if case .edited = self.state { return true }
             return false
-        case .edited:
-            return true
         }
-    }
 
-    public var checkoutState: CheckoutState? {
-        if case .checkout(let checkoutState) = state {
-            return checkoutState
+        /// The checked out path of the dependency on disk, relative to the workspace checkouts path.
+        public let subpath: RelativePath
+
+        public var packageIdentity: PackageIdentity {
+            self.packageRef.identity
         }
-        return nil
-    }
 
-    /// The checked out path of the dependency on disk, relative to the workspace checkouts path.
-    public let subpath: RelativePath
+        internal init(
+            packageRef: PackageReference,
+            state: State,
+            subpath: RelativePath
+        ) {
+            self.packageRef = packageRef
+            self.subpath = subpath
+            self.state = state
+        }
 
-    /// A dependency which in editable state is based on a dependency from
-    /// which it edited from.
-    ///
-    /// This information is useful so it can be restored when users
-    /// unedit a package.
-    public internal(set) var basedOn: ManagedDependency?
+        /// Create an editable managed dependency based on a dependency which
+        /// was *not* in edit state.
+        ///
+        /// - Parameters:
+        ///     - subpath: The subpath inside the editable directory.
+        ///     - unmanagedPath: A custom absolute path instead of the subpath.
+        public func edited(subpath: RelativePath, unmanagedPath: AbsolutePath?) -> ManagedDependency {
+            return .edited(packageRef: self.packageRef, subpath: subpath, basedOn: self, unmanagedPath: unmanagedPath)
+        }
 
-    public var packageIdentity: PackageIdentity {
-        self.packageRef.identity
-    }
+        /// Create a dependency present locally on the filesystem.
+        public static func local(
+            packageRef: PackageReference
+        ) -> ManagedDependency {
+            return ManagedDependency(
+                packageRef: packageRef,
+                state: .local,
+                // FIXME: This is just a fake entry, we should fix it.
+                subpath: RelativePath(packageRef.identity.description)
+            )
+        }
 
-    public init(
-        packageRef: PackageReference,
-        subpath: RelativePath,
-        checkoutState: CheckoutState
-    ) {
-        self.packageRef = packageRef
-        self.state = .checkout(checkoutState)
-        self.basedOn = nil
-        self.subpath = subpath
-    }
+        /// Create a remote dependency checked out
+        public static func remote(
+            packageRef: PackageReference,
+            state: CheckoutState,
+            subpath: RelativePath
+        ) -> ManagedDependency {
+            return ManagedDependency(
+                packageRef: packageRef,
+                state: .checkout(state),
+                subpath: subpath
+            )
+        }
 
-    /// Create a dependency present locally on the filesystem.
-    public static func local(
-        packageRef: PackageReference
-    ) -> ManagedDependency {
-        return ManagedDependency(
-            packageRef: packageRef,
-            state: .local,
-            // FIXME: This is just a fake entry, we should fix it.
-            subpath: RelativePath(packageRef.identity.description),
-            basedOn: nil
-        )
-    }
-
-    internal init(
-        packageRef: PackageReference,
-        state: State,
-        subpath: RelativePath,
-        basedOn: ManagedDependency?
-    ) {
-        self.packageRef = packageRef
-        self.subpath = subpath
-        self.basedOn = basedOn
-        self.state = state
-    }
-
-    private init(
-        basedOn dependency: ManagedDependency,
-        subpath: RelativePath,
-        unmanagedPath: AbsolutePath?
-    ) {
-        assert(dependency.state.isCheckout)
-        self.basedOn = dependency
-        self.packageRef = dependency.packageRef
-        self.subpath = subpath
-        self.state = .edited(unmanagedPath)
-    }
-
-    /// Create an editable managed dependency based on a dependency which
-    /// was *not* in edit state.
-    ///
-    /// - Parameters:
-    ///     - subpath: The subpath inside the editable directory.
-    ///     - unmanagedPath: A custom absolute path instead of the subpath.
-    public func editedDependency(subpath: RelativePath, unmanagedPath: AbsolutePath?) -> ManagedDependency {
-        return ManagedDependency(basedOn: self, subpath: subpath, unmanagedPath: unmanagedPath)
+        /// Create an edited dependency
+        public static func edited(
+            packageRef: PackageReference,
+            subpath: RelativePath,
+            basedOn: ManagedDependency?,
+            unmanagedPath: AbsolutePath?
+        ) -> ManagedDependency {
+            return ManagedDependency(
+                packageRef: packageRef,
+                state: .edited(basedOn: basedOn, unmanagedPath: unmanagedPath),
+                subpath: subpath
+            )
+        }
     }
 }
 
-extension ManagedDependency: CustomStringConvertible {
+extension Workspace.ManagedDependency: CustomStringConvertible {
     public var description: String {
         return "<ManagedDependency: \(self.packageRef.name) \(self.state)>"
     }
 }
 
-
 // MARK: - ManagedDependencies
 
-/// A collection of managed dependencies.
-public final class ManagedDependencies {
-    /// The dependencies keyed by the package URL.
-    private var dependencyMap: [String: ManagedDependency]
+extension Workspace {
+    /// A collection of managed dependencies.
+    final public class ManagedDependencies {
+        // FIXME: this should be identity based
+        private var dependencies: [PackageIdentity: ManagedDependency]
 
-    init(dependencyMap: [String: ManagedDependency] = [:]) {
-        self.dependencyMap = dependencyMap
-    }
+        init(_ dependencies: [ManagedDependency] = []) {
+            self.dependencies = Dictionary(uniqueKeysWithValues: dependencies.map{ ($0.packageRef.identity, $0) })
+        }
 
-    public subscript(forURL url: String) -> ManagedDependency? {
-        dependencyMap[url]
-    }
+        public subscript(identity: PackageIdentity) -> ManagedDependency? {
+            return self.dependencies[identity]
+        }
 
-    public subscript(forIdentity identity: PackageIdentity) -> ManagedDependency? {
-        dependencyMap.values.first(where: { $0.packageRef.identity == identity })
-    }
+        // When loading manifests in Workspace, there are cases where we must also compare the location
+        // as it may attempt to load manifests for dependencies that have the same identity but from a different location
+        // (e.g. dependency is changed to  a fork with the same identity)
+        public subscript(comparingLocation package: PackageReference) -> ManagedDependency? {
+            if let dependency = self.dependencies[package.identity], dependency.packageRef.location == package.location {
+                return dependency
+            }
+            return .none
+        }
 
-    public subscript(forNameOrIdentity nameOrIdentity: String) -> ManagedDependency? {
-        let lowercasedNameOrIdentity = nameOrIdentity.lowercased()
-        return dependencyMap.values.first(where: {
-            $0.packageRef.name == nameOrIdentity || $0.packageRef.identity.description == lowercasedNameOrIdentity
-        })
-    }
+        public func add(_ dependency: ManagedDependency) {
+            self.dependencies[dependency.packageRef.identity] = dependency
+        }
 
-    public func add(_ dependency: ManagedDependency) {
-        self.dependencyMap[dependency.packageRef.location] = dependency
-    }
-
-    public func remove(forURL url: String) {
-        self.dependencyMap[url] = nil
+        public func remove(_ identity: PackageIdentity) {
+            self.dependencies[identity] = nil
+        }
     }
 }
 
-extension ManagedDependencies: Collection {
-    public typealias Index = Dictionary<String, ManagedDependency>.Index
-    public typealias Element = ManagedDependency
+extension Workspace.ManagedDependencies: Collection {
+    public typealias Index = Dictionary<PackageIdentity, Workspace.ManagedDependency>.Index
+    public typealias Element = Workspace.ManagedDependency
 
     public var startIndex: Index {
-        self.dependencyMap.startIndex
+        self.dependencies.startIndex
     }
 
     public var endIndex: Index {
-        self.dependencyMap.endIndex
+        self.dependencies.endIndex
     }
 
     public subscript(index: Index) -> Element {
-        self.dependencyMap[index].value
+        self.dependencies[index].value
     }
 
     public func index(after index: Index) -> Index {
-        self.dependencyMap.index(after: index)
+        self.dependencies.index(after: index)
     }
 }
 
-extension ManagedDependencies: CustomStringConvertible {
+extension Workspace.ManagedDependencies: CustomStringConvertible {
     public var description: String {
-        "<ManagedDependencies: \(Array(dependencyMap.values))>"
+        "<ManagedDependencies: \(Array(self.dependencies.values))>"
     }
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -30,7 +30,7 @@ public enum WorkspaceResolveReason: Equatable {
     /// The requirement of a dependency has changed.
     case packageRequirementChange(
         package: PackageReference,
-        state: ManagedDependency.State?,
+        state: Workspace.ManagedDependency.State?,
         requirement: PackageRequirement
     )
 
@@ -562,7 +562,7 @@ extension Workspace {
         root: PackageGraphRootInput,
         diagnostics: DiagnosticsEngine
     ) throws {
-        guard let dependency = state.dependencies[forNameOrIdentity: packageName] else {
+        guard let dependency = self.state.dependencies[.plain(packageName)] else {
             diagnostics.emit(.dependencyNotFound(packageName: packageName))
             return
         }
@@ -593,7 +593,7 @@ extension Workspace {
         diagnostics: DiagnosticsEngine
     ) throws {
         // Look up the dependency and check if we can pin it.
-        guard let dependency = state.dependencies[forNameOrIdentity: packageName] else {
+        guard let dependency = self.state.dependencies[.plain(packageName)] else {
             diagnostics.emit(.dependencyNotFound(packageName: packageName))
             return
         }
@@ -1022,7 +1022,7 @@ extension Workspace {
         diagnostics: DiagnosticsEngine
     ) throws {
         // Look up the dependency and check if we can edit it.
-        guard let dependency = state.dependencies[forNameOrIdentity: packageName] else {
+        guard let dependency = self.state.dependencies[.plain(packageName)] else {
             diagnostics.emit(.dependencyNotFound(packageName: packageName))
             return
         }
@@ -1118,8 +1118,10 @@ extension Workspace {
         }
 
         // Save the new state.
-        state.dependencies.add(dependency.editedDependency(subpath: RelativePath(packageName), unmanagedPath: path))
-        try state.saveState()
+        self.state.dependencies.add(
+            dependency.edited(subpath: RelativePath(packageName), unmanagedPath: path)
+        )
+        try self.state.save()
     }
 
     /// Unedit a managed dependency. See public API unedit(packageName:forceRemove:).
@@ -1138,7 +1140,7 @@ extension Workspace {
         case .checkout, .local:
             throw WorkspaceDiagnostics.DependencyNotInEditMode(dependencyName: dependency.packageRef.name)
 
-        case .edited(let path):
+        case .edited(_, let path):
             if path != nil {
                 // Set force remove to true for unmanaged dependencies.  Note that
                 // this only removes the symlink under the editable directory and
@@ -1168,15 +1170,15 @@ extension Workspace {
             try fileSystem.removeFileTree(self.location.editsDirectory)
         }
 
-        if let checkoutState = dependency.basedOn?.checkoutState {
-                // Restore the original checkout.
-                //
-                // The clone method will automatically update the managed dependency state.
-                _ = try clone(package: dependency.packageRef, at: checkoutState)
+        if case .edited(let basedOn, _) = dependency.state, case .checkout(let checkoutState) = basedOn?.state {
+            // Restore the original checkout.
+            //
+            // The clone method will automatically update the managed dependency state.
+            _ = try clone(package: dependency.packageRef, at: checkoutState)
         } else {
             // The original dependency was removed, update the managed dependency state.
-            state.dependencies.remove(forURL: dependency.packageRef.location)
-            try state.saveState()
+            self.state.dependencies.remove(dependency.packageRef.identity)
+            try self.state.save()
         }
 
         // Resolve the dependencies if workspace root is provided. We do this to
@@ -1203,7 +1205,7 @@ extension Workspace {
 
         let requiredURLs = dependencyManifests.computePackageURLs().required
 
-        for dependency in state.dependencies  {
+        for dependency in self.state.dependencies  {
             if requiredURLs.contains(where: { $0.location == dependency.packageRef.location }) {
                 pinsStore.pin(dependency)
             }
@@ -1222,7 +1224,7 @@ fileprivate extension PinsStore {
     /// Pin a managed dependency at its checkout state.
     ///
     /// This method does nothing if the dependency is in edited state.
-    func pin(_ dependency: ManagedDependency) {
+    func pin(_ dependency: Workspace.ManagedDependency) {
 
         // Get the checkout state.
         let checkoutState: CheckoutState
@@ -1255,7 +1257,7 @@ extension Workspace {
 
         fileprivate init(
             root: PackageGraphRoot,
-            dependencies: [(Manifest, ManagedDependency, ProductFilter)],
+            dependencies: [(manifest: Manifest, dependency: ManagedDependency, productFilter: ProductFilter)],
             workspace: Workspace
         ) {
             self.root = root
@@ -1264,8 +1266,10 @@ extension Workspace {
         }
 
         /// Returns all manifests contained in DependencyManifests.
-        public func allDependencyManifests() -> [Manifest] {
-            return self.dependencies.map{ $0.manifest }
+        public func allDependencyManifests() -> OrderedDictionary<PackageIdentity, Manifest> {
+            return self.dependencies.reduce(into: OrderedDictionary<PackageIdentity, Manifest>()) { partial, item in
+                partial[item.dependency.packageIdentity] = item.manifest
+            }
         }
 
         /// Computes the identities which are declared in the manifests but aren't present in dependencies.
@@ -1433,11 +1437,11 @@ extension Workspace {
     /// Checkout dependencies will return the subpath inside `checkoutsPath` and
     /// edited dependencies will either return a subpath inside `editablesPath` or
     /// a custom path.
-    public func path(to dependency: ManagedDependency) -> AbsolutePath {
+    public func path(to dependency: Workspace.ManagedDependency) -> AbsolutePath {
         switch dependency.state {
         case .checkout:
             return self.location.repositoriesCheckoutsDirectory.appending(dependency.subpath)
-        case .edited(let path):
+        case .edited(_, let path):
             return path ?? self.location.editsDirectory.appending(dependency.subpath)
         case .local:
             return AbsolutePath(dependency.packageRef.location)
@@ -1459,9 +1463,7 @@ extension Workspace {
     /// Load the manifests for the current dependency tree.
     ///
     /// This will load the manifests for the root package as well as all the
-    /// current dependencies from the working checkouts.
-    // @testable internal
-    // FIXME: this logic should be changed to use identity instead of location once identity is unique
+    /// current dependencies from the working checkouts.l
     public func loadDependencyManifests(
         root: PackageGraphRoot,
         diagnostics: DiagnosticsEngine,
@@ -1470,12 +1472,11 @@ extension Workspace {
         // Utility Just because a raw tuple cannot be hashable.
         struct Key: Hashable {
             let identity: PackageIdentity
-            let url: String
             let productFilter: ProductFilter
         }
 
         // Make a copy of dependencies as we might mutate them in the for loop.
-        let dependenciesToCheck = Array(state.dependencies)
+        let dependenciesToCheck = Array(self.state.dependencies)
         // Remove any managed dependency which has become a root.
         for dependency in dependenciesToCheck {
             if root.packages.keys.contains(dependency.packageRef.identity) {
@@ -1485,93 +1486,124 @@ extension Workspace {
             }
         }
 
-        // Try to load current managed dependencies, or emit and return.
+        // Validates that all the managed dependencies are still present in the file system.
         self.fixManagedDependencies(with: diagnostics)
         guard !diagnostics.hasErrors else {
             return DependencyManifests(root: root, dependencies: [], workspace: self)
         }
 
+/*
         // optimization: preload in parallel
         let rootDependencyManifestsURLs = root.dependencies.map{ $0.location }
         let rootDependencyManifests = try temp_await { self.loadManifests(forURLs: rootDependencyManifestsURLs, diagnostics: diagnostics, completion: $0) }
             .map{ try (self.identityResolver.resolveIdentity(for: $0.packageKind), $0) }
             .spm_createDictionary{ ($0.0, $0.1) }
+*/
+        // Load root dependencies manifests (in parallel)
+        let rootDependencies = root.dependencies.map{ $0.createPackageRef() }
+        let rootDependenciesManifests = try temp_await { self.loadManagedManifests(for: rootDependencies, diagnostics: diagnostics, completion: $0) }
 
-        let inputManifests = root.manifests.merging(rootDependencyManifests, uniquingKeysWith: { lhs, rhs in
+        let topLevelManifests = root.manifests.merging(rootDependenciesManifests, uniquingKeysWith: { lhs, rhs in
             return lhs // prefer roots!
         })
 
-        // Create a map of loaded manifests. We do this to avoid reloading the shared nodes.
-        // optimization: preload manifest we know about in parallel
-        // note: loadManifest emits diagnostics in case it fails
-        let inputManifestsDependenciesURLs = inputManifests.values.map { $0.dependencies.map{ $0.location } }.flatMap { $0 }
-        var loadedManifests = try temp_await { self.loadManifests(forURLs: inputManifestsDependenciesURLs, diagnostics: diagnostics, completion: $0) }.spm_createDictionary{ ($0.packageLocation, $0) } // FIXME: this should not block
+        // optimization: preload first level dependencies manifest (in parallel)
+        let firstLevelDependencies = topLevelManifests.values.map { $0.dependencies.map{ $0.createPackageRef() } }.flatMap { $0 }
+        let firstLevelManifests = try temp_await { self.loadManagedManifests(for: firstLevelDependencies, diagnostics: diagnostics, completion: $0) } // FIXME: this should not block
 
         // Continue to load the rest of the manifest for this graph
+        // Creates a map of loaded manifests. We do this to avoid reloading the shared nodes.
+        var loadedManifests = firstLevelManifests
         // Compute the transitive closure of available dependencies.
-        let inputPairs = inputManifests.map { identity, manifest -> KeyedPair<Manifest, Key> in
-            let key = Key(identity: identity, url: manifest.packageLocation, productFilter: .everything)
-            return KeyedPair(manifest, key: key)
-        }
-
-        let allManifestsWithPossibleDuplicates = try topologicalSort(inputPairs) { pair in
+        let input = topLevelManifests.map { identity, manifest in KeyedPair(manifest, key: Key(identity: identity, productFilter: .everything)) }
+        let allManifestsWithPossibleDuplicates = try topologicalSort(input) { pair in
             // optimization: preload manifest we know about in parallel
             let dependenciesRequired = pair.item.dependenciesRequired(for: pair.key.productFilter)
             // prepopulate managed dependencies if we are asked to do so
             // FIXME: this seems like hack, needs further investigation why this is needed
             if automaticallyAddManagedDependencies {
                 dependenciesRequired.filter { $0.isLocal }.forEach { dependency in
-                    state.dependencies.add(.local(packageRef: dependency.createPackageRef()))
+                    self.state.dependencies.add(.local(packageRef: dependency.createPackageRef()))
                 }
-                diagnostics.wrap { try state.saveState() }
+                diagnostics.wrap { try self.state.save() }
             }
-            let dependenciesRequiredURLs = dependenciesRequired.map{ $0.location }.filter { !loadedManifests.keys.contains($0) }
-            // note: loadManifest emits diagnostics in case it fails
-            let dependenciesRequiredManifests = try temp_await { self.loadManifests(forURLs: dependenciesRequiredURLs, diagnostics: diagnostics, completion: $0) }
-            dependenciesRequiredManifests.forEach { loadedManifests[$0.packageLocation] = $0 }
+            let dependenciesToLoad = dependenciesRequired.map{ $0.createPackageRef() }.filter { !loadedManifests.keys.contains($0.identity) }
+            let dependenciesManifests = try temp_await { self.loadManagedManifests(for: dependenciesToLoad, diagnostics: diagnostics, completion: $0) }
+            dependenciesManifests.forEach { loadedManifests[$0.key] = $0.value }
             return pair.item.dependenciesRequired(for: pair.key.productFilter).compactMap{ dependency in
-                loadedManifests[dependency.location].flatMap { KeyedPair($0, key: Key(identity: dependency.identity, url: $0.packageLocation, productFilter: dependency.productFilter)) }
+                loadedManifests[dependency.identity].flatMap {
+                    // we also compare the location as this function may attempt to load
+                    // dependencies that have the same identity but from a different location
+                    // which is an error case we diagnose an report about in the GraphLoading part which
+                    // is prepared to handle the case where not all manifest are available
+                    $0.packageLocation == dependency.location ?
+                    KeyedPair($0, key: Key(identity: dependency.identity, productFilter: dependency.productFilter)) : nil
+                }
             }
         }
 
-        // remove duplicates of the same manifest (by identity)
+        // merge the productFilter of the same package (by identity)
         var deduplication = [PackageIdentity: Int]()
-        var allManifests = [(manifest: Manifest, productFilter: ProductFilter)]()
+        var allManifests = [(identity: PackageIdentity, manifest: Manifest, productFilter: ProductFilter)]()
         for pair in allManifestsWithPossibleDuplicates {
             if let index = deduplication[pair.key.identity]  {
                 let productFilter = allManifests[index].productFilter.merge(pair.key.productFilter)
-                allManifests[index] = (pair.item, productFilter)
+                allManifests[index] = (pair.key.identity, pair.item, productFilter)
             } else {
                 deduplication[pair.key.identity] = allManifests.count
-                allManifests.append((pair.item, pair.key.productFilter))
+                allManifests.append((pair.key.identity, pair.item, pair.key.productFilter))
             }
         }
 
         let dependencyManifests = allManifests.filter{ !root.manifests.values.contains($0.manifest) }
 
+        // TODO: this check should go away when introducing explicit overrides
         // check for overrides attempts with same name but different path
         let rootManifestsByName = Array(root.manifests.values).spm_createDictionary{ ($0.name, $0) }
-        dependencyManifests.forEach { manifest, _ in
+        dependencyManifests.forEach { identity, manifest, _ in
             if let override = rootManifestsByName[manifest.name], override.packageLocation != manifest.packageLocation  {
                 diagnostics.emit(error: "unable to override package '\(manifest.name)' because its identity '\(PackageIdentity(urlString: manifest.packageLocation))' doesn't match override's identity (directory name) '\(PackageIdentity(urlString: override.packageLocation))'")
             }
         }
 
-        let dependencies = try dependencyManifests.map{ manifest, productFilter -> (Manifest, ManagedDependency, ProductFilter) in
-            guard let dependency = self.state.dependencies[forURL: manifest.packageLocation] else {
-                throw InternalError("dependency not found for \(manifest.packageLocation)")
+        let dependencies = try dependencyManifests.map{ identity, manifest, productFilter -> (Manifest, ManagedDependency, ProductFilter) in
+            guard let dependency = self.state.dependencies[identity] else {
+                throw InternalError("dependency not found for \(identity) at \(manifest.packageLocation)")
             }
             return (manifest, dependency, productFilter)
         }
+        
         return DependencyManifests(root: root, dependencies: dependencies, workspace: self)
     }
 
+    /// Loads the given manifests, if it is present in the managed dependencies.
+    private func loadManagedManifests(for packages: [PackageReference], diagnostics: DiagnosticsEngine, completion: @escaping (Result<[PackageIdentity: Manifest], Error>) -> Void) {
+        let sync = DispatchGroup()
+        let manifests = ThreadSafeKeyValueStore<PackageIdentity, Manifest>()
+        Set(packages).forEach { package in
+            sync.enter()
+            self.loadManagedManifest(for: package, diagnostics: diagnostics) { manifest in
+                defer { sync.leave() }
+                if let manifest = manifest {
+                    manifests[package.identity] = manifest
+                }
+            }
+        }
+
+        sync.notify(queue: .sharedConcurrent) {
+            completion(.success(manifests.get()))
+        }
+    }
 
     /// Loads the given manifest, if it is present in the managed dependencies.
-    fileprivate func loadManifest(forURL packageURL: String, diagnostics: DiagnosticsEngine, completion: @escaping (Manifest?) -> Void) {
+    fileprivate func loadManagedManifest(for package: PackageReference, diagnostics: DiagnosticsEngine, completion: @escaping (Manifest?) -> Void) {
         // Check if this dependency is available.
-        guard let managedDependency = self.state.dependencies[forURL: packageURL] else {
-            return completion(nil)
+        // we also compare the location as this function may attempt to load
+        // dependencies that have the same identity but from a different location
+        // which is an error case we diagnose an report about in the GraphLoading part which
+        // is prepared to handle the case where not all manifest are available
+        guard let managedDependency = self.state.dependencies[comparingLocation: package] else {
+            return completion(.none)
         }
 
         // Get the path of the package.
@@ -1604,28 +1636,6 @@ extension Workspace {
                           diagnostics: diagnostics) { result in
             // error is added to diagnostics in the function above
             completion(try? result.get())
-        }
-    }
-
-    private func loadManifests(forURLs urls: [String], diagnostics: DiagnosticsEngine, completion: @escaping (Result<[Manifest], Error>) -> Void) {
-        // this is allot of boilerplate code but its is important for performance
-        let lock = Lock()
-        let sync = DispatchGroup()
-        var manifests = [Manifest]()
-        Set(urls).forEach { url in
-            sync.enter()
-            self.loadManifest(forURL: url, diagnostics: diagnostics) { manifest in
-                defer { sync.leave() }
-                if let manifest = manifest {
-                    lock.withLock {
-                        manifests.append(manifest)
-                    }
-                }
-            }
-        }
-
-        sync.notify(queue: .sharedConcurrent) {
-            completion(.success(manifests))
         }
     }
 
@@ -1776,7 +1786,7 @@ extension Workspace {
         }
 
         diagnostics.wrap {
-            try self.state.saveState()
+            try self.state.save()
         }
     }
 
@@ -2044,7 +2054,8 @@ extension Workspace {
         // We require cloning if there is no checkout or if the checkout doesn't
         // match with the pin.
         let requiredPins = pinsStore.pins.filter{ pin in
-            guard let dependency = state.dependencies[forURL: pin.packageRef.location] else {
+            // also compare the location in case it has changed
+            guard let dependency = state.dependencies[comparingLocation: pin.packageRef] else {
                 return true
             }
             switch dependency.state {
@@ -2299,7 +2310,7 @@ extension Workspace {
         let pins = pinsStore.pinsMap.keys
         let requiredURLs = dependencyManifests.computePackageURLs().required
 
-        for dependency in state.dependencies {
+        for dependency in self.state.dependencies {
             switch dependency.state {
             case .checkout: break
             case .edited, .local: continue
@@ -2406,35 +2417,22 @@ extension Workspace {
         resolvedDependencies: [(PackageReference, BoundVersion, ProductFilter)],
         updateBranches: Bool
     ) throws -> [(PackageReference, PackageStateChange)] {
-        // Load pins store and managed dependendencies.
+        // Load pins store and managed dependencies.
         let pinsStore = try self.pinsStore.load()
         var packageStateChanges: [PackageIdentity: (PackageReference, PackageStateChange)] = [:]
 
         // Set the states from resolved dependencies results.
         for (packageRef, binding, products) in resolvedDependencies {
             // Get the existing managed dependency for this package ref, if any.
-            let currentDependency: ManagedDependency?
-            if let existingDependency = state.dependencies[forURL: packageRef.location] {
-                currentDependency = existingDependency
+
+            // first find by identity only since edit location may be different by design
+            var currentDependency = self.state.dependencies[packageRef.identity]
+            // Check if this is an edited dependency.
+            if case .edited(let basedOn, _) = currentDependency?.state, let originalReference = basedOn?.packageRef {
+                packageStateChanges[originalReference.identity] = (originalReference, .unchanged)
             } else {
-                // Check if this is a edited dependency.
-                //
-                // This is a little bit ugly but can probably be cleaned up by
-                // putting information in the PackageReference type. We change
-                // the package reference for edited packages which causes the
-                // original checkout in somewhat of a dangling state when computing
-                // the state changes this method. We basically need to ensure that
-                // the edited checkout is unchanged.
-                if let editedDependency = state.dependencies.first(where: {
-                    guard $0.basedOn != nil else { return false }
-                    return self.path(to: $0).pathString == packageRef.location
-                }) {
-                    currentDependency = editedDependency
-                    let originalReference = editedDependency.basedOn!.packageRef // forced unwrap safe
-                    packageStateChanges[originalReference.identity] = (originalReference, .unchanged)
-                } else {
-                    currentDependency = nil
-                }
+                // if not edited, also compare by location since it may have changed
+                currentDependency = self.state.dependencies[comparingLocation: packageRef]
             }
 
             switch binding {
@@ -2516,7 +2514,7 @@ extension Workspace {
             }
         }
         // Set the state of any old package that might have been removed.
-        for packageRef in state.dependencies.lazy.map({ $0.packageRef }) where packageStateChanges[packageRef.identity] == nil {
+        for packageRef in self.state.dependencies.lazy.map({ $0.packageRef }) where packageStateChanges[packageRef.identity] == nil {
             packageStateChanges[packageRef.identity] = (packageRef, .removed)
         }
 
@@ -2571,12 +2569,12 @@ extension Workspace {
     fileprivate func fixManagedDependencies(with diagnostics: DiagnosticsEngine) {
 
         // Reset managed dependencies if the state file was removed during the lifetime of the Workspace object.
-        if !state.dependencies.isEmpty && !state.stateFileExists() {
+        if !self.state.dependencies.isEmpty && !self.state.stateFileExists() {
             try? self.state.reset()
         }
 
         // Make a copy of dependencies as we might mutate them in the for loop.
-        let allDependencies = Array(state.dependencies)
+        let allDependencies = Array(self.state.dependencies)
         for dependency in allDependencies {
             diagnostics.wrap {
 
@@ -2601,8 +2599,8 @@ extension Workspace {
                     diagnostics.emit(.editedDependencyMissing(packageName: dependency.packageRef.name))
 
                 case .local:
-                    state.dependencies.remove(forURL: dependency.packageRef.location)
-                    try state.saveState()
+                    self.state.dependencies.remove(dependency.packageRef.identity)
+                    try self.state.save()
                 }
             }
         }
@@ -2676,7 +2674,8 @@ extension Workspace {
     /// - Throws: If the operation could not be satisfied.
     private func fetch(package: PackageReference) throws -> AbsolutePath {
         // If we already have it, fetch to update the repo from its remote.
-        if let dependency = state.dependencies[forURL: package.location] {
+        // also compare the location as it may have changed
+        if let dependency = self.state.dependencies[comparingLocation: package] {
             let path = self.location.repositoriesCheckoutsDirectory.appending(dependency.subpath)
 
             // Make sure the directory is not missing (we will have to clone again
@@ -2752,11 +2751,12 @@ extension Workspace {
         try? fileSystem.chmod(.userUnWritable, path: path, options: [.recursive, .onlyFiles])
 
         // Write the state record.
-        state.dependencies.add(ManagedDependency(
+        self.state.dependencies.add(.remote(
             packageRef: package,
-            subpath: path.relative(to: self.location.repositoriesCheckoutsDirectory),
-            checkoutState: checkoutState))
-        try state.saveState()
+            state: checkoutState,
+            subpath: path.relative(to: self.location.repositoriesCheckoutsDirectory)
+        ))
+        try self.state.save()
 
         delegate?.didCheckOut(repository: package.location, revision: checkoutState.description, at: path, error: nil)
 
@@ -2795,8 +2795,8 @@ extension Workspace {
             checkoutState = .branch(name: branch, revision: revision)
 
         case .unversioned:
-            state.dependencies.add(ManagedDependency.local(packageRef: package))
-            try state.saveState()
+            self.state.dependencies.add(ManagedDependency.local(packageRef: package))
+            try self.state.save()
             return AbsolutePath(package.location)
         }
 
@@ -2805,8 +2805,8 @@ extension Workspace {
 
     /// Removes the clone and checkout of the provided specifier.
     fileprivate func remove(package: PackageReference) throws {
-        guard let dependency = state.dependencies[forURL: package.location] else {
-            throw InternalError("trying to remove \(package.name) which isn't in workspace")
+        guard let dependency = self.state.dependencies[package.identity] else {
+            throw InternalError("trying to remove \(package.identity) which isn't in workspace")
         }
 
         // We only need to update the managed dependency structure to "remove"
@@ -2815,8 +2815,8 @@ extension Workspace {
         // Note that we don't actually remove a local package from disk.
         switch dependency.state {
         case .local:
-            state.dependencies.remove(forURL: package.location)
-            try state.saveState()
+            self.state.dependencies.remove(package.identity)
+            try self.state.save()
             return
         case .checkout, .edited:
             break
@@ -2828,14 +2828,19 @@ extension Workspace {
         // Compute the dependency which we need to remove.
         let dependencyToRemove: ManagedDependency
 
-        if let basedOn = dependency.basedOn {
+        if case .edited(let _basedOn, let unmanagedPath) = dependency.state, let basedOn = _basedOn {
             // Remove the underlying dependency for edited packages.
             dependencyToRemove = basedOn
-            dependency.basedOn = nil
-            state.dependencies.add(dependency)
+            let updatedDependency = Workspace.ManagedDependency.edited(
+                packageRef: dependency.packageRef,
+                subpath: dependency.subpath,
+                basedOn: .none,
+                unmanagedPath: unmanagedPath
+            )
+            self.state.dependencies.add(updatedDependency)
         } else {
             dependencyToRemove = dependency
-            state.dependencies.remove(forURL: dependencyToRemove.packageRef.location)
+            self.state.dependencies.remove(dependencyToRemove.packageRef.identity)
         }
 
         // Remove the checkout.
@@ -2852,7 +2857,7 @@ extension Workspace {
         try repositoryManager.remove(repository: dependencyToRemove.packageRef.makeRepositorySpecifier())
 
         // Save the state.
-        try state.saveState()
+        try state.save()
     }
 
     public static func format(workspaceResolveReason reason: WorkspaceResolveReason) -> String {

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -23,8 +23,9 @@ class PackageGraphPerfTests: XCTestCasePerf {
         let N = 100
         let files = (1...N).map { "/Foo\($0)/source.swift" }
         let fs = InMemoryFileSystem(emptyFiles: files)
-        
-        var externalManifests = [Manifest]()
+
+        let identityResolver = DefaultIdentityResolver()
+        var externalManifests = OrderedDictionary<PackageIdentity, Manifest>()
         var rootManifest: Manifest!
         for pkg in 1...N {
             let name = "Foo\(pkg)"
@@ -61,11 +62,10 @@ class PackageGraphPerfTests: XCTestCasePerf {
             if isRoot {
                 rootManifest = manifest
             } else {
-                externalManifests.append(manifest)
+                let identity = try identityResolver.resolveIdentity(for: manifest.packageKind)
+                externalManifests[identity] = manifest
             }
         }
-
-        let identityResolver = DefaultIdentityResolver()
 
         measure {
             let observability = ObservabilitySystem.bootstrapForTesting()


### PR DESCRIPTION
motivation: ManagedDependencies are based on location instead of on identity, refactor them to be based on identity as part of the transition to identity based logic

changes:
* transition ManagedDependencies underlying hashmap to be based on identity
* update the ManagedDependencies edit state to include the "basedOn" property which is only relevant to that state
* update calls ites to use package identity instead of location when reading/writing managed depedencies
* refactor related call-sites to handle edited state more safely and correctly
* add code comments to explain some of the more subtle business logic
* adjust tests where needed

rdar://82954076