### PR TITLE
refactor managed artifacts

### DIFF
--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -379,7 +379,7 @@ public final class MockWorkspace {
     public func set(
         pins: [PackageReference: CheckoutState] = [:],
         managedDependencies: [ManagedDependency] = [],
-        managedArtifacts: [ManagedArtifact] = []
+        managedArtifacts: [Workspace.ManagedArtifact] = []
     ) throws {
         let workspace = try self.getOrCreateWorkspace()
         let pinsStore = try workspace.pinsStore.load()
@@ -463,36 +463,44 @@ public final class MockWorkspace {
     }
 
     public struct ManagedArtifactResult {
-        public let managedArtifacts: ManagedArtifacts
+        public let managedArtifacts: Workspace.ManagedArtifacts
 
-        public init(_ managedArtifacts: ManagedArtifacts) {
+        public init(_ managedArtifacts: Workspace.ManagedArtifacts) {
             self.managedArtifacts = managedArtifacts
         }
 
+        public func checkNotPresent(packageName: String, targetName: String, file: StaticString = #file, line: UInt = #line) {
+            self.checkNotPresent(packageIdentity: .plain(packageName), targetName: targetName, file : file, line: line)
+        }
+
         public func checkNotPresent(
-            packageName: String,
+            packageIdentity: PackageIdentity,
             targetName: String,
             file: StaticString = #file,
             line: UInt = #line
         ) {
-            let artifact = self.managedArtifacts[packageName: packageName, targetName: targetName]
-            XCTAssert(artifact == nil, "Unexpectedly found \(packageName).\(targetName) in managed artifacts", file: file, line: line)
+            let artifact = self.managedArtifacts[packageIdentity: packageIdentity, targetName: targetName]
+            XCTAssert(artifact == nil, "Unexpectedly found \(packageIdentity).\(targetName) in managed artifacts", file: file, line: line)
         }
 
         public func checkEmpty(file: StaticString = #file, line: UInt = #line) {
             XCTAssertEqual(self.managedArtifacts.count, 0, file: file, line: line)
         }
 
+        public func check(packageName: String, targetName: String, source: Workspace.ManagedArtifact.Source, path: AbsolutePath, file: StaticString = #file, line: UInt = #line) {
+            self.check(packageIdentity: .plain(packageName), targetName: targetName, source: source, path: path, file: file, line: line)
+        }
+
         public func check(
-            packageName: String,
+            packageIdentity: PackageIdentity,
             targetName: String,
-            source: ManagedArtifact.Source,
+            source: Workspace.ManagedArtifact.Source,
             path: AbsolutePath,
             file: StaticString = #file,
             line: UInt = #line
         ) {
-            guard let artifact = managedArtifacts[packageName: packageName, targetName: targetName] else {
-                XCTFail("\(packageName).\(targetName) does not exists", file: file, line: line)
+            guard let artifact = managedArtifacts[packageIdentity: packageIdentity, targetName: targetName] else {
+                XCTFail("\(packageIdentity).\(targetName) does not exists", file: file, line: line)
                 return
             }
             XCTAssertEqual(artifact.path, path)

--- a/Sources/Workspace/ManagedArtifact.swift
+++ b/Sources/Workspace/ManagedArtifact.swift
@@ -14,83 +14,83 @@ import SourceControl
 import TSCBasic
 import TSCUtility
 
-/// A downloaded artifact managed by the workspace.
-public struct ManagedArtifact {
-    /// The package reference.
-    public let packageRef: PackageReference
+extension Workspace {
+    /// A downloaded artifact managed by the workspace.
+    public struct ManagedArtifact {
+        /// The package reference.
+        public let packageRef: PackageReference
 
-    /// The name of the binary target the artifact corresponds to.
-    public let targetName: String
+        /// The name of the binary target the artifact corresponds to.
+        public let targetName: String
 
-    /// The source of the artifact (local or remote).
-    public let source: Source
+        /// The source of the artifact (local or remote).
+        public let source: Source
 
-    /// The path of the artifact on disk
-    public let path: AbsolutePath
+        /// The path of the artifact on disk
+        public let path: AbsolutePath
 
-    public init(
-        packageRef: PackageReference,
-        targetName: String,
-        source: Source,
-        path: AbsolutePath
-    ) {
-        self.packageRef = packageRef
-        self.targetName = targetName
-        self.source = source
-        self.path = path
-    }
+        public init(
+            packageRef: PackageReference,
+            targetName: String,
+            source: Source,
+            path: AbsolutePath
+        ) {
+            self.packageRef = packageRef
+            self.targetName = targetName
+            self.source = source
+            self.path = path
+        }
 
-    /// Create an artifact downloaded from a remote url.
-    public static func remote(
-        packageRef: PackageReference,
-        targetName: String,
-        url: String,
-        checksum: String,
-        path: AbsolutePath
-    ) -> ManagedArtifact {
-        return ManagedArtifact(
-            packageRef: packageRef,
-            targetName: targetName,
-            source: .remote(url: url, checksum: checksum),
-            path: path
-        )
-    }
+        /// Create an artifact downloaded from a remote url.
+        public static func remote(
+            packageRef: PackageReference,
+            targetName: String,
+            url: String,
+            checksum: String,
+            path: AbsolutePath
+        ) -> ManagedArtifact {
+            return ManagedArtifact(
+                packageRef: packageRef,
+                targetName: targetName,
+                source: .remote(url: url, checksum: checksum),
+                path: path
+            )
+        }
 
-    /// Create an artifact present locally on the filesystem.
-    public static func local(
-        packageRef: PackageReference,
-        targetName: String,
-        path: AbsolutePath
-    ) -> ManagedArtifact {
-        return ManagedArtifact(
-            packageRef: packageRef,
-            targetName: targetName,
-            source: .local,
-            path: path
-        )
-    }
+        /// Create an artifact present locally on the filesystem.
+        public static func local(
+            packageRef: PackageReference,
+            targetName: String,
+            path: AbsolutePath
+        ) -> ManagedArtifact {
+            return ManagedArtifact(
+                packageRef: packageRef,
+                targetName: targetName,
+                source: .local,
+                path: path
+            )
+        }
 
-    /// Represents the source of the artifact.
-    public enum Source: Equatable {
+        /// Represents the source of the artifact.
+        public enum Source: Equatable {
 
-        /// Represents a remote artifact, with the url it was downloaded from, its checksum, and its path relative to
-        /// the workspace artifacts path.
-        case remote(url: String, checksum: String)
+            /// Represents a remote artifact, with the url it was downloaded from, its checksum, and its path relative to
+            /// the workspace artifacts path.
+            case remote(url: String, checksum: String)
 
-        /// Represents a locally available artifact, with its path relative to its package.
-        case local
+            /// Represents a locally available artifact, with its path relative to its package.
+            case local
+        }
     }
 }
 
-// MARK: - CustomStringConvertible
-
-extension ManagedArtifact: CustomStringConvertible {
+extension Workspace.ManagedArtifact: CustomStringConvertible {
     public var description: String {
         return "<ManagedArtifact: \(self.packageRef.name).\(self.targetName) \(self.source) \(self.path)>"
     }
 }
 
-extension ManagedArtifact.Source: CustomStringConvertible {
+extension Workspace.ManagedArtifact.Source: CustomStringConvertible {
     public var description: String {
         switch self {
         case .local:
@@ -101,63 +101,59 @@ extension ManagedArtifact.Source: CustomStringConvertible {
     }
 }
 
-// MARK: -
+// MARK: - ManagedArtifacts
 
-/// A collection of managed artifacts which have been downloaded.
-public final class ManagedArtifacts {
+extension Workspace {
+    /// A collection of managed artifacts which have been downloaded.
+    public final class ManagedArtifacts {
+        /// A mapping from package identity, to target name, to ManagedArtifact.
+        private var artifactMap: [PackageIdentity: [String: ManagedArtifact]]
 
-    /// A mapping from package url, to target name, to ManagedArtifact.
-    private var artifactMap: [String: [String: ManagedArtifact]]
+        internal var artifacts: AnyCollection<ManagedArtifact> {
+            AnyCollection(self.artifactMap.values.lazy.flatMap{ $0.values })
+        }
 
-    internal var artifacts: AnyCollection<ManagedArtifact> {
-        AnyCollection(artifactMap.values.lazy.flatMap({ $0.values }))
-    }
+        init(_ artifacts: [ManagedArtifact] = []) {
+            let artifactsByPackagePath = Dictionary(grouping: artifacts, by: { $0.packageRef.identity })
+            self.artifactMap = artifactsByPackagePath.mapValues{ artifacts in
+                Dictionary(uniqueKeysWithValues: artifacts.map{ ($0.targetName, $0) })
+            }
+        }
 
-    init(artifactMap: [String: [String: ManagedArtifact]] = [:]) {
-        self.artifactMap = artifactMap
-    }
+        public subscript(packageIdentity packageIdentity: PackageIdentity, targetName targetName: String) -> ManagedArtifact? {
+            self.artifactMap[packageIdentity]?[targetName]
+        }
 
-    public subscript(packageURL packageURL: String, targetName targetName: String) -> ManagedArtifact? {
-        artifactMap[packageURL]?[targetName]
-    }
+        public func add(_ artifact: ManagedArtifact) {
+            self.artifactMap[artifact.packageRef.identity, default: [:]][artifact.targetName] = artifact
+        }
 
-    public subscript(packageName packageName: String, targetName targetName: String) -> ManagedArtifact? {
-        artifacts.first(where: { $0.packageRef.name == packageName && $0.targetName == targetName })
-    }
-
-    public func add(_ artifact: ManagedArtifact) {
-        artifactMap[artifact.packageRef.location, default: [:]][artifact.targetName] = artifact
-    }
-
-    public func remove(packageURL: String, targetName: String) {
-        artifactMap[packageURL]?[targetName] = nil
+        public func remove(packageIdentity: PackageIdentity, targetName: String) {
+            self.artifactMap[packageIdentity]?[targetName] = nil
+        }
     }
 }
 
-// MARK: - Collection
-
-extension ManagedArtifacts: Collection {
+extension Workspace.ManagedArtifacts: Collection {
     public var startIndex: AnyIndex {
-        artifacts.startIndex
+        self.artifacts.startIndex
     }
 
     public var endIndex: AnyIndex {
-        artifacts.endIndex
+        self.artifacts.endIndex
     }
 
-    public subscript(index: AnyIndex) -> ManagedArtifact {
-        artifacts[index]
+    public subscript(index: AnyIndex) -> Workspace.ManagedArtifact {
+        self.artifacts[index]
     }
 
     public func index(after index: AnyIndex) -> AnyIndex {
-        artifacts.index(after: index)
+        self.artifacts.index(after: index)
     }
 }
 
-// MARK: - CustomStringConvertible
-
-extension ManagedArtifacts: CustomStringConvertible {
+extension Workspace.ManagedArtifacts: CustomStringConvertible {
     public var description: String {
-        "<ManagedArtifacts: \(Array(artifacts))>"
+        "<ManagedArtifacts: \(Array(self.artifacts))>"
     }
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1672,8 +1672,8 @@ extension Workspace {
         }
 
         for artifact in manifestArtifacts.local {
-            let existingArtifact = state.artifacts[
-                packageURL: artifact.packageRef.location,
+            let existingArtifact = self.state.artifacts[
+                packageIdentity: artifact.packageRef.identity,
                 targetName: artifact.targetName
             ]
 
@@ -1686,8 +1686,8 @@ extension Workspace {
         }
 
         for artifact in manifestArtifacts.remote {
-            let existingArtifact = state.artifacts[
-                packageURL: artifact.packageRef.location,
+            let existingArtifact = self.state.artifacts[
+                packageIdentity: artifact.packageRef.identity,
                 targetName: artifact.targetName
             ]
 
@@ -1712,7 +1712,7 @@ extension Workspace {
         // Remove the artifacts and directories which are not needed anymore.
         diagnostics.wrap {
             for artifact in artifactsToRemove {
-                state.artifacts.remove(packageURL: artifact.packageRef.location, targetName: artifact.targetName)
+                state.artifacts.remove(packageIdentity: artifact.packageRef.identity, targetName: artifact.targetName)
 
                 if case .remote = artifact.source {
                     try fileSystem.removeFileTree(artifact.path)
@@ -2878,7 +2878,7 @@ private struct ArchiveIndexFile: Decodable {
     }
 }
 
-private extension ManagedArtifact {
+private extension Workspace.ManagedArtifact {
     var originURL: String? {
         switch self.source {
         case .remote(let url, _):

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -4044,7 +4044,7 @@ final class WorkspaceTests: XCTestCase {
     func testTargetBasedDependency() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
-        
+
         let barProducts: [MockProduct]
         #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
         barProducts = [MockProduct(name: "Bar", targets: ["Bar"]), MockProduct(name: "BarUnused", targets: ["BarUnused"])]
@@ -4365,7 +4365,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         workspace.checkManagedArtifacts { result in
-            result.check(packageName: "A",
+            result.check(packageIdentity: .plain("a"),
                          targetName: "A1",
                          source: .remote(
                             url: "https://a.com/a1.zip",
@@ -4373,7 +4373,7 @@ final class WorkspaceTests: XCTestCase {
                          ),
                          path: workspace.artifactsDir.appending(components: "A", "A1.xcframework")
             )
-            result.check(packageName: "A",
+            result.check(packageIdentity: .plain("a"),
                          targetName: "A2",
                          source: .remote(
                             url: "https://a.com/a2.zip",
@@ -4381,7 +4381,7 @@ final class WorkspaceTests: XCTestCase {
                          ),
                          path: workspace.artifactsDir.appending(components: "A", "A2.xcframework")
             )
-            result.check(packageName: "B",
+            result.check(packageIdentity: .plain("b"),
                          targetName: "B",
                          source: .remote(
                             url: "https://b.com/b.zip",
@@ -4547,7 +4547,7 @@ final class WorkspaceTests: XCTestCase {
             pins: [aRef: aState],
             managedDependencies: [],
             managedArtifacts: [
-                ManagedArtifact(
+                .init(
                     packageRef: aRef,
                     targetName: "A1",
                     source: .remote(
@@ -4556,7 +4556,7 @@ final class WorkspaceTests: XCTestCase {
                     ),
                     path: workspace.artifactsDir.appending(components: "A", "A1.xcframework")
                 ),
-                ManagedArtifact(
+                .init(
                     packageRef: aRef,
                     targetName: "A3",
                     source: .remote(
@@ -4565,7 +4565,7 @@ final class WorkspaceTests: XCTestCase {
                     ),
                     path: workspace.artifactsDir.appending(components: "A", "A3.xcframework")
                 ),
-                ManagedArtifact(
+                .init(
                     packageRef: aRef,
                     targetName: "A4",
                     source: .remote(
@@ -4574,7 +4574,7 @@ final class WorkspaceTests: XCTestCase {
                     ),
                     path: workspace.artifactsDir.appending(components: "A", "A4.xcframework")
                 ),
-                ManagedArtifact(
+                .init(
                     packageRef: aRef,
                     targetName: "A5",
                     source: .remote(
@@ -4583,7 +4583,7 @@ final class WorkspaceTests: XCTestCase {
                     ),
                     path: workspace.artifactsDir.appending(components: "A", "A5.xcframework")
                 ),
-                ManagedArtifact(
+                .init(
                     packageRef: aRef,
                     targetName: "A6",
                     source: .local,
@@ -4622,7 +4622,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         workspace.checkManagedArtifacts { result in
-            result.check(packageName: "A",
+            result.check(packageIdentity: .plain("a"),
                          targetName: "A1",
                          source: .remote(
                             url: "https://a.com/a1.zip",
@@ -4630,7 +4630,7 @@ final class WorkspaceTests: XCTestCase {
                          ),
                          path: workspace.artifactsDir.appending(components: "A", "A1.xcframework")
             )
-            result.check(packageName: "A",
+            result.check(packageIdentity: .plain("a"),
                          targetName: "A2",
                          source: .remote(
                             url: "https://a.com/a2.zip",
@@ -4639,13 +4639,13 @@ final class WorkspaceTests: XCTestCase {
                          path: workspace.artifactsDir.appending(components: "A", "A2.xcframework")
             )
             result.checkNotPresent(packageName: "A", targetName: "A3")
-            result.check(packageName: "A",
+            result.check(packageIdentity: .plain("a"),
                          targetName: "A4",
                          source: .local,
                          path: a4FrameworkPath
             )
             result.checkNotPresent(packageName: "A", targetName: "A5")
-            result.check(packageName: "B",
+            result.check(packageIdentity: .plain("b"),
                          targetName: "B",
                          source: .remote(
                             url: "https://b.com/b.zip",
@@ -4792,7 +4792,7 @@ final class WorkspaceTests: XCTestCase {
         XCTAssertEqual(
             downloads.map { $0.1 }.sorted(),
             archiver.extractions.map { $0.archivePath }.sorted()
-        )        
+        )
     }
 
     func testArtifactDownloaderOrArchiverError() throws {
@@ -4942,7 +4942,7 @@ final class WorkspaceTests: XCTestCase {
             pins: [aRef: aState],
             managedDependencies: [aDependency],
             managedArtifacts: [
-                ManagedArtifact(
+                .init(
                     packageRef: aRef,
                     targetName: "A",
                     source: .remote(
@@ -5161,7 +5161,7 @@ final class WorkspaceTests: XCTestCase {
         }
 
         workspace.checkManagedArtifacts { result in
-            result.check(packageName: "A",
+            result.check(packageIdentity: .plain("a"),
                          targetName: "A1",
                          source: .remote(
                             url: "https://a.com/a1.zip",
@@ -5169,7 +5169,7 @@ final class WorkspaceTests: XCTestCase {
                          ),
                          path: workspace.artifactsDir.appending(components: "A", "A1.artifactbundle")
             )
-            result.check(packageName: "A",
+            result.check(packageIdentity: .plain("a"),
                          targetName: "A2",
                          source: .remote(
                             url: "https://a.com/a2/a2.zip",
@@ -5177,7 +5177,7 @@ final class WorkspaceTests: XCTestCase {
                          ),
                          path: workspace.artifactsDir.appending(components: "A", "A2.artifactbundle")
             )
-            result.check(packageName: "B",
+            result.check(packageIdentity: .plain("b"),
                          targetName: "B",
                          source: .remote(
                             url: "https://b.com/b.zip",
@@ -5352,7 +5352,7 @@ final class WorkspaceTests: XCTestCase {
             pins: [aRef: aState],
             managedDependencies: [aDependency],
             managedArtifacts: [
-                ManagedArtifact(
+                .init(
                     packageRef: aRef,
                     targetName: "A",
                     source: .remote(


### PR DESCRIPTION
motivation: ManagedArtifacts are based on location instead of on identity, refactor them to be based on identity as part of the transition to identity based logic

changes:
* transition ManagedArtifacts underlying hashmap to be based on identity
* update call sites to use package identity instead of location when reading/writing managed artifacts
* adjust tests where needed