### PR TITLE
Tests Refactor: Adopt XCTAssertMatch and eliminate most bare `XCTAssert(string.contains())`

### DIFF
--- a/Tests/BasicsTests/SandboxTests.swift
+++ b/Tests/BasicsTests/SandboxTests.swift
@@ -9,6 +9,7 @@
  */
 
 @testable import Basics
+import SPMTestSupport
 import TSCBasic
 import TSCUtility
 import XCTest
@@ -32,7 +33,7 @@ final class SandboxTest: XCTestCase {
             guard case ProcessResult.Error.nonZeroExit(let result) = error else {
                 return XCTFail("invalid error \(error)")
             }
-            XCTAssertTrue(try! result.utf8stderrOutput().contains("Operation not permitted"), try! result.utf8stderrOutput())
+            XCTAssertMatch(try! result.utf8stderrOutput(), .contains("Operation not permitted"))
         }
     }
 
@@ -58,7 +59,7 @@ final class SandboxTest: XCTestCase {
                 guard case ProcessResult.Error.nonZeroExit(let result) = error else {
                     return XCTFail("invalid error \(error)")
                 }
-                XCTAssertTrue(try! result.utf8stderrOutput().contains("Operation not permitted") ,try! result.utf8stderrOutput())
+                XCTAssertMatch(try! result.utf8stderrOutput(), .contains("Operation not permitted"))
             }
         }
     }
@@ -77,7 +78,7 @@ final class SandboxTest: XCTestCase {
                 guard case ProcessResult.Error.nonZeroExit(let result) = error else {
                     return XCTFail("invalid error \(error)")
                 }
-                XCTAssertTrue(try! result.utf8stderrOutput().contains("Operation not permitted"), try! result.utf8stderrOutput())
+                XCTAssertMatch(try! result.utf8stderrOutput(), .contains("Operation not permitted"))
             }
         }
     }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -727,8 +727,8 @@ final class BuildPlanTests: XCTestCase {
             let llbuild = LLBuildManifestBuilder(plan)
             try llbuild.generateManifest(at: yaml)
             let contents = try localFileSystem.readFileContents(yaml).description
-            XCTAssertTrue(contents.contains("-std=gnu99\",\"-c\",\"/Pkg/Sources/lib/lib.c"))
-            XCTAssertTrue(contents.contains("-std=c++1z\",\"-c\",\"/Pkg/Sources/lib/libx.cpp"))
+            XCTAssertMatch(contents, .contains(#"-std=gnu99","-c","/Pkg/Sources/lib/lib.c"#))
+            XCTAssertMatch(contents, .contains(#"-std=c++1z","-c","/Pkg/Sources/lib/libx.cpp"#))
         }
     }
 
@@ -994,15 +994,15 @@ final class BuildPlanTests: XCTestCase {
 
         // Check that the first target (single source file not named main) has -parse-as-library.
         let exe1 = try result.target(for: "exe1").swiftTarget().emitCommandLine()
-        XCTAssertMatch(exe1, ["-parse-as-library", .anySequence])
+        XCTAssertMatch(exe1, ["-parse-as-library"])
 
         // Check that the second target (single source file named main) does not have -parse-as-library.
         let exe2 = try result.target(for: "exe2").swiftTarget().emitCommandLine()
-        XCTAssertNoMatch(exe2, ["-parse-as-library", .anySequence])
+        XCTAssertNoMatch(exe2, ["-parse-as-library"])
 
         // Check that the third target (multiple source files) does not have -parse-as-library.
         let exe3 = try result.target(for: "exe3").swiftTarget().emitCommandLine()
-        XCTAssertNoMatch(exe3, ["-parse-as-library", .anySequence])
+        XCTAssertNoMatch(exe3, ["-parse-as-library"])
     }
 
     func testCModule() throws {
@@ -1090,9 +1090,9 @@ final class BuildPlanTests: XCTestCase {
         let linkArgs = try result.buildProduct(for: "exe").linkArguments()
 
       #if os(macOS)
-        XCTAssertTrue(linkArgs.contains("-lc++"))
+        XCTAssertMatch(linkArgs, ["-lc++"])
       #else
-        XCTAssertTrue(linkArgs.contains("-lstdc++"))
+        XCTAssertMatch(linkArgs, ["-lstdc++"])
       #endif
     }
 
@@ -2204,10 +2204,10 @@ final class BuildPlanTests: XCTestCase {
             let llbuild = LLBuildManifestBuilder(plan)
             try llbuild.generateManifest(at: yaml)
             let contents = try localFileSystem.readFileContents(yaml).description
-            XCTAssertTrue(contents.contains("""
+            XCTAssertMatch(contents, .contains("""
                     inputs: ["/PkgA/Sources/swiftlib/lib.swift","/path/to/build/debug/exe"]
                     outputs: ["/path/to/build/debug/swiftlib.build/lib.swift.o","/path/to/build/debug/
-                """), contents)
+                """))
         }
     }
 
@@ -2514,10 +2514,10 @@ final class BuildPlanTests: XCTestCase {
 
         let resourceAccessor = fooTarget.sources.first{ $0.basename == "resource_bundle_accessor.swift" }!
         let contents = try fs.readFileContents(resourceAccessor).cString
-        XCTAssertTrue(contents.contains("extension Foundation.Bundle"), contents)
+        XCTAssertMatch(contents, .contains("extension Foundation.Bundle"))
         // Assert that `Bundle.main` is executed in the compiled binary (and not during compilation)
         // See https://bugs.swift.org/browse/SR-14555 and https://github.com/apple/swift-package-manager/pull/2972/files#r623861646
-        XCTAssertTrue(contents.contains("let mainPath = Bundle.main."), contents)
+        XCTAssertMatch(contents, .contains("let mainPath = Bundle.main."))
 
         let barTarget = try result.target(for: "Bar").swiftTarget()
         XCTAssertEqual(barTarget.objects.map{ $0.pathString }, [
@@ -2554,11 +2554,11 @@ final class BuildPlanTests: XCTestCase {
             )
 
             let exe = try result.target(for: "exe").swiftTarget().compileArguments()
-            XCTAssertTrue(exe.contains("-static-stdlib"))
+            XCTAssertMatch(exe, ["-static-stdlib"])
             let lib = try result.target(for: "lib").swiftTarget().compileArguments()
-            XCTAssertTrue(lib.contains("-static-stdlib"))
+            XCTAssertMatch(lib, ["-static-stdlib"])
             let link = try result.buildProduct(for: "exe").linkArguments()
-            XCTAssertTrue(link.contains("-static-stdlib"))
+            XCTAssertMatch(link, ["-static-stdlib"])
         }
     }
 
@@ -2856,15 +2856,15 @@ final class BuildPlanTests: XCTestCase {
         result.checkTargetsCount(3)
 
         let exe = try result.target(for: "exe").swiftTarget().compileArguments()
-        XCTAssertTrue(exe.contains("-sanitize=\(expectedName)"))
+        XCTAssertMatch(exe, ["-sanitize=\(expectedName)"])
 
         let lib = try result.target(for: "lib").swiftTarget().compileArguments()
-        XCTAssertTrue(lib.contains("-sanitize=\(expectedName)"))
+        XCTAssertMatch(lib, ["-sanitize=\(expectedName)"])
 
         let clib  = try result.target(for: "clib").clangTarget().basicArguments()
-        XCTAssertTrue(clib.contains("-fsanitize=\(expectedName)"))
+        XCTAssertMatch(clib, ["-fsanitize=\(expectedName)"])
 
-        XCTAssertTrue(try result.buildProduct(for: "exe").linkArguments().contains("-sanitize=\(expectedName)"))
+        XCTAssertMatch(try result.buildProduct(for: "exe").linkArguments(), ["-sanitize=\(expectedName)"])
     }
 }
 

--- a/Tests/BuildTests/IncrementalBuildTests.swift
+++ b/Tests/BuildTests/IncrementalBuildTests.swift
@@ -44,7 +44,7 @@ final class IncrementalBuildTests: XCTestCase {
             // Check various things that we expect to see in the full build log.
             // FIXME:  This is specific to the format of the log output, which
             // is quite unfortunate but not easily avoidable at the moment.
-            XCTAssertTrue(fullLog.contains("Compiling CLibrarySources Foo.c"))
+            XCTAssertMatch(fullLog, .contains("Compiling CLibrarySources Foo.c"))
 
             let llbuildManifest = prefix.appending(components: ".build", "debug.yaml")
 
@@ -61,7 +61,7 @@ final class IncrementalBuildTests: XCTestCase {
 
             // Now build again.  This should be an incremental build.
             let (log2, _) = try executeSwiftBuild(prefix)
-            XCTAssertTrue(log2.contains("Compiling CLibrarySources Foo.c"))
+            XCTAssertMatch(log2, .contains("Compiling CLibrarySources Foo.c"))
 
             // Read the second llbuild manifest.
             let llbuildContents2 = try localFileSystem.readFileContents(llbuildManifest)
@@ -69,7 +69,7 @@ final class IncrementalBuildTests: XCTestCase {
             // Now build again without changing anything.  This should be a null
             // build.
             let (log3, _) = try executeSwiftBuild(prefix)
-            XCTAssertFalse(log3.contains("Compiling CLibrarySources Foo.c"))
+            XCTAssertNoMatch(log3, .contains("Compiling CLibrarySources Foo.c"))
 
             // Read the third llbuild manifest.
             let llbuildContents3 = try localFileSystem.readFileContents(llbuildManifest)
@@ -87,7 +87,7 @@ final class IncrementalBuildTests: XCTestCase {
 
             // Now build again.  This should be an incremental build.
             let (log4, _) = try executeSwiftBuild(prefix)
-            XCTAssertTrue(log4.contains("Compiling CLibrarySources Foo.c"))
+            XCTAssertMatch(log4, .contains("Compiling CLibrarySources Foo.c"))
         }
     }
 
@@ -100,27 +100,27 @@ final class IncrementalBuildTests: XCTestCase {
 
             // Perform a full build.
             let log1 = try build()
-            XCTAssertTrue(log1.contains("Compiling Library"), log1)
+            XCTAssertMatch(log1, .contains("Compiling Library"))
 
             // Ensure manifest caching kicks in.
             let log2 =  try build()
-            XCTAssertTrue(log2.contains("Planning build"), log2)
+            XCTAssertMatch(log2, .contains("Planning build"))
 
             // Check that we're not re-planning when nothing has changed.
             let log3 = try build()
-            XCTAssertFalse(log3.contains("Planning build"), log3)
+            XCTAssertNoMatch(log3, .contains("Planning build"))
 
             // Check that we do run planning when a new source file is added.
             let sourceFile = prefix.appending(components: "Sources", "Library", "new.swift")
             try localFileSystem.writeFileContents(sourceFile, bytes: "")
             let log4 = try build()
-            XCTAssertTrue(log4.contains("Compiling Library"), log4)
-            XCTAssertTrue(log4.contains("Planning build"), log4)
+            XCTAssertMatch(log4, .contains("Compiling Library"))
+            XCTAssertMatch(log4, .contains("Planning build"))
 
             // Check that we don't run planning when a source file is modified.
             try localFileSystem.writeFileContents(sourceFile, bytes: "\n\n\n\n")
             let log5 = try build()
-            XCTAssertFalse(log5.contains("Planning build"), log5)
+            XCTAssertNoMatch(log5, .contains("Planning build"))
         }
     }
 
@@ -133,11 +133,11 @@ final class IncrementalBuildTests: XCTestCase {
 
             // Perform a full build.
             let log1 = try build()
-            XCTAssertTrue(log1.contains("Compiling Library"), log1)
+            XCTAssertMatch(log1, .contains("Compiling Library"))
 
             // Ensure manifest caching does not kick in.
             let log2 = try build()
-            XCTAssertFalse(log2.contains("Planning build"), log2)
+            XCTAssertNoMatch(log2, .contains("Planning build"))
         }
     }
 }

--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -84,8 +84,8 @@ final class APIDiffTests: XCTestCase {
                     XCTFail("Unexpected error")
                     return
                 }
-                XCTAssertTrue(output.contains("1 breaking change detected in Foo"))
-                XCTAssertTrue(output.contains("💔 API breakage: func foo() has been removed"))
+                XCTAssertMatch(output, .contains("1 breaking change detected in Foo"))
+                XCTAssertMatch(output, .contains("💔 API breakage: func foo() has been removed"))
             }
         }
     }
