### PR TITLE
Tests Refactor: Improve Diagnostics checks

### DIFF
--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -1036,7 +1036,9 @@ class PackageGraphTests: XCTestCase {
             ]
         )
 
-        XCTAssertTrue(diagnostics.diagnostics.contains(where: { $0.description.contains("multiple products named 'Bar' in: 'bar', 'baz'") }), "\(diagnostics.diagnostics)")
+        DiagnosticsEngineTester(diagnostics, ignoreNotes: true) { result in
+            result.check(diagnostic: "multiple products named 'Bar' in: 'bar', 'baz'", behavior: .error)
+        }
     }
 
     func testUnsafeFlags() throws {
@@ -1275,7 +1277,7 @@ class PackageGraphTests: XCTestCase {
             ]
         )
 
-        XCTAssert(diagnostics.diagnostics.isEmpty, "\(diagnostics.diagnostics)")
+        XCTAssertNoDiagnostics(diagnostics)
     }
 
     func testPinsStoreIsResilientAgainstDupes() throws {
@@ -1345,7 +1347,7 @@ class PackageGraphTests: XCTestCase {
             ]
         )
 
-        XCTAssert(diagnostics.diagnostics.isEmpty, "\(diagnostics.diagnostics)")
+        XCTAssertNoDiagnostics(diagnostics)
     }
 
     func testTargetDependencies_Pre52_UnknownProduct() throws {
@@ -1431,7 +1433,7 @@ class PackageGraphTests: XCTestCase {
             ]
         )
 
-        XCTAssert(diagnostics.diagnostics.isEmpty, "\(diagnostics.diagnostics)")
+        XCTAssertNoDiagnostics(diagnostics)
     }
 
     func testTargetDependencies_Post52_UnknownProduct() throws {
@@ -1540,7 +1542,7 @@ class PackageGraphTests: XCTestCase {
 
             let diagnostics = DiagnosticsEngine()
             _ = try loadPackageGraph(fs: fs, diagnostics: diagnostics, manifests: fixedManifests)
-            XCTAssert(diagnostics.diagnostics.isEmpty, "\(diagnostics.diagnostics)")
+            XCTAssertNoDiagnostics(diagnostics)
         }
     }
 
@@ -1606,7 +1608,7 @@ class PackageGraphTests: XCTestCase {
 
             let diagnostics = DiagnosticsEngine()
             _ = try loadPackageGraph(fs: fs, diagnostics: diagnostics, manifests: fixedManifests)
-            XCTAssert(diagnostics.diagnostics.isEmpty, "\(diagnostics.diagnostics)")
+            XCTAssertNoDiagnostics(diagnostics)
         }
     }
 
@@ -1669,7 +1671,7 @@ class PackageGraphTests: XCTestCase {
 
             let diagnostics = DiagnosticsEngine()
             _ = try loadPackageGraph(fs: fs, diagnostics: diagnostics, manifests: fixedManifests)
-            XCTAssert(diagnostics.diagnostics.isEmpty, "\(diagnostics.diagnostics)")
+            XCTAssertNoDiagnostics(diagnostics)
         }
     }
 
@@ -1732,7 +1734,7 @@ class PackageGraphTests: XCTestCase {
 
             let diagnostics = DiagnosticsEngine()
             _ = try loadPackageGraph(fs: fs, diagnostics: diagnostics, manifests: fixedManifests)
-            XCTAssert(diagnostics.diagnostics.isEmpty, "\(diagnostics.diagnostics)")
+            XCTAssertNoDiagnostics(diagnostics)
         }
     }
 
@@ -1773,7 +1775,7 @@ class PackageGraphTests: XCTestCase {
 
         let diagnostics = DiagnosticsEngine()
         _ = try loadPackageGraph(fs: fs, diagnostics: diagnostics, manifests: manifests)
-        XCTAssert(diagnostics.diagnostics.isEmpty, "\(diagnostics.diagnostics)")
+        XCTAssertNoDiagnostics(diagnostics)
     }
 
     // test backwards compatibility 5.2 < 5.4
