### PR TITLE
[Documentation] Update package collection docs

### DIFF
--- a/Documentation/PackageCollections.md
+++ b/Documentation/PackageCollections.md
@@ -309,6 +309,8 @@ Certificates used for signing package collections must meet the following requir
 - The certificate must not be revoked. The certificate authority must support OCSP, which means the certificate must have the "Certificate Authority Information Access" extension that includes OCSP as a method, specifying the responder's URL.
 - The certificate chain is valid and root certificate must be trusted.
 
+Non-expired, non-revoked Swift Package Collection certificates from [developer.apple.com](https://developer.apple.com) satisfy all of the criteria above.
+
 ##### Trusted root certificates
 
 With the `package-collection-sign` tool, the root certificate provided as input for signing a collection is automatically trusted. When SwiftPM user tries to add the collection, however,


### PR DESCRIPTION
Add information about the new Swift Package Collection certificate type, available on
developer.apple.com, that can be used for signing package collections.