@@ -105,11 +105,11 @@ final class APIDiffTests: XCTestCase {
                     XCTFail("Unexpected error")
                     return
                 }
-                XCTAssertTrue(output.contains("2 breaking changes detected in Qux"))
-                XCTAssertTrue(output.contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
-                XCTAssertTrue(output.contains("💔 API breakage: var Qux.x has been removed"))
-                XCTAssertTrue(output.contains("1 breaking change detected in Baz"))
-                XCTAssertTrue(output.contains("💔 API breakage: func bar() has been removed"))
+                XCTAssertMatch(output, .contains("2 breaking changes detected in Qux"))
+                XCTAssertMatch(output, .contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
+                XCTAssertMatch(output, .contains("💔 API breakage: var Qux.x has been removed"))
+                XCTAssertMatch(output, .contains("1 breaking change detected in Baz"))
+                XCTAssertMatch(output, .contains("💔 API breakage: func bar() has been removed"))
             }
         }
     }
@@ -135,11 +135,11 @@ final class APIDiffTests: XCTestCase {
                     XCTFail("Unexpected error")
                     return
                 }
-                XCTAssertTrue(output.contains("1 breaking change detected in Qux"))
-                XCTAssertFalse(output.contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
-                XCTAssertTrue(output.contains("💔 API breakage: var Qux.x has been removed"))
-                XCTAssertTrue(output.contains("1 breaking change detected in Baz"))
-                XCTAssertTrue(output.contains("💔 API breakage: func bar() has been removed"))
+                XCTAssertMatch(output, .contains("1 breaking change detected in Qux"))
+                XCTAssertNoMatch(output, .contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
+                XCTAssertMatch(output, .contains("💔 API breakage: var Qux.x has been removed"))
+                XCTAssertMatch(output, .contains("1 breaking change detected in Baz"))
+                XCTAssertMatch(output, .contains("💔 API breakage: func bar() has been removed"))
             }
 
         }
@@ -166,17 +166,17 @@ final class APIDiffTests: XCTestCase {
                     XCTFail("Unexpected error")
                     return
                 }
-                XCTAssertTrue(output.contains("1 breaking change detected in Foo"))
-                XCTAssertTrue(output.contains("💔 API breakage: struct Foo has been removed"))
-                XCTAssertTrue(output.contains("1 breaking change detected in Bar"))
-                XCTAssertTrue(output.contains("💔 API breakage: func bar() has been removed"))
-                XCTAssertTrue(output.contains("1 breaking change detected in Baz"))
-                XCTAssertTrue(output.contains("💔 API breakage: enumelement Baz.b has been added as a new enum case"))
+                XCTAssertMatch(output, .contains("1 breaking change detected in Foo"))
+                XCTAssertMatch(output, .contains("💔 API breakage: struct Foo has been removed"))
+                XCTAssertMatch(output, .contains("1 breaking change detected in Bar"))
+                XCTAssertMatch(output, .contains("💔 API breakage: func bar() has been removed"))
+                XCTAssertMatch(output, .contains("1 breaking change detected in Baz"))
+                XCTAssertMatch(output, .contains("💔 API breakage: enumelement Baz.b has been added as a new enum case"))
 
                 // Qux is not part of a library product, so any API changes should be ignored
-                XCTAssertFalse(output.contains("2 breaking changes detected in Qux"))
-                XCTAssertFalse(output.contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
-                XCTAssertFalse(output.contains("💔 API breakage: var Qux.x has been removed"))
+                XCTAssertNoMatch(output, .contains("2 breaking changes detected in Qux"))
+                XCTAssertNoMatch(output, .contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
+                XCTAssertNoMatch(output, .contains("💔 API breakage: var Qux.x has been removed"))
             }
         }
     }
@@ -204,16 +204,16 @@ final class APIDiffTests: XCTestCase {
                     return
                 }
 
-                XCTAssertTrue(output.contains("1 breaking change detected in Foo"))
-                XCTAssertTrue(output.contains("💔 API breakage: struct Foo has been removed"))
-                XCTAssertTrue(output.contains("1 breaking change detected in Bar"))
-                XCTAssertTrue(output.contains("💔 API breakage: func bar() has been removed"))
+                XCTAssertMatch(output, .contains("1 breaking change detected in Foo"))
+                XCTAssertMatch(output, .contains("💔 API breakage: struct Foo has been removed"))
+                XCTAssertMatch(output, .contains("1 breaking change detected in Bar"))
+                XCTAssertMatch(output, .contains("💔 API breakage: func bar() has been removed"))
 
-                XCTAssertFalse(output.contains("1 breaking change detected in Baz"))
-                XCTAssertFalse(output.contains("💔 API breakage: enumelement Baz.b has been added as a new enum case"))
-                XCTAssertFalse(output.contains("2 breaking changes detected in Qux"))
-                XCTAssertFalse(output.contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
-                XCTAssertFalse(output.contains("💔 API breakage: var Qux.x has been removed"))
+                XCTAssertNoMatch(output, .contains("1 breaking change detected in Baz"))
+                XCTAssertNoMatch(output, .contains("💔 API breakage: enumelement Baz.b has been added as a new enum case"))
+                XCTAssertNoMatch(output, .contains("2 breaking changes detected in Qux"))
+                XCTAssertNoMatch(output, .contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
+                XCTAssertNoMatch(output, .contains("💔 API breakage: var Qux.x has been removed"))
             }
 
             // Diff a target which didn't have a baseline generated as part of the first invocation
@@ -224,16 +224,16 @@ final class APIDiffTests: XCTestCase {
                     return
                 }
 
-                XCTAssertTrue(output.contains("1 breaking change detected in Baz"))
-                XCTAssertTrue(output.contains("💔 API breakage: enumelement Baz.b has been added as a new enum case"))
+                XCTAssertMatch(output, .contains("1 breaking change detected in Baz"))
+                XCTAssertMatch(output, .contains("💔 API breakage: enumelement Baz.b has been added as a new enum case"))
 
-                XCTAssertFalse(output.contains("1 breaking change detected in Foo"))
-                XCTAssertFalse(output.contains("💔 API breakage: struct Foo has been removed"))
-                XCTAssertFalse(output.contains("1 breaking change detected in Bar"))
-                XCTAssertFalse(output.contains("💔 API breakage: func bar() has been removed"))
-                XCTAssertFalse(output.contains("2 breaking changes detected in Qux"))
-                XCTAssertFalse(output.contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
-                XCTAssertFalse(output.contains("💔 API breakage: var Qux.x has been removed"))
+                XCTAssertNoMatch(output, .contains("1 breaking change detected in Foo"))
+                XCTAssertNoMatch(output, .contains("💔 API breakage: struct Foo has been removed"))
+                XCTAssertNoMatch(output, .contains("1 breaking change detected in Bar"))
+                XCTAssertNoMatch(output, .contains("💔 API breakage: func bar() has been removed"))
+                XCTAssertNoMatch(output, .contains("2 breaking changes detected in Qux"))
+                XCTAssertNoMatch(output, .contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
+                XCTAssertNoMatch(output, .contains("💔 API breakage: var Qux.x has been removed"))
             }
 
             // Test diagnostics
@@ -245,10 +245,10 @@ final class APIDiffTests: XCTestCase {
                     return
                 }
 
-                XCTAssertTrue(stderr.contains("error: no such product 'NotAProduct'"))
-                XCTAssertTrue(stderr.contains("error: no such target 'NotATarget'"))
-                XCTAssertTrue(stderr.contains("'Exec' is not a library product"))
-                XCTAssertTrue(stderr.contains("'Exec' is not a library target"))
+                XCTAssertMatch(stderr, .contains("error: no such product 'NotAProduct'"))
+                XCTAssertMatch(stderr, .contains("error: no such target 'NotATarget'"))
+                XCTAssertMatch(stderr, .contains("'Exec' is not a library product"))
+                XCTAssertMatch(stderr, .contains("'Exec' is not a library target"))
             }
         }
     }