@@ -1837,7 +1839,7 @@ class PackageGraphTests: XCTestCase {
 
             let diagnostics = DiagnosticsEngine()
             _ = try loadPackageGraph(fs: fs, diagnostics: diagnostics, manifests: fixedManifests)
-            XCTAssert(diagnostics.diagnostics.isEmpty, "\(diagnostics.diagnostics)")
+            XCTAssertNoDiagnostics(diagnostics)
         }
     }
 }

--- a/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
@@ -589,7 +589,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                 diagnostics: diagnostics
             )
 
-            XCTAssertTrue(diagnostics.diagnostics.isEmpty)
+            XCTAssertNoDiagnostics(diagnostics)
             XCTAssertEqual(manifest.name, "Trivial")
 
             let moduleTraceJSON = try XCTUnwrap(try localFileSystem.readFileContents(moduleTraceFilePath).validDescription)

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -552,8 +552,10 @@ class TargetSourcesBuilderTests: XCTestCase {
             diags: diags
         )
 
-        XCTAssertEqual(diags.diagnostics.count, 2)
-        diags.diagnostics.forEach { XCTAssert($0.description.contains("Invalid Exclude")) }
+        DiagnosticsEngineTester(diags) { result in
+            result.checkUnordered(diagnostic: "Invalid Exclude '/fileOutsideRoot.py': File not found.", behavior: .warning)
+            result.checkUnordered(diagnostic: "Invalid Exclude '/fakeDir': File not found.", behavior: .warning)
+        }
     }
     
     func testMissingResource() throws {
@@ -588,8 +590,10 @@ class TargetSourcesBuilderTests: XCTestCase {
         )
         _ = try builder.run()
 
-        XCTAssertEqual(diags.diagnostics.count, 2)
-        diags.diagnostics.forEach { XCTAssert($0.description.contains("Invalid Resource")) }
+        DiagnosticsEngineTester(diags) { result in
+            result.checkUnordered(diagnostic: "Invalid Resource '../../../Fake.txt': File not found.", behavior: .warning)
+            result.checkUnordered(diagnostic: "Invalid Resource 'NotReal': File not found.", behavior: .warning)
+        }
     }
     
     func testMissingSource() throws {
@@ -624,8 +628,11 @@ class TargetSourcesBuilderTests: XCTestCase {
             diags: diags
         )
 
-        XCTAssertEqual(diags.diagnostics.count, 3)
-        diags.diagnostics.forEach { XCTAssert($0.description.contains("Invalid Source")) }
+        DiagnosticsEngineTester(diags) { result in
+            result.checkUnordered(diagnostic: "Invalid Source '/InvalidPackage.swift': File not found.", behavior: .warning)
+            result.checkUnordered(diagnostic: "Invalid Source '/DoesNotExist.swift': File not found.", behavior: .warning)
+            result.checkUnordered(diagnostic: "Invalid Source '/Tests/InvalidPackageTests/InvalidPackageTests.swift': File not found.", behavior: .warning)
+        }
     }
 
     func testXcodeSpecificResourcesAreNotIncludedByDefault() throws {
@@ -659,7 +666,9 @@ class TargetSourcesBuilderTests: XCTestCase {
         )
         _ = try builder.run()
 
-        XCTAssertEqual(diags.diagnostics.map { $0.description }, ["found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target\n    /Foo.xcdatamodel\n"])
+        DiagnosticsEngineTester(diags) { result in
+            result.check(diagnostic: "found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target\n    /Foo.xcdatamodel\n", behavior: .warning)
+        }
     }
 
     func testDocCFilesDoNotCauseWarningOutsideXCBuild() throws {
@@ -694,6 +703,6 @@ class TargetSourcesBuilderTests: XCTestCase {
         )
         _ = try builder.run()
 
-        XCTAssertTrue(diags.diagnostics.isEmpty)
+        XCTAssertNoDiagnostics(diags)
     }
 }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -781,7 +781,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         try workspace.checkPrecomputeResolution { result in
-            XCTAssertEqual(result.diagnostics.hasErrors, false)
+            XCTAssertEqual(result.diagnostics.hasErrors, false, result.diagnostics.description)
             XCTAssertEqual(result.result.isRequired, false)
         }
     }
