### PR TITLE
Do not inherit host destination's extra flags for target destination when cross-compiling

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -838,6 +838,9 @@ public class SwiftTool {
             // Create custom toolchain if present.
             if let customDestination = self.options.customCompileDestination {
                 destination = try Destination(fromFile: customDestination)
+            } else if let target = self.options.customCompileTriple,
+                      let targetDestination = Destination.defaultDestination(for: target, host: hostDestination) {
+                destination = targetDestination
             } else {
                 // Otherwise use the host toolchain.
                 destination = hostDestination
@@ -854,18 +857,6 @@ public class SwiftTool {
         }
         if let sdk = self.options.customCompileSDK {
             destination.sdk = sdk
-        } else if let target = destination.target, target.isWASI() {
-            // Set default SDK path when target is WASI whose SDK is embeded
-            // in Swift toolchain
-            do {
-                let compilers = try UserToolchain.determineSwiftCompilers(binDir: destination.binDir)
-                destination.sdk = compilers.compile
-                    .parentDirectory // bin
-                    .parentDirectory // usr
-                    .appending(components: "share", "wasi-sysroot")
-            } catch {
-                return .failure(error)
-            }
         }
         destination.archs = options.archs
 

--- a/Sources/Workspace/Destination.swift
+++ b/Sources/Workspace/Destination.swift
@@ -178,6 +178,24 @@ public struct Destination: Encodable, Equatable {
     }
     /// Cache storage for sdk platform path.
     private static var _sdkPlatformFrameworkPath: (fwk: AbsolutePath, lib: AbsolutePath)? = nil
+
+    /// Returns a default destination of a given target environment
+    public static func defaultDestination(for triple: Triple, host: Destination) -> Destination? {
+        if triple.isWASI() {
+            let wasiSysroot = host.binDir
+                .parentDirectory // usr
+                .appending(components: "share", "wasi-sysroot")
+            return Destination(
+                target: triple,
+                sdk: wasiSysroot,
+                binDir: host.binDir,
+                extraCCFlags: [],
+                extraSwiftCFlags: [],
+                extraCPPFlags: []
+            )
+        }
+        return nil
+    }
 }
 
 extension Destination {


### PR DESCRIPTION
Do not inherit host destination's extra flags for target destination

### Motivation:

Host environment specific flags, such as XCTest module directory, were implicitly inherited by target destination. It caused unexpected reference to host module file when cross-compiling for WASI, so drop them explicitly


### Modifications:

Create a new fresh Destination for WASI target and move some logic into Destination to be more generic for different targets.


CC: @MaxDesiatov 