@@ -273,8 +273,8 @@ final class APIDiffTests: XCTestCase {
                     XCTFail("Unexpected error")
                     return
                 }
-                XCTAssertTrue(output.contains("1 breaking change detected in Bar"))
-                XCTAssertTrue(output.contains("💔 API breakage: func bar() has return type change from Swift.Int to Swift.String"))
+                XCTAssertMatch(output, .contains("1 breaking change detected in Bar"))
+                XCTAssertMatch(output, .contains("💔 API breakage: func bar() has return type change from Swift.Int to Swift.String"))
             }
 
             // Report an error if we explicitly ask to diff a C-family target
@@ -284,7 +284,7 @@ final class APIDiffTests: XCTestCase {
                     return
                 }
 
-                XCTAssertTrue(stderr.contains("error: 'Foo' is not a Swift language target"))
+                XCTAssertMatch(stderr, .contains("error: 'Foo' is not a Swift language target"))
             }
         }
     }
@@ -298,8 +298,8 @@ final class APIDiffTests: XCTestCase {
                 $0 <<< "public func bar() -> Int { 100 }"
             }
             let (output, _) = try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)
-            XCTAssertTrue(output.contains("No breaking changes detected in Baz"))
-            XCTAssertTrue(output.contains("No breaking changes detected in Qux"))
+            XCTAssertMatch(output, .contains("No breaking changes detected in Baz"))
+            XCTAssertMatch(output, .contains("No breaking changes detected in Qux"))
         }
     }
 