@@ -4173,7 +4173,7 @@ final class WorkspaceTests: XCTestCase {
 
             let diagnostics = DiagnosticsEngine()
             let checksum = ws.checksum(forBinaryArtifactAt: binaryPath, diagnostics: diagnostics)
-            XCTAssertTrue(!diagnostics.hasErrors)
+            XCTAssertTrue(!diagnostics.hasErrors, diagnostics.description)
             XCTAssertEqual(workspace.checksumAlgorithm.hashes.map { $0.contents }, [[0xAA, 0xBB, 0xCC]])
             XCTAssertEqual(checksum, "ccbbaa")
         }
@@ -4340,7 +4340,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
-            XCTAssertTrue(diagnostics.diagnostics.isEmpty, diagnostics.description)
+            XCTAssertNoDiagnostics(diagnostics)
             XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/A")))
             XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/B")))
             XCTAssertEqual(downloads.map { $0.key.absoluteString }.sorted(), [
@@ -4750,7 +4750,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
-            XCTAssertTrue(diagnostics.diagnostics.isEmpty, diagnostics.description)
+            XCTAssertNoDiagnostics(diagnostics)
             XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/A")))
             XCTAssertEqual(workspace.checksumAlgorithm.hashes.map{ $0.hexadecimalRepresentation }.sorted(), [
                 ByteString([0xA1]).hexadecimalRepresentation,
@@ -4775,7 +4775,7 @@ final class WorkspaceTests: XCTestCase {
         // do it again
 
         workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
-            XCTAssertTrue(diagnostics.diagnostics.isEmpty, diagnostics.description)
+            XCTAssertNoDiagnostics(diagnostics)
             XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/A")))
 
             XCTAssertEqual(workspace.checksumAlgorithm.hashes.map{ $0.hexadecimalRepresentation }.sorted(), [
@@ -5130,7 +5130,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraph(roots: ["Foo"]) { graph, diagnostics in
-            XCTAssertTrue(diagnostics.diagnostics.isEmpty, diagnostics.description)
+            XCTAssertNoDiagnostics(diagnostics)
             XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/A")))
             XCTAssert(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/B")))
             XCTAssertEqual(downloads.map { $0.key.absoluteString }.sorted(), [
@@ -5833,9 +5833,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                XCTAssert(diagnostics.diagnostics.isEmpty, diagnostics.description)
-            }
+            XCTAssertNoDiagnostics(diagnostics)
         }
     }
 
@@ -5890,9 +5888,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                XCTAssert(diagnostics.diagnostics.isEmpty, diagnostics.description)
-            }
+            XCTAssertNoDiagnostics(diagnostics)
         }
     }
 
@@ -5947,9 +5943,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                XCTAssert(diagnostics.diagnostics.isEmpty, diagnostics.description)
-            }
+            XCTAssertNoDiagnostics(diagnostics)
         }
     }
 
@@ -6070,9 +6064,7 @@ final class WorkspaceTests: XCTestCase {
         )
 
         workspace.checkPackageGraph(roots: ["Root"]) { graph, diagnostics in
-            DiagnosticsEngineTester(diagnostics) { result in
-                XCTAssert(diagnostics.diagnostics.isEmpty, diagnostics.description)
-            }
+            XCTAssertNoDiagnostics(diagnostics)
         }
     }
 


### PR DESCRIPTION
Broadly refactor tests to use helper functions that print better failures and use consistent verification logic.

### Motivation:

We have useful helper functions and patterns around verifying diagnostics, so we should adopt those everywhere we can.

### Modifications:

* Use `DiagnosticsEngineTester` to verify the contents and count of diagnostics.
* Use `XCTAssertNoDiagnostics(`) instead of `diagnostics.isEmpty`.

### Result:

- When these tests fail they'll have better failure messages.
- Verification logic is reconsolidated into helper functions.
