### PR TITLE
add more tests for additional dependency uniqueness validation 

### DIFF
--- a/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Pubgrub/PubgrubDependencyResolver.swift
@@ -230,7 +230,7 @@ public struct PubgrubDependencyResolver {
                 return (package: package, binding: details.binding, products: details.products)
             }
 
-        // Add overriden packages to the result.
+        // Add overridden packages to the result.
         for (package, override) in state.overriddenPackages {
             // TODO: replace with async/await when available
             let container = try temp_await { provider.getContainer(for: package, completion: $0) }

--- a/Sources/SPMTestSupport/InMemoryGitRepository.swift
+++ b/Sources/SPMTestSupport/InMemoryGitRepository.swift
@@ -385,7 +385,7 @@ public final class InMemoryGitRepositoryProvider: RepositoryProvider {
     /// Add a repository to this provider. Only the repositories added with this interface can be operated on
     /// with this provider.
     public func add(specifier: RepositorySpecifier, repository: InMemoryGitRepository) {
-        // Save the repository in specifer map.
+        // Save the repository in specifier map.
         specifierMap[specifier] = repository
     }
 
@@ -398,7 +398,7 @@ public final class InMemoryGitRepositoryProvider: RepositoryProvider {
     // Note: These methods use force unwrap (instead of throwing) to honor their preconditions.
 
     public func fetch(repository: RepositorySpecifier, to path: AbsolutePath) throws {
-        let repo = specifierMap[RepositorySpecifier(url: repository.url.spm_dropGitSuffix())]!
+        let repo = specifierMap[RepositorySpecifier(url: repository.url)]!
         fetchedMap[path] = try repo.copy()
         add(specifier: RepositorySpecifier(url: path.asURL.absoluteString), repository: repo)
     }

--- a/Sources/SPMTestSupport/MockDependency.swift
+++ b/Sources/SPMTestSupport/MockDependency.swift
@@ -16,46 +16,86 @@ public struct MockDependency {
     public typealias Requirement = PackageDependency.SourceControl.Requirement
 
     public let deprecatedName: String?
-    public let path: String
-    public let requirement: Requirement?
+    public let location: Location
     public let products: ProductFilter
-    
-    init(deprecatedName: String? = nil, path: String, requirement: Requirement?, products: ProductFilter = .everything) {
+
+    init(deprecatedName: String? = nil, location: Location, products: ProductFilter = .everything) {
         self.deprecatedName = deprecatedName
-        self.path = path
-        self.requirement = requirement
+        self.location = location
         self.products = products
     }
-    
+
     // TODO: refactor this when adding registry support
     public func convert(baseURL: AbsolutePath, identityResolver: IdentityResolver) -> PackageDependency {
-        let path = baseURL.appending(RelativePath(self.path))
-        let location = identityResolver.resolveLocation(from: path.pathString)
-        let identity = identityResolver.resolveIdentity(for: location)
-        if let requirement = self.requirement {
-            return .scm(identity: identity,
-                        deprecatedName: self.deprecatedName,
-                        location: location,
-                        requirement: requirement,
-                        productFilter: self.products)
-        } else {
-            return .local(identity: identity,
-                          deprecatedName: self.deprecatedName,
-                          path: location,
-                          productFilter: self.products)
+        switch self.location {
+        case .fileSystem(let path):
+            let path = baseURL.appending(path)
+            let location = identityResolver.resolveLocation(from: path.pathString)
+            let identity = identityResolver.resolveIdentity(for: location)
+            return .fileSystem(
+                identity: identity,
+                deprecatedName: self.deprecatedName,
+                path: location,
+                productFilter: self.products
+            )
+        case .sourceControlPath(let path, let requirement):
+            let path = baseURL.appending(path)
+            let location = identityResolver.resolveLocation(from: path.pathString)
+            let identity = identityResolver.resolveIdentity(for: location)
+            return .sourceControl(
+                identity: identity,
+                deprecatedName: self.deprecatedName,
+                location: location,
+                requirement: requirement,
+                productFilter: self.products
+            )
+        case .sourceControlURL(let url, let requirement):
+            let location = identityResolver.resolveLocation(from: url)
+            let identity = identityResolver.resolveIdentity(for: location)
+            return .sourceControl(
+                identity: identity,
+                deprecatedName: self.deprecatedName,
+                location: location,
+                requirement: requirement,
+                productFilter: self.products
+            )
         }
     }
-    
+
+    public static func fileSystem(path: String, products: ProductFilter = .everything) -> MockDependency {
+        MockDependency(location: .fileSystem(path: RelativePath(path)), products: products)
+    }
+
+    public static func sourceControl(path: String, requirement: Requirement, products: ProductFilter = .everything) -> MockDependency {
+        MockDependency(location: .sourceControlPath(path: RelativePath(path), requirement: requirement), products: products)
+    }
+
+    public static func sourceControlWithDeprecatedName(name: String, path: String, requirement: Requirement, products: ProductFilter = .everything) -> MockDependency {
+        MockDependency(deprecatedName: name, location: .sourceControlPath(path: RelativePath(path), requirement: requirement), products: products)
+    }
+
+    public static func sourceControl(url: String, requirement: Requirement, products: ProductFilter = .everything) -> MockDependency {
+        MockDependency(location: .sourceControlURL(url: url, requirement: requirement), products: products)
+    }
+
+    // for backwards compatibility
     public static func local(path: String, products: ProductFilter = .everything) -> MockDependency {
-        MockDependency(path: path, requirement: nil, products: products)
+        Self.fileSystem(path: path, products: products)
     }
 
+    // for backwards compatibility
     public static func scm(path: String, requirement: Requirement, products: ProductFilter = .everything) -> MockDependency {
-        MockDependency(path: path, requirement: requirement, products: products)
+        Self.sourceControl(path: path, requirement: requirement, products: products)
     }
 
+    // for backwards compatibility
     public static func scmWithDeprecatedName(name: String, path: String, requirement: Requirement, products: ProductFilter = .everything) -> MockDependency {
-        MockDependency(deprecatedName: name, path: path, requirement: requirement, products: products)
+        Self.sourceControlWithDeprecatedName(name: name, path: path, requirement: requirement, products: products)
     }
 
+    public enum Location {
+        case fileSystem(path: RelativePath)
+        case sourceControlPath(path: RelativePath, requirement: Requirement)
+        case sourceControlURL(url: String, requirement: Requirement)
+    }
 }

--- a/Sources/SPMTestSupport/MockPackage.swift
+++ b/Sources/SPMTestSupport/MockPackage.swift
@@ -9,11 +9,12 @@
  */
 
 import PackageModel
+import TSCBasic
 
 public struct MockPackage {
     public let name: String
     public let platforms: [PlatformDescription]
-    public let path: String?
+    public let location: Location
     public let targets: [MockTarget]
     public let products: [MockProduct]
     public let dependencies: [MockDependency]
@@ -33,7 +34,27 @@ public struct MockPackage {
     ) {
         self.name = name
         self.platforms = platforms
-        self.path = path
+        self.location = .fileSystem(path: RelativePath(path ?? name))
+        self.targets = targets
+        self.products = products
+        self.dependencies = dependencies
+        self.versions = versions
+        self.toolsVersion = toolsVersion
+    }
+
+    public init(
+        name: String,
+        platforms: [PlatformDescription] = [],
+        url: String,
+        targets: [MockTarget],
+        products: [MockProduct],
+        dependencies: [MockDependency] = [],
+        versions: [String?] = [],
+        toolsVersion: ToolsVersion? = nil
+    ) {
+        self.name = name
+        self.platforms = platforms
+        self.location = .sourceControl(url: url)
         self.targets = targets
         self.products = products
         self.dependencies = dependencies
@@ -52,5 +73,10 @@ public struct MockPackage {
             ],
             versions: ["1.0.0"]
         )
+    }
+
+    public enum Location {
+        case fileSystem(path: RelativePath)
+        case sourceControl(url: String)
     }
 }

--- a/Sources/SPMTestSupport/PackageDependencyDescriptionExtensions.swift
+++ b/Sources/SPMTestSupport/PackageDependencyDescriptionExtensions.swift
@@ -35,30 +35,6 @@ public extension PackageDependency {
                            productFilter: productFilter)
     }
 
-    // backwards compatibility with existing tests
-    static func local(identity: PackageIdentity? = nil,
-                      deprecatedName: String? = nil,
-                      path: String,
-                      productFilter: ProductFilter = .everything
-    ) -> Self {
-        return .fileSystem(identity: identity,
-                           deprecatedName: deprecatedName,
-                           path: AbsolutePath(path),
-                           productFilter: productFilter)
-    }
-
-    // backwards compatibility with existing tests
-    static func local(identity: PackageIdentity? = nil,
-                      deprecatedName: String? = nil,
-                      path: AbsolutePath,
-                      productFilter: ProductFilter = .everything
-    ) -> Self {
-        return .fileSystem(identity: identity,
-                           deprecatedName: deprecatedName,
-                           path: path,
-                           productFilter: productFilter)
-    }
-
     static func sourceControl(identity: PackageIdentity? = nil,
                               deprecatedName: String? = nil,
                               location: String,

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -358,8 +358,8 @@ final class PackageToolTests: XCTestCase {
             packageLocation: "/PackageA",
             v: .v5_3,
             dependencies: [
-                .local(path: "/PackageB"),
-                .local(path: "/PackageC"),
+                .fileSystem(path: "/PackageB"),
+                .fileSystem(path: "/PackageC"),
             ],
             products: [
                 .init(name: "exe", type: .executable, targets: ["TargetA"])
@@ -376,8 +376,8 @@ final class PackageToolTests: XCTestCase {
             packageLocation: "/PackageB",
             v: .v5_3,
             dependencies: [
-                .local(path: "/PackageC"),
-                .local(path: "/PackageD"),
+                .fileSystem(path: "/PackageC"),
+                .fileSystem(path: "/PackageD"),
             ],
             products: [
                 .init(name: "PackageB", type: .library(.dynamic), targets: ["TargetB"])
@@ -394,7 +394,7 @@ final class PackageToolTests: XCTestCase {
             packageLocation: "/PackageC",
             v: .v5_3,
             dependencies: [
-                .local(path: "/PackageD"),
+                .fileSystem(path: "/PackageD"),
             ],
             products: [
                 .init(name: "PackageC", type: .library(.dynamic), targets: ["TargetC"])

--- a/Tests/PackageGraphTests/PackageGraphTests.swift
+++ b/Tests/PackageGraphTests/PackageGraphTests.swift
@@ -1128,7 +1128,7 @@ class PackageGraphTests: XCTestCase {
                     path: "/Foo",
                     packageLocation: "/Foo",
                     dependencies: [
-                        .local(path: "/Biz"),
+                        .fileSystem(path: "/Biz"),
                     ],
                     targets: [
                         TargetDescription(name: "Foo", dependencies: [

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -2135,7 +2135,7 @@ class PackageBuilderTests: XCTestCase {
             name: "Foo",
             v: .v5,
             dependencies: [
-                .local(path: "/Biz"),
+                .fileSystem(path: "/Biz"),
             ],
             targets: [
                 try TargetDescription(

--- a/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
+++ b/Tests/XcodeprojTests/GenerateXcodeprojTests.swift
@@ -357,7 +357,7 @@ class GenerateXcodeprojTests: XCTestCase {
                         path: fooPackagePath.pathString,
                         packageLocation: fooPackagePath.pathString,
                         dependencies: [
-                            .local(path: barPackagePath)
+                            .fileSystem(path: barPackagePath)
                         ],
                         targets: [
                             TargetDescription(name: "Foo", dependencies: [


### PR DESCRIPTION
motivation: expand the test suite as we are changing the dependency uniqueness validation functionality 

changes:
* add facilities to use urls in mocks, not just path
* add tests that demonstrate the current behavior when dependency identity conflict (different URLs, same identity) is encountered