@@ -331,9 +331,9 @@ final class APIDiffTests: XCTestCase {
                 """
             }
             let (output, _) = try execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot)
-            XCTAssertTrue(output.contains("No breaking changes detected in Baz"))
-            XCTAssertTrue(output.contains("No breaking changes detected in Qux"))
-            XCTAssertTrue(output.contains("Skipping Foo because it does not exist in the baseline"))
+            XCTAssertMatch(output, .contains("No breaking changes detected in Baz"))
+            XCTAssertMatch(output, .contains("No breaking changes detected in Qux"))
+            XCTAssertMatch(output, .contains("Skipping Foo because it does not exist in the baseline"))
         }
     }
 
@@ -346,7 +346,7 @@ final class APIDiffTests: XCTestCase {
                     XCTFail("Unexpected error")
                     return
                 }
-                XCTAssertTrue(stderr.contains("error: Couldn’t get revision"))
+                XCTAssertMatch(stderr, .contains("error: Couldn’t get revision"))
             }
         }
     }
@@ -370,8 +370,8 @@ final class APIDiffTests: XCTestCase {
                         XCTFail("Unexpected error")
                         return
                     }
-                    XCTAssertTrue(output.contains("1 breaking change detected in Foo"))
-                    XCTAssertTrue(output.contains("💔 API breakage: func foo() has been removed"))
+                    XCTAssertMatch(output, .contains("1 breaking change detected in Foo"))
+                    XCTAssertMatch(output, .contains("💔 API breakage: func foo() has been removed"))
                 }
 
                 // Update `main` and ensure the baseline is regenerated.
@@ -384,7 +384,7 @@ final class APIDiffTests: XCTestCase {
                 try repo.checkout(revision: .init(identifier: "feature"))
                 let (output, _) = try execute(["diagnose-api-breaking-changes", "main", "--baseline-dir", baselineDir.pathString],
                                               packagePath: packageRoot)
-                XCTAssertTrue(output.contains("No breaking changes detected in Foo"))
+                XCTAssertMatch(output, .contains("No breaking changes detected in Foo"))
             }
         }
     }
@@ -409,8 +409,8 @@ final class APIDiffTests: XCTestCase {
                     XCTFail("Unexpected error")
                     return
                 }
-                XCTAssertTrue(output.contains("1 breaking change detected in Foo"))
-                XCTAssertTrue(output.contains("💔 API breakage: func foo() has been removed"))
+                XCTAssertMatch(output, .contains("1 breaking change detected in Foo"))
+                XCTAssertMatch(output, .contains("💔 API breakage: func foo() has been removed"))
                 XCTAssertTrue(localFileSystem.exists(baselineDir.appending(components: revision.identifier, "Foo.json")))
             }
         }
@@ -444,8 +444,8 @@ final class APIDiffTests: XCTestCase {
                     XCTFail("Unexpected error")
                     return
                 }
-                XCTAssertTrue(output.contains("1 breaking change detected in Foo"))
-                XCTAssertTrue(output.contains("💔 API breakage: func foo() has been removed"))
+                XCTAssertMatch(output, .contains("1 breaking change detected in Foo"))
+                XCTAssertMatch(output, .contains("💔 API breakage: func foo() has been removed"))
                 XCTAssertTrue(localFileSystem.exists(fooBaselinePath))
                 XCTAssertNotEqual((try! localFileSystem.readFileContents(fooBaselinePath)).description, "Old Baseline")
             }
@@ -459,7 +459,7 @@ final class APIDiffTests: XCTestCase {
                 XCTFail("Unexpected error")
                 return
             }
-            XCTAssertTrue(output.contains("`swift package experimental-api-diff` has been renamed to `swift package diagnose-api-breaking-changes`"))
+            XCTAssertMatch(output, .contains("`swift package experimental-api-diff` has been renamed to `swift package diagnose-api-breaking-changes`"))
         }
     }
 }

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -43,17 +43,17 @@ final class BuildToolTests: XCTestCase {
     
     func testUsage() throws {
         let stdout = try execute(["-help"]).stdout
-        XCTAssert(stdout.contains("USAGE: swift build"), "got stdout:\n" + stdout)
+        XCTAssertMatch(stdout, .contains("USAGE: swift build"))
     }
 
     func testSeeAlso() throws {
         let stdout = try execute(["--help"]).stdout
-        XCTAssert(stdout.contains("SEE ALSO: swift run, swift package, swift test"), "got stdout:\n" + stdout)
+        XCTAssertMatch(stdout, .contains("SEE ALSO: swift run, swift package, swift test"))
     }
 
     func testVersion() throws {
         let stdout = try execute(["--version"]).stdout
-        XCTAssert(stdout.contains("Swift Package Manager"), "got stdout:\n" + stdout)
+        XCTAssertMatch(stdout, .contains("Swift Package Manager"))
     }
 
     func testCreatingSanitizers() throws {
@@ -67,8 +67,7 @@ final class BuildToolTests: XCTestCase {
             _ = try Sanitizer(argument: "invalid")
             XCTFail("Should have failed to create Sanitizer")
         } catch let error as StringError {
-            XCTAssertEqual(
-                error.description, "valid sanitizers: address, thread, undefined, scudo")
+            XCTAssertEqual(error.description, "valid sanitizers: address, thread, undefined, scudo")
         }
     }
 
@@ -109,8 +108,8 @@ final class BuildToolTests: XCTestCase {
 
             do {
                 let result = try build(["--product", "exec1"], packagePath: fullPath)
-                XCTAssert(result.binContents.contains("exec1"))
-                XCTAssert(!result.binContents.contains("exec2.build"))
+                XCTAssertMatch(result.binContents, ["exec1"])
+                XCTAssertNoMatch(result.binContents, ["exec2.build"])
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
                 XCTFail(stderr)
             }
@@ -123,8 +122,8 @@ final class BuildToolTests: XCTestCase {
 
             do {
                 let result = try build(["--target", "exec2"], packagePath: fullPath)
-                XCTAssert(result.binContents.contains("exec2.build"))
-                XCTAssert(!result.binContents.contains("exec1"))
+                XCTAssertMatch(result.binContents, ["exec2.build"])
+                XCTAssertNoMatch(result.binContents, ["exec1"])
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
                 XCTFail(stderr)
             }
@@ -178,21 +177,21 @@ final class BuildToolTests: XCTestCase {
             let fullPath = resolveSymlinks(path)
             do {
                 let result = try build(["--product", "ClangExecSingleFile"], packagePath: fullPath)
-                XCTAssert(result.binContents.contains("ClangExecSingleFile"))
+                XCTAssertMatch(result.binContents, ["ClangExecSingleFile"])
             } catch SwiftPMProductError.executionFailure(_, let stdout, let stderr) {
                 XCTFail(stdout + "\n" + stderr)
             }
 
             do {
                 let result = try build(["--product", "SwiftExecSingleFile"], packagePath: fullPath)
-                XCTAssert(result.binContents.contains("SwiftExecSingleFile"))
+                XCTAssertMatch(result.binContents, ["SwiftExecSingleFile"])
             } catch SwiftPMProductError.executionFailure(_, let stdout, let stderr) {
                 XCTFail(stdout + "\n" + stderr)
             }
 
             do {
                 let result = try build(["--product", "SwiftExecMultiFile"], packagePath: fullPath)
-                XCTAssert(result.binContents.contains("SwiftExecMultiFile"))
+                XCTAssertMatch(result.binContents, ["SwiftExecMultiFile"])
             } catch SwiftPMProductError.executionFailure(_, let stdout, let stderr) {
                 XCTFail(stdout + "\n" + stderr)
             }
@@ -205,10 +204,10 @@ final class BuildToolTests: XCTestCase {
 
             do {
                 let result = try build([], packagePath: aPath)
-                XCTAssert(!result.binContents.contains("bexec"))
-                XCTAssert(!result.binContents.contains("BTarget2.build"))
-                XCTAssert(!result.binContents.contains("cexec"))
-                XCTAssert(!result.binContents.contains("CTarget.build"))
+                XCTAssertNoMatch(result.binContents, ["bexec"])
+                XCTAssertNoMatch(result.binContents, ["BTarget2.build"])
+                XCTAssertNoMatch(result.binContents, ["cexec"])
+                XCTAssertNoMatch(result.binContents, ["CTarget.build"])
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
                 XCTFail(stderr)
             }
@@ -217,25 +216,25 @@ final class BuildToolTests: XCTestCase {
 
             do {
                 let result = try build(["--product", "bexec"], packagePath: aPath)
-                XCTAssert(result.binContents.contains("BTarget2.build"))
-                XCTAssert(result.binContents.contains("bexec"))
-                XCTAssert(!result.binContents.contains("aexec"))
-                XCTAssert(!result.binContents.contains("ATarget.build"))
-                XCTAssert(!result.binContents.contains("BLibrary.a"))
+                XCTAssertMatch(result.binContents, ["BTarget2.build"])
+                XCTAssertMatch(result.binContents, ["bexec"])
+                XCTAssertNoMatch(result.binContents, ["aexec"])
+                XCTAssertNoMatch(result.binContents, ["ATarget.build"])
+                XCTAssertNoMatch(result.binContents, ["BLibrary.a"])
 
                 // FIXME: We create the modulemap during build planning, hence this uglyness.
                 let bTargetBuildDir = ((try? localFileSystem.getDirectoryContents(result.binPath.appending(component: "BTarget1.build"))) ?? []).filter{ $0 != moduleMapFilename }
-                XCTAssertEqual(bTargetBuildDir, [])
+                XCTAssertTrue(bTargetBuildDir.isEmpty, "bTargetBuildDir should be empty")
 
-                XCTAssert(!result.binContents.contains("cexec"))
-                XCTAssert(!result.binContents.contains("CTarget.build"))
+                XCTAssertNoMatch(result.binContents, ["cexec"])
+                XCTAssertNoMatch(result.binContents, ["CTarget.build"])
 
                 // Also make sure we didn't emit parseable module interfaces
                 // (do this here to avoid doing a second build in
                 // testParseableInterfaces().
-                XCTAssert(!result.binContents.contains("ATarget.swiftinterface"))
-                XCTAssert(!result.binContents.contains("BTarget.swiftinterface"))
-                XCTAssert(!result.binContents.contains("CTarget.swiftinterface"))
+                XCTAssertNoMatch(result.binContents, ["ATarget.swiftinterface"])
+                XCTAssertNoMatch(result.binContents, ["BTarget.swiftinterface"])
+                XCTAssertNoMatch(result.binContents, ["CTarget.swiftinterface"])
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
                 XCTFail(stderr)
             }
@@ -246,8 +245,8 @@ final class BuildToolTests: XCTestCase {
         fixture(name: "Miscellaneous/ParseableInterfaces") { path in
             do {
                 let result = try build(["--enable-parseable-module-interfaces"], packagePath: path)
-                XCTAssert(result.binContents.contains("A.swiftinterface"))
-                XCTAssert(result.binContents.contains("B.swiftinterface"))
+                XCTAssertMatch(result.binContents, ["A.swiftinterface"])
+                XCTAssertMatch(result.binContents, ["B.swiftinterface"])
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
                 XCTFail(stderr)
             }
@@ -258,8 +257,8 @@ final class BuildToolTests: XCTestCase {
         fixture(name: "Miscellaneous/LibraryEvolution") { path in
             do {
                 let result = try build([], packagePath: path)
-                XCTAssert(result.binContents.contains("A.swiftinterface"))
-                XCTAssert(result.binContents.contains("B.swiftinterface"))
+                XCTAssertMatch(result.binContents, ["A.swiftinterface"])
+                XCTAssertMatch(result.binContents, ["B.swiftinterface"])
             } catch SwiftPMProductError.executionFailure(_, _, let stderr) {
                 XCTFail(stderr)
             }
@@ -277,7 +276,7 @@ final class BuildToolTests: XCTestCase {
             do {
                 let result = try execute([], packagePath: path)
                 // test second time, to make sure message is presented even when nothing to build (cached)
-                XCTAssertTrue(result.stdout.contains("[0/0] Build complete!"), result.stdout)
+                XCTAssertMatch(result.stdout, .contains("[0/0] Build complete!"))
             }
         }
     }
@@ -291,7 +290,7 @@ final class BuildToolTests: XCTestCase {
             let defaultOutput = try execute(["-c", "debug", "-v"], packagePath: path).stdout
             
             // Look for certain things in the output from XCBuild.
-            XCTAssert(defaultOutput.contains("-target \(UserToolchain.default.triple.tripleString)"), defaultOutput)
+            XCTAssertMatch(defaultOutput, .contains("-target \(UserToolchain.default.triple.tripleString)"))
         }
     }
 
@@ -302,7 +301,7 @@ final class BuildToolTests: XCTestCase {
         fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { path in
             // Try building using XCBuild without specifying overrides.  This should succeed, and should use the default compiler path.
             let defaultOutput = try execute(["-c", "debug", "-v"], packagePath: path).stdout
-            XCTAssert(defaultOutput.contains(ToolchainConfiguration.default.swiftCompilerPath.pathString), defaultOutput)
+            XCTAssertMatch(defaultOutput, .contains(ToolchainConfiguration.default.swiftCompilerPath.pathString))
 
             // Now try building using XCBuild while specifying a faulty compiler override.  This should fail.  Note that we need to set the executable to use for the manifest itself to the default one, since it defaults to SWIFT_EXEC if not provided.
             var overriddenOutput = ""
@@ -322,7 +321,7 @@ final class BuildToolTests: XCTestCase {
             catch {
                 XCTFail("`swift build' failed in an unexpected manner")
             }
-            XCTAssert(overriddenOutput.contains("/usr/bin/false"), overriddenOutput)
+            XCTAssertMatch(overriddenOutput, .contains("/usr/bin/false"))
         }
     }
 

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -35,17 +35,17 @@ final class PackageToolTests: XCTestCase {
 
     func testUsage() throws {
         let stdout = try execute(["-help"]).stdout
-        XCTAssert(stdout.contains("USAGE: swift package"), "got stdout:\n" + stdout)
+        XCTAssertMatch(stdout, .contains("USAGE: swift package"))
     }
 
     func testSeeAlso() throws {
         let stdout = try execute(["--help"]).stdout
-        XCTAssert(stdout.contains("SEE ALSO: swift build, swift run, swift test"), "got stdout:\n" + stdout)
+        XCTAssertMatch(stdout, .contains("SEE ALSO: swift build, swift run, swift test"))
     }
 
     func testVersion() throws {
         let stdout = try execute(["--version"]).stdout
-        XCTAssert(stdout.contains("Swift Package Manager"), "got stdout:\n" + stdout)
+        XCTAssertMatch(stdout, .contains("Swift Package Manager"))
     }
 
     func testNetrcFile() throws {
@@ -61,12 +61,12 @@ final class PackageToolTests: XCTestCase {
                 try execute(["--netrc-file", netrcPath.pathString, "resolve"], packagePath: packageRoot)
                 // file does not exist, but is optional
                 let textOutput = try execute(["--netrc-file", "/foo", "--netrc-optional", "resolve"], packagePath: packageRoot).stderr
-                XCTAssert(textOutput.contains("warning: Did not find optional .netrc file at /foo."))
+                XCTAssertMatch(textOutput, .contains("warning: Did not find optional .netrc file at /foo."))
 
                 // required file does not exist, will throw
                 try execute(["--netrc-file", "/foo", "resolve"], packagePath: packageRoot)
             } catch {
-                XCTAssert(String(describing: error).contains("Cannot find mandatory .netrc file at /foo"), "\(error)")
+                XCTAssertMatch(String(describing: error), .contains("Cannot find mandatory .netrc file at /foo"))
             }
         }
 
@@ -78,17 +78,17 @@ final class PackageToolTests: XCTestCase {
                 } else {
                     // file does not exist, but is optional
                     let textOutput = try execute(["--netrc", "--netrc-optional", "resolve"], packagePath: packageRoot)
-                    XCTAssert(textOutput.stderr.contains("Did not find optional .netrc file at \(localFileSystem.homeDirectory)/.netrc."))
+                    XCTAssertMatch(textOutput.stderr, .contains("Did not find optional .netrc file at \(localFileSystem.homeDirectory)/.netrc."))
 
                     // file does not exist, but is optional
                     let textOutput2 = try execute(["--netrc-optional", "resolve"], packagePath: packageRoot)
-                    XCTAssert(textOutput2.stderr.contains("Did not find optional .netrc file at \(localFileSystem.homeDirectory)/.netrc."))
+                    XCTAssertMatch(textOutput2.stderr, .contains("Did not find optional .netrc file at \(localFileSystem.homeDirectory)/.netrc."))
 
                     // required file does not exist, will throw
                     try execute(["--netrc", "resolve"], packagePath: packageRoot)
                 }
             } catch {
-                XCTAssert(String(describing: error).contains("Cannot find mandatory .netrc file at \(localFileSystem.homeDirectory)/.netrc"))
+                XCTAssertMatch(String(describing: error), .contains("Cannot find mandatory .netrc file at \(localFileSystem.homeDirectory)/.netrc"))
             }
         }
     }
@@ -180,8 +180,8 @@ final class PackageToolTests: XCTestCase {
 
             // Check that the JSON description contains what we expect it to.
             XCTAssertEqual(json["name"]?.string, "SwiftCMixed")
-            XCTAssertEqual(json["path"]?.string?.hasPrefix("/"), true)
-            XCTAssertEqual(json["path"]?.string?.hasSuffix("/" + prefix.basename), true)
+            XCTAssertMatch(json["path"]?.string, .prefix("/"))
+            XCTAssertMatch(json["path"]?.string, .suffix("/" + prefix.basename))
             XCTAssertEqual(json["targets"]?.array?.count, 3)
             let jsonTarget0 = try XCTUnwrap(json["targets"]?.array?[0])
             XCTAssertEqual(jsonTarget0["name"]?.stringValue, "SeaLib")
@@ -217,42 +217,42 @@ final class PackageToolTests: XCTestCase {
             // Check that the text description contains what we expect it to.
             // FIXME: This is a bit inelegant, but any errors are easy to reason about.
             let textChunk0 = try XCTUnwrap(textChunks[0])
-            XCTAssert(textChunk0.contains("Name: SwiftCMixed"), textChunk0)
-            XCTAssert(textChunk0.contains("Path: /"), textChunk0)
-            XCTAssert(textChunk0.contains("/" + prefix.basename + "\n"), textChunk0)
-            XCTAssert(textChunk0.contains("Tools version: 4.2"), textChunk0)
-            XCTAssert(textChunk0.contains("Products:"), textChunk0)
+            XCTAssertMatch(textChunk0, .contains("Name: SwiftCMixed"))
+            XCTAssertMatch(textChunk0, .contains("Path: /"))
+            XCTAssertMatch(textChunk0, .contains("/" + prefix.basename + "\n"))
+            XCTAssertMatch(textChunk0, .contains("Tools version: 4.2"))
+            XCTAssertMatch(textChunk0, .contains("Products:"))
             let textChunk1 = try XCTUnwrap(textChunks[1])
-            XCTAssert(textChunk1.contains("Name: SeaExec"), textChunk1)
-            XCTAssert(textChunk1.contains("Type:\n        Executable"), textChunk1)
-            XCTAssert(textChunk1.contains("Targets:\n        SeaExec"), textChunk1)
+            XCTAssertMatch(textChunk1, .contains("Name: SeaExec"))
+            XCTAssertMatch(textChunk1, .contains("Type:\n        Executable"))
+            XCTAssertMatch(textChunk1, .contains("Targets:\n        SeaExec"))
             let textChunk2 = try XCTUnwrap(textChunks[2])
-            XCTAssert(textChunk2.contains("Name: CExec"), textChunk2)
-            XCTAssert(textChunk2.contains("Type:\n        Executable"), textChunk2)
-            XCTAssert(textChunk2.contains("Targets:\n        CExec"), textChunk2)
+            XCTAssertMatch(textChunk2, .contains("Name: CExec"))
+            XCTAssertMatch(textChunk2, .contains("Type:\n        Executable"))
+            XCTAssertMatch(textChunk2, .contains("Targets:\n        CExec"))
             let textChunk3 = try XCTUnwrap(textChunks[3])
-            XCTAssert(textChunk3.contains("Targets:"), textChunk3)
+            XCTAssertMatch(textChunk3, .contains("Targets:"))
             let textChunk4 = try XCTUnwrap(textChunks[4])
-            XCTAssert(textChunk4.contains("Name: SeaLib"), textChunk4)
-            XCTAssert(textChunk4.contains("C99name: SeaLib"), textChunk4)
-            XCTAssert(textChunk4.contains("Type: library"), textChunk4)
-            XCTAssert(textChunk4.contains("Module type: ClangTarget"), textChunk4)
-            XCTAssert(textChunk4.contains("Path: Sources/SeaLib"), textChunk4)
-            XCTAssert(textChunk4.contains("Sources:\n        Foo.c"), textChunk4)
+            XCTAssertMatch(textChunk4, .contains("Name: SeaLib"))
+            XCTAssertMatch(textChunk4, .contains("C99name: SeaLib"))
+            XCTAssertMatch(textChunk4, .contains("Type: library"))
+            XCTAssertMatch(textChunk4, .contains("Module type: ClangTarget"))
+            XCTAssertMatch(textChunk4, .contains("Path: Sources/SeaLib"))
+            XCTAssertMatch(textChunk4, .contains("Sources:\n        Foo.c"))
             let textChunk5 = try XCTUnwrap(textChunks[5])
-            XCTAssert(textChunk5.contains("Name: SeaExec"), textChunk5)
-            XCTAssert(textChunk5.contains("C99name: SeaExec"), textChunk5)
-            XCTAssert(textChunk5.contains("Type: executable"), textChunk5)
-            XCTAssert(textChunk5.contains("Module type: SwiftTarget"), textChunk5)
-            XCTAssert(textChunk5.contains("Path: Sources/SeaExec"), textChunk5)
-            XCTAssert(textChunk5.contains("Sources:\n        main.swift"), textChunk5)
+            XCTAssertMatch(textChunk5, .contains("Name: SeaExec"))
+            XCTAssertMatch(textChunk5, .contains("C99name: SeaExec"))
+            XCTAssertMatch(textChunk5, .contains("Type: executable"))
+            XCTAssertMatch(textChunk5, .contains("Module type: SwiftTarget"))
+            XCTAssertMatch(textChunk5, .contains("Path: Sources/SeaExec"))
+            XCTAssertMatch(textChunk5, .contains("Sources:\n        main.swift"))
             let textChunk6 = try XCTUnwrap(textChunks[6])
-            XCTAssert(textChunk6.contains("Name: CExec"), textChunk6)
-            XCTAssert(textChunk6.contains("C99name: CExec"), textChunk6)
-            XCTAssert(textChunk6.contains("Type: executable"), textChunk6)
-            XCTAssert(textChunk6.contains("Module type: ClangTarget"), textChunk6)
-            XCTAssert(textChunk6.contains("Path: Sources/CExec"), textChunk6)
-            XCTAssert(textChunk6.contains("Sources:\n        main.c"), textChunk6)
+            XCTAssertMatch(textChunk6, .contains("Name: CExec"))
+            XCTAssertMatch(textChunk6, .contains("C99name: CExec"))
+            XCTAssertMatch(textChunk6, .contains("Type: executable"))
+            XCTAssertMatch(textChunk6, .contains("Module type: ClangTarget"))
+            XCTAssertMatch(textChunk6, .contains("Path: Sources/CExec"))
+            XCTAssertMatch(textChunk6, .contains("Sources:\n        main.c"))
         }
 
         fixture(name: "DependencyResolution/External/Simple/Bar") { prefix in
@@ -528,9 +528,9 @@ final class PackageToolTests: XCTestCase {
 
             let manifest = path.appending(component: "Package.swift")
             let contents = try localFileSystem.readFileContents(manifest).description
-			let version = InitPackage.newPackageToolsVersion
+            let version = InitPackage.newPackageToolsVersion
             let versionSpecifier = "\(version.major).\(version.minor)"
-            XCTAssertTrue(contents.hasPrefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
+            XCTAssertMatch(contents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
 
             XCTAssertTrue(fs.exists(manifest))
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "Foo")), ["main.swift"])
@@ -564,9 +564,9 @@ final class PackageToolTests: XCTestCase {
 
             let manifest = path.appending(component: "Package.swift")
             let contents = try localFileSystem.readFileContents(manifest).description
-			let version = InitPackage.newPackageToolsVersion
-			let versionSpecifier = "\(version.major).\(version.minor)"
-			XCTAssertTrue(contents.hasPrefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
+            let version = InitPackage.newPackageToolsVersion
+            let versionSpecifier = "\(version.major).\(version.minor)"
+            XCTAssertMatch(contents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
 
             XCTAssertTrue(fs.exists(manifest))
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "CustomName")), ["main.swift"])

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -71,7 +71,7 @@ class DependencyResolutionTests: XCTestCase {
             // Tests the convenience init .package(url: , branch: )
             let app = prefix.appending(component: "Bar")
             let result = try SwiftPMProduct.SwiftBuild.executeProcess([], packagePath: app)
-            XCTAssert(result.exitStatus == .terminated(code: 0))
+            XCTAssertEqual(result.exitStatus, .terminated(code: 0))
         }
     }
 
@@ -91,14 +91,14 @@ class DependencyResolutionTests: XCTestCase {
             // run with no mirror
             do {
                 let output = try executeSwiftPackage(appPath, extraArgs: ["show-dependencies"])
-                XCTAssertTrue(output.stdout.contains("Fetching \(prefix.pathString)/Foo\n"), output.stdout)
-                XCTAssertTrue(output.stdout.contains("Fetching \(prefix.pathString)/Bar\n"), output.stdout)
-                XCTAssertTrue(output.stdout.contains("foo<\(prefix.pathString)/Foo@unspecified"), output.stdout)
-                XCTAssertTrue(output.stdout.contains("bar<\(prefix.pathString)/Bar@unspecified"), output.stdout)
+                XCTAssertMatch(output.stdout, .contains("Fetching \(prefix.pathString)/Foo\n"))
+                XCTAssertMatch(output.stdout, .contains("Fetching \(prefix.pathString)/Bar\n"))
+                XCTAssertMatch(output.stdout, .contains("foo<\(prefix.pathString)/Foo@unspecified"))
+                XCTAssertMatch(output.stdout, .contains("bar<\(prefix.pathString)/Bar@unspecified"))
 
                 let pins = try String(bytes: localFileSystem.readFileContents(appPinsPath).contents, encoding: .utf8)!
-                XCTAssertTrue(pins.contains("\"\(prefix.pathString)/Foo\""), pins)
-                XCTAssertTrue(pins.contains("\"\(prefix.pathString)/Bar\""), pins)
+                XCTAssertMatch(pins, .contains("\"\(prefix.pathString)/Foo\""))
+                XCTAssertMatch(pins, .contains("\"\(prefix.pathString)/Bar\""))
 
                 XCTAssertBuilds(appPath)
             }
@@ -115,19 +115,19 @@ class DependencyResolutionTests: XCTestCase {
             // run with mirror
             do {
                 let output = try executeSwiftPackage(appPath, extraArgs: ["show-dependencies"])
-                XCTAssertTrue(output.stdout.contains("Fetching \(prefix.pathString)/Foo\n"), output.stdout)
-                XCTAssertTrue(output.stdout.contains("Fetching \(prefix.pathString)/BarMirror\n"), output.stdout)
-                XCTAssertFalse(output.stdout.contains("Fetching \(prefix.pathString)/Bar\n"), output.stdout)
+                XCTAssertMatch(output.stdout, .contains("Fetching \(prefix.pathString)/Foo\n"))
+                XCTAssertMatch(output.stdout, .contains("Fetching \(prefix.pathString)/BarMirror\n"))
+                XCTAssertNoMatch(output.stdout, .contains("Fetching \(prefix.pathString)/Bar\n"))
 
-                XCTAssertTrue(output.stdout.contains("foo<\(prefix.pathString)/Foo@unspecified"), output.stdout)
-                XCTAssertTrue(output.stdout.contains("barmirror<\(prefix.pathString)/BarMirror@unspecified"), output.stdout)
-                XCTAssertFalse(output.stdout.contains("bar<\(prefix.pathString)/Bar@unspecified"), output.stdout)
+                XCTAssertMatch(output.stdout, .contains("foo<\(prefix.pathString)/Foo@unspecified"))
+                XCTAssertMatch(output.stdout, .contains("barmirror<\(prefix.pathString)/BarMirror@unspecified"))
+                XCTAssertNoMatch(output.stdout, .contains("bar<\(prefix.pathString)/Bar@unspecified"))
 
                 // rdar://52529014 mirrors should not be reflected in pins file
                 let pins = try String(bytes: localFileSystem.readFileContents(appPinsPath).contents, encoding: .utf8)!
-                XCTAssertTrue(pins.contains("\"\(prefix.pathString)/Foo\""), pins)
-                XCTAssertTrue(pins.contains("\"\(prefix.pathString)/Bar\""), pins)
-                XCTAssertFalse(pins.contains("\"\(prefix.pathString)/BarMirror\""), pins)
+                XCTAssertMatch(pins, .contains("\"\(prefix.pathString)/Foo\""))
+                XCTAssertMatch(pins, .contains("\"\(prefix.pathString)/Bar\""))
+                XCTAssertNoMatch(pins, .contains("\"\(prefix.pathString)/BarMirror\""))
 
                 XCTAssertBuilds(appPath)
             }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -219,9 +219,9 @@ class MiscellaneousTestCase: XCTestCase {
             _ = try SwiftPMProduct.SwiftTest.execute([], packagePath: prefix)
           } catch SwiftPMProductError.executionFailure(_, let output, let stderr) {
             #if os(macOS)
-              XCTAssertTrue(stderr.contains("Executed 2 tests"))
+              XCTAssertMatch(stderr, .contains("Executed 2 tests"))
             #else
-              XCTAssertTrue(output.contains("Executed 2 tests"))
+              XCTAssertMatch(output, .contains("Executed 2 tests"))
             #endif
           }
 
@@ -229,11 +229,11 @@ class MiscellaneousTestCase: XCTestCase {
             // Run tests in parallel.
             _ = try SwiftPMProduct.SwiftTest.execute(["--parallel"], packagePath: prefix)
           } catch SwiftPMProductError.executionFailure(_, let output, _) {
-            XCTAssert(output.contains("testExample1"))
-            XCTAssert(output.contains("testExample2"))
-            XCTAssert(!output.contains("'ParallelTestsTests' passed"))
-            XCTAssert(output.contains("'ParallelTestsFailureTests' failed"))
-            XCTAssert(output.contains("[3/3]"))
+            XCTAssertMatch(output, .contains("testExample1"))
+            XCTAssertMatch(output, .contains("testExample2"))
+            XCTAssertNoMatch(output, .contains("'ParallelTestsTests' passed"))
+            XCTAssertMatch(output, .contains("'ParallelTestsFailureTests' failed"))
+            XCTAssertMatch(output, .contains("[3/3]"))
           }
 
           let xUnitOutput = prefix.appending(component: "result.xml")
@@ -243,17 +243,17 @@ class MiscellaneousTestCase: XCTestCase {
                 ["--parallel", "--verbose", "--xunit-output", xUnitOutput.pathString],
                 packagePath: prefix)
           } catch SwiftPMProductError.executionFailure(_, let output, _) {
-            XCTAssert(output.contains("testExample1"))
-            XCTAssert(output.contains("testExample2"))
-            XCTAssert(output.contains("'ParallelTestsTests' passed"))
-            XCTAssert(output.contains("'ParallelTestsFailureTests' failed"))
-            XCTAssert(output.contains("[3/3]"))
+            XCTAssertMatch(output, .contains("testExample1"))
+            XCTAssertMatch(output, .contains("testExample2"))
+            XCTAssertMatch(output, .contains("'ParallelTestsTests' passed"))
+            XCTAssertMatch(output, .contains("'ParallelTestsFailureTests' failed"))
+            XCTAssertMatch(output, .contains("[3/3]"))
           }
 
           // Check the xUnit output.
           XCTAssertTrue(localFileSystem.exists(xUnitOutput))
           let contents = try localFileSystem.readFileContents(xUnitOutput).description
-          XCTAssertTrue(contents.contains("tests=\"3\" failures=\"1\""))
+          XCTAssertMatch(contents, .contains("tests=\"3\" failures=\"1\""))
         }
     }
 

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -79,7 +79,7 @@ class TestDiscoveryTests: XCTestCase {
             try localFileSystem.writeFileContents(manifestPath, bytes: ByteString("fatalError(\"should not be called\")".utf8))
             let (stdout, _) = try executeSwiftTest(path, extraArgs: ["--enable-test-discovery"])
             XCTAssertMatch(stdout, .contains("Merging module Simple"))
-            XCTAssertNoMatch(stdout.contains("Executed 1 test"))
+            XCTAssertNoMatch(stdout, .contains("Executed 1 test"))
         }
         #endif
     }

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -18,9 +18,9 @@ class TestDiscoveryTests: XCTestCase {
         fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
             let (stdout, _) = try executeSwiftBuild(path)
             #if os(macOS)
-            XCTAssertTrue(stdout.contains("Merging module Simple"), stdout)
+            XCTAssertMatch(stdout, .contains("Merging module Simple"))
             #else
-            XCTAssertTrue(stdout.contains("Merging module Simple"), stdout)
+            XCTAssertMatch(stdout, .contains("Merging module Simple"))
             #endif
         }
     }
@@ -29,11 +29,11 @@ class TestDiscoveryTests: XCTestCase {
         fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
             let (stdout, stderr) = try executeSwiftTest(path)
             #if os(macOS)
-            XCTAssertTrue(stdout.contains("Merging module Simple"), stdout)
-            XCTAssertTrue(stderr.contains("Executed 2 tests"), stderr)
+            XCTAssertMatch(stdout, .contains("Merging module Simple"))
+            XCTAssertMatch(stderr, .contains("Executed 2 tests"))
             #else
-            XCTAssertTrue(stdout.contains("Merging module Simple"), stdout)
-            XCTAssertTrue(stdout.contains("Executed 2 tests"), stdout)
+            XCTAssertMatch(stdout, .contains("Merging module Simple"))
+            XCTAssertMatch(stdout, .contains("Executed 2 tests"))
             #endif
         }
     }
@@ -42,11 +42,11 @@ class TestDiscoveryTests: XCTestCase {
         fixture(name: "Miscellaneous/TestDiscovery/hello world") { path in
             let (stdout, stderr) = try executeSwiftTest(path)
             #if os(macOS)
-            XCTAssertTrue(stdout.contains("Merging module hello_world"), stdout)
-            XCTAssertTrue(stderr.contains("Executed 1 test"), stderr)
+            XCTAssertMatch(stdout, .contains("Merging module hello_world"))
+            XCTAssertMatch(stderr, .contains("Executed 1 test"))
             #else
-            XCTAssertTrue(stdout.contains("Merging module hello_world"), stdout)
-            XCTAssertTrue(stdout.contains("Executed 1 test"), stdout)
+            XCTAssertMatch(stdout, .contains("Merging module hello_world"))
+            XCTAssertMatch(stdout, .contains("Executed 1 test"))
             #endif
         }
     }
@@ -61,9 +61,9 @@ class TestDiscoveryTests: XCTestCase {
                 let manifestPath = path.appending(components: "Tests", name)
                 try localFileSystem.writeFileContents(manifestPath, bytes: ByteString("print(\"\(random)\")".utf8))
                 let (stdout, _) = try executeSwiftTest(path)
-                XCTAssertTrue(stdout.contains("Merging module Simple"), stdout)
-                XCTAssertFalse(stdout.contains("Executed 1 test"), stdout)
-                XCTAssertTrue(stdout.contains(random), stdout)
+                XCTAssertMatch(stdout, .contains("Merging module Simple"))
+                XCTAssertNoMatch(stdout, .contains("Executed 1 test"))
+                XCTAssertMatch(stdout, .contains(random))
             }
         }
         #endif
@@ -78,8 +78,8 @@ class TestDiscoveryTests: XCTestCase {
             let manifestPath = path.appending(components: "Tests", name)
             try localFileSystem.writeFileContents(manifestPath, bytes: ByteString("fatalError(\"should not be called\")".utf8))
             let (stdout, _) = try executeSwiftTest(path, extraArgs: ["--enable-test-discovery"])
-            XCTAssertTrue(stdout.contains("Merging module Simple"), stdout)
-            XCTAssertFalse(stdout.contains("Executed 1 test"), stdout)
+            XCTAssertMatch(stdout, .contains("Merging module Simple"))
+            XCTAssertNoMatch(stdout.contains("Executed 1 test"))
         }
         #endif
     }
@@ -90,15 +90,15 @@ class TestDiscoveryTests: XCTestCase {
         #else
         fixture(name: "Miscellaneous/TestDiscovery/Extensions") { path in
             let (stdout, _) = try executeSwiftTest(path, extraArgs: ["--enable-test-discovery"])
-            XCTAssertTrue(stdout.contains("Merging module Simple"), stdout)
-            XCTAssertTrue(stdout.contains("SimpleTests1.testExample1"), stdout)
-            XCTAssertTrue(stdout.contains("SimpleTests1.testExample1_a"), stdout)
-            XCTAssertTrue(stdout.contains("SimpleTests2.testExample2"), stdout)
-            XCTAssertTrue(stdout.contains("SimpleTests2.testExample2_a"), stdout)
-            XCTAssertTrue(stdout.contains("SimpleTests4.testExample"), stdout)
-            XCTAssertTrue(stdout.contains("SimpleTests4.testExample1"), stdout)
-            XCTAssertTrue(stdout.contains("SimpleTests4.testExample2"), stdout)
-            XCTAssertTrue(stdout.contains("Executed 7 tests"), stdout)
+            XCTAssertMatch(stdout, .contains("Merging module Simple"))
+            XCTAssertMatch(stdout, .contains("SimpleTests1.testExample1"))
+            XCTAssertMatch(stdout, .contains("SimpleTests1.testExample1_a"))
+            XCTAssertMatch(stdout, .contains("SimpleTests2.testExample2"))
+            XCTAssertMatch(stdout, .contains("SimpleTests2.testExample2_a"))
+            XCTAssertMatch(stdout, .contains("SimpleTests4.testExample"))
+            XCTAssertMatch(stdout, .contains("SimpleTests4.testExample1"))
+            XCTAssertMatch(stdout, .contains("SimpleTests4.testExample2"))
+            XCTAssertMatch(stdout, .contains("Executed 7 tests"))
         }
         #endif
     }

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -15,6 +15,7 @@ import PackageLoading
 @testable import PackageModel
 @testable import PackageGraph
 import SourceControl
+import SPMTestSupport
 
 
 
@@ -1155,11 +1156,11 @@ final class PubgrubTests: XCTestCase {
             ("bar", .version("2.0.1")),
         ])
 
-        XCTAssertTrue(delegate.events.contains("willResolve 'foo'"), "\(delegate.events)")
-        XCTAssertTrue(delegate.events.contains("didResolve 'foo' at '1.1.0'"), "\(delegate.events)")
-        XCTAssertTrue(delegate.events.contains("willResolve 'bar'"), "\(delegate.events)")
-        XCTAssertTrue(delegate.events.contains("didResolve 'bar' at '2.0.1'"), "\(delegate.events)")
-        XCTAssertTrue(delegate.events.contains("solved: 'bar' at '2.0.1', 'foo' at '1.1.0'"), "\(delegate.events)")
+        XCTAssertMatch(delegate.events, ["willResolve 'foo'"])
+        XCTAssertMatch(delegate.events, ["didResolve 'foo' at '1.1.0'"])
+        XCTAssertMatch(delegate.events, ["willResolve 'bar'"])
+        XCTAssertMatch(delegate.events, ["didResolve 'bar' at '2.0.1'"])
+        XCTAssertMatch(delegate.events, ["solved: 'bar' at '2.0.1', 'foo' at '1.1.0'"])
     }
 }
 

--- a/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
@@ -593,7 +593,7 @@ class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
             XCTAssertEqual(manifest.name, "Trivial")
 
             let moduleTraceJSON = try XCTUnwrap(try localFileSystem.readFileContents(moduleTraceFilePath).validDescription)
-            XCTAssert(moduleTraceJSON.contains("PackageDescription"))
+            XCTAssertMatch(moduleTraceJSON, .contains("PackageDescription"))
         }
     }
 }

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -34,17 +34,17 @@ class InitTests: XCTestCase {
             try initPackage.writePackageStructure()
 
             // Not picky about the specific progress messages, just checking that we got some.
-            XCTAssert(progressMessages.count > 0)
+            XCTAssertGreaterThan(progressMessages.count, 0)
 
             // Verify basic file system content that we expect in the package
             let manifest = path.appending(component: "Package.swift")
             XCTAssertTrue(fs.exists(manifest))
             let manifestContents = try localFileSystem.readFileContents(manifest).description
-			let version = InitPackage.newPackageToolsVersion
-			let versionSpecifier = "\(version.major).\(version.minor)"
-			XCTAssertTrue(manifestContents.hasPrefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
-            XCTAssertTrue(manifestContents.contains(packageWithNameAndDependencies(with: name)))
-            XCTAssert(fs.exists(path.appending(component: "README.md")))
+            let version = InitPackage.newPackageToolsVersion
+            let versionSpecifier = "\(version.major).\(version.minor)"
+            XCTAssertMatch(manifestContents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
+            XCTAssertMatch(manifestContents, .contains(packageWithNameAndDependencies(with: name)))
+            XCTAssertFileExists(path.appending(component: "README.md"))
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources")), [])
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Tests")), [])
         }
@@ -66,21 +66,20 @@ class InitTests: XCTestCase {
             try initPackage.writePackageStructure()
 
             // Not picky about the specific progress messages, just checking that we got some.
-            XCTAssert(progressMessages.count > 0)
-
+            XCTAssertGreaterThan(progressMessages.count, 0)
             
             // Verify basic file system content that we expect in the package
             let manifest = path.appending(component: "Package.swift")
             XCTAssertTrue(fs.exists(manifest))
             let manifestContents = try localFileSystem.readFileContents(manifest).description
-			let version = InitPackage.newPackageToolsVersion
-			let versionSpecifier = "\(version.major).\(version.minor)"
-			XCTAssertTrue(manifestContents.hasPrefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
+            let version = InitPackage.newPackageToolsVersion
+            let versionSpecifier = "\(version.major).\(version.minor)"
+            XCTAssertMatch(manifestContents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
             
             let readme = path.appending(component: "README.md")
             XCTAssertTrue(fs.exists(readme))
             let readmeContents = try localFileSystem.readFileContents(readme).description
-            XCTAssertTrue(readmeContents.hasPrefix("# Foo\n"))
+            XCTAssertMatch(readmeContents, .prefix("# Foo\n"))
 
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "Foo")), ["main.swift"])
             XCTAssertEqual(
@@ -114,20 +113,20 @@ class InitTests: XCTestCase {
             try initPackage.writePackageStructure()
 
             // Not picky about the specific progress messages, just checking that we got some.
-            XCTAssert(progressMessages.count > 0)
+            XCTAssertGreaterThan(progressMessages.count, 0)
 
             // Verify basic file system content that we expect in the package
             let manifest = path.appending(component: "Package.swift")
             XCTAssertTrue(fs.exists(manifest))
             let manifestContents = try localFileSystem.readFileContents(manifest).description
-			let version = InitPackage.newPackageToolsVersion
-			let versionSpecifier = "\(version.major).\(version.minor)"
-			XCTAssertTrue(manifestContents.hasPrefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
+            let version = InitPackage.newPackageToolsVersion
+            let versionSpecifier = "\(version.major).\(version.minor)"
+            XCTAssertMatch(manifestContents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
 
             let readme = path.appending(component: "README.md")
             XCTAssertTrue(fs.exists(readme))
             let readmeContents = try localFileSystem.readFileContents(readme).description
-            XCTAssertTrue(readmeContents.hasPrefix("# Foo\n"))
+            XCTAssertMatch(readmeContents, .prefix("# Foo\n"))
 
             XCTAssertEqual(try fs.getDirectoryContents(path.appending(component: "Sources").appending(component: "Foo")), ["Foo.swift"])
 
@@ -142,7 +141,7 @@ class InitTests: XCTestCase {
                           Validates formatting of XCTest source file, in particular that it does not contain leading whitespace:
                           \(testFileContents)
                           """)
