### PR TITLE
rename resolveToResolvedVersion to resolveBasedOnResolvedVersionsFile

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -572,7 +572,7 @@ public class SwiftTool {
         let root = try getWorkspaceRoot()
 
         if options.forceResolvedVersions {
-            try workspace.resolveToResolvedVersion(root: root, diagnostics: diagnostics)
+            try workspace.resolveBasedOnResolvedVersionsFile(root: root, diagnostics: diagnostics)
         } else {
             try workspace.resolve(root: root, diagnostics: diagnostics)
         }

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -392,7 +392,7 @@ public final class MockWorkspace {
             root: root,
             dependencyManifests: dependencyManifests,
             pinsStore: pinsStore,
-            extraConstraints: []
+            constraints: []
         )
 
         check(ResolutionPrecomputationResult(result: result, diagnostics: diagnostics))


### PR DESCRIPTION
motivation: code should be easier to reason about

changes:
* rename resolveToResolvedVersion to resolveBasedOnResolvedVersionsFile
* cleanup redundant private function abstractions where possible to reduce complexity
