### PR TITLE
mark edit/unedit functionality as deprecated

### DIFF
--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -193,6 +193,7 @@ public final class MockWorkspace {
         return packages.map { rootsDir.appending(RelativePath($0)) }
     }
 
+    @available(*, deprecated)
     public func checkEdit(
         packageName: String,
         path: AbsolutePath? = nil,
@@ -214,6 +215,7 @@ public final class MockWorkspace {
         result(diagnostics)
     }
 
+    @available(*, deprecated)
     public func checkUnedit(
         packageName: String,
         roots: [String],

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -2075,6 +2075,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
+    @available(*, deprecated)
     func testEditDependency() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
@@ -2183,6 +2184,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
+    @available(*, deprecated)
     func testMissingEditCanRestoreOriginalCheckout() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
@@ -2241,6 +2243,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
+    @available(*, deprecated)
     func testCanUneditRemovedDependencies() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
@@ -2307,6 +2310,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
+    @available(*, deprecated)
     func testDependencyResolutionWithEdit() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
@@ -2428,7 +2432,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
-    func testPrefetchingWithOverridenPackage() throws {
+    func testPrefetchingWithOverriddenPackage() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
 
@@ -2598,6 +2602,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
+    @available(*, deprecated)
     func testResolutionFailureWithEditedDependency() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
@@ -2727,6 +2732,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
+    @available(*, deprecated) // for editing part, rest should stay
     func testLocalDependencyBasics() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
@@ -3940,6 +3946,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
+    @available(*, deprecated)
     func testEditDependencyHadOverridableConstraints() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()


### PR DESCRIPTION
motivation: edit/unedit functionality was put in place prior to the ability to do local overrides, making it redundant. it also add signfincant complexity to the code which could be good to remove

changes:
* mark the public edit/unedit API as deprecated
* emit deprecation warning on the edit/unedit CLI commands