-            XCTAssertTrue(testFileContents.contains("func testExample() throws"), "Contents:\n\(testFileContents)")
+            XCTAssertMatch(testFileContents, .contains("func testExample() throws"))
 
             // Try building it
             XCTAssertBuilds(path)
@@ -167,16 +166,16 @@ class InitTests: XCTestCase {
             try initPackage.writePackageStructure()
             
             // Not picky about the specific progress messages, just checking that we got some.
-            XCTAssert(progressMessages.count > 0)
+            XCTAssertGreaterThan(progressMessages.count, 0)
 
             // Verify basic file system content that we expect in the package
             let manifest = path.appending(component: "Package.swift")
             XCTAssertTrue(fs.exists(manifest))
             let manifestContents = try localFileSystem.readFileContents(manifest).description
-			let version = InitPackage.newPackageToolsVersion
-			let versionSpecifier = "\(version.major).\(version.minor)"
-			XCTAssertTrue(manifestContents.hasPrefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
-            XCTAssertTrue(manifestContents.contains(packageWithNameAndDependencies(with: name)))
+            let version = InitPackage.newPackageToolsVersion
+            let versionSpecifier = "\(version.major).\(version.minor)"
+            XCTAssertMatch(manifestContents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
+            XCTAssertMatch(manifestContents, .contains(packageWithNameAndDependencies(with: name)))
             XCTAssert(fs.exists(path.appending(component: "README.md")))
             XCTAssert(fs.exists(path.appending(component: "module.modulemap")))
         }
@@ -198,15 +197,15 @@ class InitTests: XCTestCase {
             try initPackage.writePackageStructure()
 
             // Not picky about the specific progress messages, just checking that we got some.
-            XCTAssert(progressMessages.count > 0)
+            XCTAssertGreaterThan(progressMessages.count, 0)
 
             // Verify basic file system content that we expect in the package
             let manifest = path.appending(component: "Package.swift")
             XCTAssertTrue(fs.exists(manifest))
             let manifestContents = try localFileSystem.readFileContents(manifest).description
-			let version = InitPackage.newPackageToolsVersion
-			let versionSpecifier = "\(version.major).\(version.minor)"
-			XCTAssertTrue(manifestContents.hasPrefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
+            let version = InitPackage.newPackageToolsVersion
+            let versionSpecifier = "\(version.major).\(version.minor)"
+            XCTAssertMatch(manifestContents, .prefix("// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"))
         }
     }
     
@@ -276,8 +275,7 @@ class InitTests: XCTestCase {
             try initPackage.writePackageStructure()
 
             let contents = try localFileSystem.readFileContents(packageRoot.appending(component: "Package.swift")).cString
-            let expectedString = #"platforms: [.macOS(.v10_15), .iOS(.v12), .watchOS("2.1"), .tvOS("999.0")],"#
-            XCTAssert(contents.contains(expectedString), contents)
+            XCTAssertMatch(contents, .contains(#"platforms: [.macOS(.v10_15), .iOS(.v12), .watchOS("2.1"), .tvOS("999.0")],"#))
         }
     }
 

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -42,7 +42,7 @@ class ManifestSourceGenerationTests: XCTestCase {
             
             // Check that the tools version was serialized properly.
             let versionSpacing = (toolsVersion >= .v5_4) ? " " : ""
-            XCTAssertTrue(newContents.hasPrefix("// swift-tools-version:\(versionSpacing)\(toolsVersion.major).\(toolsVersion.minor)"), newContents)
+            XCTAssertMatch(newContents, .prefix("// swift-tools-version:\(versionSpacing)\(toolsVersion.major).\(toolsVersion.minor)"))
             
             // Write out the generated manifest to replace the old manifest file contents, and load it again.
             try fs.writeFileContents(packageDir.appending(component: Manifest.filename), bytes: ByteString(encodingAsUTF8: newContents))

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -90,13 +90,13 @@ final class WorkspaceTests: XCTestCase {
         }
 
         // Check the load-package callbacks.
-        XCTAssertTrue(workspace.delegate.events.contains("will load manifest for root package: /tmp/ws/roots/Foo"))
-        XCTAssertTrue(workspace.delegate.events.contains("did load manifest for root package: /tmp/ws/roots/Foo"))
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for root package: /tmp/ws/roots/Foo"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for root package: /tmp/ws/roots/Foo"])
 
-        XCTAssertTrue(workspace.delegate.events.contains("will load manifest for remote package: /tmp/ws/pkgs/Quix"))
-        XCTAssertTrue(workspace.delegate.events.contains("did load manifest for remote package: /tmp/ws/pkgs/Quix"))
-        XCTAssertTrue(workspace.delegate.events.contains("will load manifest for remote package: /tmp/ws/pkgs/Baz"))
-        XCTAssertTrue(workspace.delegate.events.contains("did load manifest for remote package: /tmp/ws/pkgs/Baz"))
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for remote package: /tmp/ws/pkgs/Quix"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for remote package: /tmp/ws/pkgs/Quix"])
+        XCTAssertMatch(workspace.delegate.events, ["will load manifest for remote package: /tmp/ws/pkgs/Baz"])
+        XCTAssertMatch(workspace.delegate.events, ["did load manifest for remote package: /tmp/ws/pkgs/Baz"])
 
         // Close and reopen workspace.
         workspace.closeWorkspace()

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -29,52 +29,52 @@ class GenerateXcodeprojTests: XCTestCase {
     func testXcodebuildCanParseIt() throws {
       #if os(macOS)
       try testWithTemporaryDirectory { dstdir in
-            let packagePath = dstdir.appending(component: "foo")
-            let modulePath = packagePath.appending(components: "Sources", "DummyModuleName")
-            try makeDirectories(modulePath)
-            try localFileSystem.writeFileContents(modulePath.appending(component: "source.swift"), bytes: "")
+          let packagePath = dstdir.appending(component: "foo")
+          let modulePath = packagePath.appending(components: "Sources", "DummyModuleName")
+          try makeDirectories(modulePath)
+          try localFileSystem.writeFileContents(modulePath.appending(component: "source.swift"), bytes: "")
 
-            let diagnostics = DiagnosticsEngine()
-            let graph = try loadPackageGraph(fs: localFileSystem, diagnostics: diagnostics,
-                manifests: [
-                    Manifest.createV4Manifest(
-                        name: "Foo",
-                        path: packagePath.pathString,
-                        packageKind: .root,
-                        packageLocation: packagePath.pathString,
-                        targets: [
-                            TargetDescription(name: "DummyModuleName"),
-                        ])
-                ]
-            )
-            XCTAssertNoDiagnostics(diagnostics)
+          let diagnostics = DiagnosticsEngine()
+          let graph = try loadPackageGraph(fs: localFileSystem, diagnostics: diagnostics,
+              manifests: [
+                  Manifest.createV4Manifest(
+                      name: "Foo",
+                      path: packagePath.pathString,
+                      packageKind: .root,
+                      packageLocation: packagePath.pathString,
+                      targets: [
+                          TargetDescription(name: "DummyModuleName"),
+                      ])
+              ]
+          )
+          XCTAssertNoDiagnostics(diagnostics)
 
-            let projectName = "DummyProjectName"
-            let outpath = Xcodeproj.buildXcodeprojPath(outputDir: dstdir, projectName: projectName)
-            try Xcodeproj.generate(projectName: projectName, xcodeprojPath: outpath, graph: graph, options: XcodeprojOptions(), diagnostics: diagnostics)
+          let projectName = "DummyProjectName"
+          let outpath = Xcodeproj.buildXcodeprojPath(outputDir: dstdir, projectName: projectName)
+          try Xcodeproj.generate(projectName: projectName, xcodeprojPath: outpath, graph: graph, options: XcodeprojOptions(), diagnostics: diagnostics)
 
-            XCTAssertDirectoryExists(outpath)
-            XCTAssertEqual(outpath, dstdir.appending(component: projectName + ".xcodeproj"))
+          XCTAssertDirectoryExists(outpath)
+          XCTAssertEqual(outpath, dstdir.appending(component: projectName + ".xcodeproj"))
 
-            // We can only validate this on OS X.
-            // Don't allow TOOLCHAINS to be overriden here, as it breaks the test below.
-            let output = try Process.checkNonZeroExit(
-                args: "env", "-u", "TOOLCHAINS", "xcodebuild", "-list", "-project", outpath.pathString).spm_chomp()
+          // We can only validate this on OS X.
+          // Don't allow TOOLCHAINS to be overriden here, as it breaks the test below.
+          let output = try Process.checkNonZeroExit(
+              args: "env", "-u", "TOOLCHAINS", "xcodebuild", "-list", "-project", outpath.pathString).spm_chomp()
 
-            XCTAssertTrue(output.contains("""
-               Information about project "DummyProjectName":
-                   Targets:
-                       DummyModuleName
+          XCTAssertMatch(output, .contains("""
+             Information about project "DummyProjectName":
+                 Targets:
+                     DummyModuleName
 
-                   Build Configurations:
-                       Debug
-                       Release
+                 Build Configurations:
+                     Debug
+                     Release
 
-                   If no build configuration is specified and -scheme is not passed then "Release" is used.
+                 If no build configuration is specified and -scheme is not passed then "Release" is used.
 
-                   Schemes:
-                       Foo-Package
-               """), output)
+                 Schemes:
+                     Foo-Package
+             """))
         }
       #endif
     }


### PR DESCRIPTION
Broadly refactor tests to use helper functions that print better failures and use consistent verification logic.

### Motivation:

Tests that use `XCTAssert()` without providing custom failure messages are difficult to debug — when they fail, we don't get much context, e.g., “XCTAssertTrue failed”.

We have `XCTAssertMatch()` (and friends) that include robust string matching options and always print nice failure messages that include the expected and actual results, so we should use those functions where we can.

### Modifications:

* Use `XCTAssertMatch()` instead of `XCTAssertTrue(string.contains())`, etc.
* Use `XCTAssertNoMatch()` instead of `XCTAssertFalse(string.contains())`, etc.

### Result:

- When these tests fail they'll have much better failure messages.
