### PR TITLE
fix potential race in the computation of cache state

### DIFF
--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -169,10 +169,10 @@ public class RepositoryManager {
                     handle.status = .pending
                     // Make sure destination is free.
                     try? self.fileSystem.removeFileTree(repositoryPath)
-
+                    let isCached = self.cachePath.map{ self.fileSystem.exists($0.appending(handle.subpath)) } ?? false
+                    
                     // Inform delegate.
                     queue.async {
-                        let isCached = self.cachePath.map{ self.fileSystem.exists($0.appending(handle.subpath)) } ?? false
                         let details = FetchDetails(fromCache: isCached, updatedCache: false)
                         self.delegate?.fetchingWillBegin(handle: handle, fetchDetails: details)
                     }


### PR DESCRIPTION
motivation: fix unstable test

changes: compute the cache state before queueing the delegate call, since otherwise it may compute the state after the cache has been created
