### PR TITLE
relax stricter validation to warning to allow transition

### DIFF
--- a/Sources/PackageModel/Manifest.swift
+++ b/Sources/PackageModel/Manifest.swift
@@ -168,7 +168,7 @@ public final class Manifest: ObjectIdentifierProtocol {
     /// Returns the package dependencies required for a particular products filter.
     public func dependenciesRequired(for productFilter: ProductFilter) -> [PackageDependency] {
         #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
-        // If we have already calcualted it, returned the cached value.
+        // If we have already calculated it, returned the cached value.
         if let dependencies = self._requiredDependencies[productFilter] {
             return self.dependencies
         } else {


### PR DESCRIPTION
motivation: recent change to SwiftPM introduced stricter validation of dependencies uniquness to address undefined behavior. however, we want to allow users some times to adjust before making a breaking change

changes: update the validation to emit a warning instead of error under the specific condition the previous behavior incorrectly ignored!

